### PR TITLE
put datalog doc in a proper subdir

### DIFF
--- a/packages/datalog/datalog.0.5.1/opam
+++ b/packages/datalog/datalog.0.5.1/opam
@@ -12,7 +12,7 @@ tags: [
   "prolog"
 ]
 build: [
-  ["./configure" "--bindir" bin "--docdir" doc]
+  ["./configure" "--bindir" bin "--docdir" "%{doc}/datalog/"]
   [make "all" "install_file" "doc" "man"]
   [make "install"]
 ]


### PR DESCRIPTION
See [this remark](https://github.com/ocaml/opam-repository/commit/f9687f76b6c9d0a6ecffbde796bcb06280d43859)
