### PR TITLE
menhir: clean up versions

### DIFF
--- a/packages/menhir/menhir.20130911/files/menhir.install
+++ b/packages/menhir/menhir.20130911/files/menhir.install
@@ -1,1 +1,1 @@
-bin: ["src/menhir.opt" {"menhir"}]
+bin: ["src/_stage2/menhir.native" {"menhir"}]

--- a/packages/menhir/menhir.20130912/descr
+++ b/packages/menhir/menhir.20130912/descr
@@ -1,1 +1,0 @@
-LR(1) parser generator

--- a/packages/menhir/menhir.20130912/files/menhir.install
+++ b/packages/menhir/menhir.20130912/files/menhir.install
@@ -1,1 +1,0 @@
-bin: ["src/_stage2/menhir.native" {"menhir"}]

--- a/packages/menhir/menhir.20130912/findlib
+++ b/packages/menhir/menhir.20130912/findlib
@@ -1,1 +1,0 @@
-menhirLib

--- a/packages/menhir/menhir.20130912/opam
+++ b/packages/menhir/menhir.20130912/opam
@@ -1,5 +1,0 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
-build: [[make "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]]
-remove: [["ocamlfind" "remove" "menhirLib"]]
-depends: ["ocamlfind"]

--- a/packages/menhir/menhir.20130912/url
+++ b/packages/menhir/menhir.20130912/url
@@ -1,2 +1,0 @@
-archive: "http://cristal.inria.fr/~fpottier/menhir/menhir-20130911.tar.gz"
-checksum: "66374f3626f9403b37eed43819210113"


### PR DESCRIPTION
remove broken version 20130911 and rename 20130912 to its proper name 20130911

as discussed in #3375 