### PR TITLE
constrain websocket to ocplib-endian 0.4

### DIFF
--- a/packages/websocket/websocket.0.8.1/opam
+++ b/packages/websocket/websocket.0.8.1/opam
@@ -14,6 +14,6 @@ depends: [
   "cryptokit"
   "cohttp" {>= "0.10.0"}
   "ssl"
-  "ocplib-endian"
+  "ocplib-endian" {= "0.4"}
 ]
 ocaml-version: [>="4.00.0"]


### PR DESCRIPTION
will provide a proper fix to websocket next week.
