### PR TITLE
glical.0.0.1: a library to glance at iCalendar data

### DIFF
--- a/packages/glical/glical.0.0.1/descr
+++ b/packages/glical/glical.0.0.1/descr
@@ -1,0 +1,2 @@
+Glical: glancing at iCalendar data.
+A library to glance at iCalendar data using OCaml.

--- a/packages/glical/glical.0.0.1/opam
+++ b/packages/glical/glical.0.0.1/opam
@@ -1,0 +1,19 @@
+maintainer: "philippe.wang@gmail.com"
+name: "glical"
+opam-version: "1"
+license: "ISC"
+authors: [ "Philippe Wang <philippe.wang@gmail.com>" ]
+homepage: "https://github.com/pw374/glical"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "build"]
+  [make "install"]
+]
+remove: [
+  ["./configure" "-prefix" prefix]
+  [make "uninstall"]
+]
+ocaml-version: [ >= "3.12.1" ]
+tags: [
+  "org:ocamllabs"
+]

--- a/packages/glical/glical.0.0.1/url
+++ b/packages/glical/glical.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "http://pw374.github.io/distrib/glical/glical-0.0.1.tar.gz"
+checksum: "36a534272550b3c68be6498dd22b480f"


### PR DESCRIPTION
Glical is a tiny library that does the minimal necessary parsing
work for iCalendar data. The library provides an extensible data
structure to allow multiple structure transformations for iCalendar
data.
