### PR TITLE
mirage-http.2.2.0 - via opam-publish

### DIFF
--- a/packages/mirage-http/mirage-http.2.2.0/descr
+++ b/packages/mirage-http/mirage-http.2.2.0/descr
@@ -1,0 +1,1 @@
+Mirage HTTP client and server driver

--- a/packages/mirage-http/mirage-http.2.2.0/opam
+++ b/packages/mirage-http/mirage-http.2.2.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/mirage-http"
+bug-reports:  "https://github.com/mirage/mirage-http/issues/"
+dev-repo:     "https://github.com/mirage/mirage-http.git"
+
+build:    [make]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "mirage-http"]
+depends: [
+  "ocamlfind" {build}
+  "mirage-types-lwt" {>= "2.0.0"}
+  "mirage-conduit"
+  "lwt" {>= "2.4.3"}
+  "cohttp" {>= "0.12.0"}
+  "camlp4"
+  "sexplib"
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/mirage-http/mirage-http.2.2.0/opam
+++ b/packages/mirage-http/mirage-http.2.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "mirage-types-lwt" {>= "2.0.0"}
   "mirage-conduit"
   "lwt" {>= "2.4.3"}
-  "cohttp" {>= "0.12.0"}
+  "cohttp" {>= "0.16.0"}
   "camlp4"
   "sexplib"
 ]

--- a/packages/mirage-http/mirage-http.2.2.0/url
+++ b/packages/mirage-http/mirage-http.2.2.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/mirage/mirage-http/archive/v2.2.0.tar.gz"
-checksum: "335e85fec271b34618d1f2064abadaf8"
+checksum: "901d47714cb6713a7b3a42bae9749a7c"

--- a/packages/mirage-http/mirage-http.2.2.0/url
+++ b/packages/mirage-http/mirage-http.2.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-http/archive/v2.2.0.tar.gz"
+checksum: "335e85fec271b34618d1f2064abadaf8"


### PR DESCRIPTION
Mirage HTTP client and server driver

---
* Homepage: https://github.com/mirage/mirage-http
* Source repo: https://github.com/mirage/mirage-http.git
* Bug tracker: https://github.com/mirage/mirage-http/issues/

---
Pull-request generated by opam-publish v0.2.1