### PR TITLE
Add optcomp dependencies to websocket.

### DIFF
--- a/packages/websocket/websocket.0.7/opam
+++ b/packages/websocket/websocket.0.7/opam
@@ -15,5 +15,6 @@ depends: [
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "ssl"
   "ocplib-endian" {>="0.4"}
+  "optcomp"
 ]
 ocaml-version: [>="4.00.0"]

--- a/packages/websocket/websocket.0.8.1/opam
+++ b/packages/websocket/websocket.0.8.1/opam
@@ -15,5 +15,6 @@ depends: [
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "ssl"
   "ocplib-endian" {>= "0.4"}
+  "optcomp"
 ]
 ocaml-version: [>="4.00.0"]

--- a/packages/websocket/websocket.0.8/opam
+++ b/packages/websocket/websocket.0.8/opam
@@ -15,5 +15,6 @@ depends: [
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "ssl"
   "ocplib-endian" {>="0.4"}
+  "optcomp"
 ]
 ocaml-version: [>="4.00.0"]


### PR DESCRIPTION
websocket versions [0.7][websocket07], [0.8][websocket08] and [0.8.1][websocket081] depend on optcomp.

[websocket07]: https://github.com/vbmithr/ocaml-websocket/blob/0.7/_oasis#L13
[websocket081]: https://github.com/vbmithr/ocaml-websocket/blob/0.8.1/_oasis#L13
[websocket08]: https://github.com/vbmithr/ocaml-websocket/blob/0.8/_oasis#L13

See @andrewray's [comments](https://github.com/ocaml/opam-repository/pull/3768#issuecomment-83681455) under #3768.