### PR TITLE
leveldb 1.0.3: fix OCaml 4.02 build

### DIFF
--- a/packages/leveldb/leveldb.1.0.3/files/warn_error.patch
+++ b/packages/leveldb/leveldb.1.0.3/files/warn_error.patch
@@ -1,0 +1,11 @@
+diff --git a/OMakefile b/OMakefile
+index 7ede325..900feb2 100644
+--- a/OMakefile
++++ b/OMakefile
+@@ -1,5 +1,5 @@
+ 
+-OCAMLFLAGS = -w +a-4-6-9-27-28-30..99 -warn-error +a-4-6-9-18-27-28-30..99 -annot -thread
++OCAMLFLAGS = -w +a-4-6-9-27-28-30..99 -warn-error +a-3-6-9-18-27-28-30..99 -annot -thread
+ OCAMLOPTFLAGS += -inline 100
+ 
+ HAS_NATDYNLINK = false

--- a/packages/leveldb/leveldb.1.0.3/opam
+++ b/packages/leveldb/leveldb.1.0.3/opam
@@ -21,4 +21,5 @@ depexts: [
   [["debian"] ["libsnappy-dev"]]
   [["ubuntu"] ["libsnappy-dev"]]
 ]
-patches: [ "fix_snappy_link_issue.patch" ]
+patches: [ "fix_snappy_link_issue.patch"
+           "warn_error.patch" ]


### PR DESCRIPTION
The leveldb build was broken by `-warn-error` and the deprecated `String` functions.  This commit adds a patch to turn deprecation back into a warning.

/cc @mfp