### PR TITLE
ppx_import.1.0 - via opam-publish

### DIFF
--- a/packages/ppx_import/ppx_import.1.0/descr
+++ b/packages/ppx_import/ppx_import.1.0/descr
@@ -1,0 +1,1 @@
+A syntax extension for importing declarations from interface files

--- a/packages/ppx_import/ppx_import.1.0/opam
+++ b/packages/ppx_import/ppx_import.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Peter Zotov <whitequark@whitequark.org>"
+authors: "Peter Zotov <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_import"
+bug-reports: "https://github.com/whitequark/ppx_import/issues"
+license: "MIT"
+tags: "syntax"
+dev-repo: "git://github.com/whitequark/ppx_import.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+build-test: ["ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_import.byte" "--"]
+depends: [
+  "ppx_tools" {>= "0.99.1"}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "ppx_deriving" {test & >= "2.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_import/ppx_import.1.0/url
+++ b/packages/ppx_import/ppx_import.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_import/archive/v1.0.tar.gz"
+checksum: "d5eef6f768536e45a4f3c557828d0a49"


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

---
* Homepage: https://github.com/whitequark/ppx_import
* Source repo: git://github.com/whitequark/ppx_import.git
* Bug tracker: https://github.com/whitequark/ppx_import/issues

---
Pull-request generated by opam-publish v0.2.1