### PR TITLE
Camlp4 is not a hard dependency of bin_prot nor sexplib

### DIFF
--- a/packages/sexplib/sexplib.111.25.00/opam
+++ b/packages/sexplib/sexplib.111.25.00/opam
@@ -10,7 +10,10 @@ remove: [
   ["ocamlfind" "remove" "sexplib_num"]
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
-depends: ["ocamlfind"
-          "camlp4"
-          "type_conv" {= "111.13.00"}]
+depends: ["ocamlfind"]
+depopts: ["camlp4" "type_conv"]
+conflicts: [
+  "type_conv" {< "111.13.00"}
+  "type_conv" {> "111.13.00"}
+]
 ocaml-version: [>= "4.00.0"]

--- a/packages/sexplib/sexplib.112.01.00/opam
+++ b/packages/sexplib/sexplib.112.01.00/opam
@@ -10,7 +10,10 @@ remove: [
   ["ocamlfind" "remove" "sexplib_num"]
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
-depends: ["ocamlfind"
-          "camlp4"
-          "type_conv" {>= "112.01.00" & < "112.02.00"}]
+depends: ["ocamlfind"]
+depopts: ["camlp4" "type_conv"]
+conflicts: [
+  "type_conv" {< "112.01.00"}
+  "type_conv" {>= "112.02.00"}
+]
 ocaml-version: [>= "4.00.0"]


### PR DESCRIPTION
/cc @diml or @bmillwood I was too lazy to fix all the opam files for these two packages, so I've just fixed the last two more recent versions. I think you might want to adapt your release scripts for future releases.
