### PR TITLE
Add compilers using musl-gcc: 4.01.0+musl, 4.01.0+musl+static

### DIFF
--- a/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.comp
+++ b/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.comp
@@ -1,0 +1,20 @@
+opam-version: "1"
+version: "4.01.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"
+    "-cc" "musl-gcc -Os"
+    "-aspp" "musl-gcc -c"
+    "-libs" "-static"
+    "-no-tk" "-no-curses" "-no-graph"
+    "-no-shared-libs"
+    ]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.descr
+++ b/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.descr
@@ -1,0 +1,3 @@
+4.01.0 release compiled with musl-gcc -static
+
+Requires musl-gcc to be installed (apt-get install musl-tools on Debian)

--- a/compilers/4.01.0/4.01.0+musl/4.01.0+musl.comp
+++ b/compilers/4.01.0/4.01.0+musl/4.01.0+musl.comp
@@ -1,0 +1,18 @@
+opam-version: "1"
+version: "4.01.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"
+    "-cc" "musl-gcc -Os"
+    "-aspp" "musl-gcc -c"
+    "-no-tk" "-no-curses" "-no-graph"
+    ]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+musl/4.01.0+musl.descr
+++ b/compilers/4.01.0/4.01.0+musl/4.01.0+musl.descr
@@ -1,0 +1,3 @@
+4.01.0 release compiled with musl-gcc
+
+Requires musl-gcc to be installed (apt-get install musl-tools on Debian)


### PR DESCRIPTION
Requires musl-gcc to be installed (apt-get install musl-tools on Debian).

Note: the +musl+static can be used to build fully statically linked applications (something you can't do with glibc due to gethostbyname etc.) that will run on multiple distributions.
It might be useful for small self-contained applications, or for solving bootstrap problems like building an opam binary that would run on CentOS 6.
