### PR TITLE
ctypes 0.2.2

### DIFF
--- a/packages/ctypes.0.2.2/descr
+++ b/packages/ctypes.0.2.2/descr
@@ -1,0 +1,1 @@
+Combinators for binding to C libraries without writing any C.

--- a/packages/ctypes.0.2.2/opam
+++ b/packages/ctypes.0.2.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "yallop@gmail.com"
+build: [
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "ctypes"]
+]
+depends: [ "ocamlfind" ]
+depexts: [
+  [ ["debian"  ] [ "libffi-dev"] ]   
+  [ ["ubuntu"] [ "libffi-dev" ] ]
+ ]
+tags: ["org:ocamllabs" "org:mirage"]
+ocaml-version: [ >= "4.00.0" ]

--- a/packages/ctypes.0.2.2/url
+++ b/packages/ctypes.0.2.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocamllabs/ocaml-ctypes/archive/ocaml-ctypes-0.2.2.tar.gz"
+checksum: "f0ae8b4537d7e169ccef6aeb2983f759"


### PR DESCRIPTION
Includes a fix for ocamllabs/ocaml-ctypes#98.
