### PR TITLE
 [Coq8.4pl1] Add dependency on camlp5.

### DIFF
--- a/packages/coq.8.4pl1/opam
+++ b/packages/coq.8.4pl1/opam
@@ -5,10 +5,14 @@ build: [
      "-configdir" "%{lib}%/coq/config"
      "-mandir" "%{man}%"
      "-docdir" "%{doc}%"
-     "--prefix" "%{prefix}%"]
+     "--prefix" "%{prefix}%"
+     "--usecamlp5"
+     "--camlp5dir" "%{lib}%/camlp5"
+]
   ["%{make}%" "world"]
   ["%{make}%" "install"]
 ]
 patches: ["coqmktop.patch" "CAML_LD_LIBRARY_PATH.patch"]
 
+depends: ["camlp5"]
 depopts: ["lablgtk"]


### PR DESCRIPTION
Camlp5 seems preferred to camlp4. Moreover other packages make the implicit assumption that camlp5 is used for compiling coq (eg. why3).

I used "%{lib}%/camlp5" for specifying the library directory of camlp5 (coq doesn't use ocamlfind). Is there a better way? No opam variable  seems to give the installation directory of a package (eg. camlp5:lib ).

Best,
