### PR TITLE
cow.1.1.0 - via opam-publish

### DIFF
--- a/packages/cow/cow.1.1.0/descr
+++ b/packages/cow/cow.1.1.0/descr
@@ -1,0 +1,17 @@
+XML, JSON, HTML, CSS, and Markdown syntax and libraries
+
+Writing web-applications requires a lot of skills: HTML, CSS, XML,
+JSON and Markdown, to name but a few! This library provides OCaml
+syntax extensions for these web formats by:
+
+* extending standard OCaml syntax with embedded web DSLs. It has a
+  quotation mechanism which parses HTML, CSS or XML to OCaml, and
+  also anti-quotations that form a template mechanism.
+
+* using type-driven code generation to generate markup directly from
+  OCaml type declarations. It is possible to mix hand-written and
+  generated code to deal with special-cases. Most of the work is done
+  at pre-processing time, so there is no runtime costs and the generated
+  OCaml code can be manually inspected if desired.
+
+Mre documentation at <https://github.com/mirage/ocaml-cow>

--- a/packages/cow/cow.1.1.0/opam
+++ b/packages/cow/cow.1.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Gazagnaire"
+  "David Sheets"
+  "Rudi Grinberg"
+]
+homepage: "https://github.com/mirage/ocaml-cow"
+bug-reports: "https://github.com/mirage/ocaml-cow/issues"
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+dev-repo: "https://github.com/mirage/ocaml-cow.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "cow"]
+depends: [
+  "ocamlfind" {build}
+  "dyntype" {>= "0.9.0"}
+  "type_conv" {>= "108.07.00"}
+  "ulex"
+  "re"
+  "ounit" {build}
+  "uri" {>= "1.3.9"}
+  "xmlm" {>= "1.1.1"}
+  "omd" {>= "0.8.2"}
+  "ezjsonm" {>= "0.4.0"}
+  "camlp4"
+]

--- a/packages/cow/cow.1.1.0/url
+++ b/packages/cow/cow.1.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cow/archive/v1.1.0.tar.gz"
+checksum: "4d0380b1526660648abbe5aa3ae3485a"


### PR DESCRIPTION
XML, JSON, HTML, CSS, and Markdown syntax and libraries

Writing web-applications requires a lot of skills: HTML, CSS, XML,
JSON and Markdown, to name but a few! This library provides OCaml
syntax extensions for these web formats by:
- extending standard OCaml syntax with embedded web DSLs. It has a
  quotation mechanism which parses HTML, CSS or XML to OCaml, and
  also anti-quotations that form a template mechanism.
- using type-driven code generation to generate markup directly from
  OCaml type declarations. It is possible to mix hand-written and
  generated code to deal with special-cases. Most of the work is done
  at pre-processing time, so there is no runtime costs and the generated
  OCaml code can be manually inspected if desired.

Mre documentation at https://github.com/mirage/ocaml-cow

---
- Homepage: https://github.com/mirage/ocaml-cow
- Source repo: https://github.com/mirage/ocaml-cow.git
- Bug tracker: https://github.com/mirage/ocaml-cow/issues

---

Pull-request generated by opam-publish v0.2.1
