### PR TITLE
bugfix release

### DIFF
--- a/packages/containers/containers.0.6.1/url
+++ b/packages/containers/containers.0.6.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/c-cube/ocaml-containers/archive/0.6.1.tar.gz"
-checksum: "98703d016f951e50bd110106173da02e"
+archive: "https://github.com/c-cube/ocaml-containers/archive/0.6.1.1.tar.gz"
+checksum: "9f817a3e3d16c74dbac94a72672d2ff9"


### PR DESCRIPTION
sorry about this, it makes the package compatible with `OPAMBUILDDOC=1` (thanks to @whitequark for spotting the issue).
