### PR TITLE
Patch readline to make omake compile on OSX

### DIFF
--- a/packages/omake.0.9.8.6-0.rc1/files/readline.patch
+++ b/packages/omake.0.9.8.6-0.rc1/files/readline.patch
@@ -1,0 +1,11 @@
+--- a/lib/configure/readline.om
++++ b/lib/configure/readline.om
+@@ -39,7 +39,7 @@
+             READLINE_CFLAGS += -DREADLINE_ENABLED
+
+             # Test for GNU
+-            if $(CheckLib ncurses readline, rl_on_new_line)
++            if $(and $(not $(equal $(SYSNAME), Darwin)), $(CheckLib ncurses readline, rl_on_new_line))
+                 READLINE_GNU = true
+                 READLINE_CFLAGS += -DREADLINE_GNU
+                 export

--- a/packages/omake.0.9.8.6-0.rc1/opam
+++ b/packages/omake.0.9.8.6-0.rc1/opam
@@ -11,4 +11,5 @@ depends: [
 patches: [
   "opam.patch"
   "fam.patch"
+  "readline.patch"
 ]


### PR DESCRIPTION
omake wouldn't compile on OSX due to an issue with the readline library.  The problem is that OSX uses libedit, but keeps readline.h and libreadline.X.  omake thus gets confused, and thinks it's using gnu readline, and expectes a history_list symbol, which doesn't exist in libedit.  Thus omake dies on a linker error.  This patch fixes the problem.
