### PR TITLE
Add ocaml-lz4

### DIFF
--- a/packages/lz4/lz4.1.0.0/descr
+++ b/packages/lz4/lz4.1.0.0/descr
@@ -1,0 +1,1 @@
+Bindings for LZ4, a very fast lossless compression algorithm

--- a/packages/lz4/lz4.1.0.0/opam
+++ b/packages/lz4/lz4.1.0.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1"
+maintainer: "whitequark@whitequark.org"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [["ocamlfind" "remove" "lz4"]]
+depends: ["base-bytes" "ocamlfind" "ctypes" {>= "0.3.2"}]
+depexts: [
+  [["debian"] ["liblz4-dev"]]
+  # [["ubuntu"] ["liblz4-dev"]] reenable when CI updates its Ubuntu
+  [["source"] ["https://gist.githubusercontent.com/whitequark/eef074a8daa14602e447/raw/c151d3ab2f35f6cac54c7ef7459e2bbfff852938/install.sh"]]
+]

--- a/packages/lz4/lz4.1.0.0/url
+++ b/packages/lz4/lz4.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/whitequark/ocaml-lz4/archive/v1.0.0.zip"
+checksum: "cd0ade08f41cd743a646c0ac4498ce57"


### PR DESCRIPTION
JaneStreet has taken the name "lz4" already, but that package exports unsafe alpha-quality bindings dependent on Core, which are also ungoogleable and have no published documentation (otherwise I'd have found them).
