### PR TITLE
biocaml.0.2.0: use opam's `make` variable

### DIFF
--- a/packages/biocaml.0.2.0/opam
+++ b/packages/biocaml.0.2.0/opam
@@ -3,8 +3,8 @@ maintainer: "seb@mondet.org"
 homepage: "http://biocaml.org"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--%{flow:enable}%-app" ]
-  ["make" "all"]
-  ["make" "install"]
+  ["%{make}%" "all"]
+  ["%{make}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "biocaml"]
@@ -13,9 +13,9 @@ depends: ["ocamlfind" "core" "sexplib" "camlzip" "xmlm" "pcre-ocaml"  ]
 depopts: [ "flow" ]
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--%{flow:enable}%-app" "--enable-tests" ]
-  ["make" "test"]
+  ["%{make}%" "test"]
 ]
 build-doc: [
-  ["make" "doc"]
-  ["make" "install-doc" "DOCDIR=%{doc}%" ]
+  ["%{make}%" "doc"]
+  ["%{make}%" "install-doc" "DOCDIR=%{doc}%" ]
 ]


### PR DESCRIPTION
The build with `make` on FreeBSD was silently generating a wrong `biocaml_about.ml` file.
