### PR TITLE
flow: restrict to ocaml<4.01.0 due to signature mismatch

### DIFF
--- a/packages/flow/flow.0.1/opam
+++ b/packages/flow/flow.0.1/opam
@@ -12,3 +12,4 @@ depends: [
   "core"
   "ssl"
 ]
+ocaml-version: [<"4.01.0"]

--- a/packages/flow/flow.0.2/opam
+++ b/packages/flow/flow.0.2/opam
@@ -12,4 +12,4 @@ depends: [
   "core" {>= "109.36.00"}
   "ssl"
 ]
-ocaml-version: [>= "4.00.0"]
+ocaml-version: [>= "4.00.0" & < "4.01.0"]


### PR DESCRIPTION
Known upstream in smondet/flow#3
Found as part of #1304
