### PR TITLE
sha.1.9: build on FreeBSD from vincenthz/ocaml-sha#12

### DIFF
--- a/packages/sha/sha.1.9/files/freebsd.patch
+++ b/packages/sha/sha.1.9/files/freebsd.patch
@@ -1,0 +1,24 @@
+From 56887bebdd395b9e98045d7d174d5d14a01c9e2b Mon Sep 17 00:00:00 2001
+From: Mykola Stryebkov <nick@mykola.org>
+Date: Fri, 10 Jan 2014 17:02:42 +0200
+Subject: [PATCH] Get endian.h from the right place at FreeBSD
+
+---
+ bitfn.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/bitfn.h b/bitfn.h
+index 525043b..87f5cf2 100644
+--- a/bitfn.h
++++ b/bitfn.h
+@@ -67,6 +67,8 @@ static inline uint64_t swap64(uint64_t a)
+ /* big endian to cpu */
+ #ifdef __APPLE__
+ #include <architecture/byte_order.h>
++#elif defined(__FreeBSD__)
++#include <sys/endian.h>
+ #else
+ #include <endian.h>
+ #endif
+-- 
+1.9.3

--- a/packages/sha/sha.1.9/opam
+++ b/packages/sha/sha.1.9/opam
@@ -5,5 +5,6 @@ build: [
   [make]
   [make "install"]
 ]
+patches: ["freebsd.patch"]
 remove: [["ocamlfind" "remove" "sha"]]
 depends: ["ocamlfind"]


### PR DESCRIPTION
6 months is long enough to fix this in the distribution.
