### PR TITLE
Restrict core_kernel.112.01.00 to x86_64 only

### DIFF
--- a/packages/core_kernel/core_kernel.112.01.00/opam
+++ b/packages/core_kernel/core_kernel.112.01.00/opam
@@ -23,3 +23,4 @@ depends: ["camlp4"
           "typerep"     {>= "111.17.00" & < "111.18.00"}
           "variantslib" {>= "109.15.00" & < "109.16.00"}]
 ocaml-version: [>= "4.01.0"]
+available: [ arch = "x86_64" ]


### PR DESCRIPTION
It fails builds on arch = i686 and armv7l (and presumably all other
32-bit ARM variants), so the restriction to x86_64 is easier than
finding all the 32-bit variants.

See ocaml/opam-repository#2764 for discussion
