### PR TITLE
Disable -warn-error so that ocamlclean builds with OCaml 4.02.0.

### DIFF
--- a/packages/ocamlclean/ocamlclean.2.0/files/disable-warn-error.patch
+++ b/packages/ocamlclean/ocamlclean.2.0/files/disable-warn-error.patch
@@ -1,0 +1,18 @@
+diff --git a/configure b/configure
+index 73cd90a..9e5fcc1 100755
+--- a/configure
++++ b/configure
+@@ -76,10 +76,10 @@ done
+ echo -n "\
+ BINDIR = $BINDIR
+ MAN1DIR = $MANDIR/man1
+-OCAMLC = $OCAMLC -w Ae -warn-error A
+-OCAMLOPT = $OCAMLOPT -w Ae -warn-error A
++OCAMLC = $OCAMLC -w Ae
++OCAMLOPT = $OCAMLOPT -w Ae
+ OCAMLC_UNSAFE = $OCAMLC
+-OCAMLBUILD = $OCAMLBUILD -cflags -w,Ae,-warn-error,A -lflags -w,Ae,-warn-error,A -no-links -classic-display
++OCAMLBUILD = $OCAMLBUILD -cflags -w,Ae -lflags -w,Ae -no-links -classic-display
+ BIN = $PWD/bin
+ ETC = $PWD/etc
+ DIST = $PWD/dist

--- a/packages/ocamlclean/ocamlclean.2.0/opam
+++ b/packages/ocamlclean/ocamlclean.2.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1"
 maintainer: "benoit.vaugon@gmail.com"
+patches: [
+  "disable-warn-error.patch"
+]
 build: [
   ["./configure" "-prefix" prefix]
   [make "all"]


### PR DESCRIPTION
Pre-patch:

```
### stdout ###
# ...[truncated]
# File "index.ml", line 23, characters 18-31:
# Warning 3: deprecated: String.create
# File "index.ml", line 24, characters 13-26:
# Warning 3: deprecated: String.create
# File "index.ml", line 1:
# Error: Some fatal warnings were triggered (2 occurrences)
```

/cc @bvaugon
