### PR TITLE
Updated checksum -- appears the archive has changed at Github

### DIFF
--- a/packages/camlpdf/camlpdf.1.7/url
+++ b/packages/camlpdf/camlpdf.1.7/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/johnwhitington/camlpdf/archive/v1.7.tar.gz"
-checksum: "76bc26b7b4df28c6945127fcc7c51a9e"
+checksum: "a777850789cc309ded0eb18d36b70d9c"


### PR DESCRIPTION
Anil reports the checksum of the archive for CamlPDF 1.7 has changed. There have been no code changes, however.

I found references on the web to the fact that, if Github regenerates the archive for whatever reason, and uses gzip rather than gzip -n, the name of the file and the timestamp become part of the archive, and so the checksum changes.

I still don't actually know what happened in this case, though.

The archive for CamlPDF 1.7.1 has not had its checksum changed -- it is still correct.
