### PR TITLE
qcheck 0.1 and 0.1.1: explicitly remove the library

### DIFF
--- a/packages/qcheck/qcheck.0.1.1/opam
+++ b/packages/qcheck/qcheck.0.1.1/opam
@@ -6,6 +6,6 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [[make "uninstall"]]
+remove: [["ocamlfind" "remove" "qcheck"]]
 depends: ["ocamlfind"]
 ocaml-version: [>= "4.00.0"]

--- a/packages/qcheck/qcheck.0.1/opam
+++ b/packages/qcheck/qcheck.0.1/opam
@@ -6,6 +6,6 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [[make "uninstall"]]
+remove: [["ocamlfind" "remove" "qcheck"]]
 depends: ["ocamlfind"]
 ocaml-version: [>= "4.00.0"]


### PR DESCRIPTION
This is a hint that these package versions also provide the findlib
library "qcheck".
