### PR TITLE
omake-mode.1.1

### DIFF
--- a/packages/omake-mode.1.1/descr
+++ b/packages/omake-mode.1.1/descr
@@ -1,0 +1,1 @@
+Omake Emacs integration

--- a/packages/omake-mode.1.1/opam
+++ b/packages/omake-mode.1.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "seanmcl@gmail.com"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [ "rm" "-rf" "%{prefix}%/share/omake-mode" ]
+depends: ["ocamlfind"
+          "oasis" {= "0.3.0"}
+          "core" {= "109.45"}
+          "core_extended" {= "109.45"}
+          "async" {= "109.42"}
+          "inotify"
+          "omake"
+         ]

--- a/packages/omake-mode.1.1/url
+++ b/packages/omake-mode.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://bitbucket.org/seanmcl/omake-mode/get/1.1.tar.gz"
+checksum: "0cec0bf899ac3a695c3431d016049828"


### PR DESCRIPTION
This is an update of omake-mode for ocaml 4.0 and Janestreet core 109.45.  It greatly improves the installation process.  The previous version wasn't functional out of the box.
