### PR TITLE
Fixed package digests

### DIFF
--- a/packages/mparser.1.0/url
+++ b/packages/mparser.1.0/url
@@ -1,2 +1,2 @@
 archive: "https://bitbucket.org/cakeplus/mparser/get/1.0.tar.gz"
-checksum: "8bc90b71ad40c5cd986de6ef169fac76"
+checksum: "cd204376cf88ffd4f6cfa40a99a06ee6"

--- a/packages/pa_comprehension.0.4/url
+++ b/packages/pa_comprehension.0.4/url
@@ -1,2 +1,2 @@
 archive: "https://bitbucket.org/cakeplus/pa_comprehension/get/0.4.tar.gz"
-checksum: "633c9330370d2277c612912de7db09c2"
+checksum: "32e695a67cbe35e99880c79949927895"


### PR DESCRIPTION
To my big surprise, it turned out that the hashes changed after I had renamed the Bitbucket user. Sorry. I must have tested the packages manually before making a pull request.

Should work now. I have tested it.
