### PR TITLE
Make dbm optional for OCsigenserver

### DIFF
--- a/packages/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver.2.2.0/opam
@@ -17,10 +17,8 @@ depends: [
   "pcre-ocaml"
   "cryptokit"
   "tyxml"
+  ("dbm" | "sqlite3-ocaml") 
 ]
 depopts: [
-  "sqlite3-ocaml"
-  "lwt" {>= "2.4.2"}
   "camlzip" {>= "1.04"}
-  "dbm"
 ]


### PR DESCRIPTION
This is a revival of
https://github.com/OCamlPro/opam-repository/pull/235
on top of OCP's `master` and tested with opam 0.9.1.
