### PR TITLE
yajl-ocaml packages - 2nd iteration

### DIFF
--- a/packages/yajl-extra.0.7.1/descr
+++ b/packages/yajl-extra.0.7.1/descr
@@ -1,0 +1,2 @@
+extended YAJL bindings with a convenient high-level JSON representation
+https://github.com/mlin/yajl-ocaml

--- a/packages/yajl-extra.0.7.1/opam
+++ b/packages/yajl-extra.0.7.1/opam
@@ -1,0 +1,9 @@
+opam-version: "1"
+maintainer: "mlin@mlin.net"
+build: [
+  ["make" "install-extra"]
+]
+remove: [
+  ["make" "uninstall"] 
+]
+depends: ["ocamlfind" "batteries" "yajl"]

--- a/packages/yajl-extra.0.7.1/url
+++ b/packages/yajl-extra.0.7.1/url
@@ -1,0 +1,2 @@
+archive: "https://raw.github.com/mlin/yajl-ocaml/tarball/yajl-ocaml-0.7.1.tar.gz"
+checksum: "5aa65b8a34f8cf4dbc05adb3f7ec717d"

--- a/packages/yajl.0.7.1/descr
+++ b/packages/yajl.0.7.1/descr
@@ -1,0 +1,2 @@
+bindings to the YAJL streaming JSON library
+https://github.com/mlin/yajl-ocaml

--- a/packages/yajl.0.7.1/opam
+++ b/packages/yajl.0.7.1/opam
@@ -1,0 +1,9 @@
+opam-version: "1"
+maintainer: "mlin@mlin.net"
+build: [
+  ["make" "install"]
+]
+remove: [
+  ["make" "uninstall"] 
+]
+depends: ["ocamlfind"]

--- a/packages/yajl.0.7.1/url
+++ b/packages/yajl.0.7.1/url
@@ -1,0 +1,2 @@
+archive: "https://raw.github.com/mlin/yajl-ocaml/tarball/yajl-ocaml-0.7.1.tar.gz"
+checksum: "5aa65b8a34f8cf4dbc05adb3f7ec717d"


### PR DESCRIPTION
- renamed the ocamlfind package installed by yajl-extra to 'yajl-extra', as suggested - https://github.com/mlin/yajl-ocaml/commit/791e554279
- add workaround for ruby dependency in upstream C library - 
  https://github.com/mlin/yajl-ocaml/commit/3a13e6c2f1
