### PR TITLE
Rerelease cohttp.0.9.16

### DIFF
--- a/packages/cohttp/cohttp.0.9.16/url
+++ b/packages/cohttp/cohttp.0.9.16/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/mirage/ocaml-cohttp/archive/v0.9.16.tar.gz"
-checksum: "13d8d190f16a1036e6534361b411d502"
+checksum: "6c4b25419b71840d407ad873ec04e07a"


### PR DESCRIPTION
The previous version merged into OPAM was actually 0.9.15, due to
an error in creating the release tag.  This was leading to all sorts
of confusing errors in OPAM!
