### PR TITLE
NOTMERGE: Trying to install Qt5 from debs manually

### DIFF
--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -8,7 +8,7 @@ build: [
 ]
 
 depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/Kakadu/7d1a144856d292d3e80e/raw/5cdd43e3898773340e13c74b1f2dd36c081e2cfd/get_qt5.sh" ] ]
+  [ ["source" "linux"] ["https://gist.githubusercontent.com/Kakadu/7d1a144856d292d3e80e/raw/c336690c7022e6b4db68d1112c4b46a3289c1fa9/get_qt5.sh" ] ] 
 
 ]
 


### PR DESCRIPTION
I continue trying to install Qt5 on Ubuntu 12.04 right. See previous episode at #2353.

I will write explicitly when patch will be ready to be merged..
