### PR TITLE
github repo moved orgs

### DIFF
--- a/repo
+++ b/repo
@@ -1,3 +1,3 @@
-upstream: "https://github.com/OCamlPro/opam-repository/tree/master/"
+upstream: "https://github.com/ocaml/opam-repository/tree/master/"
 browse: "https://opam.ocaml.org/pkg/"
 redirect: [ "https://opam.ocaml.org" ]


### PR DESCRIPTION
Makes edit links read (mostly) the same as their destination.
