### PR TITLE
camlp4 4.01.0 on Debian may require an external package

### DIFF
--- a/packages/camlp4/camlp4.4.01.0/opam
+++ b/packages/camlp4/camlp4.4.01.0/opam
@@ -2,6 +2,10 @@ opam-version: "1"
 maintainer: "jeremie@dimino.org"
 homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
-build: [] # dummy package
+build: ["sh" "-c" "which camlp4o || (echo 'Error: no camlp4o in PATH.  On Debian or Ubuntu this error can be solved by installing the camlp4 package using the package manager of the Linux distribution.' ;exit 1)"] # dummy package
 remove: []
 ocaml-version: [<"4.02.0"]
+depexts: [
+  [["debian"] ["camlp4"]]
+  [["ubuntu"] ["camlp4"]]
+]


### PR DESCRIPTION
On Debian OCaml is split in two packages, the compiler and camlp4,
even if the upstream tarball includes both software.  This means
that the dummy package, on Debian, has an external dependency.