### PR TITLE
ox: Add version constraint to openflow dependency

### DIFF
--- a/packages/ox/ox.1.0.1/opam
+++ b/packages/ox/ox.1.0.1/opam
@@ -11,5 +11,5 @@ depends: [
   "lwt"
   "cstruct"
   "packet"
-  "openflow"
+  "openflow" {< "0.3.0"}
 ]


### PR DESCRIPTION
The lwt runtime code was removed in version 0.3.0, so ox must depend on an earlier version.

Related to frenetic-lang/ox#2
