### PR TITLE
4.02.1+musl*: don't pass -no-tk.

### DIFF
--- a/compilers/4.02.1/4.02.1+musl+static/4.02.1+musl+static.comp
+++ b/compilers/4.02.1/4.02.1+musl+static/4.02.1+musl+static.comp
@@ -6,7 +6,7 @@ build: [
     "-cc" "musl-gcc -Os"
     "-aspp" "musl-gcc -c"
     "-libs" "-static"
-    "-no-tk" "-no-curses" "-no-graph"
+    "-no-curses" "-no-graph"
     "-no-shared-libs"
     ]
   [make "world.opt"]

--- a/compilers/4.02.1/4.02.1+musl/4.02.1+musl.comp
+++ b/compilers/4.02.1/4.02.1+musl/4.02.1+musl.comp
@@ -5,7 +5,7 @@ build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"
     "-cc" "musl-gcc -Os"
     "-aspp" "musl-gcc -c"
-    "-no-tk" "-no-curses" "-no-graph"
+    "-no-curses" "-no-graph"
     ]
   [make "world.opt"]
   [make "install"]


### PR DESCRIPTION
labltk was separated from the compiler in 4.02.