### PR TITLE
Constrain atdgen to OCaml versions below 4.02.0.

### DIFF
--- a/packages/atdgen/atdgen.1.2.2/opam
+++ b/packages/atdgen/atdgen.1.2.2/opam
@@ -14,3 +14,4 @@ depends: [
   "biniou"
   "yojson"
 ]
+ocaml-version: [ < "4.02.0" ]

--- a/packages/atdgen/atdgen.1.2.3/opam
+++ b/packages/atdgen/atdgen.1.2.3/opam
@@ -14,3 +14,4 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson"
 ]
+ocaml-version: [ < "4.02.0" ]

--- a/packages/atdgen/atdgen.1.2.4/opam
+++ b/packages/atdgen/atdgen.1.2.4/opam
@@ -14,3 +14,4 @@ depends: [
   "biniou"
   "yojson"
 ]
+ocaml-version: [ < "4.02.0" ]

--- a/packages/atdgen/atdgen.1.3.0/opam
+++ b/packages/atdgen/atdgen.1.3.0/opam
@@ -14,3 +14,4 @@ depends: [
   "biniou"
   "yojson"
 ]
+ocaml-version: [ < "4.02.0" ]

--- a/packages/atdgen/atdgen.1.3.1/opam
+++ b/packages/atdgen/atdgen.1.3.1/opam
@@ -14,3 +14,4 @@ depends: [
   "biniou"
   "yojson"
 ]
+ocaml-version: [ < "4.02.0" ]


### PR DESCRIPTION
See [discussion on caml-list](https://sympa.inria.fr/sympa/arc/caml-list/2014-09/msg00041.html).
