### PR TITLE
add first depext to sqlite3

### DIFF
--- a/packages/sqlite3-ocaml.2.0.4/opam
+++ b/packages/sqlite3-ocaml.2.0.4/opam
@@ -9,3 +9,9 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: ["ocamlfind"]
+depexts: [
+  [ ["debian" "wheezy" "amd64"] ["libsqlite3-dev"]    ]
+  [ ["freebsd" ]                ["database/sqlite3"]  ]
+  [ ["openbsd" ]                [ "database/sqlite3"] ]
+]
+


### PR DESCRIPTION
This was added in 0.9.4 in OPAM, so should be safe to add now
