### PR TITLE
openflow.0.6.2: fix version constraint for async_extra

### DIFF
--- a/packages/openflow/openflow.0.6.2/opam
+++ b/packages/openflow/openflow.0.6.2/opam
@@ -16,4 +16,4 @@ depends: [
   "sexplib"
 ]
 depopts: [ "async" "quickcheck" ]
-conflicts: [ "async_extra" {<= "111.25.00"} ]
+conflicts: [ "async_extra" {< "111.25.00"} ]


### PR DESCRIPTION
This version of the library is in fact compatible with async_extra.111.25.00.
