### PR TITLE
add mshinwell's allocation profiling branch

### DIFF
--- a/compilers/4.00.1+alloc-profiling.comp
+++ b/compilers/4.00.1+alloc-profiling.comp
@@ -1,0 +1,13 @@
+opam-version: "1"
+version: "4.00.1"
+src: "https://github.com/mshinwell/ocaml/tarball/4.00.1-allocation-profiling"
+build: [
+  ["./configure" "-prefix" "%{prefix}%"]
+  ["%{make}%" "world"]
+  ["%{make}%" "world.opt"]
+  ["%{make}%" "install"]
+]
+packages: ["base-unix" "base-bigarray" "base-threads"]
+env: [
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]

--- a/compilers/4.00.1+alloc-profiling.descr
+++ b/compilers/4.00.1+alloc-profiling.descr
@@ -1,0 +1,1 @@
+support allocation profiling on x86_64


### PR DESCRIPTION
From Mark:

```
1. Use -allocation-tracing to ocamlopt.

2. Run with OCAMLRUNPARAM=T

3. Either:

 external decode : unit -> unit
   = "caml_dump_allocation_tracing_arrays"
 ...
 Pervasives.at_exit decode

or: run under gdb, break on [exit] or similar, then run:
 call caml_dump_allocation_tracing_arrays(0)

4. Copy and paste the output into two files, one for minor, one for
major, and strip off the first column which says "minor" or "major".

5. Run through the decoding script (below).  Syntax:
 ./decode.sh <executable> <allocation output file>

--

#!/bin/bash

set -eu -o pipefail

exe="$1"
allocs="$2"

commands=$(mktemp)
lines=$(mktemp)
nums=$(mktemp)
addrs=$(mktemp)

cat $allocs | sed 's/,.*//' > $addrs
cat $addrs | sed 's/^/inf line */' > $commands
paste <(sed -e 's/.*,//' $allocs) <(gdb $exe -batch -x $commands) | \
 sed 's/__/./g' | \
 sed 's/<caml\([A-Z]\)/<\1/g' | \
 sed 's/ starts at address /: /' | \
 sed 's/and ends at/->/' | \
 sort -k 1 -n -r
```
