### PR TITLE
Restrict dns cstruct to < 1.6.0 for expr open 'compare'

### DIFF
--- a/packages/dns/dns.0.14.1/opam
+++ b/packages/dns/dns.0.14.1/opam
@@ -28,7 +28,7 @@ remove: [["ocamlfind" "remove" "dns"]]
 depends: [
   "base-bytes"
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"
   "re"
   "cmdliner"


### PR DESCRIPTION
`Packet` contained nonsense `open Cstruct`, too.