### PR TITLE
xen-api-client 0.9.3 wants ocamlfind 'rpclib'

### DIFF
--- a/packages/xen-api-client.0.9.3/opam
+++ b/packages/xen-api-client.0.9.3/opam
@@ -7,5 +7,5 @@ build: [
 remove: [
   ["ocamlfind" "remove" "xen-api-client"]
 ]
-depends: [ "ocamlfind" "lwt" "ssl" "ounit" "cohttp" {>= "0.9.8"} "uri" "xmlm" "rpc" ]
+depends: [ "ocamlfind" "lwt" "ssl" "ounit" "cohttp" {>= "0.9.8"} "uri" "xmlm" "rpc" { >= "1.3.0" } ]
 depopts: [ "async" {>="109.15.00"} ]


### PR DESCRIPTION
@djs55 'rpclib' is the ocamlfind name for rpc in 1.3.0 and above.
