### PR TITLE
Add remove target for atdgen

### DIFF
--- a/packages/atdgen/atdgen.1.2.2/opam
+++ b/packages/atdgen/atdgen.1.2.2/opam
@@ -5,6 +5,9 @@ build: [
   [make]
   [make "install" "BINDIR=%{bin}%"]
 ]
+remove: [
+    ["ocamlfind" "remove" "atdgen"]
+]
 depends: [
   "ocamlfind"
   "atd" {= "1.0.2"}

--- a/packages/atdgen/atdgen.1.2.3/opam
+++ b/packages/atdgen/atdgen.1.2.3/opam
@@ -5,6 +5,9 @@ build: [
   [make]
   [make "install" "BINDIR=%{bin}%"]
 ]
+remove: [
+    ["ocamlfind" "remove" "atdgen"]
+]
 depends: [
   "ocamlfind"
   "atd" {>= "1.0.2"}

--- a/packages/atdgen/atdgen.1.2.4/opam
+++ b/packages/atdgen/atdgen.1.2.4/opam
@@ -5,6 +5,9 @@ build: [
   [make]
   [make "install" "BINDIR=%{bin}%"]
 ]
+remove: [
+    ["ocamlfind" "remove" "atdgen"]
+]
 depends: [
   "ocamlfind"
   "atd" {>= "1.0.3"}

--- a/packages/atdgen/atdgen.1.3.0/opam
+++ b/packages/atdgen/atdgen.1.3.0/opam
@@ -5,6 +5,9 @@ build: [
   [make]
   [make "install" "BINDIR=%{bin}%"]
 ]
+remove: [
+    ["ocamlfind" "remove" "atdgen"]
+]
 depends: [
   "ocamlfind"
   "atd" {>= "1.1.0"}

--- a/packages/atdgen/atdgen.1.3.1/opam
+++ b/packages/atdgen/atdgen.1.3.1/opam
@@ -5,6 +5,9 @@ build: [
   [make]
   [make "install" "BINDIR=%{bin}%"]
 ]
+remove: [
+    ["ocamlfind" "remove" "atdgen"]
+]
 depends: [
   "ocamlfind"
   "atd" {>= "1.1.0"}


### PR DESCRIPTION
This is to fix an issue when I was upgrading opam from
opam 1.1.2 to opam 1.2~beta4. See #2535.
