### PR TITLE
magic update of 0.2 in place

### DIFF
--- a/packages/zipperposition.0.2/url
+++ b/packages/zipperposition.0.2/url
@@ -1,2 +1,2 @@
 archive: "https://www.rocq.inria.fr/deducteam/Zipperposition/files/zipperposition-0.2.tar.gz"
-checksum: "a402291f70cda7b829812e7b884fe2ac"
+checksum: "a4ecf7f741c1039575fb66b9d3267170"


### PR DESCRIPTION
I know, it's evil, but I changed the 0.2 because it was quite broken (install target was building tests as well, although it has more dependencies); make it nicer to the user by using an env variable to store some files. 
