### PR TITLE
dumpast.0.2.0 - via opam-publish

### DIFF
--- a/packages/dumpast/dumpast.0.2.0/descr
+++ b/packages/dumpast/dumpast.0.2.0/descr
@@ -1,0 +1,11 @@
+OCaml AST dumper
+
+Usage:
+
+```
+ocaml-dumpast [TOOL FLAGS*]? INPUT
+```
+
+The only feature of that tool is to *not* call `TOOL` if
+`FLAGS` are empty, but use compiler-libs directly. This
+can be used to speed-up camlp4 invoctions.

--- a/packages/dumpast/dumpast.0.2.0/opam
+++ b/packages/dumpast/dumpast.0.2.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "https://github.com/samoht/ocaml-dumpast"
+bug-reports:  "https://github.com/samoht/ocaml-dumpast/issues"
+dev-repo:     "https://github.com/samoht/ocaml-dumpast.git"
+license:      "ISC"
+build: [
+  make
+    "OCAML_VERSION=402" {ocaml-version >= "4.02.0"}
+    "OCAML_VERSION=401" {ocaml-version <  "4.02.0"}
+]
+depends: ["ocamlfind"]

--- a/packages/dumpast/dumpast.0.2.0/opam
+++ b/packages/dumpast/dumpast.0.2.0/opam
@@ -7,6 +7,7 @@ dev-repo:     "https://github.com/samoht/ocaml-dumpast.git"
 license:      "ISC"
 build: [
   make
+    "HAS_ANNOT=false"
     "OCAML_VERSION=402" {ocaml-version >= "4.02.0"}
     "OCAML_VERSION=401" {ocaml-version <  "4.02.0"}
 ]

--- a/packages/dumpast/dumpast.0.2.0/opam
+++ b/packages/dumpast/dumpast.0.2.0/opam
@@ -12,3 +12,4 @@ build: [
     "OCAML_VERSION=401" {ocaml-version <  "4.02.0"}
 ]
 depends: ["ocamlfind"]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/dumpast/dumpast.0.2.0/url
+++ b/packages/dumpast/dumpast.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/samoht/ocaml-dumpast/archive/0.2.0.tar.gz"
+checksum: "3696c216ca25970fd6fb13c9a6b80766"


### PR DESCRIPTION
OCaml AST dumper

Usage:

```
ocaml-dumpast [TOOL FLAGS*]? INPUT
```

The only feature of that tool is to *not* call `TOOL` if
`FLAGS` are empty, but use compiler-libs directly. This
can be used to speed-up camlp4 invoctions.

---
* Homepage: https://github.com/samoht/ocaml-dumpast
* Source repo: https://github.com/samoht/ocaml-dumpast.git
* Bug tracker: https://github.com/samoht/ocaml-dumpast/issues

---
Pull-request generated by opam-publish v0.2.1