### PR TITLE
Bump Slacko minimum dependency of CoHTTP to 0.10

### DIFF
--- a/packages/slacko/slacko.0.9.0/opam
+++ b/packages/slacko/slacko.0.9.0/opam
@@ -17,6 +17,6 @@ depends: [
   "yojson"
   "lwt"
   "ssl"
-  "cohttp"
+  "cohttp" {>= "0.10.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/slacko/slacko.0.9.1/opam
+++ b/packages/slacko/slacko.0.9.1/opam
@@ -17,6 +17,6 @@ depends: [
   "yojson"
   "lwt"
   "ssl"
-  "cohttp"
+  "cohttp" {>= "0.10.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]


### PR DESCRIPTION
As mentioned by @avsm on #2828, older versions have different APIs. Some testing revealed that it works with 0.10.0 onwards at the moment, so I set this as minimum version.
