### PR TITLE
merge-ropes.0.2.0 - via opam-publish

### DIFF
--- a/packages/merge-ropes/merge-ropes.0.2.0/descr
+++ b/packages/merge-ropes/merge-ropes.0.2.0/descr
@@ -1,0 +1,3 @@
+Mergeable ropes
+
+The package implements "mergeable" ropes, ie. persistent ropes with a fast merge operation.

--- a/packages/merge-ropes/merge-ropes.0.2.0/opam
+++ b/packages/merge-ropes/merge-ropes.0.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Benjamin Farinier" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/merge-ropes"
+bug-reports:  "https://github.com/mirage/merge-ropes/issues"
+dev-repo:     "https://github.com/mirage/merge-ropes.git"
+license:      "ISC"
+
+build: [
+  ["./configure" "--prefix" prefix "--%{alcotest+irmin-unix:enable}%-tests"]
+  [make]
+]
+build-test: [
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "merge-ropes"]
+depends: [
+  "irmin" {>= "0.9.4"}
+  "comparelib"
+  "alcotest"   {test}
+  "irmin-unix" {test}
+]

--- a/packages/merge-ropes/merge-ropes.0.2.0/url
+++ b/packages/merge-ropes/merge-ropes.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/merge-ropes/archive/0.2.0.tar.gz"
+checksum: "5b988734ddb2b22c53318e03a23bced5"


### PR DESCRIPTION
Mergeable ropes

The package implements "mergeable" ropes, ie. persistent ropes with a fast merge operation.

---
* Homepage: https://github.com/mirage/merge-ropes
* Source repo: https://github.com/mirage/merge-ropes.git
* Bug tracker: https://github.com/mirage/merge-ropes/issues

---
Pull-request generated by opam-publish v0.2.1