### PR TITLE
Proposal for an `opam-update` package, allowing easy upgrade from 1.2.0 to 1.2.1, from source

### DIFF
--- a/packages/opam-update/opam-update.1.2.1/descr
+++ b/packages/opam-update/opam-update.1.2.1/descr
@@ -1,0 +1,4 @@
+OPAM self-upgrade package
+
+This is a special package that self-upgrades your installation of OPAM.
+In case of trouble, simply remove `~/.opam/opam.*`

--- a/packages/opam-update/opam-update.1.2.1/opam
+++ b/packages/opam-update/opam-update.1.2.1/opam
@@ -9,22 +9,12 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure"]
-  ["rm" "opam.install"]
+  ["make" "lib-ext"]
   [make "opam"]
 ]
 install: [
   ["sh" "-c" "echo \"%{version}%\" > \"%{root}%/opam.version\""]
-  ["install" "--backup" "-m" "755" "src/opam" "%{root}%/opam"]
-]
-remove: ["rm" "-f" "%{root}%/opam" "%{root}%/opam.version"]
-depends: [
-  "ocamlgraph" {build}
-  "cmdliner" {build}
-  "dose" {build & = "3.3"}
-  "cudf" {build}
-  "re" {build & >= "1.2.0"}
-  "ocamlfind" {build}
-  "jsonm" {build}
+  ["install" "-m" "755" "src/opam" "%{root}%/opam"]
 ]
 # Restrict self-upgrade to "official" versions, just in case
 available: [
@@ -38,8 +28,7 @@ available: [
    (compiler = "system" & ocaml-version >= "3.12.1" & ocaml-version < "4.03"))
 ]
 post-messages: [
-"IMPORTANT: OPAM %{version}% has been installed to %{root}%, and it will be used by default for ALL switches. In case of trouble, you can revert with:
-    opam remove %{name}% --switch %{switch}% --no-self-upgrade
-(or remove `%{root}%/opam' and `%{root}%/opam-version')
-" {success}
-]
+"IMPORTANT: OPAM %{version}% has been installed to %{root}%, and it will be used by default for ALL switches. To avoid accidentally downgrading, removing the package WON'T revert this.
+
+In case you need to downgrade to %{opam-version}% temporarily, use option --no-self-upgrade. To really uninstall, delete `%{root}%/opam' and `%{root}%/opam.version'.
+" {success} ]

--- a/packages/opam-update/opam-update.1.2.1/opam
+++ b/packages/opam-update/opam-update.1.2.1/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure"]
+  ["rm" "opam.install"]
+  [make "opam"]
+]
+install: [
+  ["sh" "-c" "echo \"%{version}%\" > \"%{root}%/opam.version\""]
+  ["install" "--backup" "-m" "755" "src/opam" "%{root}%/opam"]
+]
+remove: ["rm" "-f" "%{root}%/opam" "%{root}%/opam.version"]
+depends: [
+  "ocamlgraph" {build}
+  "cmdliner" {build}
+  "dose" {build & = "3.3"}
+  "cudf" {build}
+  "re" {build & >= "1.2.0"}
+  "ocamlfind" {build}
+  "jsonm" {build}
+]
+# Restrict self-upgrade to "official" versions, just in case
+available: [
+  opam-version >= "1.2" & opam-version <= version &
+  (compiler = "3.12.1" |
+   compiler = "4.00.0" |
+   compiler = "4.00.1" |
+   compiler = "4.01.0" |
+   compiler = "4.02.0" |
+   compiler = "4.02.1" |
+   (compiler = "system" & ocaml-version >= "3.12.1" & ocaml-version < "4.03"))
+]
+post-messages: [
+"IMPORTANT: OPAM %{version}% has been installed to %{root}%, and it will be used by default for ALL switches. In case of trouble, you can revert with:
+    opam remove %{name}% --switch %{switch}% --no-self-upgrade
+(or remove `%{root}%/opam' and `%{root}%/opam-version')
+" {success}
+]

--- a/packages/opam-update/opam-update.1.2.1/url
+++ b/packages/opam-update/opam-update.1.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/opam/archive/1.2.1.tar.gz"
+checksum: "6f69a4dcaead73d1685c45647c71e063"

--- a/packages/opam-update/opam-update.1.2.1/url
+++ b/packages/opam-update/opam-update.1.2.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/ocaml/opam/archive/1.2.1.tar.gz"
-checksum: "6f69a4dcaead73d1685c45647c71e063"
+archive: "https://github.com/ocaml/opam/releases/download/1.2.1/opam-full-1.2.1.tar.gz"
+checksum: "04e8823a099ab631943952e4c2ab18fc"


### PR DESCRIPTION
This leverages the "self-upgrade" feature introduced in 1.2.0: the
package compiles OPAM 1.2.1 from source in the current switch
(checking that it's not an experimental one) and installs the binary
to OPAMROOT, together with a version file (to prevent downgrading).

Then, the system OPAM (1.2.0) checks these files and exec()s the newer
version transparently on boot. Since the repository format is
compatible, there is no problem with uninstalling the upgrade.

`opam config report` can be used to check the usage of the feature,
and `--no-self-upgrade` can be used to bypass it. There are several
safeguards against looping, downgrading or getting confused (if the
system OPAM is a development version, there is a warning).

I do believe that can be a nice way for people using system packages
to get the update more quickly.