### PR TITLE
mirage-net-socket.0.9.4 does not work with newer versions of mirage

### DIFF
--- a/packages/mirage-net-socket/mirage-net-socket.0.9.4/opam
+++ b/packages/mirage-net-socket/mirage-net-socket.0.9.4/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "mirage-net"]]
 depends: [
-  "mirage" {>= "0.9.5"}
+  "mirage" {>= "0.9.5" & < "0.10.0"}
   "ocamlfind"
 ]
 conflicts: [


### PR DESCRIPTION
This is similar to #2689 .
