### PR TITLE
made opam verbose

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,3 +1,6 @@
+bash -c "while true; do echo \$(date) - building ...; sleep 360; done" &
+PING_LOOP_PID=$!
+
 echo pull req: $TRAVIS_PULL_REQUEST
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   curl https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST.diff -o pullreq.diff
@@ -119,3 +122,5 @@ function build_one {
 for i in `cat tobuild.txt`; do
   build_one $i
 done
+
+kill $PING_LOOP_PID


### PR DESCRIPTION
Travis will kill any task if it doesn't output anything to console in a
ten minutes or so. That means that applications that take more than that
time to compile can't pass the CI test.