### PR TITLE
fix remove/reinstall of config-file

### DIFF
--- a/packages/config-file/config-file.1.2/opam
+++ b/packages/config-file/config-file.1.2/opam
@@ -11,5 +11,5 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [[ocamlfind "remove" "config-file"]]
+remove: [["ocamlfind" "remove" "config-file"]]
 depends: ["ocamlfind"]


### PR DESCRIPTION
A remove/reinstall of config-file failed like this:
[ERROR] global-config does not define the variable ocamlfind.
[ERROR] global-config does not define the variable ocamlfind.
