### PR TITLE
constrain ocp-index to ocp-build 1.99.6-beta

### DIFF
--- a/packages/ocp-index/ocp-index.1.0.2/opam
+++ b/packages/ocp-index/ocp-index.1.0.2/opam
@@ -8,7 +8,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocp-build" {>= "1.99.4-beta"}
+  "ocp-build" {= "1.99.6-beta"}
   "ocp-indent" {>= "1.4.1"}
   "re"
   "cmdliner"


### PR DESCRIPTION
Related to #2525 

Locally pinning to ocp-build 1.99.6-beta (and having the same version of typerex) seemed to fix my problem. I'm curious to see what Travis says.
