### PR TITLE
git.1.4.10 - via opam-publish

### DIFF
--- a/packages/git/git.1.4.10/descr
+++ b/packages/git/git.1.4.10/descr
@@ -1,0 +1,17 @@
+Low-level Git bindings in pure OCaml
+
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also the
+pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects. For instance, it is
+possible to make a pack file position independant (as the Zlib
+compression might change the relative offsets between the packed
+objects), to generate pack indexes from pack files, or to expand
+the filesystem of a given commit.
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git/git.1.4.10/opam
+++ b/packages/git/git.1.4.10/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+
+build: [
+  ["./configure"
+     "--prefix" prefix
+     "--%{mirage-types-lwt:enable}%-mirage"
+     "--%{mirage-fs-unix+alcotest:enable}%-tests"
+     "--%{conduit+cohttp+base-unix:enable}%-unix"
+  ]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "git"]
+  ["rm" "-f" "%{bin}%/ogit"]
+]
+depends: [
+  "mstruct" {>= "1.3.1"}
+  "dolog" {>= "1.0"}
+  "ocamlgraph"
+  "camlzip" {>= "1.05"}
+  "nocrypto" {>= "0.2.0"}
+  "uri" {>= "1.3.12"}
+  "lwt" {>= "2.4.7"}
+  "hex"
+  "alcotest" {test}
+  "mirage-fs-unix" {test}
+  "mirage-types-lwt" {test}
+  "cohttp" {test}
+  "conduit" {test}
+  "cmdliner"
+]
+depopts: [
+  "cohttp"
+  "conduit"
+  "mirage-types-lwt"
+]
+conflicts: [
+ "cohttp"  {<= "0.15.0"}
+ "conduit" {< "0.6.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.4.10/url
+++ b/packages/git/git.1.4.10/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-git/archive/1.4.10.tar.gz"
+checksum: "c8065e2bb292fafb262fa2ae7ca8fd28"


### PR DESCRIPTION
Low-level Git bindings in pure OCaml

Support for on-disk and in-memory Git stores. Can read and write all
the Git objects: the usual blobs, trees, commits and tags but also the
pack files, pack indexes and the index file (where the staging area
lives).

All the objects share a consistent API, and convenience functions are
provided to manipulate the different objects. For instance, it is
possible to make a pack file position independant (as the Zlib
compression might change the relative offsets between the packed
objects), to generate pack indexes from pack files, or to expand
the filesystem of a given commit.

The library comes with a command-line tool called `ogit` which shares
a similar interface with `git`, but where all operations are mapped to
the API exposed `ocaml-git` (and hence using only OCaml code).

---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---
Pull-request generated by opam-publish v0.2.1