### PR TITLE
Initial versions of 'xen-disk' and dependencies

### DIFF
--- a/packages/vhd-format.0.0.2/descr
+++ b/packages/vhd-format.0.0.2/descr
@@ -1,0 +1,1 @@
+A pure OCaml library for reading and writing .vhd format data

--- a/packages/vhd-format.0.0.2/opam
+++ b/packages/vhd-format.0.0.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  ["make"]
+  ["make" "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["make" "uninstall" "BINDIR=%{bin}%"]
+]
+depends: [
+  "ocamlfind"
+  "lwt"
+  "cstruct"
+]

--- a/packages/vhd-format.0.0.2/url
+++ b/packages/vhd-format.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/djs55/ocaml-vhd/archive/0.0.2.tar.gz"
+checksum: "2cfcea772777e990a3a607050ade21a8"

--- a/packages/xen-block-driver.0.2.0/descr
+++ b/packages/xen-block-driver.0.2.0/descr
@@ -1,0 +1,1 @@
+Xen disk device drivers: both client ("frontend") and server ("backend")

--- a/packages/xen-block-driver.0.2.0/opam
+++ b/packages/xen-block-driver.0.2.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  [make]
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  [make "uninstall" "BINDIR=%{bin}%"]
+]
+depends: [
+  "ocamlfind"
+  "cmdliner"
+  "lwt"
+  "cstruct"
+  "shared-memory-ring" {>= "0.4.0"}
+  "mirage"
+]
+depopts: [
+  "xenctrl"
+]

--- a/packages/xen-block-driver.0.2.0/url
+++ b/packages/xen-block-driver.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-xen-block-driver/archive/0.2.0.tar.gz"
+checksum: "405b50caa96d4a44164d85f76c8f1301"

--- a/packages/xen-disk.1.0.2/descr
+++ b/packages/xen-disk.1.0.2/descr
@@ -1,0 +1,1 @@
+A command-line tool for attaching disks to VMs running on a xen host.

--- a/packages/xen-disk.1.0.2/opam
+++ b/packages/xen-disk.1.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  ["make"]
+  ["make" "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["make" "uninstall" "BINDIR=%{bin}%"]
+]
+depends: [
+  "ocamlfind"
+  "obuild"
+  "mirage-unix"
+  "xen-block-driver" {>= "0.2.0"}
+  "xenctrl" {>="0.9.7"}
+  "xenstore"
+  "xenstore_transport"
+  "vhd-format"
+  "cmdliner"
+]

--- a/packages/xen-disk.1.0.2/url
+++ b/packages/xen-disk.1.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/xen-disk/archive/1.0.2.tar.gz"
+checksum: "e36a653bcff2c8b22d3f66c51a6bb7c6"

--- a/packages/xenctrl.0.9.7/descr
+++ b/packages/xenctrl.0.9.7/descr
@@ -1,0 +1,4 @@
+Low-level xen hypercall bindings.
+
+These are experimental bindings based on the code in xen-unstable.git.
+This package should compile and work against xen 4.2 and 4.3.

--- a/packages/xenctrl.0.9.7/opam
+++ b/packages/xenctrl.0.9.7/opam
@@ -1,0 +1,13 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  ["make"]
+  ["make" "install"]
+]
+remove: [
+  ["make" "uninstall"]
+]
+depends: [
+  "ocamlfind"
+  "lwt"
+]

--- a/packages/xenctrl.0.9.7/url
+++ b/packages/xenctrl.0.9.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/archive/0.9.7.tar.gz"
+checksum: "2f3200b762027646a765e345bdfac004"

--- a/packages/xenstore_transport.0.9.0/descr
+++ b/packages/xenstore_transport.0.9.0/descr
@@ -1,0 +1,6 @@
+Low-level libraries for connecting to a xenstore service on a xen host.
+
+These libraries contain the IO functions for communicating with a
+xenstore service on a xen host. One subpackage deals with regular Unix
+threads and another deals with Lwt co-operative threads.
+

--- a/packages/xenstore_transport.0.9.0/opam
+++ b/packages/xenstore_transport.0.9.0/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  ["make" "all"]
+  ["make" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "xenstore_transport"]
+]
+depends: ["lwt" "xenstore" {> "1.2.0"} "ocamlfind"]

--- a/packages/xenstore_transport.0.9.0/url
+++ b/packages/xenstore_transport.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/djs55/ocaml-xenstore-clients/archive/ocaml-xenstore-clients-0.9.0.tar.gz"
+checksum: "21cdad449eda250f30a8ce89ecc29b08"


### PR DESCRIPTION
xen-disk:           serve a disk to a running VM tool
vhd-format:         reads and writes .vhd disk images
xenstore_transport: low-level xenstore read/write
xenctrl:            low-level xen hypercalls
xen-block-driver:   xen virtual disk protocol implementations
