### PR TITLE
Bignum doesn't need zarith 1.2 specifically

### DIFF
--- a/packages/bignum/bignum.111.08.00/opam
+++ b/packages/bignum/bignum.111.08.00/opam
@@ -14,5 +14,5 @@ depends: ["camlp4"
           "ocamlfind" {>= "1.3.2"}
           "core" {= "111.08.00"}
           "re2" {= "111.08.00"}
-          "zarith" {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.00.1"]

--- a/packages/bignum/bignum.111.13.00/opam
+++ b/packages/bignum/bignum.111.13.00/opam
@@ -13,5 +13,5 @@ remove: [
 depends: ["camlp4"
           "ocamlfind" {>= "1.3.2"}
           "core_kernel" {= "111.13.00"}
-          "zarith" {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.00.1"]

--- a/packages/bignum/bignum.111.17.00/opam
+++ b/packages/bignum/bignum.111.17.00/opam
@@ -13,5 +13,5 @@ remove: [
 depends: ["camlp4"
           "ocamlfind" {>= "1.3.2"}
           "core_kernel" {>= "111.17.00" & <= "111.25.00"}
-          "zarith" {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.00.1"]

--- a/packages/bignum/bignum.111.28.00/opam
+++ b/packages/bignum/bignum.111.28.00/opam
@@ -13,5 +13,5 @@ remove: [
 depends: ["camlp4"
           "ocamlfind" {>= "1.3.2"}
           "core_kernel" {= "111.28.00"}
-          "zarith" {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.00.1"]

--- a/packages/bignum/bignum.112.01.00/opam
+++ b/packages/bignum/bignum.112.01.00/opam
@@ -14,5 +14,5 @@ depends: ["camlp4"
           "ocamlfind"   {>= "1.3.2"}
           "core_kernel" {>= "112.01.00" & < "112.02.00"}
           "typerep"     {>= "111.17.00" & < "111.18.00"}
-          "zarith"      {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.00.1"]

--- a/packages/bignum/bignum.112.06.00/opam
+++ b/packages/bignum/bignum.112.06.00/opam
@@ -14,5 +14,5 @@ depends: ["camlp4"
           "ocamlfind" {>= "1.3.2"}
           "core_kernel" {>= "112.06.00" & < "112.07.00"}
           "typerep" {>= "112.06.00" & < "112.07.00"}
-          "zarith" {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.00.1"]

--- a/packages/bignum/bignum.112.06.02/opam
+++ b/packages/bignum/bignum.112.06.02/opam
@@ -14,5 +14,5 @@ depends: ["camlp4"
           "ocamlfind" {>= "1.3.2"}
           "core_kernel" {>= "112.06.00" & < "112.07.00"}
           "typerep" {>= "112.06.00" & < "112.07.00"}
-          "zarith" {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.00.1"]

--- a/packages/bignum/bignum.112.17.00/opam
+++ b/packages/bignum/bignum.112.17.00/opam
@@ -14,5 +14,5 @@ depends: ["camlp4"
           "ocamlfind"   {>= "1.3.2"}
           "core_kernel" {>= "112.17.00" & < "112.18.00"}
           "typerep"     {>= "112.17.00" & < "112.18.00"}
-          "zarith"      {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.02.1"]


### PR DESCRIPTION
Bignum currently depends on zarith=1.2 but it works fine with the latest version.