### PR TITLE
dns.0.4.0: fix dependency on cstruct versions

### DIFF
--- a/packages/dns/dns.0.4.0/opam
+++ b/packages/dns/dns.0.4.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "cstruct" {< "0.6.0"}
+  "cstruct" {>= "0.5.0" & < "0.6.0"}
   "lwt"
   "ocamlfind"
   "cryptokit"


### PR DESCRIPTION
dns.0.4.0 does not compile with cstruct versions 0.4.*
