### PR TITLE
Fix 'apt-get autoremove' being too agressive in Travis CI scripts

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -64,7 +64,7 @@ function build_one {
     depext=`opam install $pkg -e ubuntu`
     echo Ubuntu depexts: $depext
     if [ "$depext" != "" ]; then
-      sudo apt-get install -qq build-essential m4 $depext
+      sudo apt-get install -qq pkg-config build-essential m4 $depext
     fi
     opam install $pkg
     opam remove $pkg


### PR DESCRIPTION
This should fix the issue seen in https://github.com/ocaml/opam-repository/pull/1601
