### PR TITLE
Basic findlib support for BER MetaOCaml [Feedback solicited]

### DIFF
--- a/compilers/4.01.0/4.01.0+BER.comp
+++ b/compilers/4.01.0/4.01.0+BER.comp
@@ -13,7 +13,7 @@ build: [
   ["%{make}%" "-C" "ber-metaocaml-101" "all"]
   ["%{make}%" "-C" "ber-metaocaml-101" "install"]
 ]
-packages : [ "base-unix" "base-bigarray" "base-threads" ]
+packages : [ "base-unix" "base-bigarray" "base-threads" "base-metaocaml-ocamlfind"]
 env: [
   [ CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs" ]
 ]

--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/descr
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/descr
@@ -1,0 +1,1 @@
+Findlib toolchain configuration for MetaOCaml.

--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/files/metaocaml.conf
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/files/metaocaml.conf
@@ -1,0 +1,2 @@
+ocamlc(metaocaml) = "metaocamlc"
+ocamlmktop(metaocaml) = "metaocamlmktop"

--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/opam
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "yallop@gmail.com"
+depopts: ["ocamlfind"]
+install: [
+  [ "mkdir" "-p" "%{lib}%/findlib.conf.d/"          ] {ocamlfind:installed}
+  [ "cp" "metaocaml.conf" "%{lib}%/findlib.conf.d/" ] {ocamlfind:installed}
+]
+remove: [
+  [ "rm" "-f" "%{lib}%/findlib.conf.d/metaocaml.conf" ]
+]


### PR DESCRIPTION
[NB: this text is much longer than the actual changeset.]

The goal of this change is to add basic Findlib support for the OPAM-packaged BER MetaOCaml.  I'd appreciate feedback about the approach described below.
#### Background

[BER MetaOCaml](http://okmij.org/ftp/ML/MetaOCaml.html) provides a few extra commands besides what's available in a standard OCaml distribution.  For example, there's a byte-code compiler, `metaocamlc`, which behaves much like `ocamlc`, but automatically links in some MetaOCaml-specific libraries.  When you're compiling a program that involves MetaOCaml features it's generally best to use `metaocamlc` rather than `ocamlc`.

The [Findlib library](http://projects.camlcity.org/projects/findlib.html) and associated `ocamlfind` tool are used by [lots of packages](%28https://opam.ocaml.org/packages/ocamlfind/ocamlfind.1.5.5/%29) to manage the process of compiling and linking OCaml libraries.  The behaviour of `ocamlfind` can be modified via a [set of configuration files](http://manpages.ubuntu.com/manpages/precise/man5/findlib.conf.5.html).  There's a master file `findlib.conf` which is generated when `findlib` is configured, and additional configuration files which the user can add to a `findlib.conf.d` directory.  One configurable feature is the "toolchain", which determines how `ocamlfind` resolves command names.  For example, you can add the following to a configuration file to indicate that `ocamlfind -toolchain metaocaml ocamlc` should invoke the `metaocamlc` command:

```
ocamlc(metaocaml) = "metaocamlc"
```
#### Desired behaviour

The `findlib.conf` file lives under the `.opam` directory, at `~/.opam/$compiler/lib/findlib.conf`.  By default there's no `findlib.conf.d` directory, but `ocamlfind` checks for one at `~/.opam/$compiler/lib/findlib.conf.d/`.

In order to use MetaOCaml and Findlib together we need to add a configuration file to `findlib.conf.d`.  Since Findlib is not always installed it seems inappropriate to unconditionally install this configuration along with the MetaOCaml compiler.  Making the Findlib package aware of MetaOCaml-specific configuration seems even worse.
#### Approach

The approach taken here is to add a new package, `base-metaocaml-ocamlfind`, which is installed along with the MetaOCaml compiler and has an optional dependency on Findlib.  If Findlib is not installed the package does nothing.  If Findlib is installed the package installs MetaOCaml toolchain configuration in `findlib.conf.d`.  Here's a typical interaction:

``` bash
$ opam switch 4.01.0+BER
[compiler.get] Downloading http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz
Now compiling OCaml. This may take a while, please bear with us...
Done.
# To setup the new switch in the current shell, you need to run:
eval `opam config env`
The following actions will be performed:
 - install   base-unix.base
 - install   base-bigarray.base
 - install   base-threads.base
 - install   base-metaocaml-ocamlfind.base
...
$ ls /home/jeremy/.opam/4.01.0+BER/lib/findlib.conf.d/
ls: cannot access /home/jeremy/.opam/4.01.0+BER/lib/findlib.conf.d/: No such file or directory
$ opam install ocamlfind
The following actions will be performed:
 - install   ocamlfind.1.5.5
 - recompile base-metaocaml-ocamlfind.base         [uses ocamlfind]
=== 1 to install | 1 to reinstall ===
Do you want to continue ? [Y/n] y
...
$ ls /home/jeremy/.opam/4.01.0+BER/lib/findlib.conf.d/
metaocaml.conf
$ ocamlfind  -toolchain metaocaml ocamlc -verbose -version
Effective set of compiler predicates: autolink,byte
+ metaocamlc -verbose -version
4.01.0
$ opam remove ocamlfind
The following actions will be performed:
 - remove    ocamlfind.1.5.5
 - recompile base-metaocaml-ocamlfind.base         [upstream changes]
=== 1 to reinstall | 1 to remove ===
Do you want to continue ? [Y/n] y
...
$ ls /home/jeremy/.opam/4.01.0+BER/lib/findlib.conf.d/
$
```
