### PR TITLE
glical.0.0.1: hash changed

### DIFF
--- a/packages/glical/glical.0.0.1/url
+++ b/packages/glical/glical.0.0.1/url
@@ -1,2 +1,2 @@
 archive: "http://pw374.github.io/distrib/glical/glical-0.0.1.tar.gz"
-checksum: "36a534272550b3c68be6498dd22b480f"
+checksum: "af7f1ab972590213e3c5d5397c51afe1"


### PR DESCRIPTION
I had to change the archive because it didn't build the archives (.cma, .cmxa) correctly (things were missing) and it didn't install all the necessary files.

(And since the contents of the library hasn't really changed, it didn't make sense to make a new version.)
