### PR TITLE
+uri.1.7.2

### DIFF
--- a/packages/uri/uri.1.7.2/descr
+++ b/packages/uri/uri.1.7.2/descr
@@ -1,0 +1,1 @@
+RFC3986 URI/URL parsing library

--- a/packages/uri/uri.1.7.2/opam
+++ b/packages/uri/uri.1.7.2/opam
@@ -1,0 +1,30 @@
+opam-version: "1"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: [
+  "url"
+  "uri"
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+build-doc: [["ocaml" "setup.ml" "-doc"]]
+remove: [["ocamlfind" "remove" "uri"]]
+depends: [
+  "ocamlfind"
+  "re"
+  "sexplib" {>="109.53.00"}
+  "type_conv"
+  "stringext"
+]
+depopts: ["ounit"]
+conflicts: ["ounit" {< "1.0.2"}]

--- a/packages/uri/uri.1.7.2/url
+++ b/packages/uri/uri.1.7.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-uri/archive/v1.7.2.tar.gz"
+checksum: "057267a916711f4c2367fc2cd7839ac7"


### PR DESCRIPTION
- Fix empty-but-existing query ("?") parsing bug
- Fix `with_userinfo` against hostless URI representation bug
- Fix `with_port` against hostless URI representation bug
- Fix `with_path` with relative path against hosted URI representation bug (#51)
- Fix `make` without host but with userinfo or port representation bug
- Fix `make` with host, userinfo, or port and relative path representation bug

In sum, the library will now try to guide the user to using an abstract value that is actually serializable.
