### PR TITLE
homepage and license for biniou

### DIFF
--- a/packages/biniou.1.0.6/opam
+++ b/packages/biniou.1.0.6/opam
@@ -8,3 +8,6 @@ remove: [
   ["ocamlfind" "remove" "biniou"]
 ]
 depends: ["ocamlfind" "easy-format"]
+
+homepage: "http://mjambon.com/biniou.html"
+license: "BSD-3-Clause"


### PR DESCRIPTION
Add again the homepage and the license fields to biniou.1.0.6/opam that was already added in biniou.1.0.5/opam.
