### PR TITLE
Add openflow v0.2.0

### DIFF
--- a/packages/openflow/openflow.0.2.0/descr
+++ b/packages/openflow/openflow.0.2.0/descr
@@ -1,0 +1,4 @@
+A serialization library for OpenFlow.
+
+This library supports almost all of OpenFlow 1.0 and also has some
+experimental support for OpenFlow 1.3.

--- a/packages/openflow/openflow.0.2.0/opam
+++ b/packages/openflow/openflow.0.2.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1"
+ocaml-version: [ >= "4.01.0" ]
+maintainer: "arjun@cs.umass.edu"
+homepage: "https://github.com/frenetic-lang/ocaml-openflow"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--%{quickcheck:enable}%-quickcheck" ]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [["ocamlfind" "remove" "openflow"]]
+depends: [
+  "ocamlfind"
+  "lwt"
+  "cstruct"
+  "packet"
+]
+depopts: [ "lwt" "quickcheck" ]

--- a/packages/openflow/openflow.0.2.0/url
+++ b/packages/openflow/openflow.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/frenetic-lang/ocaml-openflow/archive/v0.2.0.tar.gz"
+checksum: "9052c45afc7ec7953029e87f4ab0134b"


### PR DESCRIPTION
This pull request adds the latest version (v0.2.0) of the openflow package to the opam-repository. See release notes [here](https://github.com/frenetic-lang/ocaml-openflow/releases/tag/v0.2.0), if you're into that.
