### PR TITLE
Fix incorrect syntax in 4.01.0+bin-ocp compiler causing opam HEAD to fail

### DIFF
--- a/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.comp
+++ b/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.comp
@@ -1,5 +1,5 @@
 opam-version: "1.1.0"
-version: "4.01.0+bin-ocp"
+version: "4.01.0"
 src: "http://www.ocamlpro.com/public/2014/binaries/ocp-compiler-cache-v2.tar.gz"
 build: [
        [ "mkdir" "-p" "%{prefix}%/../ocp-compiler-cache" ]


### PR DESCRIPTION
Introduced in ocaml/opam@a2f6ca121b942447086549a1b45cd9332684cd43.