### PR TITLE
opium.0.12.0 - via opam-publish

### DIFF
--- a/packages/opium/opium.0.12.0/descr
+++ b/packages/opium/opium.0.12.0/descr
@@ -1,0 +1,11 @@
+Sinatra like web toolkit based on Lwt + Cohttp
+
+Opium is a minimalistic library for quickly binding functions
+to http routes. Its features include (but not limited to):
+
+* Middleware system for app independent components
+* A simple router for matching urls and parsing parameters
+* Request/Response pretty printing for easier debugging
+
+Note: This library is still at an early stage so expect breakages
+until 1.0

--- a/packages/opium/opium.0.12.0/opam
+++ b/packages/opium/opium.0.12.0/opam
@@ -1,0 +1,47 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/opium"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+dev-repo: "https://github.com/rgrinberg/opium.git"
+
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: ["ocaml" "setup.ml" "-install"]
+
+remove: [
+  ["ocamlfind" "remove" "opium_rock"]
+  ["ocamlfind" "remove" "opium"]
+]
+
+build-doc: ["ocaml" "setup.ml" "-doc"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "cohttp" {>= "0.15.0"}
+  "ezjsonm" {>= "0.4.0"}
+  "base64" {>= "2.0.0"}
+  "lwt"
+  "core_kernel"
+  "cmdliner"
+  "fieldslib"
+  "sexplib"
+  "humane-re"
+  "ounit" {test}
+  "cow" {test}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opium/opium.0.12.0/url
+++ b/packages/opium/opium.0.12.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/opium/archive/v0.12.0.tar.gz"
+checksum: "dc6500c727af18ff3ba98fd11b5fdae9"


### PR DESCRIPTION
Sinatra like web toolkit based on Lwt + Cohttp

Opium is a minimalistic library for quickly binding functions
to http routes. Its features include (but not limited to):
- Middleware system for app independent components
- A simple router for matching urls and parsing parameters
- Request/Response pretty printing for easier debugging

Note: This library is still at an early stage so expect breakages
## until 1.0
- Homepage: https://github.com/rgrinberg/opium
- Source repo: https://github.com/rgrinberg/opium.git
- Bug tracker: https://github.com/rgrinberg/opium/issues

---

Pull-request generated by opam-publish v0.2
