### PR TITLE
rdf: add conflicts with ocaml-rdf

### DIFF
--- a/packages/rdf/rdf.0.7.0/opam
+++ b/packages/rdf/rdf.0.7.0/opam
@@ -33,4 +33,7 @@ depopts: [
   "mysql" {>= "1.1.1"}
   "postgresql-ocaml"
 ]
+conflicts: [
+  "ocaml-rdf"
+]
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.7.1/opam
+++ b/packages/rdf/rdf.0.7.1/opam
@@ -33,4 +33,7 @@ depopts: [
   "mysql" {>= "1.1.1"}
   "postgresql-ocaml"
 ]
+conflicts: [
+  "ocaml-rdf"
+]
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.8.0/opam
+++ b/packages/rdf/rdf.0.8.0/opam
@@ -33,4 +33,7 @@ depopts: [
   "mysql" {>= "1.1.1"}
   "postgresql-ocaml"
 ]
+conflicts: [
+  "ocaml-rdf"
+]
 ocaml-version: [>= "4.00.0"]


### PR DESCRIPTION
rdf and ocaml-rdf cannot be installed at the same time.
