### PR TITLE
ppx_deriving.2.0 - via opam-publish

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.2.0/descr
+++ b/packages/ppx_deriving/ppx_deriving.2.0/descr
@@ -1,0 +1,5 @@
+Type-driven code generation for OCaml >=4.02
+
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.

--- a/packages/ppx_deriving/ppx_deriving.2.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Peter Zotov <whitequark@whitequark.org>"
+authors: "Peter Zotov <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_deriving"
+bug-reports: "https://github.com/whitequark/ppx_deriving/issues"
+license: "MIT"
+doc: "http://whitequark.github.io/ppx_deriving"
+tags: "syntax"
+dev-repo: "git://github.com/whitequark/ppx_deriving.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native-dynlink}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+build-test: ["ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_deriving.byte" "--"]
+build-doc: [make "doc"]
+depends: [
+  "ppx_tools" {>= "0.99.2"}
+  "ocamlfind" {build & >= "1.5.4"}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.02.1"]

--- a/packages/ppx_deriving/ppx_deriving.2.0/url
+++ b/packages/ppx_deriving/ppx_deriving.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving/archive/v2.0.tar.gz"
+checksum: "c15ad1c87f88a5876389fe28d05d925c"


### PR DESCRIPTION
Type-driven code generation for OCaml >=4.02

ppx_deriving provides common infrastructure for generating
code based on type definitions, and a set of useful plugins
for common tasks.

---
* Homepage: https://github.com/whitequark/ppx_deriving
* Source repo: git://github.com/whitequark/ppx_deriving.git
* Bug tracker: https://github.com/whitequark/ppx_deriving/issues

---
Pull-request generated by opam-publish v0.2.1