### PR TITLE
with latest compile attempt for piqilib to incorporate byte-code-library

### DIFF
--- a/packages/piqilib/piqilib.0.6.8/opam
+++ b/packages/piqilib/piqilib.0.6.8/opam
@@ -17,4 +17,5 @@ depends: [
   "ulex"
   "xmlm"
   "optcomp"
+  "base64"
 ]


### PR DESCRIPTION
base64 broke the build since it wasn't already installed. Document issue, push upstream
