### PR TITLE
ocamlnet.3.6.0: remove contraint on camlzip

### DIFF
--- a/packages/ocamlnet.3.6.0/opam
+++ b/packages/ocamlnet.3.6.0/opam
@@ -41,6 +41,6 @@ depopts: [
   "lablgtk"
   "pcre-ocaml"
   "ssl"
-  "camlzip" {= "1.04"}
+  "camlzip"
   "cryptokit"
 ]


### PR DESCRIPTION
It seems to work with camlzip 1.05.
