### PR TITLE
fix dependency of mirage-xen on OCaml versions

### DIFF
--- a/packages/mirage-xen/mirage-xen.0.9.1/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.1/opam
@@ -14,4 +14,4 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]

--- a/packages/mirage-xen/mirage-xen.0.9.2/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.2/opam
@@ -14,4 +14,4 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]

--- a/packages/mirage-xen/mirage-xen.0.9.3/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.3/opam
@@ -14,4 +14,4 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]

--- a/packages/mirage-xen/mirage-xen.0.9.4/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.4/opam
@@ -14,4 +14,4 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]

--- a/packages/mirage-xen/mirage-xen.0.9.5/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.5/opam
@@ -15,4 +15,4 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]

--- a/packages/mirage-xen/mirage-xen.0.9.6/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.6/opam
@@ -15,4 +15,4 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]

--- a/packages/mirage-xen/mirage-xen.0.9.7/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.7/opam
@@ -15,4 +15,4 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 os: ["linux"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]

--- a/packages/mirage-xen/mirage-xen.0.9.8/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.8/opam
@@ -14,5 +14,5 @@ depends: [
   "ipaddr" {>= "0.2.3"}
 ]
 conflicts: ["mirage-unix"]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]
 os: ["linux"]

--- a/packages/mirage-xen/mirage-xen.0.9.9/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.9/opam
@@ -14,5 +14,5 @@ depends: [
   "shared-memory-ring" {>= "0.4.3"}
   "xenstore" {>= "1.2.5"}
 ]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]
 os: ["linux"]

--- a/packages/mirage-xen/mirage-xen.1.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.1.0.0/opam
@@ -14,5 +14,5 @@ depends: [
   "shared-memory-ring" {>= "0.4.3"}
   "xenstore" {>= "1.2.5"}
 ]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]
 os: ["linux"]

--- a/packages/mirage-xen/mirage-xen.1.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.1.1.0/opam
@@ -16,5 +16,5 @@ depends: [
   "xen-evtchn" {>="0.9.9"}
   "xen-gnt" {>="0.9.9"}
 ]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]
 os: ["linux"]

--- a/packages/mirage-xen/mirage-xen.1.1.1/opam
+++ b/packages/mirage-xen/mirage-xen.1.1.1/opam
@@ -16,5 +16,5 @@ depends: [
   "xen-evtchn" {>="0.9.9"}
   "xen-gnt" {>="0.9.9"}
 ]
-ocaml-version: [>= "4.00.1" & <"4.02.0"]
+ocaml-version: [>= "4.00.1" & < "4.02.0"]
 os: ["linux"]


### PR DESCRIPTION
All recent versions of mirage-xen have a configure script that mandates OCaml version 4.00.1 or 4.01.0
