### PR TITLE
A workaround of CamlGI issue (see #410)

### DIFF
--- a/packages/CamlGI.0.6/files/CamlGI.install
+++ b/packages/CamlGI.0.6/files/CamlGI.install
@@ -1,1 +1,1 @@
-lib: [ "camlGI.o" ]
+lib: [ "camlGI.a" ]


### PR DESCRIPTION
This CamlGI.install file should work-around the installation issue described in #410.
