### PR TITLE
conduit.0.8.0 - via opam-publish

### DIFF
--- a/packages/conduit/conduit.0.8.0/descr
+++ b/packages/conduit/conduit.0.8.0/descr
@@ -1,0 +1,15 @@
+Network connection library for TCP and SSL
+
+The `conduit` library takes care of establishing and listening for TCP and
+SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways to bind to
+a library (e.g. the C FFI, or the Ctypes library), as well as well as which
+library is used (either OpenSSL or a native OCaml TLS implementation).
+
+If you are using the `Lwt_unix` version of the library, you can set two
+environment variables to control the behaviour of the library:
+
+- `CONDUIT_DEBUG=1` will output debug information to standard error.
+- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.

--- a/packages/conduit/conduit.0.8.0/opam
+++ b/packages/conduit/conduit.0.8.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/ocaml-conduit"
+dev-repo:     "https://github.com/mirage/ocaml-conduit.git"
+bug-reports:  "https://github.com/mirage/ocaml-conduit/issues"
+tags:         "org:mirage"
+
+build:   [make]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "conduit"]
+
+depends: [
+  "ocamlfind"
+  "sexplib" {>="109.15.00"}
+  "stringext"
+  "uri"
+  "cstruct" {>="1.0.1"}
+  "ipaddr" {>="2.5.0"}
+]
+depopts: [
+  "async"
+  "lwt"
+  "ssl"
+  "async_ssl"
+  "mirage-dns"
+  "vchan"
+  "tls"
+]
+conflicts: [
+  "async" {<"109.15.00"}
+  "lwt" {<"2.4.3"}
+  "async_ssl" {>= "112.24.00"}
+  "mirage-types" {<"2.0.0"}
+  "dns" {<"0.10.0"}
+  "tls" {<"0.4.0"}
+  "vchan" {<"2.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/conduit/conduit.0.8.0/url
+++ b/packages/conduit/conduit.0.8.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-conduit/archive/v0.8.0.tar.gz"
+checksum: "b686a295a96a7e3b15d0b6dd316323ee"

--- a/packages/mirage-conduit/mirage-conduit.2.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.0.0/opam
@@ -12,6 +12,6 @@ depends: [
   "mirage-dns" {>="2.0.0"}
   "tcpip"
   "vchan"
-  "conduit" {>="0.6.0"}
+  "conduit" {="0.7.2"}
 ]
 ocaml-version: [>="4.01.0"]

--- a/packages/mirage-conduit/mirage-conduit.2.1.0/descr
+++ b/packages/mirage-conduit/mirage-conduit.2.1.0/descr
@@ -1,0 +1,1 @@
+Virtual package for the Mirage Conduit transports

--- a/packages/mirage-conduit/mirage-conduit.2.1.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/ocaml-conduit"
+dev-repo:     "https://github.com/mirage/ocaml-conduit.git"
+bug-reports:  "https://github.com/mirage/ocaml-conduit/issues"
+tags:         "org:mirage"
+
+build: [
+ [ "ocamlfind" "query" "conduit.mirage" ]
+]
+depends: [
+  "mirage-types" {>="2.0.0"}
+  "mirage-dns" {>="2.0.0"}
+  "tcpip"
+  "vchan"
+  "conduit" {>"0.8.0"}
+  "tls" {>= "0.4.0"}
+]
+available: [ocaml-version >="4.01.0"]


### PR DESCRIPTION
Network connection library for TCP and SSL

The `conduit` library takes care of establishing and listening for TCP and
SSL/TLS connections for the Lwt and Async libraries.

The reason this library exists is to provide a degree of abstraction
from the precise SSL library used, since there are a variety of ways to bind to
a library (e.g. the C FFI, or the Ctypes library), as well as well as which
library is used (either OpenSSL or a native OCaml TLS implementation).

If you are using the `Lwt_unix` version of the library, you can set two
environment variables to control the behaviour of the library:

- `CONDUIT_DEBUG=1` will output debug information to standard error.
- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.

---
* Homepage: https://github.com/mirage/ocaml-conduit
* Source repo: https://github.com/mirage/ocaml-conduit.git
* Bug tracker: https://github.com/mirage/ocaml-conduit/issues

---
Pull-request generated by opam-publish v0.2.1