### PR TITLE
Remove mirari dependence on mirage

### DIFF
--- a/packages/mirari.0.9.5/opam
+++ b/packages/mirari.0.9.5/opam
@@ -3,4 +3,4 @@ maintainer: "anil@recoil.org"
 build: [
   [make]
 ]
-depends: ["cmdliner" "tuntap" {>="0.5"} "fd-send-recv" "mirage" {>="0.9.3"}]
+depends: ["cmdliner" "tuntap" {>="0.5"} "fd-send-recv"]

--- a/packages/mirari.0.9.6/opam
+++ b/packages/mirari.0.9.6/opam
@@ -3,4 +3,4 @@ maintainer: "anil@recoil.org"
 build: [
   [make]
 ]
-depends: ["cmdliner" "tuntap" {>="0.5"} "fd-send-recv" "mirage" {>="0.9.3"}]
+depends: ["cmdliner" "tuntap" {>="0.5"} "fd-send-recv"]

--- a/packages/mirari.0.9.7/opam
+++ b/packages/mirari.0.9.7/opam
@@ -3,4 +3,4 @@ maintainer: "anil@recoil.org"
 build: [
   [make]
 ]
-depends: ["cmdliner" "tuntap" {>="0.5"} "fd-send-recv" "mirage" {>="0.9.5"}]
+depends: ["cmdliner" "tuntap" {>="0.5"} "fd-send-recv"]


### PR DESCRIPTION
As it results in the CLI being removed in the middle of mirage dev.

There's no strong dependency anyway...
