### PR TITLE
why 2.35 (compilation needs ocaml >= 4.01)

### DIFF
--- a/packages/why/why.2.35/descr
+++ b/packages/why/why.2.35/descr
@@ -1,0 +1,8 @@
+Why is a software verification platform.
+
+Why is not any longer under active development. Our efforts have moved
+to the development of Why3.
+
+Why is still maintained, in particular to provide the Jessie plug-in
+of Frama-C and the Krakatoa front-end for Java.
+

--- a/packages/why/why.2.35/opam
+++ b/packages/why/why.2.35/opam
@@ -20,6 +20,7 @@ tags: [
   "C"
   "ACSL"
 ]
+available: [ ocaml-version >= "4.01.0" ]
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/why/why.2.35/opam
+++ b/packages/why/why.2.35/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2.0"
+maintainer: "Claude.Marche@inria.fr"
+authors: [
+  "Jean-Christophe Filliâtre"
+  "Claude Marché"
+  "Yannick Moy"
+  "Romain Bardou"
+]
+homepage: "http://krakatoa.lri.fr/"
+license: "GNU Lesser General Public License version 2.1"
+doc: ["http://krakatoa.lri.fr/#jessie"]
+tags: [
+  "deductive"
+  "program verification"
+  "specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+  "Java"
+  "JML"
+  "C"
+  "ACSL"
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+  [make "install"]
+]
+depends: [
+  "why3" {>= "0.84"}
+  "frama-c" {>= "20150201"}
+]

--- a/packages/why/why.2.35/url
+++ b/packages/why/why.2.35/url
@@ -1,0 +1,2 @@
+archive: "http://why.lri.fr/download/why-2.35.tar.gz"
+checksum: "10bde72f95de8bc34135a8207cfcc9ec"


### PR DESCRIPTION
compilation needs ocaml >= 4.01