### PR TITLE
Ctypes 0.4.0 netlink fix

### DIFF
--- a/packages/netlink/netlink.0.1.0/opam
+++ b/packages/netlink/netlink.0.1.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "obuild"
   "ocamlfind"
-  "ctypes"
+  "ctypes" {< "0.4.0"}
 ]
 os: [ "linux" ]
 depexts: [


### PR DESCRIPTION
Netlink fails to build with the latest ctypes due to an obuild issue: https://github.com/ocaml-obuild/obuild/issues/126