### PR TITLE
added 4.00.1+annot.comp

### DIFF
--- a/compilers/4.00.1+annot.comp
+++ b/compilers/4.00.1+annot.comp
@@ -1,0 +1,9 @@
+opam-version: "1"
+name: "4.00.1+annot"
+src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
+patches: ["https://bitbucket.org/camlspotter/spotinstall/raw/26c014770721e44be11f364f09b149cff54a047f/ocaml-annot-4.00.1.patch"]
+make: [ "world" "world.opt" ]
+packages : [ "base-unix" "base-bigarray" "base-threads" ]
+env: [
+  [ CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs" ]
+]


### PR DESCRIPTION
Get bored of explaining many times how to use ocamlspotter nicely,  I added a compiler variant 4.00.1+annot, which automatically turn on -annot and -bin-annot if OCAML_ANNOT env var is defined. Could you pull this?

Feel free to reject this if you think having too many compiler variants is a bad idea.

j
