### PR TITLE
Add opam-version constraints to ppx_deriving.

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.1.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.0/opam
@@ -24,4 +24,4 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit"     {test}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.1.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.1/opam
@@ -16,4 +16,4 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit" {test}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.0/opam
@@ -16,4 +16,4 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit" {test}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]


### PR DESCRIPTION
ppx_deriving's [`META.in`](https://github.com/whitequark/ppx_deriving/blob/d66862c08c66067e05f6e4105674d33b85048019/pkg/META.in#L1) uses an OPAM variable `%(version)%` which is only available since OPAM 1.2.

As a result recent versions of `ppx_deriving` don't build with OPAM 1.1 (see Travis logs for [1.0](https://travis-ci.org/ocaml/opam-repository/jobs/39004409#L519), [1.1](https://travis-ci.org/ocaml/opam-repository/jobs/44813488#L567) and [2.0](https://travis-ci.org/ocaml/opam-repository/jobs/47117175#L589)), resulting in build failures for packages which use ppx_deriving (e.g.  #3391, #3359).

/cc @whitequark