### PR TITLE
bibtex2html depends on hevea

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.97/opam
+++ b/packages/bibtex2html/bibtex2html.1.97/opam
@@ -10,3 +10,6 @@ build: [
   [make]
   [make "install"]
 ]
+depends: [
+  "hevea"
+]


### PR DESCRIPTION
This should fix issue #1723
