### PR TITLE
Irmin depends on stringext >= 1.1.0

### DIFF
--- a/packages/irmin/irmin.0.9.0/opam
+++ b/packages/irmin/irmin.0.9.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mstruct"
   "uri" {>= "1.3.12"}
   "bin_prot"
-  "stringext"
+  "stringext" {>= "1.1.0"}
   "hex"
   "re"
   "cmdliner"

--- a/packages/irmin/irmin.0.9.1/opam
+++ b/packages/irmin/irmin.0.9.1/opam
@@ -32,7 +32,7 @@ depends: [
   "mstruct"
   "uri" {>= "1.3.12"}
   "bin_prot"
-  "stringext"
+  "stringext" {>= "1.1.0"}
   "hex"
   "re"
   "cmdliner"

--- a/packages/irmin/irmin.0.9.2/opam
+++ b/packages/irmin/irmin.0.9.2/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-tc" {>= "0.3.0"}
   "mstruct"
   "uri" {>= "1.3.12"}
-  "stringext"
+  "stringext" {>= "1.1.0"}
   "hex"
   "re"
   "cmdliner"


### PR DESCRIPTION
See also mirage/irmin#126.