### PR TITLE
new package : numerix 0.22 library

### DIFF
--- a/packages/numerix.0.22/descr
+++ b/packages/numerix.0.22/descr
@@ -1,0 +1,15 @@
+Big integer library, written by Michel Quercia. Compares well to GMP.
+
+Numerix is a library implementing arbitrary long signed integers and
+the usual arithmetic operations between those numbers. It primarily
+targets ocaml, but is also available with reduced functionalities for
+the Camllight, C and Pascal languages on 32 or 64 bit Unix-type computers.
+
+doc (en) : http://pauillac.inria.fr/~quercia/cdrom/bibs/numerix-eng.pdf
+doc (fr) : http://pauillac.inria.fr/~quercia/cdrom/bibs/numerix.pdf
+
+Note: this opam package only builds the ocaml version (all modules,
+e.g. slong, dlong, clong, gmp and big), with the --enable-sse2 flag.
+Because of gmp, you need gmp headers (aptitude install libgmp-dev on
+debian). The --enable-longlong flag is not uses (gives some troubles
+on x86-64 architecture).

--- a/packages/numerix.0.22/opam
+++ b/packages/numerix.0.22/opam
@@ -1,0 +1,37 @@
+opam-version: "1"
+name: "numerix"
+version: "0.22"
+maintainer: "iksnalybok@gmail.com"
+homepage: "http://pauillac.inria.fr/~quercia/"
+authors: [ "Michel Quercia" ]
+license: "GNU Library General Public License version 2 with special exception (cf LICENCE file)"
+depexts: [ [ "debian" "libgmp-dev " ] ]
+build: [
+  [ "./configure" "--prefix=%{prefix}%" "--enable-sse2" "--disable-lang" "--enable-ocaml" "--enable-clong" "--enable-dlong" "--enable-slong" "--enable-gmp" "--enable-ocaml_bignum" ]
+  [ make "clean" "lib" "examples" "test" ]
+  [ make "install" ]
+  [ "mkdir" "-p" "%{prefix}%/doc/numerix/" ]
+  [ "cp" "doc/english/numerix.pdf" "%{prefix}%/doc/numerix/numerix-en.pdf" ]
+  [ "cp" "doc/francais/numerix.pdf" "%{prefix}%/doc/numerix/numerix-fr.pdf" ]
+  [ "echo" "*** Check that %{lib}% is in your LD_LIBRARY_PATH ***" ]
+]
+remove: [
+  [ "rm" "-f" "%{bin}%/ocamlnumx" ]
+  [ "rm" "-f" "%{prefix}%/include/numerix.h" ]
+  [ "rm" "-f" "%{prefix}%/include/numerix.mli" ]
+  [ "rm" "-f" "%{prefix}%/include/numerix.ml" ]
+  [ "rm" "-f" "%{lib}%/numerix.cmi" ]
+  [ "rm" "-f" "%{lib}%/numerix.cma" ]
+  [ "rm" "-f" "%{lib}%/numerix.cmxa" ]
+  [ "rm" "-f" "%{lib}%/numerix.a" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-ocaml.a" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-ocaml.so" ]
+  [ "rm" "-f" "%{lib}%/dllnumerix-ocaml.so" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-c.so" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-c.so.0" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-c.so.0.22" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-ocaml.so" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-ocaml.so.0" ]
+  [ "rm" "-f" "%{lib}%/libnumerix-ocaml.so.0.22" ]
+  [ "rm" "-f" "-r" "%{doc}%/numerix/" ]
+]

--- a/packages/numerix.0.22/url
+++ b/packages/numerix.0.22/url
@@ -1,0 +1,2 @@
+archive: "http://pauillac.inria.fr/~quercia/cdrom/bibs/numerix.tar.gz"
+checksum: "a2169c2251508ee2fb891f878e17ef96"


### PR DESCRIPTION
Big integer library.

NB: currently build with support for gmp, which requires gmp headers to be installed (aptitude install libgmp-dev on debian). This can be annoying. I didn't find %{&lt;package&gt;:enable}% similar syntax expension for depexts.
