### PR TITLE
Add CIL 1.7.1

### DIFF
--- a/packages/cil.1.7.1/descr
+++ b/packages/cil.1.7.1/descr
@@ -1,0 +1,1 @@
+A front-end for the C programming language that facilitates program analysis and transformation

--- a/packages/cil.1.7.1/opam
+++ b/packages/cil.1.7.1/opam
@@ -1,0 +1,12 @@
+opam-version: "1"
+maintainer: "gabriel@kerneis.info"
+build: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" "%{prefix}%"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" "%{prefix}%"]
+  [make "uninstall"]
+]
+depends: ["ocamlfind"]

--- a/packages/cil.1.7.1/url
+++ b/packages/cil.1.7.1/url
@@ -1,0 +1,2 @@
+archive: "http://downloads.sourceforge.net/project/cil/cil/cil-1.7.1.tar.gz"
+checksum: "c143ee9433b3298e5fa355aea5b251ff"


### PR DESCRIPTION
I just released CIL 1.7.1 with lots of improvements. I have in particular made sure that it behaves properly wrt. opam. Here is a package (tested on Linux only).
