### PR TITLE
themoviedb: fix remove instructions

### DIFF
--- a/packages/themoviedb/themoviedb.0.8.1/opam
+++ b/packages/themoviedb/themoviedb.0.8.1/opam
@@ -8,7 +8,7 @@ build: [
   ["ocaml" "setup.ml" "-install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "themoviedb"]]
+remove: [["ocamlfind" "remove" "theMovieDb"]]
 depends: [
   "ocamlfind"
   "ocsigenserver"

--- a/packages/themoviedb/themoviedb.0.8/opam
+++ b/packages/themoviedb/themoviedb.0.8/opam
@@ -8,7 +8,7 @@ build: [
   ["ocaml" "setup.ml" "-install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "themoviedb"]]
+remove: [["ocamlfind" "remove" "theMovieDb"]]
 depends: [
   "ocamlfind"
   "ocsigenserver"


### PR DESCRIPTION
The case is wrong in the remove commands. It works on MacOS but not on Linux.
