### PR TITLE
Added extprot.1.1.2.

### DIFF
--- a/packages/extprot/extprot.1.1.2/descr
+++ b/packages/extprot/extprot.1.1.2/descr
@@ -1,0 +1,5 @@
+Extensible binary protocols for cross-language communication and long-term serialization
+extprot allows you to create compact, efficient, extensible, binary protocols that can
+be used for cross-language communication and long-term data serialization.
+extprot supports protocols with rich, composable types, whose definition can evolve
+while keeping both forward and backward compatibility.

--- a/packages/extprot/extprot.1.1.2/findlib
+++ b/packages/extprot/extprot.1.1.2/findlib
@@ -1,0 +1,1 @@
+extprot

--- a/packages/extprot/extprot.1.1.2/opam
+++ b/packages/extprot/extprot.1.1.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/mfp/extprot"
+license: "MIT"
+doc: ["https://github.com/mfp/extprot/blob/master/README.md"]
+build: [
+  ["omake"]
+  ["omake" "install" "prefix=%{prefix}%"]
+]
+build-test: [["omake" "test"] {"%{ounit:installed}"}]
+remove: [
+  ["ocamlfind" "remove" "extprot"]
+  ["rm" "-f" "%{bin}%/extprotc" "%{bin}%/extprotc.exe"]
+]
+depends: [
+  "ocamlfind"
+  ("extlib" | "extlib-compat")
+  "sexplib"
+  "omake"
+]

--- a/packages/extprot/extprot.1.1.2/url
+++ b/packages/extprot/extprot.1.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mfp/extprot/archive/v1.1.2.tar.gz"
+checksum: "0f24a1c6b7561fef1b7cace0daffcf7d"


### PR DESCRIPTION
# Changes since version 1.1.1
- conditionally enable -bin-annot for ocaml >= 4.00 (ygrek)
- change in generated pretty-printers for records: print module path only for
  first field
- keep relative order of constant and non-constant constructors in generated
  OCaml type definition (required for "type_equals").
- OCaml 4.02.0 compatibility
