### PR TITLE
dose.3.3 - via opam-publish

### DIFF
--- a/packages/dose/dose.3.3/opam
+++ b/packages/dose/dose.3.3/opam
@@ -31,7 +31,7 @@ remove: [
   ]
 ]
 depends: [
-  "ocamlgraph" {>= "1.8.5"}
+  "ocamlgraph" {= "1.8.5"}
   "cudf" {>= "0.7"}
   ("extlib" | "extlib-compat")
   "re" {>= "1.2.0"}


### PR DESCRIPTION
Doesn't compile with ocamlgraph 1.8.6

---
Dose library (part of Mancoosi tools)


---
* Homepage: http://www.mancoosi.org/software/
* Source repo: https://gforge.inria.fr/git/dose/dose.git
* Bug tracker: https://gforge.inria.fr/tracker/?group_id=4395

---
### opam-lint failures
- **WARNING** long description unspecified

---

Pull-request generated by opam-publish v0.2.1