### PR TITLE
update urls for atd and atdgen

### DIFF
--- a/packages/atd.1.0.3/opam
+++ b/packages/atd.1.0.3/opam
@@ -8,4 +8,4 @@ remove: [
   ["ocamlfind" "remove" "atd"]
 ]
 depends: ["ocamlfind" "menhir" "easy-format"]
-homepage: "https://github.com/MyLifeLabs/atd"
+homepage: "https://github.com/mjambon/atd"

--- a/packages/atdgen.1.2.3/opam
+++ b/packages/atdgen.1.2.3/opam
@@ -5,4 +5,4 @@ build: [
   [make "install" "BINDIR=%{bin}%"]
 ]
 depends: ["ocamlfind" "atd" {>"1.0.2"} "biniou" "yojson"]
-homepage: "https://github.com/MyLifeLabs/atdgen"
+homepage: "https://github.com/mjambon/atdgen"

--- a/packages/atdgen.1.2.3/url
+++ b/packages/atdgen.1.2.3/url
@@ -1,2 +1,3 @@
-archive: "https://github.com/MyLifeLabs/atdgen/archive/v1.2.3.tar.gz"
+archive: "http://mjambon.com/releases/atdgen/atdgen-1.2.3.tar.gz"
 checksum: "06156ff3ef4018ffcbafd753f160c09c"
+


### PR DESCRIPTION
Noticed that the urls in the opam files were pointing to repos marked as OLD. Updated URLs to point to new places.

Noticed this while looking into #592
