### PR TITLE
constraint core.109.07.00 as Linux-only

### DIFF
--- a/packages/core.109.07.00/opam
+++ b/packages/core.109.07.00/opam
@@ -9,3 +9,4 @@ remove: [
   ["ocamlfind" "remove" "core"]
 ]
 depends: ["ocamlfind" "bin_prot" {= "109.07.00"} "fieldslib" {= "109.07.00"} "pa_ounit" {= "109.07.00"} "pipebang" {= "109.07.00"} "sexplib" {= "109.07.00"} "variantslib" {= "109.07.00"} "res" "ounit" "comparelib" {= "109.07.00"}]
+os: ["linux"]


### PR DESCRIPTION
This should prevent forced upgrades by mistake that will always break on this
version for non-Linux.  Note that you require the latest opam
(3fb1a97d72bd00bae05122c844b48b28704e87af) to have a solver that can handle
this situation.
