### PR TITLE
argot: requires ocaml < 4.02.0

### DIFF
--- a/packages/argot/argot.1.1/opam
+++ b/packages/argot/argot.1.1/opam
@@ -10,4 +10,4 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "argot"]]
 depends: ["ocamlfind"]
-ocaml-version: [>= "4.0.0"]
+ocaml-version: [>= "4.0.0" & < "4.02.0"]


### PR DESCRIPTION
argot is broken in 4.02.0 by changes in ocamldoc
