### PR TITLE
+mirage-profile.0.4

### DIFF
--- a/packages/mirage-profile/mirage-profile.0.4/descr
+++ b/packages/mirage-profile/mirage-profile.0.4/descr
@@ -1,0 +1,6 @@
+Collect profiling information
+
+This library can be used to trace execution of OCaml/Lwt programs (such as
+Mirage unikernels) at the level of Lwt threads. The traces can be viewed using
+JavaScript or GTK viewers provided by mirage-trace-viewer or processed by tools
+supporting the Common Trace Format (CTF).

--- a/packages/mirage-profile/mirage-profile.0.4/opam
+++ b/packages/mirage-profile/mirage-profile.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "mirage-profile"
+version: "0.4"
+available: [ ocaml-version >= "4.00" ]
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/mirage/mirage-profile"
+bug-reports: "https://github.com/mirage/mirage-profile"
+license: "BSD-2-clause"
+build: [
+	["./configure"
+	  "--prefix" prefix
+	  "--%{mirage-xen-minios:enable}%-xen"
+	]
+	[make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-profile"]
+depends: [
+  "ocamlfind" {build}
+  "cstruct"
+  "ocplib-endian"
+  "io-page"
+  "lwt"
+]
+depopts: [
+	"mirage-xen-minios"
+]

--- a/packages/mirage-profile/mirage-profile.0.4/url
+++ b/packages/mirage-profile/mirage-profile.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-profile/archive/v0.4.tar.gz"
+checksum: "af5270ef46314959c9e987bafc5b9a47"


### PR DESCRIPTION
Sorry for the frequent releases. This update is needed when Lwt tracing is enabled, to support the new lwt#tracing feature of tracing conditions. Hopefully, new tracing features can be added in future without breaking mirage-profile...
