### PR TITLE
Add Homepage and Doc fields to OUnit 2.0.0 file.

### DIFF
--- a/packages/ounit/ounit.2.0.0/opam
+++ b/packages/ounit/ounit.2.0.0/opam
@@ -1,5 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
+homepage: "https://forge.ocamlcore.org/projects/ounit/"
+doc: ["https://forge.ocamlcore.org/plugins/scmdarcs/cgi-bin/darcsweb.cgi?r=ounit/ounit;a=plainblob;f=/doc/manual.txt"]
 build: [
   [make "build"]
   [make "install"]


### PR DESCRIPTION
The doc link is the best approximation to a published doc that I know of (unrendered HEAD manual.txt instead of rendered version + ocamldoc-generated html doc for the 2.0.0 version).
