### PR TITLE
user-setup.0.1 - via opam-publish

### DIFF
--- a/packages/user-setup/user-setup.0.1/descr
+++ b/packages/user-setup/user-setup.0.1/descr
@@ -1,0 +1,8 @@
+OPAM User Setup helper to configure various editors and tools for OCaml
+
+This package, currently in alpha, attempts to help initial setup for new OCaml
+users by automating the tedious task of adjusting editor and tool configuration.
+
+It will run after the installation of ocp-indent, merlin or similar tools and
+adjust the configuration for your available editors accordingly. It won't suit
+advanced users who prefer to do such things by hand anyway.

--- a/packages/user-setup/user-setup.0.1/opam
+++ b/packages/user-setup/user-setup.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/AltGr/opam-user-setup"
+bug-reports: "https://github.com/AltGr/opam-user-setup/issues"
+license: "ISC"
+dev-repo: "https://github.com/AltGr/opam-user-setup.git"
+build: [make]
+install: [
+  "./opam-user-setup"
+  "ocp-indent" {ocp-indent:installed}
+  "ocp-index" {ocp-index:installed}
+  "merlin" {merlin:installed}
+]
+depends: [
+  "merlin" {test}
+  "ocamlfind" {build}
+  "re"
+]
+depopts: ["merlin" "ocp-indent" "ocp-index"]
+available: [ocaml-version >= "4.02"]

--- a/packages/user-setup/user-setup.0.1/url
+++ b/packages/user-setup/user-setup.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/opam-user-setup/archive/0.1.tar.gz"
+checksum: "d029d44a9f3fc242e05597d5ae401b3d"


### PR DESCRIPTION
OPAM User Setup helper to configure various editors and tools for OCaml

This package, currently in alpha, attempts to help initial setup for new OCaml
users by automating the tedious task of adjusting editor and tool configuration.

It will run after the installation of ocp-indent, merlin or similar tools and
adjust the configuration for your available editors accordingly. It won't suit
advanced users who prefer to do such things by hand anyway.


---
* Homepage: https://github.com/AltGr/opam-user-setup
* Source repo: https://github.com/AltGr/opam-user-setup.git
* Bug tracker: https://github.com/AltGr/opam-user-setup/issues

---
Pull-request generated by opam-publish v0.2.1