### PR TITLE
uint should allow ospec 0.3.1 as a satisfied constrained

### DIFF
--- a/packages/uint.1.1.0/opam
+++ b/packages/uint.1.1.0/opam
@@ -8,4 +8,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "uint"]
 ]
-depends: ["ocamlfind" "ospec" {>= "0.3.0"}]
+depends: ["ocamlfind" "ospec" {>= "0.3.1"}]


### PR DESCRIPTION
Per this issue https://github.com/OCamlPro/opam-repository/issues/849 we can upgrade the uint opsec dependency to 0.3.1.
