### PR TITLE
The (official?) release of lwt 2.4.0 on the OSCIgen site has a later dat...

### DIFF
--- a/url/lwt.2.4.0
+++ b/url/lwt.2.4.0
@@ -1,1 +1,1 @@
-http://www.dimino.org/lwt-2.4.0.tar.gz
+http://ocsigen.org/download/lwt-2.4.0.tar.gz


### PR DESCRIPTION
...e and different interfaces to the (snapshot?) on dimino.org

[ NB I'm not sure how to test this -- I grepped around for anything
else that might break and couldn't see anything obvious (to me) ]

$ curl -f http://www.dimino.org/lwt-2.4.0.tar.gz | md5sum -
6650d51cdc572c8f66d5a49b1304e29c  -

$ curl -f http://ocsigen.org/download/lwt-2.4.0.tar.gz | md5sum -
fefff147103123180c50f6ee862979d9  -

The CHANGES file in the OCSIgen version has date: 2012-07-16
The CHANGES file in the dimino.org version has date: 2012-06-02

The OCSIgen version has significant interface changes in the Lwt_unix
C interface. It also matches the version of the documentation on the
OSCIgen website.
