### PR TITLE
Package ocp-indent version 0.6.1

### DIFF
--- a/packages/ocp-indent.0.6.1/descr
+++ b/packages/ocp-indent.0.6.1/descr
@@ -1,0 +1,1 @@
+A simple tool to indent OCaml programs

--- a/packages/ocp-indent.0.6.1/opam
+++ b/packages/ocp-indent.0.6.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+build: [
+  ["./configure" "--prefix" "%{prefix}%"]
+  ["ocamlbuild" "src/main.native"]
+  ["cp" "-f" "_build/src/main.native" "./ocp-indent"]
+  ["cp" "-f" "_build/src/main.native" "%{prefix}%/bin/ocp-indent"]
+  ["mkdir" "-p" "%{prefix}%/share/typerex/ocp-indent"]
+  ["cp" "-f" "tools/ocp-indent.el" "%{prefix}%/share/typerex/ocp-indent/"]
+]
+remove: [
+  ["./configure" "--prefix" "%{prefix}%"]
+  ["%{make}%" "uninstall"]
+]

--- a/packages/ocp-indent.0.6.1/url
+++ b/packages/ocp-indent.0.6.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/OCamlPro/ocp-indent/archive/0.6.1.tar.gz"
+checksum: "daa738345f34eaa433e31112a7ff77b1"


### PR DESCRIPTION
This temporarily avoids problematic dependency to ocp-build
