### PR TITLE
gen.0.2.4 - via opam-publish

### DIFF
--- a/packages/gen/gen.0.2.4/descr
+++ b/packages/gen/gen.0.2.4/descr
@@ -1,0 +1,4 @@
+Simple and efficient iterators (modules Gen and GenLabels).
+
+Now provides additional modules GenClone and GenMList for lower-level control
+over persistency and duplication of iterators.

--- a/packages/gen/gen.0.2.4/opam
+++ b/packages/gen/gen.0.2.4/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+author: "Simon Cruanes"
+build: [
+    ["./configure" "--disable-docs" "--disable-tests" "--disable-bench"]
+    [make "all"]
+]
+install: [
+    [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "gen"]
+]
+depends: ["ocamlfind"]
+tags: [ "gen" "iterator" "iter" "fold" ]
+homepage: "https://github.com/c-cube/gen/"
+doc: "http://cedeela.fr/~simon/software/gen/"
+bug-reports: "https://github.com/c-cube/gen/issues"
+dev-repo: "https://github.com/c-cube/gen.git"

--- a/packages/gen/gen.0.2.4/url
+++ b/packages/gen/gen.0.2.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/gen/archive/0.2.4.tar.gz"
+checksum: "0fcded8fdc3f4e222b4b689354a37e26"


### PR DESCRIPTION
Simple and efficient iterators (modules Gen and GenLabels).

Now provides additional modules GenClone and GenMList for lower-level control
over persistency and duplication of iterators.

---
* Homepage: https://github.com/c-cube/gen/
* Source repo: https://github.com/c-cube/gen.git
* Bug tracker: https://github.com/c-cube/gen/issues

---
Pull-request generated by opam-publish v0.2.1