### PR TITLE
Added Ascii85 0.3 - fixes bugs wrt. findlib

### DIFF
--- a/packages/ascii85/ascii85.0.3/descr
+++ b/packages/ascii85/ascii85.0.3/descr
@@ -1,0 +1,7 @@
+ascii85 - Adobe's Ascii85 encoding as a module and a command line tool
+
+The ascii85 module implements the Ascii85 encoding as defined by Adobe for
+use in the PostScript language. The module is accompanied by a small
+utility ascii85enc to encode files from the command line.
+
+

--- a/packages/ascii85/ascii85.0.3/opam
+++ b/packages/ascii85/ascii85.0.3/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "ascii85"
+version: "0.3"
+maintainer: "Christian Lindig <lindig@gmail.com>"
+authors: "Christian Lindig <lindig@gmail.com>"
+homepage: "https://github.com/lindig/ascii85"
+bug-reports: "https://github.com/lindig/ascii85/issues"
+license: "BSD"
+dev-repo: "https://github.com/lindig/ascii85.git"
+build: [
+  [make]
+]
+install: [make "PREFIX=%{prefix}%" "install"]
+remove: [make "PREFIX=%{prefix}%" "remove"]
+available: [ ocaml-version >= "4.01.0" ]
+depends: "ocamlfind"

--- a/packages/ascii85/ascii85.0.3/url
+++ b/packages/ascii85/ascii85.0.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/lindig/ascii85/archive/v0.3.zip"
+checksum: "4d7a5eb46d6e6140fb8948b4151e0fcf"


### PR DESCRIPTION
The previously 0.2 release had a serious bug as the install target would write library files into the directory of the ago package (of which I'm the author). Other problems fixed:

- META files wasn't installed such that ocamlfind would not work
- ascii85.a file wasn't installed
