### PR TITLE
ipaddr depends on type_conv

### DIFF
--- a/packages/ipaddr/ipaddr.2.5.0/opam
+++ b/packages/ipaddr/ipaddr.2.5.0/opam
@@ -17,4 +17,4 @@ build: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "ipaddr"]]
-depends: ["ocamlfind" "sexplib"]
+depends: ["ocamlfind" "sexplib" "type_conv"]


### PR DESCRIPTION
This was caused by https://github.com/ocaml/opam-repository/pull/3197

See https://github.com/mirage/ocaml-dns/pull/29#issuecomment-67147218
