### PR TITLE
Add post-message m4 on ocamlfind install failure

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -7,3 +7,7 @@ build: [
   [make "install"]
 ]
 ocaml-version: [< "3.12.2"]
+depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]

--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -7,3 +7,7 @@ build: [
   [make "install"]
 ]
 ocaml-version: [> "3.12.2"]
+depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -7,3 +7,7 @@ build: [
   [make "install"]
   ["ocamlfind" "remove" "dbm"]
 ]
+depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -6,3 +6,7 @@ build: [
   [make "opt"]
   [make "install"]
 ]
+depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -6,3 +6,7 @@ build: [
   [make "opt"]
   [make "install"]
 ]
+depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -11,3 +11,7 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
+depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -11,3 +11,7 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
+depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]


### PR DESCRIPTION
Failing to install ocamlfind is a common source of confusion, and usually
caused by a missing m4 package. Better tell the users more clearly.
