### PR TITLE
issue with why.2.33 configure's patches

### DIFF
--- a/packages/why.2.33/opam
+++ b/packages/why.2.33/opam
@@ -16,6 +16,7 @@ tags: ["deductive" "program verification" "specification" "automated theorem pro
 
 substs: ["opam.patch"]
 build: [
+  ["rm" "configure"]
   ["autoconf"]
   ["./configure" "--enable-verbosemake" "OCAMLGRAPHLIB=%{lib}%/ocamlgraph" "--prefix" "%{prefix}%" "--sbindir=%{lib}%/why/sbin" "--libexecdir=%{lib}%/why/libexec" "--sysconfdir=%{lib}%/why/etc" "--sharedstatedir=%{lib}%/why/com" "--localstatedir=%{lib}%/why/var" "--libdir=%{lib}%/why/lib" "--includedir=%{lib}%/why/include" "--datarootdir=%{lib}%/why/share"]
   [make]


### PR DESCRIPTION
`opam install why` randomly fails at configuration stage. From the diff between successful and failed runs, it seems that in the latter case, the patches of `configure.in` in `opam.patch.in` are not present in `configure`. It's probably due to the fact that `configure.Fluorine-version` (applied later) patches both files and depending on the resulting timestamps, `autoconf` may consider `configure` as newer than `configure.in`. Removing `configure` before launching `autoconf`, as in the proposed patch, seems to stabilize the build.
