### PR TITLE
Fix compilation of dose3 on 4.02

### DIFF
--- a/packages/dose/dose.3.2.2+opam/opam
+++ b/packages/dose/dose.3.2.2+opam/opam
@@ -14,17 +14,10 @@ homepage: "http://www.mancoosi.org/software/"
 license: "LGPL-v3+ with OCaml linking exception"
 build: [
  ["./configure" "--with-ocamlgraph" "--bindir=%{bin}%"]
- ["make"]
- ["make" "install"]
+ [make "TARGETS="]
+ [make "install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "dose3"]
-  ["rm" "-f"
-      "%{bin}%/distchek"
-      "%{bin}%/debchek"
-      "%{bin}%/rpmchek"
-      "%{bin}%/eclipsechek"]
-]
+remove: ["ocamlfind" "remove" "dose3"]
 depends: [
   "ocamlgraph" {>= "1.8.5"}
   "cudf" {>= "0.7"}


### PR DESCRIPTION
Due to a change in ocamlbuild, the binaries do not compile anymore.
