### PR TITLE
Remove runtime dependency on ospec

### DIFF
--- a/packages/uint/uint.1.1.1/opam
+++ b/packages/uint/uint.1.1.1/opam
@@ -8,4 +8,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "uint"]
 ]
-depends: ["ocamlfind" "ospec" {>= "0.3.1"}]
+depends: ["ocamlfind"]


### PR DESCRIPTION
ospec is required neither for building nor for running uint.
