### PR TITLE
openflow.0.6.2

### DIFF
--- a/packages/openflow/openflow.0.6.2/descr
+++ b/packages/openflow/openflow.0.6.2/descr
@@ -1,0 +1,5 @@
+Serialization and protocol implementation for OpenFlow 1.{0,3}
+
+This library provides the basic building blocks that are necessary to build an
+OpenFlow 1.0 or 1.3.4 based network controller, including serialzation
+functions and async-based protocol implementations.

--- a/packages/openflow/openflow.0.6.2/opam
+++ b/packages/openflow/openflow.0.6.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1"
+ocaml-version: [ >= "4.01.0" ]
+maintainer: "seliopou@gmail.com"
+homepage: "https://github.com/frenetic-lang/ocaml-openflow"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--%{async:enable}%-async" "--%{quickcheck:enable}%-quickcheck" ]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [["ocamlfind" "remove" "openflow"]]
+depends: [
+  "ocamlfind"
+  "core"
+  "cstruct" {>= "1.0.1"}
+  "packet"  {>= "0.3.0" }
+  "sexplib"
+]
+depopts: [ "async" "quickcheck" ]
+conflicts: [ "async_extra" {<= "111.25.00"} ]

--- a/packages/openflow/openflow.0.6.2/url
+++ b/packages/openflow/openflow.0.6.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/frenetic-lang/ocaml-openflow/archive/v0.6.2.tar.gz"
+checksum: "4b94b5d6a410c68eaca2e79b41956e3f"


### PR DESCRIPTION
Release notes can be found [here](https://github.com/frenetic-lang/ocaml-openflow/releases/tag/v0.6.2).
