### PR TITLE
ezjsonm.0.4.1 - via opam-publish

### DIFF
--- a/packages/ezjsonm/ezjsonm.0.4.1/descr
+++ b/packages/ezjsonm/ezjsonm.0.4.1/descr
@@ -1,0 +1,9 @@
+An easy interface on top of the Jsonm library
+
+This version provides more convenient (but far less flexible)
+input and output functions that go to and from [string] values.
+This avoids the need to write signal code, which is useful for
+quick scripts that manipulate JSON.
+
+More advanced users should go straight to the Jsonm library and
+use it directly, rather than be saddled with the Ezjsonm interface.

--- a/packages/ezjsonm/ezjsonm.0.4.1/opam
+++ b/packages/ezjsonm/ezjsonm.0.4.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+homepage: "https://github.com/mirage/ezjsonm"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:ocamllabs"
+]
+dev-repo: "https://github.com/mirage/ezjsonm.git"
+build: [
+  ["./configure" "--prefix" prefix "--%{lwt:enable}%-lwt"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ezjsonm"]
+depends: [
+  "ocamlfind" {build}
+  "jsonm" {>= "0.9.1"}
+  "sexplib"
+  "hex"
+]
+depopts: "lwt"

--- a/packages/ezjsonm/ezjsonm.0.4.1/url
+++ b/packages/ezjsonm/ezjsonm.0.4.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ezjsonm/archive//0.4.1.tar.gz"
+checksum: "4fec6bfe31e9d24bd6e5596c9bb657ed"


### PR DESCRIPTION
An easy interface on top of the Jsonm library

This version provides more convenient (but far less flexible)
input and output functions that go to and from [string] values.
This avoids the need to write signal code, which is useful for
quick scripts that manipulate JSON.

More advanced users should go straight to the Jsonm library and
use it directly, rather than be saddled with the Ezjsonm interface.

---
* Homepage: https://github.com/mirage/ezjsonm
* Source repo: https://github.com/mirage/ezjsonm.git
* Bug tracker: https://github.com/mirage/ezjsonm/issues

---
Pull-request generated by opam-publish v0.2.1