### PR TITLE
genet: fix remove instructions and dependency on xtmpl

### DIFF
--- a/packages/genet/genet.0.4/opam
+++ b/packages/genet/genet.0.4/opam
@@ -24,7 +24,7 @@ depends: [
   "lablgtk-extras" {>= "1.2"}
   "lablgtk" {>= "2.16.0"}
   "menhir" {>= "20120123"}
-  "xtmpl" {>= "0.5"}
+  "xtmpl" {>= "0.5" & <= "0.7"}
   "mysql" {>= "1.1.1"}
   "pcre-ocaml" {>= "7.0.2"}
   "ocamlnet" {>= "3.6.5"}


### PR DESCRIPTION
Remove commands don't work because you need to configure before "make uninstall".
Dependency on xtmpl: genet won't compile with xtmpl versions greater than 0.7.
