### PR TITLE
Stone 0.1: Other (and last one) patch for the ./configure script

### DIFF
--- a/packages/stone.0.1/files/configure2.diff
+++ b/packages/stone.0.1/files/configure2.diff
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+index fc98909..23da9bc 100755
+--- a/configure
++++ b/configure
+@@ -9,7 +9,7 @@ fi
+ cp Makefile.in Makefile
+
+ if [ "$BIN_DIR" != "." ]; then
+-    echo -e "
++    echo "
+ install: stone
+ \tcp stone $BIN_DIR/

--- a/packages/stone.0.1/opam
+++ b/packages/stone.0.1/opam
@@ -11,4 +11,5 @@ remove: [
 depends: ["ocamlfind" "cow" "config-file"]
 patches: [
   "configure.diff"
+  "configure2.diff"
 ]


### PR DESCRIPTION
dash's echo doesn't know about the -e option
