### PR TITLE
zipperposition: make compilation procedure compatible with MacOS X

### DIFF
--- a/packages/zipperposition.0.1.1/files/sed-bsd-compatible.patch
+++ b/packages/zipperposition.0.1.1/files/sed-bsd-compatible.patch
@@ -1,0 +1,10 @@
+--- zipperposition.0.1.1/Makefile.orig	2013-04-04 13:58:39.000000000 +0200
++++ zipperposition.0.1.1/Makefile	2013-04-04 13:58:48.000000000 +0200
+@@ -1,6 +1,6 @@
+ 
+ VERSION=0.1.1
+-PP = 'sed -r s/ZIPPERPOSITION_VERSION/$(VERSION)/g'
++PP = 'sed s/ZIPPERPOSITION_VERSION/$(VERSION)/g'
+ 
+ INTERFACE_FILES = $(shell find src -name '*.mli')
+ IMPLEMENTATION_FILES = $(shell find src -name '*.ml')

--- a/packages/zipperposition.0.1.1/opam
+++ b/packages/zipperposition.0.1.1/opam
@@ -8,3 +8,4 @@ remove: [
     ["rm" "%{bin}%/zipperposition"]
 ]
 homepage: "https://www.rocq.inria.fr/deducteam/Zipperposition/index.html"
+patches: ["sed-bsd-compatible.patch"]


### PR DESCRIPTION
The new version of zipperposition needlessly uses the -r option of sed, but this option is not recognized by the MacOS version of sed. This patch simply removes it.

I have not yet sent this patch to upstream.
