### PR TITLE
wget: fix build commands

### DIFF
--- a/packages/wget/wget.0.1.0/opam
+++ b/packages/wget/wget.0.1.0/opam
@@ -1,4 +1,7 @@
 opam-version: "1"
 maintainer: "thomas@gazagnaire.org"
-build: [[make]]
+build: [
+  ["ocp-build" "-init"]
+  ["ocp-build" "-scan" "ocaml-wget" "owget"]
+]
 depends: ["ocp-build"]


### PR DESCRIPTION
It looks like the ocp-build command-line parsing has changed recently and it broke the makefile and the build instructions for this package.
