### PR TITLE
cudf.0.6.3: fix build commands

### DIFF
--- a/packages/cudf/cudf.0.6.3/opam
+++ b/packages/cudf/cudf.0.6.3/opam
@@ -1,7 +1,10 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 substs: ["cudf.ocp"]
-build: [["ocp-build" "-init" "-scan" "cudf" "-v" "0"]]
+build: [
+  ["ocp-build" "-init"]
+  ["ocp-build" "-scan" "cudf" "-v" "0"]
+]
 depends: [
   "ocp-build"
   ("extlib" | "extlib-compat")


### PR DESCRIPTION
It looks like the ocp-build command-line parsing has changed recently and it broke the build instructions for this package.
