### PR TITLE
constrain older async_ssl to right ctypes version

### DIFF
--- a/packages/async_ssl/async_ssl.111.06.00/opam
+++ b/packages/async_ssl/async_ssl.111.06.00/opam
@@ -11,7 +11,7 @@ depends: ["camlp4"
           "pa_bench" {>= "109.55.00" & <= "109.55.02"}
           "pa_ounit" {>= "109.53.00" & <= "109.53.02"}
           "sexplib" {= "111.03.00"}
-          "ctypes" "ctypes-foreign"]
+          "ctypes" {>= "0.3.2" & < "0.4.0"} "ctypes-foreign"]
 ocaml-version: [>= "4.00.0"]
 depexts: [
   [["debian"] ["libssl-dev"]]

--- a/packages/async_ssl/async_ssl.111.08.00/opam
+++ b/packages/async_ssl/async_ssl.111.08.00/opam
@@ -11,7 +11,7 @@ depends: ["camlp4"
           "pa_bench" {>= "109.55.00" & <= "109.55.02"}
           "pa_ounit" {>= "109.53.00" & <= "109.53.02"}
           "sexplib" {>= "111.03.00" & <= "111.17.00"}
-          "ctypes" "ctypes-foreign"]
+          "ctypes" {>= "0.3.2" & < "0.4.0"} "ctypes-foreign"]
 ocaml-version: [>= "4.00.0"]
 depexts: [
   [["debian"] ["libssl-dev"]]


### PR DESCRIPTION
Not doing this causes OCaml 4.01.0 builds to fail (since they cant
use the latest Async_ssl which is 4.02.1 only)