### PR TITLE
dlist: fix install instructions

### DIFF
--- a/packages/dlist/dlist.0.0.3/opam
+++ b/packages/dlist/dlist.0.0.3/opam
@@ -4,11 +4,13 @@ authors: ["BYVoid <byvoid@byvoid.com>"]
 homepage: "https://github.com/BYVoid/Dlist"
 license: "BSD3"
 build: [
-  ["ocp-build" "root"]
+  ["ocp-build" "-init"]
+  ["ocp-build" "build"]
   ["ocp-build" "install" "dlist"]
 ]
 remove: [
-  ["ocp-build" "root"]
+  ["ocp-build" "-init"]
+  ["ocp-build" "build"]
   ["ocp-build" "uninstall"]
 ]
 depends: ["ocp-build" {>= "1.99.6-beta"}]

--- a/packages/dlist/dlist.0.1.0/opam
+++ b/packages/dlist/dlist.0.1.0/opam
@@ -4,12 +4,12 @@ authors: ["BYVoid <byvoid@byvoid.com>"]
 homepage: "https://github.com/BYVoid/Dlist"
 license: "BSD3"
 build: [
-  ["ocp-build" "init"]
+  ["ocp-build" "-init"]
   ["ocp-build" "build"]
   ["ocp-build" "install"]
 ]
 remove: [
-  ["ocp-build" "init"]
+  ["ocp-build" "-init"]
   ["ocp-build" "build"]
   ["ocp-build" "uninstall"]
 ]


### PR DESCRIPTION
Fix install instructions to work on both ocp-build.1.99.6-beta and 1.99.8-beta

`ocp-build root` -- works on 1.99.6 but not on 1.99.8
`ocp-build init` -- works on 1.99.8 but not on 1.99.6
`ocp-build -init` -- works on both
