### PR TITLE
Add typerex 1.99.0-beta

### DIFF
--- a/packages/typerex.1.99.0-beta/descr
+++ b/packages/typerex.1.99.0-beta/descr
@@ -1,0 +1,1 @@
+/home/lefessan/GIT/OCamlPro/typerex-private/typerex/packages/opam/typerex.descr

--- a/packages/typerex.1.99.0-beta/opam
+++ b/packages/typerex.1.99.0-beta/opam
@@ -1,0 +1,1 @@
+/home/lefessan/GIT/OCamlPro/typerex-private/typerex/packages/opam/typerex.opam

--- a/packages/typerex.1.99.0-beta/url
+++ b/packages/typerex.1.99.0-beta/url
@@ -1,0 +1,1 @@
+/home/lefessan/GIT/OCamlPro/typerex-private/typerex/packages/opam/typerex.url


### PR DESCRIPTION
Note that this package conflict with ocp-build. However, I was not able to create an ocp-build package with the content

ocp-build.1.99.0-beta/opam:
opam-version: "1"
depends: [ typerex ]

"opam upgrade ocp-build"  does not see the new version.
