### PR TITLE
mtime.0.8.0 - via opam-publish

### DIFF
--- a/packages/mtime/mtime.0.8.0/descr
+++ b/packages/mtime/mtime.0.8.0/descr
@@ -1,0 +1,10 @@
+Monotonic wall-clock time for OCaml
+
+Mtime is an OCaml module to access monotonic wall-clock time. It
+allows to measure time spans without being subject to operating system
+calendar time adjustments.
+
+Mtime depends only on your platform system library. The optional
+JavaScript support depends on [js_of_ocaml][1]. It is distributed
+under the BSD3 license.
+

--- a/packages/mtime/mtime.0.8.0/opam
+++ b/packages/mtime/mtime.0.8.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/mtime"
+doc: "http://erratique.ch/software/mtime"
+dev-repo: "http://erratique.ch/repos/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+tags: [ "time" "monotonic" "system" "org:erratique" ]
+license: "BSD3"
+available: [ ocaml-version >= "4.01.0"]
+# FIXME this should eventually be a deptopt, build system brain damage
+depends: [ "ocamlfind" "js_of_ocaml" ] 
+# depopts: [ "js_of_ocaml" ] 
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "jsoo=%{js_of_ocaml:installed}%" ]
+]

--- a/packages/mtime/mtime.0.8.0/url
+++ b/packages/mtime/mtime.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/mtime/releases/mtime-0.8.0.tbz"
+checksum: "bd36b1821e1db62ccea5b47e6fb5be98"


### PR DESCRIPTION
Monotonic wall-clock time for OCaml

Mtime is an OCaml module to access monotonic wall-clock time. It
allows to measure time spans without being subject to operating system
calendar time adjustments.

Mtime depends only on your platform system library. The optional
JavaScript support depends on [js_of_ocaml][1]. It is distributed
under the BSD3 license.


---
* Homepage: http://erratique.ch/software/mtime
* Source repo: http://erratique.ch/repos/mtime.git
* Bug tracker: https://github.com/dbuenzli/mtime/issues

---
Pull-request generated by opam-publish v0.2.1