### PR TITLE
Add packet v0.2.0

### DIFF
--- a/packages/packet/packet.0.2.0/descr
+++ b/packages/packet/packet.0.2.0/descr
@@ -1,0 +1,4 @@
+A serialization library for several common packet formats
+
+This library includes serializers for ethernet, TCP, IP, ARP, ICMP, and
+others.

--- a/packages/packet/packet.0.2.0/opam
+++ b/packages/packet/packet.0.2.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1"
+maintainer: "arjun@cs.umass.edu"
+homepage: "https://github.com/frenetic-lang/ocaml-packet"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--%{quickcheck:enable}%-quickcheck"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [["ocamlfind" "remove" "packet"]]
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "0.7.0"}
+]
+depopts: ["quickcheck"]

--- a/packages/packet/packet.0.2.0/url
+++ b/packages/packet/packet.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/frenetic-lang/ocaml-packet/archive/v0.2.0.tar.gz"
+checksum: "c81335824da31e6905b64d32896d4c4e"


### PR DESCRIPTION
This pull request adds the latest version (v0.2.0) of the packet package to the opam-repository. See release notes [here](https://github.com/frenetic-lang/ocaml-packet/releases/tag/v0.2.0), if you're into that.
