### PR TITLE
bson: better fix for the dependency problem with js_of_ocaml and deriving

### DIFF
--- a/packages/bson/bson.0.89.3/opam
+++ b/packages/bson/bson.0.89.3/opam
@@ -3,12 +3,13 @@ maintainer: "opam-devel@lists.ocaml.org"
 authors: ["MassD http://massd.github.io/, Marc Simon marc.simon42@gmail.com"]
 license: "GPL-3"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--%{deriving:enable}%-syntax" "--%{js_of_ocaml:enable}%-client" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-configure" "--%{deriving:enable}%-syntax" "--%{js_of_ocaml+deriving:enable}%-client" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [["ocamlfind" "remove" "bson"]]
-depends: ["ocamlfind" "deriving"]
+depends: ["ocamlfind"]
 depopts: [
+  "deriving"
   "js_of_ocaml"
 ]


### PR DESCRIPTION
This is a follow-up to #2513. Use advanced features of OPAM to describe the dependencies exactly rather than approximately.
