### PR TITLE
batsh.0.0.5: various fixes to opam file

### DIFF
--- a/packages/batsh/batsh.0.0.5/opam
+++ b/packages/batsh/batsh.0.0.5/opam
@@ -5,23 +5,21 @@ homepage: "https://github.com/BYVoid/Batsh"
 license: "MIT"
 build: [
   ["ocp-build" "init"]
-  ["ocp-build" "root"]
   ["ocp-build" "build" "-njobs" "8"]
   ["ocp-build" "install" "-install-lib" "%{lib}%/batsh"]
 ]
 remove: [
   ["ocp-build" "init"]
-  ["ocp-build" "root"]
-  ["ocp-build" "uninstall" "-install-lib" "%{lib}%/batsh"]
+  ["ocp-build" "uninstall"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.6-beta"}
+  "ocp-build" {>= "1.99.8-beta"}
   "core_kernel" {>= "109.47.00"}
+  "core" {>= "109.47.00"}
   "dlist" {>= "0.0.3"}
   "cmdliner" {>= "0.9.2"}
 ]
 depopts: [
   "ounit"
-  "core" {>= "109.47.00"}
 ]
 ocaml-version: [>= "4.00.1"]


### PR DESCRIPTION
Several things:

1. I couldn't find any variant of the build instructions that would work with both versions of `ocp-build` (1.99.6-beta and 1.99.8-beta) so settle on 1.99.8-beta.
2. Fixed the remove instructions.
3. The dependency on `core` is not optional.
