### PR TITLE
gtk-light doesnt build on newer ocaml compilers

### DIFF
--- a/packages/gtk-light/gtk-light.0.0.1/opam
+++ b/packages/gtk-light/gtk-light.0.0.1/opam
@@ -16,3 +16,4 @@ depends: [
   "react"
   "ocamlfind"
 ]
+available: [ ocaml-version <= "4.01.0" ]


### PR DESCRIPTION
```
File "myocamlbuild.ml", line 25, characters 6-78:
 # Error: This expression has type Lexing.lexbuf
 #        but an expression was expected of type
 #          Ocamlbuild_pack.Loc.source = string
```