### PR TITLE
Add flow 0.3

### DIFF
--- a/packages/flow/flow.0.3/descr
+++ b/packages/flow/flow.0.3/descr
@@ -1,0 +1,1 @@
+Deprecated exceptionless “systems” library on top of Core and Lwt.

--- a/packages/flow/flow.0.3/opam
+++ b/packages/flow/flow.0.3/opam
@@ -1,0 +1,15 @@
+opam-version: "1"
+maintainer: "seb@mondet.org"
+build: [
+  ["omake"]
+  ["omake" "install"]
+]
+remove: [["ocamlfind" "remove" "flow"]]
+depends: [
+  "ocamlfind"
+  "omake"
+  "lwt"
+  "core" {>= "109.36.00"}
+  "ssl"
+]
+ocaml-version: [>= "4.00.0" ]

--- a/packages/flow/flow.0.3/url
+++ b/packages/flow/flow.0.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/smondet/flow/archive/0.3.tar.gz"
+checksum: "f06435af31cc7f1e17a63811a6c14caa"


### PR DESCRIPTION
This was asked for here: https://github.com/smondet/flow/issues/3#issuecomment-31010799

The restriction on 0.2 there: https://github.com/ocaml/opam-repository/pull/1481 is a bit wrong since the problem is the API of the Core library not the OCaml version.
