### PR TITLE
apron: fix remove & note conflict with gmp

### DIFF
--- a/packages/apron/apron.0.9.10/findlib
+++ b/packages/apron/apron.0.9.10/findlib
@@ -1,1 +1,2 @@
 apron
+gmp

--- a/packages/apron/apron.0.9.10/opam
+++ b/packages/apron/apron.0.9.10/opam
@@ -8,7 +8,10 @@ build: [
   ["make"]
   ["make" "install"]
 ]
-remove: [["ocamlfind" "-remove" "apron"]]
+remove: [
+  ["ocamlfind" "-remove" "apron"]
+  ["ocamlfind" "-remove" "gmp"]
+]
 depends: [
   "ocamlfind"
   "camlidl"
@@ -17,5 +20,8 @@ depends: [
 ]
 patches: [
    "opam.patch"
+]
+conflicts: [
+  "mlgmp"
 ]
 os: ["linux"]

--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -19,3 +19,6 @@ depexts: [
   [["debian"] ["libmpfr-dev"]]
   [["ubuntu"] ["libmpfr-dev"]]
 ]
+conflicts: [
+  "apron"
+]


### PR DESCRIPTION
`apron` installs a findlib package called `gmp`, which is not removed correctly and interferes with `mlgmp`
