### PR TITLE
New version of Frama-C available

### DIFF
--- a/packages/frama-c.Fluorine-20130501/descr
+++ b/packages/frama-c.Fluorine-20130501/descr
@@ -1,0 +1,9 @@
+Platform dedicated to the static analysis of source code written in C
+Frama-C is a suite of tools dedicated to the analysis of the source
+code of software written in C.
+
+Frama-C gathers several static analysis techniques in a single
+collaborative framework. The collaborative approach of Frama-C allows
+static analyzers to build upon the results already computed by other
+analyzers in the framework. Thanks to this approach, Frama-C provides
+sophisticated tools, such as a slicer and dependency analysis.

--- a/packages/frama-c.Fluorine-20130501/files/frama-c.install
+++ b/packages/frama-c.Fluorine-20130501/files/frama-c.install
@@ -1,0 +1,7 @@
+bin: [
+  "bin/ptests.byte"
+  "bin/toplevel.byte" {"frama-c.byte"}
+  "bin/toplevel.opt" {"frama-c"}
+  "bin/viewer.byte" {"frama-c-gui.byte"}
+  "bin/viewer.opt" { "frama-c-gui" }
+]

--- a/packages/frama-c.Fluorine-20130501/opam
+++ b/packages/frama-c.Fluorine-20130501/opam
@@ -1,0 +1,8 @@
+opam-version: "1"
+maintainer: "virgile.prevosto@m4x.org"
+build: [
+  ["./configure" "--prefix" "%{prefix}%" "--sbindir=%{lib}%/frama-c/sbin" "--libexecdir=%{lib}%/frama-c/libexec" "--sysconfdir=%{lib}%/frama-c/etc" "--sharedstatedir=%{lib}%/frama-c/com" "--localstatedir=%{lib}%/frama-c/var" "--libdir=%{lib}%/frama-c/lib" "--includedir=%{lib}%/frama-c/include" "--datarootdir=%{lib}%/frama-c/share"]
+  [make]
+  [make "install"]
+]
+depends: ["ocamlgraph" {>= "1.8.2"} "lablgtk"]

--- a/packages/frama-c.Fluorine-20130501/url
+++ b/packages/frama-c.Fluorine-20130501/url
@@ -1,0 +1,2 @@
+archive: "http://frama-c.com/download/frama-c-Fluorine-20130501.tar.gz"
+checksum: "47a4c649f0b8c0f87006316054522688"


### PR DESCRIPTION
This patch provides a package for the latest Frama-C version, Fluorine-2 (largely copied from Frama-C Oxygen package).
