### PR TITLE
ppx_include.1.0 - via opam-publish

### DIFF
--- a/packages/ppx_include/ppx_include.1.0/descr
+++ b/packages/ppx_include/ppx_include.1.0/descr
@@ -1,0 +1,4 @@
+Include OCaml source files in each other
+
+ppx_include is a syntax extension that allows to include
+an OCaml source file inside another one.

--- a/packages/ppx_include/ppx_include.1.0/opam
+++ b/packages/ppx_include/ppx_include.1.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Peter Zotov <whitequark@whitequark.org>"
+authors: "Peter Zotov <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_include"
+bug-reports: "https://github.com/whitequark/ppx_include/issues"
+license: "MIT"
+tags: "syntax"
+dev-repo: "git://github.com/whitequark/ppx_include.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+build-test: ["ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_include.byte" "--"]
+depends: "ocamlfind" {build}
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_include/ppx_include.1.0/url
+++ b/packages/ppx_include/ppx_include.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_include/archive/v1.0.tar.gz"
+checksum: "3769d59301ea69105c410347744f72d9"


### PR DESCRIPTION
Include OCaml source files in each other

ppx_include is a syntax extension that allows to include
an OCaml source file inside another one.

---
- Homepage: https://github.com/whitequark/ppx_include
- Source repo: git://github.com/whitequark/ppx_include.git
- Bug tracker: https://github.com/whitequark/ppx_include/issues

---

Pull-request generated by opam-publish v0.2.1
