### PR TITLE
Fix build for fd-send-recv.1.0.1 on FreeBSD

### DIFF
--- a/packages/fd-send-recv.1.0.1/opam
+++ b/packages/fd-send-recv.1.0.1/opam
@@ -1,8 +1,8 @@
 opam-version: "1"
 maintainer: "dave.scott@eu.citrix.com"
 build: [
-  ["make"]
-  ["make" "install"]
+  [make]
+  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "fd-send-recv"]


### PR DESCRIPTION
The `fd-send-recv` package will not build on FreeBSD unless invocation of `make` is not quoted -- this allows OPAM to use GNU make instead.
