### PR TITLE
Typo: description file for packages should be "descr" instead of "desc"

### DIFF
--- a/packages/alt-ergo.0.95.2/opam
+++ b/packages/alt-ergo.0.95.2/opam
@@ -3,7 +3,6 @@ maintainer: "alt-ergo@ocamlpro.com"
 license: "CeCILL-C"
 homepage: "http://alt-ergo.ocamlpro.com/"
 build: [
-	["autoconf"]
 	["./configure" "-prefix" "%{prefix}%"]
 	[make]
 	[make "install" "MANDIR=%{man}%/man1"]

--- a/packages/altgr-ergo.0.95.2/opam
+++ b/packages/altgr-ergo.0.95.2/opam
@@ -3,7 +3,6 @@ maintainer: "alt-ergo@ocamlpro.com"
 license: "CeCILL-C"
 homepage: "http://alt-ergo.ocamlpro.com/"
 build: [
-	["autoconf"]
 	["./configure" "-prefix" "%{prefix}%"]
 	[make "gui"]
 	[make "install-gui" "MANDIR=%{man}%/man1"]


### PR DESCRIPTION
Typo: description file for packages should be "descr" instead of "desc"
