### PR TITLE
Resubmitted sociaml-facebook-api with license changed to ISC/BSD

### DIFF
--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
@@ -4,7 +4,7 @@ version: "0.4.0"
 maintainer: "dominic.price@nottingham.ac.uk"
 homepage: "https://github.com/dominicjprice/sociaml-facebook-api"
 authors: [ "Dominic Price" ]
-license: "GPL-3"
+license: "ISC"
 ocaml-version: [ >= "4.01.0" ]
 build: [
   ["oasis" "setup"]

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/url
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/dominicjprice/sociaml-facebook-api/archive/v0.4.0.tar.gz"
-checksum: "a1b571fd38c3f9124918b76c30a9d9ed"
+checksum: "7cb24524f736f554b1c132a586c81b1a"


### PR DESCRIPTION
Licence has been changed from GPL-3 to ISC/BSD.
