### PR TITLE
Request for package "why 2.32"

### DIFF
--- a/packages/why.2.32/descr
+++ b/packages/why.2.32/descr
@@ -1,0 +1,6 @@
+The Why platform is not any longer under active development. Our
+effort has moved to the development of Why3.
+
+Why is still maintained, in particular to provide the Jessie plug-in
+of Frama-C and the Krakatoa front-end for Java.
+

--- a/packages/why.2.32/files/opam.patch.in
+++ b/packages/why.2.32/files/opam.patch.in
@@ -1,0 +1,30 @@
+diff -ru /tmp/opam-12040-1071/why.2.31/configure.in /tmp/opam-12040-1607/why.2.31/configure.in
+--- /tmp/opam-12040-1071/why.2.31/configure.in	2012-07-19 20:33:10.000000000 +0200
++++ /tmp/opam-12040-1607/why.2.31/configure.in	2012-10-05 18:15:13.738308197 +0200
+@@ -105,7 +105,7 @@
+ 
+ # Ocaml library path
+ # old way: OCAMLLIB=`$OCAMLC -v | tail -1 | cut -f 4 -d ' ' | tr -d '\\r'`
+-OCAMLLIB=`$OCAMLC -where | tr -d '\\r'`
++OCAMLLIB=%{lib}% #`$OCAMLC -where | tr -d '\\r'`
+ echo "ocaml library path is $OCAMLLIB"
+ 
+ 
+@@ -236,7 +236,7 @@
+       LOCALOCAMLGRAPH=yes
+     fi
+  else
+-    OCAMLGRAPHLIB="-I +ocamlgraph"
++    OCAMLGRAPHLIB="-I %{lib}%/ocamlgraph"
+     OCAMLGRAPHVER=" in Ocaml lib, subdir ocamlgraph"
+  fi
+ 
+@@ -255,7 +255,7 @@
+ AC_CHECK_FILE($OCAMLLIB/lablgtk2/lablgtk.cma,LABLGTK2=yes,LABLGTK2=no)
+ # AC_CHECK_PROG(LABLGTK2,lablgtk2,yes,no) not always available (Win32)
+ if test "$LABLGTK2" = yes ; then
+-      INCLUDEGTK2="-I +lablgtk2"
++      INCLUDEGTK2="-I %{lib}%/lablgtk2"
+ fi
+ 
+ AC_CHECK_PROG(OCAMLWEB,ocamlweb,ocamlweb,true)

--- a/packages/why.2.32/files/warn-error.patch
+++ b/packages/why.2.32/files/warn-error.patch
@@ -1,0 +1,13 @@
+--- Makefile.in.orig	2013-02-14 13:58:30.984219962 +0000
++++ Makefile.in	2013-02-14 13:58:40.380219678 +0000
+@@ -64,8 +64,8 @@
+ CAMLP4   = @CAMLP4O@
+ 
+ INCLUDES = -I src -I jc -I c -I java -I intf -I tools -I mix -I ml
+-BFLAGS   = -w Z -warn-error A -dtypes -g $(INCLUDES) @INCLUDEGTK2@ -I +threads @OCAMLGRAPHLIB@
+-OFLAGS   = -w Z -warn-error A -dtypes $(INCLUDES) @INCLUDEGTK2@ -I +threads @OCAMLGRAPHLIB@
++BFLAGS   = -w Z -dtypes -g $(INCLUDES) @INCLUDEGTK2@ -I +threads @OCAMLGRAPHLIB@
++OFLAGS   = -w Z -dtypes $(INCLUDES) @INCLUDEGTK2@ -I +threads @OCAMLGRAPHLIB@
+ 
+ LCFLAGS = -L/usr/lib -L/usr/local/lib/ocaml
+ 

--- a/packages/why.2.32/files/why.install
+++ b/packages/why.2.32/files/why.install
@@ -1,0 +1,16 @@
+bin: [
+  "bin/why2html.opt" {"why2html"}
+  "bin/why-stat.opt" {"why-stat"}
+  "bin/why-obfuscator.opt" {"why-obfuscator"}
+  "bin/why-dp.opt" {"why-dp"}
+  "bin/why-cpulimit"
+  "bin/why-config.opt" {"why-config"}
+  "bin/why.opt" {"why"}
+  "bin/tool-stat.opt" {"tool-stat"}
+  "bin/simplify2why.opt" {"simplify2why"}
+  "bin/rv_merge.opt" {"rv_merge"}
+  "bin/krakatoa.opt" {"krakatoa"}
+  "bin/jessie.opt" {"jessie"}
+  "bin/gwhy.opt" {"gwhy-bin"}
+  "bin/gwhy.sh" {"gwhy"}
+]

--- a/packages/why.2.32/opam
+++ b/packages/why.2.32/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "Claude.Marche@inria.fr"
+substs: ["opam.patch"]
+build: [
+  ["autoconf"]
+  ["./configure" "--enable-verbosemake" "OCAMLGRAPHLIB=%{lib}%/ocamlgraph" "--prefix" "%{prefix}%" "--sbindir=%{lib}%/why/sbin" "--libexecdir=%{lib}%/why/libexec" "--sysconfdir=%{lib}%/why/etc" "--sharedstatedir=%{lib}%/why/com" "--localstatedir=%{lib}%/why/var" "--libdir=%{lib}%/why/lib" "--includedir=%{lib}%/why/include" "--datarootdir=%{lib}%/why/share"]
+  [make]
+  [make "install"]
+]
+depends: [
+  "lablgtk"
+  "ocamlgraph" {= "1.8.2"}
+  "why3" {= "0.81"}
+  "coq" {>= "8.4pl1"}
+  "frama-c" {= "Oxygen"}
+  "alt-ergo" {>= "0.95.1"}
+  "
+]
+patches: ["opam.patch" "warn-error.patch"]
+

--- a/packages/why.2.32/url
+++ b/packages/why.2.32/url
@@ -1,0 +1,2 @@
+archive: "http://why.lri.fr/download/why-2.32.tar.gz"
+checksum: "8983b1058bd651a4eb3db16fa23a458b"


### PR DESCRIPTION
I request to add a package for the new version 2.32 of Why. I copied the files from the package of the version 2.31, but made a few in order to force dependencies on Why3, Frama-C, Coq and Alt-Ergo. This is because the main purpose of the Why distribution is the distribution of the krakatoa and jessie front-end respectively for Java and C. There is no point to use why without Why3, Frama-C and at elast one automatic prover (alt-ergo) and one interactive one (Coq).

I'm afraid the the file "files/why.install" is far from complete: it should list the jessie plugin for Frama-C (Jessie.cmo and Jessie.cmxs) and the Coq librairies. I'm afraid I am too much a beginner in opam to make it correct.
