### PR TITLE
[travis] Remove OPAM 1.0.0 from the test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: c
 script: bash -e .travis-ci.sh
 env:
-  - OCAML_VERSION=4.01.0 OPAM_VERSION=1.0.0
-  - OCAML_VERSION=4.00.1 OPAM_VERSION=1.0.0
-  - OCAML_VERSION=3.12.1 OPAM_VERSION=1.0.0
   - OCAML_VERSION=4.01.0 OPAM_VERSION=1.1.0
   - OCAML_VERSION=4.00.1 OPAM_VERSION=1.1.0
   - OCAML_VERSION=3.12.1 OPAM_VERSION=1.1.0
@@ -12,6 +9,3 @@ notifications:
     - opam-commits@lists.ocaml.org
   irc:
     - "chat.freenode.net#opam"
-matrix:
-  allow_failures:
-    - OCAML_VERSION=3.12.1 OPAM_VERSION=1.0.0


### PR DESCRIPTION
The repository that's being tested is now OPAM 1.1-compatible only,
so there's no point testing the older version.
