### PR TITLE
fftw3: remove syntax error due to new string syntax appearing in comments

### DIFF
--- a/packages/fftw3/fftw3.0.7/files/new-string-syntax.diff
+++ b/packages/fftw3/fftw3.0.7/files/new-string-syntax.diff
@@ -1,0 +1,36 @@
+diff -u -r fftw3.0.7-orig/src/fftw3_geomC.ml fftw3.0.7/src/fftw3_geomC.ml
+--- fftw3.0.7-orig/src/fftw3_geomC.ml	2013-08-04 14:26:12.000000000 +0200
++++ fftw3.0.7/src/fftw3_geomC.ml	2014-08-27 14:38:33.000000000 +0200
+@@ -66,7 +66,7 @@
+     let dimk = Genarray.nth_dim mat k in
+     let abs_inck = abs inc.(k) in
+     if n.(k) = 0 && abs_inck <> 0 then (
+-      (* nk = max {n| ofs.(k) + (n-1) * abs inc.(k) <= dimk - 1} *)
++      (* nk = max {n | ofs.(k) + (n-1) * abs inc.(k) <= dimk - 1} *)
+       let nk = 1 + (dimk - 1 - ofs.(k)) / abs_inck in
+       if nk > 1 then incr rank
+       else if nk < 1 then
+diff -u -r fftw3.0.7-orig/src/fftw3_geomCF.ml fftw3.0.7/src/fftw3_geomCF.ml
+--- fftw3.0.7-orig/src/fftw3_geomCF.ml	2013-08-03 19:59:09.000000000 +0200
++++ fftw3.0.7/src/fftw3_geomCF.ml	2014-08-27 14:24:48.000000000 +0200
+@@ -65,7 +65,7 @@
+     let dimk = Genarray.nth_dim mat k in
+     let abs_inck = abs inc.(k) in
+     if n.(k) = 0 && abs_inck <> 0 then (
+-      (* nk = max {n| ofs.(k) + (n-1) * abs inc.(k) <= LAST_INDEX(dimk)} *)
++      (* nk = max {n | ofs.(k) + (n-1) * abs inc.(k) <= LAST_INDEX(dimk)} *)
+       let nk = 1 + (LAST_INDEX(dimk) - ofs.(k)) / abs_inck in
+       if nk > 1 then incr rank
+       else if nk < 1 then
+diff -u -r fftw3.0.7-orig/src/fftw3_geomF.ml fftw3.0.7/src/fftw3_geomF.ml
+--- fftw3.0.7-orig/src/fftw3_geomF.ml	2013-08-04 14:26:12.000000000 +0200
++++ fftw3.0.7/src/fftw3_geomF.ml	2014-08-27 14:38:33.000000000 +0200
+@@ -66,7 +66,7 @@
+     let dimk = Genarray.nth_dim mat k in
+     let abs_inck = abs inc.(k) in
+     if n.(k) = 0 && abs_inck <> 0 then (
+-      (* nk = max {n| ofs.(k) + (n-1) * abs inc.(k) <= dimk} *)
++      (* nk = max {n | ofs.(k) + (n-1) * abs inc.(k) <= dimk} *)
+       let nk = 1 + (dimk - ofs.(k)) / abs_inck in
+       if nk > 1 then incr rank
+       else if nk < 1 then

--- a/packages/fftw3/fftw3.0.7/opam
+++ b/packages/fftw3/fftw3.0.7/opam
@@ -21,3 +21,6 @@ depexts: [
   [["freebsd"] ["math/fftw3"]]
   [["openbsd"] ["math/fftw3"]]
 ]
+patches: [
+  "new-string-syntax.diff"
+]


### PR DESCRIPTION
The new string syntax means that the characters {n| cannot appear anymore in a comment without the matching |n}. Inserting a space solves the problem.
