### PR TITLE
Put back all old minor version of js_of_ocaml

### DIFF
--- a/packages/js_of_ocaml.1.3.1/descr
+++ b/packages/js_of_ocaml.1.3.1/descr
@@ -1,0 +1,1 @@
+Compiler from OCaml bytecode to Javascript

--- a/packages/js_of_ocaml.1.3.1/files/js_of_ocaml.install
+++ b/packages/js_of_ocaml.1.3.1/files/js_of_ocaml.install
@@ -1,0 +1,3 @@
+bin: [
+  "compiler/js_of_ocaml"
+]

--- a/packages/js_of_ocaml.1.3.1/opam
+++ b/packages/js_of_ocaml.1.3.1/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "zol@benozol.de"
+build: [
+  ["%{make}%"]
+  ["%{make}%" "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "js_of_ocaml"]
+]
+depends: ["ocamlfind" "deriving-ocsigen" "lwt"]

--- a/packages/js_of_ocaml.1.3.1/url
+++ b/packages/js_of_ocaml.1.3.1/url
@@ -1,0 +1,2 @@
+archive: "http://ocsigen.org/download/js_of_ocaml-1.3.1.tar.gz"
+checksum: "902d9efbaf884a0330b54ec3da17ab37"

--- a/packages/js_of_ocaml.1.3/descr
+++ b/packages/js_of_ocaml.1.3/descr
@@ -1,0 +1,1 @@
+Compiler from OCaml bytecode to Javascript

--- a/packages/js_of_ocaml.1.3/files/js_of_ocaml.install
+++ b/packages/js_of_ocaml.1.3/files/js_of_ocaml.install
@@ -1,0 +1,3 @@
+bin: [
+  "compiler/js_of_ocaml"
+]

--- a/packages/js_of_ocaml.1.3/opam
+++ b/packages/js_of_ocaml.1.3/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "zol@benozol.de"
+build: [
+  ["%{make}%"]
+  ["%{make}%" "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "js_of_ocaml"]
+]
+depends: ["ocamlfind" "deriving-ocsigen" "lwt"]

--- a/packages/js_of_ocaml.1.3/url
+++ b/packages/js_of_ocaml.1.3/url
@@ -1,0 +1,2 @@
+archive: "http://ocsigen.org/download/js_of_ocaml-1.3.tar.gz"
+checksum: "731abe6f4bc4ea48a11f9e8b4468a400"


### PR DESCRIPTION
I'm sorry, I would not have done that. (especially for the last version which change the api)
