### PR TITLE
tgls.0.8.3 - via opam-publish

### DIFF
--- a/packages/tgls/tgls.0.8.3/descr
+++ b/packages/tgls/tgls.0.8.3/descr
@@ -1,0 +1,11 @@
+Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml
+
+Tgls is a set of independent OCaml libraries providing thin bindings
+to OpenGL libraries. It has support for core OpenGL 3.{2,3} and
+4.{0,1,2,3,4} and OpenGL ES 2 and 3.{0,1}.
+
+Tgls depends on [ocaml-ctypes][1] and the C OpenGL library of your
+platform. It is distributed under the BSD3 license.
+          
+[1]: https://github.com/ocamllabs/ocaml-ctypes
+

--- a/packages/tgls/tgls.0.8.3/opam
+++ b/packages/tgls/tgls.0.8.3/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/tgls"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/tgls/doc/"
+dev-repo: "http://erratique.ch/repos/tgls.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "bindings" "opengl" "opengl-es" "graphics" "org:erratique" ]
+license: "BSD3"
+depends: [ "ocamlfind" "ctypes" {>= "0.4.0"} "ctypes-foreign" ]
+available: [ ocaml-version >= "4.01.0"]
+build: 
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%" ]
+]
+

--- a/packages/tgls/tgls.0.8.3/url
+++ b/packages/tgls/tgls.0.8.3/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/tgls/releases/tgls-0.8.3.tbz"
+checksum: "333e78ef78503d77f49ea9f181e2851a"


### PR DESCRIPTION
Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml

Tgls is a set of independent OCaml libraries providing thin bindings
to OpenGL libraries. It has support for core OpenGL 3.{2,3} and
4.{0,1,2,3,4} and OpenGL ES 2 and 3.{0,1}.

Tgls depends on [ocaml-ctypes][1] and the C OpenGL library of your
platform. It is distributed under the BSD3 license.
          
[1]: https://github.com/ocamllabs/ocaml-ctypes


---
* Homepage: http://erratique.ch/software/tgls
* Source repo: http://erratique.ch/repos/tgls.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---
Pull-request generated by opam-publish v0.2.1