### PR TITLE
Revert "Add ocamlfind 1.5.1"

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.5.1/descr
+++ b/packages/ocamlfind/ocamlfind.1.5.1/descr
@@ -1,6 +1,0 @@
-A library manager for OCaml
-Findlib is a library manager for OCaml. It provides a convention how
-to store libraries, and a file format ("META") to describe the
-properties of libraries. There is also a tool (ocamlfind) for
-interpreting the META files, so that it is very easy to use libraries
-in programs and scripts.

--- a/packages/ocamlfind/ocamlfind.1.5.1/files/ocamlfind.install
+++ b/packages/ocamlfind/ocamlfind.1.5.1/files/ocamlfind.install
@@ -1,6 +1,0 @@
-bin: [
-  "src/findlib/ocamlfind" {"ocamlfind"}
-  "?src/findlib/ocamlfind_opt" {"ocamlfind"}
-  "?tools/safe_camlp4"
-]
-toplevel: ["src/findlib/topfind"]

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -1,8 +1,0 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
-build: [
-  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
-  [make "all"]
-  [make "opt"]
-  [make "install"]
-]

--- a/packages/ocamlfind/ocamlfind.1.5.1/url
+++ b/packages/ocamlfind/ocamlfind.1.5.1/url
@@ -1,2 +1,0 @@
-archive: "http://download.camlcity.org/download/findlib-1.5.1.tar.gz"
-checksum: "6bf0d0da66104bc8bdcb3018bd13a202"


### PR DESCRIPTION
Reverts ocaml/opam-repository#2289

Suspicious failure on https://travis-ci.org/ocaml/opam-repository/jobs/28454399, reverting for now on:

```
===== ERROR while installing ocamlfind.1.5.1 =====
# opam-version 1.1.1
# os           linux
# command      make install
# path         /home/travis/.opam/system/build/ocamlfind.1.5.1
# compiler     system (4.01.0)
# exit-code    2
# env-file     /home/travis/.opam/system/build/ocamlfind.1.5.1/ocamlfind-7038-a00279.env
# stdout-file  /home/travis/.opam/system/build/ocamlfind.1.5.1/ocamlfind-7038-a00279.out
# stderr-file  /home/travis/.opam/system/build/ocamlfind.1.5.1/ocamlfind-7038-a00279.err
### stdout ###
# ...[truncated]
# # the following "if" block is only needed for 4.00beta2
# if [ 1 -eq 0 -a -f "/usr/lib/ocaml/compiler-libs/topdirs.cmi" ]; then \
#       cd "/usr/lib/ocaml/compiler-libs/"; \
#       cp topdirs.cmi toploop.cmi "/home/travis/.opam/system/lib/findlib/"; \
#   fi
# make[1]: Leaving directory `/home/travis/.opam/system/build/ocamlfind.1.5.1/src/findlib'
# make[1]: Entering directory `/home/travis/.opam/system/build/ocamlfind.1.5.1/src/bytes'
# ocamlbuild -classic-display -no-links bytes.cmi bytes.cma
# cd _build/ && ocamlfind install bytes ../META bytes.cmi bytes.cma -optional bytes.cmx bytes.cmxa bytes.a bytes.cmxs
# make[1]: Leaving directory `/home/travis/.opam/system/build/ocamlfind.1.5.1/src/bytes'
### stderr ###
# Makefile:150: depend: No such file or directory
# File "topfind.ml", line 54, characters 10-19:
# Warning 26: unused variable stdlibdir.
# File "topfind.ml", line 116, characters 11-12:
# Warning 26: unused variable d.
# ocamlfind: Package bytes is already installed
#  - (file /home/travis/.opam/system/lib/bytes/META already exists)
# make[1]: *** [install] Error 2
# make: *** [install] Error 2
```
