### PR TITLE
camlimages 4.1.0 requires OCaml 4.00.0

### DIFF
--- a/packages/camlimages.4.1.0/opam
+++ b/packages/camlimages.4.1.0/opam
@@ -17,3 +17,5 @@ authors: [
   "François Pessaux"
   "Pierre Weis"
 ]
+
+ocaml-version: [ >= "4.00.0" ]


### PR DESCRIPTION
I've tested it, with OCaml 3.12.1 opam chooses camlimages 4.0.2 which compiles and works good.
