### PR TITLE
Revert "core 112.01.00 does not builde on i686"

### DIFF
--- a/packages/core_kernel/core_kernel.112.01.00/opam
+++ b/packages/core_kernel/core_kernel.112.01.00/opam
@@ -23,4 +23,3 @@ depends: ["camlp4"
           "typerep" {= "111.17.00"}
           "variantslib" {>= "109.15.00" & <= "109.15.03"}]
 ocaml-version: [>= "4.01.0"]
-available: [ arch != "i686" ]


### PR DESCRIPTION
Reverts ocaml/opam-repository#2956
