### PR TITLE
js_of_ocaml: add deps on Ocaml version

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.1.4.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.1.4.0/opam
@@ -15,3 +15,4 @@ depends: [
 depopts: [
   "deriving-ocsigen" {>= "0.5"}
 ]
+ocaml-version: [<= "4.01.0"]

--- a/packages/js_of_ocaml/js_of_ocaml.2.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.0/opam
@@ -17,3 +17,4 @@ depends: [
 
 depopts: ["deriving"]
 conflicts: ["deriving" {< "0.6"}]
+ocaml-version: [<= "4.01.0"]


### PR DESCRIPTION
Versions 1.4.0 and 2.0 of js_of_ocaml do not compile on OCaml 4.02.0.
