### PR TITLE
Constrain release to lwt <= 2.4.6.

### DIFF
--- a/packages/release/release.1.0.0/opam
+++ b/packages/release/release.1.0.0/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "release"]]
 depends: [
-  "lwt"
+  "lwt" {<="2.4.6"}
   "ocamlfind"
   "uint"
 ]

--- a/packages/release/release.1.0.1/opam
+++ b/packages/release/release.1.0.1/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "release"]]
 depends: [
-  "lwt"
+  "lwt" {<="2.4.6"}
   "ocamlfind"
   "uint"
 ]

--- a/packages/release/release.1.0.2/opam
+++ b/packages/release/release.1.0.2/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "release"]]
 depends: [
-  "lwt"
+  "lwt" {<="2.4.6"}
   "ocamlfind"
   "uint"
 ]

--- a/packages/release/release.1.0.3/opam
+++ b/packages/release/release.1.0.3/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "release"]]
 depends: [
-  "lwt"
+  "lwt" {<="2.4.6"}
   "ocamlfind"
   "uint"
 ]

--- a/packages/release/release.1.0.4/opam
+++ b/packages/release/release.1.0.4/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "release"]]
 depends: [
-  "lwt"
+  "lwt" {<="2.4.6"}
   "ocamlfind"
   "uint"
 ]

--- a/packages/release/release.1.1.0/opam
+++ b/packages/release/release.1.1.0/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "release"]]
 depends: [
-  "lwt"
+  "lwt" {<="2.4.6"}
   "ocamlfind"
   "uint"
 ]


### PR DESCRIPTION
Release [doesn't build with the latest lwt](http://www.recoil.org/~avsm/opam-bulk/logs/local-debian-stable-ocaml-4.02.1/raw/release.html):

```
E: Cannot find findlib package lwt.syntax
E: Cannot find findlib package lwt.syntax (>= 2.4.0)
```

/cc @andrenth 