### PR TITLE
mldonkey: two problems with 4.02.0

### DIFF
--- a/packages/mldonkey/mldonkey.3.1.3/opam
+++ b/packages/mldonkey/mldonkey.3.1.3/opam
@@ -7,4 +7,5 @@ build: [
   [make]
   [make "install"]
 ]
-ocaml-version: [>= "3.10.1"]
+ocaml-version: [>= "3.10.1" & < "4.02.0"]
+depends: ["camlp4"]

--- a/packages/mldonkey/mldonkey.3.1.5/opam
+++ b/packages/mldonkey/mldonkey.3.1.5/opam
@@ -7,7 +7,8 @@ build: [
   [make]
   [make "install"]
 ]
-ocaml-version: [>= "3.10.1"]
+ocaml-version: [>= "3.10.1" & < "4.02.0"]
+depends: ["camlp4"]
 depexts: [
   [ ["ubuntu"] ["zlib1g-dev"] ]
   [ ["debian"] ["zlib1g-dev"] ]


### PR DESCRIPTION
- requires camlp4
- does not work on 4.02.0 because of the new-string-syntax-in-comment problem
