### PR TITLE
Constrain lbfgs to OCaml < 4.02.0.

### DIFF
--- a/packages/lbfgs/lbfgs.0.8.5/opam
+++ b/packages/lbfgs/lbfgs.0.8.5/opam
@@ -16,3 +16,4 @@ depexts: [
   [["debian"] ["gfortran"]]
   [["ubuntu"] ["gfortran"]]
 ]
+available: [ ocaml-version < "4.02.0" ]


### PR DESCRIPTION
lbfgs doesn't build on OCaml 4.02.*:

```
File "src/lbfgs.mli", line 109, characters 24-26:
Error: String literal begins here
Command exited with code 2.
``
```
