### PR TITLE
ocamlfind 1.3.3 depends on camlp4

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -7,6 +7,7 @@ build: [
   [make "install"]
   ["ocamlfind" "remove" "dbm"]
 ]
+ocaml-version: [<= "4.01.0"]
 depexts: [ [ ["debian"] ["m4"] ] [ ["ubuntu"] ["m4"] ] ]
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}


### PR DESCRIPTION
Restrict to OCaml <= 4.01.0 to avoid circular dependency.
