### PR TITLE
Experimental fix for mirage/mirage#221

### DIFF
--- a/packages/mirage/mirage.1.1.0/opam
+++ b/packages/mirage/mirage.1.1.0/opam
@@ -13,7 +13,7 @@ build: [
   [make "install"]
 ]
 remove: [
-  ["mv" "%{bin}%/mirage" "%{bin}%/mirage.old"]
+  ["rm" "-f" "%{bin}%/mirage"]
   ["ocamlfind" "remove" "mirage"]
 ]
 depends: [


### PR DESCRIPTION
This leaves a stray binary after an uninstall, but fixes the
situation where the `mirage` binary attempts to upgrade itself
(due to invoking OPAM, which installs some optional dependencies,
which then proceed to try and recompile mirage).

The only long-term fix is to lift `mirage` into being a host-level
tool and not tracked by the same tool it uses to install libraries,
but for the moment renaming the active `mirage` binary to `mirage.old`
on uninstall should do the trick.
