### PR TITLE
textwrap.0.2 - via opam-publish

### DIFF
--- a/packages/textwrap/textwrap.0.2/descr
+++ b/packages/textwrap/textwrap.0.2/descr
@@ -1,0 +1,3 @@
+Text wrapping and filling library
+
+An almost complete port of Python's textwrap library to OCaml.

--- a/packages/textwrap/textwrap.0.2/opam
+++ b/packages/textwrap/textwrap.0.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Sergei Lebedev <superbobry@gmail.com>"
+authors: "Sergei Lebedev <superbobry@gmail.com>"
+homepage: "https://github.com/superbobry/ocaml-textwrap"
+bug-reports: "https://github.com/superbobry/ocaml-textwrap/issues"
+dev-repo: "https://github.com/superbobry/ocaml-textwrap.git"
+license: "MIT"
+build: [
+  ["./configure" "--prefix" "%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "textwrap"]
+depends: "ocamlfind"

--- a/packages/textwrap/textwrap.0.2/url
+++ b/packages/textwrap/textwrap.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/superbobry/ocaml-textwrap/archive/0.2.tar.gz"
+checksum: "1185e1cc3427fcdda0c07dedae842244"


### PR DESCRIPTION
Text wrapping and filling library

An almost complete port of Python's textwrap library to OCaml.

---
* Homepage: https://github.com/superbobry/ocaml-textwrap
* Source repo: https://github.com/superbobry/ocaml-textwrap.git
* Bug tracker: https://github.com/superbobry/ocaml-textwrap/issues

---
Pull-request generated by opam-publish v0.2.1