### PR TITLE
Remove the coq depopt of frama-c for now

### DIFF
--- a/packages/frama-c.20130601/opam
+++ b/packages/frama-c.20130601/opam
@@ -39,4 +39,4 @@ build: [
 ]
 depends: ["ocamlgraph" {>= "1.8.3"} "lablgtk"]
 
-depopts: [ "coq" {>= "8.4"} "why3" {>= "0.81"} ]
+depopts: [ "why3" {>= "0.81"} ]


### PR DESCRIPTION
This coq depopt constraint is causing the opam constraint solver to return incorrect answers resulting in widespread build failures. Fixes #865
