### PR TITLE
Milter 1.0.0 requires OCaml < 4.02.0

### DIFF
--- a/packages/milter/milter.1.0.0/opam
+++ b/packages/milter/milter.1.0.0/opam
@@ -14,3 +14,4 @@ depexts: [
   [["debian"] ["libmilter-dev"]]
   [["ubuntu"] ["libmilter-dev"]]
 ]
+ocaml-version: [< "4.02.0"]


### PR DESCRIPTION
OCaml 4.02's new string literal syntax `{x|...|x}` causes a parse failure in [this comment](https://github.com/andrenth/ocaml-milter/blob/1.0.0/lib/milter.mli#L161):

```
   - [{unix|local}:/path/to/file] -- A named pipe.
```

as [shown in the bulk logs](https://github.com/ocaml/opam-bulk-logs/blob/master/ubuntu-trusty/4.02.0/20140930/raw/milter#L149-L153)

/cc @andrenth
