### PR TITLE
camlzip 1.04: don't remove zip

### DIFF
--- a/packages/camlzip/camlzip.1.04/opam
+++ b/packages/camlzip/camlzip.1.04/opam
@@ -6,7 +6,6 @@ build: [
   [make "install"]
 ]
 remove: [
-  ["ocamlfind" "remove" "zip"]
   ["ocamlfind" "remove" "camlzip"]
 ]
 depends: ["ocamlfind"]


### PR DESCRIPTION
camlzip 1.04 provides only the `camlzip` findlib package. I just tested
and it is only 1.05 that provides both `zip` and `camlzip`.
