### PR TITLE
iocaml.0.4.5  - compatibility with js_of_ocaml 2.4

### DIFF
--- a/packages/iocaml/iocaml.0.4.5/descr
+++ b/packages/iocaml/iocaml.0.4.5/descr
@@ -1,0 +1,1 @@
+A webserver for iocaml-kernel and iocamljs-kernel.

--- a/packages/iocaml/iocaml.0.4.5/files/iocaml.install
+++ b/packages/iocaml/iocaml.0.4.5/files/iocaml.install
@@ -1,0 +1,3 @@
+bin: [
+  "_build/iocamlserver.byte" { "iocaml" }
+]

--- a/packages/iocaml/iocaml.0.4.5/opam
+++ b/packages/iocaml/iocaml.0.4.5/opam
@@ -1,0 +1,21 @@
+opam-version: "1.1"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocamlserver"
+build: [
+  [ "cp" "config.darwin.ml" "config.ml" ] {os = "darwin"}
+  [ make "all" ]
+]
+depends: [
+  "ocamlfind"
+  "uuidm"
+  "yojson"
+  "cow"
+  "lwt" {>= "2.4"}
+  "websocket" {>= "0.8"}
+  "cohttp" {>= "0.10.0"}
+  "crunch"
+  "ctypes" {>= "0.3"}
+  "iocaml-kernel" {= "0.4.4"}
+  "iocamljs-kernel" {= "0.4.5"}
+]
+ocaml-version: [ >= "4.01.0" ]

--- a/packages/iocaml/iocaml.0.4.5/url
+++ b/packages/iocaml/iocaml.0.4.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andrewray/iocamlserver/archive/v0.4.5.tar.gz"
+checksum: "8ec466e45178a1894cdfbfdf138bc5a5"

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/descr
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/descr
@@ -1,0 +1,1 @@
+An OCaml javascript kernel for the IPython notebook.

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/files/iocamljs-kernel.install
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/files/iocamljs-kernel.install
@@ -1,0 +1,7 @@
+share: [
+  "static/services/kernels/js/kernel.min.js" { "profile/static/services/kernels/js/kernel.min.js" }
+  "static/services/kernels/js/kernel.full.js" { "profile/static/services/kernels/js/kernel.full.js" }
+  "static/services/kernels/js/kernel.full.js" { "profile/static/services/kernels/js/kernel.js" }
+  "static/custom/custom.js" { "profile/static/custom/custom.js" }
+  "static/custom/iocamljsnblogo.png" { "profile/static/custom/iocamljsnblogo.png" }
+]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/opam
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/opam
@@ -1,0 +1,13 @@
+opam-version: "1.1"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocamljs"
+build: [
+  [ make "clean" "min" ]
+  [ make "clean" "full" ]
+]
+depends: [
+  "ocamlfind"
+  "lwt" {>= "2.4"}
+  "js_of_ocaml" {>= "2.4"}
+]
+ocaml-version: [ >= "4.01.0" ]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/url
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andrewray/iocamljs/archive/v0.4.5.tar.gz"
+checksum: "700688f162309e7734ec3b4a07b351ef"


### PR DESCRIPTION
some reformating of ipynb files for better version control.
