### PR TITLE
Added Ascii85 0.2

### DIFF
--- a/packages/ascii85/ascii85.0.2/descr
+++ b/packages/ascii85/ascii85.0.2/descr
@@ -1,4 +1,3 @@
-
 ascii85 - Adobe's Ascii85 encoding as a module and a command line tool
 
 The ascii85 module implements the Ascii85 encoding as defined by Adobe for

--- a/packages/ascii85/ascii85.0.2/descr
+++ b/packages/ascii85/ascii85.0.2/descr
@@ -1,0 +1,8 @@
+
+ascii85 - Adobe's Ascii85 encoding as a module and a command line tool
+
+The ascii85 module implements the Ascii85 encoding as defined by Adobe for
+use in the PostScript language. The module is accompanied by a small
+utility ascii85enc to encode files from the command line.
+
+

--- a/packages/ascii85/ascii85.0.2/opam
+++ b/packages/ascii85/ascii85.0.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "ascii85"
+version: "0.1"
+maintainer: "Christian Lindig <lindig@gmail.com>"
+authors: "Christian Lindig <lindig@gmail.com>"
+homepage: "https://github.com/lindig/ascii85"
+bug-reports: "https://github.com/lindig/ascii85/issues"
+license: "BSD"
+dev-repo: "https://github.com/lindig/ascii85.git"
+build: [
+  [make]
+]
+install: [make "PREFIX=%{prefix}%" "install"]
+remove: [make "PREFIX=%{prefix}%" "remove"]
+available: [ ocaml-version >= "4.01.0" ]
+depends: "ocamlfind"

--- a/packages/ascii85/ascii85.0.2/opam
+++ b/packages/ascii85/ascii85.0.2/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "ascii85"
-version: "0.1"
+version: "0.2"
 maintainer: "Christian Lindig <lindig@gmail.com>"
 authors: "Christian Lindig <lindig@gmail.com>"
 homepage: "https://github.com/lindig/ascii85"

--- a/packages/ascii85/ascii85.0.2/url
+++ b/packages/ascii85/ascii85.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/lindig/ascii85/archive/v0.2.zip"
+checksum: "26c9e8ec6cb29ed2826422d411700177"


### PR DESCRIPTION
I've added a new project – a library and tool for Ascii85 encoding. It starts with version 0.2 rather than 0.1 and I hope this isn't a problem.