### PR TITLE
vrt.0.1.0 - via opam-publish

### DIFF
--- a/packages/vrt/vrt.0.1.0/descr
+++ b/packages/vrt/vrt.0.1.0/descr
@@ -1,0 +1,7 @@
+A setup command line tools to help with development on remote AWS desktops
+
+The `vrt` command is the entry point for all the tooling in an was
+system. Vrt itself doesn't provide any commands. It consists of
+command groups that provide subcommands for the various areas of
+tooling. A good example of this is the `build` subcommand group. That
+consists of all the tooling related to build and development.

--- a/packages/vrt/vrt.0.1.0/opam
+++ b/packages/vrt/vrt.0.1.0/opam
@@ -1,0 +1,19 @@
+
+opam-version: "1.2"
+maintainer: "contact@afiniate.com"
+author: "contact@afiniate.com"
+homepage: "https://github.com/afiniate/vrt"
+bug-reports: "https://github.com/afiniate/vrt/issues"
+license: "Apache v2"
+dev-repo: "git@github.com:afiniate/vrt.git"
+
+available: [ ocaml-version >= "4.02" ]
+
+build: [
+  [make "build"]
+]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "remove" "PREFIX=%{prefix}%"]
+depends: ["ocamlfind" "core" "async" "async_shell" "async_unix" "async_extra"
+          "sexplib" "async_shell" "core_extended" "async_find"]
+

--- a/packages/vrt/vrt.0.1.0/url
+++ b/packages/vrt/vrt.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/afiniate/vrt/archive/v0.1.0.tar.gz"
+checksum: "be3bd2fdc543d2dab7accd7390d3b1e4"


### PR DESCRIPTION
A setup command line tools to help with development on remote AWS desktops

The `vrt` command is the entry point for all the tooling in an was
system. Vrt itself doesn't provide any commands. It consists of
command groups that provide subcommands for the various areas of
tooling. A good example of this is the `build` subcommand group. That
consists of all the tooling related to build and development.

---
* Homepage: https://github.com/afiniate/vrt
* Source repo: git@github.com:afiniate/vrt.git
* Bug tracker: https://github.com/afiniate/vrt/issues

---
Pull-request generated by opam-publish v0.2.1