### PR TITLE
genet.0.3: fix remove instructions and dependency on ocaml-rdf version

### DIFF
--- a/packages/genet/genet.0.3/opam
+++ b/packages/genet/genet.0.3/opam
@@ -24,7 +24,7 @@ depends: [
   "lablgtk-extras" {>= "1.2"}
   "lablgtk" {>= "2.16.0"}
   "menhir" {>= "20120123"}
-  "xtmpl" {>= "0.5"}
+  "xtmpl" {>= "0.5" & <= "0.7"}
   "mysql" {>= "1.0.4"}
   "pcre-ocaml" {>= "6.2.5"}
   "ocamlnet" {>= "3.6"}


### PR DESCRIPTION
Remove instructions: need to configure before make uninstall.
Dependency: genet 0.3 does not compile with ocaml-rdf versions later than 0.4.
