### PR TITLE
cairo: make lablgtk an optional dep

### DIFF
--- a/packages/cairo.0.4.2/opam
+++ b/packages/cairo.0.4.2/opam
@@ -1,11 +1,12 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--%{lablgtk:enable}%-lablgtk2"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [
   ["ocamlfind" "remove" "cairo2"]
 ]
-depends: ["ocamlfind" "lablgtk"]
+depends: ["ocamlfind"]
+depopts: ["lablgtk"]


### PR DESCRIPTION
Lablgtk is an optional dep for cairo:

```
[cochinois:~/tmp/cairo-0.4.2 12:44]$ocaml setup.ml -configure -help
configure options:
  --override var+val   Override any configuration variable.
  --enable-lablgtk2    Whether to connect Cairo and lablgtk2. [default: disabled]
  --disable-lablgtk2   Whether to connect Cairo and lablgtk2. [default: disabled]
...
```
