### PR TITLE
fix dependencies of sociaml-tumblr-api

### DIFF
--- a/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.1.0/opam
+++ b/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.1.0/opam
@@ -26,5 +26,5 @@ depends: [
   "uri"
   "csv"
   "calendar"
-  "sociaml-oauth-client"
+  "sociaml-oauth-client" {< "0.5.0"}
 ]

--- a/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.2.0/opam
+++ b/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.2.0/opam
@@ -26,5 +26,5 @@ depends: [
   "uri"
   "csv"
   "calendar"
-  "sociaml-oauth-client"
+  "sociaml-oauth-client" {>= "0.5.0"}
 ]


### PR DESCRIPTION
`sociaml-tumblr-api.0.1.0` does not work with newer versions of `sociaml-oauth-client`.
`sociaml-tumblr-api.0.2.0` does not work with older versions of `sociaml-oauth-client`.
