### PR TITLE
Fix Mirage compilation

### DIFF
--- a/packages/mirage-www.0.3.0/opam
+++ b/packages/mirage-www.0.3.0/opam
@@ -7,9 +7,9 @@ depends: [
   "mirage-net" {>="0.5.2"} 
   "mirage-fs" {>="0.4.0"} 
   "ocamlfind" 
-  "cohttp" 
+  "cohttp" {<="0.9.6"}
   "mirage" {>="0.8.0"} 
   "re" 
-  "cow" 
+  "cow" {<="0.5.3"}
   "mirari" {>="0.9.1"}
 ] 

--- a/packages/mirage-www.0.3.0/url
+++ b/packages/mirage-www.0.3.0/url
@@ -1,1 +1,2 @@
-git: "git://github.com/mirage/mirage-www"
+archive: "https://github.com/mirage/mirage-www/archive/0.3.0.tar.gz"
+checksum: "68632f478af54069f293f0af102fd3c8"

--- a/packages/mirage.0.7.2/opam
+++ b/packages/mirage.0.7.2/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
-depends: ["cstruct" {>="0.6.0"} "ocamlfind" "lwt" "xenstore" "shared-memory-ring"]
+depends: ["cstruct" {>="0.6.0"} "ocamlfind" "lwt" "xenstore" "shared-memory-ring" {<"0.4.0"}]

--- a/packages/mirage.0.8.0/opam
+++ b/packages/mirage.0.8.0/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
-depends: ["cstruct" {>="0.6.0"} "ocamlfind" "lwt" {>="2.4.0"} "xenstore" {>="1.2.0"} "shared-memory-ring"]
+depends: ["cstruct" {>="0.6.0"} "ocamlfind" "lwt" {>="2.4.0"} "xenstore" {>="1.2.0"} "shared-memory-ring" {<"0.4.0"}]

--- a/packages/mirage.0.8.1/opam
+++ b/packages/mirage.0.8.1/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
-depends: ["cstruct" {>="0.6.0"} "ocamlfind" "lwt" {>="2.4.0"} "xenstore" {>="1.2.0"} "shared-memory-ring"]
+depends: ["cstruct" {>="0.6.0"} "ocamlfind" "lwt" {>="2.4.0"} "xenstore" {>="1.2.0"} "shared-memory-ring" {<"0.4.0"}]


### PR DESCRIPTION
- Mirage platform needs shared-memory-ring <0.4.0 (which improved the Ring API)
- Mirage-www now has a fixed URL and tag (not git), and depends on the older Cow
