### PR TITLE
+cow.0.9.1

### DIFF
--- a/packages/cow/cow.0.9.1/descr
+++ b/packages/cow/cow.0.9.1/descr
@@ -1,0 +1,1 @@
+XML, JSON, HTML, CSS, and Markdown syntax and libraries

--- a/packages/cow/cow.0.9.1/opam
+++ b/packages/cow/cow.0.9.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [make "all"]
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "cow"]]
+depends: [
+  "ocamlfind"
+  "dyntype" {>= "0.9.0"}
+  "type_conv" {>= "108.07.00"}
+  "ulex"
+  "re"
+  "ounit"
+  "uri" {>= "1.3.9"}
+  "xmlm" {>= "1.1.1"}
+  "omd" {>= "0.8.2"}
+]

--- a/packages/cow/cow.0.9.1/url
+++ b/packages/cow/cow.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cow/archive/v0.9.1.tar.gz"
+checksum: "37c484b2abc489e087bba549d8d7f78f"


### PR DESCRIPTION
Cut a new release instead of updating 0.9.0 due to tests already
running vs 0.9.0 -- this is an important bugfix though.
