### PR TITLE
Dummy stub inotify support for osx.  

### DIFF
--- a/packages/inotify.1.3/descr
+++ b/packages/inotify.1.3/descr
@@ -1,0 +1,1 @@
+Inotify bindings for ocaml.

--- a/packages/inotify.1.3/opam
+++ b/packages/inotify.1.3/opam
@@ -1,0 +1,12 @@
+opam-version: "1"
+maintainer: "seanmcl@gmail.com"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "inotify"]
+]
+os: ["linux" | "darwin"]
+depends: ["ocamlfind"]

--- a/packages/inotify.1.3/url
+++ b/packages/inotify.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://bitbucket.org/seanmcl/ocaml-inotify/get/1.3.tar.gz"
+checksum: "bf175498f7c72325e7c6042f8bb3e169"


### PR DESCRIPTION
This allows opam projects that build,e.g. on linux with inotify support, and mac without inotify support.
