### PR TITLE
opium v0.6.0

### DIFF
--- a/packages/opium/opium.0.6.0/descr
+++ b/packages/opium/opium.0.6.0/descr
@@ -1,0 +1,11 @@
+Sinatra like web toolkit based on Async + Cohttp
+
+Opium is a minimalistic library for quickly binding functions
+to http routes. Its features include (but not limited to):
+
+* Middleware system for app independent components
+* A simple router for matching urls and parsing parameters
+* Request/Response pretty printing for easier debugging
+
+Note: This library is still at an early stage so expect breakages
+until 1.0

--- a/packages/opium/opium.0.6.0/opam
+++ b/packages/opium/opium.0.6.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "WTFPL"
+
+build: [
+  ["make" "configure-no-tests"]
+  ["make" "build"]
+  ["make" "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "opium_rock"]
+  ["ocamlfind" "remove" "opium"]
+]
+
+depends: [
+  "ocamlfind"
+  "cohttp" {>= "0.10.0"}
+  "oasis"
+  "async"
+  "core"
+  "fieldslib"
+  "sexplib"
+  "cow"
+]
+
+ocaml-version: [>="4.01.0"]

--- a/packages/opium/opium.0.6.0/url
+++ b/packages/opium/opium.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/rgrinberg/opium/archive/v0.6.0.tar.gz"
+checksum: "40782c97e379b98ad7e7be6f89ca11b4"


### PR DESCRIPTION
pcre dependency is removed
tightened cohttp constraints (thanks @avsm)
