### PR TITLE
adds opass 0.2.1 which removes the unnecessary async dependency

### DIFF
--- a/packages/opass.0.2.1/descr
+++ b/packages/opass.0.2.1/descr
@@ -1,0 +1,1 @@
+A simple password database written in OCaml.  

--- a/packages/opass.0.2.1/files/opass.install
+++ b/packages/opass.0.2.1/files/opass.install
@@ -1,0 +1,4 @@
+lib: []
+bin: ["main.native" {"opass"}]
+toplevel: []
+misc: []

--- a/packages/opass.0.2.1/opam
+++ b/packages/opass.0.2.1/opam
@@ -1,0 +1,6 @@
+opam-version: "1"
+maintainer: "d@lobraico.com"
+build: [
+	["ocamlbuild" "-use-ocamlfind" "-Is" "lib,bin" "bin/main.native"]
+]
+depends: ["ocamlfind" "core" "core_extended"]

--- a/packages/opass.0.2.1/url
+++ b/packages/opass.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pygatea/opass/archive/0.2.1-ocamlbuild.tar.gz"
+checksum: "4568e8f717b57a98a9736e6a719d8450"


### PR DESCRIPTION
As per the conversation on my previous pull request.
