### PR TITLE
`pci-db` fix remove instructions

### DIFF
--- a/packages/pci-db/pci-db.0.3.0/opam
+++ b/packages/pci-db/pci-db.0.3.0/opam
@@ -7,6 +7,6 @@ build: [
   [ make "PREFIX=%{prefix}%" "install" ]
 ]
 
-remove: [[ make "PREFIX=%{prefix}%" "uninstall" ]]
+remove: ["ocamlfind" "remove" "pci-db"]
 
 depends: [ "ocamlfind" "ounit" ]


### PR DESCRIPTION
For some reason the `uninstall` entry of the `Makefile` works only just after doing a `make install`.
