### PR TITLE
4.01.0beta1: -no-camlp4

### DIFF
--- a/compilers/4.01.0beta1+no-camlp4.comp
+++ b/compilers/4.01.0beta1+no-camlp4.comp
@@ -1,0 +1,13 @@
+opam-version: "1"
+version: "4.01.0beta1"
+src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0+beta1.tar.bz2"
+build: [
+  ["./configure" "-prefix" "%{prefix}%" "-no-camlp4"]
+  ["%{make}%" "world"]
+  ["%{make}%" "world.opt"]
+  ["%{make}%" "install"]
+]
+packages: ["base-unix" "base-bigarray" "base-threads"]
+env: [
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]

--- a/compilers/4.01.0beta1+no-camlp4.descr
+++ b/compilers/4.01.0beta1+no-camlp4.descr
@@ -1,0 +1,1 @@
+Beta1 release of 4.01.0, without camlp4


### PR DESCRIPTION
For the few of us using low-memory computers with slow CPUs (i.e. people using EeePCs).
Since the option is available, might as well use it.
