### PR TITLE
Batteries.2.3.0 broken with ocaml 4.01 as well

### DIFF
--- a/packages/batteries/batteries.2.3.0/opam
+++ b/packages/batteries/batteries.2.3.0/opam
@@ -10,4 +10,4 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "batteries"]]
 depends: ["ocamlfind" {>= "1.5.3"}]
-ocaml-version: [>= "4.01.0" & < "4.03.0"]
+ocaml-version: [>= "4.02.0" & < "4.03.0"]


### PR DESCRIPTION
due to missing bytes package in META

@gasche ? what do you think ? The other solution is to patch batteries.2.3.0 opam package ?  
