### PR TITLE
new package: mascot.1.0

### DIFF
--- a/packages/mascot.1.0/descr
+++ b/packages/mascot.1.0/descr
@@ -1,0 +1,1 @@
+A style-checker for OCaml sources (code, documentation, interface, metrics, and typography).

--- a/packages/mascot.1.0/files/mascot.install
+++ b/packages/mascot.1.0/files/mascot.install
@@ -1,0 +1,4 @@
+lib: []
+bin: ["_build/src/driver/mascot.native" {"mascot"}]
+toplevel: []
+misc: []

--- a/packages/mascot.1.0/opam
+++ b/packages/mascot.1.0/opam
@@ -1,0 +1,11 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+build: [
+  ["./configure"]
+  ["make" "all"]
+  ["make" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "mascot"]
+]
+depends: ["ocamlfind"]

--- a/packages/mascot.1.0/url
+++ b/packages/mascot.1.0/url
@@ -1,0 +1,2 @@
+archive: "http://forge.ocamlcore.org/frs/download.php/990/mascot-1.0.tar.gz"
+checksum: "09bd8a57156ffb553e32e82248615119"


### PR DESCRIPTION
Mascot is a style-checker for OCaml sources, written by Xavier Clerc.
