### PR TITLE
Fix ocamlfind installation

### DIFF
--- a/packages/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind.1.3.3/opam
@@ -5,4 +5,5 @@ build: [
   ["%{make}%" "all"]
   ["%{make}%" "opt"]
   ["%{make}%" "install"]
+  ["ocamlfind" "remove" "dbm"]
 ]


### PR DESCRIPTION
Hi

This works for me with OCaml 4.00.1 and 3.12.1 (It removes the dbm findlib name in any case).
Then, OCamlfind is a pretty delicate subject :)

On 3.12.1 the dbm.cm\* files are still there in lib/ocaml, but it does not seem to be a problem (one can install dbm through opam and use it normally).

(but it does not completely fix the problems of
https://github.com/OCamlPro/opam-repository/pull/235
now, at the very end, the `make install` assumes that either dbm or sqlite are there,
Is it possible to express in Opam? )
