### PR TITLE
remove the circular io-page -> mirage-types-lwt test-only dependency

### DIFF
--- a/packages/io-page/io-page.1.2.0/opam
+++ b/packages/io-page/io-page.1.2.0/opam
@@ -20,6 +20,5 @@ depends: [
   "ocamlfind"
   "cstruct" {>="1.0.1"}
   "ounit" {test}
-  "mirage-types-lwt" {test}
 ]
 available: [ocaml-version >= "4.00.0"]


### PR DESCRIPTION
This is only here for {test}, but it's still problematic for OPAM 1.1
clients.  It also appears to happen sometimes on OPAM 1.2 (#3128)
which may be a bug (but depends on the semantics of test).

Fixes #3128
