### PR TITLE
Stog depends on pcre-ocaml

### DIFF
--- a/packages/stog.0.5/opam
+++ b/packages/stog.0.5/opam
@@ -13,5 +13,6 @@ depends: [
   "xtmpl" {>="0.5"}
   "config-file" {>= "1.1"}
   "ocamlrss" {>= "2.0"}
+  "pcre-ocaml"
 ]
 ocaml-version: [ >= "4.00.0" ]


### PR DESCRIPTION
This should be enough to fix it I guess, but please check that the syntax is correct, that's my first change for the `opam-repository`.

Thanks,

jonathan
