### PR TITLE
Fix availability for lablgtk-extras for ocaml < 4.02

### DIFF
--- a/packages/lablgtk-extras/lablgtk-extras.1.2/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.2/opam
@@ -13,4 +13,4 @@ depends: [
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
 ]
-available: ["ocaml-version" < "4.02.0"]
+available: [ocaml-version < "4.02.0"]

--- a/packages/lablgtk-extras/lablgtk-extras.1.3/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.3/opam
@@ -13,4 +13,4 @@ depends: [
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
 ]
-available: ["ocaml-version" < "4.02.0"]
+available: [ocaml-version < "4.02.0"]

--- a/packages/lablgtk-extras/lablgtk-extras.1.4/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.4/opam
@@ -22,4 +22,4 @@ depends: [
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
 ]
-available: ["ocaml-version" < "4.02.0"]
+available: [ocaml-version < "4.02.0"]


### PR DESCRIPTION
See https://github.com/ocaml/opam/issues/1755
