### PR TITLE
add stringext as cohttp dependency explictly

### DIFF
--- a/packages/cohttp/cohttp.0.11.0/opam
+++ b/packages/cohttp/cohttp.0.11.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0"}
+  "stringext"
   "ounit"
   "fieldslib" {>= "109.20.00"}
   "sexplib" {>= "109.53.00"}

--- a/packages/cohttp/cohttp.0.11.1/opam
+++ b/packages/cohttp/cohttp.0.11.1/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0"}
+  "stringext"
   "ounit"
   "fieldslib" {>= "109.20.00"}
   "sexplib" {>= "109.53.00"}

--- a/packages/cohttp/cohttp.0.11.2/opam
+++ b/packages/cohttp/cohttp.0.11.2/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0"}
+  "stringext"
   "ounit"
   "fieldslib" {>= "109.20.00"}
   "sexplib" {>= "109.53.00"}


### PR DESCRIPTION
currently cohttp relies on uri to pull it in but if uri ever drops it
then cohttp will break because it depends on it explictly.
