### PR TITLE
allow coccinelle to compile w ocaml 4.00.0 and 4.01.0

### DIFF
--- a/packages/coccinelle/coccinelle.1.0.0-rc21/opam
+++ b/packages/coccinelle/coccinelle.1.0.0-rc21/opam
@@ -14,7 +14,7 @@ remove: [
 depends: [
   "menhir"
   "ocamlfind"
-  "pcre" {= "7.1.1"}
+  "pcre" {<= "7.1.1"}
   "conf-pkg-config"
   "conf-python-2-7"
   "conf-python-2-7-dev"

--- a/packages/coccinelle/coccinelle.1.0.0-rc22/opam
+++ b/packages/coccinelle/coccinelle.1.0.0-rc22/opam
@@ -14,7 +14,7 @@ remove: [
 depends: [
   "menhir"
   "ocamlfind"
-  "pcre" {= "7.1.1"}
+  "pcre" {<= "7.1.1"}
   "conf-pkg-config"
   "conf-python-2-7"
   "conf-python-2-7-dev"


### PR DESCRIPTION
coccinelle doesn't compile with pcre newer than 7.1.1 with ocaml 4.00.0 and
4.01.0, so I am fixing the version of pcre needed by coccinelle to 7.1.1
since not everybody is working with a bleeding edge 4.02.0 ocaml compiler
