### PR TITLE
Experimental support for Travis source install

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -66,6 +66,10 @@ function build_one {
     if [ "$depext" != "" ]; then
       sudo apt-get install -qq pkg-config build-essential m4 $depext
     fi
+    srcext=`opam install $pkg -e source,linux`
+    if [ "$srcext" != "" ]; then
+      curl -s ${srcext} | bash
+    fi  
     opam install $pkg
     opam remove $pkg
     if [ "$depext" != "" ]; then

--- a/packages/sodium/sodium.0.1.0/opam
+++ b/packages/sodium/sodium.0.1.0/opam
@@ -11,3 +11,6 @@ depends: [
   "ocamlfind"
   "ctypes" {>= "0.1.1"}
 ]
+depexts: [
+  [ ["source" "linux"] ["https://gist.github.com/avsm/9037146/raw"] ]
+]


### PR DESCRIPTION
If a package defines a depext with the `["source" "linux"]` tags,
it will be treated as a URL and piped through a shell.  This script
should download and install any external source dependencies
required.

This depext is run _after_ any binary depexts, so they can install
prerequisite libraries.

This commit includes a working sodium.0.1.0 as an example.
