### PR TITLE
base-bytes.base should also require ocamlfind >= 1.5.1

### DIFF
--- a/packages/base-bytes/base-bytes.base/opam
+++ b/packages/base-bytes/base-bytes.base/opam
@@ -1,3 +1,4 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
+depends: ["ocamlfind" {>= "1.5.1"}]
 ocaml-version: [>= "4.02.0"]


### PR DESCRIPTION
otherwise package bytes is not available
