### PR TITLE
add explicit ocamlfind dependency on travis-senv

### DIFF
--- a/packages/travis-senv/travis-senv.1.0.0/opam
+++ b/packages/travis-senv/travis-senv.1.0.0/opam
@@ -6,4 +6,4 @@ tags: [
   "org:mirage"
 ]
 build: [[make]]
-depends: ["cmdliner"]
+depends: ["cmdliner" "ocamlfind"]


### PR DESCRIPTION
This was exposed by cmdliner dropping its dependency