### PR TITLE
openflow.0.7.0 requires packet >= 0.3.1 for string_of_ipv6

### DIFF
--- a/packages/openflow/openflow.0.7.0/opam
+++ b/packages/openflow/openflow.0.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind"
   "core"
   "cstruct" {>= "1.0.1"}
-  "packet"  {>= "0.3.0" }
+  "packet"  {>= "0.3.1" }
   "sexplib"
 ]
 depopts: [ "async" "quickcheck" ]


### PR DESCRIPTION
Exposed by #3619.