### PR TITLE
Batteries.2.2.0 fails on OCaml 4.02.0 with an unbound Printf.CamlinternalPR

### DIFF
--- a/packages/batteries/batteries.1.5.0/opam
+++ b/packages/batteries/batteries.1.5.0/opam
@@ -13,3 +13,4 @@ depends: [
   "ocamlfind"
   "camomile"
 ]
+ocaml-version: [<="4.00.1"]

--- a/packages/batteries/batteries.2.1.0/opam
+++ b/packages/batteries/batteries.2.1.0/opam
@@ -10,3 +10,4 @@ build: [
 remove: [["ocamlfind" "remove" "batteries"]]
 depends: ["ocamlfind"]
 patches: ["cloexec.patch" {ocaml-version >= "4.01.0"}]
+ocaml-version: [<"4.02.0"]

--- a/packages/batteries/batteries.2.2.0/opam
+++ b/packages/batteries/batteries.2.2.0/opam
@@ -9,3 +9,4 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "batteries"]]
 depends: ["ocamlfind"]
+ocaml-version: [<"4.02.0"]


### PR DESCRIPTION
see ocaml-batteries-team/batteries-included#572
