### PR TITLE
dose.3.3 - via opam-publish

### DIFF
--- a/packages/dose/dose.3.3/descr
+++ b/packages/dose/dose.3.3/descr
@@ -1,0 +1,1 @@
+Dose library (part of Mancoosi tools)

--- a/packages/dose/dose.3.3/opam
+++ b/packages/dose/dose.3.3/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "roberto@dicosmo.org"
+authors: [
+  "Roberto Di Cosmo"
+  "Ralf Treinen"
+  "Stefano Zacchiroli"
+  "Pietro Abate"
+  "Jaap Boender"
+  "Jakub Zwolakowski"
+  "Olivier Rosello"
+  "Johannes Schauer"
+]
+homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
+license: "LGPL-v3+ with OCaml linking exception"
+dev-repo: "https://gforge.inria.fr/git/dose/dose.git"
+build: [
+  ["./configure" "--with-ocamlgraph" "--bindir=%{bin}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "dose3"]
+  [
+    "rm"
+    "-f"
+    "%{bin}%/distcheck"
+    "%{bin}%/debcheck"
+    "%{bin}%/rpmcheck"
+    "%{bin}%/eclipsecheck"
+  ]
+]
+depends: [
+  "ocaml"
+  "ocamlgraph" {>= "1.8.5"}
+  "cudf" {>= "0.7"}
+  ("extlib" | "extlib-compat")
+  "re" {>= "1.2.0"}
+]

--- a/packages/dose/dose.3.3/url
+++ b/packages/dose/dose.3.3/url
@@ -1,0 +1,2 @@
+http: "https://gforge.inria.fr/frs/download.php/file/34277/dose3-3.3.tar.gz"
+checksum: "ea947804c636059bb8b64dbda5c1df08"


### PR DESCRIPTION
Dose library (part of Mancoosi tools)


---
* Homepage: http://www.mancoosi.org/software/
* Source repo: https://gforge.inria.fr/git/dose/dose.git
* Bug tracker: https://gforge.inria.fr/tracker/?group_id=4395

---
Pull-request generated by opam-publish v0.2.1