### PR TITLE
sqlite3-ocaml.2.0.3: fix uninstallation command

### DIFF
--- a/packages/sqlite3-ocaml.2.0.3/opam
+++ b/packages/sqlite3-ocaml.2.0.3/opam
@@ -6,6 +6,6 @@ build: [
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [
-  ["ocaml" "setup.ml" "-uninstall"]
+  ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: ["ocamlfind"]


### PR DESCRIPTION
sqlite3-ocaml fails to reinstall when it needs to be recompiled
 (My guess it's because "ocaml setup.ml -uninstall" works only when setup.log contains the log of a successful "ocaml setup.ml -install" ...)

This patch just removes the ocamlfind package.
