### PR TITLE
imap.1.0 - via opam-publish

### DIFF
--- a/packages/imap/imap.1.0/descr
+++ b/packages/imap/imap.1.0/descr
@@ -1,0 +1,9 @@
+Non-blocking client library for the IMAP4rev1 protocol
+
+ocaml-imap is a non-blocking codec to encode and decode the full IMAP4rev1
+protocol, together with some extensions.  It can process input without blocking
+on IO and is completely independent of any particular buffering and/or IO
+strategy (concurrent, like Lwt or Async, sequential, etc.).
+
+ocaml-imap is made of a single module Imap and distributed under the MIT
+license. Its only dependencies are Uutf, Base64, and Uint.

--- a/packages/imap/imap.1.0/opam
+++ b/packages/imap/imap.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+authors: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+homepage: "https://www.github.com/nojb/ocaml-imap"
+dev-repo: "https://www.github.com/nojb/ocaml-imap.git"
+bug-reports: "https://www.github.com/nojb/ocaml-imap/issues"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+build-doc: [make "doc"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "imap"]
+depends: [
+  "uint"
+  "base64"
+  "uutf"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/imap/imap.1.0/url
+++ b/packages/imap/imap.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nojb/ocaml-imap/archive/v1.0.tar.gz"
+checksum: "9196a4e228b1472bd968cfdd93a0bc8c"


### PR DESCRIPTION
Non-blocking client library for the IMAP4rev1 protocol

ocaml-imap is a non-blocking codec to encode and decode the full IMAP4rev1
protocol, together with some extensions.  It can process input without blocking
on IO and is completely independent of any particular buffering and/or IO
strategy (concurrent, like Lwt or Async, sequential, etc.).

ocaml-imap is made of a single module Imap and distributed under the MIT
license. Its only dependencies are Uutf, Base64, and Uint.

---
* Homepage: https://www.github.com/nojb/ocaml-imap
* Source repo: https://www.github.com/nojb/ocaml-imap.git
* Bug tracker: https://www.github.com/nojb/ocaml-imap/issues

---
Pull-request generated by opam-publish v0.2.1