### PR TITLE
ppx_deriving_yojson.2.3 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/descr
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/descr
@@ -1,0 +1,4 @@
+JSON codec generator for OCaml >=4.02
+
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator.

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Peter Zotov <whitequark@whitequark.org>"
+authors: "Peter Zotov <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_deriving_yojson"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+license: "MIT"
+doc: "http://whitequark.github.io/ppx_deriving_yojson"
+tags: [
+  "syntax"
+  "json"
+]
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+build-test: ["ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_yojson.byte" "--"]
+depends: [
+  "yojson"
+  "ppx_deriving" {>= "1.0"}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "ppx_import" {test}
+]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/url
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving_yojson/archive/v2.3.tar.gz"
+checksum: "9275fb20ac0de8d2f84382f7d2dac474"


### PR DESCRIPTION
JSON codec generator for OCaml >=4.02

ppx_deriving_yojson is a ppx_deriving plugin that provides
a JSON codec generator.

---
* Homepage: https://github.com/whitequark/ppx_deriving_yojson
* Source repo: git://github.com/whitequark/ppx_deriving_yojson.git
* Bug tracker: https://github.com/whitequark/ppx_deriving_yojson/issues

---
Pull-request generated by opam-publish v0.2.1