### PR TITLE
ocamltter.3.0.0 does not work with orakuda.2.0.0

### DIFF
--- a/packages/ocamltter/ocamltter.3.0.0/opam
+++ b/packages/ocamltter/ocamltter.3.0.0/opam
@@ -10,4 +10,12 @@ remove: [
   ["ocaml" "setup.ml" "-uninstall"]
 ]
 ocaml-version: [>= "4.02.0"]
-depends: ["ocamlfind" "omake" "cryptokit" "ocurl" {>="0.5.3"} "tiny_json_conv" {>="1.4.1"} "spotlib" {>="2.5.0"} "orakuda" {>="1.2.2"} ]
+depends: [
+  "ocamlfind"
+  "omake"
+  "cryptokit"
+  "ocurl" {>="0.5.3"}
+  "tiny_json_conv" {>="1.4.1"}
+  "spotlib" {>="2.5.0"}
+  "orakuda" {>="1.2.2" & < "2.0.0"}
+]


### PR DESCRIPTION
I thought I had fixed this, but apparently I missed one case.
