### PR TITLE
iocaml-kernel depends on older Ctypes due to Array->CArray change

### DIFF
--- a/packages/iocaml-kernel/iocaml-kernel.0.4.3/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.3/opam
@@ -17,7 +17,7 @@ depends: [
   "atdgen"
   "ocp-index" {>= "1.0.1"} 
   "lwt" {>= "2.4"}
-  "ctypes" {>= "0.2.3" & < "0.3.0"}
+  "ctypes" {>= "0.2.3" & < "0.3"}
 ]
 depexts: [
   [["debian"] ["libzmq3-dev"]]


### PR DESCRIPTION
See andrewray/iocaml#20
