### PR TITLE
cmdliner.0.9.7 - via opam-publish

### DIFF
--- a/packages/cmdliner/cmdliner.0.9.7/descr
+++ b/packages/cmdliner/cmdliner.0.9.7/descr
@@ -1,0 +1,17 @@
+Declarative definition of command line interfaces for OCaml
+
+Cmdliner is a module for the declarative definition of command line
+interfaces.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner is made of a single independent module and distributed under
+the BSD3 license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+

--- a/packages/cmdliner/cmdliner.0.9.7/opam
+++ b/packages/cmdliner/cmdliner.0.9.7/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "BSD3"
+available: [ocaml-version >= "4.00.0"]
+build: 
+[
+  ["ocaml" "pkg/git.ml" ] 
+  ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                          "native-dynlink=%{ocaml-native-dynlink}%" ]
+]

--- a/packages/cmdliner/cmdliner.0.9.7/url
+++ b/packages/cmdliner/cmdliner.0.9.7/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-0.9.7.tbz"
+checksum: "46d7553b95f623f811df2a844fb448fb"


### PR DESCRIPTION
Declarative definition of command line interfaces for OCaml

Cmdliner is a module for the declarative definition of command line
interfaces.

It provides a simple and compositional mechanism to convert command
line arguments to OCaml values and pass them to your functions. The
module automatically handles syntax errors, help messages and UNIX man
page generation. It supports programs with single or multiple commands
and respects most of the [POSIX][1] and [GNU][2] conventions.

Cmdliner is made of a single independent module and distributed under
the BSD3 license.

[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html


---
* Homepage: http://erratique.ch/software/cmdliner
* Source repo: http://erratique.ch/repos/cmdliner.git
* Bug tracker: https://github.com/dbuenzli/cmdliner/issues

---
Pull-request generated by opam-publish v0.2.1