### PR TITLE
bencode 1.0.1, fixing an issue in META

### DIFF
--- a/packages/bencode/bencode.1.0.1/descr
+++ b/packages/bencode/bencode.1.0.1/descr
@@ -1,0 +1,1 @@
+Read/Write bencode (.torrent) files in OCaml

--- a/packages/bencode/bencode.1.0.1/opam
+++ b/packages/bencode/bencode.1.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1"
+maintainer: "rudi.grinberg@gmail.com"
+authors: [ "Rudi Grinberg" "Simon Cruanes" ]
+license: "MIT"
+build: [
+  [make "all"]
+  [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "bencode"]
+]
+depends: ["ocamlfind"]
+ocaml-version: [>="4.00.1"]

--- a/packages/bencode/bencode.1.0.1/url
+++ b/packages/bencode/bencode.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/rgrinberg/bencode/archive/1.0.1.tar.gz"
+checksum: "90c6f46e97b0b53bf8731c54eafb96f5"


### PR DESCRIPTION
Small fix required, bencode depends on `bytes`, not `base-bytes` from ocamlfind's pov.
