### PR TITLE
uutf.0.9.4: should use conflicts not depopt constraint.

### DIFF
--- a/packages/uutf/uutf.0.9.4/opam
+++ b/packages/uutf/uutf.0.9.4/opam
@@ -9,8 +9,9 @@ tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.00.0"]
 depends: ["ocamlfind"]
-depopts: ["cmdliner" { >= "0.9.6" }
+depopts: ["cmdliner"
           "cmdliner" {test} ]
+conflicts : ["cmdliner" { < "0.9.6" } ]
 build:
 [
   [ "ocaml" "pkg/git.ml" ]


### PR DESCRIPTION
need more sleep. Not sure why #3665 was merged.