### PR TITLE
fPIC compiler

### DIFF
--- a/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.comp
+++ b/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.comp
@@ -1,0 +1,11 @@
+opam-version: "1"
+version: "4.02.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
+build: [
+  ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: ["base-unix" "base-bigarray" "base-threads"]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.descr
+++ b/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.descr
@@ -1,0 +1,1 @@
+OCaml 4.02, with -fPIC runtime libs.


### PR DESCRIPTION
Version of 4.02.0 configured with -fPIC, which is necessary to link libasmrun.a and such into a shared library.
(There's already such a 4.01.0 variant. More discussion at http://www.camlcity.org/knowledge/kb_002_shared_library.html)
