### PR TITLE
Constrain spdiff to menhir <= 20140422.

### DIFF
--- a/packages/spdiff/spdiff.0.1/opam
+++ b/packages/spdiff/spdiff.0.1/opam
@@ -7,5 +7,5 @@ build: [
   ["make" "opt"]
 ]
 depends: [
-  "menhir"
+  "menhir" {<= "20140422"}
 ]


### PR DESCRIPTION
spdiff [doesn't build with the latest menhir](http://www.recoil.org/~avsm/opam-bulk/logs/local-ubuntu-14.04-ocaml-4.02.1/raw/spdiff.html):

```
# Error: reinit generates the language {epsilon}.
# make[1]: *** [parser_cocci_menhir.ml] Error 1
# make: *** [depend] Error 2
```

/cc @jespera @UnixJunkie