### PR TITLE
mirage-flow.1.0.0 - via opam-publish

### DIFF
--- a/packages/mirage-flow/mirage-flow.1.0.0/descr
+++ b/packages/mirage-flow/mirage-flow.1.0.0/descr
@@ -1,0 +1,4 @@
+Various implementations of the mirage FLOW interface
+
+- `Fflow` uses input/output functions to build a flow
+- `Lwt_io_flow` uses `Lwt_io.channel`

--- a/packages/mirage-flow/mirage-flow.1.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.1.0.0/opam
@@ -14,7 +14,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-flow"]
 depends: [
   "ocamlfind" {build}
-  "mirage-types"
+  "mirage-types-lwt"
   "cstruct"
   "lwt"
   "alcotest" {test}

--- a/packages/mirage-flow/mirage-flow.1.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.1.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage: "https://github.com/mirage/mirage-flow"
+bug-reports: "https://github.com/mirage/mirage-flow/issues/"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-flow.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--%{alcotest:enable}%-tests"]
+  [make]
+]
+build-test: [make "test"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-flow"]
+depends: [
+  "ocamlfind" {build}
+  "mirage-types"
+  "cstruct"
+  "lwt"
+  "alcotest" {test}
+]

--- a/packages/mirage-flow/mirage-flow.1.0.0/url
+++ b/packages/mirage-flow/mirage-flow.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-flow/archive/1.0.0.tar.gz"
+checksum: "f0a5922933d5223abe94f74e343b3a01"


### PR DESCRIPTION
Various implementations of the mirage FLOW interface

- `Fflow` uses input/output functions to build a flow
- `Lwt_io_flow` uses `Lwt_io.channel`

---
* Homepage: https://github.com/mirage/mirage-flow
* Source repo: https://github.com/mirage/mirage-flow.git
* Bug tracker: https://github.com/mirage/mirage-flow/issues/

---
Pull-request generated by opam-publish v0.2.1