### PR TITLE
Relax/fix uint version restriction

### DIFF
--- a/packages/uint/uint.1.1.1/opam
+++ b/packages/uint/uint.1.1.1/opam
@@ -8,4 +8,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "uint"]
 ]
-depends: ["ocamlfind" "ospec" {= "0.3.0"}]
+depends: ["ocamlfind" "ospec" {>= "0.3.1"}]


### PR DESCRIPTION
The ospec 0.3.0 package can not be installed which in turn blocked uint 1.1.1.

This caused/causes opam to try to install uint 1.0.2 which doesn't work on OCaml 4.x.
