### PR TITLE
depext.0.2 - via opam-publish

### DIFF
--- a/packages/depext/depext.0.2/descr
+++ b/packages/depext/depext.0.2/descr
@@ -1,0 +1,7 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can perform OS and
+distribution detection, query OPAM for the right external dependencies on a set
+of packages, and call the OS's package manager in the appropriate way to install
+them.

--- a/packages/depext/depext.0.2/opam
+++ b/packages/depext/depext.0.2/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/AltGr/opam-depext"
+bug-reports: "https://github.com/AltGr/opam-depext/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/AltGr/opam-depext.git"
+build: [make]
+depends: "cmdliner"
+available: [ opam-version >= "4.02" ]

--- a/packages/depext/depext.0.2/url
+++ b/packages/depext/depext.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/opam-depext/archive/0.2.tar.gz"
+checksum: "9493eaa8867ec7a02bcb4bde3de8c04f"


### PR DESCRIPTION
Query and install external dependencies of OPAM packages

opam-depext is a simple program intended to facilitate the interaction between
OPAM packages and the host package management system. It can perform OS and
distribution detection, query OPAM for the right external dependencies on a set
of packages, and call the OS's package manager in the appropriate way to install
them.


---
* Homepage: https://github.com/AltGr/opam-depext
* Source repo: https://github.com/AltGr/opam-depext.git
* Bug tracker: https://github.com/AltGr/opam-depext/issues

---

Pull-request generated by opam-publish v0.2.1