### PR TITLE
+cohttp.0.15.2

### DIFF
--- a/packages/cohttp/cohttp.0.15.2/descr
+++ b/packages/cohttp/cohttp.0.15.2/descr
@@ -1,0 +1,9 @@
+HTTP library for Lwt, Async and Mirage
+
+There are several optional dependencies which activate functionality:
+
+* Lwt: `opam install lwt cohttp`
+* Lwt and SSL: `opam install lwt ssl cohttp`
+* Async: `opam install async cohttp`
+* Async and SSL: `opam install async_ssl cohttp`
+

--- a/packages/cohttp/cohttp.0.15.2/opam
+++ b/packages/cohttp/cohttp.0.15.2/opam
@@ -1,0 +1,59 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [ "Anil Madhavapeddy"
+           "Stefano Zacchiroli"
+           "David Sheets"
+           "Thomas Gazagnaire"
+           "David Scott"
+           "Rudi Grinberg"
+           "Andy Ray" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+
+build: [
+  [make "PREFIX=%{prefix}%"]
+]
+
+install: [make "PREFIX=%{prefix}%" "install"]
+
+remove: [["ocamlfind" "remove" "cohttp"]]
+
+depends: [
+  "ocamlfind" {build}
+  "cmdliner" {build & >= "0.9.4"}
+  "re"
+  "uri" {>= "1.5.0"}
+  "fieldslib" {>= "109.20.00"}
+  "sexplib" {>= "109.53.00"}
+  "conduit" {>= "0.7.0"}
+  "stringext"
+  "base64" {>="2.0.0"}
+  "ounit" {test}
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+
+depopts: [
+  "async"
+  "lwt"
+  "js_of_ocaml"
+]
+
+conflicts: [
+  "async" {<"109.15.00"}
+  "lwt" {<"2.4.7"}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/cohttp/cohttp.0.15.2/opam
+++ b/packages/cohttp/cohttp.0.15.2/opam
@@ -52,7 +52,7 @@ depopts: [
 ]
 
 conflicts: [
-  "async" {<"109.15.00"}
+  "async" {<"111.25.00"}
   "lwt" {<"2.4.7"}
 ]
 

--- a/packages/cohttp/cohttp.0.15.2/url
+++ b/packages/cohttp/cohttp.0.15.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cohttp/archive/v0.15.2.tar.gz"
+checksum: "0298462b68c70b719f1889aa36863c03"


### PR DESCRIPTION
* When transfer encoding is unknown, read until EOF when body size is unknown. (#241)
* Add some missing documentation to `Cohttp.S.IO` signature. (#233)
* Add `Cohttp.Header.mem` to check if a header exists.
* Add `Cohttp.Conf` module to expose the library version number. (#259)
* Add `Cohttp.Header.add_unless_exists` to update a key if it doesn't already exist. (#244)
* Add `Cohttp.Header.get_location` to retrieve redirection information. (#254)
* [async] Clean up the `Net.lookup` function to use `Or_error.t` instead of raising. (#247)
* [tests] Add more tests for `content-range` handling. (#249)