### PR TITLE
mirage-xen-ocaml.2.3.0 - via opam-publish

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/descr
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/descr
@@ -1,0 +1,3 @@
+MirageOS headers for the OCaml runtime
+
+The package contains the OCaml runtime patches and build system.

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-ocaml-build"]
+install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "mirage-xen-posix"
+  "conf-pkg-config"
+  "ocaml-src"
+]
+available: [ocaml-version >= "4.01.0" & os = "linux"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/url
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v2.3.0.tar.gz"
+checksum: "4bae08a22f8260f764646620ce83d084"


### PR DESCRIPTION
MirageOS headers for the OCaml runtime

The package contains the OCaml runtime patches and build system.

---
* Homepage: https://github.com/mirage/mirage-platform
* Source repo: https://github.com/mirage/mirage-platform.git
* Bug tracker: https://github.com/mirage/mirage-platform/issues/

---
Pull-request generated by opam-publish v0.2.1