### PR TITLE
depext.0.3 - via opam-publish

### DIFF
--- a/packages/depext/depext.0.3/opam
+++ b/packages/depext/depext.0.3/opam
@@ -5,5 +5,12 @@ homepage: "https://github.com/OCamlPro/opam-depext"
 bug-reports: "https://github.com/OCamlPro/opam-depext/issues"
 license: "LGPL-3.0 with OCaml linking exception"
 dev-repo: "https://github.com/OCamlPro/opam-depext.git"
-build: [make]
+build: [
+  [ "ocamlopt" "-I" cmdliner:lib "unix.cmxa" "cmdliner.cmxa"
+      "-o" "opam-depext" "depext.ml" ]
+    {ocaml-native}
+  [ "ocamlc" "-I" cmdliner:lib "unix.cma" "cmdliner.cma"
+    "-o" "opam-depext" "depext.ml" ]
+    {!ocaml-native}
+]
 depends: "cmdliner"


### PR DESCRIPTION
Query and install external dependencies of OPAM packages

opam-depext is a simple program intended to facilitate the interaction between
OPAM packages and the host package management system. It can perform OS and
distribution detection, query OPAM for the right external dependencies on a set
of packages, and call the OS's package manager in the appropriate way to install
them.


---
* Homepage: https://github.com/OCamlPro/opam-depext
* Source repo: https://github.com/OCamlPro/opam-depext.git
* Bug tracker: https://github.com/OCamlPro/opam-depext/issues

---

Pull-request generated by opam-publish v0.2.1