### PR TITLE
ranger.0.1.0 - via opam-publish

### DIFF
--- a/packages/ranger/ranger.0.1.0/descr
+++ b/packages/ranger/ranger.0.1.0/descr
@@ -1,0 +1,7 @@
+A consecutive range slice library for strings, arrays, etc.
+
+The main type provided by ranger generalizes substrings to arbitrary data
+structures that are "indexed" by an integer. The biggest difference between
+ranger and other libraries like it (e.g. various Substring functors) is that
+ranger doesn't use functors and is polymorphic over the base type (e.g. char in
+the case of substrings).

--- a/packages/ranger/ranger.0.1.0/opam
+++ b/packages/ranger/ranger.0.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: "Rudi Grinberg"
+homepage: "https://github.com/rgrinberg/ranger"
+bug-reports: "https://github.com/rgrinberg/ranger/issues"
+license: "MIT"
+dev-repo: "https://github.com/rgrinberg/ranger.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "ranger"]
+depends: [
+  "ocamlfind" {build}
+  "kaputt" {test}
+  "base-bytes"
+  "oasis" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/ranger/ranger.0.1.0/url
+++ b/packages/ranger/ranger.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ranger/archive/v0.1.0.tar.gz"
+checksum: "415036856207646d1bf229f45cd1f8f6"


### PR DESCRIPTION
A consecutive range slice library for strings, arrays, etc.

The main type provided by ranger generalizes substrings to arbitrary data
structures that are "indexed" by an integer. The biggest difference between
ranger and other libraries like it (e.g. various Substring functors) is that
ranger doesn't use functors and is polymorphic over the base type (e.g. char in
the case of substrings).

---
- Homepage: https://github.com/rgrinberg/ranger
- Source repo: https://github.com/rgrinberg/ranger.git
- Bug tracker: https://github.com/rgrinberg/ranger/issues

---

Pull-request generated by opam-publish v0.2
