### PR TITLE
mirage-xen.0.9.4 and mirage-xen.0.9.5 need an exact versions of xenstore

### DIFF
--- a/packages/mirage-xen.0.9.4/opam
+++ b/packages/mirage-xen.0.9.4/opam
@@ -11,7 +11,7 @@ depends: ["cstruct" {>="0.7.1"}
           "ocamlfind" 
           "lwt" {>="2.4.0"} 
           "shared-memory-ring" {>="0.4.1"}
-          "xenstore" {>="1.2.2"}
+          "xenstore" {="1.2.2"}
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]

--- a/packages/mirage-xen.0.9.5/opam
+++ b/packages/mirage-xen.0.9.5/opam
@@ -11,7 +11,7 @@ depends: ["cstruct" {>="0.7.1"}
           "ocamlfind" 
           "lwt" {>="2.4.0"} 
           "shared-memory-ring" {>="0.4.1"}
-          "xenstore" {>="1.2.2"}
+          "xenstore" {="1.2.2"}
           "ipaddr" {>="0.2.2"}
 ]
 conflicts: ["mirage-unix"]

--- a/packages/mirage-xen.0.9.6/opam
+++ b/packages/mirage-xen.0.9.6/opam
@@ -11,7 +11,7 @@ depends: ["cstruct" {>="0.7.1"}
           "ocamlfind" 
           "lwt" {>="2.4.0"} 
           "shared-memory-ring" {>="0.4.1"}
-          "xenstore" {>="1.2.2"}
+          "xenstore" {>="1.2.3"}
           "ipaddr" {>="0.2.2"}
 ]
 conflicts: ["mirage-unix"]


### PR DESCRIPTION
Fixes mirage/ocaml-xen-block-driver#2

Signed-off-by: David Scott dave.scott@eu.citrix.com
