### PR TITLE
New package deriving-0.5

### DIFF
--- a/packages/deriving.0.5/descr
+++ b/packages/deriving.0.5/descr
@@ -1,0 +1,1 @@
+Extension to OCaml for deriving functions from type declarations

--- a/packages/deriving.0.5/opam
+++ b/packages/deriving.0.5/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "gregoire.henry@inria.fr"
+build: [
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "deriving"]
+]
+depends: [
+  "ocamlfind"
+  "optcomp"
+]
+depopts: [
+  "type_conv" {>= "108.07.00"}
+]

--- a/packages/deriving.0.5/url
+++ b/packages/deriving.0.5/url
@@ -1,0 +1,2 @@
+archive: "http://ocsigen.org/download/deriving-0.5.tar.gz"
+checksum: "e0e601655235ef8ea481c63f78ddcdc7"


### PR DESCRIPTION
With the agrement of the orginal deriving authors [1], we renamed our
fork 'deriving-ocsigen' into 'deriving'. We may keep old packages in
'opam-repository' until we update dependent packages,
i.e. js_of_ocaml/eliom, and while [2] isn't fixed.

[1] https://github.com/ocsigen/deriving/issues/5
[2] https://github.com/OCamlPro/opam/issues/740
