### PR TITLE
rresult.0.1.0 - via opam-publish

### DIFF
--- a/packages/rresult/rresult.0.1.0/descr
+++ b/packages/rresult/rresult.0.1.0/descr
@@ -1,0 +1,9 @@
+Result value combinators for OCaml
+
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines a result type and combinators to operate on
+these values.
+
+Rresult has no dependency and is distributed under the BSD3 license.
+

--- a/packages/rresult/rresult.0.1.0/opam
+++ b/packages/rresult/rresult.0.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "BSD3"
+available: [ ocaml-version >= "4.01.0"]
+depends: ["ocamlfind"]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"]
+]

--- a/packages/rresult/rresult.0.1.0/url
+++ b/packages/rresult/rresult.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/rresult/releases/rresult-0.1.0.tbz"
+checksum: "df97d537e07099bd90ee5a7c74652956"


### PR DESCRIPTION
Result value combinators for OCaml

Rresult is an OCaml module for handling computation results and errors
in an explicit and declarative manner, without resorting to
exceptions. It defines a result type and combinators to operate on
these values.

Rresult has no dependency and is distributed under the BSD3 license.


---
* Homepage: http://erratique.ch/software/rresult
* Source repo: http://erratique.ch/repos/rresult.git
* Bug tracker: https://github.com/dbuenzli/rresult/issues

---
Pull-request generated by opam-publish v0.2.1