### PR TITLE
Change ocsigen server dependency to always install dbm

### DIFF
--- a/packages/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver.2.2.0/opam
@@ -17,8 +17,9 @@ depends: [
   "pcre-ocaml"
   "cryptokit"
   "tyxml"
-  ("dbm" | "sqlite3-ocaml") 
+  "dbm"
 ]
 depopts: [
+  "sqlite3-ocaml"
   "camlzip" {>= "1.04"}
 ]


### PR DESCRIPTION
dbm is used in the default config of ocsigenserver and don't have any other dependency.
