### PR TITLE
conduit 0.7.x conflict with tls 0.4.0+ 

### DIFF
--- a/packages/conduit/conduit.0.7.1/opam
+++ b/packages/conduit/conduit.0.7.1/opam
@@ -32,6 +32,7 @@ conflicts: [
   "mirage-types" {<"2.0.0"}
   "dns" {<"0.10.0"}
   "tls" {<"0.2.0"}
+  "tls" {>="0.4.0"}
   "vchan" {<"2.0.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/conduit/conduit.0.7.2/opam
+++ b/packages/conduit/conduit.0.7.2/opam
@@ -32,6 +32,7 @@ conflicts: [
   "mirage-types" {<"2.0.0"}
   "dns" {<"0.10.0"}
   "tls" {<"0.2.0"}
+  "tls" {>="0.4.0"}
   "vchan" {<"2.0.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
```
  File "lib/conduit_lwt_tls.ml", line 62, characters 35-47:
  Error: The function applied to this argument has type
           ?ciphers:Tls.Ciphersuite.ciphersuite list ->
           ?version:Tls.Core.tls_version * Tls.Core.tls_version ->
           ?hashes:Nocrypto.Hash.hash list ->
           ?reneg:bool ->
           ?certificates:Tls.Config.own_cert ->
           ?authenticator:X509_lwt.authenticator -> Tls.Config.server
  This argument cannot be applied with label ~certificate
```