### PR TITLE
Add dependency on base-bytes to deriving.0.7.

### DIFF
--- a/packages/deriving/deriving.0.7/opam
+++ b/packages/deriving/deriving.0.7/opam
@@ -8,6 +8,7 @@ build: [
 remove: [["ocamlfind" "remove" "deriving"]]
 depends: [
   "ocamlfind"
+  "base-bytes"
   "optcomp" {>= "1.6"}
   "camlp4"
 ]


### PR DESCRIPTION
Fixes #2808.
