### PR TITLE
lilis.0.1.3: fix configure and dependencies

### DIFF
--- a/packages/lilis/lilis.0.1.3/opam
+++ b/packages/lilis/lilis.0.1.3/opam
@@ -4,7 +4,7 @@ authors: ["Gabriel Radanne <drupyog@zoho.com>"]
 homepage: "http://drup.github.io/LILiS/"
 license: "MIT"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{cairo2:enable}%-cairo" "--%{tyxml:enable}%-tyxml" "--%{cmdliner:enable}%-glilis-ex"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{cairo2+lablgtk:enable}%-cairo" "--disable-tyxml" "--%{cmdliner:enable}%-glilis-ex"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
@@ -22,4 +22,5 @@ depends: [
 depopts: [
   "cmdliner"
   "cairo2"
+  "lablgtk"
 ]


### PR DESCRIPTION
`lilis.0.1.3` only works with `cairo2` if it is configured with `lablgtk`.
It does not work with any version of `tyxml`.
