### PR TITLE
add conflict between base64.1.* and extlib

### DIFF
--- a/packages/base64/base64.1.0.0/opam
+++ b/packages/base64/base64.1.0.0/opam
@@ -14,3 +14,6 @@ remove: [
 depends: [
   "ocamlfind"
 ]
+conflicts: [
+  "extlib"
+]

--- a/packages/base64/base64.1.1.0/opam
+++ b/packages/base64/base64.1.1.0/opam
@@ -24,3 +24,6 @@ depends: [
   "ocamlfind"  {build}
   "base-bytes"
 ]
+conflicts: [
+  "extlib"
+]


### PR DESCRIPTION
Older versions of `base64` are not compatible with `extlib` because they both define a module named `Base64`. When both are installed, the compilation of `opam-publish.0.2.1` fails.