### PR TITLE
Allow coq to build with trunk

### DIFF
--- a/packages/coq/coq.8.4.5/files/build_with_trunk.patch
+++ b/packages/coq/coq.8.4.5/files/build_with_trunk.patch
@@ -1,0 +1,330 @@
+diff -ru coq-8.4pl5/kernel/byterun/coq_fix_code.c coq-8.4pl5_patched/kernel/byterun/coq_fix_code.c
+--- coq-8.4pl5/kernel/byterun/coq_fix_code.c	2015-02-23 18:44:01.580258761 +0100
++++ coq-8.4pl5_patched/kernel/byterun/coq_fix_code.c	2015-02-24 17:22:36.242153692 +0100
+@@ -13,6 +13,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h> 
++#include <stdint.h>
+ #include <caml/config.h>
+ #include <caml/misc.h>
+ #include <caml/mlvalues.h>
+@@ -154,7 +155,7 @@
+     };
+     *q++ = VALINSTR(instr);
+     if (instr == SWITCH) {
+-      uint32 i, sizes, const_size, block_size;
++      uint32_t i, sizes, const_size, block_size;
+       COPY32(q,p); p++;
+       sizes=*q++;
+       const_size = sizes & 0xFFFF;
+@@ -162,13 +163,13 @@
+       sizes = const_size + block_size;
+       for(i=0; i<sizes; i++) { COPY32(q,p); p++; q++; };
+     } else if (instr == CLOSUREREC || instr==CLOSURECOFIX) {
+-      uint32 i, n;
++      uint32_t i, n;
+       COPY32(q,p); p++; /* ndefs */
+       n = 3 + 2*(*q);  /* ndefs, nvars, start, typlbls,lbls*/
+       q++;
+       for(i=1; i<n; i++) { COPY32(q,p); p++; q++; };
+     } else {
+-      uint32 i, ar;
++      uint32_t i, ar;
+       ar = arity[instr]; 
+       for(i=0; i<ar; i++) { COPY32(q,p); p++; q++; };
+     }
+diff -ru coq-8.4pl5/kernel/byterun/coq_interp.c coq-8.4pl5_patched/kernel/byterun/coq_interp.c
+--- coq-8.4pl5/kernel/byterun/coq_interp.c	2015-02-23 18:44:03.108250284 +0100
++++ coq-8.4pl5_patched/kernel/byterun/coq_interp.c	2015-02-24 17:23:23.277801735 +0100
+@@ -15,6 +15,7 @@
+ 
+ #include <stdio.h>
+ #include <signal.h>
++#include <stdint.h>
+ #include "coq_gc.h"
+ #include "coq_instruct.h"
+ #include "coq_fix_code.h"
+@@ -30,9 +31,9 @@
+ #endif
+ 
+ /* spiwack: I append here a few macros for value/number manipulation */
+-#define uint32_of_value(val) (((uint32)val >> 1))
+-#define value_of_uint32(i)   ((value)(((uint32)(i) << 1) | 1))
+-#define UI64_of_uint32(lo)  ((uint64)(I64_literal(0,(uint32)(lo))))
++#define uint32_of_value(val) (((uint32_t)val >> 1))
++#define value_of_uint32(i)   ((value)(((uint32_t)(i) << 1) | 1))
++#define UI64_of_uint32(lo)  ((uint64_t)(I64_literal(0,(uint32_t)(lo))))
+ #define UI64_of_value(val) (UI64_of_uint32(uint32_of_value(val)))
+ /* /spiwack */
+ 
+@@ -788,7 +789,7 @@
+ /* Access to components of blocks */
+         
+       Instruct(SWITCH) {
+-	uint32 sizes = *pc++;
++	uint32_t sizes = *pc++;
+ 	print_instr("SWITCH");
+ 	print_int(sizes & 0xFFFF);
+ 	if (Is_block(accu)) {
+@@ -1074,7 +1075,7 @@
+            the one ontop of the stack (which is poped)*/
+         print_instr("ADDINT31");
+         accu = 
+-           (value)((uint32) accu + (uint32) *sp++ - 1); 
++           (value)((uint32_t) accu + (uint32_t) *sp++ - 1); 
+         /* nota,unlike CaML we don't want
+            to have a different behavior depending on the 
+            architecture. Thus we cast the operand to uint32 */
+@@ -1084,9 +1085,9 @@
+       Instruct (ADDCINT31) {
+ 	print_instr("ADDCINT31");
+ 	/* returns the sum with a carry */
+-	uint32 s;
+-	s = (uint32)accu + (uint32)*sp++ - 1;
+-        if( (uint32)s < (uint32)accu ) {
++	uint32_t s;
++	s = (uint32_t)accu + (uint32_t)*sp++ - 1;
++        if( (uint32_t)s < (uint32_t)accu ) {
+           /* carry */
+ 	  Alloc_small(accu, 1, 2); /* ( _ , arity, tag ) */
+ 	}
+@@ -1101,10 +1102,10 @@
+       Instruct (ADDCARRYCINT31) {
+ 	print_instr("ADDCARRYCINT31");
+ 	/* returns the sum plus one with a carry */
+-	uint32 s;
+-	s = (uint32)accu + (uint32)*sp++ + 1;
++	uint32_t s;
++	s = (uint32_t)accu + (uint32_t)*sp++ + 1;
+ 	value block;
+-        if( (uint32)s <= (uint32)accu ) {
++        if( (uint32_t)s <= (uint32_t)accu ) {
+           /* carry */
+ 	  Alloc_small(accu, 1, 2); /* ( _ , arity, tag ) */
+ 	}
+@@ -1120,18 +1121,18 @@
+ 	print_instr("SUBINT31");
+ 	/* returns the subtraction */
+ 	accu = 
+-	  (value)((uint32) accu - (uint32) *sp++ + 1); 
++	  (value)((uint32_t) accu - (uint32_t) *sp++ + 1); 
+         Next;
+       }
+ 
+       Instruct (SUBCINT31) {
+ 	print_instr("SUBCINT31");
+ 	/* returns the subtraction with a carry */
+-	uint32 b;
+-	uint32 s;
+-	b = (uint32)*sp++;
+-	s = (uint32)accu - b + 1;
+-        if( (uint32)accu < b ) {
++	uint32_t b;
++	uint32_t s;
++	b = (uint32_t)*sp++;
++	s = (uint32_t)accu - b + 1;
++        if( (uint32_t)accu < b ) {
+           /* carry */
+ 	  Alloc_small(accu, 1, 2); /* ( _ , arity, tag ) */
+ 	}
+@@ -1146,11 +1147,11 @@
+       Instruct (SUBCARRYCINT31) {
+ 	print_instr("SUBCARRYCINT31");
+ 	/* returns the subtraction minus one with a carry */
+-	uint32 b;
+-	uint32 s;
+-	b = (uint32)*sp++;
+-	s = (value)((uint32)accu - b - 1);
+-        if( (uint32)accu <= b ) {
++	uint32_t b;
++	uint32_t s;
++	b = (uint32_t)*sp++;
++	s = (value)((uint32_t)accu - b - 1);
++        if( (uint32_t)accu <= b ) {
+           /* carry */
+ 	  Alloc_small(accu, 1, 2); /* ( _ , arity, tag ) */
+ 	}
+@@ -1174,7 +1175,7 @@
+         /*returns the multiplication on a double size word
+           (special case for 0) */
+         print_instr("MULCINT31");
+-	uint64 p;
++	uint64_t p;
+         /*accu = 2v+1, *sp=2w+1 ==> p = 2v*w */
+         p = I64_mul (UI64_of_value (accu), UI64_of_uint32 ((*sp++)^1));
+ 	if ( I64_is_zero(p) ) {
+@@ -1197,10 +1198,10 @@
+ 	/* spiwack: takes three int31 (the two first ones represent an
+                     int62) and performs the euclidian division of the
+                     int62 by the int31 */
+-        uint64 bigint;
++        uint64_t bigint;
+         bigint = UI64_of_value(accu);
+         bigint = I64_or(I64_lsl(bigint, 31),UI64_of_value(*sp++));
+-        uint64 divisor;
++        uint64_t divisor;
+         divisor = UI64_of_value(*sp++);
+         Alloc_small(accu, 2, 1); /* ( _ , arity, tag ) */
+         if (I64_is_zero (divisor)) {
+@@ -1208,7 +1209,7 @@
+           Field(accu, 1) = 1; /* 2*0+1 */
+ 	}
+ 	else {
+-	  uint64 quo, mod;
++	  uint64_t quo, mod;
+           I64_udivmod(bigint, divisor, &quo, &mod);
+           Field(accu, 0) = value_of_uint32(I64_to_int32(quo));
+ 	  Field(accu, 1) = value_of_uint32(I64_to_int32(mod));
+@@ -1221,7 +1222,7 @@
+         /* spiwack: a priori no need of the NON_STANDARD_DIV_MOD flag
+                     since it probably only concerns negative number.
+                     needs to be checked at this point */
+-        uint32 divisor;
++        uint32_t divisor;
+         divisor = uint32_of_value(*sp++);
+         if (divisor == 0) { 
+           Alloc_small(accu, 2, 1); /* ( _ , arity, tag ) */
+@@ -1229,7 +1230,7 @@
+           Field(accu, 1) = 1; /* 2*0+1 */
+         }
+         else {
+-          uint32 modulus;
++          uint32_t modulus;
+           modulus = uint32_of_value(accu);
+           Alloc_small(accu, 2, 1); /* ( _ , arity, tag ) */
+ 	  Field(accu, 0) = value_of_uint32(modulus/divisor);
+@@ -1241,7 +1242,7 @@
+       Instruct (ADDMULDIVINT31) {
+         print_instr("ADDMULDIVINT31");
+         /* higher level shift (does shifts and cycles and such) */
+-        uint32 shiftby;
++        uint32_t shiftby;
+         shiftby = uint32_of_value(accu);
+         if (shiftby > 31) {
+           if (shiftby < 62) {
+@@ -1256,7 +1257,7 @@
+         /* *sp = 2*x+1 --> accu = 2^(shiftby+1)*x */
+         accu = (value)(((*sp++)^1) << shiftby);
+         /* accu = 2^(shiftby+1)*x --> 2^(shifby+1)*x+2*y/2^(31-shiftby)+1 */
+-        accu = (value)((accu | (((uint32)(*sp++)) >> (31-shiftby)))|1);
++        accu = (value)((accu | (((uint32_t)(*sp++)) >> (31-shiftby)))|1);
+ 	}
+         Next;
+       }
+@@ -1265,11 +1266,11 @@
+ 	/* returns Eq if equal, Lt if accu is less than *sp, Gt otherwise */
+ 	/* assumes Inudctive _ : _ := Eq | Lt | Gt */
+ 	print_instr("COMPAREINT31");
+-	if ((uint32)accu == (uint32)*sp) {
++	if ((uint32_t)accu == (uint32_t)*sp) {
+ 	  accu = 1;  /* 2*0+1 */
+ 	  sp++;
+ 	}
+-	else{if ((uint32)accu < (uint32)(*sp++)) {
++	else{if ((uint32_t)accu < (uint32_t)(*sp++)) {
+ 	  accu = 3;  /* 2*1+1 */
+ 	}
+ 	else{
+@@ -1280,9 +1281,9 @@
+  
+       Instruct (HEAD0INT31) {
+ 	int r = 0;
+-        uint32 x;
++        uint32_t x;
+         print_instr("HEAD0INT31");
+-	x = (uint32) accu;
++	x = (uint32_t) accu;
+         if (!(x & 0xFFFF0000)) { x <<= 16; r += 16; }
+         if (!(x & 0xFF000000)) { x <<= 8;  r += 8; }
+         if (!(x & 0xF0000000)) { x <<= 4;  r += 4; }
+@@ -1295,9 +1296,9 @@
+         
+       Instruct (TAIL0INT31) {
+ 	int r = 0;
+-        uint32 x;
++        uint32_t x;
+         print_instr("TAIL0INT31");
+-	x = (((uint32) accu >> 1) | 0x80000000);
++	x = (((uint32_t) accu >> 1) | 0x80000000);
+         if (!(x & 0xFFFF)) { x >>= 16; r += 16; }
+         if (!(x & 0x00FF)) { x >>= 8;  r += 8; }
+         if (!(x & 0x000F)) { x >>= 4;  r += 4; }
+@@ -1347,7 +1348,7 @@
+         /*accu=accu or accu = (value)((unsigned long)1-accu) if bool
+ 	               is used for the bits */
+         for(i=0; i < 30; i++) {
+-	  accu = (value) ((((uint32)accu-1) << 1) | *sp++);
++	  accu = (value) ((((uint32_t)accu-1) << 1) | *sp++);
+           /* -1 removes the tag bit, << 1 multiplies the value by 2, 
+               | *sp++ pops the last value and add it (no carry involved)
+ 	      not that it reintroduces a tag bit */
+@@ -1367,7 +1368,7 @@
+         for(i = 30; i >= 0; i--) {
+           Field(block, i) = (value)(accu & 3); /* two last bits of the accumulator */
+           //Field(block, i) = 3;
+-          accu = (value) ((uint32)accu >> 1) | 1;  /* last bit must be a one */
++          accu = (value) ((uint32_t)accu >> 1) | 1;  /* last bit must be a one */
+         };
+ 	accu = block;
+         Next;
+diff -ru coq-8.4pl5/kernel/byterun/int64_native.h coq-8.4pl5_patched/kernel/byterun/int64_native.h
+--- coq-8.4pl5/kernel/byterun/int64_native.h	2015-02-23 18:44:03.856246133 +0100
++++ coq-8.4pl5_patched/kernel/byterun/int64_native.h	2015-02-23 17:22:34.320002821 +0100
+@@ -18,9 +18,9 @@
+ #ifndef CAML_INT64_NATIVE_H
+ #define CAML_INT64_NATIVE_H
+ 
+-#define I64_literal(hi,lo) ((int64)(hi) << 32 | (lo))
++#define I64_literal(hi,lo) ((int64_t)(hi) << 32 | (lo))
+ #define I64_compare(x,y) (((x) > (y)) - ((x) < (y)))
+-#define I64_ult(x,y) ((uint64)(x) < (uint64)(y))
++#define I64_ult(x,y) ((uint64_t)(x) < (uint64_t)(y))
+ #define I64_neg(x) (-(x))
+ #define I64_add(x,y) ((x) + (y))
+ #define I64_sub(x,y) ((x) - (y))
+@@ -30,19 +30,19 @@
+ #define I64_div(x,y) ((x) / (y))
+ #define I64_mod(x,y) ((x) % (y))
+ #define I64_udivmod(x,y,quo,rem) \
+-  (*(rem) = (uint64)(x) % (uint64)(y), \
+-   *(quo) = (uint64)(x) / (uint64)(y))
++  (*(rem) = (uint64_t)(x) % (uint64_t)(y), \
++   *(quo) = (uint64_t)(x) / (uint64_t)(y))
+ #define I64_and(x,y) ((x) & (y))
+ #define I64_or(x,y) ((x) | (y))
+ #define I64_xor(x,y) ((x) ^ (y))
+ #define I64_lsl(x,y) ((x) << (y))
+ #define I64_asr(x,y) ((x) >> (y))
+-#define I64_lsr(x,y) ((uint64)(x) >> (y))
++#define I64_lsr(x,y) ((uint64_t)(x) >> (y))
+ #define I64_to_intnat(x) ((intnat) (x))
+ #define I64_of_intnat(x) ((intnat) (x))
+-#define I64_to_int32(x) ((int32) (x))
+-#define I64_of_int32(x) ((int64) (x))
++#define I64_to_int32(x) ((int32_t) (x))
++#define I64_of_int32(x) ((int64_t) (x))
+ #define I64_to_double(x) ((double)(x))
+-#define I64_of_double(x) ((int64)(x))
++#define I64_of_double(x) ((int64_t)(x))
+ 
+ #endif /* CAML_INT64_NATIVE_H */
+diff -ru coq-8.4pl5/plugins/subtac/subtac_obligations.ml coq-8.4pl5_patched/plugins/subtac/subtac_obligations.ml
+--- coq-8.4pl5/plugins/subtac/subtac_obligations.ml	2015-02-23 18:44:04.868240689 +0100
++++ coq-8.4pl5_patched/plugins/subtac/subtac_obligations.ml	2015-02-23 17:24:59.398722514 +0100
+@@ -683,12 +683,12 @@
+       obls;
+     ignore(update_obls prg obls 0)
+ 
+-exception Found of int
++exception Found' of int
+ 
+ let array_find f arr =
+-  try Array.iteri (fun i x -> if f x then raise (Found i)) arr;
++  try Array.iteri (fun i x -> if f x then raise (Found' i)) arr;
+     raise Not_found
+-  with Found i -> i
++  with Found' i -> i
+ 
+ let next_obligation n tac =
+   let prg = get_prog_err n in

--- a/packages/coq/coq.8.4.5/opam
+++ b/packages/coq/coq.8.4.5/opam
@@ -10,4 +10,6 @@ build: [
   [make "install"]
 ]
 depends: ["camlp5" | "camlp4"]
-patches: ["build_with_trunk.patch"]
+patches: [
+  "build_with_trunk.patch" { ocaml-version >= "4.03" }
+]

--- a/packages/coq/coq.8.4.5/opam
+++ b/packages/coq/coq.8.4.5/opam
@@ -1,10 +1,13 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
+homepage: "https://coq.inria.fr/"
+dev-repo: "git://scm.gforge.inria.fr/coq/coq.git"
+bug-reports: "https://coq.inria.fr/bugs/"
 build: [
-  ["./configure" "-configdir" "%{lib}%/coq/config" "-mandir" man "-docdir" doc "--prefix" prefix "--usecamlp5" "--camlp5dir" "%{lib}%/camlp5" "--coqide" "no"]
+  ["./configure" "-configdir" "%{lib}%/coq/config" "-mandir" man "-docdir" doc "--prefix" prefix "--usecamlp5" { camlp5:installed } "--camlp5dir" { camlp5:installed } "%{lib}%/camlp5" { camlp5:installed } "--usecamlp4" { camlp4:installed} "--coqide" "no"]
   [make "-j%{jobs}%" "world"]
   [make "-j%{jobs}%" "states"]
   [make "install"]
 ]
-depends: ["camlp5"]
-patches: []
+depends: ["camlp5" | "camlp4"]
+patches: ["build_with_trunk.patch"]


### PR DESCRIPTION
There are 2 parts to this change:
  * allow the coq package to build with camlp4
  * Fix the things in coq that are not valid with trunk:
    * C stubs using uint32 int32 uint64 int64 -> now use uint32_t ...
    * an exception name declare 2 times in the same file (this is now forbidden)

Unfortunately, the patch to the opam file is opam 1.2.1 specific: the syntax
    "%{camlp5:installed?--usecamlp5:--usecamlp4}%"
 is not accepted with opam 1.2.0 (at least the debian package version)