### PR TITLE
new version for dolog (0.2)

### DIFF
--- a/packages/dolog.0.2/descr
+++ b/packages/dolog.0.2/descr
@@ -1,0 +1,2 @@
+the dumb ocaml logger
+

--- a/packages/dolog.0.2/opam
+++ b/packages/dolog.0.2/opam
@@ -1,0 +1,11 @@
+opam-version: "1"
+maintainer: "berenger@riken.jp"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "dolog"]
+]
+depends: ["ocamlfind" "base-unix"]

--- a/packages/dolog.0.2/url
+++ b/packages/dolog.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/HappyCrow/dolog/archive/v0.2.tar.gz"
+checksum: "9a0dded99c7d19a6f424a7d4d8b04e7e"


### PR DESCRIPTION
- I was missing the dependency to base-unix in the opam
  description in the previous release
- I was also missing it in the _oasis file in the archive of the library
- I added a getter for the log level in the library (there was only a setter previously)
