### PR TITLE
Omake patch for Ubuntu which requires linker flags after source files.

### DIFF
--- a/packages/omake.0.9.8.6-0.rc1/files/fam.patch
+++ b/packages/omake.0.9.8.6-0.rc1/files/fam.patch
@@ -1,0 +1,12 @@
+diff -ru a/lib/configure/Configure.om b/lib/configure/Configure.om
+--- a/lib/configure/Configure.om
++++ b/lib/configure/Configure.om
+@@ -266,7 +266,7 @@
+ # \end{doc}
+ #
+ public.CheckCLib(libs, funs) =
+-    CFLAGS += $(addprefix -l, $(libs))
++    LDFLAGS += $(addprefix -l, $(libs))
+
+     return $(TryLinkC $"""
+ #ifdef __cplusplus

--- a/packages/omake.0.9.8.6-0.rc1/opam
+++ b/packages/omake.0.9.8.6-0.rc1/opam
@@ -8,4 +8,7 @@ build: [
 depends: [
   "ocamlfind"
 ]
-patches: ["opam.patch"]
+patches: [
+  "opam.patch"
+  "fam.patch"
+]


### PR DESCRIPTION
Installing omake with opam yielded an omake that didn't have FAM linked, thus the
useful -P option was not available. This was due to a change described here
https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition

With the given patch, omake compiles again with FAM support.
