### PR TITLE
Slacko 0.12.0 released

### DIFF
--- a/packages/slacko/slacko.0.12.0/descr
+++ b/packages/slacko/slacko.0.12.0/descr
@@ -1,0 +1,5 @@
+Access the Slack API
+
+Slacko provides an easy to use interface to 100% of the Slack REST API, which
+allows to join Slack channels, post messages, create channels and groups and
+manage those, upload and search files, manage presence.

--- a/packages/slacko/slacko.0.12.0/opam
+++ b/packages/slacko/slacko.0.12.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1"
+maintainer: "marek@xivilization.net"
+homepage: "https://github.com/Leonidas-from-XIV/slacko"
+license: "LGPL-3 with OCaml linking exception"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "slacko"]
+]
+depends: [
+  "ocamlfind"
+  "cmdliner"
+  "yojson"
+  "lwt" {>= "2.4.6"}
+  "ssl"
+  "cohttp" {>= "0.10.0"}
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/slacko/slacko.0.12.0/url
+++ b/packages/slacko/slacko.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Leonidas-from-XIV/slacko/releases/download/0.12.0/slacko-0.12.0.tar.gz"
+checksum: "555023502adc2256360912b8746b08aa"


### PR DESCRIPTION
- Added type `chat` to abstract away from all types of channels Slack supports
- Removed topic-is-too-long errors as the binding checks the topic length beforehand
- Added `conversation` as a new type instead of string IM conversation type
- More syntactic sugar in code, endpoint definitions now a long pipe
