### PR TITLE
Turn constrained depopts to conflicts, enforcing good semantics

### DIFF
--- a/packages/archimedes/archimedes.0.4.17/opam
+++ b/packages/archimedes/archimedes.0.4.17/opam
@@ -15,11 +15,14 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "archimedes"]]
-depends: ["ocamlfind" "camlp4"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "archimedes"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]
 depopts: [
-  "cairo" {= "0.4.2"}
-  "cairo" {= "0.4.1"}
+  "cairo"
   "cairo2"
 ]
+conflicts: "cairo" {= "1.2.0"}

--- a/packages/batsh/batsh.0.0.4/opam
+++ b/packages/batsh/batsh.0.0.4/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 maintainer: "byvoid@byvoid.com"
-authors: ["BYVoid <byvoid@byvoid.com>"]
+authors: "BYVoid <byvoid@byvoid.com>"
 homepage: "https://github.com/BYVoid/Batsh"
 license: "MIT"
 build: [
@@ -8,7 +8,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "batsh"]]
+remove: ["ocamlfind" "remove" "batsh"]
 depends: [
   "ocamlfind" {>= "1.3.2"}
   "core_kernel" {>= "109.42.00"}
@@ -18,6 +18,7 @@ depends: [
 ]
 depopts: [
   "ounit"
-  "core" {>= "109.42.00"}
+  "core"
 ]
+conflicts: "core" {< "109.42.00"}
 ocaml-version: [>= "4.00.1"]

--- a/packages/batsh/batsh.0.0.5/opam
+++ b/packages/batsh/batsh.0.0.5/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 maintainer: "byvoid@byvoid.com"
-authors: ["BYVoid <byvoid@byvoid.com>"]
+authors: "BYVoid <byvoid@byvoid.com>"
 homepage: "https://github.com/BYVoid/Batsh"
 license: "MIT"
 build: [
@@ -20,6 +20,7 @@ depends: [
 ]
 depopts: [
   "ounit"
-  "core" {>= "109.47.00"}
+  "core"
 ]
+conflicts: "core" {< "109.47.00"}
 ocaml-version: [>= "4.00.1"]

--- a/packages/cohttp/cohttp.0.10.0/opam
+++ b/packages/cohttp/cohttp.0.10.0/opam
@@ -8,7 +8,7 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
@@ -18,11 +18,11 @@ depends: [
   "sexplib" {>= "109.53.00"}
 ]
 depopts: [
-  "async" {>= "109.15.00"}
-  "lwt" {>= "2.4.3"}
-  ("lwt" {>= "2.4.3"} & "ssl")
+  "async"
+  "lwt"
+  "ssl"
 ]
 conflicts: [
-  "async" {<"109.15.00"}
-  "lwt" {<"2.4.3"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
 ]

--- a/packages/cohttp/cohttp.0.10.1/opam
+++ b/packages/cohttp/cohttp.0.10.1/opam
@@ -8,7 +8,7 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
@@ -18,7 +18,13 @@ depends: [
   "sexplib" {>= "109.53.00"}
 ]
 depopts: [
-  ("async" {>= "109.15.00"} & "async_ssl" {>= "111.06.00"})
-  "lwt" {>= "2.4.3"}
-  ("lwt" {>= "2.4.3"} & "ssl")
+  "async"
+  "async_ssl"
+  "lwt"
+  "ssl"
+]
+conflicts: [
+  "async" {< "109.15.00"}
+  "async_ssl" {< "111.06.00"}
+  "lwt" {< "2.4.3"}
 ]

--- a/packages/cohttp/cohttp.0.9.1/opam
+++ b/packages/cohttp/cohttp.0.9.1/opam
@@ -8,7 +8,7 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
@@ -16,7 +16,11 @@ depends: [
   "ounit"
 ]
 depopts: [
-  "async" {= "108.00.02"}
-  "lwt" {>= "2.4.1"}
+  "async"
+  "lwt"
   "mirage-net"
+]
+conflicts: [
+  "async" {!= "108.00.02"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.10/opam
+++ b/packages/cohttp/cohttp.0.9.10/opam
@@ -8,16 +8,22 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct"
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-net" {>= "0.5.0"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.11/opam
+++ b/packages/cohttp/cohttp.0.9.11/opam
@@ -8,16 +8,22 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct" {>= "0.8.0"}
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-net" {>= "0.9.4"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.9.4"}
 ]

--- a/packages/cohttp/cohttp.0.9.12/opam
+++ b/packages/cohttp/cohttp.0.9.12/opam
@@ -8,17 +8,23 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct" {>= "0.8.0"}
   "fieldslib" {>= "109.20.00"}
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-net" {>= "0.9.4"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.9.4"}
 ]

--- a/packages/cohttp/cohttp.0.9.13/opam
+++ b/packages/cohttp/cohttp.0.9.13/opam
@@ -8,18 +8,25 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct" {>= "1.0.1"}
   "fieldslib" {>= "109.20.00"}
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-tcpip-unix" {>= "0.9.5"}
-  "mirage-tcpip-xen" {>= "0.9.5"}
+  "async"
+  "lwt"
+  "mirage-tcpip-unix"
+  "mirage-tcpip-xen"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-tcpip-unix" {< "0.9.5"}
+  "mirage-tcpip-xen" {< "0.9.5"}
 ]

--- a/packages/cohttp/cohttp.0.9.14/opam
+++ b/packages/cohttp/cohttp.0.9.14/opam
@@ -8,18 +8,25 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct" {>= "1.0.1"}
   "fieldslib" {>= "109.20.00"}
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-tcpip-unix" {>= "0.9.5"}
-  "mirage-tcpip-xen" {>= "0.9.5"}
+  "async"
+  "lwt"
+  "mirage-tcpip-unix"
+  "mirage-tcpip-xen"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-tcpip-unix" {< "0.9.5"}
+  "mirage-tcpip-xen" {< "0.9.5"}
 ]

--- a/packages/cohttp/cohttp.0.9.15/opam
+++ b/packages/cohttp/cohttp.0.9.15/opam
@@ -8,18 +8,24 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct" {>= "1.0.1"}
   "fieldslib" {>= "109.20.00"}
 ]
 depopts: [
-  "async" {>= "109.15.00"}
-  "lwt" {>= "2.4.3"}
-  "mirage-tcpip-unix" {>= "0.9.5"}
-  "mirage-tcpip-xen" {>= "0.9.5"}
+  "async"
+  "lwt"
+  "mirage-tcpip-unix"
+  "mirage-tcpip-xen"
+]
+conflicts: [
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-tcpip-unix" {< "0.9.5"}
+  "mirage-tcpip-xen" {< "0.9.5"}
 ]

--- a/packages/cohttp/cohttp.0.9.16/opam
+++ b/packages/cohttp/cohttp.0.9.16/opam
@@ -8,18 +8,22 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct" {>= "1.0.1"}
   "fieldslib" {>= "109.20.00"}
   "sexplib" {>= "109.53.00"}
 ]
 depopts: [
-  "async" {>= "109.15.00"}
-  "lwt" {>= "2.4.3"}
-  ("lwt" {>= "2.4.3"} & "ssl")
+  "async"
+  "lwt"
+  "ssl"
+]
+conflicts: [
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
 ]

--- a/packages/cohttp/cohttp.0.9.2/opam
+++ b/packages/cohttp/cohttp.0.9.2/opam
@@ -9,15 +9,19 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.2" & <"1.5.0"}
+  "uri" {>= "1.3.2" & < "1.5.0"}
   "ounit"
 ]
 depopts: [
-  "async" {= "108.00.02"}
-  "lwt" {>= "2.4.1"}
+  "async"
+  "lwt"
   "mirage-net"
+]
+conflicts: [
+  "async" {!= "108.00.02"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.3/opam
+++ b/packages/cohttp/cohttp.0.9.3/opam
@@ -8,15 +8,19 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.2" & <"1.5.0"}
+  "uri" {>= "1.3.2" & < "1.5.0"}
   "ounit"
 ]
 depopts: [
-  "async" {= "108.00.02"}
-  "lwt" {>= "2.4.1"}
+  "async"
+  "lwt"
   "mirage-net"
+]
+conflicts: [
+  "async" {!= "108.00.02"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.4/opam
+++ b/packages/cohttp/cohttp.0.9.4/opam
@@ -8,15 +8,20 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.2" & <"1.5.0"}
+  "uri" {>= "1.3.2" & < "1.5.0"}
   "ounit"
 ]
 depopts: [
-  "async" {>= "108.07.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.1"}
+  "async"
+  "lwt"
   "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "108.07.00"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.5/opam
+++ b/packages/cohttp/cohttp.0.9.5/opam
@@ -8,15 +8,21 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.2" & <"1.5.0"}
+  "uri" {>= "1.3.2" & < "1.5.0"}
   "ounit"
 ]
 depopts: [
-  "async" {>= "108.07.00" & <= "109.53.02" } 
-  "lwt" {>= "2.4.1"}
-  "mirage-net" {>= "0.5.0"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "108.07.00"}
+  "lwt" {< "2.4.1"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.6/opam
+++ b/packages/cohttp/cohttp.0.9.6/opam
@@ -8,15 +8,21 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.2" & <"1.5.0"}
+  "uri" {>= "1.3.2" & < "1.5.0"}
   "ounit"
 ]
 depopts: [
-  "async" {>= "109.12.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.1"}
-  "mirage-net" {>= "0.5.0"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.12.00"}
+  "lwt" {< "2.4.1"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.7/opam
+++ b/packages/cohttp/cohttp.0.9.7/opam
@@ -8,16 +8,22 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.2" & <"1.5.0"}
+  "uri" {>= "1.3.2" & < "1.5.0"}
   "ounit"
   "cstruct"
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-net" {>= "0.5.0"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.8/opam
+++ b/packages/cohttp/cohttp.0.9.8/opam
@@ -8,16 +8,22 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct"
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-net" {>= "0.5.0"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.9/opam
+++ b/packages/cohttp/cohttp.0.9.9/opam
@@ -8,16 +8,22 @@ build: [
   [make "PREFIX=%{prefix}%"]
   [make "PREFIX=%{prefix}%" "install"]
 ]
-remove: [["ocamlfind" "remove" "cohttp"]]
+remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
   "ocamlfind"
   "re"
-  "uri" {>= "1.3.8" & <"1.5.0"}
+  "uri" {>= "1.3.8" & < "1.5.0"}
   "ounit"
   "cstruct"
 ]
 depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3"}
-  "mirage-net" {>= "0.5.0"}
+  "async"
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/conduit/conduit.0.5.0/opam
+++ b/packages/conduit/conduit.0.5.0/opam
@@ -1,25 +1,23 @@
 opam-version: "1"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-]
+tags: "org:mirage"
 build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "conduit"]]
+remove: ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind"
-  "sexplib" {>="109.15.00"}
+  "sexplib" {>= "109.15.00"}
 ]
 depopts: [
   "async"
   "lwt"
-  ("lwt" & "ssl")
+  "ssl"
   "async_ssl"
 ]
 conflicts: [
-  "async" {<"109.15.00"}
-  "lwt" {<"2.4.3"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
 ]
-ocaml-version: [>="4.00.0"]
+ocaml-version: [>= "4.00.0"]

--- a/packages/conduit/conduit.0.5.1/opam
+++ b/packages/conduit/conduit.0.5.1/opam
@@ -1,26 +1,24 @@
 opam-version: "1"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-]
+tags: "org:mirage"
 build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "conduit"]]
+remove: ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind"
-  "sexplib" {>="109.15.00"}
+  "sexplib" {>= "109.15.00"}
 ]
 depopts: [
   "async"
   "lwt"
-  ("lwt" & "ssl")
+  "ssl"
   "async_ssl"
 ]
 conflicts: [
-  "async" {<"109.15.00"}
-  "lwt" {<"2.4.3"}
-  "async_ssl" {<"111.21.00"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "async_ssl" {< "111.21.00"}
 ]
-ocaml-version: [>="4.00.0"]
+ocaml-version: [>= "4.00.0"]

--- a/packages/conduit/conduit.0.6.0/opam
+++ b/packages/conduit/conduit.0.6.0/opam
@@ -1,34 +1,34 @@
 opam-version: "1"
-version: "0.6.0"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-]
+tags: "org:mirage"
 build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "conduit"]]
+remove: ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind"
-  "sexplib" {>="109.15.00"}
+  "sexplib" {>= "109.15.00"}
   "stringext"
   "uri"
-  "cstruct" {>="1.0.1"}
-  "ipaddr" {>="2.5.0"}
+  "cstruct" {>= "1.0.1"}
+  "ipaddr" {>= "2.5.0"}
 ]
 depopts: [
   "async"
   "lwt"
-  ("lwt" & "ssl")
+  "ssl"
   "async_ssl"
-  ("mirage-types" & "dns" & "tcpip" & "vchan")
+  "mirage-types"
+  "dns"
+  "tcpip"
+  "vchan"
 ]
 conflicts: [
-  "async" {<"109.15.00"}
-  "lwt" {<"2.4.3"}
-  "async_ssl" {<"111.21.00"}
-  "mirage-types" {<"2.0.0"}
-  "dns" {<"0.10.0"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "async_ssl" {< "111.21.00"}
+  "mirage-types" {< "2.0.0"}
+  "dns" {< "0.10.0"}
 ]
-ocaml-version: [>="4.01.0"]
+ocaml-version: [>= "4.01.0"]

--- a/packages/conduit/conduit.0.6.1/opam
+++ b/packages/conduit/conduit.0.6.1/opam
@@ -1,34 +1,34 @@
 opam-version: "1"
-version: "0.6.1"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-]
+tags: "org:mirage"
 build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "conduit"]]
+remove: ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind"
-  "sexplib" {>="109.15.00"}
+  "sexplib" {>= "109.15.00"}
   "stringext"
   "uri"
-  "cstruct" {>="1.0.1"}
-  "ipaddr" {>="2.5.0"}
+  "cstruct" {>= "1.0.1"}
+  "ipaddr" {>= "2.5.0"}
 ]
 depopts: [
   "async"
   "lwt"
-  ("lwt" & "ssl")
+  "ssl"
   "async_ssl"
-  ("mirage-types" & "dns" & "tcpip" & "vchan")
+  "mirage-types"
+  "dns"
+  "tcpip"
+  "vchan"
 ]
 conflicts: [
-  "async" {<"109.15.00"}
-  "lwt" {<"2.4.3"}
-  "async_ssl" {<"111.21.00"}
-  "mirage-types" {<"2.0.0"}
-  "dns" {<"0.10.0"}
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+  "async_ssl" {< "111.21.00"}
+  "mirage-types" {< "2.0.0"}
+  "dns" {< "0.10.0"}
 ]
-ocaml-version: [>="4.01.0"]
+ocaml-version: [>= "4.01.0"]

--- a/packages/cubicle/cubicle.1.0.1/opam
+++ b/packages/cubicle/cubicle.1.0.1/opam
@@ -6,11 +6,12 @@ authors: [
 ]
 homepage: "http://cubicle.lri.fr"
 license: "Apache Software License version 2.0"
-ocaml-version: [ >= "4.00.0"] 
 build: [
   ["./configure" "--prefix" prefix]
   [make]
   [make "install" "MANDIR=%{man}%"]
 ]
-depends: ["ocamlfind"]
-depopts: ["functory" {>= "0.5"}]
+depends: "ocamlfind"
+depopts: "functory"
+conflicts: "functory" {< "0.5"}
+ocaml-version: [>= "4.00.0"]

--- a/packages/cubicle/cubicle.1.0/opam
+++ b/packages/cubicle/cubicle.1.0/opam
@@ -6,15 +6,16 @@ authors: [
 ]
 homepage: "http://cubicle.lri.fr"
 license: "Apache Software License version 2.0"
-ocaml-version: [ >= "4.00.0"] 
 build: [
   ["./configure" "--prefix" prefix]
   [make]
   [make "install" "MANDIR=%{man}%"]
 ]
-depends: ["ocamlfind"]
-depopts: ["functory" {>= "0.5"}]
+depends: "ocamlfind"
+depopts: "functory"
 depexts: [
   [["debian"] ["graphviz"]]
   [["ubuntu"] ["graphviz"]]
 ]
+conflicts: "functory" {< "0.5"}
+ocaml-version: [>= "4.00.0"]

--- a/packages/deriving-ocsigen/deriving-ocsigen.0.3c/opam
+++ b/packages/deriving-ocsigen/deriving-ocsigen.0.3c/opam
@@ -4,6 +4,10 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "deriving-ocsigen"]]
-depends: ["ocamlfind" "camlp4"]
-depopts: ["type_conv" {< "108.07.00"}]
+remove: ["ocamlfind" "remove" "deriving-ocsigen"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]
+depopts: "type_conv"
+conflicts: "type_conv" {>= "108.07.00"}

--- a/packages/deriving-ocsigen/deriving-ocsigen.0.5/opam
+++ b/packages/deriving-ocsigen/deriving-ocsigen.0.5/opam
@@ -4,10 +4,11 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "deriving-ocsigen"]]
+remove: ["ocamlfind" "remove" "deriving-ocsigen"]
 depends: [
   "ocamlfind"
   "optcomp"
   "camlp4"
 ]
-depopts: ["type_conv" {>= "108.07.00"}]
+depopts: "type_conv"
+conflicts: "type_conv" {< "108.07.00"}

--- a/packages/deriving/deriving.0.5/opam
+++ b/packages/deriving/deriving.0.5/opam
@@ -4,11 +4,12 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "deriving"]]
+remove: ["ocamlfind" "remove" "deriving"]
 depends: [
   "ocamlfind"
   "optcomp" {>= "1.6"}
   "camlp4"
 ]
-depopts: ["type_conv" {>= "108.07.00"}]
+depopts: "type_conv"
+conflicts: "type_conv" {< "108.07.00"}
 ocaml-version: [<= "4.01.0"]

--- a/packages/dlist/dlist.0.0.1/opam
+++ b/packages/dlist/dlist.0.0.1/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 maintainer: "byvoid@byvoid.com"
-authors: ["BYVoid <byvoid@byvoid.com>"]
+authors: "BYVoid <byvoid@byvoid.com>"
 homepage: "https://github.com/BYVoid/Dlist"
 license: "BSD3"
 build: [
@@ -8,11 +8,15 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dlist"]]
-depends: ["ocamlfind" {>= "1.3.2"}]
+remove: ["ocamlfind" "remove" "dlist"]
+depends: "ocamlfind" {>= "1.3.2"}
 depopts: [
-  "core" {>= "109.42.00"}
-  "core_bench" {>= "109.41.00"}
+  "core"
+  "core_bench"
   "ounit"
+]
+conflicts: [
+  "core" {< "109.42.00"}
+  "core_bench" {< "109.41.00"}
 ]
 ocaml-version: [>= "4.00.1"]

--- a/packages/dlist/dlist.0.0.2/opam
+++ b/packages/dlist/dlist.0.0.2/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 maintainer: "byvoid@byvoid.com"
-authors: ["BYVoid <byvoid@byvoid.com>"]
+authors: "BYVoid <byvoid@byvoid.com>"
 homepage: "https://github.com/BYVoid/Dlist"
 license: "BSD3"
 build: [
@@ -8,11 +8,15 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dlist"]]
-depends: ["ocamlfind" {>= "1.3.2"}]
+remove: ["ocamlfind" "remove" "dlist"]
+depends: "ocamlfind" {>= "1.3.2"}
 depopts: [
-  "core" {>= "109.42.00"}
-  "core_bench" {>= "109.41.00"}
+  "core"
+  "core_bench"
   "ounit"
+]
+conflicts: [
+  "core" {< "109.42.00"}
+  "core_bench" {< "109.41.00"}
 ]
 ocaml-version: [>= "4.00.1"]

--- a/packages/dlist/dlist.0.0.3/opam
+++ b/packages/dlist/dlist.0.0.3/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 maintainer: "byvoid@byvoid.com"
-authors: ["BYVoid <byvoid@byvoid.com>"]
+authors: "BYVoid <byvoid@byvoid.com>"
 homepage: "https://github.com/BYVoid/Dlist"
 license: "BSD3"
 build: [
@@ -13,9 +13,10 @@ remove: [
   ["ocp-build" "build"]
   ["ocp-build" "uninstall"]
 ]
-depends: ["ocp-build" {>= "1.99.6-beta"}]
+depends: "ocp-build" {>= "1.99.6-beta"}
 depopts: [
-  "core_bench" {>= "109.41.00"}
+  "core_bench"
   "ounit"
 ]
+conflicts: "core_bench" {< "109.41.00"}
 ocaml-version: [>= "4.00.1"]

--- a/packages/dlist/dlist.0.1.0/opam
+++ b/packages/dlist/dlist.0.1.0/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 maintainer: "byvoid@byvoid.com"
-authors: ["BYVoid <byvoid@byvoid.com>"]
+authors: "BYVoid <byvoid@byvoid.com>"
 homepage: "https://github.com/BYVoid/Dlist"
 license: "BSD3"
 build: [
@@ -13,11 +13,10 @@ remove: [
   ["ocp-build" "build"]
   ["ocp-build" "uninstall"]
 ]
-depends: [
-  "ocp-build" {>= "1.99.6-beta"}
-]
+depends: "ocp-build" {>= "1.99.6-beta"}
 depopts: [
-  "core_bench" {>= "109.41.00"}
+  "core_bench"
   "ounit"
 ]
+conflicts: "core_bench" {< "109.41.00"}
 ocaml-version: [>= "4.00.1"]

--- a/packages/dns/dns.0.11.0/opam
+++ b/packages/dns/dns.0.11.0/opam
@@ -9,7 +9,9 @@ authors: [
   "Thomas Gazagnaire"
 ]
 homepage: "https://github.com/mirage/ocaml-dns"
-license: "LGPL-2.0 &\n   LGPL-2.1 with OCaml linking exception &\n   ISC"
+license: "LGPL-2.0 &
+   LGPL-2.1 with OCaml linking exception &
+   ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -19,7 +21,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
@@ -30,11 +32,12 @@ depends: [
   "base64" {< "2.0.0"}
 ]
 depopts: [
-  ("mirage-types" & "tcpip")
+  "mirage-types"
+  "tcpip"
   "async"
 ]
 conflicts: [
-  "mirage-types" {<"1.2.0"}
-  "async" {<"109.21.00"}
+  "mirage-types" {< "1.2.0"}
+  "async" {< "109.21.00"}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/dns/dns.0.12.0/opam
+++ b/packages/dns/dns.0.12.0/opam
@@ -9,7 +9,9 @@ authors: [
   "Thomas Gazagnaire"
 ]
 homepage: "https://github.com/mirage/ocaml-dns"
-license: "LGPL-2.0 &\n   LGPL-2.1 with OCaml linking exception &\n   ISC"
+license: "LGPL-2.0 &
+   LGPL-2.1 with OCaml linking exception &
+   ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -19,7 +21,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
@@ -30,11 +32,12 @@ depends: [
   "base64" {>= "2.0.0"}
 ]
 depopts: [
-  ("mirage-types" & "tcpip")
+  "mirage-types"
+  "tcpip"
   "async"
 ]
 conflicts: [
-  "mirage-types" {<"1.2.0"}
-  "async" {<"109.21.00"}
+  "mirage-types" {< "1.2.0"}
+  "async" {< "109.21.00"}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/dns/dns.0.5.0/opam
+++ b/packages/dns/dns.0.5.0/opam
@@ -9,7 +9,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "cstruct" {>= "0.5.1" & < "0.6.0"}
   "ocamlfind"
@@ -18,7 +18,8 @@ depends: [
   "uri"
 ]
 depopts: [
-  "lwt" {>= "2.4.1"}
+  "lwt"
   "mirage-net"
 ]
+conflicts: "lwt" {< "2.4.1"}
 ocaml-version: [>= "4.0.0"]

--- a/packages/dns/dns.0.5.1/opam
+++ b/packages/dns/dns.0.5.1/opam
@@ -9,7 +9,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "cstruct" {>= "0.5.1" & < "0.6.0"}
   "ocamlfind"
@@ -18,7 +18,11 @@ depends: [
   "uri"
 ]
 depopts: [
-  "lwt" {>= "2.4.1"}
-  "mirage-net" {<= "0.9.4"}
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "lwt" {< "2.4.1"}
+  "mirage-net" {> "0.9.4"}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/dns/dns.0.6.0/opam
+++ b/packages/dns/dns.0.6.0/opam
@@ -9,7 +9,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "cstruct" {>= "0.6.0" & < "1.0.0"}
   "ocamlfind"
@@ -19,6 +19,11 @@ depends: [
   "cmdliner"
 ]
 depopts: [
-  "lwt" {>= "2.4.1"}
-  "mirage-net" {>= "0.5.2" & <= "0.9.4"} 
+  "lwt"
+  "mirage-net"
+]
+conflicts: [
+  "lwt" {< "2.4.1"}
+  "mirage-net" {> "0.9.4"}
+  "mirage-net" {< "0.5.2"}
 ]

--- a/packages/dns/dns.0.6.1/opam
+++ b/packages/dns/dns.0.6.1/opam
@@ -9,7 +9,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "lwt" {>= "2.4.1"}
   "cstruct" {>= "0.6.0" & < "1.0.0"}
@@ -19,5 +19,9 @@ depends: [
   "uri"
   "cmdliner"
 ]
-depopts: ["mirage-net" {>= "0.5.2" & <= "0.9.4"} ]
+depopts: "mirage-net"
+conflicts: [
+  "mirage-net" {> "0.9.4"}
+  "mirage-net" {< "0.5.2"}
+]
 ocaml-version: [>= "4.00.0"]

--- a/packages/dns/dns.0.6.2/opam
+++ b/packages/dns/dns.0.6.2/opam
@@ -7,7 +7,9 @@ authors: [
   "Haris Rotsos"
 ]
 homepage: "https://github.com/mirage/ocaml-dns"
-license: "LGPL-2.0 &\n   LGPL-2.1 with OCaml linking exception &\n   ISC"
+license: "LGPL-2.0 &
+   LGPL-2.1 with OCaml linking exception &
+   ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,7 +19,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "lwt" {>= "2.4.1"}
   "cstruct" {>= "0.6.0" & < "1.0.0"}
@@ -27,5 +29,9 @@ depends: [
   "uri"
   "cmdliner"
 ]
-depopts: ["mirage-net" {>= "0.5.2" & <= "0.9.4"} ]
+depopts: "mirage-net"
+conflicts: [
+  "mirage-net" {> "0.9.4"}
+  "mirage-net" {< "0.5.2"}
+]
 ocaml-version: [>= "4.00.0"]

--- a/packages/dns/dns.0.7.0/opam
+++ b/packages/dns/dns.0.7.0/opam
@@ -9,7 +9,9 @@ authors: [
   "Thomas Gazagnaire"
 ]
 homepage: "https://github.com/mirage/ocaml-dns"
-license: "LGPL-2.0 &\n   LGPL-2.1 with OCaml linking exception &\n   ISC"
+license: "LGPL-2.0 &
+   LGPL-2.1 with OCaml linking exception &
+   ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -19,7 +21,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "dns"]]
+remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "lwt" {>= "2.4.1"}
   "cstruct" {>= "0.7.1" & < "1.0.0"}
@@ -28,5 +30,6 @@ depends: [
   "cmdliner"
   "ipaddr" {>= "0.2.2" & < "2.0.0"}
 ]
-depopts: ["mirage-net" {= "0.9.4"}]
+depopts: "mirage-net"
+conflicts: "mirage-net" {!= "0.9.4"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/frenetic/frenetic.2.0.0/opam
+++ b/packages/frenetic/frenetic.2.0.0/opam
@@ -1,24 +1,30 @@
 opam-version: "1"
-ocaml-version: [ >= "4.01.0" ]
 maintainer: "seliopou@gmail.com"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{async:enable}%-async" "--%{quickcheck:enable}%-quickcheck" ]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{async:enable}%-async" "--%{quickcheck:enable}%-quickcheck"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "netkat"]
-]
+remove: ["ocamlfind" "remove" "netkat"]
 depends: [
   "ocamlfind"
   "core"
   "fieldslib"
-  "openflow"    {>= "0.3.0" & < "0.4.0"}
+  "openflow" {>= "0.3.0" & < "0.4.0"}
   "ounit"
   "sexplib"
-  "topology"    {>= "0.1.0"}
+  "topology" {>= "0.1.0"}
 ]
 depopts: [
-  ("async" & "topology" {>= "0.1.0"} & "cstruct" {>= "1.0.1"} & "packet" {>= "0.2.1"})
+  "async"
+  "topology"
+  "cstruct"
+  "packet"
   "quickcheck"
 ]
+conflicts: [
+  "cstruct" {< "1.0.1"}
+  "packet" {< "0.2.1"}
+  "topology" {< "0.1.0"}
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/frenetic/frenetic.3.0.0/opam
+++ b/packages/frenetic/frenetic.3.0.0/opam
@@ -1,30 +1,33 @@
 opam-version: "1"
-ocaml-version: [ >= "4.01.0" ]
 maintainer: "seliopou@gmail.com"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{async:enable}%-async" "--%{quickcheck:enable}%-quickcheck" ]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{async:enable}%-async" "--%{quickcheck:enable}%-quickcheck"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "netkat"]
-]
+remove: ["ocamlfind" "remove" "netkat"]
 depends: [
   "ocamlfind"
   "core"
   "fieldslib"
-  "ocamlgraph"  {>= "1.8.0"}
-  "openflow"    {>= "0.5.0"}
+  "ocamlgraph" {>= "1.8.0"}
+  "openflow" {>= "0.5.0"}
   "ounit"
   "sexplib"
-  "topology"    {>= "0.1.0"}
+  "topology" {>= "0.1.0"}
 ]
 depopts: [
-  ( "async"
-  & "cmdliner"  {>= "0.9.5"}
-  & "cstruct"   {>= "1.0.1"}
-  & "packet"    {>= "0.2.1"}
-  & "topology"  {>= "0.1.0"}
-  )
+  "async"
+  "cmdliner"
+  "cstruct"
+  "packet"
+  "topology"
   "quickcheck"
 ]
+conflicts: [
+  "cmdliner" {< "0.9.5"}
+  "cstruct" {< "1.0.1"}
+  "packet" {< "0.2.1"}
+  "topology" {< "0.1.0"}
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/frenetic/frenetic.3.1.0/opam
+++ b/packages/frenetic/frenetic.3.1.0/opam
@@ -1,30 +1,33 @@
 opam-version: "1"
-ocaml-version: [ >= "4.01.0" ]
 maintainer: "arjun@cs.umass.edu"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{async:enable}%-async" "--%{quickcheck:enable}%-quickcheck" ]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{async:enable}%-async" "--%{quickcheck:enable}%-quickcheck"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "netkat"]
-]
+remove: ["ocamlfind" "remove" "netkat"]
 depends: [
   "ocamlfind"
   "core"
   "fieldslib"
-  "ocamlgraph"  {>= "1.8.0"}
-  "openflow"    {>= "0.5.0"}
+  "ocamlgraph" {>= "1.8.0"}
+  "openflow" {>= "0.5.0"}
   "ounit"
   "sexplib"
-  "topology"    {>= "0.1.0"}
+  "topology" {>= "0.1.0"}
 ]
 depopts: [
-  ( "async"
-  & "cmdliner"  {>= "0.9.5"}
-  & "cstruct"   {>= "1.0.1"}
-  & "packet"    {>= "0.2.1"}
-  & "topology"  {>= "0.1.0"}
-  )
+  "async"
+  "cmdliner"
+  "cstruct"
+  "packet"
+  "topology"
   "quickcheck"
 ]
+conflicts: [
+  "cmdliner" {< "0.9.5"}
+  "cstruct" {< "1.0.1"}
+  "packet" {< "0.2.1"}
+  "topology" {< "0.1.0"}
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/git/git.1.2.0/opam
+++ b/packages/git/git.1.2.0/opam
@@ -1,17 +1,17 @@
 opam-version: "1"
 maintainer: "thomas@gazagnaire.org"
-authors: [ "Thomas Gazagnaire" ]
+authors: "Thomas Gazagnaire"
 license: "ISC"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{mirage-types:enable}%-mirage" ]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{mirage-types:enable}%-mirage"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
+build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: [
   ["ocamlfind" "remove" "git"]
   ["rm" "-f" "%{bin}%/ogit"]
 ]
-build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "dolog" {>= "0.4" & <= "0.6"}
   "mstruct" {>= "1.3.0"}
@@ -26,6 +26,8 @@ depends: [
   "conduit" {= "0.5.1"}
 ]
 depopts: [
-  ("mirage-types" & "io-page" & "ipaddr")
+  "mirage-types"
+  "io-page"
+  "ipaddr"
 ]
 ocaml-version: [>= "4.01.0"]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.6/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.6/opam
@@ -2,13 +2,10 @@ opam-version: "1.1"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocaml"
 build: [
-  [ make "all" ]
-  [ make "install" ]
+  [make "all"]
+  [make "install"]
 ]
-patches: [ "4.00.1.patch" ]
-remove: [
-  [ make "uninstall" ]
-]
+remove: [make "uninstall"]
 depends: [
   "ocamlfind"
   "optcomp"
@@ -20,12 +17,12 @@ depends: [
   "ctypes" {>= "0.3"}
   "lwt" {>= "2.4"}
 ]
-depopts: [
-  "ocp-index" {>= "1.0.1"} 
-]
+depopts: "ocp-index"
 depexts: [
   [["debian"] ["libzmq3-dev"]]
+  [["homebrew" "osx"] ["zeromq"]]
   [["ubuntu"] ["libzmq3-dev"]]
-  [["osx" "homebrew"] ["zeromq"]]
 ]
-ocaml-version: [ >= "4.00.1" ]
+conflicts: "ocp-index" {< "1.0.1"}
+patches: "4.00.1.patch"
+ocaml-version: [>= "4.00.1"]

--- a/packages/js_of_ocaml/js_of_ocaml.1.4.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.1.4.0/opam
@@ -5,14 +5,13 @@ build: [
   [make]
   [make "install" "BINDIR=%{bin}%"]
 ]
-remove: [["ocamlfind" "remove" "js_of_ocaml"]]
+remove: ["ocamlfind" "remove" "js_of_ocaml"]
 depends: [
   "ocamlfind"
   "lwt" {>= "2.3.0"}
   "menhir"
   "camlp4"
 ]
-depopts: [
-  "deriving-ocsigen" {>= "0.5"}
-]
+depopts: "deriving-ocsigen"
+conflicts: "deriving-ocsigen" {< "0.5"}
 ocaml-version: [<= "4.01.0"]

--- a/packages/liquidsoap/liquidsoap.1.1.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.1.0/opam
@@ -22,7 +22,7 @@ depopts: [
   "alsa"
   "pulseaudio"
   "bjack"
-  "taglib" {>= "0.3.0"}
+  "taglib"
   "lame"
   "aacplus"
   "ogg"
@@ -49,4 +49,5 @@ depexts: [
   [["debian"] ["libao-dev" "libfaad-dev" "libflac-dev" "libgavl-dev" "libgstreamer-plugins-base0.10-dev" "libgstreamer0.10-dev" "libgstreamer1.0-dev" "liblo-dev" "libmp3lame-dev" "libogg-dev" "libsamplerate-dev" "libschroedinger-dev" "libsoundtouch-dev" "libspeex-dev" "libtheora-dev" "libvo-aacenc-dev" "libvorbis-dev" "portaudio19-dev"]]
   [["ubuntu"] ["libao-dev" "libfaad-dev" "libflac-dev" "libgavl-dev" "libgstreamer-plugins-base0.10-dev" "libgstreamer0.10-dev" "libgstreamer1.0-dev" "liblo-dev" "libmp3lame-dev" "libogg-dev" "libsamplerate-dev" "libschroedinger-dev" "libsoundtouch-dev" "libspeex-dev" "libtheora-dev" "libvo-aacenc-dev" "libvorbis-dev" "portaudio19-dev"]]
 ]
+conflicts: "taglib" {< "0.3.0"}
 ocaml-version: [>= "3.11"]

--- a/packages/lwt/lwt.2.3.2/opam
+++ b/packages/lwt/lwt.2.3.2/opam
@@ -1,17 +1,20 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-ocaml-version: [ < "3.13.0" ]
 build: [
   ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{base-unix:enable}%-unix" "--%{base-unix:enable}%-extra" "--%{base-threads:enable}%-preemptive"]
   [make "build"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "lwt"]]
-depends: ["ocamlfind" "camlp4"]
+remove: ["ocamlfind" "remove" "lwt"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]
 depopts: [
   "base-threads"
   "base-unix"
   "conf-libev"
-  "react" {< "1.0.0" }
+  "react"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: "react" {>= "1.0.0"}
+ocaml-version: [< "3.13.0"]

--- a/packages/lwt/lwt.2.4.0/opam
+++ b/packages/lwt/lwt.2.4.0/opam
@@ -1,18 +1,21 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-ocaml-version: [ < "4.01.0" ]
 build: [
   ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix:enable}%-extra" "--%{base-threads:enable}%-preemptive"]
   [make "build"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "lwt"]]
-depends: ["ocamlfind" "camlp4"]
+remove: ["ocamlfind" "remove" "lwt"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]
 depopts: [
   "base-threads"
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: "react" {>= "1.0.0"}
+ocaml-version: [< "4.01.0"]

--- a/packages/lwt/lwt.2.4.1/opam
+++ b/packages/lwt/lwt.2.4.1/opam
@@ -1,18 +1,21 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-ocaml-version: [ < "4.01.0" ]
 build: [
   ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix:enable}%-extra" "--%{base-threads:enable}%-preemptive"]
   [make "build"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "lwt"]]
-depends: ["ocamlfind" "camlp4"]
+remove: ["ocamlfind" "remove" "lwt"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]
 depopts: [
   "base-threads"
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: "react" {>= "1.0.0"}
+ocaml-version: [< "4.01.0"]

--- a/packages/lwt/lwt.2.4.2/opam
+++ b/packages/lwt/lwt.2.4.2/opam
@@ -1,19 +1,22 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-ocaml-version: [ < "4.01.0" ]
 build: [
   ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix:enable}%-extra" "--%{base-threads:enable}%-preemptive" "--%{lablgtk:enable}%-glib"]
   [make "build"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "lwt"]]
-depends: ["ocamlfind" "camlp4"]
+remove: ["ocamlfind" "remove" "lwt"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]
 depopts: [
   "base-threads"
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
   "lablgtk"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: "react" {>= "1.0.0"}
+ocaml-version: [< "4.01.0"]

--- a/packages/lwt/lwt.2.4.3/opam
+++ b/packages/lwt/lwt.2.4.3/opam
@@ -6,16 +6,19 @@ build: [
   [make "build"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "lwt"]]
-depends: ["ocamlfind" "camlp4"]
+remove: ["ocamlfind" "remove" "lwt"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]
 depopts: [
   "base-threads"
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
   "lablgtk"
   "text"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
-ocaml-version: [<"4.02.0"]
+conflicts: "react" {>= "1.0.0"}
+ocaml-version: [< "4.02.0"]

--- a/packages/lwt/lwt.2.4.4/opam
+++ b/packages/lwt/lwt.2.4.4/opam
@@ -5,15 +5,18 @@ build: [
   [make "build"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "lwt"]]
-depends: ["ocamlfind" "camlp4" {< "4.02.0"}]
+remove: ["ocamlfind" "remove" "lwt"]
+depends: [
+  "ocamlfind"
+  "camlp4" {< "4.02.0"}
+]
 depopts: [
   "base-threads"
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
   "lablgtk"
   "text"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: "react" {>= "1.0.0"}

--- a/packages/mikmatch/mikmatch.1.0.7/opam
+++ b/packages/mikmatch/mikmatch.1.0.7/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "http://mjambon.com/micmatch.html"
-doc: ["http://mjambon.com/mikmatch-manual.html"]
+doc: "http://mjambon.com/mikmatch-manual.html"
 build: [
   [make "str"]
   [make "install-str"]
@@ -17,9 +17,8 @@ depends: [
   "camlp4"
   "tophide" {>= "1.0.2"}
 ]
-depopts: [
-  "pcre" {= "7.0.4"}
-]
+depopts: "pcre"
+conflicts: "pcre" {!= "7.0.4"}
 patches: [
   "mikmatch.patch"
   "fix_build.patch"

--- a/packages/mirage-console/mirage-console.2.0.0/opam
+++ b/packages/mirage-console/mirage-console.2.0.0/opam
@@ -8,18 +8,15 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "mirage-console"]
-]
+remove: ["ocamlfind" "remove" "mirage-console"]
 depends: [
   "ocamlfind"
   "mirage-types-lwt"
-  "mirage-unix" {>="1.1.0"}
+  "mirage-unix" {>= "1.1.0"}
 ]
-depopts: [
-  "mirage-xen" {>="1.1.0"}
-]
+depopts: "mirage-xen"
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
+  "mirage-xen" {< "1.1.0"}
 ]

--- a/packages/mirage-console/mirage-console.2.1.0/opam
+++ b/packages/mirage-console/mirage-console.2.1.0/opam
@@ -8,18 +8,15 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "mirage-console"]
-]
+remove: ["ocamlfind" "remove" "mirage-console"]
 depends: [
   "ocamlfind"
   "mirage-types-lwt"
-  "mirage-unix" {>="1.1.0"}
+  "mirage-unix" {>= "1.1.0"}
 ]
-depopts: [
-  "mirage-xen" {>="1.1.0"}
-]
+depopts: "mirage-xen"
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
+  "mirage-xen" {< "1.1.0"}
 ]

--- a/packages/mirage-types/mirage-types.1.1.0/opam
+++ b/packages/mirage-types/mirage-types.1.1.0/opam
@@ -4,12 +4,13 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind"]
+depends: "ocamlfind"
 depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
 ]
-ocaml-version: [>="4.00.0"]
+ocaml-version: [>= "4.00.0"]

--- a/packages/mirage-types/mirage-types.1.1.1/opam
+++ b/packages/mirage-types/mirage-types.1.1.1/opam
@@ -4,12 +4,13 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind"]
+depends: "ocamlfind"
 depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
 ]
-ocaml-version: [>="4.00.0"]
+ocaml-version: [>= "4.00.0"]

--- a/packages/mirage-types/mirage-types.1.1.2/opam
+++ b/packages/mirage-types/mirage-types.1.1.2/opam
@@ -4,12 +4,13 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind"]
+depends: "ocamlfind"
 depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
 ]
-ocaml-version: [>="4.00.0"]
+ocaml-version: [>= "4.00.0"]

--- a/packages/mirage-types/mirage-types.1.1.3/opam
+++ b/packages/mirage-types/mirage-types.1.1.3/opam
@@ -4,12 +4,13 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind"]
+depends: "ocamlfind"
 depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
 ]
-ocaml-version: [>="4.00.0"]
+ocaml-version: [>= "4.00.0"]

--- a/packages/mirage-types/mirage-types.1.2.0/opam
+++ b/packages/mirage-types/mirage-types.1.2.0/opam
@@ -4,12 +4,13 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind"]
+depends: "ocamlfind"
 depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
 ]
-ocaml-version: [>="4.00.0"]
+ocaml-version: [>= "4.00.0"]

--- a/packages/mirage-types/mirage-types.2.0.0/opam
+++ b/packages/mirage-types/mirage-types.2.0.0/opam
@@ -4,12 +4,16 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+depends: [
+  "ocamlfind"
+  "sexplib"
 ]
-ocaml-version: [>="4.01.0"]
+depopts: [
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/mirage-types/mirage-types.2.0.1/opam
+++ b/packages/mirage-types/mirage-types.2.0.1/opam
@@ -4,12 +4,16 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+depends: [
+  "ocamlfind"
+  "sexplib"
 ]
-ocaml-version: [>="4.01.0"]
+depopts: [
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/mirage-types/mirage-types.2.1.0/opam
+++ b/packages/mirage-types/mirage-types.2.1.0/opam
@@ -4,12 +4,16 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+depends: [
+  "ocamlfind"
+  "sexplib"
 ]
-ocaml-version: [>="4.01.0"]
+depopts: [
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/mirage-types/mirage-types.2.1.1/opam
+++ b/packages/mirage-types/mirage-types.2.1.1/opam
@@ -4,12 +4,16 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+depends: [
+  "ocamlfind"
+  "sexplib"
 ]
-ocaml-version: [>="4.01.0"]
+depopts: [
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/mirage-types/mirage-types.2.2.0/opam
+++ b/packages/mirage-types/mirage-types.2.2.0/opam
@@ -4,12 +4,16 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [
-  [make "install-types"]
-]
+build: [make "install-types"]
 remove: ["ocamlfind" "remove" "mirage-types"]
-depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr")
+depends: [
+  "ocamlfind"
+  "sexplib"
 ]
-ocaml-version: [>="4.01.0"]
+depopts: [
+  "lwt"
+  "cstruct"
+  "io-page"
+  "ipaddr"
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/ocamleditor/ocamleditor.1.12.0/opam
+++ b/packages/ocamleditor/ocamleditor.1.12.0/opam
@@ -1,16 +1,17 @@
 opam-version: "1"
 maintainer: "ftovagliari@gmail.com"
-authors: ["Francesco Tovagliari"]
+authors: "Francesco Tovagliari"
 homepage: "https://forge.ocamlcore.org/projects/ocamleditor/"
 build: [
   ["ocaml" "build.ml" "ocamleditor"]
   ["ocaml" "tools/install.ml" "-prefix" prefix]
 ]
-remove: [["ocaml" "tools/uninstall.ml" "-prefix" prefix]]
+remove: ["ocaml" "tools/uninstall.ml" "-prefix" prefix]
 depends: [
   "ocamlfind" {>= "1.4.0"}
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
-depopts: ["ocurl" {>= "0.6"}]
+depopts: "ocurl"
+conflicts: "ocurl" {< "0.6"}
 ocaml-version: [= "4.01.0"]

--- a/packages/ocamleditor/ocamleditor.1.13.1/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.1/opam
@@ -5,14 +5,18 @@ build: [
   ["ocaml" "build.ml" "ocamleditor"]
   ["ocaml" "tools/install.ml" "-prefix" prefix]
 ]
-remove: [["ocaml" "tools/uninstall.ml" "-prefix" prefix]]
+remove: ["ocaml" "tools/uninstall.ml" "-prefix" prefix]
 depends: [
   "ocamlfind" {>= "1.4.0"}
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
 depopts: [
-  "ocurl" {>= "0.6"}
-  "ocamldiff" {>= "1.1"}
+  "ocurl"
+  "ocamldiff"
+]
+conflicts: [
+  "ocamldiff" {< "1.1"}
+  "ocurl" {< "0.6"}
 ]
 ocaml-version: [= "4.01.0"]

--- a/packages/ocamleditor/ocamleditor.1.13.2/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.2/opam
@@ -5,14 +5,18 @@ build: [
   ["ocaml" "build.ml" "ocamleditor"]
   ["ocaml" "tools/install.ml" "-prefix" prefix]
 ]
-remove: [["ocaml" "tools/uninstall.ml" "-prefix" prefix]]
+remove: ["ocaml" "tools/uninstall.ml" "-prefix" prefix]
 depends: [
   "ocamlfind" {>= "1.4.0"}
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
 depopts: [
-  "ocurl" {>= "0.6"}
-  "ocamldiff" {>= "1.1"}
+  "ocurl"
+  "ocamldiff"
+]
+conflicts: [
+  "ocamldiff" {< "1.1"}
+  "ocurl" {< "0.6"}
 ]
 ocaml-version: [= "4.01.0"]

--- a/packages/ocamleditor/ocamleditor.1.9.0-2/opam
+++ b/packages/ocamleditor/ocamleditor.1.9.0-2/opam
@@ -1,16 +1,17 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-authors: ["Francesco Tovagliari"]
+authors: "Francesco Tovagliari"
 homepage: "https://forge.ocamlcore.org/projects/ocamleditor/"
 build: [
   ["ocaml" "build.ml" "ocamleditor"]
   ["ocaml" "tools/install.ml" "-prefix" prefix]
 ]
-remove: [["ocaml" "tools/uninstall.ml" "-prefix" prefix]]
+remove: ["ocaml" "tools/uninstall.ml" "-prefix" prefix]
 depends: [
   "ocamlfind" {>= "1.3.3"}
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
-depopts: ["ocurl" {>= "0.5.5"}]
+depopts: "ocurl"
+conflicts: "ocurl" {< "0.5.5"}
 ocaml-version: [>= "4.00.0" & <= "4.00.1"]

--- a/packages/ocamlnet/ocamlnet.3.5.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.5.1/opam
@@ -41,7 +41,8 @@ depopts: [
   "lablgtk"
   "pcre"
   "ssl"
-  "camlzip" {= "1.04"}
+  "camlzip"
   "cryptokit"
 ]
+conflicts: "camlzip" {!= "1.04"}
 ocaml-version: [< "4.00.0"]

--- a/packages/ocsigenserver/ocsigenserver.2.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.1/opam
@@ -5,10 +5,10 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["rm" "-rf" "%{lib}%/ocsigenserver"]]
+remove: ["rm" "-rf" "%{lib}%/ocsigenserver"]
 depends: [
   "ocamlfind"
-  "react" {< "1.0.0" }
+  "react" {< "1.0.0"}
   "ssl"
   "lwt" {>= "2.4.0" & < "2.4.7"}
   "ocamlnet" {= "3.6.0"}
@@ -19,5 +19,6 @@ depends: [
 ]
 depopts: [
   "sqlite3"
-  "camlzip" {= "1.04"}
+  "camlzip"
 ]
+conflicts: "camlzip" {!= "1.04"}

--- a/packages/ocsigenserver/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.2.0/opam
@@ -5,10 +5,10 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["rm" "-rf" "%{lib}%/ocsigenserver"]]
+remove: ["rm" "-rf" "%{lib}%/ocsigenserver"]
 depends: [
   "ocamlfind"
-  "react" {< "1.0.0" }
+  "react" {< "1.0.0"}
   "ssl"
   "lwt" {>= "2.4.0" & < "2.4.7"}
   "ocamlnet" {>= "3.6.0"}
@@ -17,5 +17,6 @@ depends: [
   "tyxml" {< "3.0.0"}
   ("dbm" | "sqlite3")
 ]
-depopts: ["camlzip" {>= "1.04"}]
-patches: ["use_netstring-pcre.patch"]
+depopts: "camlzip"
+conflicts: "camlzip" {< "1.04"}
+patches: "use_netstring-pcre.patch"

--- a/packages/ocsigenserver/ocsigenserver.2.3.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.3.1/opam
@@ -5,12 +5,12 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["rm" "-rf" "%{lib}%/ocsigenserver"]]
+remove: ["rm" "-rf" "%{lib}%/ocsigenserver"]
 depends: [
   "ocamlfind"
   "base-unix"
   "base-threads"
-  "react" {< "1.0.0" }
+  "react" {< "1.0.0"}
   "ssl"
   "lwt" {>= "2.4.0" & < "2.4.7"}
   "ocamlnet" {>= "3.6.0"}
@@ -19,4 +19,5 @@ depends: [
   "tyxml" {>= "3.0.0" & < "3.2"}
   ("dbm" | "sqlite3")
 ]
-depopts: ["camlzip" {>= "1.04"}]
+depopts: "camlzip"
+conflicts: "camlzip" {< "1.04"}

--- a/packages/rdf/rdf.0.2/opam
+++ b/packages/rdf/rdf.0.2/opam
@@ -15,7 +15,8 @@ depends: [
   "ocamlnet"
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.3/opam
+++ b/packages/rdf/rdf.0.3/opam
@@ -15,7 +15,8 @@ depends: [
   "ocamlnet"
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.4/opam
+++ b/packages/rdf/rdf.0.4/opam
@@ -15,7 +15,8 @@ depends: [
   "ocamlnet" {>= "3.6"}
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.5/opam
+++ b/packages/rdf/rdf.0.5/opam
@@ -1,9 +1,9 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://ocaml-rdf.forge.ocamlcore.org/"
 license: "GNU Lesser General Public License version 3"
-doc: ["http://ocaml-rdf.forge.ocamlcore.org/ocamldoc/index.html"]
+doc: "http://ocaml-rdf.forge.ocamlcore.org/ocamldoc/index.html"
 tags: [
   "rdf"
   "semantic web"
@@ -28,7 +28,8 @@ depends: [
   "menhir" {>= "20120123"}
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.6.0/opam
+++ b/packages/rdf/rdf.0.6.0/opam
@@ -1,9 +1,9 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://zoggy.github.io/ocaml-rdf/"
 license: "GNU Lesser General Public License version 3"
-doc: ["http://zoggy.github.io/ocaml-rdf/doc.html"]
+doc: "http://zoggy.github.io/ocaml-rdf/doc.html"
 tags: [
   "rdf"
   "semantic web"
@@ -16,7 +16,7 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "rdf"]]
+remove: ["ocamlfind" "remove" "rdf"]
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.1"}
@@ -28,7 +28,8 @@ depends: [
   "pcre" {>= "7.0.2"}
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.7.0/opam
+++ b/packages/rdf/rdf.0.7.0/opam
@@ -1,9 +1,9 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://zoggy.github.io/ocaml-rdf/"
 license: "GNU Lesser General Public License version 3"
-doc: ["http://zoggy.github.io/ocaml-rdf/doc.html"]
+doc: "http://zoggy.github.io/ocaml-rdf/doc.html"
 tags: [
   "rdf"
   "semantic web"
@@ -18,7 +18,7 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "rdf"]]
+remove: ["ocamlfind" "remove" "rdf"]
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.1"}
@@ -30,7 +30,8 @@ depends: [
   "pcre" {>= "7.0.2"}
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.7.1/opam
+++ b/packages/rdf/rdf.0.7.1/opam
@@ -1,9 +1,9 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://zoggy.github.io/ocaml-rdf/"
 license: "GNU Lesser General Public License version 3"
-doc: ["http://zoggy.github.io/ocaml-rdf/doc.html"]
+doc: "http://zoggy.github.io/ocaml-rdf/doc.html"
 tags: [
   "rdf"
   "semantic web"
@@ -18,7 +18,7 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "rdf"]]
+remove: ["ocamlfind" "remove" "rdf"]
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.1"}
@@ -30,7 +30,8 @@ depends: [
   "pcre" {>= "7.0.2"}
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.8.0/opam
+++ b/packages/rdf/rdf.0.8.0/opam
@@ -1,9 +1,9 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://zoggy.github.io/ocaml-rdf/"
 license: "GNU Lesser General Public License version 3"
-doc: ["http://zoggy.github.io/ocaml-rdf/doc.html"]
+doc: "http://zoggy.github.io/ocaml-rdf/doc.html"
 tags: [
   "rdf"
   "semantic web"
@@ -18,7 +18,7 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "rdf"]]
+remove: ["ocamlfind" "remove" "rdf"]
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.1"}
@@ -30,7 +30,8 @@ depends: [
   "pcre" {>= "7.0.2"}
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
 ]
+conflicts: "mysql" {< "1.1.1"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/rdf/rdf.0.9.0/opam
+++ b/packages/rdf/rdf.0.9.0/opam
@@ -1,9 +1,9 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://zoggy.github.io/ocaml-rdf/"
 license: "GNU Lesser General Public License version 3"
-doc: ["http://zoggy.github.io/ocaml-rdf/doc.html"]
+doc: "http://zoggy.github.io/ocaml-rdf/doc.html"
 tags: [
   "rdf"
   "semantic web"
@@ -18,7 +18,7 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "rdf"]]
+remove: ["ocamlfind" "remove" "rdf"]
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.1"}
@@ -31,9 +31,14 @@ depends: [
   "yojson" {>= "1.1.8"}
 ]
 depopts: [
-  "mysql" {>= "1.1.1"}
+  "mysql"
   "postgresql"
-  "cohttp" {>= "0.11.2"}
-  "lwt" {>= "2.4.5"}
+  "cohttp"
+  "lwt"
+]
+conflicts: [
+  "cohttp" {< "0.11.2"}
+  "lwt" {< "2.4.5"}
+  "mysql" {< "1.1.1"}
 ]
 ocaml-version: [>= "4.02.0"]

--- a/packages/stog/stog.0.13.0/opam
+++ b/packages/stog/stog.0.13.0/opam
@@ -1,32 +1,43 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://zoggy.github.io/stog/"
 license: "GNU General Public License version 3"
-doc: ["http://zoggy.github.io/stog/doc.html"]
-tags: ["publication" "web" "blog"]
+doc: "http://zoggy.github.io/stog/doc.html"
+tags: [
+  "publication"
+  "web"
+  "blog"
+]
 build: [
   ["./configure" "--prefix" prefix]
   [make "stog_filter_parser.mli"]
   [make "all"]
   [make "install-lib" "install-share"]
 ]
-remove: [["ocamlfind" "remove" "stog"]]
+remove: ["ocamlfind" "remove" "stog"]
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1"}
   "xtmpl" {>= "0.10"}
   "config-file" {>= "1.2"}
   "ocamlnet" {>= "3.6"}
-  "higlo" { >= "0.4" }
+  "higlo" {>= "0.4"}
 ]
 depopts: [
-  "js_of_ocaml" { >= "2.5"}
-  "xmldiff" { >= "0.3.0" }
-  "lwt" { >= "2.4.5" }
-  "websocket" { >= "0.8.1" }
-  "cstruct" { >= "0.3.1" }
-  "crunch" { >= "1.1.0" }
+  "js_of_ocaml"
+  "xmldiff"
+  "lwt"
+  "websocket"
+  "cstruct"
+  "crunch"
 ]
-
+conflicts: [
+  "crunch" {< "1.1.0"}
+  "cstruct" {< "0.3.1"}
+  "js_of_ocaml" {< "2.5"}
+  "lwt" {< "2.4.5"}
+  "websocket" {< "0.8.1"}
+  "xmldiff" {< "0.3.0"}
+]
 ocaml-version: [>= "4.02.0"]

--- a/packages/stog/stog.0.14.0/opam
+++ b/packages/stog/stog.0.14.0/opam
@@ -1,33 +1,45 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
+authors: "Maxence Guesdon"
 homepage: "http://zoggy.github.io/stog/"
 license: "GNU General Public License version 3"
-doc: ["http://zoggy.github.io/stog/doc.html"]
-tags: ["publication" "web" "blog"]
+doc: "http://zoggy.github.io/stog/doc.html"
+tags: [
+  "publication"
+  "web"
+  "blog"
+]
 build: [
   ["./configure" "--prefix" prefix]
   [make "stog_filter_parser.mli"]
   [make "all"]
   [make "install-lib" "install-share"]
 ]
-remove: [["ocamlfind" "remove" "stog"]]
+remove: ["ocamlfind" "remove" "stog"]
 depends: [
   "ocamlfind"
   "xmlm" {>= "1.1"}
   "xtmpl" {>= "0.10"}
   "config-file" {>= "1.2"}
   "ocamlnet" {>= "3.6"}
-  "higlo" { >= "0.4" }
+  "higlo" {>= "0.4"}
 ]
 depopts: [
-  "js_of_ocaml" { >= "2.5"}
-  "xmldiff" { >= "0.5.0" }
-  "lwt" { >= "2.4.5" }
-  "websocket" { >= "0.8.1" }
-  "cstruct" { >= "0.3.1" }
-  "crunch" { >= "1.1.0" }
-  "ojs-base" { >= "0.2" }
+  "js_of_ocaml"
+  "xmldiff"
+  "lwt"
+  "websocket"
+  "cstruct"
+  "crunch"
+  "ojs-base"
 ]
-
+conflicts: [
+  "crunch" {< "1.1.0"}
+  "cstruct" {< "0.3.1"}
+  "js_of_ocaml" {< "2.5"}
+  "lwt" {< "2.4.5"}
+  "ojs-base" {< "0.2"}
+  "websocket" {< "0.8.1"}
+  "xmldiff" {< "0.5.0"}
+]
 ocaml-version: [>= "4.02.1"]

--- a/packages/themoviedb/themoviedb.0.8.1/opam
+++ b/packages/themoviedb/themoviedb.0.8.1/opam
@@ -1,14 +1,14 @@
 opam-version: "1"
 maintainer: "opam-devel@lists.ocaml.org"
-authors: ["Marc Simon marc.simon42@gmail.com"]
+authors: "Marc Simon marc.simon42@gmail.com"
 license: "GPL-3"
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{ounit:enable}%-utest" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "theMovieDb"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "theMovieDb"]
 depends: [
   "ocamlfind"
   "ocsigenserver"
@@ -16,6 +16,5 @@ depends: [
   "yojson"
   "lwt"
 ]
-depopts: [
-  "ounit" {>= "2.0.0" }
-]
+depopts: "ounit"
+conflicts: "ounit" {< "2.0.0"}

--- a/packages/themoviedb/themoviedb.0.8/opam
+++ b/packages/themoviedb/themoviedb.0.8/opam
@@ -1,14 +1,14 @@
 opam-version: "1"
 maintainer: "opam-devel@lists.ocaml.org"
-authors: ["Marc Simon marc.simon42@gmail.com"]
+authors: "Marc Simon marc.simon42@gmail.com"
 license: "GPL-3"
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{ounit:enable}%-utest" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "theMovieDb"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "theMovieDb"]
 depends: [
   "ocamlfind"
   "ocsigenserver"
@@ -16,6 +16,5 @@ depends: [
   "yojson"
   "lwt"
 ]
-depopts: [
-  "ounit" {>= "2.0.0" }
-]
+depopts: "ounit"
+conflicts: "ounit" {< "2.0.0"}

--- a/packages/uri/uri.1.3.10/opam
+++ b/packages/uri/uri.1.3.10/opam
@@ -16,10 +16,11 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}

--- a/packages/uri/uri.1.3.11/opam
+++ b/packages/uri/uri.1.3.11/opam
@@ -16,10 +16,11 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}

--- a/packages/uri/uri.1.3.12/opam
+++ b/packages/uri/uri.1.3.12/opam
@@ -16,10 +16,11 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}

--- a/packages/uri/uri.1.3.13/opam
+++ b/packages/uri/uri.1.3.13/opam
@@ -16,11 +16,12 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
-  "sexplib" {>="109.53.00"}
+  "sexplib" {>= "109.53.00"}
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}

--- a/packages/uri/uri.1.3.6/opam
+++ b/packages/uri/uri.1.3.6/opam
@@ -16,11 +16,12 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}
 ocaml-version: [>= "4.00.0"]

--- a/packages/uri/uri.1.3.8/opam
+++ b/packages/uri/uri.1.3.8/opam
@@ -16,11 +16,12 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}
 ocaml-version: [>= "4.0.0"]

--- a/packages/uri/uri.1.3.9/opam
+++ b/packages/uri/uri.1.3.9/opam
@@ -16,10 +16,11 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}

--- a/packages/uri/uri.1.4.0/opam
+++ b/packages/uri/uri.1.4.0/opam
@@ -16,12 +16,13 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
-  "sexplib" {>="109.53.00"}
+  "sexplib" {>= "109.53.00"}
   "type_conv"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}

--- a/packages/uri/uri.1.5.0/opam
+++ b/packages/uri/uri.1.5.0/opam
@@ -17,13 +17,14 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "uri"]]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "uri"]
 depends: [
   "ocamlfind"
   "re"
-  "sexplib" {>="109.53.00"}
+  "sexplib" {>= "109.53.00"}
   "type_conv"
   "stringext"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: "ounit"
+conflicts: "ounit" {< "1.0.2"}

--- a/packages/uuseg/uuseg.0.8.0/opam
+++ b/packages/uuseg/uuseg.0.8.0/opam
@@ -1,24 +1,29 @@
 opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
-authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/uuseg"
-doc: "http://erratique.ch/software/uuseg"
-dev-repo: "http://erratique.ch/repos/uuseg.git"
 bug-reports: "https://github.com/dbuenzli/uuseg/issues"
-tags: [ "segmentation" "text" "unicode" "org:erratique" ]
 license: "BSD3"
-available: [ ocaml-version >= "4.01.0"]
-depends: [ "ocamlfind"
-           "uucp" {>= "0.9.1"} ]
-depopts: [ "uutf"
-           "cmdliner"
-           "uutf" {test}
-           "cmdliner" {test} ]
-build:
-[
-  [ "ocaml" "pkg/git.ml" ]
-  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
-                           "native-dynlink=%{ocaml-native-dynlink}%"
-                           "uutf=%{uutf:installed}%"
-                           "cmdliner=%{cmdliner:installed}%" ]
+doc: "http://erratique.ch/software/uuseg"
+tags: [
+  "segmentation"
+  "text"
+  "unicode"
+  "org:erratique"
 ]
+dev-repo: "http://erratique.ch/repos/uuseg.git"
+build: [
+  ["ocaml" "pkg/git.ml"]
+  ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%" "uutf=%{uutf:installed}%" "cmdliner=%{cmdliner:installed}%"]
+]
+depends: [
+  "ocamlfind"
+  "uucp" {>= "0.9.1"}
+]
+depopts: [
+  "uutf" {test}
+  "cmdliner" {test}
+  "uutf" {test}
+  "cmdliner" {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/vchan/vchan.2.0.0/opam
+++ b/packages/vchan/vchan.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "vchan"]]
+remove: ["ocamlfind" "remove" "vchan"]
 depends: [
   "ocamlfind"
   "lwt" {>= "2.4.4"}
@@ -24,8 +24,9 @@ depends: [
   "cmdliner"
 ]
 depopts: [
-  "xen-evtchn" {>= "1.0.3"}
+  "xen-evtchn"
   "xen-gnt"
   "mirage-xen"
 ]
+conflicts: "xen-evtchn" {< "1.0.3"}
 ocaml-version: [>= "4.00.1"]

--- a/packages/why3/why3.0.81/opam
+++ b/packages/why3/why3.0.81/opam
@@ -9,7 +9,7 @@ authors: [
 ]
 homepage: "http://why3.lri.fr/"
 license: "GNU Lesser General Public License version 2.1"
-doc: ["http://why3.lri.fr/#documentation"]
+doc: "http://why3.lri.fr/#documentation"
 tags: [
   "deductive"
   "program verification"
@@ -32,8 +32,12 @@ depends: [
   "conf-gtksourceview"
 ]
 depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.3"}
+  "ocamlgraph"
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.3"}
+  "ocamlgraph" {< "1.8.2"}
 ]
 patches: [
   "configure.patch"

--- a/packages/why3/why3.0.82/opam
+++ b/packages/why3/why3.0.82/opam
@@ -9,7 +9,7 @@ authors: [
 ]
 homepage: "http://why3.lri.fr/"
 license: "GNU Lesser General Public License version 2.1"
-doc: ["http://why3.lri.fr/#documentation"]
+doc: "http://why3.lri.fr/#documentation"
 tags: [
   "deductive"
   "program verification"
@@ -32,9 +32,11 @@ depends: [
   "conf-gtksourceview"
 ]
 depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.3"}
+  "ocamlgraph"
+  "coq"
 ]
-patches: [
-  "Makefile.patch"
+conflicts: [
+  "coq" {< "8.3"}
+  "ocamlgraph" {< "1.8.2"}
 ]
+patches: "Makefile.patch"

--- a/packages/why3/why3.0.83/opam
+++ b/packages/why3/why3.0.83/opam
@@ -9,7 +9,7 @@ authors: [
 ]
 homepage: "http://why3.lri.fr/"
 license: "GNU Lesser General Public License version 2.1"
-doc: ["http://why3.lri.fr/#documentation"]
+doc: "http://why3.lri.fr/#documentation"
 tags: [
   "deductive"
   "program verification"
@@ -32,6 +32,10 @@ depends: [
   "conf-gtksourceview"
 ]
 depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.3"}
+  "ocamlgraph"
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.3"}
+  "ocamlgraph" {< "1.8.2"}
 ]

--- a/packages/why3/why3.0.84/opam
+++ b/packages/why3/why3.0.84/opam
@@ -9,7 +9,7 @@ authors: [
 ]
 homepage: "http://why3.lri.fr/"
 license: "GNU Lesser General Public License version 2.1"
-doc: ["http://why3.lri.fr/#documentation"]
+doc: "http://why3.lri.fr/#documentation"
 tags: [
   "deductive"
   "program verification"
@@ -28,12 +28,16 @@ build-doc: [
 ]
 depends: [
   "alt-ergo"
-  "lablgtk"    {>= "2.14.2"}
+  "lablgtk" {>= "2.14.2"}
   "conf-gtksourceview"
   "camlzip"
   "zarith"
 ]
 depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.4"}
+  "ocamlgraph"
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.4"}
+  "ocamlgraph" {< "1.8.2"}
 ]

--- a/packages/why3/why3.0.85/opam
+++ b/packages/why3/why3.0.85/opam
@@ -9,7 +9,7 @@ authors: [
 ]
 homepage: "http://why3.lri.fr/"
 license: "GNU Lesser General Public License version 2.1"
-doc: ["http://why3.lri.fr/#documentation"]
+doc: "http://why3.lri.fr/#documentation"
 tags: [
   "deductive"
   "program verification"
@@ -28,12 +28,16 @@ build-doc: [
 ]
 depends: [
   "alt-ergo"
-  "lablgtk"    {>= "2.14.2"}
+  "lablgtk" {>= "2.14.2"}
   "conf-gtksourceview"
   "camlzip"
   "zarith"
 ]
 depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.4"}
+  "ocamlgraph"
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.4"}
+  "ocamlgraph" {< "1.8.2"}
 ]

--- a/packages/xapi-xenopsd/xapi-xenopsd.0.9.44/opam
+++ b/packages/xapi-xenopsd/xapi-xenopsd.0.9.44/opam
@@ -28,6 +28,7 @@ depends: [
   "oclock"
   "xapi-inventory"
 ]
-depopts: "libvirt" {> "0.6.1.2"}
-patches: [ "disable-warn-error.patch" ]
+depopts: "libvirt"
+conflicts: "libvirt" {<= "0.6.1.2"}
+patches: "disable-warn-error.patch"
 ocaml-version: [>= "4.01.0"]

--- a/packages/xen-api-client/xen-api-client.0.9.3/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.3/opam
@@ -8,16 +8,19 @@ build: [
   [make]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "xen-api-client"]]
+remove: ["ocamlfind" "remove" "xen-api-client"]
 depends: [
   "ocamlfind"
   "lwt"
   "ssl"
   "ounit"
-  "cohttp" {>= "0.9.8" & <"0.9.14"}
+  "cohttp" {>= "0.9.8" & < "0.9.14"}
   "uri"
   "xmlm"
   "rpc" {>= "1.3.0"}
 ]
-depopts: ["async" {>= "109.15.00"}]
-conflicts: ["async" {< "109.15.00"} "async" {>= "111.13.00"}]
+depopts: "async"
+conflicts: [
+  "async" {< "109.15.00"}
+  "async" {>= "111.13.00"}
+]

--- a/packages/xen-block-driver/xen-block-driver.0.2.2/opam
+++ b/packages/xen-block-driver/xen-block-driver.0.2.2/opam
@@ -8,7 +8,7 @@ build: [
   [make]
   [make "install" "BINDIR=%{bin}%"]
 ]
-remove: [[make "uninstall" "BINDIR=%{bin}%"]]
+remove: [make "uninstall" "BINDIR=%{bin}%"]
 depends: [
   "ocamlfind"
   "cmdliner"
@@ -17,4 +17,5 @@ depends: [
   "shared-memory-ring" {>= "0.4.1"}
   "mirage" {>= "0.9.4"}
 ]
-depopts: ["xenctrl" {>= "0.9.8"}]
+depopts: "xenctrl"
+conflicts: "xenctrl" {< "0.9.8"}

--- a/packages/xmldiff/xmldiff.0.3.0/opam
+++ b/packages/xmldiff/xmldiff.0.3.0/opam
@@ -1,24 +1,20 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
-homepage: ["https://zoggy.github.io/xmldiff/"]
+authors: "Maxence Guesdon"
+homepage: "https://zoggy.github.io/xmldiff/"
 license: "GNU Lesser General Public License version 3"
-doc: ["https://zoggy.github.io/xmldiff/refdoc/"]
+doc: "https://zoggy.github.io/xmldiff/refdoc/"
 build: [
   ["./configure" "--prefix" prefix]
   [make "all"]
   [make "install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "xmldiff"]
-]
+remove: ["ocamlfind" "remove" "xmldiff"]
 depends: [
   "ocamlfind"
-  "xmlm" {>= "1.1.0" }
+  "xmlm" {>= "1.1.0"}
   "camlp4"
 ]
-depopts: [
-  "js_of_ocaml" {>= "2.4.0" }
-]
+depopts: "js_of_ocaml"
+conflicts: "js_of_ocaml" {< "2.4.0"}
 ocaml-version: [>= "4.02.0"]
-

--- a/packages/xmldiff/xmldiff.0.4.0/opam
+++ b/packages/xmldiff/xmldiff.0.4.0/opam
@@ -1,24 +1,20 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
-homepage: ["https://zoggy.github.io/xmldiff/"]
+authors: "Maxence Guesdon"
+homepage: "https://zoggy.github.io/xmldiff/"
 license: "GNU Lesser General Public License version 3"
-doc: ["https://zoggy.github.io/xmldiff/refdoc/"]
+doc: "https://zoggy.github.io/xmldiff/refdoc/"
 build: [
   ["./configure" "--prefix" prefix]
   [make "all"]
   [make "install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "xmldiff"]
-]
+remove: ["ocamlfind" "remove" "xmldiff"]
 depends: [
   "ocamlfind"
-  "xmlm" {>= "1.1.0" }
+  "xmlm" {>= "1.1.0"}
   "camlp4"
 ]
-depopts: [
-  "js_of_ocaml" {>= "2.4.0" }
-]
+depopts: "js_of_ocaml"
+conflicts: "js_of_ocaml" {< "2.4.0"}
 ocaml-version: [>= "4.02.0"]
-

--- a/packages/xmldiff/xmldiff.0.5.0/opam
+++ b/packages/xmldiff/xmldiff.0.5.0/opam
@@ -1,23 +1,19 @@
 opam-version: "1"
 maintainer: "zoggy@bat8.org"
-authors: ["Maxence Guesdon"]
-homepage: ["https://zoggy.github.io/xmldiff/"]
+authors: "Maxence Guesdon"
+homepage: "https://zoggy.github.io/xmldiff/"
 license: "GNU Lesser General Public License version 3"
-doc: ["https://zoggy.github.io/xmldiff/refdoc/"]
+doc: "https://zoggy.github.io/xmldiff/refdoc/"
 build: [
   ["./configure" "--prefix" prefix]
   [make "all"]
   [make "install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "xmldiff"]
-]
+remove: ["ocamlfind" "remove" "xmldiff"]
 depends: [
   "ocamlfind"
-  "xmlm" {>= "1.1.0" }
+  "xmlm" {>= "1.1.0"}
 ]
-depopts: [
-  "js_of_ocaml" {>= "2.4.0" }
-]
+depopts: "js_of_ocaml"
+conflicts: "js_of_ocaml" {< "2.4.0"}
 ocaml-version: [>= "4.02.0"]
-


### PR DESCRIPTION
This is the semantics they should have had. For example, if `b` has `depopts: "a" {> "1"}`,
it was _possible_ to have `a.1` and `b` installed together, depending on the order of commands.

Previous attempt to push this caused problems with OPAM 1.1 because it
made existing installations inconsistent, which wasn't handled
well. It should now go more smoothly and make the situation more sane.