### PR TITLE
Release CIL 1.7.3

### DIFF
--- a/packages/cil.1.7.3/descr
+++ b/packages/cil.1.7.3/descr
@@ -1,0 +1,1 @@
+A front-end for the C programming language that facilitates program analysis and transformation

--- a/packages/cil.1.7.3/opam
+++ b/packages/cil.1.7.3/opam
@@ -1,0 +1,12 @@
+opam-version: "1"
+maintainer: "gabriel@kerneis.info"
+build: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" "%{prefix}%"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" "%{prefix}%"]
+  [make "uninstall"]
+]
+depends: ["ocamlfind"]

--- a/packages/cil.1.7.3/url
+++ b/packages/cil.1.7.3/url
@@ -1,0 +1,2 @@
+archive: "http://downloads.sourceforge.net/project/cil/cil/cil-1.7.3.tar.gz"
+checksum: "dffd5ee8f812b86b5352583c223ef6e6"


### PR DESCRIPTION
24 July 2013: cil-1.7.3

```
* Fix installation of CIL library.
* Fix machine-independant flags in cilly (eg. -fPIC).
```
