### PR TITLE
xenctrl.0.9.26: add dependency on debian/ubuntu uuid-dev

### DIFF
--- a/packages/xenctrl/xenctrl.0.9.26/opam
+++ b/packages/xenctrl/xenctrl.0.9.26/opam
@@ -18,8 +18,8 @@ depends: [
   "cmdliner"
 ]
 depexts: [
-  [["debian"] ["libxen-dev"]]
-  [["ubuntu"] ["libxen-dev"]]
+  [["debian"] ["libxen-dev" "uuid-dev"]]
+  [["ubuntu"] ["libxen-dev" "uuid-dev"]]
   [["centos"] ["xen-devel"]]
   [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
 ]


### PR DESCRIPTION
Ideally uuid-dev should be a dependency of libxen-dev, but adding it
here should work around the packaging bug.

This only triggers a problem against Xen 4.4

Signed-off-by: David Scott dave.scott@citrix.com
