### PR TITLE
Add Coq 8.4pl4

### DIFF
--- a/packages/coq/coq.8.4pl4/descr
+++ b/packages/coq/coq.8.4pl4/descr
@@ -1,0 +1,2 @@
+Formal proof management system
+

--- a/packages/coq/coq.8.4pl4/files/coq.install
+++ b/packages/coq/coq.8.4pl4/files/coq.install
@@ -1,0 +1,13 @@
+bin: [
+  "bin/gallina"
+  "bin/coqwc"
+  "bin/coqtop.opt" {"coqtop"}
+  "bin/coqmktop.opt" {"coqmktop"}
+  "?bin/coqide.opt" {"coqide"}
+  "bin/coqdoc"
+  "bin/coqdep"
+  "bin/coqchk.opt" {"coqchk"}
+  "bin/coqc.opt" {"coqc"}
+  "bin/coq_makefile"
+  "bin/coq-tex"
+]

--- a/packages/coq/coq.8.4pl4/opam
+++ b/packages/coq/coq.8.4pl4/opam
@@ -1,0 +1,9 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+build: [
+  ["./configure" "-configdir" "%{lib}%/coq/config" "-mandir" man "-docdir" doc "--prefix" prefix "--usecamlp5" "--camlp5dir" "%{lib}%/camlp5" "--coqide" "no"]
+  [make "world" "states"]
+  [make "install"]
+]
+depends: ["camlp5"]
+patches: []

--- a/packages/coq/coq.8.4pl4/url
+++ b/packages/coq/coq.8.4pl4/url
@@ -1,0 +1,2 @@
+archive: "http://coq.inria.fr/distrib/V8.4pl4/files/coq-8.4pl4.tar.gz"
+checksum: "6a9f61cf0ece644b170f722fbc8cf2a1"


### PR DESCRIPTION
As a solution for #2161, this commit adds Coq 8.4pl4 (newest version at 2014/06/03) to opam-repository.
