### PR TITLE
llvm: Use -j %{jobs}% instead of -j9 to improve scalling

### DIFF
--- a/packages/llvm/llvm.3.1/opam
+++ b/packages/llvm/llvm.3.1/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "sebastien.fricker@gmail.com"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
-  [make "-j %{jobs}%"]
+  [make "-j%{jobs}%"]
   [make "install"]
   ["cp" "%{lib}%/llvm/META.llvm" "%{lib}%/llvm/META"]
 ]

--- a/packages/llvm/llvm.3.2/opam
+++ b/packages/llvm/llvm.3.2/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "sebastien.fricker@gmail.com"
 build: [
   ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--%{conf-llvm-debug:enable}%-doxygen" "--%{conf-llvm-debug:enable}%-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
-  [make "-j %{jobs}%"]
+  [make "-j%{jobs}%"]
   [make "install"]
   ["cp" "%{lib}%/llvm/META.llvm" "%{lib}%/llvm/META"]
 ]

--- a/packages/llvm/llvm.3.4/opam
+++ b/packages/llvm/llvm.3.4/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "jp.deplaix@gmail.com"
 build: [
   ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--%{conf-llvm-debug:enable}%-doxygen" "--%{conf-llvm-debug:enable}%-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
-  [make "-j %{jobs}%"]
+  [make "-j%{jobs}%"]
   [make "install"]
   ["cp" "%{lib}%/llvm/META.llvm" "%{lib}%/llvm/META"]
 ]


### PR DESCRIPTION
Fix #1268
