### PR TITLE
Add async_graphics.0.5 package

### DIFF
--- a/packages/async_graphics.0.5/descr
+++ b/packages/async_graphics.0.5/descr
@@ -1,0 +1,1 @@
+Async wrapper for the OCaml Graphics library

--- a/packages/async_graphics.0.5/opam
+++ b/packages/async_graphics.0.5/opam
@@ -1,0 +1,12 @@
+opam-version: "1"
+maintainer: "Leo White <leo@lpw25.net>"
+authors: ["Leo White <leo@lpw25.net>"]
+tags: [ "async" "graphics" ]
+license: "LGPL-2.0 with OCaml linking exception"
+build: [
+  ["./install.sh"]
+]
+remove: [
+  ["ocamlfind" "remove" "async_graphics"]
+]
+depends: ["ocamlfind" "async"]

--- a/packages/async_graphics.0.5/url
+++ b/packages/async_graphics.0.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/lpw25/async_graphics/archive/0.5.tar.gz"
+checksum: "f30f88239882c5583776b8697739db06"


### PR DESCRIPTION
An Async wrapper around OCaml's builtin Graphics library
