### PR TITLE
Fix sexplib deps

### DIFF
--- a/packages/sexplib/sexplib.112.06.01/descr
+++ b/packages/sexplib/sexplib.112.06.01/descr
@@ -1,0 +1,5 @@
+Library for serializing OCaml values to and from S-expressions
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib/sexplib.112.06.01/findlib
+++ b/packages/sexplib/sexplib.112.06.01/findlib
@@ -1,0 +1,3 @@
+sexplib
+sexplib_num
+sexplib_unix

--- a/packages/sexplib/sexplib.112.06.01/opam
+++ b/packages/sexplib/sexplib.112.06.01/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "opensource@janestreet.com"
+build: [
+  ["./configure" "--%{type_conv:enable}%-syntax"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "sexplib"]
+  ["ocamlfind" "remove" "sexplib_num"]
+  ["ocamlfind" "remove" "sexplib_unix"]
+]
+depends: ["ocamlfind"]
+depopts: ["camlp4" {>= "4.02.0+1"}
+          "type_conv"]
+conflicts: [
+  "type_conv" {< "112.01.00"}
+  "type_conv" {>= "112.02.00"}
+]
+ocaml-version: [>= "4.02.0"]

--- a/packages/sexplib/sexplib.112.06.01/url
+++ b/packages/sexplib/sexplib.112.06.01/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/112.06/individual/sexplib-112.06.01.tar.gz"
+checksum: "42851d3ce0bc39c432ff6b7c432bc5cf"

--- a/packages/sexplib/sexplib.112.06.01/url
+++ b/packages/sexplib/sexplib.112.06.01/url
@@ -1,2 +1,2 @@
 archive: "https://ocaml.janestreet.com/ocaml-core/112.06/individual/sexplib-112.06.01.tar.gz"
-checksum: "42851d3ce0bc39c432ff6b7c432bc5cf"
+checksum: "dd9005342d2f3124b2006186c5c69949"

--- a/packages/sexplib/sexplib.112.17.01/descr
+++ b/packages/sexplib/sexplib.112.17.01/descr
@@ -1,0 +1,5 @@
+Library for serializing OCaml values to and from S-expressions
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib/sexplib.112.17.01/findlib
+++ b/packages/sexplib/sexplib.112.17.01/findlib
@@ -1,0 +1,3 @@
+sexplib
+sexplib_num
+sexplib_unix

--- a/packages/sexplib/sexplib.112.17.01/opam
+++ b/packages/sexplib/sexplib.112.17.01/opam
@@ -1,0 +1,19 @@
+opam-version: "1"
+maintainer: "opensource@janestreet.com"
+build: [
+  ["./configure" "--%{type_conv:enable}%-syntax"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "sexplib"]
+  ["ocamlfind" "remove" "sexplib_num"]
+  ["ocamlfind" "remove" "sexplib_unix"]
+]
+depends: ["ocamlfind"]
+depopts: ["camlp4" "type_conv"]
+conflicts: [
+  "type_conv" {< "112.01.00"}
+  "type_conv" {>= "112.02.00"}
+]
+ocaml-version: [>= "4.02.1"]

--- a/packages/sexplib/sexplib.112.17.01/url
+++ b/packages/sexplib/sexplib.112.17.01/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/112.17/files/sexplib-112.17.01.tar.gz"
+checksum: "f62bd67e75609fe3e76597bcedcd26e8"

--- a/packages/sexplib/sexplib.112.17.01/url
+++ b/packages/sexplib/sexplib.112.17.01/url
@@ -1,2 +1,2 @@
 archive: "https://ocaml.janestreet.com/ocaml-core/112.17/files/sexplib-112.17.01.tar.gz"
-checksum: "f62bd67e75609fe3e76597bcedcd26e8"
+checksum: "21fc49cd993b66ba4738e0a20ae9a215"

--- a/packages/sexplib/sexplib.112.24.01/descr
+++ b/packages/sexplib/sexplib.112.24.01/descr
@@ -1,0 +1,5 @@
+Library for serializing OCaml values to and from S-expressions
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib/sexplib.112.24.01/findlib
+++ b/packages/sexplib/sexplib.112.24.01/findlib
@@ -1,0 +1,3 @@
+sexplib
+sexplib_num
+sexplib_unix

--- a/packages/sexplib/sexplib.112.24.01/opam
+++ b/packages/sexplib/sexplib.112.24.01/opam
@@ -1,0 +1,19 @@
+opam-version: "1"
+maintainer: "opensource@janestreet.com"
+build: [
+  ["./configure" "--%{type_conv:enable}%-syntax"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "sexplib"]
+  ["ocamlfind" "remove" "sexplib_num"]
+  ["ocamlfind" "remove" "sexplib_unix"]
+]
+depends: ["ocamlfind"]
+depopts: ["camlp4" "type_conv"]
+conflicts: [
+  "type_conv" {< "112.01.00"}
+  "type_conv" {>= "112.02.00"}
+]
+ocaml-version: [>= "4.02.1"]

--- a/packages/sexplib/sexplib.112.24.01/url
+++ b/packages/sexplib/sexplib.112.24.01/url
@@ -1,2 +1,2 @@
 archive: "https://ocaml.janestreet.com/ocaml-core/112.24/files/sexplib-112.24.01.tar.gz"
-checksum: "4bc0e41e750884a63fed7fb8c105c0c8"
+checksum: "afd85fa98296808b2d7831ac39b77c56"

--- a/packages/sexplib/sexplib.112.24.01/url
+++ b/packages/sexplib/sexplib.112.24.01/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/112.24/files/sexplib-112.24.01.tar.gz"
+checksum: "4bc0e41e750884a63fed7fb8c105c0c8"


### PR DESCRIPTION
Targets the same problem as #3841 but by pointing to fresh packages which don't depend on camlp4 anymore.

This is complementary to @yallop's patch, as the old packages are still broken with this PR.