### PR TITLE
remove non-existent kaputt patch

### DIFF
--- a/packages/kaputt.1.1/opam
+++ b/packages/kaputt.1.1/opam
@@ -11,4 +11,3 @@ remove: [
 depends: [
   "ocamlfind"
 ]
-patches: ["opam.patch"]


### PR DESCRIPTION
I don't know what this patch was for but it doesn't exist and when its declaration is removed, the package builds fine.
