### PR TITLE
Coq depends only on Camlp5

### DIFF
--- a/packages/coq/coq.8.4.5/descr
+++ b/packages/coq/coq.8.4.5/descr
@@ -1,2 +1,1 @@
-Formal proof management system
-
+Formal proof management system.

--- a/packages/coq/coq.8.4.5/opam
+++ b/packages/coq/coq.8.4.5/opam
@@ -4,12 +4,14 @@ homepage: "https://coq.inria.fr/"
 dev-repo: "git://scm.gforge.inria.fr/coq/coq.git"
 bug-reports: "https://coq.inria.fr/bugs/"
 build: [
-  ["./configure" "-configdir" "%{lib}%/coq/config" "-mandir" man "-docdir" doc "--prefix" prefix "--usecamlp5" { camlp5:installed } "--camlp5dir" { camlp5:installed } "%{lib}%/camlp5" { camlp5:installed } "--usecamlp4" { camlp4:installed} "--coqide" "no"]
+  ["./configure" "-configdir" "%{lib}%/coq/config" "-mandir" man "-docdir" doc "--prefix" prefix "--usecamlp5" "--camlp5dir" "%{lib}%/camlp5" "--coqide" "no"]
   [make "-j%{jobs}%" "world"]
   [make "-j%{jobs}%" "states"]
   [make "install"]
 ]
-depends: ["camlp5" | "camlp4"]
+depends: [
+  "camlp5"
+]
 patches: [
   "build_with_trunk.patch" { ocaml-version >= "4.03" }
 ]


### PR DESCRIPTION
Because many additional libraries require Camlp5 to work well (mainly SSReflect, see the [ssreflect bench](https://coq-bench.github.io/clean/Linux-x86_64-4.02.1-1.2.0/stable/8.4.5/ssreflect/1.5.0.html)), the Coq packages now depends only on Camlp5.