### PR TITLE
Fix stublib install in bitstring

### DIFF
--- a/packages/bitstring.2.0.3/opam
+++ b/packages/bitstring.2.0.3/opam
@@ -6,6 +6,6 @@ build: [
   ["%{make}%" "install"]
 ]
 remove: [
-  ["rm" "-rf" "%{lib}%/stublibs/dllbitstring.so" "%{lib}%/bitstring"]
+  ["ocamlfind" "remove" "bitstring"]
 ]
 depends: ["ocamlfind" "base-unix"]


### PR DESCRIPTION
opam install bitstring fails for me in this way:

```
Build commands:
  ./configure --prefix /home/mike/.opam/4.00.1
  make
  make install
  cp /home/mike/.opam/4.00.1/lib/bitstring/dllbitstring.so /home/mike/.opam/4.00.1/lib/stublibs
Uninstalling bitstring.2.0.3 ...
The compilation of bitstring.2.0.3 failed in /home/mike/.opam/4.00.1/build/bitstring.2.0.3.
...
* cp: cannot stat `/home/mike/.opam/4.00.1/lib/bitstring/dllbitstring.so': No such file or directory
  'opam install bitstring' failed
```

We can remove the stublib copy build step from bitstring/opam, because it is apparently unecessary and fails during build.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
