### PR TITLE
batteries.2.3 not compatible with ocaml < 4.01

### DIFF
--- a/packages/batteries/batteries.2.3.0/opam
+++ b/packages/batteries/batteries.2.3.0/opam
@@ -10,4 +10,4 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "batteries"]]
 depends: ["ocamlfind" {>= "1.5.3"}]
-ocaml-version: [< "4.03.0"]
+ocaml-version: [>= "4.01.0" & < "4.03.0"]


### PR DESCRIPTION
a bugfix release should restore the compatibility.
