### PR TITLE
Update mindstorm checksum.

### DIFF
--- a/packages/mindstorm/mindstorm.0.5.3/url
+++ b/packages/mindstorm/mindstorm.0.5.3/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/Chris00/ocaml-mindstorm/releases/download/0.5.3/mindstorm-0.5.3.tar.gz"
-checksum: "d1466034ffe5c87f180c4b47303aa9bc"
+checksum: "1751ad556c6c9056c0d27dfe4ab221fc"


### PR DESCRIPTION
As the [bulk logs](https://github.com/ocaml/opam-bulk-logs/blob/master/ubuntu-trusty/4.02.0/20140930/raw/mindstorm#L47-L49) show, the checksum for the mindstorm 0.5.3 tarball has apparently changed:

```
[ERROR] Wrong checksum for /home/opam/.opam/packages.dev/mindstorm.0.5.3/mindstorm-0.5.3.tar.gz:
- d1466034ffe5c87f180c4b47303aa9bc [expected result]
- 1751ad556c6c9056c0d27dfe4ab221fc [actual result]
```

I don't know how it's changed, since the release was last tagged before the package was submitted:

``` bash
$ git log -1 --format=%ai 0.5.3   # in ocaml-mindstorm
2014-04-16 16:36:14 +0200
```

``` bash
$ git log packages/mindstorm/mindstorm.0.5.3/url   # in opam-repository
commit bc4e27eb9cce7e33933be77ff20f969f8df911df
Author: Christophe Troestler <Christophe.Troestler@umons.ac.be>
Date:   Wed Apr 16 16:47:20 2014 +0200

    Add mindstorm 0.5.3
```

/cc @Chris00 
