### PR TITLE
Add compiler using LSB: 4.01.0+lsb

### DIFF
--- a/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
+++ b/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
@@ -1,0 +1,27 @@
+opam-version: "1"
+version: "4.01.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+build: [
+  ["sed" "-i" "-e" "s/lcurses/lncurses/" "configure"]
+  ["sed" "-i" "-e"
+   "s/typedef greg_t context_reg;/#include <ucontext.h>\\ntypedef greg_t context_reg;/"
+   "asmrun/signals_osdep.h"
+  ]
+  ["./configure" "-prefix" prefix "-with-debug-runtime"
+    "-cc" "/opt/lsb/bin/lsbcc"
+    "-aspp" "/opt/lsb/bin/lsbcc -c"
+    "-no-shared-libs"
+  ]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [
+    [LSBCC_LSBVERSION = "4.0"]
+    [LSBCC_BESTEFFORT = "1"]
+    [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]

--- a/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.descr
+++ b/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.descr
@@ -1,0 +1,4 @@
+4.01.0 release compiled with lsbcc.
+
+Requires the Linux Standard Base SDK installed in /opt/lsb:
+http://www.linuxfoundation.org/collaborate/workgroups/lsb/download


### PR DESCRIPTION
Requires the Linux Standard Base SDK: http://www.linuxfoundation.org/collaborate/workgroups/lsb/download

Note: this can be used to build LSB-compliant binaries that will run on multiple distributions.
For example to solve a bootstrap problem and build an 'opam' binary that will run on CentOS 6.
