### PR TITLE
add OS X clang patch to 4.01.0+PIC and +fp

### DIFF
--- a/compilers/4.01.0/4.01.0+PIC/4.01.0+PIC.comp
+++ b/compilers/4.01.0/4.01.0+PIC/4.01.0+PIC.comp
@@ -1,6 +1,7 @@
 opam-version: "1"
 version: "4.01.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -fPIC" "-aspp" "gcc -c -fPIC"]
   [make "world"]

--- a/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
+++ b/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
@@ -1,6 +1,7 @@
 opam-version: "1"
 version: "4.01.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
   [make "world"]


### PR DESCRIPTION
After this patch, all switches that are supposed to compile on OS X
using clang have this patch:

$grep -Rl bd7fa181cb64742c3b6cbb8ee13436554eb18cd7 *
4.01.0/4.01.0.comp
4.01.0+32bit/4.01.0+32bit.comp
4.01.0+BER.comp
4.01.0+PIC/4.01.0+PIC.comp
4.01.0+fp/4.01.0+fp.comp
4.01.0+jocaml/4.01.0+jocaml.comp
4.01.0+open-types/4.01.0+open-types.comp
