### PR TITLE
mustache 0.1.0

### DIFF
--- a/packages/mustache/mustache.0.1.0/descr
+++ b/packages/mustache/mustache.0.1.0/descr
@@ -1,0 +1,1 @@
+Mustache logic-less templates in OCaml

--- a/packages/mustache/mustache.0.1.0/files/add_pipe.patch
+++ b/packages/mustache/mustache.0.1.0/files/add_pipe.patch
@@ -1,0 +1,38 @@
+diff --git a/lib/mustache.ml b/lib/mustache.ml
+index f6ffcc7..2c702fa 100644
+--- a/lib/mustache.ml
++++ b/lib/mustache.ml
+@@ -5,6 +5,9 @@ module Str = Re_str
+ module List = ListLabels
+ module String = StringLabels
+ 
++let (|>) x f = f x
++let (@@) f x = f x
++
+ exception Invalid_param of string with sexp
+ exception Invalid_template of string with sexp
+ 
+diff --git a/lib_test/mustache_cli.ml b/lib_test/mustache_cli.ml
+index ff90ae9..49ee0ba 100644
+--- a/lib_test/mustache_cli.ml
++++ b/lib_test/mustache_cli.ml
+@@ -1,3 +1,5 @@
++let (|>) x f = f x
++let (@@) f x = f x
+ 
+ let apply_mustache json_data template_data =
+ 	let env = Ezjsonm.from_string json_data
+diff --git a/lib_test/test_mustache.ml b/lib_test/test_mustache.ml
+index 2b49f5a..2c6bc1d 100644
+--- a/lib_test/test_mustache.ml
++++ b/lib_test/test_mustache.ml
+@@ -2,6 +2,9 @@ open OUnit2
+ open Printf
+ open Sexplib.Std
+ 
++let (|>) x f = f x
++let (@@) f x = f x
++
+ module List = ListLabels
+ module String = StringLabels
+ 

--- a/packages/mustache/mustache.0.1.0/findlib
+++ b/packages/mustache/mustache.0.1.0/findlib
@@ -1,0 +1,1 @@
+mustache

--- a/packages/mustache/mustache.0.1.0/opam
+++ b/packages/mustache/mustache.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1"
+maintainer: "rudi.grinberg@gmail.com"
+authors: [ "Rudi Grinberg" ]
+license: "WTFPL"
+build: [
+  [make "configure"]
+  [make "build"]
+  [make "install"]
+]
+build-test: [
+  [make "configure"]
+  [make "test"]
+]
+remove: [
+  ["ocamlfind" "remove" "mustache"]
+]
+build-doc: [ make "doc" ]
+depends: [
+  "ocamlfind"
+  "ezjsonm"
+  "oasis"
+  "re"
+  "sexplib"
+  "ounit" {build}
+]
+patches: ["add_pipe.patch" {ocaml-version < "4.01.0"}]
+ocaml-version: [>="3.12.1"]

--- a/packages/mustache/mustache.0.1.0/url
+++ b/packages/mustache/mustache.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/rgrinberg/ocaml-mustache/archive/v0.1.0.tar.gz"
+checksum: "532f10dfbc934e45c40c76f031da6816"


### PR DESCRIPTION
Updated to url and checksum to point to the latest version of ocaml-mustache.
All the other files are the same as the v0.0.2.
