### PR TITLE
Protobuf doesn't compile on 4.02.0.  Add a version constraint.

### DIFF
--- a/packages/protobuf/protobuf.0.0.2/opam
+++ b/packages/protobuf/protobuf.0.0.2/opam
@@ -7,6 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "protobuf"]]
 depends: [
   "ocamlfind"
-  "core"
+  "core" { <= "111.13.00"}
   "bitstring"
 ]
+

--- a/packages/protobuf/protobuf.1.0.0/opam
+++ b/packages/protobuf/protobuf.1.0.0/opam
@@ -7,6 +7,6 @@ build: [
 remove: [["ocamlfind" "remove" "protobuf"]]
 depends: [
   "ocamlfind"
-  "core"
+  "core" { <= "111.13.00"}
   "bitstring"
 ]


### PR DESCRIPTION
/cc @orbitz

Protobuf 1.0.0 doesn't compile with OCaml 4.02.0:

```
### stderr ###
# ...[truncated]
#        Values do not match:
#          val map : 'a t -> f:('a -> 'b) -> 'b t
#        is not included in
#          val map :
#            [ `Custom of 'a t -> f:('a -> 'b) -> 'b t | `Define_using_bind ]
#        File "parser.ml", line 69, characters 6-9: Actual declaration
# make[3]: *** [parser.cmx] Error 2
# make[2]: *** [protobuf] Error 2
# make[1]: *** [all_trampoline] Error 2
# make: *** [all] Error 2
```

protobuf 0.0.2 fails with a different error:

```
### stderr ###
# File "parser.ml", line 44, characters 21-489:
# Error: Signature mismatch:
#        ...
#        The value `map' is required but not provided
# make[2]: *** [parser.cmx] Error 2
# make[1]: *** [protobuf] Error 2
# make: *** [lib] Error 2
```

This pull request adds a version constraint to restrict both packages to 4.01.0 and earlier.
