### PR TITLE
riakc_ppx version 3.1.2

### DIFF
--- a/packages/riakc_ppx/riakc_ppx.3.1.2/descr
+++ b/packages/riakc_ppx/riakc_ppx.3.1.2/descr
@@ -1,0 +1,1 @@
+An OCaml library that provides type safe caching extensions to riakc using ppx deriving

--- a/packages/riakc_ppx/riakc_ppx.3.1.2/findlib
+++ b/packages/riakc_ppx/riakc_ppx.3.1.2/findlib
@@ -1,0 +1,1 @@
+riakc_ppx

--- a/packages/riakc_ppx/riakc_ppx.3.1.2/opam
+++ b/packages/riakc_ppx/riakc_ppx.3.1.2/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "riakc_ppx"
+version: "3.1.2"
+author : "Carmelo Piccione carmelo.piccione+riakc_ppx@gmail.com"
+maintainer: "carmelo.piccione+riakc_ppx@gmail.com"
+homepage: "https://github.com/struktured/riakc_ppx"
+build: [
+  ["omake" "-j2"]
+  ["omake" "install"]
+]
+
+available: [ ocaml-version >= "4.02.1" ]
+
+remove: [
+  ["ocamlfind" "remove" "riakc_ppx"]
+]
+
+depends: [
+  "ocamlfind"
+  "core" {>= "109.12.00"}
+  "async"
+  "ppx_deriving_protobuf" {>= "2.0"}
+  "bitstring" {>= "2.0.4"}
+  "omake"
+]

--- a/packages/riakc_ppx/riakc_ppx.3.1.2/url
+++ b/packages/riakc_ppx/riakc_ppx.3.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/struktured/riakc_ppx/archive/3.1.2.zip"
+checksum: "47079b4da143a4a1bdd4a3c1bd4261b3"


### PR DESCRIPTION
Adds protocol versioning support, fixes some bugs, and introduces persistent capable Float module.
