### PR TITLE
Add opass.1.0.1, fixes OS X compilation issue

### DIFF
--- a/packages/opass/opass.1.0.1/descr
+++ b/packages/opass/opass.1.0.1/descr
@@ -1,0 +1,2 @@
+A simple command line tool for storing, retreiving, and generating password and
+secret notes, using PGP for encryption.

--- a/packages/opass/opass.1.0.1/opam
+++ b/packages/opass/opass.1.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1"
+maintainer: "mmatalka@gmail.com"
+build: [
+  [make]
+  [make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+  ["rm" "-v" "%{prefix}%/bin/opass"]
+]
+
+depends: [
+  "ocamlfind"
+  "core" {>= "108.08.00"}
+  "core_extended"
+  "csv"
+]
+
+ocaml-version: [>= "4.0.0"]

--- a/packages/opass/opass.1.0.1/url
+++ b/packages/opass/opass.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/orbitz/opass/archive/1.0.1.tar.gz"
+checksum: "bdc26211ae2e323dcc1303e68ec855f8"


### PR DESCRIPTION
sed on OS X doesn't match sed on linux, which the compilation process uses.  This fixes that by switching to awk.
