### PR TITLE
Add cairo 0.4.6

### DIFF
--- a/packages/cairo2.0.4.6/descr
+++ b/packages/cairo2.0.4.6/descr
@@ -1,0 +1,5 @@
+Binding to Cairo, a 2D Vector Graphics Library.
+This is a binding to Cairo, a 2D graphics library with support for
+multiple output devices. Currently supported output targets include
+the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
+and SVG file output.

--- a/packages/cairo2.0.4.6/opam
+++ b/packages/cairo2.0.4.6/opam
@@ -1,0 +1,32 @@
+opam-version: "1"
+maintainer: "Christophe.Troestler@umons.ac.be"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <antegallya@gmail.com>" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "http://forge.ocamlcore.org/projects/cairo/"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix
+    "--%{lablgtk:enable}%-lablgtk2"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "cairo2"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "ocamlfind"
+]
+depopts: [
+  "lablgtk"
+]
+conflicts: [
+  "cairo" {= "0.4.1"}
+  "cairo" {= "0.4.2"}
+]
+depexts: [
+  [ ["mageia"] ["libcairo-devel"] ]
+  [ [ "debian"  ] [ "libcairo2-dev" "liblablgtk2-ocaml-dev" ] ]
+  [ [ "freebsd" ] [ "Graphics/cairo" ] ]
+  [ [ "openbsd" ] [ "Graphics/cairo" ] ]
+]

--- a/packages/cairo2.0.4.6/url
+++ b/packages/cairo2.0.4.6/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1279/cairo2-0.4.6.tar.gz"
+checksum: "ad1f9a4eff1d60c2c6bb3c078cc716e9"


### PR DESCRIPTION
This makes lablgtk an optional dependency.
