### PR TITLE
Fixed camlidl

### DIFF
--- a/packages/camlidl.1.05/files/cpp-location.diff
+++ b/packages/camlidl.1.05/files/cpp-location.diff
@@ -1,0 +1,15 @@
+diff -Naur camlidl-1.05/config/Makefile.unix camlidl-1.05-patched/config/Makefile.unix
+--- camlidl-1.05/config/Makefile.unix	2002-04-22 12:50:46.000000000 +0100
++++ camlidl-1.05-patched/config/Makefile.unix	2013-04-09 13:43:56.751790572 +0100
+@@ -19,9 +19,9 @@
+ 
+ # How to invoke the C preprocessor
+ # Works on most Unix systems:
+-CPP=/lib/cpp
++CPP=cpp
+ # Alternatives:
+-# CPP=cpp
++# CPP=/lib/cpp
+ # CPP=/usr/ccs/lib/cpp
+ # CPP=gcc -x c -E
+ 

--- a/packages/camlidl.1.05/opam
+++ b/packages/camlidl.1.05/opam
@@ -7,3 +7,4 @@ build: [
   [make "all"]
   [make "install" "BINDIR=%{bin}%" "OCAMLLIB=%{lib}%/camlidl"]
 ]
+patches: ["cpp-location.diff"]


### PR DESCRIPTION
Do not hardcode cpp to be installed in /lib/cpp, but use "cpp" instead (search cpp in the PATH)
