### PR TITLE
+cstruct.1.4.0

### DIFF
--- a/packages/cstruct/cstruct.1.4.0/descr
+++ b/packages/cstruct/cstruct.1.4.0/descr
@@ -1,0 +1,19 @@
+access C structures via a camlp4 extension
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the Bigarray module.
+
+An example pcap description is:
+
+```
+cstruct pcap_header {
+  uint32_t magic_number;   (* magic number *)
+  uint16_t version_major;  (* major version number *)
+  uint16_t version_minor;  (* minor version number *)
+  uint32_t thiszone;       (* GMT to local correction *)
+  uint32_t sigfigs;        (* accuracy of timestamps *)
+  uint32_t snaplen;        (* max length of captured packets, in octets *)
+  uint32_t network         (* data link type *)
+} as little_endian
+```

--- a/packages/cstruct/cstruct.1.4.0/opam
+++ b/packages/cstruct/cstruct.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy"]
+homepage: "https://github.com/mirage/ocaml-cstruct"
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [make]
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "cstruct"]]
+depends: [
+  "ocamlfind"
+  "ocplib-endian"
+  "ounit"
+  "camlp4"
+  "sexplib"
+]
+depopts: [
+  "async"
+  "lwt"
+]

--- a/packages/cstruct/cstruct.1.4.0/url
+++ b/packages/cstruct/cstruct.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cstruct/archive/v1.4.0.tar.gz"
+checksum: "1abb98c513db70654ef31c76fb379427"


### PR DESCRIPTION
Comprehensive addition of bounds checking to all cstruct operations (from @pqwy in #33).  The major API-facing changes are:
- Disallow negative indexing with all cstruct accessors.
- Disallow negative `sub` and `shift` operations.
- Make sure `of_bigarray` cannot create invalid `cstruct` values.

This may break some older `cstruct` consumers that assumed that negative shifts were allowed, and so the version has been bumped to 1.4.0.
