### PR TITLE
Add OCaml-Buddy 0.6.1

### DIFF
--- a/packages/ocaml-buddy.0.6.1/descr
+++ b/packages/ocaml-buddy.0.6.1/descr
@@ -1,0 +1,1 @@
+Bindings for the Buddy BDD library.

--- a/packages/ocaml-buddy.0.6.1/opam
+++ b/packages/ocaml-buddy.0.6.1/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "pietro.abate@pps.jussieu.fr"
+build: [
+       [make]
+       [make "install"]
+]
+
+remove: [
+        [make "uninstall"]
+]

--- a/packages/ocaml-buddy.0.6.1/url
+++ b/packages/ocaml-buddy.0.6.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/abate/ocaml-buddy/archive/0.6.1.tar.gz"
+checksum: "23b5d83b2341d34045378428f8e0758e"


### PR DESCRIPTION
This depends on the user having the Buddy BDD library installed (for example libbdd\* on Debian/Ubuntu). I'm not sure if/how opam manages external C library dependencies so I haven't specified any dependencies in this commit. 
