### PR TITLE
(travis) Fixed 1.1 check for availability again

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -61,11 +61,9 @@ function build_one {
   opam switch
   # test for installability
   echo "Checking for availability"
-  if ! opam list $pkg; then
+  if ! opam install $pkg --dry-run; then
       echo "Package unavailable."
-      unav_arg=$(if [[ $OPAM_VERSION = 1.1.* ]];
-                 then echo "-a"; else echo "-A"; fi)
-      if opam list $unav_arg $pkg; then
+      if opam show $pkg; then
           echo "Package is unavailable on this configuration, skipping:"
           opam install $pkg --dry-run || true
       else


### PR DESCRIPTION
in 1.1, `opam list pkg.version` doesn't return failure when `version` is unavailable but others are. This has been fixed in 1.2,
but `opam install --dry-run` is safer and works on both. The meaning is a bit different though:
  - `opam list` would report packages that are explicitely unavailable
  - `opam install --dry` reports all packages that can not be installed, e.g. because of unavailable dependencies

So with this change, packages marked available on a given OCaml
version but that can't be installed on that version due to
dependencies will pass tests. There is no clear policy yet: such
packages are dubbed "bad" by the Opam Weather Service
(http://ows.irill.org). It sounds OK to let them pass and not force
them to include constraints that they may not intrisically need, but
OTOH it means we pass on something we didn't test, and the package may
become broken later on if the dependency constraint is relaxed and
they _were_ relying themselves on the OCaml version...

OPAM 1.1 also didn't have `opam list --unavailable`, so it's also
replaced with `opam show`, that reliably succeeds on unavailable
packages but fails on non existing versions, in 1.1 and 1.2