### PR TITLE
Version 2.3 of xml-light

### DIFF
--- a/packages/xml-light.2.3/descr
+++ b/packages/xml-light.2.3/descr
@@ -1,0 +1,5 @@
+Xml-Light is a minimal XML parser & printer for OCaml 
+It provide functions to parse an XML document into an OCaml data
+structure, work with it, and print it back to an XML document. It
+support also DTD parsing and checking, and is entirely written in
+OCaml, hence it does not require additional C library.

--- a/packages/xml-light.2.3/opam
+++ b/packages/xml-light.2.3/opam
@@ -1,0 +1,8 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+build: [
+  [make "all"]
+  [make "opt"]
+  [make "install_ocamlfind"]
+]
+depends: ["ocamlfind"]

--- a/packages/xml-light.2.3/url
+++ b/packages/xml-light.2.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/bguil/ocamllibs/releases/download/xml-light.2.3/xml-light.2.3.tar.gz"
+checksum: "e2f79f07bd5706ded2baf8c43574e24b"


### PR DESCRIPTION
Version 2.3:
- The version 2.2 used a broken link
- Different implementations of the code are tagged 2.2. We move to 2.3 to avoid this ambiguity
- ocamfind is used for installation 
