### PR TITLE
opam-publish.0.2.1 - via opam-publish

### DIFF
--- a/packages/opam-publish/opam-publish.0.2.1/descr
+++ b/packages/opam-publish/opam-publish.0.2.1/descr
@@ -1,0 +1,4 @@
+A tool to ease contributions to opam repositories.
+
+Opam-publish helps gather metadata to form an OPAM package and submit it
+to a remote repository.

--- a/packages/opam-publish/opam-publish.0.2.1/opam
+++ b/packages/opam-publish/opam-publish.0.2.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "http://opam.ocaml.org"
+bug-reports: "https://github.com/AltGr/opam-publish/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/AltGr/opam-publish.git"
+build: [make]
+depends: [
+  "opam-lib" {build & >= "1.2.0"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  "github" {build & >= "0.9.0"}
+]

--- a/packages/opam-publish/opam-publish.0.2.1/url
+++ b/packages/opam-publish/opam-publish.0.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/opam-publish/archive/0.2.1.tar.gz"
+checksum: "0ed6f6b47047fedafee448e3c2562881"


### PR DESCRIPTION
A tool to ease contributions to opam repositories.

Opam-publish helps gather metadata to form an OPAM package and submit it
to a remote repository.

---
- Homepage: http://opam.ocaml.org
- Source repo: https://github.com/AltGr/opam-publish.git
- Bug tracker: https://github.com/AltGr/opam-publish/issues

---

Pull-request generated by opam-publish v0.2.1
