### PR TITLE
Make warning 3 (deprecated feature) non-fatal for the mezzo build.

### DIFF
--- a/packages/mezzo/mezzo.0.0.m8/files/no-deprecated-fatal-warning.patch
+++ b/packages/mezzo/mezzo.0.0.m8/files/no-deprecated-fatal-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/myocamlbuild.pre.ml b/myocamlbuild.pre.ml
+index 24b1d3c..1bf6c8e 100644
+--- a/myocamlbuild.pre.ml
++++ b/myocamlbuild.pre.ml
+@@ -28,7 +28,7 @@ let _ =
+     match event with
+     | After_rules ->
+         flag ["ocaml"; "compile"; "my_warnings"]
+-          (S[A "-w"; A "@1..3@8..12@14..21@23..40-41@43"]);
++          (S[A "-w"; A "@1-2+3@8..12@14..21@23..40-41@43"]);
+     | _ -> ()
+   );
+ ;;

--- a/packages/mezzo/mezzo.0.0.m8/opam
+++ b/packages/mezzo/mezzo.0.0.m8/opam
@@ -11,6 +11,9 @@ depends: [
   "functory"
   "pprint"
 ]
+patches: [
+  "no-deprecated-fatal-warning.patch"
+]
 build: [
   ["./configure"]
   [make]


### PR DESCRIPTION
The fatal warning for deprecated features causes the mezzo build to fail with OCaml 4.02.0:

```
# File "utils/Utils.ml", line 74, characters 10-23:
# Warning 3: deprecated: String.create
# File "utils/Utils.ml", line 1:
# Error: Some fatal warnings were triggered (1 occurrences)
# Command exited with code 2.
# Makefile:35: recipe for target 'all' failed
```

0695745 adds a patch to make the warning non-fatal.

/cc @protz
