### PR TITLE
cryptokit requires ocaml <4.03.0 to compile

### DIFF
--- a/packages/cryptokit/cryptokit.1.6/opam
+++ b/packages/cryptokit/cryptokit.1.6/opam
@@ -10,3 +10,4 @@ depexts: [
   [["debian"] ["zlib1g-dev"]]
   [["ubuntu"] ["zlib1g-dev"]]
 ]
+ocaml-version: [<"4.03.0"]

--- a/packages/cryptokit/cryptokit.1.7/opam
+++ b/packages/cryptokit/cryptokit.1.7/opam
@@ -10,3 +10,4 @@ depexts: [
   [["debian"] ["zlib1g-dev"]]
   [["ubuntu"] ["zlib1g-dev"]]
 ]
+ocaml-version: [<"4.03.0"]

--- a/packages/cryptokit/cryptokit.1.9/opam
+++ b/packages/cryptokit/cryptokit.1.9/opam
@@ -10,3 +10,4 @@ depexts: [
   [["debian"] ["zlib1g-dev"]]
   [["ubuntu"] ["zlib1g-dev"]]
 ]
+ocaml-version: [<"4.03.0"]


### PR DESCRIPTION
Due to removed uint32 typedef:

```
src/stubs-md5.c:21:9: error: unknown type name 'uint32'
  uint32 buf[4];
  ^
```

/cc @xavierleroy (maintainer)
