### PR TITLE
Update google-drive-ocamlfuse 0.3.1

### DIFF
--- a/packages/google-drive-ocamlfuse.0.3.1/descr
+++ b/packages/google-drive-ocamlfuse.0.3.1/descr
@@ -1,1 +1,3 @@
-FUSE filesystem over Google Drive
+A FUSE filesystem over Google Drive
+google-drive-ocamlfuse is a FUSE-based file system backed by Google
+Drive, written in OCaml.

--- a/packages/google-drive-ocamlfuse.0.3.1/files/google-drive-ocamlfuse.install
+++ b/packages/google-drive-ocamlfuse.0.3.1/files/google-drive-ocamlfuse.install
@@ -1,0 +1,4 @@
+bin: [
+  "?_build/src/gdfuse.byte" {"google-drive-ocamlfuse"}
+  "?_build/src/gdfuse.native" {"google-drive-ocamlfuse"}
+]

--- a/packages/google-drive-ocamlfuse.0.3.1/opam
+++ b/packages/google-drive-ocamlfuse.0.3.1/opam
@@ -1,16 +1,12 @@
 opam-version: "1"
 maintainer: "alessandro.strada@gmail.com"
+authors: [ "Alessandro Strada" ]
+license: "MIT"
+homepage: "http://gdfuse.forge.ocamlcore.org/"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "google-drive-ocamlfuse"]
-]
-depends: [
-  "ocamlfind"
-  "gapi-ocaml"
-  "ocamlfuse"
-  "sqlite3-ocaml"
-]
+depends: [ "camlidl" "gapi-ocaml" "ocamlfind" "ocamlfuse" "sqlite3-ocaml" ]
+ocaml-version: [ >= "3.12.0" ]

--- a/packages/google-drive-ocamlfuse.0.3.1/url
+++ b/packages/google-drive-ocamlfuse.0.3.1/url
@@ -1,2 +1,2 @@
-archive: "https://forge.ocamlcore.org/frs/download.php/1086/google-drive-ocamlfuse-0.3.1-src.tar.gz"
-checksum: "6b5e2f0ca786273d651d00c3c700cda3"
+archive: "https://forge.ocamlcore.org/frs/download.php/1157/google-drive-ocamlfuse-0.3.1-opam.tar.gz"
+checksum: "69c846055be8e90462832def9a170c3b"


### PR DESCRIPTION
Update google-drive-ocamlfuse package using oasis2opam (https://github.com/ocaml/oasis2opam)
