### PR TITLE
ouija.0.1.0 - via opam-publish

### DIFF
--- a/packages/ouija/ouija.0.1.0/descr
+++ b/packages/ouija/ouija.0.1.0/descr
@@ -1,0 +1,3 @@
+Ouija is a path resolution library for ocaml
+
+Ouija is designed to resolve restful paths.

--- a/packages/ouija/ouija.0.1.0/opam
+++ b/packages/ouija/ouija.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Afiniate, Inc."
+author: "Afiniate, Inc."
+homepage: "https://github.com/afiniate/ouija"
+bug-reports: "https://github.com/afiniate/ouija/issues"
+license: "OSI Approved :: Apache Software License v2.0"
+dev-repo: "git@github.com:afiniate/ouija.git"
+
+build: [
+    [make]
+]
+
+install: [
+    [make "install" "PREFIX=%{prefix}%"]
+]
+
+remove: [
+    [make "remove" "PREFIX=%{prefix}%"]
+]
+
+
+depends: [ "vrt" {build} "core"  "async"  "async_unix"  "async_shell"  "cohttp"  "atdgen"  "sexplib"  "cryptokit" ]

--- a/packages/ouija/ouija.0.1.0/url
+++ b/packages/ouija/ouija.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/afiniate/ouija/archive/0.1.0.tar.gz"
+checksum: "d7e09f6c3c4fd1859292955b4c756b39"


### PR DESCRIPTION
Ouija is a path resolution library for ocaml

Ouija is designed to resolve restful paths.

---
* Homepage: https://github.com/afiniate/ouija
* Source repo: git@github.com:afiniate/ouija.git
* Bug tracker: https://github.com/afiniate/ouija/issues

---
Pull-request generated by opam-publish v0.2.1