### PR TITLE
conduit: dns must be at least 0.10.0

### DIFF
--- a/packages/conduit/conduit.0.6.0/opam
+++ b/packages/conduit/conduit.0.6.0/opam
@@ -29,5 +29,6 @@ conflicts: [
   "lwt" {<"2.4.3"}
   "async_ssl" {<"111.21.00"}
   "mirage-types" {<"2.0.0"}
+  "dns" {<"0.10.0"}
 ]
 ocaml-version: [>="4.01.0"]

--- a/packages/conduit/conduit.0.6.1/opam
+++ b/packages/conduit/conduit.0.6.1/opam
@@ -29,5 +29,6 @@ conflicts: [
   "lwt" {<"2.4.3"}
   "async_ssl" {<"111.21.00"}
   "mirage-types" {<"2.0.0"}
+  "dns" {<"0.10.0"}
 ]
 ocaml-version: [>="4.01.0"]


### PR DESCRIPTION
findlib name dns.mirage minted for 0.10.0

See also mirage/ocaml-conduit#26.
