### PR TITLE
+opam-installext.1.0.0

### DIFF
--- a/packages/opam-installext/opam-installext.1.0.0/descr
+++ b/packages/opam-installext/opam-installext.1.0.0/descr
@@ -1,0 +1,19 @@
+OPAM plugin to install external system dependencies
+
+This plugin will use the `depexts` metadata in the OPAM database to install any
+prerequisite system libraries before installing the OPAM package.  It detects
+your operating system distribution and uses the relevant package manager.
+
+Supported ones include:
+
+- Linux
+  - Debian (`apt-get`)
+  - Ubuntu (`apt-get`)
+  - CentOS (`yum`)
+- BSD
+  - OpenBSD (`pkg_add`)
+  - FreeBSD (`pkg install`)
+  - NetBSD (`pkg_add`)
+- Mac OS X
+  - Homebrew (`brew`)
+  - MacPorts (`port`)

--- a/packages/opam-installext/opam-installext.1.0.0/opam
+++ b/packages/opam-installext/opam-installext.1.0.0/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/ocaml/opam-installext"
+dev-repo: "https://github.com/ocaml/opam-installext.git"
+bug-reports: "https://github.com/ocaml/opam-installext/issues"
+license: "ISC"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: ["rm" "-f" "%{prefix}%/bin/opam-installext"]

--- a/packages/opam-installext/opam-installext.1.0.0/url
+++ b/packages/opam-installext/opam-installext.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/opam-installext/archive/v1.0.0.tar.gz"
+checksum: "9ca1a7e3e7e10963b3f2dbca2297da13"


### PR DESCRIPTION
This OPAM plugin will use the `depexts` metadata in the OPAM database to
install any prerequisite system libraries before installing the OPAM package.
It detects your operating system distribution and uses the relevant package
manager.  Supported ones include:
- Linux
  - Debian (`apt-get`)
  - Ubuntu (`apt-get`)
  - CentOS (`yum`)
- BSD
  - OpenBSD (`pkg_add`)
  - FreeBSD (`pkg install`)
  - NetBSD (`pkg_add`)
- Mac OS X
  - Homebrew (`brew`)
  - MacPorts (`port`)
