### PR TITLE
Update MD5 sum for fixed release of Slacko

### DIFF
--- a/packages/slacko/slacko.0.10.0/url
+++ b/packages/slacko/slacko.0.10.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/Leonidas-from-XIV/slacko/releases/download/0.10.0/slacko-0.10.0.tar.gz"
-checksum: "f4692f1135405ed3fc065082a96a527b"
+checksum: "f80964d96f45adf22c131550dd4ea9e4"


### PR DESCRIPTION
Forgot to set the proper version in `_oasis` in the original upload; this tarball contains the proper information. Thanks to @dsheets for spotting this issue. Fixes #2891.
