### PR TITLE
camlp5 is compatible with 4.01.x

### DIFF
--- a/packages/camlp5.6.07/opam
+++ b/packages/camlp5.6.07/opam
@@ -5,7 +5,7 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-ocaml-version: [< "4.02.0"]
+ocaml-version: [< "4.01.0"]
 
 homepage: "http://pauillac.inria.fr/~ddr/camlp5"
 license: "BSD-3-Clause"


### PR DESCRIPTION
camlp5 should be marked compatible with anything less than 4.02.0 to account for all 4.01.x including development revisions.
