### PR TITLE
simplify camlimages to not strongly depend on lablgtk

### DIFF
--- a/packages/camlimages.4.0.2/opam
+++ b/packages/camlimages.4.0.2/opam
@@ -7,4 +7,5 @@ build: [
 remove: [
   ["ocamlfind" "remove" "camlimages"]
 ]
-depends: ["ocamlfind" "lablgtk" "omake"]
+depends: ["ocamlfind" "omake"]
+depopts: ["lablgtk"]


### PR DESCRIPTION
since lablgtk is a pain to install, this simplifies using camlimages for common formats that dont need lablgtk
