### PR TITLE
+github.0.8.6

### DIFF
--- a/packages/github/github.0.8.6/descr
+++ b/packages/github/github.0.8.6/descr
@@ -1,0 +1,1 @@
+GitHub APIv3 client bindings

--- a/packages/github/github.0.8.6/opam
+++ b/packages/github/github.0.8.6/opam
@@ -1,0 +1,23 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [make "PREFIX=%{prefix}%"]
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [["ocamlfind" "remove" "github"]]
+depends: [
+  "ocamlfind"
+  "ssl"
+  "uri" {>= "1.5.0"}
+  "cohttp" {>= "0.10.1"}
+  "lwt" {>= "2.4.3"}
+  "atdgen" {>= "1.2.3"}
+  "yojson" {>= "1.1.6"}
+  "stringext"
+  "lambda-term"
+  "cmdliner"
+]

--- a/packages/github/github.0.8.6/url
+++ b/packages/github/github.0.8.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-github/archive/v0.8.6.tar.gz"
+checksum: "9f7ec53277ee7c7a6f784fc914fe5db8"


### PR DESCRIPTION
- Fix `pull_action_type` `synchronize` tag typo (avsm/ocaml-github#33 from Philipp Gesang).
- Add a `git create-release` to create a GitHub release, including binary assets
  (avsm/ocaml-github#32 from Markus Mottl).
