### PR TITLE
Restrict stone 0.2 to use cow < 0.6.0

### DIFF
--- a/packages/stone.0.2/opam
+++ b/packages/stone.0.2/opam
@@ -8,4 +8,4 @@ build: [
 remove: [
   [make "uninstall"]
 ]
-depends: ["ocamlfind" "cow" "config-file"]
+depends: ["ocamlfind" "cow" {< "0.6.0"} "config-file"]


### PR DESCRIPTION
cow 0.6 removed the ?templates argument which stone 0.2 depends on.

@Armael I hope this is OK. ?templates was removed from cow to decouple it from xmlm (now a dependency rather than included with cow). Will an XML tree traversal satisfy your use case?
