### PR TITLE
+lwt.2.4.4

### DIFF
--- a/packages/lwt.2.4.4/descr
+++ b/packages/lwt.2.4.4/descr
@@ -1,0 +1,5 @@
+A cooperative threads library for OCaml
+This library is part of the Ocsigen project. See:
+
+http://ocsigen.org/lwt
+

--- a/packages/lwt.2.4.4/opam
+++ b/packages/lwt.2.4.4/opam
@@ -1,0 +1,30 @@
+opam-version: "1"
+maintainer: "jeremie@dimino.org"
+build: [
+  ["./configure"
+     "--%{conf-libev:enable}%-libev"
+     "--%{react:enable}%-react"
+     "--%{ssl:enable}%-ssl"
+     "--%{base-unix:enable}%-unix"
+     "--%{base-unix:enable}%-extra"
+     "--%{base-threads:enable}%-preemptive"
+     "--%{lablgtk:enable}%-glib"
+     "--%{ocaml-text:enable}%-text" {"%{react:installed}%"} ]
+  [make "build"]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "lwt"]
+]
+depends: [
+  "ocamlfind"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+  "ssl"
+  "react"
+  "lablgtk"
+  "ocaml-text"
+]

--- a/packages/lwt.2.4.4/url
+++ b/packages/lwt.2.4.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/2.4.4.tar.gz"
+checksum: "7f3e8d63055763004bb49ff4e7db44ea"


### PR DESCRIPTION
@diml, is the upstream for Ocsigen now GitHub?  There's no 2.4.4 in the ocsigen releases website.
