### PR TITLE
fix dependencies of "bson"

### DIFF
--- a/packages/bson/bson.0.89.3/opam
+++ b/packages/bson/bson.0.89.3/opam
@@ -8,8 +8,7 @@ build: [
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [["ocamlfind" "remove" "bson"]]
-depends: ["ocamlfind"]
+depends: ["ocamlfind" "deriving"]
 depopts: [
-  "deriving"
   "js_of_ocaml"
 ]


### PR DESCRIPTION
'opam install bson' works, but 'opam install js_of_ocaml bson' fails because 'deriving' is needed when 'js_of_ocaml' is present, but both are listed as optional dependencies.

Solution: move 'deriving' from the list of optional to strong dependencies.
