### PR TITLE
fix ocp-index: relies on compiler-libs

### DIFF
--- a/packages/ocp-index.0.1.0/opam
+++ b/packages/ocp-index.0.1.0/opam
@@ -26,4 +26,5 @@ depends: [
 depopts: [
   "curses"
 ]
+ocaml-version: [ >= "4.00.0" ]
 homepage: "https://github.com/OCamlPro/ocp-index"

--- a/packages/ocp-index.0.2.0/opam
+++ b/packages/ocp-index.0.2.0/opam
@@ -26,4 +26,5 @@ depends: [
 depopts: [
   "curses"
 ]
+ocaml-version: [ >= "4.00.0" ]
 homepage: "https://github.com/OCamlPro/ocp-index"

--- a/packages/ocp-index.0.3.0/opam
+++ b/packages/ocp-index.0.3.0/opam
@@ -27,4 +27,6 @@ depends: [
 depopts: [
   "curses"
 ]
+# needs compiler-libs
+ocaml-version: [ >= "4.00.0" ]
 homepage: "http://www.typerex.org/ocp-index.html"


### PR DESCRIPTION
ref: https://github.com/OCamlPro/ocp-index/issues/16
