### PR TITLE
Fix ocaml-version constraint on ppx_tools again

### DIFF
--- a/packages/ppx_tools/ppx_tools.0.99.1/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.1/opam
@@ -6,4 +6,4 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]
-available: [ ocaml-version = "4.02.1" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03.0" ]

--- a/packages/ppx_tools/ppx_tools.0.99.2/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.2/opam
@@ -6,4 +6,4 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]
-available: [ ocaml-version = "4.02.1" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03.0" ]


### PR DESCRIPTION
Ok, I'm not sure how exactly, but #2921 got the versions wrong. 0.99.1 and 0.99.2 work both on 4.02.0 and 4.02.1, but not on 4.03; 0.99 and 0.1 works only on 4.02.0. I've manually verified all the combinations to work.
