### PR TITLE
irmin needs ezjsonm version 0.2.0

### DIFF
--- a/packages/irmin/irmin.0.8.3/opam
+++ b/packages/irmin/irmin.0.8.3/opam
@@ -12,7 +12,7 @@ remove: [
   ["rm" "-f" "%{bin}%/irmin"]
 ]
 depends: [
-  "ezjsonm"
+  "ezjsonm" {>= "0.2.0"}
   "ocamlgraph"
   "lwt"
   "sha"


### PR DESCRIPTION
add a versioned dependency on ezjsonm because irmin does not compile with ezjsonm 0.1.0
