### PR TITLE
beluga: remove broken remove instruction (it removes oUnit instead of beluga)

### DIFF
--- a/packages/beluga/beluga.0.5/opam
+++ b/packages/beluga/beluga.0.5/opam
@@ -1,7 +1,6 @@
 opam-version: "1"
 maintainer: "fferre8@cs.cmgill.ca"
 build: [["omake" "NATIVE_ENABLED=true"]]
-remove: [["ocamlfind" "remove" "oUnit"]]
 depends: [
   "ocamlfind"
   ("extlib" | "extlib-compat")


### PR DESCRIPTION
When you remove the "beluga" package (or when you try to install it and it fails), it removes oUnit from ocamlfind (but of course not from opam's index). This is particularly bad because it desynchronizes ocamlfind from opam.

In this patch, I just removed the offending line, but it probably should be replaced by something else. I don't know what exactly because beluga fails to compile on my setup for other reasons.
