### PR TITLE
xmldiff 0.3.0 and 0.4.0 depend on camlp4

### DIFF
--- a/packages/xmldiff/xmldiff.0.3.0/opam
+++ b/packages/xmldiff/xmldiff.0.3.0/opam
@@ -15,6 +15,7 @@ remove: [
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.0" }
+  "camlp4"
 ]
 depopts: [
   "js_of_ocaml" {>= "2.4.0" }

--- a/packages/xmldiff/xmldiff.0.4.0/opam
+++ b/packages/xmldiff/xmldiff.0.4.0/opam
@@ -15,6 +15,7 @@ remove: [
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.0" }
+  "camlp4"
 ]
 depopts: [
   "js_of_ocaml" {>= "2.4.0" }


### PR DESCRIPTION
xmldiff depends on camlp4, as [shown in the bulk logs](https://github.com/ocaml/opam-bulk-logs/blob/master/ubuntu-trusty/4.02.0/20140930/raw/xmldiff#L60-L62):

```
checking for camlp4... no
Exception: Program_not_found "camlp4".
[ERROR] The compilation of xmldiff.0.3.0 failed.
```
