### PR TITLE
[opam-publish] cmdliner.0.9.6

### DIFF
--- a/packages/cmdliner/cmdliner.0.9.6/opam
+++ b/packages/cmdliner/cmdliner.0.9.6/opam
@@ -1,17 +1,21 @@
 opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
-authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
+
+authors: "Daniel Bünzli <daniel.buenzli i@erratique.ch>"
 homepage: "http://erratique.ch/software/cmdliner"
-doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
-dev-repo: "http://erratique.ch/repos/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
-tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "BSD3"
-depends: ["ocamlfind"]
-available: [ocaml-version >= "4.00.0"]
-build: 
-[
-  ["ocaml" "pkg/git.ml" ] 
-  ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
-                          "native-dynlink=%{ocaml-native-dynlink}%" ]
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+tags: [
+  "cli"
+  "system"
+  "declarative"
+  "org:erratique"
 ]
+dev-repo: "http://erratique.ch/repos/cmdliner.git"
+build: [
+  ["ocaml" "pkg/git.ml"]
+  ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+]
+depends: "ocamlfind"
+available: [ocaml-version >= "4.00.0"]

--- a/packages/cmdliner/cmdliner.0.9.6/url
+++ b/packages/cmdliner/cmdliner.0.9.6/url
@@ -1,2 +1,2 @@
-archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-0.9.6.tbz"
+http: "http://erratique.ch/software/cmdliner/releases/cmdliner-0.9.6.tbz"
 checksum: "9c2490a6d1def1e6a8bb264f235682cb"


### PR DESCRIPTION
Pull-request generated by opam-publish v0.2

---

Declarative definition of command line interfaces for OCaml

Cmdliner is a module for the declarative definition of command line
interfaces.

It provides a simple and compositional mechanism to convert command
line arguments to OCaml values and pass them to your functions. The
module automatically handles syntax errors, help messages and UNIX man
page generation. It supports programs with single or multiple commands
and respects most of the [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html) and [GNU](http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html) conventions.

Cmdliner is made of a single independent module and distributed under
the BSD3 license.

---
- Homepage: http://erratique.ch/software/cmdliner
- Source repo: http://erratique.ch/repos/cmdliner.git
- Bug tracker: https://github.com/dbuenzli/cmdliner/issues
