### PR TITLE
containers 0.7.0.1 (missing flags)

### DIFF
--- a/packages/containers/containers.0.7/url
+++ b/packages/containers/containers.0.7/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/c-cube/ocaml-containers/archive/0.7.tar.gz"
-checksum: "2392277243264c75599daf458135b9e5"
+archive: "https://github.com/c-cube/ocaml-containers/archive/0.7.0.1.tar.gz"
+checksum: "32ee1096036e53aee54116c7ef1d0758"


### PR DESCRIPTION
fix the flags responsible for documentation (only build it if enough dependencies are present).
