### PR TITLE
llvm: Improve the script and the compatibility with Mac OS X

### DIFF
--- a/packages/llvm/llvm.3.4/files/compile.sh
+++ b/packages/llvm/llvm.3.4/files/compile.sh
@@ -1,12 +1,37 @@
 #!/bin/sh
 
 version=3.4
+make=$1
+prefix=$2
+libdir=$3
 
-for config in llvm-config-$version llvm-config-mp-$version llvm-config; do
-    case `$config --version` in
+brew_llvm_config=/usr/local/Cellar/llvm/${version}*/bin/llvm-config
+if ! stat -t $brew_llvm_config
+then
+    brew_llvm_config=
+fi
+
+execute() {
+    echo "Executing: $@"
+    "$@"
+}
+
+common_configure() {
+    execute ./configure CC=gcc CXX=g++ --prefix="$prefix" --disable-doxygen --disable-docs --enable-static "$@" --with-ocaml-libdir="$libdir/llvm"
+}
+
+for config in llvm-config-$version llvm-config-mp-$version $brew_llvm_config llvm-config; do
+    case `"$config" --version` in
         $version|$version.*)
-            $1 -C bindings/ocaml build SYSTEM_LLVM_CONFIG=$config
-            $1 -C bindings/ocaml install SYSTEM_LLVM_CONFIG=$config
+            case `uname -s` in
+                Darwin)
+                    common_configure --disable-shared || exit 1;;
+                *)
+                    common_configure --enable-shared || exit 1;;
+            esac
+            "$make" -C bindings/ocaml build SYSTEM_LLVM_CONFIG="$config" || exit 1
+            "$make" -C bindings/ocaml install SYSTEM_LLVM_CONFIG="$config" || exit 1
+            cp "$libdir/llvm/META.llvm" "$libdir/llvm/META" || exit 1
             exit 0;;
         *)
             continue;;

--- a/packages/llvm/llvm.3.4/opam
+++ b/packages/llvm/llvm.3.4/opam
@@ -5,9 +5,7 @@ patches: [
   "makefile+system.patch"
 ]
 build: [
-  ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--disable-doxygen" "--disable-docs" "--enable-static" "--enable-shared" "--with-ocaml-libdir=%{lib}%/llvm"]
-  ["./compile.sh" make]
-  ["cp" "%{lib}%/llvm/META.llvm" "%{lib}%/llvm/META"]
+  ["./compile.sh" make prefix lib]
 ]
 remove: [
   ["./configure" "CC=gcc" "CXX=g++" "--prefix=%{prefix}%" "--disable-doxygen" "--disable-docs" "--enable-static" "--enable-shared" "--with-ocaml-libdir=%{lib}%/llvm"]


### PR DESCRIPTION
Workaround for #2358.

@artagnon @toroidal-code @maverickwoo @gudbergur It should work even without the symlink to the good llvm-config if you are using homebrew.
