### PR TITLE
patch for coq when Make 4.0 is present (issue #1262)

### DIFF
--- a/packages/coq/coq.8.3/files/configure.patch
+++ b/packages/coq/coq.8.3/files/configure.patch
@@ -1,0 +1,11 @@
+--- configure	2014-04-14 22:28:39.174177924 +0200
++++ configure	2014-04-14 22:29:23.253025166 +0200
+@@ -335,7 +335,7 @@
+   MAKEVERSION=`$MAKE -v | head -1 | cut -d" " -f3`
+   MAKEVERSIONMAJOR=`echo $MAKEVERSION | cut -d. -f1`
+   MAKEVERSIONMINOR=`echo $MAKEVERSION | cut -d. -f2`
+-  if [ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 ]; then
++  if [ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 ] || [ "$MAKEVERSIONMAJOR" -ge 4 ] ; then
+       echo "You have GNU Make $MAKEVERSION. Good!"
+   else
+       OK="no"

--- a/packages/coq/coq.8.3/opam
+++ b/packages/coq/coq.8.3/opam
@@ -7,3 +7,4 @@ build: [
 ]
 depends: ["camlp5"]
 depopts: ["lablgtk"]
+patches: ["configure.patch"]

--- a/packages/coq/coq.8.4pl1/files/configure.patch
+++ b/packages/coq/coq.8.4pl1/files/configure.patch
@@ -1,0 +1,11 @@
+--- configure	2014-04-14 22:28:39.174177924 +0200
++++ configure	2014-04-14 22:29:23.253025166 +0200
+@@ -335,7 +335,7 @@
+   MAKEVERSION=`$MAKE -v | head -1 | cut -d" " -f3`
+   MAKEVERSIONMAJOR=`echo $MAKEVERSION | cut -d. -f1`
+   MAKEVERSIONMINOR=`echo $MAKEVERSION | cut -d. -f2`
+-  if [ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 ]; then
++  if [ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 ] || [ "$MAKEVERSIONMAJOR" -ge 4 ] ; then
+       echo "You have GNU Make $MAKEVERSION. Good!"
+   else
+       OK="no"

--- a/packages/coq/coq.8.4pl1/opam
+++ b/packages/coq/coq.8.4pl1/opam
@@ -10,4 +10,5 @@ depopts: ["lablgtk"]
 patches: [
   "coqmktop.patch"
   "CAML_LD_LIBRARY_PATH.patch"
+  "configure.patch"
 ]

--- a/packages/coq/coq.8.4pl2/files/configure.patch
+++ b/packages/coq/coq.8.4pl2/files/configure.patch
@@ -1,0 +1,11 @@
+--- configure	2014-04-14 22:28:39.174177924 +0200
++++ configure	2014-04-14 22:29:23.253025166 +0200
+@@ -335,7 +335,7 @@
+   MAKEVERSION=`$MAKE -v | head -1 | cut -d" " -f3`
+   MAKEVERSIONMAJOR=`echo $MAKEVERSION | cut -d. -f1`
+   MAKEVERSIONMINOR=`echo $MAKEVERSION | cut -d. -f2`
+-  if [ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 ]; then
++  if [ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 ] || [ "$MAKEVERSIONMAJOR" -ge 4 ] ; then
+       echo "You have GNU Make $MAKEVERSION. Good!"
+   else
+       OK="no"

--- a/packages/coq/coq.8.4pl2/opam
+++ b/packages/coq/coq.8.4pl2/opam
@@ -6,4 +6,4 @@ build: [
   [make "install"]
 ]
 depends: ["camlp5"]
-patches: ["CAML_LD_LIBRARY_PATH.patch"]
+patches: ["CAML_LD_LIBRARY_PATH.patch" "configure.patch"]


### PR DESCRIPTION
This should allow people with a more recent Makefile to build coq.

The patch is from the `configure` file of `8.4pl3`, but it may work for other versions too (for me it works on `8.3`). I hope this will fix the problem of people who have too recent a `make` (archlinux...)
