### PR TITLE
restrict this version of async_ssl to not be available on darwin

### DIFF
--- a/packages/async_ssl/async_ssl.112.24.00/opam
+++ b/packages/async_ssl/async_ssl.112.24.00/opam
@@ -12,9 +12,9 @@ depends: ["camlp4"
           "pa_ounit" {>= "112.24.00" & < "112.25.00"}
           "sexplib"  {>= "112.24.00" & < "112.25.00"}
           "ctypes"   {>= "0.4.0"}]
-ocaml-version: [>= "4.02.1"]
 depexts: [
   [["debian"] ["libssl-dev"]]
   [["ubuntu"] ["libssl-dev"]]
   [["centos"] ["openssl-devel"]]
 ]
+available: [ ocaml-version >= "4.02.1" & os != "darwin" ]

--- a/packages/async_ssl/async_ssl.112.24.01/opam
+++ b/packages/async_ssl/async_ssl.112.24.01/opam
@@ -16,9 +16,9 @@ depends: ["camlp4"
           "pipebang"   {>= "110.01.00" & < "110.02.00"}
           "sexplib"    {>= "112.24.00" & < "112.25.00"}
           "ctypes"     {>= "0.4.0"}]
-ocaml-version: [>= "4.02.1"]
 depexts: [
   [["debian"] ["libssl-dev"]]
   [["ubuntu"] ["libssl-dev"]]
   [["centos"] ["openssl-devel"]]
 ]
+available: [ ocaml-version >= "4.02.1" & os != "darwin" ]


### PR DESCRIPTION
due to janestreet/async_ssl#3

/cc @trefis 