### PR TITLE
lilis: add missing dependency on menhir

### DIFF
--- a/packages/lilis.0.1.3/opam
+++ b/packages/lilis.0.1.3/opam
@@ -20,6 +20,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "batteries"
   "ocamlfind"
+  "menhir"
 ]
 depopts: [
   "cmdliner"


### PR DESCRIPTION
found as part of OCamlot triage run OCamlPro/opam-repository#1029
