### PR TITLE
Recent versions of sexplib depend on camlp4

### DIFF
--- a/packages/sexplib/sexplib.111.25.00/opam
+++ b/packages/sexplib/sexplib.111.25.00/opam
@@ -10,8 +10,8 @@ remove: [
   ["ocamlfind" "remove" "sexplib_num"]
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
-depends: ["ocamlfind"]
-depopts: ["camlp4" "type_conv"]
+depends: ["ocamlfind" "camlp4"]
+depopts: ["type_conv"]
 conflicts: [
   "type_conv" {< "111.13.00"}
   "type_conv" {> "111.13.00"}

--- a/packages/sexplib/sexplib.112.01.00/opam
+++ b/packages/sexplib/sexplib.112.01.00/opam
@@ -10,8 +10,8 @@ remove: [
   ["ocamlfind" "remove" "sexplib_num"]
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
-depends: ["ocamlfind"]
-depopts: ["camlp4" "type_conv"]
+depends: ["ocamlfind" "camlp4"]
+depopts: ["type_conv"]
 conflicts: [
   "type_conv" {< "112.01.00"}
   "type_conv" {>= "112.02.00"}

--- a/packages/sexplib/sexplib.112.06.00/opam
+++ b/packages/sexplib/sexplib.112.06.00/opam
@@ -10,9 +10,8 @@ remove: [
   ["ocamlfind" "remove" "sexplib_num"]
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
-depends: ["ocamlfind"]
-depopts: ["camlp4" {>= "4.02.0+1"}
-          "type_conv"]
+depends: ["ocamlfind" "camlp4" {>= "4.02.0+1"}]
+depopts: ["type_conv"]
 conflicts: [
   "type_conv" {< "112.01.00"}
   "type_conv" {>= "112.02.00"}

--- a/packages/sexplib/sexplib.112.17.00/opam
+++ b/packages/sexplib/sexplib.112.17.00/opam
@@ -10,8 +10,8 @@ remove: [
   ["ocamlfind" "remove" "sexplib_num"]
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
-depends: ["ocamlfind"]
-depopts: ["camlp4" "type_conv"]
+depends: ["ocamlfind" "camlp4"]
+depopts: ["type_conv"]
 conflicts: [
   "type_conv" {< "112.01.00"}
   "type_conv" {>= "112.02.00"}

--- a/packages/sexplib/sexplib.112.24.00/opam
+++ b/packages/sexplib/sexplib.112.24.00/opam
@@ -10,8 +10,8 @@ remove: [
   ["ocamlfind" "remove" "sexplib_num"]
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
-depends: ["ocamlfind"]
-depopts: ["camlp4" "type_conv"]
+depends: ["ocamlfind" "camlp4"]
+depopts: ["type_conv"]
 conflicts: [
   "type_conv" {< "112.01.00"}
   "type_conv" {>= "112.02.00"}


### PR DESCRIPTION
```
$ opam install sexplib.112.24.00
The following actions will be performed:
  ∗  install sexplib 112.24.00

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[sexplib.112.24.00] https://ocaml.janestreet.com/ocaml-core/112.24/files/sexplib-112.24.tar.gz downloaded

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[ERROR] The compilation of sexplib failed at "./configure --disable-syntax".
Processing  1/1: [sexplib: ocamlfind remove]
#=== ERROR while installing sexplib.112.24.00 =================================#
# opam-version 1.2.1~rc2
# os           linux
# command      ./configure --disable-syntax
# path         /home/jeremy/.opam/4.02.1/build/sexplib.112.24.00
# compiler     4.02.1
# exit-code    1
# env-file     /home/jeremy/.opam/4.02.1/build/sexplib.112.24.00/sexplib-561-d2c37b.env
# stdout-file  /home/jeremy/.opam/4.02.1/build/sexplib.112.24.00/sexplib-561-d2c37b.out
# stderr-file  /home/jeremy/.opam/4.02.1/build/sexplib.112.24.00/sexplib-561-d2c37b.err
### stderr ###
# W: Field 'camlp4o' is not set
# W: Not_found
# W: Not_found
# W: Not_found
# E: Cannot find external tool 'camlp4o'
# E: Failure("1 configuration error")



=-=- Error report -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
The following actions failed
  ∗  install sexplib 112.24.00
No changes have been performed
```