### PR TITLE
Add dependency on conf-glade to gtktop.

### DIFF
--- a/packages/gtktop/gtktop.2.0/opam
+++ b/packages/gtktop/gtktop.2.0/opam
@@ -10,5 +10,6 @@ depends: [
   "ocamlfind"
   "lablgtk-extras" {>= "1.2"}
   "lablgtk" {>= "2.16.0"}
+  "conf-glade"
 ]
 ocaml-version: [>= "4.00.0"]


### PR DESCRIPTION
Fixes errors for
- [gtk-top](https://github.com/ocaml/opam-bulk-logs/blob/master/20140606/roo/4.01.0/raw/gtktop#L1784-L1813)
- [ocamltop-gtk](https://github.com/ocaml/opam-bulk-logs/blob/master/20140606/roo/4.01.0/raw/ocamltop-gtk#L1787-L1816)
