### PR TITLE
macaroons.0.1.0 - via opam-publish

### DIFF
--- a/packages/macaroons/macaroons.0.1.0/descr
+++ b/packages/macaroons/macaroons.0.1.0/descr
@@ -1,0 +1,12 @@
+Macaroons for OCaml
+
+This is a minimal reimplementation of libmacaroons
+(https://github.com/rescrv/libmacaroons) in OCaml.
+
+It consists of two findlib libraries: `macaroons` and `macaroons.sodium`.  The
+first provides a functor over the required cryptographic operations, while the
+second uses libsodium for crypto, and is only installed if the OPAM package
+`sodium` is installed.
+
+See the paper http://research.google.com/pubs/pub41892.html to learn about
+Macaroons.

--- a/packages/macaroons/macaroons.0.1.0/opam
+++ b/packages/macaroons/macaroons.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+authors: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+homepage: "https://www.github.com/nojb/ocaml-macaroons"
+dev-repo: "https://www.github.com/nojb/ocaml-macaroons.git"
+bug-reports: "https://www.github.com/nojb/ocaml-macaroons/issues"
+license: "MIT"
+build: [
+  [make "macaroons"]
+  [make "sodium_macaroons"] {sodium:installed}
+]
+build-doc: [make "doc"]
+install: [
+  [make "install"] {!sodium:installed}
+  [make "install_sodium"] {sodium:installed}
+]
+remove: ["ocamlfind" "remove" "macaroons"]
+depends: [
+  "hex"
+  "base64" {>= "2.0.0"}
+  "ocamlfind" {build}
+]
+depopts: "sodium"
+available: [ocaml-version >= "4.01.0"]

--- a/packages/macaroons/macaroons.0.1.0/url
+++ b/packages/macaroons/macaroons.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nojb/ocaml-macaroons/archive/v0.1.0.tar.gz"
+checksum: "6816ced35f687944f58e1a0d27bc888c"


### PR DESCRIPTION
Macaroons for OCaml

This is a minimal reimplementation of libmacaroons
(https://github.com/rescrv/libmacaroons) in OCaml.

It consists of two findlib libraries: `macaroons` and `macaroons.sodium`.  The
first provides a functor over the required cryptographic operations, while the
second uses libsodium for crypto, and is only installed if the OPAM package
`sodium` is installed.

See the paper http://research.google.com/pubs/pub41892.html to learn about
Macaroons.

---
* Homepage: https://www.github.com/nojb/ocaml-macaroons
* Source repo: https://www.github.com/nojb/ocaml-macaroons.git
* Bug tracker: https://www.github.com/nojb/ocaml-macaroons/issues

---
Pull-request generated by opam-publish v0.2.1