### PR TITLE
prob-cache.1.0.0 - via opam-publish

### DIFF
--- a/packages/prob-cache/prob-cache.1.0.0/descr
+++ b/packages/prob-cache/prob-cache.1.0.0/descr
@@ -1,0 +1,5 @@
+Polymorphic probability cache API, including a distributed riak backed cache.
+
+A polymorphic cache for managing probability distributions and expectations
+over them. Includes a set based model and sequence based model, both of 
+which can be backed by in-process containers or distributed riak caches.

--- a/packages/prob-cache/prob-cache.1.0.0/opam
+++ b/packages/prob-cache/prob-cache.1.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+author : "Carmelo Piccione carmelo.piccione+prob_cache@gmail.com"
+maintainer: "carmelo.piccione+prob_cache@gmail.com"
+homepage: "https://github.com/struktured/ocaml-prob-cache"
+dev-repo: "git://github.com/struktured/ocaml-prob-cache.git#master"
+bug-reports: "https://github.com/struktured/ocaml-prob-cache/issues"
+
+build: [
+  ["./configure" "--disable-containers-examples" "--disable-riak-examples"]
+  [make "clean"]
+  [make "-j2"]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+ ["ocamlfind" "remove" "prob_cache_riak"]
+ ["ocamlfind" "remove" "prob_cache_containers"]
+ ["ocamlfind" "remove" "prob_cache_common"]
+]
+
+depends: [
+  "ocamlfind"
+  "core" {>= "109.12.00"}
+  "async"
+  "ppx_deriving" {>= "1.1"}
+  "ppx_deriving_protobuf" {>= "2.0"}
+  "riakc_ppx" {>= "3.1.2"}
+  "containers" 
+  "sequence"
+]

--- a/packages/prob-cache/prob-cache.1.0.0/url
+++ b/packages/prob-cache/prob-cache.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/struktured/ocaml-prob-cache/archive/1.0.0.zip"
+checksum: "b4f5fec9393742312f30f90af1a21756"


### PR DESCRIPTION
Polymorphic probability cache API, including a distributed riak backed cache.

A polymorphic cache for managing probability distributions and expectations
over them. Includes a set based model and sequence based model, both of 
which can be backed by in-process containers or distributed riak caches.

---
- Homepage: https://github.com/struktured/ocaml-prob-cache
- Source repo: git://github.com/struktured/ocaml-prob-cache.git#master
- Bug tracker: https://github.com/struktured/ocaml-prob-cache/issues

---

Pull-request generated by opam-publish v0.2.1
