### PR TITLE
tplib: remove spurious ocamlbuild options from Makefile

### DIFF
--- a/packages/tplib/tplib.1.3/files/fix-makefile.diff
+++ b/packages/tplib/tplib.1.3/files/fix-makefile.diff
@@ -1,0 +1,12 @@
+diff -u -r tplib.1.3-orig/Makefile.in tplib.1.3/Makefile.in
+--- tplib.1.3-orig/Makefile.in	2013-02-14 12:08:25.000000000 +0100
++++ tplib.1.3/Makefile.in	2014-08-28 18:31:03.000000000 +0200
+@@ -31,7 +31,7 @@
+ CP = cp
+ RANLIB = ranlib
+ BUILD_DIR = _build
+-OCAMLBUILD = @OCAMLBUILD@ -ocamlc ocp-ocamlc.opt -ocamlopt ocp-ocamlopt.opt -classic-display -no-links -build-dir $(BUILD_DIR) -use-ocamlfind
++OCAMLBUILD = @OCAMLBUILD@ -classic-display -no-links -build-dir $(BUILD_DIR) -use-ocamlfind
+ OCAMLFIND = @OCAMLFIND@
+ TPLIB = @PACKAGE_NAME@
+ 

--- a/packages/tplib/tplib.1.3/opam
+++ b/packages/tplib/tplib.1.3/opam
@@ -15,3 +15,6 @@ depopts: [
   "mlgmp"
 ]
 ocaml-version: [>= "3.12.0"]
+patches: [
+  "fix-makefile.diff"
+]


### PR DESCRIPTION
Makefile.in contains options "-ocamlc ocp-ocamlc.opt -ocamlopt ocp-ocamlopt.opt" to ocamlbuild, which on my machine makes ocamlfind fail with a strange error message. Just removing the options fixes the problem.
