### PR TITLE
ocaml-markdown: fix dependencies

### DIFF
--- a/packages/ocaml-markdown/ocaml-markdown.0.1.0/opam
+++ b/packages/ocaml-markdown/ocaml-markdown.0.1.0/opam
@@ -10,7 +10,8 @@ depends: [
   "ocamlfind"
   "extlib" {= "1.5.3"}
   "sexplib"
+  "type_conv"
   "ounit"
-  "tyxml"
+  "tyxml" {< "3.2.0"}
 ]
 patches: ["opam.patch"]

--- a/packages/ocaml-markdown/ocaml-markdown.0.1.1/opam
+++ b/packages/ocaml-markdown/ocaml-markdown.0.1.1/opam
@@ -10,6 +10,7 @@ depends: [
   "ocamlfind"
   "extlib" {= "1.5.3"}
   "sexplib"
+  "type_conv"
   "ounit"
-  "tyxml"
+  "tyxml" {< "3.2.0"}
 ]


### PR DESCRIPTION
- depends on type_conv
- does not work with newer versions of tyxml