### PR TITLE
Correct opam-lib's URL

### DIFF
--- a/packages/opam-lib.1.0.0/url
+++ b/packages/opam-lib.1.0.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/OCamlPro/opam/archive/0.9.6.tar.gz"
-checksum: "96c50c8baa1fc9e4b9e1d187fa5c8dce"
+archive: "https://github.com/OCamlPro/opam/archive/1.0.0.tar.gz"
+checksum: "dd84ffc0dc534c2b311d900e576fb577"


### PR DESCRIPTION
Fixes OCamlPro/opam-repository#684 and OCamlPro/opam#574
