### PR TITLE
relax uint's ospec requirement now that 0.3.0 is broken

### DIFF
--- a/packages/uint.1.0.2/opam
+++ b/packages/uint.1.0.2/opam
@@ -8,4 +8,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "uint"]
 ]
-depends: ["ocamlfind" "ospec" {= "0.3.0"}]
+depends: ["ocamlfind" "ospec" {>= "0.3.0"}]

--- a/packages/uint.1.0.3/opam
+++ b/packages/uint.1.0.3/opam
@@ -8,4 +8,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "uint"]
 ]
-depends: ["ocamlfind" "ospec" {= "0.3.0"}]
+depends: ["ocamlfind" "ospec" {>= "0.3.0"}]

--- a/packages/uint.1.1.0/opam
+++ b/packages/uint.1.1.0/opam
@@ -8,4 +8,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "uint"]
 ]
-depends: ["ocamlfind" "ospec" {= "0.3.0"}]
+depends: ["ocamlfind" "ospec" {>= "0.3.0"}]


### PR DESCRIPTION
Without this, uint is unusable.
