### PR TITLE
tuareg.2.0.8 - via opam-publish

### DIFF
--- a/packages/tuareg/tuareg.2.0.8/files/tuareg.install
+++ b/packages/tuareg/tuareg.2.0.8/files/tuareg.install
@@ -1,0 +1,5 @@
+share_root: [
+  "tuareg.el" {"emacs/site-lisp/tuareg.el"}
+  "ocamldebug.el" {"emacs/site-lisp/ocamldebug.el"}
+  "tuareg-site-file.el" {"emacs/site-lisp/tuareg-site-file.el"}
+]

--- a/packages/tuareg/tuareg.2.0.8/opam
+++ b/packages/tuareg/tuareg.2.0.8/opam
@@ -1,20 +1,15 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Christophe.Troestler@umons.ac.be"
-build: [
-  [make "install" "INSTALL_DIR=%{prefix}%/share/tuareg"]
+authors: [
+  "Albert Cohen <Albert.Cohen@prism.uvsq.fr>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
 ]
-remove: [
-  [make "uninstall"]
-]
-depends: []
-depexts: [
- [["ubuntu"] ["emacs"]]
- [["debian"] ["emacs"]]
-]
-post-messages: [
-"Please add in ~/.emacs.d/init.el or ~/.emacs to following lines:
-    (add-to-list 'load-path \"INSTALL_DIR\")
-    (load \"tuareg-site-file\")
-where you must replace INSTALL_DIR by the value displayed during the
-above installation"
-  {success} ]
+homepage: "https://forge.ocamlcore.org/projects/tuareg/"
+bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=43"
+dev-repo: "https://github.com/ocaml/tuareg.git"
+build: [make "tuareg-site-file.el"]
+post-messages: "
+If you have not yet done so, please add in ~/.emacs.d/init.el or
+in ~/.emacs to following line:
+    (load \"%{share}%/emacs/site-lisp/tuareg-site-file\")
+  " {success}

--- a/packages/tuareg/tuareg.2.0.8/url
+++ b/packages/tuareg/tuareg.2.0.8/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/Chris00/tuareg/releases/download/2.0.8/tuareg-2.0.8.tar.gz"
+http: "https://github.com/ocaml/tuareg/releases/download/2.0.8/tuareg-2.0.8.tar.gz"
 checksum: "df4b67ba48dea8934c8ea0fa88afdc3c"


### PR DESCRIPTION
OCaml mode for GNU Emacs and XEmacs.

Tuareg handles automatic indentation of OCaml and Camllight codes.
Key parts of the code are highlighted using Font-Lock.  Support to run
an interactive OCaml toplevel and debugger is provided.

---
* Homepage: https://forge.ocamlcore.org/projects/tuareg/
* Source repo: https://github.com/ocaml/tuareg.git
* Bug tracker: https://forge.ocamlcore.org/tracker/?group_id=43

---
Pull-request generated by opam-publish v0.2.1