### PR TITLE
mustache.1.0.1 - via opam-publish

### DIFF
--- a/packages/mustache/mustache.1.0.1/descr
+++ b/packages/mustache/mustache.1.0.1/descr
@@ -1,0 +1,3 @@
+Mustache logic-less templates in OCaml
+
+Manual for mustache: http://mustache.github.io/mustache.5.html

--- a/packages/mustache/mustache.1.0.1/opam
+++ b/packages/mustache/mustache.1.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: "Rudi Grinberg"
+homepage: "https://github.com/rgrinberg/ocaml-mustache"
+bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
+license: "MIT"
+dev-repo: "https://github.com/rgrinberg/ocaml-mustache.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "mustache"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build & >= "0.4.0"}
+  "ezjsonm" {>= "0.4.0"}
+  "sexplib"
+  "re"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mustache/mustache.1.0.1/url
+++ b/packages/mustache/mustache.1.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ocaml-mustache/archive/v1.0.1.tar.gz"
+checksum: "f8363183b1ebc46a9d6a0c998814d7be"


### PR DESCRIPTION
Mustache logic-less templates in OCaml

Manual for mustache: http://mustache.github.io/mustache.5.html
---
* Homepage: https://github.com/rgrinberg/ocaml-mustache
* Source repo: https://github.com/rgrinberg/ocaml-mustache.git
* Bug tracker: https://github.com/rgrinberg/ocaml-mustache/issues

---
Pull-request generated by opam-publish v0.2