### PR TITLE
Add ocplib-endian 0.7 (fix missing ocamlfind dependency)

### DIFF
--- a/packages/ocplib-endian/ocplib-endian.0.7/descr
+++ b/packages/ocplib-endian/ocplib-endian.0.7/descr
@@ -1,0 +1,6 @@
+Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01.
+
+The library implements three modules:
+* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;

--- a/packages/ocplib-endian/ocplib-endian.0.7/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.7/opam
@@ -1,0 +1,15 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+homepage: "https://github.com/OCamlPro/ocplib-endian"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--disable-debug" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [["ocamlfind" "remove" "ocplib-endian"]]
+depends: [
+  "ocamlfind"
+  "optcomp"
+  "camlp4"
+  "bytes" { >= "1.1" }
+]

--- a/packages/ocplib-endian/ocplib-endian.0.7/url
+++ b/packages/ocplib-endian/ocplib-endian.0.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/OCamlPro/ocplib-endian/archive/0.7.tar.gz"
+checksum: "c5d7ddb431dc10b01718fe303e642491"


### PR DESCRIPTION
Fix problem with Bytes.t being different from string.

By the way, Bytes 1.0 and ocplib-endian 0.6 are broken, hence should probably be removed.
What is the policy about that ? Should I propose a patch removing it ?
