### PR TITLE
dbforge: fix remove instructions (need to configure before make uninstall)

### DIFF
--- a/packages/dbforge/dbforge.2.0.1/opam
+++ b/packages/dbforge/dbforge.2.0.1/opam
@@ -12,7 +12,10 @@ build: [
   [make "all"]
   [make "install-lib"]
 ]
-remove: [[make "uninstall-lib"]]
+remove: [
+  ["./configure" "--prefix" prefix]
+  [make "uninstall-lib"]
+]
 depends: [
   "ocamlfind"
   "config-file" {>= "1.1"}


### PR DESCRIPTION
Fix the remove commands for dbforge: you need to call ./configure before you can "make uninstall".
