### PR TITLE
cppo: fix dependencies

### DIFF
--- a/packages/utop/utop.1.16/opam
+++ b/packages/utop/utop.1.16/opam
@@ -23,7 +23,7 @@ depends: [
   "lambda-term" {>= "1.2"}
   "lwt"
   "react"       {>= "1.0.0"}
-  "cppo"        {>= "1.0.1"}
+  "cppo"        {>= "1.1.2"}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.17/opam
+++ b/packages/utop/utop.1.17/opam
@@ -19,11 +19,13 @@ remove: [
   ["ocamlfind" "remove" "utop"]
 ]
 depends: [
+  "base-unix"
+  "base-threads"
   "ocamlfind"   {>= "1.4.0"}
   "lambda-term" {>= "1.2"}
   "lwt"
   "react"       {>= "1.0.0"}
-  "cppo"        {>= "1.0.1"}
+  "cppo"        {>= "1.1.2"}
 ]
 depopts: [
   "camlp4"


### PR DESCRIPTION
Some dependencies were not updated in the opam repo, see https://github.com/diml/utop/issues/121.
