### PR TITLE
Experimentally activate Apt caching for Travis downloads.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 script: bash -e .travis-ci.sh
+cache: apt
 os:
 - linux
 - osx


### PR DESCRIPTION
This should improve the reliability of builds, which have been
failing with sporadic network errors recently.
See http://docs.travis-ci.com/user/caching/ for more info.
