### PR TITLE
dnscurve: cap dns dep at 0.10.x series

### DIFF
--- a/packages/dnscurve/dnscurve.0.1.0/opam
+++ b/packages/dnscurve/dnscurve.0.1.0/opam
@@ -8,7 +8,7 @@ build: [
 remove: [["ocamlfind" "remove" "dnscurve"]]
 depends: [
   "ocamlfind"
-  "dns" {>= "0.7.0"}
+  "dns" {>= "0.7.0" & < "0.11.0"}
   "sodium" {< "0.2.0"}
 ]
 depopts: ["lwt"]

--- a/packages/dnscurve/dnscurve.0.2.0/opam
+++ b/packages/dnscurve/dnscurve.0.2.0/opam
@@ -8,7 +8,7 @@ build: [
 remove: [["ocamlfind" "remove" "dnscurve"]]
 depends: [
   "ocamlfind"
-  "dns" {>= "0.8.0"}
+  "dns" {>= "0.8.0" & < "0.11.0"}
   "sodium" {>= "0.2.0"}
 ]
 depopts: ["lwt"]


### PR DESCRIPTION
marshal now takes an optional allocator for page-aligned buffers in mirage
