### PR TITLE
Fix autodetect of typerex package type

### DIFF
--- a/packages/typerex.1.99.6-beta/url
+++ b/packages/typerex.1.99.6-beta/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/OCamlPro/typerex/tarball/typerex.1.99.6-beta"
-checksum: "db459156dd94fbfd1a63211d5c65b451"
+archive: "https://github.com/OCamlPro/typerex/archive/typerex.1.99.6-beta.tar.gz"
+checksum: "d27b8513fa00b4904f885d5948d6f623"


### PR DESCRIPTION
Now opam can figure out how to unpack the archive.
