### PR TITLE
Make tyxml.2.2.0 use ocamlnet 3.6 or later.

### DIFF
--- a/packages/tyxml.2.2.0/opam
+++ b/packages/tyxml.2.2.0/opam
@@ -9,6 +9,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlnet" {= "3.6.0"}
+  "ocamlnet" {>= "3.6.0"}
   "pcre-ocaml"
 ]


### PR DESCRIPTION
See https://github.com/OCamlPro/opam-repository/issues/867
