### PR TITLE
3.12.1 with native dynlink for darwin >= 10

### DIFF
--- a/compilers/3.12.1+natdynlink-osx.comp
+++ b/compilers/3.12.1+natdynlink-osx.comp
@@ -1,0 +1,18 @@
+opam-version: "1"
+version: "3.12.1"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
+build: [
+  ["sed" "-iold" "s/darwin10/darwin1[0123456789]/g" "configure"]
+  ["./configure" "-prefix" "%{prefix}%"]
+  ["%{make}%" "world"]
+  ["%{make}%" "world.opt"]
+  ["%{make}%" "opt"]
+  ["%{make}%" "opt.opt"]
+  ["%{make}%" "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: ["base-unix" "base-bigarray" "base-threads"]
+env: [
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]


### PR DESCRIPTION
native dynlink was only enable for darwin10
this patch enable native dynlink for darwin (>= 10)
