### PR TITLE
lablgl META: package name should be lablgl, not lablGL

### DIFF
--- a/packages/lablgl.20120306/files/META
+++ b/packages/lablgl.20120306/files/META
@@ -6,7 +6,7 @@ archive(native) = "lablgl.cmxa"
 package "togl" (
 	description = "OpenGL widget for labltk"
 	version = "1.01"
-	requires = "lablGL, labltk"
+	requires = "lablgl, labltk"
 	archive(byte) = "togl.cma"
 	archive(native) = "togl.cmxa"
 )
@@ -14,7 +14,7 @@ package "togl" (
 package "glut" (
 	description = "Platform-independent OpenGL window"
 	version = "1.01"
-	requires = "lablGL"
+	requires = "lablgl"
 	archive(byte) = "lablglut.cma"
 	archive(native) = "lablglut.cmxa"
 )


### PR DESCRIPTION
lablgl's META file had some inconsistent capitalisation, which led to lablgl.glut depending on lablGL, when it should depend on lablgl.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
