### PR TITLE
Release CIL 1.7.2

### DIFF
--- a/packages/cil.1.7.2/descr
+++ b/packages/cil.1.7.2/descr
@@ -1,0 +1,1 @@
+A front-end for the C programming language that facilitates program analysis and transformation

--- a/packages/cil.1.7.2/opam
+++ b/packages/cil.1.7.2/opam
@@ -1,0 +1,12 @@
+opam-version: "1"
+maintainer: "gabriel@kerneis.info"
+build: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" "%{prefix}%"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" "%{prefix}%"]
+  [make "uninstall"]
+]
+depends: ["ocamlfind"]

--- a/packages/cil.1.7.2/url
+++ b/packages/cil.1.7.2/url
@@ -1,0 +1,2 @@
+archive: "http://downloads.sourceforge.net/project/cil/cil/cil-1.7.2.tar.gz"
+checksum: "319ff039078420e2c0692b5c3d77ad19"


### PR DESCRIPTION
Bug fix release (wrong META, missing files in cil.cm{a,xa}).
