### PR TITLE
higlo: depends on xtmpl >= 0.8

### DIFF
--- a/packages/higlo/higlo.0.1/opam
+++ b/packages/higlo/higlo.0.1/opam
@@ -12,5 +12,5 @@ remove: [["ocamlfind" "remove" "higlo"]]
 depends: [
   "ocamlfind"
   "ulex"
-  "xtmpl"
+  "xtmpl" {>= "0.8"}
 ]

--- a/packages/higlo/higlo.0.2/opam
+++ b/packages/higlo/higlo.0.2/opam
@@ -12,5 +12,5 @@ remove: [["ocamlfind" "remove" "higlo"]]
 depends: [
   "ocamlfind"
   "ulex"
-  "xtmpl"
+  "xtmpl" {>= "0.8"}
 ]


### PR DESCRIPTION
fixing higlo versions 0.1 and 0.2
