### PR TITLE
why3: all dependencies are in fact optional

### DIFF
--- a/packages/why3/why3.0.85/opam
+++ b/packages/why3/why3.0.85/opam
@@ -26,14 +26,17 @@ build-doc: [
   [make "doc" "stdlibdoc" "apidoc"]
   [make "DOCDIR=%{doc}%/why3" "install-doc"]
 ]
-depends: [
-  "alt-ergo"
-  "lablgtk"    {>= "2.14.2"}
-  "conf-gtksourceview"
-  "camlzip"
-  "zarith"
-]
 depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.4"}
+  "lablgtk"
+  "conf-gtksourceview"
+  "zarith"
+  "camlzip"
+  "ocamlgraph"
+  "frama-c"
+  "coq"
+]
+conflicts: [
+  "lablgtk" {< "2.14.2"}
+  "ocamlgraph" {< "1.8.2"}
+  "coq" {< "8.4"}
 ]


### PR DESCRIPTION
Also, fixed some depopts with version constraints.
