### PR TITLE
packaged APRON

### DIFF
--- a/packages/apron/apron.0.9.10/descr
+++ b/packages/apron/apron.0.9.10/descr
@@ -1,0 +1,1 @@
+APRON numerical abstract domain library

--- a/packages/apron/apron.0.9.10/opam
+++ b/packages/apron/apron.0.9.10/opam
@@ -1,0 +1,17 @@
+opam-version: "1"
+maintainer: "francois.berenger@inria.fr"
+authors: ["Bertrand Jeannet and Antoine Mine et. al."]
+homepage: "http://apron.cri.ensmp.fr/library/"
+license: "LGPL"
+build: [
+  ["make" "rebuild"]
+  ["make"]
+  ["make" "install"]
+]
+remove: [["ocamlfind" "remove" "apron"]]
+depends: [
+  "ocamlfind"
+  "camlidl"
+  "conf-gmp"
+  "conf-mpfr"
+]

--- a/packages/apron/apron.0.9.10/url
+++ b/packages/apron/apron.0.9.10/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/UnixJunkie/apron_for_opam/archive/v0.9.10.tar.gz"
+checksum: "89b2f67348adced0f41608a8f58cde98"


### PR DESCRIPTION
The package will not compile on Mac.
But that's quite fine since at least Linux users will
be able to install the APRON library automatically via OPAM
from now on.
