### PR TITLE
camlhighlight depends on type_conv

### DIFF
--- a/packages/camlhighlight/camlhighlight.3.0/opam
+++ b/packages/camlhighlight/camlhighlight.3.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocamlfind"
   "batteries" {>= "2"}
   "sexplib"
+  "type_conv"
   "tyxml" {>= "3.2" & < "4"}
 ]
 depexts: [


### PR DESCRIPTION
Adding `type_conv` enables the `sexplib` syntax extension.  See #3838.