### PR TITLE
cohttp 0.15.2 had an oasis build dependency sneak in, so add dep

### DIFF
--- a/packages/cohttp/cohttp.0.15.2/opam
+++ b/packages/cohttp/cohttp.0.15.2/opam
@@ -36,6 +36,7 @@ depends: [
   "stringext"
   "base64" {>="2.0.0"}
   "ounit" {test}
+  "oasis" {build & >= "0.4.4"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 


### PR DESCRIPTION
This will not be the case in future revisions, and was not the case
in past ones...