### PR TITLE
vhd-tool: add conflict with tls

### DIFF
--- a/packages/vhd-tool/vhd-tool.0.7.6/opam
+++ b/packages/vhd-tool/vhd-tool.0.7.6/opam
@@ -25,3 +25,6 @@ depends: [
   "cohttp" {>="0.12.0"}
   "ssl"
 ]
+conflicts: [
+  "tls"
+]


### PR DESCRIPTION
When `tls` is present, `conduit` somehow forces `vhd-tool` to link with `cstruct`, which conflicts on module name `Common`.
