### PR TITLE
user-setup.0.3 - via opam-publish

### DIFF
--- a/packages/user-setup/user-setup.0.3/descr
+++ b/packages/user-setup/user-setup.0.3/descr
@@ -1,0 +1,8 @@
+OPAM User Setup helper to configure various editors and tools for OCaml
+
+This package, currently in alpha, attempts to help initial setup for new OCaml
+users by automating the tedious task of adjusting editor and tool configuration.
+
+It will run after the installation of ocp-indent, merlin or similar tools and
+adjust the configuration for your available editors accordingly. It won't suit
+advanced users who prefer to do such things by hand anyway.

--- a/packages/user-setup/user-setup.0.3/opam
+++ b/packages/user-setup/user-setup.0.3/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/OCamlPro/opam-user-setup"
+bug-reports: "https://github.com/OCamlPro/opam-user-setup/issues"
+license: "ISC"
+dev-repo: "https://github.com/OCamlPro/opam-user-setup.git"
+build: [make]
+install: [
+  "./opam-user-setup"
+  "tuareg" {tuareg:installed}
+  "ocp-indent" {ocp-indent:installed}
+  "ocp-index" {ocp-index:installed}
+  "merlin" {merlin:installed}
+]
+depends: [
+  "ocamlfind" {build}
+  "re"
+]
+depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]
+available: [ocaml-version >= "4.02"]

--- a/packages/user-setup/user-setup.0.3/url
+++ b/packages/user-setup/user-setup.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/opam-user-setup/archive/0.3.tar.gz"
+checksum: "bfc34a76d34268a9c479ec43ac40e907"


### PR DESCRIPTION
OPAM User Setup helper to configure various editors and tools for OCaml

This package, currently in alpha, attempts to help initial setup for new OCaml
users by automating the tedious task of adjusting editor and tool configuration.

It will run after the installation of ocp-indent, merlin or similar tools and
adjust the configuration for your available editors accordingly. It won't suit
advanced users who prefer to do such things by hand anyway.


---
* Homepage: https://github.com/OCamlPro/opam-user-setup
* Source repo: https://github.com/OCamlPro/opam-user-setup.git
* Bug tracker: https://github.com/OCamlPro/opam-user-setup/issues

---
### opam-lint failures
- **WARNING** No field 'remove' while a field 'install' is present, uncomplete uninstallation suspected

---

Pull-request generated by opam-publish v0.2.1