### PR TITLE
Add version constraints on opass

### DIFF
--- a/packages/opass.0.2.1/opam
+++ b/packages/opass.0.2.1/opam
@@ -3,4 +3,4 @@ maintainer: "d@lobraico.com"
 build: [
 	["ocamlbuild" "-use-ocamlfind" "-Is" "lib,bin" "bin/main.native"]
 ]
-depends: ["ocamlfind" "core" "core_extended"]
+depends: ["ocamlfind" "core" {= "108.08.00"} "core_extended" {= "108.08.00"}]


### PR DESCRIPTION
Resolving [Issue #422](https://github.com/OCamlPro/opam-repository/issues/422).

I limited this to 108.08.00, let me know if I should actually use >=
