### PR TITLE
Test the dbm library before installing to avoid silent failure

### DIFF
--- a/packages/dbm.1.0/opam
+++ b/packages/dbm.1.0/opam
@@ -3,7 +3,8 @@ maintainer: "contact@ocamlpro.com"
 build: [
   ["mkdir" "-p" "%{lib}%/dbm"]
   ["./configure"]
-  ["%{make}%"]
+  ["%{make}%" "all"]
+  ["%{make}%" "test"]
   ["%{make}%" "install" "STUBLIBDIR=%{lib}%/stublibs" "LIBDIR=%{lib}%/dbm"]
   ["cp" "META" "%{lib}%/dbm"]
 ]


### PR DESCRIPTION
Package dbm may fail to successfully install the dbm binding (for example because there is a problem with the C gdbm lib), and still return code 0 for make (the stub lib just has broken libs). This patch will make the compilation fail, so the user will be warned that dbm is not working.
