### PR TITLE
dose: typo in the remove instructions for the package

### DIFF
--- a/packages/dose/dose.3.2.2+opam/opam
+++ b/packages/dose/dose.3.2.2+opam/opam
@@ -20,10 +20,10 @@ build: [
 remove: [
   ["ocamlfind" "remove" "dose3"]
   ["rm" "-f"
-      "%{bin}%/distchek"
-      "%{bin}%/debchek"
-      "%{bin}%/rpmchek"
-      "%{bin}%/eclipsechek"]
+      "%{bin}%/distcheck"
+      "%{bin}%/debcheck"
+      "%{bin}%/rpmcheck"
+      "%{bin}%/eclipsecheck"]
 ]
 depends: [
   "ocamlgraph" {>= "1.8.5"}


### PR DESCRIPTION
this typo makes a "remove+reinstall" fail
