### PR TITLE
base64 is incompatible with extlib-compat...

### DIFF
--- a/packages/base64/base64.1.0.0/opam
+++ b/packages/base64/base64.1.0.0/opam
@@ -16,4 +16,5 @@ depends: [
 ]
 conflicts: [
   "extlib"
+  "extlib-compat"
 ]

--- a/packages/base64/base64.1.1.0/opam
+++ b/packages/base64/base64.1.1.0/opam
@@ -26,4 +26,5 @@ depends: [
 ]
 conflicts: [
   "extlib"
+  "extlib-compat"
 ]


### PR DESCRIPTION
... for the same reason that it is incompatible with extlib.
See #3565.
