### PR TITLE
mtime.0.8.1 - via opam-publish

### DIFF
--- a/packages/mtime/mtime.0.8.1/descr
+++ b/packages/mtime/mtime.0.8.1/descr
@@ -1,0 +1,12 @@
+Monotonic wall-clock time for OCaml
+
+Mtime is an OCaml module to access monotonic wall-clock time. It
+allows to measure time spans without being subject to operating system
+calendar time adjustments.
+
+Mtime depends only on your platform system library. The optional
+JavaScript support depends on [js_of_ocaml][1]. It is distributed
+under the BSD3 license.
+
+[1]: http://ocsigen.org/js_of_ocaml/
+

--- a/packages/mtime/mtime.0.8.1/opam
+++ b/packages/mtime/mtime.0.8.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/mtime"
+doc: "http://erratique.ch/software/mtime"
+dev-repo: "http://erratique.ch/repos/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+tags: [ "time" "monotonic" "system" "org:erratique" ]
+license: "BSD3"
+available: [ ocaml-version >= "4.01.0"]
+depends: [ "ocamlfind"
+           "js_of_ocaml" # FIXME should become a deptopt 
+]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "jsoo=%{js_of_ocaml:installed}%" ]
+]

--- a/packages/mtime/mtime.0.8.1/url
+++ b/packages/mtime/mtime.0.8.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/mtime/releases/mtime-0.8.1.tbz"
+checksum: "d1c7b3ef298448ecd7757f62f98e79f4"


### PR DESCRIPTION
Monotonic wall-clock time for OCaml

Mtime is an OCaml module to access monotonic wall-clock time. It
allows to measure time spans without being subject to operating system
calendar time adjustments.

Mtime depends only on your platform system library. The optional
JavaScript support depends on [js_of_ocaml][1]. It is distributed
under the BSD3 license.

[1]: http://ocsigen.org/js_of_ocaml/


---
* Homepage: http://erratique.ch/software/mtime
* Source repo: http://erratique.ch/repos/mtime.git
* Bug tracker: https://github.com/dbuenzli/mtime/issues

---
Pull-request generated by opam-publish v0.2.1