### PR TITLE
Apply the "redirection patch" to ocamlnet 3.7.7

### DIFF
--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -43,3 +43,4 @@ depopts: [
   "camlzip"
   "cryptokit"
 ]
+patches: ["robust-host.patch"]


### PR DESCRIPTION
This is essential to be able to download Jane Street blog feed
https://blogs.janestreet.com/category/ocaml/feed/
