### PR TITLE
typerex version 1.99.7-beta

### DIFF
--- a/packages/typerex.1.99.7-beta/descr
+++ b/packages/typerex.1.99.7-beta/descr
@@ -1,0 +1,2 @@
+Set of tools and libraries for OCaml, developed by OCamlPro and INRIA
+

--- a/packages/typerex.1.99.7-beta/opam
+++ b/packages/typerex.1.99.7-beta/opam
@@ -1,0 +1,12 @@
+opam-version: "1"
+maintainer: "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+build: [
+  [ "./configure" "--prefix" "%{prefix}%"  ]
+  [ make ]
+  [ make "install" ]
+]
+remove: [
+  [ "ocp-build" "-uninstall" "typerex" ]
+]
+depends: [ "ocamlfind" "ocp-build" {> "1.99.6"} ]
+conflicts: [ "ocp-build"  {< "1.99"} ]

--- a/packages/typerex.1.99.7-beta/url
+++ b/packages/typerex.1.99.7-beta/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/OCamlPro/typerex/tarball/typerex.1.99.7-beta"
+checksum: "fc3f7faf2013109d312dd64dcf8594d6"


### PR DESCRIPTION
TypeRex without ocp-build in it... It requires to have ocp-build 1.99.7-beta installed (thus, the corresponding pull-request should be accepted before this one...)
