### PR TITLE
ocaml-planet.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-planet/ocaml-planet.0.1/descr
+++ b/packages/ocaml-planet/ocaml-planet.0.1/descr
@@ -1,0 +1,10 @@
+A planet (feed aggregator) in OCaml.
+
+A library for aggregating RSS2 and Atom feeds in OCaml.
+
+Features:
+
+* Performs deduplication.
+* Sorts the posts from most recent to oldest.
+* Supports pagination and generating well-formed html prefix snippets.
+* Depends on ocamlnet for html parsing.

--- a/packages/ocaml-planet/ocaml-planet.0.1/opam
+++ b/packages/ocaml-planet/ocaml-planet.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "sk826@cl.cam.ac.uk"
+authors: "KC Sivaramakrishnan"
+homepage: "https://github.com/kayceesrk/ocaml-planet"
+bug-reports: "https://github.com/kayceesrk/ocaml-planet/issues"
+license: "ISC"
+dev-repo: "https://github.com/kayceesrk/ocaml-planet.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "ocaml_planet"]
+]
+depends: [
+  "ocamlnet" {>= "4.0.2"}
+  "lwt" {>= "2.4.7"}
+  "cohttp" {>= "0.15.1"}
+  "syndic" {>= "1.2"}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/ocaml-planet/ocaml-planet.0.1/url
+++ b/packages/ocaml-planet/ocaml-planet.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/kayceesrk/ocaml-planet/archive/v0.1.tar.gz"
+checksum: "eb2a1e7ff127f1777674e550fd111045"


### PR DESCRIPTION
A planet (feed aggregator) in OCaml.

A library for aggregating RSS2 and Atom feeds in OCaml.

Features:

* Performs deduplication.
* Sorts the posts from most recent to oldest.
* Supports pagination and generating well-formed html prefix snippets.
* Depends on ocamlnet for html parsing.

---
* Homepage: https://github.com/kayceesrk/ocaml-planet
* Source repo: https://github.com/kayceesrk/ocaml-planet.git
* Bug tracker: https://github.com/kayceesrk/ocaml-planet/issues

---
Pull-request generated by opam-publish v0.2.1