### PR TITLE
ocp-indent.1.5 - via opam-publish

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.5/descr
+++ b/packages/ocp-indent/ocp-indent.1.5/descr
@@ -1,0 +1,13 @@
+A simple tool to indent OCaml programs
+
+Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
+machine ; this is much faster and more reliable than using regexps. Presets and
+configuration options available, with the possibility to set them project-wide.
+Supports most common syntax extensions, and extensible for others.
+
+Includes:
+
+* An indentor program, callable from the command-line or from within editors
+* Bindings for popular editors
+* A library that can be directly used by editor writers, or just for
+approximate parsing.

--- a/packages/ocp-indent/ocp-indent.1.5/opam
+++ b/packages/ocp-indent/ocp-indent.1.5/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "contact@ocamlpro.com"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "http://www.typerex.org/ocp-indent.html"
+license: "LGPL"
+tags: ["org:ocamlpro" "org:typerex"]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocp-build" {>= "1.99.6-beta"}
+  "cmdliner"
+]
+post-messages: [
+  "To use from emacs, add the following to your .emacs:
+  (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")
+  (require 'ocp-indent)
+
+To use from Vim, add to your .vimrc:
+  execute \":source \" . \"%{share}%/vim/syntax/ocp-indent.vim\"
+"
+  {success}
+]
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+dev-repo: "https://github.com/OCamlPro/ocp-indent.git"

--- a/packages/ocp-indent/ocp-indent.1.5/url
+++ b/packages/ocp-indent/ocp-indent.1.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocp-indent/archive/1.5.tar.gz"
+checksum: "4fffaf408044ef3a7add15c40ad0aa37"


### PR DESCRIPTION
A simple tool to indent OCaml programs

Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
machine ; this is much faster and more reliable than using regexps. Presets and
configuration options available, with the possibility to set them project-wide.
Supports most common syntax extensions, and extensible for others.

Includes:

* An indentor program, callable from the command-line or from within editors
* Bindings for popular editors
* A library that can be directly used by editor writers, or just for
approximate parsing.


---
* Homepage: http://www.typerex.org/ocp-indent.html
* Source repo: https://github.com/OCamlPro/ocp-indent.git
* Bug tracker: https://github.com/OCamlPro/ocp-indent/issues

---

Pull-request generated by opam-publish v0.2.1