### PR TITLE
ocamlnet: Add a patch for ocaml >= 4.02

### DIFF
--- a/packages/ocamlnet/ocamlnet.3.6.5/files/fix-ocaml-4.02.patch
+++ b/packages/ocamlnet/ocamlnet.3.6.5/files/fix-ocaml-4.02.patch
@@ -1,0 +1,12 @@
+--- a/src/netstring/netencoding.mli	2014-03-17 23:07:25.757083686 +0100
++++ b/src/netstring/netencoding.mli	2014-03-17 23:05:15.801089492 +0100
+@@ -120,7 +120,7 @@
+ 	 * to ensure that all output lines have a length <= 76 bytes.
+ 	 *
+ 	 * Note unsafe characters:
+-	 *   As recommended by RFC 2045, the characters [!#$\@[]^`{|}~]
++	 *   As recommended by RFC 2045, the characters [!#$\@[]^`|{}~]
+ 	 *   and the double quotes
+ 	 *   are additionally represented as hex tokens.        
+ 	 *   Furthermore, the letter 'F' is considered as unsafe if it
+

--- a/packages/ocamlnet/ocamlnet.3.6.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.5/opam
@@ -47,4 +47,5 @@ patches: [
   "netpop.patch"
   "nethttpd_types.patch"
   "cloexec.patch" {ocaml-version >= "4.01.0"}
+  "fix-ocaml-4.02.patch" {ocaml-version >= "4.02.0"}
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.3/files/fix-ocaml-4.02.patch
+++ b/packages/ocamlnet/ocamlnet.3.7.3/files/fix-ocaml-4.02.patch
@@ -1,0 +1,12 @@
+--- a/src/netstring/netencoding.mli	2014-03-17 23:07:25.757083686 +0100
++++ b/src/netstring/netencoding.mli	2014-03-17 23:05:15.801089492 +0100
+@@ -120,7 +120,7 @@
+ 	 * to ensure that all output lines have a length <= 76 bytes.
+ 	 *
+ 	 * Note unsafe characters:
+-	 *   As recommended by RFC 2045, the characters [!#$\@[]^`{|}~]
++	 *   As recommended by RFC 2045, the characters [!#$\@[]^`|{}~]
+ 	 *   and the double quotes
+ 	 *   are additionally represented as hex tokens.        
+ 	 *   Furthermore, the letter 'F' is considered as unsafe if it
+

--- a/packages/ocamlnet/ocamlnet.3.7.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.3/opam
@@ -43,3 +43,6 @@ depopts: [
   "camlzip"
   "cryptokit"
 ]
+patches: [
+  "fix-ocaml-4.02.patch" {ocaml-version >= "4.02.0"}
+]


### PR DESCRIPTION
ocaml 4.02 add a new string construct: `{| foo " bar |}` but it is parsed in comments and fails at compile-time with `This comment contains an unterminated string literal`.

This patch fix this
