### PR TITLE
Fix Cohttp version in Ketrew 0.0.0

### DIFF
--- a/packages/ketrew/ketrew.0.0.0/opam
+++ b/packages/ketrew/ketrew.0.0.0/opam
@@ -13,7 +13,7 @@ remove: [
 depends: [
   "ocp-build" {= "1.99.6-beta" } "atd2cconv" "ocamlfind"
   "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix" "cmdliner" "atd"
-  "cconv" {= "0.1" } "yojson" "uri" "toml" "cohttp" { >= "0.12.0" <= "0.13.0" }
+  "cconv" {= "0.1" } "yojson" "uri" "toml" "cohttp" { = "0.13.0" }
   "lwt" "ssl" "conduit"
 ]
 


### PR DESCRIPTION
It seems that sometimes Opam picks `0.12.0` which does not work with Ketrew, and we didn't catch that earlier because Opam was picking `0.13.0`.