### PR TITLE
New release of Menhir: 20141215.

### DIFF
--- a/packages/menhir/menhir.20141215/descr
+++ b/packages/menhir/menhir.20141215/descr
@@ -1,0 +1,1 @@
+LR(1) parser generator

--- a/packages/menhir/menhir.20141215/files/menhir.install
+++ b/packages/menhir/menhir.20141215/files/menhir.install
@@ -1,0 +1,1 @@
+bin: ["src/_stage2/menhir.native" {"menhir"}]

--- a/packages/menhir/menhir.20141215/findlib
+++ b/packages/menhir/menhir.20141215/findlib
@@ -1,0 +1,1 @@
+menhirLib

--- a/packages/menhir/menhir.20141215/opam
+++ b/packages/menhir/menhir.20141215/opam
@@ -1,0 +1,9 @@
+opam-version: "1"
+maintainer: "opam-devel@lists.ocaml.org"
+build: [
+  [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+  [make "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+remove: [["ocamlfind" "remove" "menhirLib"]]
+depends: ["ocamlfind"]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20141215/url
+++ b/packages/menhir/menhir.20141215/url
@@ -1,0 +1,2 @@
+archive: "http://cristal.inria.fr/~fpottier/menhir/menhir-20141215.tar.gz"
+checksum: "5e1d1ac11364adcfe445cd6e3cbf7fc3"


### PR DESCRIPTION
New release of Menhir.
Note: this version of Menhir requires ocaml 4.02, whereas previous versions required ocaml 3.09.
