### PR TITLE
+opamfu.0.1.1

### DIFF
--- a/packages/opamfu/opamfu.0.1.1/descr
+++ b/packages/opamfu/opamfu.0.1.1/descr
@@ -1,0 +1,6 @@
+Functions over OPAM Universes
+
+opamfu provides a simple opam universe (stack of opam remotes) query
+facility and standard command-line interface library for OPAM-based
+applications. Also included is a module with a pretty-printing-friendly
+representation of OPAM formulae.

--- a/packages/opamfu/opamfu.0.1.1/opam
+++ b/packages/opamfu/opamfu.0.1.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "David Sheets"
+]
+homepage: "https://github.com/ocamllabs/opamfu"
+license: "ISC"
+tags: [
+]
+build: [
+  [make "build"]
+  [make "install"]
+]
+remove: [[make "uninstall"]]
+depends: [
+  "ocamlfind"
+  "opam-lib" { >= "1.1.1" }
+  "uri"
+]
+depopts: ["cmdliner"]

--- a/packages/opamfu/opamfu.0.1.1/url
+++ b/packages/opamfu/opamfu.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocamllabs/opamfu/archive/0.1.1.tar.gz"
+checksum: "d556b02f2ea58fdfa93e032630ee30d3"


### PR DESCRIPTION
Bugfix: packages live in `packages/` in opam repos not `pkg/`
