### PR TITLE
some mirage.0.10.0 package fixes

### DIFF
--- a/packages/mirage/mirage.0.10.0/opam
+++ b/packages/mirage/mirage.0.10.0/opam
@@ -7,4 +7,5 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
+build: [ ["make" "build" "install"] ]
 depends: ["ipaddr" "mirage-types" "lwt" "cstruct" "re"]


### PR DESCRIPTION
- typo in depedencies: `ipadrr` -> `ipaddr`
- implicit build rule doesn't seem to run "make install" or equivalent
