### PR TITLE
ocamlsdl: optional dependency on lablgl

### DIFF
--- a/packages/ocamlsdl.0.9.1/opam
+++ b/packages/ocamlsdl.0.9.1/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
-  ["./configure" "--with-installdir=%{lib}%/ocamlsdl" "--with-lablgldir=%{lib}%/lablgl"]
+  ["./configure" "--with-installdir=%{lib}%/ocamlsdl" "--with-lablgldir=%{lib}%/lablgl" {"%{lablgl:installed}%"}]
   ["%{make}%"]
   ["%{make}%" "install"]
 ]


### PR DESCRIPTION
ocamlsdl has a module Sdlgl which is compiled only if lablgl is available. Without this patch ocamlsdl is unconditionnally compiled without GL support.

The patch works but maybe is not as elegant as it could be: the switch --with-lablgldir is always present but indicates a wrong directory if lablgl is not installed. It doesn't bother ocamlsdl makefile, but it sure would be nicer to put the switch on the command line only if lablgl is installed. Is there a way to do that currently?
