### PR TITLE
mirage-net-unix.0.9.0: fix dependency versions

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.0.9.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.0.9.0/opam
@@ -9,7 +9,7 @@ depends: [
   "cstruct" {>= "0.8.1"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "mirage-types" {>= "0.4.0" & < "1.1.0"}
+  "mirage-types" {= "0.4.0"}
   "io-page-unix" {>= "0.9.9"}
   "tuntap" {>= "0.7.0"}
   "ounit"


### PR DESCRIPTION
mirage-net-unix.0.9.0 does not work with mirage-types versions greater than 0.4.0
