### PR TITLE
Align dose patches for portable /tmp directory and quoting criteria

### DIFF
--- a/packages/dose/dose.3.1.2/files/dose-mktemp.diff
+++ b/packages/dose/dose.3.1.2/files/dose-mktemp.diff
@@ -1,0 +1,13 @@
+diff --git a/common/cudfSolver.ml b/common/cudfSolver.ml
+index bb4c5c5..da7bdb6 100644
+--- a/common/cudfSolver.ml
++++ b/common/cudfSolver.ml
+@@ -27,6 +27,6 @@ let check_fail file =
+ (** see mktemp(1) for the syntax of [tmp_pattern] *)
+ let mktmpdir tmp_pattern =
+   let ic =
+-    Unix.open_process_in (Printf.sprintf "mktemp --tmpdir -d %s" tmp_pattern) in
++    Unix.open_process_in (Printf.sprintf "(mktemp --tmpdir -d %s || mktemp -d -t %s) 2>/dev/null" tmp_pattern tmp_pattern) in
+   let path = input_line ic in
+   ignore (Unix.close_process_in ic);
+   path

--- a/packages/dose/dose.3.1.2/files/dose-quotecriteria.diff
+++ b/packages/dose/dose.3.1.2/files/dose-quotecriteria.diff
@@ -1,0 +1,50 @@
+diff --git a/common/cudfSolver.ml b/common/cudfSolver.ml
+index bb4c5c5..de561bd 100644
+--- a/common/cudfSolver.ml
++++ b/common/cudfSolver.ml
+@@ -53,11 +53,17 @@ let rec input_all_lines acc chan =
+ (** Solver "exec:" line. Contains three named wildcards to be interpolated:
+    "$in", "$out", and "$pref"; corresponding to, respectively, input CUDF
+    document, output CUDF universe, user preferences. *)
++
++(* quote string for the shell, after removing all characters disallowed in criteria *)
++let quote s = Printf.sprintf "\"%s\"" s;;
++let sanitize s = quote (Pcre.substitute ~rex:(Pcre.regexp "[^+()a-z,\"-]") ~subst:(fun _ -> "") s);;
++
+ let interpolate_solver_pat exec cudf_in cudf_out pref =
+-  let _, exec = String.replace ~str:exec ~sub:"$in"   ~by:cudf_in  in
+-  let _, exec = String.replace ~str:exec ~sub:"$out"  ~by:cudf_out in
+-  let _, exec = String.replace ~str:exec ~sub:"$pref" ~by:pref     in
+-  exec
++  let (|>) f g = fun x -> g(f x) in
++  let dequote s = Pcre.regexp ("\"*"^(Pcre.quote s)^"\"*") in
++  (Pcre.substitute ~rex:(dequote "$in")   ~subst: (fun _ -> (quote cudf_in))  |>
++   Pcre.substitute ~rex:(dequote "$out")  ~subst: (fun _ -> (quote cudf_out)) |>
++   Pcre.substitute ~rex:(dequote "$pref") ~subst: (fun _ -> (sanitize pref))) exec
+ ;;
+ 
+ exception Error of string
+diff --git a/common/cudfSolver.ml b/common/cudfSolver.ml
+index de561bd..97d889c 100644
+--- a/common/cudfSolver.ml
++++ b/common/cudfSolver.ml
+@@ -56,14 +56,14 @@ let rec input_all_lines acc chan =
+ 
+ (* quote string for the shell, after removing all characters disallowed in criteria *)
+ let quote s = Printf.sprintf "\"%s\"" s;;
+-let sanitize s = quote (Pcre.substitute ~rex:(Pcre.regexp "[^+()a-z,\"-]") ~subst:(fun _ -> "") s);;
++let sanitize s = quote (Re_pcre.substitute ~rex:(Re_pcre.regexp "[^+()a-z,\"-]") ~subst:(fun _ -> "") s);;
+ 
+ let interpolate_solver_pat exec cudf_in cudf_out pref =
+   let (|>) f g = fun x -> g(f x) in
+-  let dequote s = Pcre.regexp ("\"*"^(Pcre.quote s)^"\"*") in
+-  (Pcre.substitute ~rex:(dequote "$in")   ~subst: (fun _ -> (quote cudf_in))  |>
+-   Pcre.substitute ~rex:(dequote "$out")  ~subst: (fun _ -> (quote cudf_out)) |>
+-   Pcre.substitute ~rex:(dequote "$pref") ~subst: (fun _ -> (sanitize pref))) exec
++  let dequote s = Re_pcre.regexp ("\"*"^(Re_pcre.quote s)^"\"*") in
++  (Re_pcre.substitute ~rex:(dequote "$in")   ~subst: (fun _ -> (quote cudf_in))  |>
++   Re_pcre.substitute ~rex:(dequote "$out")  ~subst: (fun _ -> (quote cudf_out)) |>
++   Re_pcre.substitute ~rex:(dequote "$pref") ~subst: (fun _ -> (sanitize pref))) exec
+ ;;
+ 
+ exception Error of string

--- a/packages/dose/dose.3.1.2/opam
+++ b/packages/dose/dose.3.1.2/opam
@@ -30,4 +30,4 @@ depends: [
   ("extlib" | "extlib-compat")
   "re" {>= "1.2.0"}
 ]
-patches: ["dose-pcre2re.diff"]
+patches: ["dose-pcre2re.diff" "dose-mktemp.diff" "dose-quotecriteria.diff"]


### PR DESCRIPTION
This is needed to ensure that building opam from internal sources or external packages yields the same results.
