### PR TITLE
Update jenga and patdiff dependencies for pcre-ocaml rename

### DIFF
--- a/packages/jenga/jenga.112.06.00/opam
+++ b/packages/jenga/jenga.112.06.00/opam
@@ -21,6 +21,6 @@ depends: ["camlp4"
           "core_extended" {>= "112.06.00" & < "112.07.00"}
           "fieldslib" {>= "109.20.00" & < "109.21.00"}
           "ocaml_plugin" {>= "112.06.00" & < "112.07.00"}
-          "pcre-ocaml"
+          "pcre"
           "sexplib" {>= "112.06.00" & < "112.07.00"}]
 ocaml-version: [>= "4.00.0"]

--- a/packages/patdiff/patdiff.112.06.00/opam
+++ b/packages/patdiff/patdiff.112.06.00/opam
@@ -8,4 +8,4 @@ build: [
 depends: ["camlp4"
           "core_extended" {>= "112.06.00" & < "112.07.00"}
           "patience_diff" {>= "111.28.00" & < "111.29.00"}
-          "pcre-ocaml"]
+          "pcre"]


### PR DESCRIPTION
Not sure how this went unnoticed earlier.