### PR TITLE
.gitignore: index.tar.gz and urls.txt (generated by opam-admin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 archives/
+index.tar.gz
+urls.txt


### PR DESCRIPTION
When I initialize a local repository for testing purposes, opam-admin creates "index.tar.gz" and "urls.txt", then they pollute my "git status" listings. This patch tells git to ignore them.
