### PR TITLE
Remove symbolic links from the package.

### DIFF
--- a/packages/ANSITerminal.0.6.3/descr
+++ b/packages/ANSITerminal.0.6.3/descr
@@ -1,0 +1,4 @@
+Allow to use the colors and cursor movements on ANSI terminals
+ANSITerminal is a module allowing to use the colors and cursor
+movements on ANSI terminals. It also works on the windows shell (but
+this part is currently work in progress).

--- a/packages/ANSITerminal.0.6.3/opam
+++ b/packages/ANSITerminal.0.6.3/opam
@@ -1,0 +1,11 @@
+opam-version: "1"
+maintainer: "Christophe.Troestler@umons.ac.be"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "ANSITerminal"]
+]
+depends: ["ocamlfind"]

--- a/packages/ANSITerminal.0.6.3/url
+++ b/packages/ANSITerminal.0.6.3/url
@@ -1,0 +1,2 @@
+archive: "http://forge.ocamlcore.org/frs/download.php/1126/ANSITerminal-0.6.3.tar.gz"
+checksum: "2ebb5c1ac9014cc3f38a4ffa8909a33c"


### PR DESCRIPTION
Better given OPAM 0.9.5 bug.
