### PR TITLE
New package version: PG'OCaml 1.7

### DIFF
--- a/packages/pgocaml.1.7/descr
+++ b/packages/pgocaml.1.7/descr
@@ -1,0 +1,9 @@
+Interface to PostgreSQL databases
+PG'OCaml provides an interface to PostgreSQL databases for OCaml
+applications. It uses Camlp4 to extend the OCaml syntax, enabling one
+to directly embed SQL statements inside the OCaml code. Moreover, it
+uses the describe feature of PostgreSQL to obtain type information
+about the database. This allows PG'OCaml to check at compile-time if
+the program is indeed consistent with the database structure. This
+type-safe database access is the primary advantage that PG'OCaml has
+over other PostgreSQL bindings for OCaml.

--- a/packages/pgocaml.1.7/opam
+++ b/packages/pgocaml.1.7/opam
@@ -1,0 +1,18 @@
+opam-version: "1"
+maintainer: "dario.teixeira@yahoo.com"
+build: [
+  ["./configure" "--prefix" "%{prefix}%"]
+  ["%{make}%"]
+  ["%{make}%" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "pgocaml"]
+]
+depends: [
+  "ocamlfind"
+  "batteries" {>= "2.0.0"}
+  "pcre-ocaml"
+  "calendar"
+  "csv"
+]
+

--- a/packages/pgocaml.1.7/url
+++ b/packages/pgocaml.1.7/url
@@ -1,0 +1,2 @@
+archive: "http://forge.ocamlcore.org/frs/download.php/1098/pgocaml-1.7.tgz"
+checksum: "0e38fdcda63704aaccbda3705da5838e"


### PR DESCRIPTION
This new version of PG'OCaml uses OASIS, which simplifies the build system and removes the need for special patches to work with OPAM.

Also, note that I took the liberty of making myself the maintainer of the OPAM package.  Since I'm also maintaining PG'OCaml and I'm an OPAM user, this should make life easier on everyone.
