### PR TITLE
Bignum doesn't need zarith 1.2 specifically

### DIFF
--- a/packages/bignum/bignum.112.24.00/opam
+++ b/packages/bignum/bignum.112.24.00/opam
@@ -14,5 +14,5 @@ depends: ["camlp4"
           "ocamlfind"   {>= "1.3.2"}
           "core_kernel" {>= "112.24.00" & < "112.25.00"}
           "typerep"     {>= "112.24.00" & < "112.25.00"}
-          "zarith"      {= "1.2"}]
+          "zarith"]
 ocaml-version: [>= "4.02.1"]


### PR DESCRIPTION
Same as #3740 but for the latest version of bignum.