### PR TITLE
extprot: add missing dependency

### DIFF
--- a/packages/extprot/extprot.1.1.2/opam
+++ b/packages/extprot/extprot.1.1.2/opam
@@ -16,5 +16,6 @@ depends: [
   "ocamlfind"
   ("extlib" | "extlib-compat")
   "sexplib"
+  "type_conv"
   "omake"
 ]


### PR DESCRIPTION
`extprot` depends on `sexplib.syntax`, which is configured in `sexplib` iff `type_conv` is present.
