### PR TITLE
mirage-unix.2.2.3 - via opam-publish

### DIFF
--- a/packages/mirage-unix/mirage-unix.2.2.3/descr
+++ b/packages/mirage-unix/mirage-unix.2.2.3/descr
@@ -1,0 +1,1 @@
+Mirage OS library for Unix compilation

--- a/packages/mirage-unix/mirage-unix.2.2.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.3/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "unix-build"]
+install: [make "unix-install" "PREFIX=%{prefix}%"]
+remove: [make "unix-uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "cstruct" {>= "1.0.1"}
+  "ocamlfind"
+  "lwt" {>= "2.4.3"}
+  "io-page" {>= "1.5.0"}
+  "mirage-clock-unix" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0"}
+  "mirage-profile" {>= "0.3"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-unix/mirage-unix.2.2.3/url
+++ b/packages/mirage-unix/mirage-unix.2.2.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v2.2.3.tar.gz"
+checksum: "dd3062184058d66327ca9868262811b8"


### PR DESCRIPTION
Mirage OS library for Unix compilation

---
* Homepage: https://github.com/mirage/mirage-platform
* Source repo: https://github.com/mirage/mirage-platform.git
* Bug tracker: https://github.com/mirage/mirage-platform/issues/

---
Pull-request generated by opam-publish v0.2.1