### PR TITLE
Make gettext usable with Ocaml >= 4.2

### DIFF
--- a/packages/gettext/gettext.0.3.5/opam
+++ b/packages/gettext/gettext.0.3.5/opam
@@ -16,4 +16,3 @@ depends: [
   "fileutils"
   "camomile"
 ]
-ocaml-version: [<"4.02.0"]


### PR DESCRIPTION
Sylvain Le Gall thinks the condition Ocaml < 4.2 is useless with gettext 0.3.5.

Thank you.
