### PR TITLE
Riakc depends on async_core, which has been renamed async_kernel.

### DIFF
--- a/packages/riakc/riakc.0.0.0/opam
+++ b/packages/riakc/riakc.0.0.0/opam
@@ -8,7 +8,7 @@ remove: [["ocamlfind" "remove" "riakc"]]
 depends: [
   "ocamlfind"
   "core" {= "108.08.00"}
-  "async"
+  "async" {< "109.58.00"}
   "protobuf"
 ]
 depexts: [

--- a/packages/riakc/riakc.1.0.0/opam
+++ b/packages/riakc/riakc.1.0.0/opam
@@ -8,7 +8,7 @@ remove: [["ocamlfind" "remove" "riakc"]]
 depends: [
   "ocamlfind"
   "core" {>= "109.12.00"}
-  "async"
+  "async" {< "109.58.00"}
   "protobuf"
 ]
 depexts: [

--- a/packages/riakc/riakc.2.0.0/opam
+++ b/packages/riakc/riakc.2.0.0/opam
@@ -8,7 +8,7 @@ remove: [["ocamlfind" "remove" "riakc"]]
 depends: [
   "ocamlfind"
   "core" {>= "109.12.00"}
-  "async"
+  "async" {< "109.58.00"}
   "protobuf"
 ]
 depexts: [


### PR DESCRIPTION
Constrain to relevant async version pending a new release /cc @orbitz
