### PR TITLE
mirage: older versions do not work with newer versions of cstruct

### DIFF
--- a/packages/mirage/mirage.0.4.0/opam
+++ b/packages/mirage/mirage.0.4.0/opam
@@ -11,7 +11,7 @@ build: [
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
   "ocamlfind"
-  "cstruct"
+  "cstruct" {< "0.6.0"}
   "lwt"
 ]
 ocaml-version: [>="4.00.1"]

--- a/packages/mirage/mirage.0.4.1/opam
+++ b/packages/mirage/mirage.0.4.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "cstruct"
+  "cstruct" {< "0.6.0"}
   "ocamlfind"
   "lwt"
   "xenstore"

--- a/packages/mirage/mirage.0.5.0/opam
+++ b/packages/mirage/mirage.0.5.0/opam
@@ -11,7 +11,7 @@ build: [
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
   "ocamlfind"
-  "cstruct"
+  "cstruct" {< "0.6.0"}
   "lwt"
   "xenstore"
 ]

--- a/packages/mirage/mirage.0.6.0/opam
+++ b/packages/mirage/mirage.0.6.0/opam
@@ -11,7 +11,7 @@ build: [
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
   "ocamlfind"
-  "cstruct"
+  "cstruct" {< "0.6.0"}
   "lwt"
   "xenstore"
 ]

--- a/packages/mirage/mirage.0.6.1/opam
+++ b/packages/mirage/mirage.0.6.1/opam
@@ -11,7 +11,7 @@ build: [
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
   "ocamlfind"
-  "cstruct"
+  "cstruct" {< "0.6.0"}
   "lwt"
   "xenstore"
 ]

--- a/packages/mirage/mirage.0.8.1/opam
+++ b/packages/mirage/mirage.0.8.1/opam
@@ -8,7 +8,7 @@ build: [
   [make "all"]
   [make "install" "PREFIX=%{prefix}%"]
 ]
-remove: [[make "uninstall"]]
+remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
   "cstruct" {>= "0.6.0"}
   "ocamlfind"


### PR DESCRIPTION
Also, fix the remove instructions for mirage.0.8.1
