### PR TITLE
base-no-ppx available when ocaml-version != 4.02

### DIFF
--- a/packages/base-no-ppx/base-no-ppx.base/opam
+++ b/packages/base-no-ppx/base-no-ppx.base/opam
@@ -1,3 +1,3 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-ocaml-version: [< "4.02.0"]
+available: [ ocaml-version < "4.02.0" | ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
Since [ppx_tools](https://github.com/alainfrisch/ppx_tools/) is not yet supported on trunk, I propose this change to allow package that depends on (base-no-ppx | ppx-tools) to be able to build.