### PR TITLE
Release shared-memory-ring, xenstore and xenstore_transport

### DIFF
--- a/packages/shared-memory-ring.0.4.1/descr
+++ b/packages/shared-memory-ring.0.4.1/descr
@@ -1,0 +1,3 @@
+Shared memory rings for RPC and bytestream communications.
+Includes concrete implementations of Xen console and Xenstore 
+rings.

--- a/packages/shared-memory-ring.0.4.1/opam
+++ b/packages/shared-memory-ring.0.4.1/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  [make "all"]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "shared-memory-ring"]
+]
+depends: ["cstruct" {>="0.6.0"} "lwt" "ocamlfind" "ounit"]

--- a/packages/shared-memory-ring.0.4.1/url
+++ b/packages/shared-memory-ring.0.4.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/shared-memory-ring/archive/shared-memory-ring-0.4.1.tar.gz"
+checksum: "888c77a261d3f5c059cee3a2d5a11fcc"

--- a/packages/xenstore.1.2.2/descr
+++ b/packages/xenstore.1.2.2/descr
@@ -1,0 +1,1 @@
+Xenstore protocol clients and server

--- a/packages/xenstore.1.2.2/opam
+++ b/packages/xenstore.1.2.2/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  [make "all"]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "xenstore"]
+]
+depends: ["cstruct" {>="0.6.0"} "lwt" "ounit" "ocamlfind"]

--- a/packages/xenstore.1.2.2/url
+++ b/packages/xenstore.1.2.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-xenstore/archive/ocaml-xenstore-1.2.2.tar.gz"
+checksum: "615105380ec8bec19fee7550808d211a"

--- a/packages/xenstore_transport.0.9.1/descr
+++ b/packages/xenstore_transport.0.9.1/descr
@@ -1,0 +1,6 @@
+Low-level libraries for connecting to a xenstore service on a xen host.
+
+These libraries contain the IO functions for communicating with a
+xenstore service on a xen host. One subpackage deals with regular Unix
+threads and another deals with Lwt co-operative threads.
+

--- a/packages/xenstore_transport.0.9.1/opam
+++ b/packages/xenstore_transport.0.9.1/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  ["make" "all"]
+  ["make" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "xenstore_transport"]
+]
+depends: ["lwt" "xenstore" {> "1.2.1"} "ocamlfind"]

--- a/packages/xenstore_transport.0.9.1/url
+++ b/packages/xenstore_transport.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/djs55/ocaml-xenstore-clients/archive/ocaml-xenstore-clients-0.9.1.tar.gz"
+checksum: "4f43929a5d5d2dbde9254993300d0cbc"


### PR DESCRIPTION
These new versions will be needed by the next mirage release.
