### PR TITLE
xapi-rrd-transport.0.7.2 is incompatible with latest io-page

### DIFF
--- a/packages/xapi-rrd-transport/xapi-rrd-transport.0.7.2/opam
+++ b/packages/xapi-rrd-transport/xapi-rrd-transport.0.7.2/opam
@@ -8,6 +8,7 @@ remove: [make "PREFIX=%{prefix}%" "uninstall"]
 depends: [
   "cmdliner"
   "cstruct" {>= "1.0.1"}
+  "io-page" {= "1.2.0"}
   "crc"
   "xapi-idl"
   "xapi-rrd"


### PR DESCRIPTION
Signed-off-by: David Scott <dave.scott@eu.citrix.com>