### PR TITLE
Fix compilation of bin_prot under 32-bit ARM

### DIFF
--- a/packages/bin_prot/bin_prot.109.53.02/files/fix-arm-double-field.diff
+++ b/packages/bin_prot/bin_prot.109.53.02/files/fix-arm-double-field.diff
@@ -1,0 +1,29 @@
+diff --git a/lib/blit_stubs.c b/lib/blit_stubs.c
+index e67d9bc..389335d 100644
+--- a/lib/blit_stubs.c
++++ b/lib/blit_stubs.c
+@@ -72,7 +72,11 @@ CAMLprim value bin_prot_blit_buf_stub(
+ CAMLprim value bin_prot_blit_float_array_buf_stub(
+   value v_src_pos, value v_arr, value v_dst_pos, value v_buf, value v_len)
+ {
++#ifdef __arm__
++  char *arr = (char*)v_arr + Long_val(v_src_pos) * sizeof(double);
++#else
+   char *arr = (char*)&Double_field(v_arr, Long_val(v_src_pos));
++#endif
+   char *buf = get_buf(v_buf, v_dst_pos);
+   memcpy(buf, arr, (size_t) (Long_val(v_len) * sizeof(double)));
+   return Val_unit;
+@@ -82,7 +86,11 @@ CAMLprim value bin_prot_blit_buf_float_array_stub(
+   value v_src_pos, value v_buf, value v_dst_pos, value v_arr, value v_len)
+ {
+   char *buf = get_buf(v_buf, v_src_pos);
++#ifdef __arm__
++  char *arr = (char*)v_arr + Long_val(v_dst_pos) * sizeof(double);
++#else
+   char *arr = (char*)&Double_field(v_arr, Long_val(v_dst_pos));
++#endif
+   memcpy(arr, buf, (size_t) (Long_val(v_len) * sizeof(double)));
+   return Val_unit;
+ }
+

--- a/packages/bin_prot/bin_prot.109.53.02/opam
+++ b/packages/bin_prot/bin_prot.109.53.02/opam
@@ -6,6 +6,7 @@ build: [
   [make]
   [make "install"]
 ]
+patches: ["fix-arm-double-field.diff"]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: ["ocamlfind"
           "type_conv" {>= "109.53.00" & <= "109.60.00"}]


### PR DESCRIPTION
This is the minimal diff to avoid changing the released code on
non-ARM.  See janestreet/bin_prot#4 where the upstream fix is
being discussed.
