### PR TITLE
CamlPDF 1.7.1, which is version 1.7 with a fixed META file

### DIFF
--- a/packages/camlpdf.1.7.1/descr
+++ b/packages/camlpdf.1.7.1/descr
@@ -1,0 +1,1 @@
+Read, write and modify PDF files

--- a/packages/camlpdf.1.7.1/opam
+++ b/packages/camlpdf.1.7.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1"
+maintainer: "contact@coherentgraphics.co.uk"
+build: [
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "camlpdf"]
+]
+depends: ["ocamlfind"]
+

--- a/packages/camlpdf.1.7.1/url
+++ b/packages/camlpdf.1.7.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/johnwhitington/camlpdf/archive/v1.7.1.tar.gz"
+checksum: "fc025a26d05bcf7452fad2c1dcebd681"


### PR DESCRIPTION
As suggested. CamlPDF now lets OCamlfind know it depends on bigarray.
