### PR TITLE
tyxml.3.4.0 - via opam-publish

### DIFF
--- a/packages/tyxml/tyxml.3.4.0/descr
+++ b/packages/tyxml/tyxml.3.4.0/descr
@@ -1,0 +1,6 @@
+A simple library for building valid HTML5 and SVG documents.
+
+TyXML allows you to build HTML5 and SVG trees whose validity is ensured by the typechecker.
+It provides a printer for said XML trees, along with a syntax extensions.
+Finally it also provides a functorial interface to choose your XML datastructure.
+It's part of the ocsigen project and is used in js_of_ocaml and eliom.

--- a/packages/tyxml/tyxml.3.4.0/opam
+++ b/packages/tyxml/tyxml.3.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+
+author: "The ocsigen team"
+maintainer: "dev@ocsigen.org"
+homepage: "https://ocsigen.org/tyxml/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+build: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "tyxml"]
+]
+depends: [
+  "ocamlfind" {build}
+  "uutf"
+  "base-bytes"
+]
+depopts: [
+  "camlp4"
+]

--- a/packages/tyxml/tyxml.3.4.0/url
+++ b/packages/tyxml/tyxml.3.4.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/tyxml/archive/3.4.0.tar.gz"
+checksum: "de93f513f01402ba6ba90bb64aa38219"


### PR DESCRIPTION
A simple library for building valid HTML5 and SVG documents.

TyXML allows you to build HTML5 and SVG trees whose validity is ensured by the typechecker.
It provides a printer for said XML trees, along with a syntax extensions.
Finally it also provides a functorial interface to choose your XML datastructure.
## It's part of the ocsigen project and is used in js_of_ocaml and eliom.
- Homepage: https://ocsigen.org/tyxml/
- Source repo: https://github.com/ocsigen/tyxml.git
- Bug tracker: https://github.com/ocsigen/tyxml/issues

---

Pull-request generated by opam-publish v0.2.1
