### PR TITLE
Add ibx-0.5.8

### DIFF
--- a/packages/ibx.0.5.8/descr
+++ b/packages/ibx.0.5.8/descr
@@ -1,0 +1,4 @@
+OCaml implementation of the Interactive Brokers TWS API
+IBX is a pure OCaml implementation of the Interactive Brokers Trader
+Workstation API (TWS API) built on top of Jane Street's Core and Async
+library.

--- a/packages/ibx.0.5.8/opam
+++ b/packages/ibx.0.5.8/opam
@@ -1,0 +1,26 @@
+opam-version: "1"
+maintainer: "gu.oliver@yahoo.com"
+authors: [ "Oliver Gu <gu.oliver@yahoo.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://bitbucket.org/ogu/ibx"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "ibx"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "async"
+  "core" {>= "109.10.00"}
+  "fieldslib"
+  "ocamlfind" {>= "1.3.1"}
+  "sexplib"
+]
+depopts: ["core_extended" 
+  "textutils" 
+  
+]
+ocaml-version: [ >= "4.00" ]

--- a/packages/ibx.0.5.8/url
+++ b/packages/ibx.0.5.8/url
@@ -1,0 +1,2 @@
+archive: "https://bitbucket.org/ogu/ibx/downloads/ibx-0.5.8.tar.gz"
+checksum: "25a9163e1b541b5cf238aa1ab7a32ffa"


### PR DESCRIPTION
Fixes the core_extended build problem pointed out here:
https://github.com/OCamlPro/opam-repository/pull/833
