### PR TITLE
git2fat: add missing dependency and dependency versions

### DIFF
--- a/packages/git2fat/git2fat.0.9.0/opam
+++ b/packages/git2fat/git2fat.0.9.0/opam
@@ -11,7 +11,8 @@ remove: [
   ["rm" "-f" "%{bin}%/git2fat"]
 ]
 depends: [
-  "git" {>= "0.10.1"}
+  "git" {>= "0.10.1" & < "1.0.0"}
   "cmdliner"
-  "fat-filesystem" {>= "0.10.0"}
+  "fat-filesystem" {= "0.10.0"}
+  "io-page-unix"
 ]


### PR DESCRIPTION
git2fat is quite picky about its dependencies
