### PR TITLE
core 112.06.00 final

### DIFF
--- a/packages/async/async.112.06.00/url
+++ b/packages/async/async.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/async/archive/112.06.00-rc1.tar.gz"
-checksum: "f427d4ef8be0bfae46270e415ae7bc48"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/async-112.06.00.tar.gz"
+checksum: "de11419c8b428fd253b61fb72aa181a4"

--- a/packages/async_extended/async_extended.112.06.00/url
+++ b/packages/async_extended/async_extended.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/async_extended/archive/112.06.00-rc1.tar.gz"
-checksum: "04663025754c6522245d0a36884bc991"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/async_extended-112.06.00.tar.gz"
+checksum: "2bbe011ff5cc6c043e0e7b09461f21cf"

--- a/packages/async_extra/async_extra.112.06.00/url
+++ b/packages/async_extra/async_extra.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/async_extra/archive/112.06.00-rc1.tar.gz"
-checksum: "7d29039b676c1b45d563178f0b2d98a7"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/async_extra-112.06.00.tar.gz"
+checksum: "7abeccbecb2d75368bc111bdb2d4bdaf"

--- a/packages/async_kernel/async_kernel.112.06.00/url
+++ b/packages/async_kernel/async_kernel.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/async_kernel/archive/112.06.00-rc1.tar.gz"
-checksum: "d65a5a93ea8d1862bfd60943df2fd260"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/async_kernel-112.06.00.tar.gz"
+checksum: "6fc395db247e7dc0d9c70afdf5d2b924"

--- a/packages/async_unix/async_unix.112.06.00/url
+++ b/packages/async_unix/async_unix.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/async_unix/archive/112.06.00-rc1.tar.gz"
-checksum: "ab5faba9e6d92f3e554f227929cdd5dc"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/async_unix-112.06.00.tar.gz"
+checksum: "6d5235ab4e30fb9d28f2463b0f31f7b5"

--- a/packages/bignum/bignum.112.06.00/url
+++ b/packages/bignum/bignum.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/bignum/archive/112.06.00-rc1.tar.gz"
-checksum: "828e3fb3527ba9beb1827b37ca2cc397"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/bignum-112.06.00.tar.gz"
+checksum: "d4c6c3f41a1ece66c2912dae0fdde7fc"

--- a/packages/bin_prot/bin_prot.112.06.00/url
+++ b/packages/bin_prot/bin_prot.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/bin_prot/archive/112.06.00-rc1.tar.gz"
-checksum: "8f3fa9bc7c3b64cdb42a46efdb693a85"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/bin_prot-112.06.00.tar.gz"
+checksum: "b47693fb0399a532d2e9dab868c8f878"

--- a/packages/core/core.112.06.00/url
+++ b/packages/core/core.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/core/archive/112.06.00-rc1.tar.gz"
-checksum: "539323672db309277f34c13788848a25"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/core-112.06.00.tar.gz"
+checksum: "2cc8efcaa3f63ca5bb917962acdb7bbb"

--- a/packages/core_bench/core_bench.112.06.00/url
+++ b/packages/core_bench/core_bench.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/core_bench/archive/112.06.00-rc1.tar.gz"
-checksum: "4787761fd26bfbbf2cc1eda0c8b08b56"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/core_bench-112.06.00.tar.gz"
+checksum: "eaf222be0778d0f83c066155843db96f"

--- a/packages/core_extended/core_extended.112.06.00/url
+++ b/packages/core_extended/core_extended.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/core_extended/archive/112.06.00-rc1.tar.gz"
-checksum: "94558a6863bd5ceba638a3541b5d6774"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/core_extended-112.06.00.tar.gz"
+checksum: "774431fe03e376d04f311b0f09fac57c"

--- a/packages/core_kernel/core_kernel.112.06.00/url
+++ b/packages/core_kernel/core_kernel.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/core_kernel/archive/112.06.00-rc1.tar.gz"
-checksum: "a2d2e28b60d6fb5e140c84eda52b4045"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/core_kernel-112.06.00.tar.gz"
+checksum: "678112808abab41b788283a869268ba4"

--- a/packages/custom_printf/custom_printf.112.06.00/url
+++ b/packages/custom_printf/custom_printf.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/custom_printf/archive/112.06.00-rc1.tar.gz"
-checksum: "1ab791de840fc55838eb0abf8c4ea7a3"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/custom_printf-112.06.00.tar.gz"
+checksum: "c5059d763330ad890ff6e92b9a208fe7"

--- a/packages/jenga/jenga.112.06.00/url
+++ b/packages/jenga/jenga.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/jenga/archive/112.06.00-rc1.tar.gz"
-checksum: "c57f3318058058756b737b3c88c57825"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/jenga-112.06.00.tar.gz"
+checksum: "3e4ea8ab98f1e880d549727f904e1d1f"

--- a/packages/ocaml_plugin/ocaml_plugin.112.06.00/url
+++ b/packages/ocaml_plugin/ocaml_plugin.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/ocaml_plugin/archive/112.06.00-rc1.tar.gz"
-checksum: "a7b73f4471f9584a296fcad86607be8c"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/ocaml_plugin-112.06.00.tar.gz"
+checksum: "2d971d5234bed7cc36b03feef7904394"

--- a/packages/pa_bench/pa_bench.112.06.00/url
+++ b/packages/pa_bench/pa_bench.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/pa_bench/archive/112.06.00-rc1.tar.gz"
-checksum: "34a9fbf03748f46fbb7fedc990512811"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/pa_bench-112.06.00.tar.gz"
+checksum: "c270ccea47f83bf2a9206d1fa502c02e"

--- a/packages/patdiff/patdiff.112.06.00/url
+++ b/packages/patdiff/patdiff.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/patdiff/archive/112.06.00-rc1.tar.gz"
-checksum: "81eaf9e3fef38394cb012bd0018b8186"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/patdiff-112.06.00.tar.gz"
+checksum: "82af5ede6d3a479a44a86dcc72398e06"

--- a/packages/re2/re2.112.06.00/url
+++ b/packages/re2/re2.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/re2/archive/112.06.00-rc1.tar.gz"
-checksum: "73e5fdb70d4741a620f364481765a936"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/re2-112.06.00.tar.gz"
+checksum: "1c28ff6eaf7c2259dce83747c3d86aef"

--- a/packages/sexplib/sexplib.112.06.00/url
+++ b/packages/sexplib/sexplib.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/sexplib/archive/112.06.00-rc1.tar.gz"
-checksum: "34c52319b51dbae3ad08c405aad8ee2c"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/sexplib-112.06.00.tar.gz"
+checksum: "431a406a036a58344de918830c69a9ce"

--- a/packages/textutils/textutils.112.06.00/url
+++ b/packages/textutils/textutils.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/textutils/archive/112.06.00-rc1.tar.gz"
-checksum: "71a618ca9bdfb86d961cc7323c45925e"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/textutils-112.06.00.tar.gz"
+checksum: "20ab149461e44f5ab4209b54b1366c78"

--- a/packages/typerep/typerep.112.06.00/url
+++ b/packages/typerep/typerep.112.06.00/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/typerep/archive/112.06.00-rc1.tar.gz"
-checksum: "ebe24e054c4bcce6e02b17408d43f580"
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06.00/individual/typerep-112.06.00.tar.gz"
+checksum: "4a12b086d9f3c6b8571c06323bbcdb2c"


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/3173 was merged a bit too soon. I think the right thing to do here is just release the rc1 as 112.06.00 and do a 112.06.01 release with the OS X fixes.
