### PR TITLE
mirage-xen.2.2.3 - via opam-publish

### DIFF
--- a/packages/mirage-xen/mirage-xen.2.2.3/descr
+++ b/packages/mirage-xen/mirage-xen.2.2.3/descr
@@ -1,0 +1,1 @@
+Mirage OS library for Xen compilation

--- a/packages/mirage-xen/mirage-xen.2.2.3/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-build"]
+install: [make "xen-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "cstruct" {>= "1.0.1"}
+  "ocamlfind"
+  "io-page" {>= "1.5.0"}
+  "mirage-clock-xen" {>= "1.0.0"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring" {>= "1.0.0"}
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "xen-gnt" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "conf-pkg-config"
+  "mirage-profile" {>= "0.3"}
+  "ocaml-src"
+]
+available: [ocaml-version >= "4.01.0" & os = "linux"]

--- a/packages/mirage-xen/mirage-xen.2.2.3/url
+++ b/packages/mirage-xen/mirage-xen.2.2.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v2.2.3.tar.gz"
+checksum: "dd3062184058d66327ca9868262811b8"


### PR DESCRIPTION
Mirage OS library for Xen compilation

---
* Homepage: https://github.com/mirage/mirage-platform
* Source repo: https://github.com/mirage/mirage-platform.git
* Bug tracker: https://github.com/mirage/mirage-platform/issues/

---
Pull-request generated by opam-publish v0.2.1