### PR TITLE
fat-filesystem won't work with io-page that has a private type

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.10.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.1/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0"}
   "mirage-block-unix" {>= "1.2.0"}
-  "io-page" {>= "1.0.0"} 
+  "io-page" {>= "1.0.0" & < "1.3.0"}
   "re"
   "cmdliner"
 ]


### PR DESCRIPTION
Also fixes mirage/mirage-skeleton#73.