### PR TITLE
Add a version constraint to ocamlpp.

### DIFF
--- a/packages/ocamlpp/ocamlpp.1.0/opam
+++ b/packages/ocamlpp/ocamlpp.1.0/opam
@@ -10,3 +10,4 @@ remove: [
   [make "uninstall"]
 ]
 depends: ["ocamlfind"]
+available: [ocaml-version < "4.02.0"]


### PR DESCRIPTION
ocamlpp [doesn't build on 4.02](https://github.com/avsm/opam-bulk-logs/blob/a237f44cd67e58e6c2291343e7fbdc3220fb6c20/20141208/4.02.1/raw/ocamlpp#L42-L45) because `-warn-error` turns a deprecation warning for `String.create` into a fatal error:
```
# + /home/opam/.opam/4.02.1/bin/ocamlc.opt -c -w Ae -warn-error A -g -o index.cmo index.ml
# File "index.ml", line 22, characters 18-31:
# Warning 3: deprecated: String.create
# Use Bytes.create instead.
```

/cc @bvaugon