### PR TITLE
merge-queues.0.2.0 - via opam-publish

### DIFF
--- a/packages/merge-queues/merge-queues.0.2.0/descr
+++ b/packages/merge-queues/merge-queues.0.2.0/descr
@@ -1,0 +1,3 @@
+Mergeable queues
+
+The package implements "mergeable" queues, ie. persistent queues with a fast merge operation.

--- a/packages/merge-queues/merge-queues.0.2.0/opam
+++ b/packages/merge-queues/merge-queues.0.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Benjamin Farinier" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/merge-queues"
+bug-reports:  "https://github.com/mirage/merge-queues/issues"
+dev-repo:     "https://github.com/mirage/merge-queues.git"
+license:      "ISC"
+
+build: [
+  ["./configure" "--prefix" prefix "--%{alcotest+git+cohttp:enable}%-tests"]
+  [make]
+]
+build-test: [
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "merge-queues"]
+depends: [
+  "irmin" {>= "0.9.3"}
+  "comparelib"
+  "alcotest"  {test}
+  "git"       {test}
+  "cohttp"    {test}
+]

--- a/packages/merge-queues/merge-queues.0.2.0/url
+++ b/packages/merge-queues/merge-queues.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/merge-queues/archive/0.2.0.tar.gz"
+checksum: "52a3e3d772290a688be2a16a1316ef34"


### PR DESCRIPTION
Mergeable queues

The package implements "mergeable" queues, ie. persistent queues with a fast merge operation.

---
* Homepage: https://github.com/mirage/merge-queues
* Source repo: https://github.com/mirage/merge-queues.git
* Bug tracker: https://github.com/mirage/merge-queues/issues

---
Pull-request generated by opam-publish v0.2.1