### PR TITLE
Removed deprecated Lwt text dependency

### DIFF
--- a/packages/lwt/lwt.2.4.6/opam
+++ b/packages/lwt/lwt.2.4.6/opam
@@ -10,7 +10,6 @@ build: [
     "--%{base-unix:enable}%-extra"
     "--%{base-threads:enable}%-preemptive"
     "--%{lablgtk:enable}%-glib"
-    "--%{ocaml-text:enable}%-text" {"%{react:installed}%"}
     "--%{ppx_tools:enable}%-ppx"]
   [make "build"]
   [make "install"]
@@ -28,7 +27,6 @@ depopts: [
   "ssl"
   "react"
   "lablgtk"
-  "text"
 ]
 conflicts: [
  "react" {<"1.0.0"}


### PR DESCRIPTION
There was discussion of Lwt text being deprecated in #2894, so I thought I might as well do the pull request. Feel free to merge or reject if the dependency is still desired in 2.4.6.
