### PR TITLE
new package version why3 0.85

### DIFF
--- a/packages/why3/why3.0.85/descr
+++ b/packages/why3/why3.0.85/descr
@@ -1,0 +1,20 @@
+Why3 is a platform for deductive program verification.
+
+It provides a rich language for specification and programming, called
+WhyML, and relies on external theorem provers, both automated and
+interactive, to discharge verification conditions. Why3 comes with a
+standard library of logical theories (integer and real arithmetic,
+Boolean operations, sets and maps, etc.) and basic programming data
+structures (arrays, queues, hash tables, etc.). A user can write WhyML
+programs directly and get correct-by-construction OCaml programs
+through an automated extraction mechanism. WhyML is also used as an
+intermediate language for the verification of C, Java, or Ada
+programs.
+
+Why3 is a complete reimplementation of the former Why platform. Among
+the new features are: numerous extensions to the input language, a new
+architecture for calling external provers, and a well-designed API,
+allowing to use Why3 as a software library. An important emphasis is
+put on modularity and genericity, giving the end user a possibility to
+easily reuse Why3 formalizations or to add support for a new external
+prover if wanted.

--- a/packages/why3/why3.0.85/opam
+++ b/packages/why3/why3.0.85/opam
@@ -1,0 +1,39 @@
+opam-version: "1"
+maintainer: "Claude.Marche@inria.fr"
+authors: [
+  "François Bobot"
+  "Jean-Christophe Filliâtre"
+  "Claude Marché"
+  "Guillaume Melquiond"
+  "Andrei Paskevich"
+]
+homepage: "http://why3.lri.fr/"
+license: "GNU Lesser General Public License version 2.1"
+doc: ["http://why3.lri.fr/#documentation"]
+tags: [
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+]
+build: [
+  ["./configure" "--prefix" prefix "--disable-bench"]
+  [make "opt" "byte"]
+  [make "install" "install-lib"]
+]
+build-doc: [
+  [make "doc" "stdlibdoc" "apidoc"]
+  [make "DOCDIR=%{doc}%/why3" "install-doc"]
+]
+depends: [
+  "alt-ergo"
+  "lablgtk"    {>= "2.14.2"}
+  "conf-gtksourceview"
+  "camlzip"
+  "zarith"
+]
+depopts: [
+  "ocamlgraph" {>= "1.8.2"}
+  "coq" {>= "8.4"}
+]

--- a/packages/why3/why3.0.85/url
+++ b/packages/why3/why3.0.85/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/file/34074/why3-0.85.tar.gz"
+checksum: "f6d36c0dc43fe75af148d92d76b15937"


### PR DESCRIPTION
A new version of why3, version 0.85, is released. This is mainly a bug-fix version w.r.t to version 0.84,
released only 2 weeks ago.
- Claude
