### PR TITLE
irmin: fix dependencies

### DIFF
--- a/packages/irmin/irmin.0.7.0/opam
+++ b/packages/irmin/irmin.0.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ezjsonm" {>= "0.2.0" & < "0.4.0"}
   "ocamlgraph"
   "lwt"
-  "sha"
+  "sha" {>= "1.9"}
   "re"
   "dolog" {>= "0.4" & <= "0.6"}
   "mstruct"

--- a/packages/irmin/irmin.0.8.0/opam
+++ b/packages/irmin/irmin.0.8.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ezjsonm" {>= "0.2.0" & < "0.4.0"}
   "ocamlgraph"
   "lwt"
-  "sha"
+  "sha" {>= "1.9"}
   "re"
   "dolog" {>= "0.4" & <= "0.6"}
   "mstruct"

--- a/packages/irmin/irmin.0.8.1/opam
+++ b/packages/irmin/irmin.0.8.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ezjsonm" {>= "0.2.0" & < "0.4.0"}
   "ocamlgraph"
   "lwt"
-  "sha"
+  "sha" {>= "1.9"}
   "re"
   "dolog" {>= "0.4" & <= "0.6"}
   "mstruct"

--- a/packages/irmin/irmin.0.8.2/opam
+++ b/packages/irmin/irmin.0.8.2/opam
@@ -15,7 +15,7 @@ depends: [
   "ezjsonm" {>= "0.2.0" & < "0.4.0"}
   "ocamlgraph"
   "lwt"
-  "sha"
+  "sha" {>= "1.9"}
   "re"
   "dolog" {>= "0.4" & <= "0.6"}
   "mstruct"

--- a/packages/irmin/irmin.0.9.0/opam
+++ b/packages/irmin/irmin.0.9.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ocamlgraph"
   "lwt" {>= "2.4.5"}
   "nocrypto" {>= "0.2.2"}
-  "dolog" {>= "0.4"}
+  "dolog" {>= "1.0"}
   "cstruct"
   "mirage-tc" {>= "0.3.0"}
   "mstruct"

--- a/packages/irmin/irmin.0.9.1/opam
+++ b/packages/irmin/irmin.0.9.1/opam
@@ -26,7 +26,7 @@ depends: [
   "ocamlgraph"
   "lwt" {>= "2.4.5"}
   "nocrypto" {>= "0.2.2"}
-  "dolog" {>= "0.4"}
+  "dolog" {>= "1.0"}
   "cstruct" {>= "1.0.1"}
   "mirage-tc" {>= "0.3.0"}
   "mstruct"
@@ -43,6 +43,6 @@ depends: [
 ]
 conflicts: [
   "git"    {!= "1.4.3"}
-  "cohttp" {< "0.14.0"}
+  "cohttp" {< "0.15.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin/irmin.0.9.2/opam
+++ b/packages/irmin/irmin.0.9.2/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlgraph"
   "lwt" {>= "2.4.5"}
   "nocrypto" {>= "0.2.2"}
-  "dolog" {>= "0.4"}
+  "dolog" {>= "1.0"}
   "cstruct" {>= "1.0.1"}
   "mirage-tc" {>= "0.3.0"}
   "mstruct"
@@ -41,6 +41,6 @@ depopts: [
 conflicts: [
   "git" {< "1.4.4"}
   "git" {> "1.4.5"}
-  "cohttp" {< "0.14.0"}
+  "cohttp" {< "0.15.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
- older versions need `sha` >= 1.9
- newer versions need `dolog` >= 1.0 and `cohttp` >= 0.15.0
