### PR TITLE
223c7ad introduced unneccessary conflicts (tls-0.1/0.2 on io-page>1.3)

### DIFF
--- a/packages/tls/tls.0.1.0/opam
+++ b/packages/tls/tls.0.1.0/opam
@@ -21,9 +21,6 @@ depopts: [
   "lwt"
   "mirage"
 ]
-conflicts: [
-  "mirage" {<"1.2.0"} 
-  "io-page" {>"1.3.0"}
-]
+conflicts: [ "mirage" {<"1.2.0"} ]
 tags: [ "org:mirage" ]
 ocaml-version: [>="4.01.0"]

--- a/packages/tls/tls.0.2.0/opam
+++ b/packages/tls/tls.0.2.0/opam
@@ -29,7 +29,4 @@ depopts: [
   "lwt"
   "mirage"
 ]
-conflicts: [
-  "mirage" {<"2.0.0"} 
-  "io-page" {>"1.3.0"}
-]
+conflicts: [ "mirage" {<"2.0.0"} ]


### PR DESCRIPTION
partially reverts 223c7ad7c6c3f81cfa3e22cceb8f001e3ee9146b