### PR TITLE
io-page.1.5.1 - via opam-publish

### DIFF
--- a/packages/io-page/io-page.1.5.1/descr
+++ b/packages/io-page/io-page.1.5.1/descr
@@ -1,0 +1,1 @@
+Allocate memory pages suitable for aligned I/O

--- a/packages/io-page/io-page.1.5.1/opam
+++ b/packages/io-page/io-page.1.5.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/io-page"
+dev-repo:     "https://github.com/mirage/io-page.git"
+bug-reports:  "https://github.com/mirage/io-page/issues"
+authors: [
+  "Anil Madhavapeddy"
+  "Dave Scott"
+  "Thomas Gazagnaire"
+]
+tags: ["org:mirage"]
+build: [
+  [ "./configure" "--prefix" prefix
+     "--%{mirage-xen-ocaml:enable}%-xen"
+  ]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "io-page"]
+depends: [
+  "ocamlfind"
+  "cstruct" {>="1.1.0"}
+  "ounit" {test}
+]
+depopts: [
+  "mirage-xen-ocaml"
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/io-page/io-page.1.5.1/url
+++ b/packages/io-page/io-page.1.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/io-page/archive/v1.5.1.tar.gz"
+checksum: "59256c3963d392cd8ea4c56f1f04e34b"


### PR DESCRIPTION
Allocate memory pages suitable for aligned I/O

---
* Homepage: https://github.com/mirage/io-page
* Source repo: https://github.com/mirage/io-page.git
* Bug tracker: https://github.com/mirage/io-page/issues

---
Pull-request generated by opam-publish v0.2.1