### PR TITLE
Fixed package syslog

### DIFF
--- a/packages/syslog.1.4/opam
+++ b/packages/syslog.1.4/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
-  ["%{make}%"]
+  ["%{make}%" "reallyall"]
   ["%{make}%" "install"]
 ]
 remove: [


### PR DESCRIPTION
Just "make" don’t build .cmxa library. "make reallyall" is required.
