### PR TITLE
cryptokit: Version 1.9

### DIFF
--- a/packages/cryptokit.1.9/descr
+++ b/packages/cryptokit.1.9/descr
@@ -1,0 +1,4 @@
+Cryptographic primitives library. 
+Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers (ARCfour),
+public-key crypto (RSA, DH), hashes (SHA-1, SHA-256), MACs, random number
+generation -- all presented with a compositional, extensible interface.

--- a/packages/cryptokit.1.9/opam
+++ b/packages/cryptokit.1.9/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+build: [
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "cryptokit"]
+]
+depends: ["ocamlfind"]

--- a/packages/cryptokit.1.9/url
+++ b/packages/cryptokit.1.9/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1229/cryptokit-1.9.tar.gz"
+checksum: "4432a426c9d260822f4ff2b0750413de"


### PR DESCRIPTION
Provide the newest (2013/08/19) `cryptokit` release.

Tested here, against OCaml 4.01.0.
