### PR TITLE
fix non-portable use of sed's -i option

### DIFF
--- a/packages/ocp-ocamlres/ocp-ocamlres.0.3/files/non-portable-sed-option.diff
+++ b/packages/ocp-ocamlres/ocp-ocamlres.0.3/files/non-portable-sed-option.diff
@@ -1,0 +1,12 @@
+diff -u -r ocp-ocamlres.0.3-orig/Makefile ocp-ocamlres.0.3/Makefile
+--- ocp-ocamlres.0.3-orig/Makefile	2014-05-15 14:19:52.000000000 +0200
++++ ocp-ocamlres.0.3/Makefile	2014-08-28 15:48:37.000000000 +0200
+@@ -76,7 +76,7 @@
+ -include .depend
+ .depend:
+ 	ocamlfind ocamldep -I src -package $(PACKAGES) $(LIB_ML) > $@
+-	sed -i s/src/build/g $@
++	sed -i.old s/src/build/g $@
+ 
+ $(BIN_CMO): build/ocplib-ocamlres.cma
+ $(BIN_CMX): build/ocplib-ocamlres.cmxa

--- a/packages/ocp-ocamlres/ocp-ocamlres.0.3/opam
+++ b/packages/ocp-ocamlres/ocp-ocamlres.0.3/opam
@@ -13,3 +13,6 @@ remove: [
   [make "DOCDIR=%{doc}%" "uninstall-doc"]
 ]
 available: [ ocaml-version >= "4.01.0" ]
+patches: [
+  "non-portable-sed-option.diff"
+]


### PR DESCRIPTION
The makefile makes use of sed's -i (in-place) option, with an empty backup suffix. Unfortunately, GNU sed and BSD sed (as used on MacOSX) have incompatible syntax in this case:

BSD:  sed -i '' ...
GNU: sed -i ...

Fortunately, they are compatible when you specify a suffix for the backup copy of the file:

both: sed -i.old ...
This PR creates a patch that should be upstreamed but can be used as an interim measure.
