### PR TITLE
Missing dependency from async_smtp to async_extended

### DIFF
--- a/packages/async_smtp/async_smtp.112.17.00/opam
+++ b/packages/async_smtp/async_smtp.112.17.00/opam
@@ -8,4 +8,5 @@ remove: [["ocamlfind" "remove" "async_smtp"]]
 depends: ["camlp4"
           "core"          {>= "109.38.00" & < "112.18.00"}
           "core_extended" {>= "109.36.00" & < "112.18.00"}
-          "email_message" {>= "109.38.00" & < "112.18.00"}]
+          "email_message" {>= "109.38.00" & < "112.18.00"}
+          "async_extended"{>= "112.17.00" & < "112.18.00"}]


### PR DESCRIPTION
I have no idea about which other version works, so I fixed to a known working one.