### PR TITLE
Incorrect md5sum in package facebook-sdk.0.3.5 corrected.

### DIFF
--- a/packages/facebook-sdk/facebook-sdk.0.3.5/url
+++ b/packages/facebook-sdk/facebook-sdk.0.3.5/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/dominicjprice/facebook-sdk/archive/v0.3.5.tar.gz"
-checksum: "c49517462152b54a949422c6d760d38b"
+checksum: "fbcf85e3c64b681c170474cbcedac055"


### PR DESCRIPTION
The md5sum was incorrect for package facebook-sdk version 0.3.5, this
has been updated with the correct md5sum.