### PR TITLE
Constrain opa-base.1.1.0+4263 to OCaml < 4.01.0

### DIFF
--- a/packages/opa-base/opa-base.1.1.0+4263/opam
+++ b/packages/opa-base/opa-base.1.1.0+4263/opam
@@ -17,3 +17,4 @@ patches: [
   "rm_deps.patch"
   "ocamlfind.patch"
 ]
+ocaml-version: [ < "4.01.0" ]


### PR DESCRIPTION
Use of `-warn-error` stops opa-base building with recent OCaml versions:

```
# + ocamlc.opt -c -warn-error A -w L -w Z -I ocamllib/libbase -I compiler -I tools -I lib -I ocamllib -I tools/build -o ocamllib/libbase/uchar.cmo ocamllib/libbase/uchar.ml
# File "ocamllib/libbase/uchar.ml", line 45, characters 38-40:
# Warning 3: deprecated feature: operator (or); you should use (||) instead
# File "ocamllib/libbase/uchar.ml", line 1:
# Error: Some fatal warnings were triggered (1 occurrences)
# Command exited with code 2.
```
