### PR TITLE
Add `ctypes-foreign` to the older async_ssl releases

### DIFF
--- a/packages/async_ssl/async_ssl.111.21.00/opam
+++ b/packages/async_ssl/async_ssl.111.21.00/opam
@@ -11,7 +11,7 @@ depends: ["camlp4"
           "pa_bench" {>= "109.55.00" & < "112.07.00"}
           "pa_ounit" {>= "109.53.00" & < "111.29.00"}
           "sexplib" {>= "111.03.00" & < "112.07.00"}
-          "ctypes" {>= "0.3.2" & < "0.4.0"}]
+          "ctypes" {>= "0.3.2" & < "0.4.0"} "ctypes-foreign"]
 ocaml-version: [>= "4.00.0"]
 depexts: [
   [["debian"] ["libssl-dev"]]

--- a/packages/async_ssl/async_ssl.112.17.00/opam
+++ b/packages/async_ssl/async_ssl.112.17.00/opam
@@ -11,7 +11,7 @@ depends: ["camlp4"
           "pa_bench" {>= "109.55.00" & < "112.07.00"}
           "pa_ounit" {>= "112.17.00" & < "112.18.00"}
           "sexplib"  {>= "112.17.00" & < "112.18.00"}
-          "ctypes"   {>= "0.3.2" & < "0.4.0"}]
+          "ctypes"   {>= "0.3.2" & < "0.4.0"} "ctypes-foreign"]
 ocaml-version: [>= "4.02.1"]
 depexts: [
   [["debian"] ["libssl-dev"]]


### PR DESCRIPTION
They use libffi and so need to pull in the depext