### PR TITLE
sequence.0.5.5 - via opam-publish

### DIFF
--- a/packages/sequence/sequence.0.5.5/descr
+++ b/packages/sequence/sequence.0.5.5/descr
@@ -1,0 +1,6 @@
+Simple and lightweight sequence abstract data type.
+
+Simple sequence abstract data type, intended to transfer a finite number of
+elements from one data structure to another. Some transformations on sequences,
+like `filter`, `map`, `take`, `drop` and `append` can be performed before the
+sequence is iterated/folded on.

--- a/packages/sequence/sequence.0.5.5/opam
+++ b/packages/sequence/sequence.0.5.5/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+author: "Simon Cruanes"
+maintainer: "simon.cruanes@inria.fr"
+build: [
+    ["./configure" "--disable-docs"
+        "--%{delimcc:enable}%-invert"
+        "--%{base-bigarray:enable}%-bigarray"
+    ]
+    [make "build"]
+]
+install: [make "install"]
+remove: [
+    ["ocamlfind" "remove" "sequence"]
+]
+depends: ["ocamlfind" "base-bytes"]
+tags: [ "sequence" "iterator" "iter" "fold" ]
+homepage: "https://github.com/c-cube/sequence/"
+depopts: ["delimcc" "base-bigarray"]
+doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
+bug-reports: "https://github.com/c-cube/sequence/issues"
+dev-repo: "https://github.com/c-cube/sequence.git"

--- a/packages/sequence/sequence.0.5.5/url
+++ b/packages/sequence/sequence.0.5.5/url
@@ -1,2 +1,2 @@
-http: "https://github.com/c-cube/sequence/archive/0.5.5.tar.gz"
-checksum: "75b2ab10593ddc26e4e63bb0690688ca"
+http: "https://github.com/c-cube/sequence/archive/0.5.5.1.tar.gz"
+checksum: "047ba0cb0428e529682a6b82553607ed"

--- a/packages/sequence/sequence.0.5.5/url
+++ b/packages/sequence/sequence.0.5.5/url
@@ -1,2 +1,2 @@
 http: "https://github.com/c-cube/sequence/archive/0.5.5.tar.gz"
-checksum: "29b3cced576026797153cd2d5286a13b"
+checksum: "75b2ab10593ddc26e4e63bb0690688ca"

--- a/packages/sequence/sequence.0.5.5/url
+++ b/packages/sequence/sequence.0.5.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/sequence/archive/0.5.5.tar.gz"
+checksum: "29b3cced576026797153cd2d5286a13b"


### PR DESCRIPTION
Simple and lightweight sequence abstract data type.

Simple sequence abstract data type, intended to transfer a finite number of
elements from one data structure to another. Some transformations on sequences,
like `filter`, `map`, `take`, `drop` and `append` can be performed before the
sequence is iterated/folded on.

---
* Homepage: https://github.com/c-cube/sequence/
* Source repo: https://github.com/c-cube/sequence.git
* Bug tracker: https://github.com/c-cube/sequence/issues

---
Pull-request generated by opam-publish v0.2.1