### PR TITLE
update compiler descr for rc2

### DIFF
--- a/compilers/4.01.0.descr
+++ b/compilers/4.01.0.descr
@@ -1,1 +1,1 @@
-Official 4.01.0 RC1 release
+Official 4.01.0 RC2 release


### PR DESCRIPTION
Not sure why this wasn't updated along with 02bf26f60d59be37dffb1fba9c9c0a403d8cdfa1
