### PR TITLE
Enable a wide character support

### DIFF
--- a/packages/curses/curses.1.0.3/opam
+++ b/packages/curses/curses.1.0.3/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "ogunden@phauna.org"
 build: [
-  ["./configure"]
+  ["./configure" "--enable-widec"]
   [make "byte"]
   [make "opt"]
   [make "install"]


### PR DESCRIPTION
I have enabled a wide character support.
I added the --enabled-widec flag to configure.
If libncursesw is not installed on the system, configure will now link the libncurses.
