### PR TITLE
smart-print: Add patch for OCaml ≤ 4.00.1

### DIFF
--- a/packages/smart-print/smart-print.0.1.0/files/operators.patch
+++ b/packages/smart-print/smart-print.0.1.0/files/operators.patch
@@ -1,0 +1,18 @@
+diff --git a/smartPrint.ml b/smartPrint.ml
+index 8d1479a..90598b7 100644
+--- a/smartPrint.ml
++++ b/smartPrint.ml
+@@ -1,3 +1,6 @@
++external (|>) : 'a -> ('a -> 'b) -> 'b = "%revapply";;
++external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
++
+ (* Separators. *)
+ module Break = struct
+   (* A break can be a whitespace or a newline if the text has to be splited. *)
+@@ -418,4 +421,4 @@ let to_out_channel (width : int) (tab : int) (c : out_channel) (d : t) : unit =
+     (output_char c) (output_string c) output_sub_string d
+ 
+ let to_stdout (width : int) (tab : int) (d : t) : unit =
+-  to_out_channel width tab stdout d
+\ No newline at end of file
++  to_out_channel width tab stdout d

--- a/packages/smart-print/smart-print.0.1.0/opam
+++ b/packages/smart-print/smart-print.0.1.0/opam
@@ -3,8 +3,9 @@ maintainer: "dev@clarus.me"
 homepage: "https://github.com/clarus/smart-print"
 license: "BSD"
 
-ocaml-version: [>="4.01.0"]
+ocaml-version: [>="4.00.0"]
 depends: ["ocamlfind"]
+patches: ["operators.patch"]
 
 build: [
   [make]


### PR DESCRIPTION
There was a constrain ocaml ≥ 4.01.0, but the projects compiles fine with a two lines patch.
