### PR TITLE
Use the official tarball release for oUnit.

### DIFF
--- a/packages/ounit/ounit.2.0.0/url
+++ b/packages/ounit/ounit.2.0.0/url
@@ -1,2 +1,2 @@
-archive: "http://opam.ocamlpro.com/archives/ounit.2.0.0+opam.tar.gz"
-checksum: "7ef765c73c29f7dd645c25ecce3c5163"
+archive: "http://forge.ocamlcore.org/frs/download.php/1258/ounit-2.0.0.tar.gz"
+checksum: "2e0a24648c55005978d4923eb4925b28"


### PR DESCRIPTION
This is preferable as it makes it clearer that this isn't a patched version of
oUnit. Moreover, the checksums between the official release and the
currently-used tarball differ.
