### PR TITLE
OSX CI: only support OCaml 4.02.1

### DIFF
--- a/.travis-ci-install.sh
+++ b/.travis-ci-install.sh
@@ -44,8 +44,6 @@ install_on_osx () {
   sudo installer -verbose -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
   case "$OCAML_VERSION,$OPAM_VERSION" in
   4.02.1,1.2.0) brew update; brew install opam ;;
-  4.02.1,1.2.0) brew update; brew install opam ;;
-  4.02.1,1.2.1) brew update; brew install opam --HEAD ;;
   4.02.1,1.2.1) brew update; brew install opam --HEAD ;;
   *) echo Unknown $OCAML_VERSION,$OPAM_VERSION; exit 1 ;;
   esac

--- a/.travis-ci-install.sh
+++ b/.travis-ci-install.sh
@@ -43,10 +43,10 @@ install_on_osx () {
   sudo hdiutil attach XQuartz-2.7.6.dmg
   sudo installer -verbose -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
   case "$OCAML_VERSION,$OPAM_VERSION" in
-  4.01.0,1.1.*) brew install opam ;;
-  4.01.0,1.2.*) brew update; brew install opam --HEAD ;;
-  4.02.1,1.1.*) brew install opam ;;
-  4.02.1,1.2.*) brew update; brew install opam --HEAD ;;
+  4.02.1,1.2.0) brew update; brew install opam ;;
+  4.02.1,1.2.0) brew update; brew install opam ;;
+  4.02.1,1.2.1) brew update; brew install opam --HEAD ;;
+  4.02.1,1.2.1) brew update; brew install opam --HEAD ;;
   *) echo Unknown $OCAML_VERSION,$OPAM_VERSION; exit 1 ;;
   esac
 }

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -53,12 +53,6 @@ function build_one {
   echo build one: $pkg
   rm -rf ~/.opam
   opam init .
-  case $OCAML_VERSION,$TRAVIS_OS_NAME in
-  4.02.1,osx)
-    opam switch 4.02.1
-    eval `opam config env`
-    ;;
-  esac
   echo Current switch is:
   opam switch
   # test for installability


### PR DESCRIPTION
Since Homebrew now has OCaml 4.02.1, the other options no
longer apply, so clean this up.