### PR TITLE
Add binary compiler for 4.01.0 by OCamlPro

### DIFF
--- a/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.comp
+++ b/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.comp
@@ -1,0 +1,19 @@
+opam-version: "1.1.0"
+version: "4.01.0+bin-ocp"
+src: "http://www.ocamlpro.com/public/2014/binaries/ocp-compiler-cache-v2.tar.gz"
+build: [
+       [ "mkdir" "-p" "%{prefix}%/../ocp-compiler-cache" ]
+       [ "./ocp-compiler-cache.sh"
+             "%{prefix}%/../ocp-compiler-cache"
+	     "4.01.0"
+             "http://www.ocamlpro.com"
+	     ]
+       [ "mkdir" "-p" "%{prefix}%/bin" ]
+       [ "mkdir" "-p" "%{prefix}%/man" ]
+       [ "mkdir" "-p" "%{prefix}%/lib/ocaml" ]
+       [ "rsync" "-auv" "ocaml/bin/." "%{prefix}%/bin/." ]
+       [ "rsync" "-auv" "ocaml/man/." "%{prefix}%/man/." ]
+       [ "rsync" "-auv" "ocaml/lib/ocaml/." "%{prefix}%/lib/ocaml/." ]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/ocaml/stublibs:%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.descr
+++ b/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.descr
@@ -1,0 +1,1 @@
+OCaml 4.01.0, binaries by OCamlPro


### PR DESCRIPTION
A binary distribution of OCaml 4.01.0, for now only for Linux 32 and 64 bits, compiled by OCamlPro. The first installation will download the binary archive (~65 MB), but subsequent ones will use the cache and be much faster than downloading and compiling the sources.
