### PR TITLE
Updated OCurl

### DIFF
--- a/packages/ocurl.0.5.3/opam
+++ b/packages/ocurl.0.5.3/opam
@@ -1,7 +1,6 @@
 opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+maintainer: "vb@luminar.eu.org"
 build: [
-  ["./configure" "--with-findlib"]
   ["%{make}%"]
   ["%{make}%" "install"]
 ]

--- a/packages/ocurl.0.5.3/url
+++ b/packages/ocurl.0.5.3/url
@@ -1,2 +1,2 @@
-archive: "http://sourceforge.net/projects/ocurl/files/ocurl/0.5.3/ocurl-0.5.3.tgz/download"
-checksum: "c8b955e51f79dd2c62ab89577b27fe37"
+archive: "https://github.com/vbmithr/ocurl/archive/0.5.3.tar.gz"
+checksum: "fcde20a60c875e3172a7e5cf07ebdddd"


### PR DESCRIPTION
The binding to curl is no longer compiling on modern version of OCaml.
Fork have been done by others (like @williamleferrand). I have just forked his fork (yeah…) to modernize a bit the _oasis file and release this version. 

I’ll try to get in touch with the original author in order to see if it is possible for him to release a fixed version. In the meantime, I feel like opam users are better of with a version that works than something not working.
