### PR TITLE
uuseg.0.8.0 - via opam-publish

### DIFF
--- a/packages/uuseg/uuseg.0.8.0/descr
+++ b/packages/uuseg/uuseg.0.8.0/descr
@@ -1,0 +1,19 @@
+Unicode text segmentation for OCaml
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the BSD3 license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+

--- a/packages/uuseg/uuseg.0.8.0/opam
+++ b/packages/uuseg/uuseg.0.8.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uuseg"
+doc: "http://erratique.ch/software/uuseg"
+dev-repo: "http://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "BSD3"
+available: [ ocaml-version >= "4.01.0"]
+depends: [ "ocamlfind"
+           "uucp" {>= "0.9.1"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {test}
+           "cmdliner" {test} ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "uutf=%{uutf:installed}%"
+                           "cmdliner=%{cmdliner:installed}%" ]
+]

--- a/packages/uuseg/uuseg.0.8.0/url
+++ b/packages/uuseg/uuseg.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uuseg/releases/uuseg-0.8.0.tbz"
+checksum: "409bbd8a3c3f00e0d7259441a5e4b648"


### PR DESCRIPTION
Unicode text segmentation for OCaml

Uuseg is an OCaml library for segmenting Unicode text. It implements
the locale independent [Unicode text segmentation algorithms](http://www.unicode.org/reports/tr29/) to
detect grapheme cluster, word and sentence boundaries and the
[Unicode line breaking algorithm](http://www.unicode.org/reports/tr14/) to detect line break
opportunities.

The library is independent from any IO mechanism or Unicode text data
structure and it can process text without a complete in-memory
representation.

Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
optionally on [Uutf](http://erratique.ch/software/uutf) for support on
OCaml UTF-X encoded strings. It is distributed under the BSD3 license.

---
- Homepage: http://erratique.ch/software/uuseg
- Source repo: http://erratique.ch/repos/uuseg.git
- Bug tracker: https://github.com/dbuenzli/uuseg/issues

---

Pull-request generated by opam-publish v0.2.1
