### PR TITLE
Tweak batteries install commands for FreeBSD

### DIFF
--- a/packages/batteries.2.0.0/opam
+++ b/packages/batteries.2.0.0/opam
@@ -2,8 +2,8 @@ opam-version: "1"
 maintainer: "thelema314@gmail.com"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+  [make "all"]
+  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "batteries"]


### PR DESCRIPTION
This modification should allow batteries 2.0.0 to install under FreeBSD
