### PR TITLE
omd 0.5.5

### DIFF
--- a/packages/omd.0.5.5/descr
+++ b/packages/omd.0.5.5/descr
@@ -1,0 +1,4 @@
+A Markdown frontend in pure OCaml.
+This Markdown library is implemented using only pure OCaml (including
+I/O operations provided by the standard OCaml compiler distribution).
+Omd targets the original Markdown with a few Github markdown features.

--- a/packages/omd.0.5.5/files/omd.install
+++ b/packages/omd.0.5.5/files/omd.install
@@ -1,0 +1,4 @@
+bin: [
+  "?_build/src/omd_main.byte" {"omd"}
+  "?_build/src/omd_main.native" {"omd"}
+]

--- a/packages/omd.0.5.5/opam
+++ b/packages/omd.0.5.5/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "philippe.wang@gmail.com"
+authors: [ "Philippe Wang <philippe.wang@gmail.com>" ]
+license: "ISC"
+homepage: "https://github.com/pw374/omd"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "omd"]
+]
+depends: [
+  "ocamlfind"
+]

--- a/packages/omd.0.5.5/url
+++ b/packages/omd.0.5.5/url
@@ -1,0 +1,2 @@
+archive: "http://pw374.github.io/distrib/omd/omd-0.5.5.tar.gz"
+checksum: "8de7bbba97c53ebad68eff9fa259200f"


### PR DESCRIPTION
fix: `script` removed from inline html tags
