### PR TITLE
dose: fix build instructions

### DIFF
--- a/packages/dose/dose.3.1.2/opam
+++ b/packages/dose/dose.3.1.2/opam
@@ -14,7 +14,8 @@ homepage: "http://www.mancoosi.org/software/"
 license: "LGPL-v3+ with OCaml linking exception"
 substs: ["dose.ocp"]
 build: [
-  ["ocp-build" "-scan" "-init" "dose" "-v" "0"]
+  ["ocp-build" "-init"]
+  ["ocp-build" "-scan" "dose" "-v" "0"]
   ["mv" "META.dose3" "META"]
   ["ocamlfind" "install" "dose3" "META"]
   ["mv" "META.dose" "META"]

--- a/packages/dose/dose.3.2-rc2/opam
+++ b/packages/dose/dose.3.2-rc2/opam
@@ -14,7 +14,8 @@ homepage: "http://www.mancoosi.org/software/"
 license: "LGPL-v3+ with OCaml linking exception"
 substs: ["dose.ocp"]
 build: [
-  ["ocp-build" "-scan" "-init" "dose" "-v" "0"]
+  ["ocp-build" "-init"]
+  ["ocp-build" "-scan" "dose" "-v" "0"]
   ["mv" "META.dose3" "META"]
   ["ocamlfind" "install" "dose3" "META"]
   ["mv" "META.dose" "META"]

--- a/packages/dose/dose.3.2.2/opam
+++ b/packages/dose/dose.3.2.2/opam
@@ -14,7 +14,8 @@ homepage: "http://www.mancoosi.org/software/"
 license: "LGPL-v3+ with OCaml linking exception"
 substs: ["dose.ocp"]
 build: [
-  ["ocp-build" "-scan" "-init" "dose" "-v" "0"]
+  ["ocp-build" "-init"]
+  ["ocp-build" "-scan" "dose" "-v" "0"]
   ["mv" "META.dose3" "META"]
   ["ocamlfind" "install" "dose3" "META"]
   ["mv" "META.dose" "META"]


### PR DESCRIPTION
With ocp-build 1.99.8-beta, I need to separate ocp-build -init from the build itself. Probably due to a change in ocp-build.
