### PR TITLE
alberto.0.4 - via opam-publish

### DIFF
--- a/packages/alberto/alberto.0.4/descr
+++ b/packages/alberto/alberto.0.4/descr
@@ -1,0 +1,7 @@
+OCaml interface to Erlang ports
+
+Alberto is an implementation of
+[Erlang External Term Format](http://erlang.org/doc/apps/erts/erl_ext_dist.html),
+a protocol, used by Erlang nodes to communicate with so called *ports*. See
+Erlang [documentation](http://www.erlang.org/doc/tutorial/c_port.html) for
+details.

--- a/packages/alberto/alberto.0.4/opam
+++ b/packages/alberto/alberto.0.4/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "superbobry@gmail.com"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "alberto"]
+depends: [
+  "ocamlfind"
+  "ocplib-endian"
+]
+available: [ocaml-version >= "4.01"]
+
+homepage: "https://github.com/selectel/alberto"
+dev-repo: "https://github.com/selectel/alberto.git"
+bug-reports: "https://github.com/selectel/alberto/issues"
+license: "LGPL-2.1+ with OCaml linking exception"
+author: "Sergei Lebedev"

--- a/packages/alberto/alberto.0.4/url
+++ b/packages/alberto/alberto.0.4/url
@@ -1,0 +1,2 @@
+http: "https://codeload.github.com/selectel/alberto/tar.gz/0.4"
+checksum: "2bf9cc79f6e164567dd837d51aed3487"


### PR DESCRIPTION
OCaml interface to Erlang ports

Alberto is an implementation of
[Erlang External Term Format](http://erlang.org/doc/apps/erts/erl_ext_dist.html),
a protocol, used by Erlang nodes to communicate with so called *ports*. See
Erlang [documentation](http://www.erlang.org/doc/tutorial/c_port.html) for
details.

---
* Homepage: https://github.com/selectel/alberto
* Source repo: https://github.com/selectel/alberto.git
* Bug tracker: https://github.com/selectel/alberto/issues

---
Pull-request generated by opam-publish v0.2.1