### PR TITLE
New Menhir version that installs properly.

### DIFF
--- a/packages/menhir.20130912/descr
+++ b/packages/menhir.20130912/descr
@@ -1,0 +1,1 @@
+LR(1) parser generator

--- a/packages/menhir.20130912/files/menhir.install
+++ b/packages/menhir.20130912/files/menhir.install
@@ -1,0 +1,3 @@
+bin: [
+  "src/_stage2/menhir.native" {"menhir"}
+]

--- a/packages/menhir.20130912/opam
+++ b/packages/menhir.20130912/opam
@@ -1,0 +1,9 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+build: [
+  [make "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+remove: [
+  ["ocamlfind" "remove" "menhirLib"]
+]
+depends: ["ocamlfind"]

--- a/packages/menhir.20130912/url
+++ b/packages/menhir.20130912/url
@@ -1,0 +1,2 @@
+archive: "http://cristal.inria.fr/~fpottier/menhir/menhir-20130911.tar.gz"
+checksum: "66374f3626f9403b37eed43819210113"


### PR DESCRIPTION
Apparently it's impossible to change files/menhir.install without bumping the
version number, so I'm doing an entire new package, which installs properly this
time.
