### PR TITLE
depext.0.3 - via opam-publish

### DIFF
--- a/packages/depext/depext.0.3/descr
+++ b/packages/depext/depext.0.3/descr
@@ -1,0 +1,7 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can perform OS and
+distribution detection, query OPAM for the right external dependencies on a set
+of packages, and call the OS's package manager in the appropriate way to install
+them.

--- a/packages/depext/depext.0.3/opam
+++ b/packages/depext/depext.0.3/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/OCamlPro/opam-depext"
+bug-reports: "https://github.com/OCamlPro/opam-depext/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/OCamlPro/opam-depext.git"
+build: [make]
+depends: "cmdliner"

--- a/packages/depext/depext.0.3/url
+++ b/packages/depext/depext.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/opam-depext/archive/0.3.tar.gz"
+checksum: "561bf1e831bf5a40566b1bcfee552a1f"


### PR DESCRIPTION
Query and install external dependencies of OPAM packages

opam-depext is a simple program intended to facilitate the interaction between
OPAM packages and the host package management system. It can perform OS and
distribution detection, query OPAM for the right external dependencies on a set
of packages, and call the OS's package manager in the appropriate way to install
them.


---
* Homepage: https://github.com/OCamlPro/opam-depext
* Source repo: https://github.com/OCamlPro/opam-depext.git
* Bug tracker: https://github.com/OCamlPro/opam-depext/issues

---

Pull-request generated by opam-publish v0.2.1