### PR TITLE
bibtex2html version 1.98

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.98/descr
+++ b/packages/bibtex2html/bibtex2html.1.98/descr
@@ -1,0 +1,1 @@
+BibTeX to HTML translator

--- a/packages/bibtex2html/bibtex2html.1.98/opam
+++ b/packages/bibtex2html/bibtex2html.1.98/opam
@@ -1,0 +1,15 @@
+opam-version: "1"
+maintainer: "filliatr@lri.fr"
+authors: [
+  "Jean-Christophe Filliâtre"
+  "Claude Marché"
+]
+license: "GNU General Public License version 2"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+  [make "install"]
+]
+depends: [
+  "hevea"
+]

--- a/packages/bibtex2html/bibtex2html.1.98/url
+++ b/packages/bibtex2html/bibtex2html.1.98/url
@@ -1,0 +1,2 @@
+archive: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.98.tar.gz"
+checksum: "33a96d32d6ca870163855573253aa720"


### PR DESCRIPTION
This is a new release of bibtex2html (version 1.98)
