### PR TITLE
Fix and update why3

### DIFF
--- a/packages/why3/why3.0.81/url
+++ b/packages/why3/why3.0.81/url
@@ -1,2 +1,2 @@
-archive: "http://why3.lri.fr/download/why3-0.81.tar.gz"
+archive: "https://gforge.inria.fr/frs/download.php/33491/why3-0.81.tar.gz"
 checksum: "82253969f7bc8ea88ca60ee694909b31"

--- a/packages/why3/why3.0.82/url
+++ b/packages/why3/why3.0.82/url
@@ -1,2 +1,2 @@
-archive: "http://why3.lri.fr/download/why3-0.82.tar.gz"
+archive: "https://gforge.inria.fr/frs/download.php/33492/why3-0.82.tar.gz"
 checksum: "1f43a3e7c753f86e2f7fe400899ee6b8"

--- a/packages/why3/why3.0.83/descr
+++ b/packages/why3/why3.0.83/descr
@@ -1,0 +1,20 @@
+Why3 is a platform for deductive program verification.
+
+It provides a rich language for specification and programming, called
+WhyML, and relies on external theorem provers, both automated and
+interactive, to discharge verification conditions. Why3 comes with a
+standard library of logical theories (integer and real arithmetic,
+Boolean operations, sets and maps, etc.) and basic programming data
+structures (arrays, queues, hash tables, etc.). A user can write WhyML
+programs directly and get correct-by-construction OCaml programs
+through an automated extraction mechanism. WhyML is also used as an
+intermediate language for the verification of C, Java, or Ada
+programs.
+
+Why3 is a complete reimplementation of the former Why platform. Among
+the new features are: numerous extensions to the input language, a new
+architecture for calling external provers, and a well-designed API,
+allowing to use Why3 as a software library. An important emphasis is
+put on modularity and genericity, giving the end user a possibility to
+easily reuse Why3 formalizations or to add support for a new external
+prover if wanted.

--- a/packages/why3/why3.0.83/opam
+++ b/packages/why3/why3.0.83/opam
@@ -1,0 +1,37 @@
+opam-version: "1"
+maintainer: "Francois.Bobot@cea.fr"
+authors: [
+  "François Bobot"
+  "Jean-Christophe Filliâtre"
+  "Claude Marché"
+  "Guillaume Melquiond"
+  "Andrei Paskevich"
+]
+homepage: "http://why3.lri.fr/"
+license: "GNU Lesser General Public License version 2.1"
+doc: ["http://why3.lri.fr/#documentation"]
+tags: [
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+]
+build: [
+  ["./configure" "--prefix" prefix "--sbindir=%{lib}%/why3/sbin" "--libexecdir=%{lib}%/why3/libexec" "--sysconfdir=%{lib}%/why3/etc" "--sharedstatedir=%{lib}%/why3/com" "--localstatedir=%{lib}%/why3/var" "--libdir=%{lib}%/why3/lib" "--includedir=%{lib}%/why3/include" "--datarootdir=%{lib}%/why3/share" "--disable-bench"]
+  [make "opt" "byte"]
+  [make "install" "install-lib"]
+]
+build-doc: [
+  [make "stdlibdoc" "apidoc"]
+  [make "DOCDIR=%{doc}%/why3" "install-doc"]
+]
+depends: [
+  "alt-ergo"
+  "lablgtk"
+  "conf-gtksourceview"
+]
+depopts: [
+  "ocamlgraph" {>= "1.8.2"}
+  "coq" {>= "8.3"}
+]

--- a/packages/why3/why3.0.83/url
+++ b/packages/why3/why3.0.83/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/33490/why3-0.83.tar.gz"
+checksum: "35f99e5f64939e50ea57f641ba2073ec"


### PR DESCRIPTION
The archives of Why3 doesn't seems to be available anymore at http://why3.lri.fr/download/ and there was a new release.

@bobot: I removed your Makefile patch for the 0.83, I hope it's fine.
