### PR TITLE
Atdgen 1.4.0 requires biniou version 1.0.6 or later.

### DIFF
--- a/packages/atdgen/atdgen.1.4.0/opam
+++ b/packages/atdgen/atdgen.1.4.0/opam
@@ -11,6 +11,6 @@ remove: [
 depends: [
   "ocamlfind"
   "atd" {>= "1.1.0"}
-  "biniou"
+  "biniou" {>= "1.0.6"}
   "yojson"
 ]


### PR DESCRIPTION
Compiling atdgen 1.4.0 against biniou 1.0.5 fails with the following:

```
File "ag_ob_run.ml", line 145, characters 11-28:
Error: Unbound value Bi_io.float32_tag
Hint: Did you mean float64_tag?
Makefile:135: recipe for target 'ag_ob_run.cmi' failed
make[1]: *** [ag_ob_run.cmi] Error 2
```

/cc @mjambon
