### PR TITLE
[xml-light] add patch to fix/suppress dtd_trace

### DIFF
--- a/packages/xml-light.2.2/files/fix_dtd_trace.patch
+++ b/packages/xml-light.2.2/files/fix_dtd_trace.patch
@@ -1,0 +1,18 @@
+--- dtd.ml.prev	2013-01-04 20:57:33.174276611 +0100
++++ dtd.ml	2013-01-04 20:58:00.722277268 +0100
+@@ -267,7 +267,7 @@
+ exception TmpResult of dtd_result
+ 
+ let prove_child dtd tag = 
+-	trace dtd tag;
++	(* trace dtd tag; *)
+ 	match dtd.current with
+ 	| DTDEmpty -> raise (Prove_error EmptyExpected)
+ 	| DTDAny -> ()
+@@ -505,4 +505,4 @@
+ 		sprintf "<!ELEMENT %s %s>" tag (etype_to_string etype)
+ 
+ ;;
+-to_string_ref := to_string
+\ No newline at end of file
++to_string_ref := to_string

--- a/packages/xml-light.2.2/opam
+++ b/packages/xml-light.2.2/opam
@@ -1,5 +1,6 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
+patches: ["fix_dtd_trace.patch"]
 build: [
   ["mkdir" "-p" "%{lib}%/xml-light"]
   ["%{make}%" "xml_parser.ml"]


### PR DESCRIPTION
Add a patch to supress the dtd trace on stdout (just like in the debian package).
