### PR TITLE
Remove trailing space from lacc distfiles that broke retrieval.

### DIFF
--- a/packages/lacc/lacc.0.1/url
+++ b/packages/lacc/lacc.0.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/UnixJunkie/lacc/archive/v0.1.tar.gz "
+archive: "https://github.com/UnixJunkie/lacc/archive/v0.1.tar.gz"
 checksum: "b04fd9155690e2d1c63369d3cbe410fa"

--- a/packages/lacc/lacc.0.2/url
+++ b/packages/lacc/lacc.0.2/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/UnixJunkie/lacc/archive/v0.2.tar.gz "
+archive: "https://github.com/UnixJunkie/lacc/archive/v0.2.tar.gz"
 checksum: "facc2c90c0e07784ab9f2c59ad2e8644"


### PR DESCRIPTION
( this used to work in OPAM 1.1.0, it appears from
https://travis-ci.org/ocaml/opam-repository/jobs/18316424 )
