### PR TITLE
Add lablgtk version constraint to gtk-light

### DIFF
--- a/packages/gtk-light/gtk-light.0.0.1/opam
+++ b/packages/gtk-light/gtk-light.0.0.1/opam
@@ -12,7 +12,7 @@ remove: [
 ]
 depends: [
   "batteries"
-  "lablgtk"
+  "lablgtk" {>= "2.16.0"}
   "react"
   "ocamlfind"
 ]


### PR DESCRIPTION
Based on @avsm's suggestion.
