### PR TITLE
Compiler target for freebsd10 on armv6

### DIFF
--- a/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
+++ b/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
@@ -1,0 +1,16 @@
+opam-version: "1"
+version: "4.01.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+patches:["https://github.com/andrewray/mirage-fpga/releases/download/v0.1/freebsd10-armv6.patch"]
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.descr
+++ b/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.descr
@@ -1,0 +1,1 @@
+OCaml 4.01.0 with patches for native code compilation on armv6 FreeBSD10-RELEASE (ie raspberrypi)


### PR DESCRIPTION
Pulls in some small patches to the configure system and arm backend to target armv6 softfloat.  Tested with a Raspberry PI.

I have an OPAM binary for [this system](https://github.com/andrewray/mirage-fpga/releases) as well.

Hopefully with this patch we should be able to get ocaml going with;

```
$ opam init --comp=4.01.0+armv6-freebsd
```
