### PR TITLE
[opam-publish] opam-publish.0.2

### DIFF
--- a/packages/opam-publish/opam-publish.0.2/descr
+++ b/packages/opam-publish/opam-publish.0.2/descr
@@ -1,0 +1,4 @@
+A tool to ease contributions to opam repositories.
+
+Opam-publish helps gather metadata to form an OPAM package and submit it
+to a remote repository.

--- a/packages/opam-publish/opam-publish.0.2/opam
+++ b/packages/opam-publish/opam-publish.0.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "http://opam.ocaml.org"
+dev-repo: "https://github.com/AltGr/opam-publish.git"
+bug-reports: "https://github.com/AltGr/opam-publish/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+build: [make]
+depends: [
+  "opam-lib" {build & >= "1.2.0"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  "github" {build & >= "0.8.5"}
+]

--- a/packages/opam-publish/opam-publish.0.2/url
+++ b/packages/opam-publish/opam-publish.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/opam-publish/archive/0.2.tar.gz"
+checksum: "2f35f25a12ab0642dad01703703b7359"


### PR DESCRIPTION
Pull-request generated by opam-publish v0.2

---

A tool to ease contributions to opam repositories.

Opam-publish helps gather metadata to form an OPAM package and submit it
to a remote repository.
