### PR TITLE
Update async_graphics.0.5 dependencies

### DIFF
--- a/packages/async_graphics/async_graphics.0.5/opam
+++ b/packages/async_graphics/async_graphics.0.5/opam
@@ -10,5 +10,5 @@ build: [["./install.sh"]]
 remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
   "ocamlfind"
-  "async"
+  "async" {>= "109.09.00"}
 ]


### PR DESCRIPTION
async_graphics.0.5 depends on at least version 109.09.00 of async
