### PR TITLE
Backport ocsigen/lwt#101 OSX build fix

### DIFF
--- a/packages/lwt/lwt.2.4.6/files/patch-ocsigen-lwt-101.diff
+++ b/packages/lwt/lwt.2.4.6/files/patch-ocsigen-lwt-101.diff
@@ -1,0 +1,49 @@
+diff -uNr lwt.2.4.6.orig/lwt.2.4.6/ppx/ppx_lwt.ml lwt.2.4.6/lwt.2.4.6/ppx/ppx_lwt.ml
+--- lwt.2.4.6.orig/lwt.2.4.6/ppx/ppx_lwt.ml	1970-01-01 01:00:00.000000000 +0100
++++ lwt.2.4.6/lwt.2.4.6/ppx/ppx_lwt.ml	2015-01-02 12:28:16.000000000 +0000
+@@ -0,0 +1 @@
++(* Dummy ML file to workaround https://github.com/ocsigen/lwt/issues/91 *)
+diff -uNr lwt.2.4.6.orig/myocamlbuild.ml lwt.2.4.6/myocamlbuild.ml
+--- lwt.2.4.6.orig/myocamlbuild.ml	2015-01-02 12:14:23.000000000 +0000
++++ lwt.2.4.6/myocamlbuild.ml	2015-01-02 12:29:08.000000000 +0000
+@@ -21,7 +21,7 @@
+  *)
+ 
+ (* OASIS_START *)
+-(* DO NOT EDIT (digest: 61e7bc76f38130ad68399b55a0e0b025) *)
++(* DO NOT EDIT (digest: bdd8da10af4f850f9a9f61b515da15ca) *)
+ module OASISGettext = struct
+ (* # 22 "src/oasis/OASISGettext.ml" *)
+ 
+@@ -634,7 +634,7 @@
+           ("lwt-syntax", ["syntax"], []);
+           ("lwt-syntax-options", ["syntax"], []);
+           ("lwt-syntax-log", ["syntax"], []);
+-          ("ppx", ["ppx"], ["Ppx_lwt"]);
++          ("ppx", ["ppx"], []);
+           ("test", ["tests"], [])
+        ];
+      lib_c =
+diff -uNr lwt.2.4.6.orig/ppx/ppx.mldylib lwt.2.4.6/ppx/ppx.mldylib
+--- lwt.2.4.6.orig/ppx/ppx.mldylib	2015-01-02 12:14:23.000000000 +0000
++++ lwt.2.4.6/ppx/ppx.mldylib	2015-01-02 12:29:08.000000000 +0000
+@@ -1,3 +1,4 @@
+ # OASIS_START
+-# DO NOT EDIT (digest: d41d8cd98f00b204e9800998ecf8427e)
++# DO NOT EDIT (digest: d62cd5ddc27d99b3e4e5b16e801ef038)
++Ppx_lwt
+ # OASIS_STOP
+diff -uNr lwt.2.4.6.orig/ppx/ppx.mllib lwt.2.4.6/ppx/ppx.mllib
+--- lwt.2.4.6.orig/ppx/ppx.mllib	2015-01-02 12:14:23.000000000 +0000
++++ lwt.2.4.6/ppx/ppx.mllib	2015-01-02 12:29:08.000000000 +0000
+@@ -1,3 +1,4 @@
+ # OASIS_START
+-# DO NOT EDIT (digest: d41d8cd98f00b204e9800998ecf8427e)
++# DO NOT EDIT (digest: d62cd5ddc27d99b3e4e5b16e801ef038)
++Ppx_lwt
+ # OASIS_STOP
+diff -uNr lwt.2.4.6.orig/ppx/ppx_lwt.ml lwt.2.4.6/ppx/ppx_lwt.ml
+--- lwt.2.4.6.orig/ppx/ppx_lwt.ml	1970-01-01 01:00:00.000000000 +0100
++++ lwt.2.4.6/ppx/ppx_lwt.ml	2015-01-02 12:29:06.000000000 +0000
+@@ -0,0 +1 @@
++(* Dummy ML file to workaround https://github.com/ocsigen/lwt/issues/91 *)

--- a/packages/lwt/lwt.2.4.6/opam
+++ b/packages/lwt/lwt.2.4.6/opam
@@ -31,4 +31,6 @@ depopts: [
 conflicts: [
  "react" {<"1.0.0"}
 ]
-available: [ os != "darwin" ]
+patches: [
+  "patch-ocsigen-lwt-101.diff" {os = "darwin"}
+]


### PR DESCRIPTION
This patch is only applied on OSX to minimise diff with upstream.
It also allows websocket.0.9+ to build, since this requires the
Lwt ppx support.