### PR TITLE
mstruct.1.3.2 - via opam-publish

### DIFF
--- a/packages/mstruct/mstruct.1.3.2/descr
+++ b/packages/mstruct/mstruct.1.3.2/descr
@@ -1,0 +1,11 @@
+Mstruct is a thin mutable layer on top of cstruct
+
+```ocaml
+# #require "mstruct";;
+# let b = Mstruct.create 9;;
+val b : Mstruct.t = <abstr>
+# Mstruct.set_string b "hello";;
+- : unit = ()
+# Mstruct.set_uint32 b 32l;;
+- : unit = ()
+```

--- a/packages/mstruct/mstruct.1.3.2/opam
+++ b/packages/mstruct/mstruct.1.3.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-mstruct"
+dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mstruct"]
+depends: [
+  "cstruct" {>= "1.4.0"}
+]

--- a/packages/mstruct/mstruct.1.3.2/url
+++ b/packages/mstruct/mstruct.1.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-mstruct/archive/1.3.2.tar.gz"
+checksum: "52cfd548d17b414a8a02a308e0331869"


### PR DESCRIPTION
Mstruct is a thin mutable layer on top of cstruct

``` ocaml
# #require "mstruct";;
# let b = Mstruct.create 9;;
val b : Mstruct.t = <abstr>
# Mstruct.set_string b "hello";;
- : unit = ()
# Mstruct.set_uint32 b 32l;;
- : unit = ()
```

---
- Homepage: https://github.com/mirage/ocaml-mstruct
- Source repo: https://github.com/mirage/ocaml-mstruct.git
- Bug tracker: https://github.com/mirage/ocaml-mstruct/issues

---

Pull-request generated by opam-publish v0.2.1
