### PR TITLE
pcre-ocaml was renamed to pcre. (But why this was Travis checked?)

### DIFF
--- a/packages/orakuda/orakuda.2.0.0/opam
+++ b/packages/orakuda/orakuda.2.0.0/opam
@@ -13,6 +13,6 @@ depends: [
   "ocamlfind"
   "omake"
   "spotlib" {>="2.5.1"}
-  "pcre-ocaml" 
+  "pcre" 
 ]
 ocaml-version: [>= "4.02.1"]

--- a/packages/orakuda/orakuda.2.0.0/opam
+++ b/packages/orakuda/orakuda.2.0.0/opam
@@ -14,5 +14,6 @@ depends: [
   "omake"
   "spotlib" {>="2.5.1"}
   "pcre" 
+  "ppx_tools"
 ]
 ocaml-version: [>= "4.02.1"]


### PR DESCRIPTION
orakuda.2.0.0 contains "pcre-ocaml", the old name of "pcre". I am wondering why it was Travis-checked without any problem... Anyway, here is a fix.
