### PR TITLE
LLVM: disable shared and docs

### DIFF
--- a/packages/llvm/llvm.3.1/opam
+++ b/packages/llvm/llvm.3.1/opam
@@ -1,13 +1,13 @@
 opam-version: "1"
 maintainer: "sebastien.fricker@gmail.com"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--enable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
+  ["./configure" "--prefix=%{prefix}%" "--disable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--disable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
   [make "-j%{jobs}%"]
   [make "install"]
   ["cp" "%{lib}%/llvm/META.llvm" "%{lib}%/llvm/META"]
 ]
 remove: [
-  ["./configure" "--prefix=%{prefix}%" "--enable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
+  ["./configure" "--prefix=%{prefix}%" "--disable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--disable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
   [make "-k" "uninstall"]
 ]
 depopts: ["conf-llvm-debug"]

--- a/packages/llvm/llvm.3.2/opam
+++ b/packages/llvm/llvm.3.2/opam
@@ -1,13 +1,13 @@
 opam-version: "1"
 maintainer: "sebastien.fricker@gmail.com"
 build: [
-  ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--%{conf-llvm-debug:enable}%-doxygen" "--%{conf-llvm-debug:enable}%-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
+  ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--disable-doxygen" "--disable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--disable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
   [make "-j%{jobs}%"]
   [make "install"]
   ["cp" "%{lib}%/llvm/META.llvm" "%{lib}%/llvm/META"]
 ]
 remove: [
-  ["./configure" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--%{conf-llvm-debug:enable}%-doxygen" "--%{conf-llvm-debug:enable}%-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
+  ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--disable-doxygen" "--disable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--disable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
   [make "-k" "uninstall"]
 ]
 depopts: ["conf-llvm-debug"]

--- a/packages/llvm/llvm.3.4/opam
+++ b/packages/llvm/llvm.3.4/opam
@@ -1,13 +1,13 @@
 opam-version: "1"
 maintainer: "jp.deplaix@gmail.com"
 build: [
-  ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--%{conf-llvm-debug:enable}%-doxygen" "--%{conf-llvm-debug:enable}%-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
+  ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--disable-doxygen" "--disable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--disable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
   [make "-j%{jobs}%"]
   [make "install"]
   ["cp" "%{lib}%/llvm/META.llvm" "%{lib}%/llvm/META"]
 ]
 remove: [
-  ["./configure" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--%{conf-llvm-debug:enable}%-doxygen" "--%{conf-llvm-debug:enable}%-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--enable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
+  ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--docdir=%{doc}%/llvm" "--disable-doxygen" "--disable-docs" "llvm_cv_cxx_visibility_inlines_hidden=no" "--enable-static" "--disable-shared" "--%{conf-llvm-debug:enable}%-debug-runtime" "--%{conf-llvm-debug:enable}%-debug-symbols" "--enable-jit" "--%{conf-llvm-debug:enable}%-assertions" "--with-ocaml-libdir=%{lib}%/llvm"]
   [make "-k" "uninstall"]
 ]
 depopts: ["conf-llvm-debug"]


### PR DESCRIPTION
Do we need documentations ?
Shared binaries doesn't work well according to @whitequark.
@whitequark, does this fix the bug ?
