### PR TITLE
mirage-tc.0.3.0 - via opam-publish

### DIFF
--- a/packages/mirage-tc/mirage-tc.0.3.0/descr
+++ b/packages/mirage-tc/mirage-tc.0.3.0/descr
@@ -1,0 +1,35 @@
+Mirage type-classes
+
+A set of functors and combinators to pretty-print (using sexplib), to
+convert to and from and JSON and Cstruct buffers.
+
+```ocaml
+# Tc.show (module Tc.S) "Hello world!";;
+- : string = "\"Hello world!\""
+# Tc.to_json (module Tc.App2(Tc.P)(Tc.I)(Tc.S)) (3, "foo");;
+- : Ezjsonm.t = `A [`String "3"; `String "foo"]
+```
+
+A slightly more complex example, using autogen code instead of functor
+composition:
+
+```ocaml
+# camlp4o;;
+# require "sexplib.syntax";;
+# require "comparelib.syntax";;
+# require "bin_prot.syntax";;
+# module M = struct
+    type t = { foo: int; bar: string list } with sexp, bin_prot, compare
+  end;;
+# module X = Tc.I0(M);;
+# let t = { foo = 3; bar = [ "hello"; "world" ] };;
+
+# Tc.to_json (module X) t;;
+- : Ezjsonm.t =
+`A
+  [`A [`String "foo"; `String "3"];
+   `A [`String "bar"; `A [`String "hello"; `String "world"]]]
+
+# Tc.write_string (module X) t;;
+- : string = "\003\002\005hello\005world"
+```

--- a/packages/mirage-tc/mirage-tc.0.3.0/opam
+++ b/packages/mirage-tc/mirage-tc.0.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+homepage: "https://github.com/mirage/mirage-tc"
+bug-reports: "https://github.com/mirage/mirage-tc/issues"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-tc.git"
+build: [
+  ["./configure" "--prefix" prefix "--%{alcotest:enable}%-tests"]
+  [make]
+]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "tc"]
+depends: [
+  "ezjsonm" {>= "0.4.0"}
+  "mstruct" {>= "1.3.1"}
+  "cstruct"
+  "bin_prot"
+  "alcotest" {test}
+  "ounit" {test}
+  "base-bytes"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-tc/mirage-tc.0.3.0/url
+++ b/packages/mirage-tc/mirage-tc.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-tc/archive//0.3.0.tar.gz"
+checksum: "909caab4b9a99a76b3fb6c1147e1741b"


### PR DESCRIPTION
Mirage type-classes

A set of functors and combinators to pretty-print (using sexplib), to
convert to and from and JSON and Cstruct buffers.

``` ocaml
# Tc.show (module Tc.S) "Hello world!";;
- : string = "\"Hello world!\""
# Tc.to_json (module Tc.App2(Tc.P)(Tc.I)(Tc.S)) (3, "foo");;
- : Ezjsonm.t = `A [`String "3"; `String "foo"]
```

A slightly more complex example, using autogen code instead of functor
composition:

``` ocaml
# camlp4o;;
# require "sexplib.syntax";;
# require "comparelib.syntax";;
# require "bin_prot.syntax";;
# module M = struct
    type t = { foo: int; bar: string list } with sexp, bin_prot, compare
  end;;
# module X = Tc.I0(M);;
# let t = { foo = 3; bar = [ "hello"; "world" ] };;

# Tc.to_json (module X) t;;
- : Ezjsonm.t =
`A
  [`A [`String "foo"; `String "3"];
   `A [`String "bar"; `A [`String "hello"; `String "world"]]]

# Tc.write_string (module X) t;;
- : string = "\003\002\005hello\005world"
```

---
- Homepage: https://github.com/mirage/mirage-tc
- Source repo: https://github.com/mirage/mirage-tc.git
- Bug tracker: https://github.com/mirage/mirage-tc/issues

---

Pull-request generated by opam-publish v0.2.1
