### PR TITLE
new version of Alt-Ergo

### DIFF
--- a/packages/alt-ergo.0.95.1/TODO
+++ b/packages/alt-ergo.0.95.1/TODO
@@ -1,0 +1,3 @@
+
+* Alt-Ergo install a gtksourceview-2.0 language-specs for its
+   language. I'm not sure it's used by gtk in the .opam directory.

--- a/packages/alt-ergo.0.95.1/descr
+++ b/packages/alt-ergo.0.95.1/descr
@@ -1,0 +1,1 @@
+Automatic theorem prover dedicated to program verification

--- a/packages/alt-ergo.0.95.1/files/alt-ergo.install
+++ b/packages/alt-ergo.0.95.1/files/alt-ergo.install
@@ -1,0 +1,3 @@
+bin: [
+  "alt-ergo.opt" {"alt-ergo"}
+]

--- a/packages/alt-ergo.0.95.1/opam
+++ b/packages/alt-ergo.0.95.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+
+authors: ["Sylvain Conchon"
+          "Alain Mebsout"
+          "Mohamed Iguernelala"]
+license: "CeCILL-C"
+homepage: "http://alt-ergo.lri.fr/"
+
+build: [
+  ["autoconf"]
+  ["./configure" "-prefix" "%{prefix}%"]
+  [make]
+  [make "install" "MANDIR=%{man}%/man1"]
+]
+depends: [
+  "ocamlfind"
+  "ocamlgraph" {= "1.8.2"}
+]
+depopts: [
+  "lablgtk"
+]

--- a/packages/alt-ergo.0.95.1/url
+++ b/packages/alt-ergo.0.95.1/url
@@ -1,0 +1,2 @@
+archive: "http://alt-ergo.lri.fr/http/alt-ergo-0.95.1/alt-ergo-0.95.1.tar.gz"
+checksum: "c0f1cbfdae04f1c37853ed5fd10154ec"


### PR DESCRIPTION
this is version 0.95.1
(note that we removed most patches, since Alt-Ergo 0.95.1 now uses ocamlfind if present)
