### PR TITLE
frama-c: fix dependencies

### DIFF
--- a/packages/frama-c/frama-c.20130601/opam
+++ b/packages/frama-c/frama-c.20130601/opam
@@ -49,3 +49,4 @@ depends: [
   "camlp4"
 ]
 patches: ["4.01-compat.patch"]
+ocaml-version: [< "4.02.0"]

--- a/packages/frama-c/frama-c.20140301/opam
+++ b/packages/frama-c/frama-c.20140301/opam
@@ -43,9 +43,11 @@ build: [
 ]
 depends: [
   "ocamlgraph" {>= "1.8.5"}
+  "camlp4"
+]
+depopts: [
   "lablgtk"
   "conf-gtksourceview"
   "conf-gnomecanvas"
-  "camlp4"
 ]
 patches: ["0004-Port-to-OCamlgraph-1.8.5.patch"]


### PR DESCRIPTION
20130601 (Fluorine): does not work with OCaml 4.02.x
20140301 (Neon): move the graphics stuff from `depends` to `depopts`
