### PR TITLE
riak-pb: add depext for protobuf compiler

### DIFF
--- a/packages/riak-pb/riak-pb.1.0.0/opam
+++ b/packages/riak-pb/riak-pb.1.0.0/opam
@@ -10,3 +10,7 @@ depends: [
   "ocamlfind"
   "piqi"
 ]
+depexts: [
+ [ ["ubuntu"] ["protobuf-compiler"] ]
+ [ ["debian"] ["protobuf-compiler"] ]
+]


### PR DESCRIPTION
Part of triage run in #1304
