### PR TITLE
fix camomile data dir

### DIFF
--- a/packages/camomile.0.8.3/opam
+++ b/packages/camomile.0.8.3/opam
@@ -1,15 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
-  ["./configure" "--prefix" "%{prefix}%"
-     "--sbindir=%{lib}%/camomile/sbin"
-     "--libexecdir=%{lib}%/camomile/libexec"
-     "--sysconfdir=%{lib}%/camomile/etc"
-     "--sharedstatedir=%{lib}%/camomile/com"
-     "--localstatedir=%{lib}%/camomile/var"
-     "--libdir=%{lib}%/camomile/lib"
-     "--includedir=%{lib}%/camomile/include"
-     "--datarootdir=%{lib}%/camomile/share"]
+  ["./configure" "--prefix" "%{prefix}%"]
   [make]
   [make "install"]
 ]
@@ -19,5 +11,6 @@ remove: [
 depends: ["ocamlfind"]
 
 homepage: "https://github.com/yoriyuki/Camomile/wiki"
+doc: "http://camomile.sourceforge.net/dochtml/index.html"
 authors: ["Yoriyuki Yamagata"]
 license: "LGPL-2+ with OCaml linking exception"


### PR DESCRIPTION
so that camomile data files are pushed to designated `share` directory and not get into the place of ocamlfind remove camomile
