### PR TITLE
ocamldbi: add missing dependencies and conflicts

### DIFF
--- a/packages/ocamldbi/ocamldbi.0.9.11/opam
+++ b/packages/ocamldbi/ocamldbi.0.9.11/opam
@@ -9,3 +9,11 @@ depends: [
   "ocamlfind"
   "pcre-ocaml"
 ]
+depopts: [
+  "postgres"
+  "mysql"
+]
+conflicts: [
+  "postgresql-ocaml"
+  "freetds"
+]


### PR DESCRIPTION
The Makefile for ocamldbi tests for the following libraries and compiles differently when they are present:
- postgres
- mysql
  --> I have added these two as optional dependencies
- postgresql
- freetds
  --> there are compilation errors when these are present, so I added them as conflicts
- perl4caml
- ocamlodbc
- sqlite
  --> these don't seem to be available on OPAM, so I left them alone
