### PR TITLE
Build native version of Buddy bindings in addition the the bytecode vers...

### DIFF
--- a/packages/ocaml-buddy.0.6.1/opam
+++ b/packages/ocaml-buddy.0.6.1/opam
@@ -1,7 +1,8 @@
 opam-version: "1"
 maintainer: "pietro.abate@pps.jussieu.fr"
 build: [
-       [make]
+       [make "all"]
+       [make "opt"]
        [make "install"]
 ]
 


### PR DESCRIPTION
I made a mistake in the original commit (Mar 4 2012) - this commit now builds both the bytecode and native versions of the bindings to Buddy. 
