### PR TITLE
Add new mirage packages that do not require OPAM switching to operate

### DIFF
--- a/packages/mirage-net-direct.0.9.1/descr
+++ b/packages/mirage-net-direct.0.9.1/descr
@@ -1,0 +1,1 @@
+TCP/IP networking stack in pure OCaml

--- a/packages/mirage-net-direct.0.9.1/opam
+++ b/packages/mirage-net-direct.0.9.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [
+  ["make" "direct-build" "PREFIX=%{prefix}%"]
+  ["make" "direct-install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "mirage-net"]
+]
+depends: ["mirage" {>="0.9.1"} "ocamlfind"]
+conflicts: ["mirage-net-socket"]

--- a/packages/mirage-net-direct.0.9.1/url
+++ b/packages/mirage-net-direct.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net/archive/mirage-net-0.9.1.tar.gz"
+checksum: "45c65e305870b38e12dbca0636749b81"

--- a/packages/mirage-net-socket.0.9.1/descr
+++ b/packages/mirage-net-socket.0.9.1/descr
@@ -1,0 +1,1 @@
+Socket-based networking stack compatible with Mirage

--- a/packages/mirage-net-socket.0.9.1/opam
+++ b/packages/mirage-net-socket.0.9.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [
+  ["make" "socket-build" "PREFIX=%{prefix}%"]
+  ["make" "socket-install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "mirage-net"]
+]
+depends: ["mirage" {>="0.9.1"} "ocamlfind"]
+conflicts: ["mirage-xen" "mirage-net-direct"]

--- a/packages/mirage-net-socket.0.9.1/url
+++ b/packages/mirage-net-socket.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net/archive/mirage-net-0.9.1.tar.gz"
+checksum: "45c65e305870b38e12dbca0636749b81"

--- a/packages/mirage-net.0.3.0/opam
+++ b/packages/mirage-net.0.3.0/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage-net"]
 ]
-depends: ["ocamlfind" "mirage"]
+depends: ["ocamlfind" "mirage" {<="0.9.0"}]

--- a/packages/mirage-net.0.3.1/opam
+++ b/packages/mirage-net.0.3.1/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage-net"]
 ]
-depends: ["ocamlfind" "mirage"]
+depends: ["ocamlfind" "mirage" {<="0.9.0"}]

--- a/packages/mirage-net.0.4.0/opam
+++ b/packages/mirage-net.0.4.0/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage-net"]
 ]
-depends: ["mirage" { >= "0.6.0" } "ocamlfind" "cstruct" { < "0.6.0" } ]
+depends: ["mirage" { >= "0.6.0" & <="0.9.0" } "ocamlfind" "cstruct" { < "0.6.0" } ]

--- a/packages/mirage-net.0.4.1/opam
+++ b/packages/mirage-net.0.4.1/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage-net"]
 ]
-depends: ["mirage" { >= "0.6.0" } "ocamlfind" "cstruct" { < "0.6.0" } ]
+depends: ["mirage" { >= "0.6.0" & <="0.9.0" } "ocamlfind" "cstruct" { < "0.6.0" } ]

--- a/packages/mirage-net.0.5.2/opam
+++ b/packages/mirage-net.0.5.2/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "mirage-net"]
 ]
-depends: ["mirage" {>="0.7.2"} "ocamlfind"]
+depends: ["mirage" {>="0.7.2" & <="0.9.0"} "ocamlfind"]

--- a/packages/mirage-net.0.9.1/descr
+++ b/packages/mirage-net.0.9.1/descr
@@ -1,0 +1,7 @@
+Mirage TCP/IP networking stack
+
+This is actually a dummy package that selects a concrete implementation that
+provides the `mirage-net` ocamlfind package.  The variants available are:
+
+* `mirage-net-direct`: a TCP/IP stack in pure OCaml that works from Ethernet.
+* `mirage-net-socket`: a TCP/IP stack that uses the POSIX sockets API.

--- a/packages/mirage-net.0.9.1/opam
+++ b/packages/mirage-net.0.9.1/opam
@@ -1,0 +1,5 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [ ]
+remove: [ ]
+depends: [ ("mirage-net-direct" | "mirage-net-socket") ]

--- a/packages/mirage-net.0.9.1/url
+++ b/packages/mirage-net.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net/archive/mirage-net-0.9.1.tar.gz"
+checksum: "45c65e305870b38e12dbca0636749b81"

--- a/packages/mirage-unix.0.9.1/descr
+++ b/packages/mirage-unix.0.9.1/descr
@@ -1,0 +1,1 @@
+Mirage platform library for UNIX compilation

--- a/packages/mirage-unix.0.9.1/opam
+++ b/packages/mirage-unix.0.9.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [
+  [make "unix-build"]
+  [make "unix-install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  [make "unix-uninstall" "PREFIX=%{prefix}%"]
+]
+depends: ["cstruct" {>="0.7.1"} 
+          "ocamlfind" 
+          "lwt" {>="2.4.0"} 
+          "shared-memory-ring" {>="0.4.0"} 
+          "tuntap" {>="0.5"}
+          "fd-send-recv"
+]
+conflicts: ["mirage-xen"]

--- a/packages/mirage-unix.0.9.1/url
+++ b/packages/mirage-unix.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-platform/archive/mirage-platform-0.9.1.tar.gz"
+checksum: "e334b5eba4fd9b21069d440860e3fbf0"

--- a/packages/mirage-www.0.3.0/opam
+++ b/packages/mirage-www.0.3.0/opam
@@ -4,12 +4,12 @@ build: [
   [make "CONF_FLAGS=--no-install"]
 ]
 depends: [ 
-  "mirage-net" {>="0.5.2"} 
+  "mirage-net" {>="0.5.2" & <"0.9.0"} 
   "mirage-fs" {>="0.4.0"} 
   "ocamlfind" 
   "cohttp" {<="0.9.6"}
-  "mirage" {>="0.8.0"} 
+  "mirage" {>="0.8.0" & <="0.9.0"} 
   "re" 
   "cow" {<="0.5.3"}
-  "mirari" {>="0.9.1"}
+  "mirari" {="0.9.1"}
 ] 

--- a/packages/mirage-www.0.4.0/opam
+++ b/packages/mirage-www.0.4.0/opam
@@ -4,12 +4,12 @@ build: [
   [make "CONF_FLAGS=--no-install"]
 ]
 depends: [ 
-  "mirage-net" {>="0.5.2"} 
+  "mirage-net" {>="0.9.1"} 
   "mirage-fs" {>="0.4.0"} 
   "ocamlfind" 
-  "cohttp" {>="0.9.7"}
-  "mirage" {>="0.8.0"} 
+  "cohttp" {>="0.9.8"}
+  "mirage" {>="0.9.1"} 
   "re" 
-  "cow" {>"0.5.3"}
-  "mirari" {>="0.9.1"}
+  "cow" {>"0.5.4"}
+  "mirari" {>="0.9.3"}
 ] 

--- a/packages/mirage-xen.0.9.1/descr
+++ b/packages/mirage-xen.0.9.1/descr
@@ -1,0 +1,1 @@
+Mirage platform library for Xen compilation

--- a/packages/mirage-xen.0.9.1/opam
+++ b/packages/mirage-xen.0.9.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [
+  [make "xen-build"]
+  [make "xen-install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  [make "xen-uninstall" "PREFIX=%{prefix}%"]
+]
+depends: ["cstruct" {>="0.7.1"} 
+          "ocamlfind" 
+          "lwt" {>="2.4.0"} 
+          "shared-memory-ring" {>="0.4.0"}
+          "xenstore"
+]
+conflicts: ["mirage-unix"]

--- a/packages/mirage-xen.0.9.1/url
+++ b/packages/mirage-xen.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-platform/archive/mirage-platform-0.9.1.tar.gz"
+checksum: "e334b5eba4fd9b21069d440860e3fbf0"

--- a/packages/mirage.0.9.1/descr
+++ b/packages/mirage.0.9.1/descr
@@ -1,0 +1,7 @@
+Mirage platform library
+
+This is actually a dummy package that chooses a specific implementation.  There
+are currently:
+
+* mirage-xen: a Xen microkernel backend
+* mirage-unix: a UNIX process-based backend

--- a/packages/mirage.0.9.1/opam
+++ b/packages/mirage.0.9.1/opam
@@ -1,0 +1,5 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [ ]
+remove: [ ]
+depends: [ ("mirage-unix" | "mirage-xen") ]

--- a/packages/mirage.0.9.1/url
+++ b/packages/mirage.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-platform/archive/mirage-platform-0.9.1.tar.gz"
+checksum: "e334b5eba4fd9b21069d440860e3fbf0"

--- a/packages/mirari.0.9.3/descr
+++ b/packages/mirari.0.9.3/descr
@@ -1,0 +1,1 @@
+Mirage application builder

--- a/packages/mirari.0.9.3/files/mirari.install
+++ b/packages/mirari.0.9.3/files/mirari.install
@@ -1,0 +1,3 @@
+bin: [
+  "dist/build/mirari/mirari" {"mirari"}
+]

--- a/packages/mirari.0.9.3/opam
+++ b/packages/mirari.0.9.3/opam
@@ -1,0 +1,6 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [
+  [make]
+]
+depends: ["cmdliner" "obuild" {>="0.0.2"} "tuntap" {>="0.5"} "fd-send-recv"]

--- a/packages/mirari.0.9.3/url
+++ b/packages/mirari.0.9.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirari/archive/mirari-0.9.3.tar.gz"
+checksum: "0ee96c73c0456c974e9ab75ea15c53be"


### PR DESCRIPTION
Fix up previous constraints as appropriate
