### PR TITLE
Core 112.06.00 does not build on osx, so constrain it

### DIFF
--- a/packages/core/core.112.06.00/opam
+++ b/packages/core/core.112.06.00/opam
@@ -25,3 +25,4 @@ depends: ["camlp4"
           "sexplib" {= "112.06.00"}
           "variantslib" {>= "109.15.00" & < "109.16.00"}]
 ocaml-version: [>= "4.00.1"]
+available: [ os != "darwin" ]


### PR DESCRIPTION
See janestreet/core#50
