### PR TITLE
tuntap.0.5: does not work with newer versions of cstruct

### DIFF
--- a/packages/tuntap/tuntap.0.5/opam
+++ b/packages/tuntap/tuntap.0.5/opam
@@ -9,4 +9,4 @@ build: [
   [make "PREFIX=%{prefix}%" "install"]
 ]
 remove: [["ocamlfind" "remove" "tuntap"]]
-depends: ["cstruct"]
+depends: ["cstruct" {< "1.0.0"}]


### PR DESCRIPTION
Strangely enough, other versions of tuntap seem to work with all versions of cstruct.
