### PR TITLE
add constraints for 0.4.6 to pick websocket.0.8.1

### DIFF
--- a/packages/iocaml/iocaml.0.4.6/opam
+++ b/packages/iocaml/iocaml.0.4.6/opam
@@ -12,7 +12,7 @@ depends: [
   "yojson"
   "cow"
   "lwt" {>= "2.4"}
-  "websocket" {>= "0.8"}
+  "websocket" {= "0.8.1"}
   "cohttp" {>= "0.10.0"}
   "crunch"
   "ctypes" {>= "0.3"}


### PR DESCRIPTION
Later versions of iocaml no longer work on ocaml < 4.02
because of websocket.  Lets keep this version installable for
earlier compilers.