### PR TITLE
Restrict ocamlnet 3.6.0, 3.6.3, and 3.6.5 to OCaml < 4.01.0

### DIFF
--- a/packages/ocamlnet.3.6.0/opam
+++ b/packages/ocamlnet.3.6.0/opam
@@ -1,5 +1,9 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
+
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+doc: "http://projects.camlcity.org/projects/dl/ocamlnet-3.6.0/doc/html-main/index.html"
+
 patches: ["ocamlnet-ocaml4.diff"]
 build: [
   ["./configure" "-bindir" "%{bin}%" "-%{pcre-ocaml:enable}%-pcre" "-%{lablgtk:enable}%-gtk2" "-%{ssl:enable}%-ssl" "-%{camlzip:enable}%-zip" "-%{cryptokit:enable}%-crypto" "-with-nethttpd"]
@@ -44,3 +48,4 @@ depopts: [
   "camlzip"
   "cryptokit"
 ]
+ocaml-version: [< "4.01.0"]

--- a/packages/ocamlnet.3.6.3/opam
+++ b/packages/ocamlnet.3.6.3/opam
@@ -1,5 +1,9 @@
 opam-version: "1"
 maintainer: "vb@luminar.eu.org"
+
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+doc: "http://projects.camlcity.org/projects/dl/ocamlnet-3.6.3/doc/html-main/index.html"
+
 build: [
   ["./configure" "-bindir" "%{bin}%" "-%{pcre-ocaml:enable}%-pcre" "-%{lablgtk:enable}%-gtk2" "-%{ssl:enable}%-ssl" "-%{camlzip:enable}%-zip" "-%{cryptokit:enable}%-crypto" "-with-nethttpd"]
   [make "all"]
@@ -43,3 +47,4 @@ depopts: [
   "camlzip"
   "cryptokit"
 ]
+ocaml-version: [< "4.01.0"]

--- a/packages/ocamlnet.3.6.5/opam
+++ b/packages/ocamlnet.3.6.5/opam
@@ -1,5 +1,9 @@
 opam-version: "1"
 maintainer: "vb@luminar.eu.org"
+
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+doc: "http://projects.camlcity.org/projects/dl/ocamlnet-3.6.5/doc/html-main/index.html"
+
 build: [
   ["./configure" "-bindir" "%{bin}%" "-%{pcre-ocaml:enable}%-pcre" "-%{lablgtk:enable}%-gtk2" "-%{ssl:enable}%-ssl" "-%{camlzip:enable}%-zip" "-%{cryptokit:enable}%-crypto" "-with-nethttpd"]
   [make "all"]
@@ -43,3 +47,4 @@ depopts: [
   "camlzip"
   "cryptokit"
 ]
+ocaml-version: [< "4.01.0"]


### PR DESCRIPTION
An error in https://godirepo.camlcity.org/wwwsvn/trunk/code/src/pop/netpop.ml?rev=1218&root=lib-ocamlnet2&view=markup (duplicate "method stat") triggers a new 4.01.0 error http://caml.inria.fr/mantis/view.php?id=6035. This causes many packages dependent on ocamlnet to fail to build under 4.01.0.

This pull request will be referenced from both the ocamlnet-devel list and the mantis issue's comments.
