### PR TITLE
Add package atd2cconv 0.0.0

### DIFF
--- a/packages/atd2cconv/atd2cconv.0.0.0/descr
+++ b/packages/atd2cconv/atd2cconv.0.0.0/descr
@@ -1,0 +1,1 @@
+Convert ATD definitions to OCaml code that uses the CConv 0.1 library

--- a/packages/atd2cconv/atd2cconv.0.0.0/opam
+++ b/packages/atd2cconv/atd2cconv.0.0.0/opam
@@ -1,0 +1,11 @@
+opam-version: "1"
+maintainer: "seb@mondet.org"
+homepage: "http://seb.mondet.org/software/atd2cconv/index.html"
+ocaml-version: [ >= "4.01.0" ]
+build: [
+  [make "-f" "Makefile-ocamlbuild"]
+  [make "-f" "Makefile-ocamlbuild" "install" "BINDIR=%{bin}%"] 
+]
+remove: [make "-f" "Makefile-ocamlbuild" "uninstall" "BINDIR=%{bin}%"] 
+depends: [ "ocamlfind" "nonstd" "smart-print" "atd"  ]
+

--- a/packages/atd2cconv/atd2cconv.0.0.0/url
+++ b/packages/atd2cconv/atd2cconv.0.0.0/url
@@ -1,0 +1,3 @@
+archive: "https://github.com/smondet/atd2cconv/archive/atd2cconv.0.0.0.tar.gz"
+checksum: "7fa2ec65acf3a2eed28322afd3cecebf"
+


### PR DESCRIPTION
The thing to note is that even though `atd2cconv` does not depend on CConv, it imposes a constraint on the project(s) that use the generated code (CConv 0.1).
I figured it is the job of the packages using `atd2cconv` to enforce the version constraint.
