### PR TITLE
pcap-format.0.3.3 does not work with older versions of mirage

### DIFF
--- a/packages/pcap-format/pcap-format.0.3.3/opam
+++ b/packages/pcap-format/pcap-format.0.3.3/opam
@@ -15,4 +15,7 @@ depends: [
   "lwt" {>= "2.4.0"}
 ]
 depopts: ["mirage-net"]
-conflicts: [ "mirage-net-socket" ]
+conflicts: [
+  "mirage-net-socket"
+  "mirage" {< "0.9.2"}
+]


### PR DESCRIPTION
The type of `OS.Io_page.get` changed between `mirage.0.9.1` and `mirage.0.9.2`.