### PR TITLE
Add gen_server 2.0.0

### DIFF
--- a/packages/gen_server/gen_server.2.0.0/descr
+++ b/packages/gen_server/gen_server.2.0.0/descr
@@ -1,0 +1,1 @@
+An Erlang-like gen_server framework written for Async.

--- a/packages/gen_server/gen_server.2.0.0/opam
+++ b/packages/gen_server/gen_server.2.0.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1"
+maintainer: "mmatalka@gmail.com"
+build: [
+  [make]
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "gen_server"]]
+depends: [
+  "ocamlfind"
+  "core" {>= "109.12.00"}
+  "async"
+]
+

--- a/packages/gen_server/gen_server.2.0.0/url
+++ b/packages/gen_server/gen_server.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/orbitz/gen_server/archive/2.0.0.tar.gz"
+checksum: "450a51170d87fb6e1ca5e027181e52b9"


### PR DESCRIPTION
Adds backwards incompatible API change: returning an Error requires taking an error and state now. Previously one could not do a controlled terminate by Error and update the state value, meaning the state passed to the terminate callback could be stale.
