### PR TITLE
bencode_rpc

### DIFF
--- a/packages/bencode_rpc/bencode_rpc.0.2.1/descr
+++ b/packages/bencode_rpc/bencode_rpc.0.2.1/descr
@@ -1,0 +1,4 @@
+Remote Procedure Call in OCaml, with B-encode and Lwt.
+
+This library allows to communicate through the network (TCP) using
+a remote call abstraction. The data is serialized with Bencode.

--- a/packages/bencode_rpc/bencode_rpc.0.2.1/opam
+++ b/packages/bencode_rpc/bencode_rpc.0.2.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "simon.cruanes@inria.fr"
+homepage: "https://github.com/c-cube/bencode_rpc/"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make]
+  [make "install"]
+]
+remove: [[make "uninstall"]]
+depends: [
+  "ocamlfind"
+  "bencode"
+  "lwt"
+  "base-unix"
+]
+ocaml-version: [>= "4.00.0"]

--- a/packages/bencode_rpc/bencode_rpc.0.2.1/url
+++ b/packages/bencode_rpc/bencode_rpc.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/c-cube/bencode_rpc/archive/0.2.1.tar.gz"
+checksum: "3d6b3bb8a158df4d6876283196b576f2"


### PR DESCRIPTION
updated version, with a new API, of a simple RPC system that serializes messages in B-encode and uses Lwt to avoid blocking on responses from the remote side.
