### PR TITLE
IOCaml 0.4 server and kernels

### DIFF
--- a/packages/iocaml-kernel/iocaml-kernel.0.4.0/descr
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.0/descr
@@ -1,0 +1,1 @@
+An OCaml kernel for the IPython notebook.

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.0/files/iocaml-kernel.install
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.0/files/iocaml-kernel.install
@@ -1,0 +1,35 @@
+bin: ["_build/iocaml.top"]
+lib: [
+    "META"
+    "_build/iocaml.cmi" 
+    "_build/Ipython_json_t.cmi" 
+    "_build/Ipython_json_j.cmi" 
+    "_build/message.cmi" 
+    "_build/completion.cmi" 
+    "_build/log.cmi" 
+    "_build/sockets.cmi"
+    "_build/iocaml.cmt" 
+    "_build/Ipython_json_t.cmt" 
+    "_build/Ipython_json_j.cmt" 
+    "_build/message.cmt" 
+    "_build/completion.cmt" 
+    "_build/log.cmt" 
+    "_build/sockets.cmt"
+    "_build/iocaml.cmti" 
+    "_build/Ipython_json_t.cmti" 
+    "_build/Ipython_json_j.cmti" 
+    "_build/message.cmti" 
+    "_build/completion.cmti" 
+    "_build/log.cmti" 
+    "_build/sockets.cmti"
+]
+share: [ 
+    "profile/ipython_config.py" {"profile/ipython_config.py"}
+    "profile/static/custom/custom.js" {"profile/static/custom/custom.js"}
+    "notebooks/iocaml-development.ipynb"
+    "notebooks/iocaml-install.ipynb"
+    "notebooks/iocaml-test-notebook.ipynb"
+    "notebooks/iocaml-the-core-language.ipynb"
+    "notebooks/iocaml-using-tyxml.ipynb"
+    "notebooks/syntax-highlighting.ipynb"
+]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.0/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.1"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocaml"
+build: [
+  [make "all"]
+]
+remove: [
+]
+depends: [
+  "ocamlfind"
+  "ounit"
+  "uint" {>= "1.1.0"}
+  "uuidm"
+  "yojson"
+  "atdgen"
+  "ocp-index" {>= "1.0.1"} 
+  "zmq" {= "3.2-2"}
+]
+depexts: [
+  [["debian"] ["libzmq3-dev"]]
+  [["ubuntu"] ["libzmq3-dev"]]
+]
+ocaml-version: [ >= "4.01.0" ]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.0/url
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andrewray/iocaml/archive/v0.4.tar.gz"
+checksum: "1fca1fed3c9bc970e10836ec71c14235"

--- a/packages/iocaml/iocaml.0.4.2/descr
+++ b/packages/iocaml/iocaml.0.4.2/descr
@@ -1,0 +1,1 @@
+A webserver for iocaml-kernel and iocamljs-kernel.

--- a/packages/iocaml/iocaml.0.4.2/files/iocaml.install
+++ b/packages/iocaml/iocaml.0.4.2/files/iocaml.install
@@ -1,0 +1,1 @@
+bin: ["_build/iocamlserver.byte" {"iocaml"}]

--- a/packages/iocaml/iocaml.0.4.2/opam
+++ b/packages/iocaml/iocaml.0.4.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.1"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocamlserver"
+build: [
+  ["cp" "config.darwin.ml" "config.ml"] {os = "darwin"}
+  ["make" "all"]
+]
+remove: [
+]
+depends: [
+  "ocamlfind"
+  "uuidm"
+  "yojson"
+  "cow"
+  "zmq" {>= "3.2-2"}
+  "lwt" {>= "2.4"}
+  "lwt-zmq"
+  "websocket" {>= "0.8"}
+  "cohttp" {>= "0.10.0"}
+  "crunch"
+  "iocaml-kernel" {>= "0.4.0"}
+  "iocamljs-kernel" {>= "0.4.0"}
+]
+ocaml-version: [ >= "4.01.0" ]

--- a/packages/iocaml/iocaml.0.4.2/url
+++ b/packages/iocaml/iocaml.0.4.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andrewray/iocamlserver/archive/v0.4.2.tar.gz"
+checksum: "d03065eaecd8ddcce9ddb98fcff062b0"

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/descr
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/descr
@@ -1,0 +1,1 @@
+An OCaml javascript kernel for the IPython notebook. 

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/files/iocamljs-kernel.install
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/files/iocamljs-kernel.install
@@ -1,0 +1,7 @@
+share: [ 
+    "services/kernels/js/kernel.min.js"  { "profile/static/services/kernels/js/kernel.min.js" }
+    "services/kernels/js/kernel.full.js" { "profile/static/services/kernels/js/kernel.full.js" }
+    "services/kernels/js/kernel.full.js" { "profile/static/services/kernels/js/kernel.js" }
+    "custom/custom.js"                   { "profile/static/custom/custom.js" }
+    "custom/iocamljsnblogo.png"          { "profile/static/custom/iocamljsnblogo.png" }
+]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/opam
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/opam
@@ -1,0 +1,9 @@
+opam-version: "1.1"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocaml"
+depends: [
+  "ocamlfind"
+  "lwt" {>= "2.4"}
+  "js_of_ocaml"
+]
+ocaml-version: [ >= "4.01.0" ]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/url
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andrewray/iocamljs/releases/download/v0.4/static.tar.gz"
+checksum: "1aa9be6036263e9768a9901890f3ec6b"


### PR DESCRIPTION
This release adds a new server application (removing the requirement for
IPython to be installed at all) and 2 JavaScript kernels.

The packages have been logically reordered a bit;
- iocaml-kernel - equivalent to what was iocaml.0.3
- iocamljs-kernel - new; javascript kernels
- iocaml - new server application, replaces old iocaml.0.3

Installing iocaml should install all 3 packages.  The kernels can be individually installed if you want to still use IPython as the server.
