### PR TITLE
re.1.3.0 - via opam-publish

### DIFF
--- a/packages/re/re.1.3.0/descr
+++ b/packages/re/re.1.3.0/descr
@@ -1,0 +1,8 @@
+RE is a regular expression library for OCaml
+
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re_perl)
+* Posix extended regular expressions (module Re_posix)
+* Emacs-style regular expressions (module Re_emacs)
+* Shell-style file globbing (module Re_glob)
+* Compatibility layer for OCaml's built-in Str module (module Re_str)

--- a/packages/re/re.1.3.0/opam
+++ b/packages/re/re.1.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "jerome.vouillon@pps.univ-paris-diderot.fr"
+authors: [
+  "Jerome Vouillon"
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+]
+homepage: "https://github.com/ocaml/ocaml-re"
+bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+license: "LGPL-2.0 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml/ocaml-re.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "re"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "ounit" {test}
+]

--- a/packages/re/re.1.3.0/url
+++ b/packages/re/re.1.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/ocaml-re/archive/ocaml-re-1.3.0.tar.gz"
+checksum: "c206c50f4c89342953dacf34def8d15d"


### PR DESCRIPTION
RE is a regular expression library for OCaml

Pure OCaml regular expressions with:
* Perl-style regular expressions (module Re_perl)
* Posix extended regular expressions (module Re_posix)
* Emacs-style regular expressions (module Re_emacs)
* Shell-style file globbing (module Re_glob)
* Compatibility layer for OCaml's built-in Str module (module Re_str)

---
* Homepage: https://github.com/ocaml/ocaml-re
* Source repo: https://github.com/ocaml/ocaml-re.git
* Bug tracker: https://github.com/ocaml/ocaml-re/issues

---
Pull-request generated by opam-publish v0.2