### PR TITLE
cohttp.0.15.0 - via opam-publish

### DIFF
--- a/packages/cohttp/cohttp.0.15.0/descr
+++ b/packages/cohttp/cohttp.0.15.0/descr
@@ -1,0 +1,9 @@
+HTTP library for Lwt, Async and Mirage
+
+There are several optional dependencies which activate functionality:
+
+* Lwt: `opam install lwt cohttp`
+* Lwt and SSL: `opam install lwt ssl cohttp`
+* Async: `opam install async cohttp`
+* Async and SSL: `opam install async_ssl cohttp`
+

--- a/packages/cohttp/cohttp.0.15.0/opam
+++ b/packages/cohttp/cohttp.0.15.0/opam
@@ -1,0 +1,50 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+
+authors: [ "Anil Madhavapeddy"
+           "Stefano Zacchiroli"
+           "David Sheets"
+           "Thomas Gazagnaire"
+           "David Scott"
+           "Rudi Grinberg"
+           "Andy Ray" ]
+
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
+build: [make "PREFIX=%{prefix}%"]
+install: [make "PREFIX=%{prefix}%" "install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "cohttp"]
+depends: [
+  "ocamlfind" {build}
+  "cmdliner" {build & >= "0.9.4"}
+  "re"
+  "uri" {>= "1.5.0"}
+  "fieldslib" {>= "109.20.00"}
+  "sexplib" {>= "109.53.00"}
+  "conduit" {>= "0.7.0"}
+  "stringext"
+  "base64" {>= "2.0.0"}
+  "ounit" {test}
+]
+depopts: [
+  "async"
+  "lwt"
+  "js_of_ocaml"
+]
+conflicts: [
+  "async" {< "109.15.00"}
+  "lwt" {< "2.4.3"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/cohttp/cohttp.0.15.0/url
+++ b/packages/cohttp/cohttp.0.15.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cohttp/archive/v0.15.0.tar.gz"
+checksum: "743fe33c63cfddcadc5e8363bd31910e"


### PR DESCRIPTION
HTTP library for Lwt, Async and Mirage

There are several optional dependencies which activate functionality:
- Lwt: `opam install lwt cohttp`
- Lwt and SSL: `opam install lwt ssl cohttp`
- Async: `opam install async cohttp`
- Async and SSL: `opam install async_ssl cohttp`

---
- Homepage: https://github.com/mirage/ocaml-cohttp
- Source repo: https://github.com/mirage/ocaml-cohttp.git
- Bug tracker: https://github.com/mirage/ocaml-cohttp/issues

---

Pull-request generated by opam-publish v0.2
