### PR TITLE
OCaml 3.11.2

### DIFF
--- a/compilers/3.11.2.comp
+++ b/compilers/3.11.2.comp
@@ -1,0 +1,16 @@
+opam-version: "1"
+version: "3.11.2"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.2.tar.gz"
+patches: ["3.11.2_binutils.patch"]
+build: [
+  ["./configure" "-prefix" "%{prefix}%"]
+  ["%{make}%" "world"]
+  ["%{make}%" "world.opt"]
+  ["%{make}%" "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: ["base-unix" "base-bigarray" "base-threads"]
+env: [
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]

--- a/compilers/3.11.2.descr
+++ b/compilers/3.11.2.descr
@@ -1,0 +1,1 @@
+Official 3.11.2 release

--- a/compilers/3.11.2_binutils.patch
+++ b/compilers/3.11.2_binutils.patch
@@ -1,0 +1,50 @@
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index 4a3f844..525c6e6 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -679,17 +679,18 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
++  begin match Config.system with
++    "linux" | "gnu" ->
++      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
++      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
++    | _ -> ()
++  end;
+   if !float_constants <> [] then begin
+     if macosx
+     then `	.literal8\n`
+     else `	.section	.rodata.cst8,\"a\",@progbits\n`;
+     List.iter emit_float_constant !float_constants
+-  end;
+-  match Config.system with
+-    "linux" | "gnu" ->
+-      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+-      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  end
+ 
+ (* Emission of data *)
+ 
+diff --git a/asmcomp/i386/emit.mlp b/asmcomp/i386/emit.mlp
+index 2992f29..0b1252c 100644
+--- a/asmcomp/i386/emit.mlp
++++ b/asmcomp/i386/emit.mlp
+@@ -905,12 +905,12 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
+-  List.iter emit_float_constant !float_constants;
+-  match Config.system with
++  begin match Config.system with
+     "linux_elf" | "bsd_elf" | "gnu" ->
+       `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+       `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  | _ -> () end;
++  List.iter emit_float_constant !float_constants
+ 
+ 
+ (* Emission of data *)
+-- 


### PR DESCRIPTION
Add support for OCaml 3.11.2. I had to patch because this version is not compatible with latest binutils, see http://caml.inria.fr/mantis/view.php?id=5237
