### PR TITLE
[missinglib] Added patch to require unix, as this is a dependency.

### DIFF
--- a/packages/missinglib/missinglib.0.4.1/files/meta-0.4.1.patch
+++ b/packages/missinglib/missinglib.0.4.1/files/meta-0.4.1.patch
@@ -1,0 +1,11 @@
+--- a/libsrc/META	2015-01-15 15:21:20.991565330 +0100
++++ b/libsrc/META	2015-01-15 15:21:42.333564587 +0100
+@@ -1,6 +1,6 @@
+ name="Missinglib"
+-version="0.0.1"
++version="0.4.1"
+ description="Utility libraries for OCaml"
+-requires="str"
++requires="str unix"
+ archive(byte)="missinglib.cma"
+ archive(native)="missinglib.cmxa"

--- a/packages/missinglib/missinglib.0.4.1/opam
+++ b/packages/missinglib/missinglib.0.4.1/opam
@@ -10,4 +10,7 @@ depends: [
   "ounit"
   "camlp4"
 ]
-patches: ["opam.patch"]
+patches: [
+  "opam.patch"
+  "meta-0.4.1.patch"
+]


### PR DESCRIPTION
Also, fix up version number.

(Not sure if this works properly, unfortunately opam pin does not download sources, but maybe the Travis run will be able to determine it.)