### PR TITLE
fix uri.1.6.0 syntax

### DIFF
--- a/packages/uri/uri.1.6.0/opam
+++ b/packages/uri/uri.1.6.0/opam
@@ -24,4 +24,4 @@ depends: [
   "stringext"
 ]
 depopts: ["ounit"]
-conflicts: [ounit {< "1.0.2"}]
+conflicts: ["ounit" {< "1.0.2"}]


### PR DESCRIPTION
opam-admin check was failing:
Fatal error: exception OpamSystem.Internal_error("File /home/edwin/something/opam-repository/packages/uri/uri.1.6.0/opam: Bad format! Expected a formula list of the form [ "item" {condition}... ], got option(ident(ounit),{symbol(<) string("1.0.2")})")
