### PR TITLE
Mirage platform.2.2.0

### DIFF
--- a/packages/mirage-unix/mirage-unix.2.2.0/descr
+++ b/packages/mirage-unix/mirage-unix.2.2.0/descr
@@ -1,0 +1,1 @@
+Mirage OS library for Unix compilation

--- a/packages/mirage-unix/mirage-unix.2.2.0/findlib
+++ b/packages/mirage-unix/mirage-unix.2.2.0/findlib
@@ -1,0 +1,1 @@
+mirage-unix

--- a/packages/mirage-unix/mirage-unix.2.2.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [
+  [make "unix-build"]
+  [make "unix-install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  [make "unix-uninstall" "PREFIX=%{prefix}%"]
+]
+depends: [
+  "cstruct" {>= "1.0.1"}
+  "ocamlfind"
+  "lwt" {>= "2.4.3"}
+  "io-page" {>= "1.0.1"}
+  "mirage-clock-unix" { >="1.0.0"}
+  "shared-memory-ring" {>= "1.0.0"}
+  "mirage-profile" {>="0.3"}
+]
+ocaml-version: [>= "4.01.0"]

--- a/packages/mirage-unix/mirage-unix.2.2.0/url
+++ b/packages/mirage-unix/mirage-unix.2.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-platform/archive/v2.2.0.tar.gz"
+checksum: "95e0e1b73a1448dca207acfad14d38c9"

--- a/packages/mirage-xen/mirage-xen.2.2.0/descr
+++ b/packages/mirage-xen/mirage-xen.2.2.0/descr
@@ -1,0 +1,1 @@
+Mirage OS library for Xen compilation

--- a/packages/mirage-xen/mirage-xen.2.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1"
+maintainer: "anil@recoil.org"
+build: [
+  [make "xen-build"]
+  [make "xen-install" "PREFIX=%{prefix}%"]
+]
+remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
+depends: [
+  "cstruct" {>= "1.0.1"}
+  "ocamlfind"
+  "io-page" {>= "1.0.1"}
+  "mirage-clock-xen" {>= "1.0.0"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring" {>= "1.0.0"}
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>="0.9.9"}
+  "xen-gnt" {>="2.0.0"}
+  "mirage-xen-minios" {>="0.6.0"}
+  "conf-pkg-config"
+  "mirage-profile" {>="0.3"}
+  "ocaml-src"
+]
+ocaml-version: [>= "4.01.0"]
+os: ["linux"]

--- a/packages/mirage-xen/mirage-xen.2.2.0/url
+++ b/packages/mirage-xen/mirage-xen.2.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-platform/archive/v2.2.0.tar.gz"
+checksum: "95e0e1b73a1448dca207acfad14d38c9"


### PR DESCRIPTION
This releases adds support for OCaml 4.02+ compilation, and changes the Xen
backend build for Mirage significantly by:

* removing the OCaml compiler runtime from the mirage-platform, which makes
  it simpler to work across multiple revisions of the compiler.  It now uses
  the `ocaml-src` OPAM package to grab the current switch's version of the
  OCaml runtime.
* split the Xen runtime build into discrete `pkg-config` libraries:
  * `mirage-xen-posix.pc` : in the `xen-posix/` directory, is the nano-posix
     layer built with no knowledge of OCaml
  * `mirage-xen-minios.pc`: defines the `__INSIDE_MINIOS__` macro to expose
     internal state via the MiniOS headers (for use only by libraries that
     know exactly what they are doing with the MiniOS)
  * `mirage-xen-ocaml.pc`: in `xen-ocaml/core/`, this builds the OCaml asmrun,
     Bigarray and Str bindings using the `mirage-xen-posix` layer.
  * `mirage-xen-ocaml-bindings.pc`: in `xen-ocaml/bindings/`, these are bindings
     required by the OCaml libraries to MiniOS.  Some of the bindings use MiniOS
     external state and hence use `mirage-xen-minios`, whereas others
    (`cstruct_stubs` and `barrier_stubs` are just OCaml bindings and so just
    use `mirage-xen-posix`).
  * `mirage-xen.pc`: depends on all the above to provide the same external
    interface as the current `mirage-platform`.

The OCaml code is now built using OASIS, since the C code is built entirely
separately and could be moved out into a separate OPAM package entirely.
