### PR TITLE
ocsigenserver.2.2.0: make dbm an optional dependency

### DIFF
--- a/packages/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver.2.2.0/opam
@@ -17,10 +17,8 @@ depends: [
   "pcre-ocaml"
   "cryptokit"
   "tyxml"
+  ("dbm" | "sqlite3-ocaml") 
 ]
 depopts: [
-  "sqlite3-ocaml"
-  "lwt" {>= "2.4.2"}
   "camlzip" {>= "1.04"}
-  "dbm"
 ]


### PR DESCRIPTION
DBM is actually optional.

Installing ocsigenserver and eliom from a fresh opam installation works even if there is not sqlite3-ocaml nor dbm.

 (Then. I don't know if an actual practical ocsigen website can work like that, it is the same thing that cohttp Vs Lwt or Async)
