### PR TITLE
arakoon: requires ocaml < 4.02.0

### DIFF
--- a/packages/arakoon/arakoon.1.6.5/opam
+++ b/packages/arakoon/arakoon.1.6.5/opam
@@ -18,3 +18,4 @@ depends: [
   "camlbz2"
 ]
 patches: ["opam.patch"]
+ocaml-version: [< "4.02.0"]

--- a/packages/arakoon/arakoon.1.6.6/opam
+++ b/packages/arakoon/arakoon.1.6.6/opam
@@ -18,3 +18,4 @@ depends: [
   "camlbz2"
 ]
 patches: ["opam.patch"]
+ocaml-version: [< "4.02.0"]

--- a/packages/arakoon/arakoon.1.6.7/opam
+++ b/packages/arakoon/arakoon.1.6.7/opam
@@ -18,3 +18,4 @@ depends: [
   "camlbz2"
 ]
 patches: ["opam.patch"]
+ocaml-version: [< "4.02.0"]


### PR DESCRIPTION
arakoon uses Printf.CamlinternalPr, which does not exist any more
