### PR TITLE
mlpost: cairo is a hard dependency

### DIFF
--- a/packages/mlpost/mlpost.0.8.1/opam
+++ b/packages/mlpost/mlpost.0.8.1/opam
@@ -24,8 +24,8 @@ remove: [
 depends: [
   "ocamlfind"
   "bitstring"
+  "cairo" {= "1.2.0"}
 ]
-depopts: ["cairo" {= "1.2.0"}]
 patches: ["opam.patch"]
 depexts: [
   [["debian"] ["autoconf"]]


### PR DESCRIPTION
mlpost requires cairo (this was incorrect to make it an optional dependency)
