### PR TITLE
add depopts for centos

### DIFF
--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -7,4 +7,5 @@ depexts: [
   [["debian"] ["libgmp-dev"]]
   [["ubuntu"] ["libgmp-dev"]]
   [["osx" "homebrew"] ["gmp"]]
+  [["centos"] ["gmp" "gmp-devel"]]
 ]


### PR DESCRIPTION
I've no centos system around, but did some research on the internet (and found the libraries are named gmp and gmp-devel, please correct me if I'm wrong)..
