### PR TITLE
hdf does not compile on ocaml 4.02

### DIFF
--- a/packages/hdf/hdf.0.9.1/opam
+++ b/packages/hdf/hdf.0.9.1/opam
@@ -20,3 +20,4 @@ depexts: [
   [["debian"] ["libhdf4-dev" "hdf4-tools"]]
   [["ubuntu"] ["libhdf4-dev" "hdf4-tools"]]
 ]
+available: [ ocaml-version < "4.02.0" ]


### PR DESCRIPTION
```
File "myocamlbuild.ml", line 588, characters 22-103:
  Error: This expression has type Lexing.lexbuf
         but an expression was expected of type
           Ocamlbuild_pack.Loc.source = string
```

/cc @hcarty