### PR TITLE
spotlib_js: fails on 4.01 due to warnings-as-errors

### DIFF
--- a/packages/spotlib_js/spotlib_js.2.2.0_js/opam
+++ b/packages/spotlib_js/spotlib_js.2.2.0_js/opam
@@ -10,5 +10,5 @@ depends: [
   "ocamlfind"
   "omake"
 ]
-ocaml-version: [>= "4.0.1"]
+ocaml-version: [= "4.00.1"]
 os: ["linux"]


### PR DESCRIPTION
part of triage run #1304
