### PR TITLE
Normalize URIs in the repository.

### DIFF
--- a/packages/imagemagick/imagemagick.0.33.1/opam
+++ b/packages/imagemagick/imagemagick.0.33.1/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 authors: ["Florent Monnier"]
-homepage: "http://www.linux-nantes.org/%7Efmonnier/OCaml/ImageMagick/"
+homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: [
   [make]
   [make "install"]

--- a/packages/imagemagick/imagemagick.0.33.2/opam
+++ b/packages/imagemagick/imagemagick.0.33.2/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 authors: ["Florent Monnier"]
-homepage: "http://www.linux-nantes.org/%7Efmonnier/OCaml/ImageMagick/"
+homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: [
   [make]
   [make "install"]

--- a/packages/imagemagick/imagemagick.0.33/opam
+++ b/packages/imagemagick/imagemagick.0.33/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 authors: ["Florent Monnier"]
-homepage: "http://www.linux-nantes.org/%7Efmonnier/OCaml/ImageMagick/"
+homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: [
   [make]
   [make "install"]

--- a/packages/imagemagick/imagemagick.0.34/opam
+++ b/packages/imagemagick/imagemagick.0.34/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 authors: ["Florent Monnier"]
-homepage: "http://www.linux-nantes.org/%7Efmonnier/OCaml/ImageMagick/"
+homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: [
   [make]
   [make "find_install"]

--- a/packages/imagemagick/imagemagick.0.34/url
+++ b/packages/imagemagick/imagemagick.0.34/url
@@ -1,2 +1,2 @@
-archive: "http://www.linux-nantes.org/%7Efmonnier/OCaml/ImageMagick/downloads/OCaml-ImageMagick-0.34.tgz"
+archive: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/downloads/OCaml-ImageMagick-0.34.tgz"
 checksum: "d4e28dce94ccefba878ad31016f05fe4"


### PR DESCRIPTION
The homepage for the ImageMagick bindings contains excessive percent escaping. @fmonnier @samoht is there a reason for this?
