### PR TITLE
cstruct: fix test instructions

### DIFF
--- a/packages/cstruct/cstruct.1.5.0/opam
+++ b/packages/cstruct/cstruct.1.5.0/opam
@@ -15,9 +15,18 @@ build: [
       "--%{lwt:enable}%-lwt"
       "--%{camlp4:enable}%-camlp4"
       "--%{async:enable}%-async"
+      "--%{base-unix:enable}%-unix"]
+  [make]
+]
+build-test: [
+  ["./configure"
+      "--prefix" prefix
+      "--%{lwt:enable}%-lwt"
+      "--%{camlp4:enable}%-camlp4"
+      "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"
       "--%{ounit:enable}%-tests"]
-  [make]
+  [make "test"]
 ]
 install: [make "install"]
 remove:  ["ocamlfind" "remove" "cstruct"]


### PR DESCRIPTION
Fix instructions and dependencies for test, as discussed in https://github.com/ocaml/opam/issues/2076