### PR TITLE
Fix dependencies for ocp-index

### DIFF
--- a/packages/ocp-index.0.1.0/opam
+++ b/packages/ocp-index.0.1.0/opam
@@ -14,6 +14,8 @@ remove: [
 ]
 depends: [
   "ocp-build" {>= "1.99.4-beta"}
+  "cmdliner"
+  "curses"
 ]
 depopts: [
   "curses"


### PR DESCRIPTION
Here's the error message I got when trying to install ocp-index:

==== ERROR [while installing ocp-index.0.1.0] ====
...[truncated]
Warning: 2 needed packages are missing !
   ABSENT package "cmdliner" missed by 2 packages
   ocp-browser (program,ocp)
     in /home/jonathan/.opam/4.00.1/build/ocp-index.0.1.0/src
   ocp-index (program,ocp)
     in /home/jonathan/.opam/4.00.1/build/ocp-index.0.1.0/src
   ABSENT package "curses" missed by 1 packages
   ocp-browser (program,ocp)
     in /home/jonathan/.opam/4.00.1/build/ocp-index.0.1.0/src
