### PR TITLE
Convert lwt depopt constraint into a conflict

### DIFF
--- a/packages/lwt/lwt.2.4.5/opam
+++ b/packages/lwt/lwt.2.4.5/opam
@@ -12,7 +12,9 @@ depopts: [
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {>= "1.0.0" }
+  "react"
   "lablgtk"
   "ocaml-text"
 ]
+conflicts: [ "react" {<"1.0.0"} ]
+


### PR DESCRIPTION
This ensures that the wrong version of react wont be picked up
when installing eliom
