### PR TITLE
Stone 0.1 : Add a patch to fix the ./configure file

### DIFF
--- a/packages/stone.0.1/files/configure.diff
+++ b/packages/stone.0.1/files/configure.diff
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 8be972f..fc98909 100755
+--- a/configure
++++ b/configure
+@@ -2,7 +2,7 @@
+
+ BIN_DIR="."
+
+-if [ "$1" == "--bin-dir" ]; then
++if [ "$1" = "--bin-dir" ]; then
+     BIN_DIR="$2"
+ fi
+

--- a/packages/stone.0.1/opam
+++ b/packages/stone.0.1/opam
@@ -9,3 +9,6 @@ remove: [
   [make "uninstall"]
 ]
 depends: ["ocamlfind" "cow" "config-file"]
+patches: [
+  "configure.diff"
+]


### PR DESCRIPTION
Here is a patch to repair the ./configure file, that contained an ugly bash-ism.
