### PR TITLE
mirage.0.9.0: fix dependency on tuntap versions and remove instructions

### DIFF
--- a/packages/mirage/mirage.0.9.0/opam
+++ b/packages/mirage/mirage.0.9.0/opam
@@ -8,13 +8,12 @@ build: [
   [make "all"]
   [make "install" "PREFIX=%{prefix}%"]
 ]
-remove: [[make "uninstall"]]
 depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
   "xenstore" {>= "1.2.0"}
   "shared-memory-ring" {>= "0.4.0"}
-  "tuntap" {>= "0.3"}
+  "tuntap" {>= "0.3" & < "0.6"}
 ]
 ocaml-version: [>="4.00.1"]


### PR DESCRIPTION
mirage.0.9.0:
Fix the remove instructions by removing them (opam seems to do the right thing by default).
Constrain the tuntap version.
