### PR TITLE
bt.0.1.2: add cohttp version constraint

### DIFF
--- a/packages/bt/bt.0.1.2/opam
+++ b/packages/bt/bt.0.1.2/opam
@@ -14,7 +14,7 @@ remove: [
 depends: [
   "bitstring"
   "cmdliner"
-  "cohttp"
+  "cohttp" {>= "0.11.2"}
   ("cryptokit" | "cryptokit-sha512")
   "lwt"
   "ocamlfind"


### PR DESCRIPTION
This should solve @jpdeplaix's issue in #1915.
