### PR TITLE
stringext.1.3.0 - via opam-publish

### DIFF
--- a/packages/stringext/stringext.1.3.0/descr
+++ b/packages/stringext/stringext.1.3.0/descr
@@ -1,0 +1,5 @@
+Extra string functions for OCaml
+
+Provides a single module named Stringext that provides a grab bug of often used
+but missing string functions from the stdlib. E.g, split, full_split, cut,
+rcut, etc.xtra string functions for OCaml

--- a/packages/stringext/stringext.1.3.0/opam
+++ b/packages/stringext/stringext.1.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer:   "rudi.grinberg@gmail.com"
+authors:      "Rudi Grinberg"
+homepage:     "https://github.com/rgrinberg/stringext"
+bug-reports:  "https://github.com/rgrinberg/stringext/issues"
+license:      "MIT"
+dev-repo:     "https://github.com/rgrinberg/stringext.git"
+
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+
+build-doc: ["ocaml" "setup.ml" "-doc"]
+
+install: ["ocaml" "setup.ml" "-install"]
+
+remove: ["ocamlfind" "remove" "stringext"]
+
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+]
+
+available: [ocaml-version >= "4.00.0"]

--- a/packages/stringext/stringext.1.3.0/url
+++ b/packages/stringext/stringext.1.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/stringext/archive/v1.3.0.tar.gz"
+checksum: "fe7a32524a90cf9ca89c700f75fc907b"


### PR DESCRIPTION
Extra string functions for OCaml

Provides a single module named Stringext that provides a grab bug of often used
but missing string functions from the stdlib. E.g, split, full_split, cut,
rcut, etc.xtra string functions for OCaml
---
* Homepage: https://github.com/rgrinberg/stringext
* Source repo: https://github.com/rgrinberg/stringext.git
* Bug tracker: https://github.com/rgrinberg/stringext/issues

---
Pull-request generated by opam-publish v0.2