### PR TITLE
WiringPi: Fix missing distfile

### DIFF
--- a/packages/wiringpi/wiringpi.0.0.1/url
+++ b/packages/wiringpi/wiringpi.0.0.1/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/Leonidas-from-XIV/ocaml-wiringpi/releases/download/0.0.1/ocaml-wiringpi-0.0.1.tar.gz"
-checksum: "ddb8f05e2555c488fc7065cf50063a1b"
+checksum: "46076ba8b12691c6a366189de0f86613"


### PR DESCRIPTION
Als notified in https://github.com/Leonidas-from-XIV/ocaml-wiringpi/issues/1, somehow the tag and the release tarball got deleted. So I've recreated both and it should build again properly.