### PR TITLE
Newer ocp-build package incompatible with older typerex

### DIFF
--- a/packages/ocp-build/ocp-build.1.99.8-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.8-beta/opam
@@ -21,4 +21,4 @@ remove: [
   [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocp-build" ]
 ]
 depends: [ "ocamlfind" "camlp4" ]
-conflicts: [ "typerex"  {< "1.99.5"} ]
+conflicts: [ "typerex"  {<= "1.99.6"} ]


### PR DESCRIPTION
previous ocp-build 1.99.6 was a virtual package relying on
typerex. typerex 1.99.6 needs to be in conflict since they both install
an ocp-build exe.
