### PR TITLE
fixup the websocket ocplib-endian dependency to be less strict

### DIFF
--- a/packages/websocket/websocket.0.7/opam
+++ b/packages/websocket/websocket.0.7/opam
@@ -14,6 +14,6 @@ depends: [
   "cryptokit"
   "cohttp" {>= "0.10.0"}
   "ssl"
-  "ocplib-endian"
+  "ocplib-endian" {>="0.4"}
 ]
 ocaml-version: [>="4.00.0"]

--- a/packages/websocket/websocket.0.8.1/opam
+++ b/packages/websocket/websocket.0.8.1/opam
@@ -14,6 +14,6 @@ depends: [
   "cryptokit"
   "cohttp" {>= "0.10.0"}
   "ssl"
-  "ocplib-endian" {= "0.4"}
+  "ocplib-endian" {>= "0.4"}
 ]
 ocaml-version: [>="4.00.0"]

--- a/packages/websocket/websocket.0.8/opam
+++ b/packages/websocket/websocket.0.8/opam
@@ -14,6 +14,6 @@ depends: [
   "cryptokit"
   "cohttp" {>= "0.10.0"}
   "ssl"
-  "ocplib-endian"
+  "ocplib-endian" {>="0.4"}
 ]
 ocaml-version: [>="4.00.0"]


### PR DESCRIPTION
Followup to #2154
