### PR TITLE
Revert "Revert "core 112.01.00 does not builde on i686""

### DIFF
--- a/packages/core_kernel/core_kernel.112.01.00/opam
+++ b/packages/core_kernel/core_kernel.112.01.00/opam
@@ -23,3 +23,4 @@ depends: ["camlp4"
           "typerep"     {>= "111.17.00" & < "111.18.00"}
           "variantslib" {>= "109.15.00" & < "109.16.00"}]
 ocaml-version: [>= "4.01.0"]
+available: [ arch != "i686" ]


### PR DESCRIPTION
reverting the revert now the upgrade scripts have been upgraded
