### PR TITLE
planck-2.1.1: Add dependency on pa_monad_custom

### DIFF
--- a/packages/planck.2.1.1/opam
+++ b/packages/planck.2.1.1/opam
@@ -8,5 +8,5 @@ build: [
 remove: [
   ["ocaml" "setup.ml" "-uninstall"]
 ]
-depends: ["ocamlfind" "sexplib" {>= "108.07.00"} "spotlib" {>= "2.1.2"} "ocamlgraph" {>= "1.8.2"} "omake"]
+depends: ["ocamlfind" "sexplib" {>= "108.07.00"} "spotlib" {>= "2.1.2"} "ocamlgraph" {>= "1.8.2"} "omake" "pa_monad_custom"]
 ocaml-version: [>= "4.00.1"]


### PR DESCRIPTION
Solves the issue with planck mentionned in https://github.com/OCamlPro/opam-repository/issues/1029.

Fairly trivial patch.
