### PR TITLE
opam-query.1.2 - via opam-publish

### DIFF
--- a/packages/opam-query/opam-query.1.2/descr
+++ b/packages/opam-query/opam-query.1.2/descr
@@ -1,0 +1,4 @@
+A tool to query opam files from shell scripts
+
+opam-query is a tool that allows querying the OPAM package
+description files from shell scripts, similar to `oasis query`.

--- a/packages/opam-query/opam-query.1.2/opam
+++ b/packages/opam-query/opam-query.1.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Peter Zotov <whitequark@whitequark.org>"
+authors: "Peter Zotov <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/opam-query"
+bug-reports: "https://github.com/whitequark/opam-query/issues"
+license: "MIT"
+dev-repo: "git://github.com/whitequark/opam-query"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+depends: [
+  "ocamlfind" {build}
+  "opam-lib"
+  "cmdliner"
+  "containers"
+  "uri"
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/opam-query/opam-query.1.2/url
+++ b/packages/opam-query/opam-query.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/opam-query/archive/v1.2.tar.gz"
+checksum: "6acf46f0caf76d97aa91c5077d4a580d"


### PR DESCRIPTION
A tool to query opam files from shell scripts

opam-query is a tool that allows querying the OPAM package
description files from shell scripts, similar to `oasis query`.

---
- Homepage: https://github.com/whitequark/opam-query
- Source repo: git://github.com/whitequark/opam-query
- Bug tracker: https://github.com/whitequark/opam-query/issues

---

Pull-request generated by opam-publish v0.2.1
