### PR TITLE
lwt-zmq 1.0.0 doesn't work with the latest zmq

### DIFF
--- a/packages/lwt-zmq/lwt-zmq.1.0.0/opam
+++ b/packages/lwt-zmq/lwt-zmq.1.0.0/opam
@@ -13,6 +13,6 @@ remove: [
 ]
 depends: [
   "lwt"
-  "zmq"
+  "zmq" {< "4.0-1"}
   "ocamlfind"
 ]


### PR DESCRIPTION
Exceptions changed which break the Lwt wrapping.
