### PR TITLE
Updated the 'record_constructors' switch to latest branch

### DIFF
--- a/compilers/4.02.0dev/4.02.0dev+record_constructors/4.02.0dev+record_constructors.comp
+++ b/compilers/4.02.0dev/4.02.0dev+record_constructors/4.02.0dev+record_constructors.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.0dev"
-src: "https://github.com/ocaml/ocaml/archive/constructors_with_record2.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/constructors_with_record3.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]

--- a/compilers/4.02.0dev/4.02.0dev+record_constructors/4.02.0dev+record_constructors.descr
+++ b/compilers/4.02.0dev/4.02.0dev+record_constructors/4.02.0dev+record_constructors.descr
@@ -1,1 +1,1 @@
-Version of compiler that implements constructors with records suggestion
+Version of the compiler that implements the 'constructors with records' suggestion


### PR DESCRIPTION
All work is now taking place on this branch, so it's the only one worth having accessible (as discussed on [Mantis](http://caml.inria.fr/mantis/view.php?id=5528#c11256))
