### PR TITLE
The license of WiringPi is actually LGPL

### DIFF
--- a/packages/wiringpi/wiringpi.0.0.1/opam
+++ b/packages/wiringpi/wiringpi.0.0.1/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "marek@xivilization.net"
 homepage: "https://github.com/Leonidas-from-XIV/ocaml-wiringpi"
-license: "GPL-3 with OCaml linking exception"
+license: "LGPL-3 with OCaml linking exception"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]


### PR DESCRIPTION
It was relicensed in the 0.0.1 release, somehow that change slipped while packaging.
