### PR TITLE
Constrain 0install 2.8 to lwt <= 2.4.6

### DIFF
--- a/packages/0install/0install.2.8/opam
+++ b/packages/0install/0install.2.8/opam
@@ -5,7 +5,7 @@ build: [
   [make]
 ]
 patches: [ "gui_gtk_dir.patch" ]
-depends: [ "yojson" "xmlm" "ounit" "react" "lwt" "extlib" "ocurl" "sha"]
+depends: [ "yojson" "xmlm" "ounit" "react" "lwt" {<= "2.4.6"} "extlib" "ocurl" "sha"]
 depopts: [ "obus" "lablgtk" ]
 depexts: [
   [["ubuntu"] ["unzip"]]


### PR DESCRIPTION
0install 2.8 [doesn't build with lwt 2.4.7](http://www.recoil.org/~avsm/opam-bulk/logs/local-debian-stable-ocaml-4.02.1/raw/0install.html):

```
# File "support/gpg.ml", line 226, characters 64-67:
# Error: This expression has type string but an expression was expected of type
#          Bytes.t = bytes
```

/cc @talex5