### PR TITLE
SSL: add local patch for fixing accept handling until upstream release

### DIFF
--- a/packages/ssl/ssl.0.4.6a/descr
+++ b/packages/ssl/ssl.0.4.6a/descr
@@ -1,0 +1,1 @@
+Bindings for the libssl

--- a/packages/ssl/ssl.0.4.6a/files/fix-accept.diff
+++ b/packages/ssl/ssl.0.4.6a/files/fix-accept.diff
@@ -1,0 +1,51 @@
+commit 13f860b8165566bcf2b5c25ba5118eb330667625
+Author: Jérôme Vouillon <jerome.vouillon@gmail.com>
+Date:   Sun Jul 29 18:26:41 2012 +0200
+
+    A return value of 0 for SSL_connect/accept was not considered as an error
+
+diff --git a/src/ssl_stubs.c b/src/ssl_stubs.c
+index 2c4e492..d15e705 100644
+--- a/src/ssl_stubs.c
++++ b/src/ssl_stubs.c
+@@ -761,21 +761,15 @@ CAMLprim value ocaml_ssl_embed_socket(value socket_, value context)
+ CAMLprim value ocaml_ssl_connect(value socket)
+ {
+   CAMLparam1(socket);
+-  int ret;
++  int ret, err;
+   SSL *ssl = SSL_val(socket);
+ 
+   caml_enter_blocking_section();
+   ret = SSL_connect(ssl);
++  err = SSL_get_error(ssl, ret);
+   caml_leave_blocking_section();
+-  if (ret < 0)
+-  {
+-    int err;
+-
+-    caml_enter_blocking_section();
+-    err = SSL_get_error(ssl, ret);
+-    caml_leave_blocking_section();
++  if (err != SSL_ERROR_NONE)
+     caml_raise_with_arg(*caml_named_value("ssl_exn_connection_error"), Val_int(err));
+-  }
+ 
+   CAMLreturn(Val_unit);
+ }
+@@ -859,12 +853,10 @@ CAMLprim value ocaml_ssl_accept(value socket)
+   int ret, err;
+   caml_enter_blocking_section();
+   ret = SSL_accept(ssl);
+-  if (ret <= 0)
+-  {
+-    err = SSL_get_error(ssl, ret);
+-    caml_leave_blocking_section();
++  err = SSL_get_error(ssl, ret);
++  caml_leave_blocking_section();
++  if (err != SSL_ERROR_NONE)
+     caml_raise_with_arg(*caml_named_value("ssl_exn_accept_error"), Val_int(err));
+-  }
+   caml_leave_blocking_section();
+ 
+   CAMLreturn(Val_unit);

--- a/packages/ssl/ssl.0.4.6a/files/pkgconfigure
+++ b/packages/ssl/ssl.0.4.6a/files/pkgconfigure
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export LDFLAGS=`pkg-config libssl --libs`
+export CFLAGS=`pkg-config libssl --cflags`
+./configure $*

--- a/packages/ssl/ssl.0.4.6a/opam
+++ b/packages/ssl/ssl.0.4.6a/opam
@@ -1,0 +1,15 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+patches: ["fix-accept.diff"]
+build: [
+  ["./pkgconfigure" "--prefix" prefix] {os = "openbsd"}
+  ["./configure" "--prefix" prefix] {os != "openbsd"}
+  [make]
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "ssl"]]
+depends: ["ocamlfind"]
+depexts: [
+  [["debian"] ["libssl-dev"]]
+  [["ubuntu"] ["libssl-dev"]]
+]

--- a/packages/ssl/ssl.0.4.6a/url
+++ b/packages/ssl/ssl.0.4.6a/url
@@ -1,0 +1,2 @@
+archive: "http://downloads.sourceforge.net/project/savonet/ocaml-ssl/0.4.6/ocaml-ssl-0.4.6.tar.gz"
+checksum: "576c677bb70ea6552e4d49913c74d420"


### PR DESCRIPTION
See savonet/ocaml-ssl#7 for more details on why this is needed.  Do not merge until upstream acks.
