### PR TITLE
Add bibtex2html 1.97

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.97/descr
+++ b/packages/bibtex2html/bibtex2html.1.97/descr
@@ -1,0 +1,1 @@
+BibTeX to HTML translator

--- a/packages/bibtex2html/bibtex2html.1.97/opam
+++ b/packages/bibtex2html/bibtex2html.1.97/opam
@@ -1,0 +1,12 @@
+opam-version: "1"
+maintainer: "filliatr@lri.fr"
+authors: [
+  "Jean-Christophe Filliâtre"
+  "Claude Marché"
+]
+license: "GNU General Public License version 2"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+  [make "install"]
+]

--- a/packages/bibtex2html/bibtex2html.1.97/url
+++ b/packages/bibtex2html/bibtex2html.1.97/url
@@ -1,0 +1,2 @@
+archive: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.97.tar.gz"
+checksum: "d20d0d607be3f6aa770554f3eee0dde1"


### PR DESCRIPTION
new package bibtex2html
(this soft is used by many people who typically do not have OCaml installed;
## an opam package may help) 

Jean-Christophe
