### PR TITLE
pcap-format: conflicts with mirage-net-socket

### DIFF
--- a/packages/pcap-format/pcap-format.0.3.3/opam
+++ b/packages/pcap-format/pcap-format.0.3.3/opam
@@ -15,3 +15,4 @@ depends: [
   "lwt" {>= "2.4.0"}
 ]
 depopts: ["mirage-net"]
+conflicts: [ "mirage-net-socket" ]


### PR DESCRIPTION
pcap-format fails to compile when mirage-net-socket is installed (some problem with the Net module).
