### PR TITLE
uutf.0.9.4 - via opam-publish

### DIFF
--- a/packages/uutf/uutf.0.9.4/descr
+++ b/packages/uutf/uutf.0.9.4/descr
@@ -1,0 +1,14 @@
+Non-blocking streaming Unicode codec for OCaml
+
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values.
+
+Uutf is made of a single, independent, module and distributed under
+the BSD3 license.
+

--- a/packages/uutf/uutf.0.9.4/opam
+++ b/packages/uutf/uutf.0.9.4/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uutf"
+doc: "http://erratique.ch/software/uutf/doc/Uutf"
+dev-repo: "http://erratique.ch/repos/uutf.git"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
+license: "BSD3"
+available: [ ocaml-version >= "4.00.0"]
+depends: ["ocamlfind"]
+depopts: ["cmdliner"
+          "cmdliner" {test} ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "cmdliner=%{cmdliner:installed}%" ]
+]

--- a/packages/uutf/uutf.0.9.4/url
+++ b/packages/uutf/uutf.0.9.4/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uutf/releases/uutf-0.9.4.tbz"
+checksum: "bf5880a8f2e75d0a9152d896ea288ba7"


### PR DESCRIPTION
Non-blocking streaming Unicode codec for OCaml

Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
work character by character without blocking on IO. Decoders perform
character position tracking and support newline normalization.

Functions are also provided to fold over the characters of UTF encoded
OCaml string values and to directly encode characters in OCaml
Buffer.t values.

Uutf is made of a single, independent, module and distributed under
the BSD3 license.


---
* Homepage: http://erratique.ch/software/uutf
* Source repo: http://erratique.ch/repos/uutf.git
* Bug tracker: https://github.com/dbuenzli/uutf/issues

---
Pull-request generated by opam-publish v0.2.1