### PR TITLE
+pa_qualified

### DIFF
--- a/packages/pa_qualified/pa_qualified.0.5/descr
+++ b/packages/pa_qualified/pa_qualified.0.5/descr
@@ -1,0 +1,7 @@
+A syntax extension that implements support for fully qualified module references
+Pa_qualified adds support for fully qualified module references to OCaml.
+If a module reference (in any possible context) starts with "Q.", then
+the rest of the reference denotes a context-independent globally unique
+path (as if the reference was located at the very beginning of the file).
+Qualified references can never be shadowed by other definitions
+(warranty void if "Q" is defined explicitly somewhere).

--- a/packages/pa_qualified/pa_qualified.0.5/findlib
+++ b/packages/pa_qualified/pa_qualified.0.5/findlib
@@ -1,0 +1,1 @@
+pa_qualified

--- a/packages/pa_qualified/pa_qualified.0.5/opam
+++ b/packages/pa_qualified/pa_qualified.0.5/opam
@@ -8,6 +8,7 @@ build: [
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [["ocamlfind" "remove" "pa_qualified"]]
+ocaml-version: [ >= "4.01.0" ]
 depends: [
   "ocamlfind"
   "camlp4"

--- a/packages/pa_qualified/pa_qualified.0.5/opam
+++ b/packages/pa_qualified/pa_qualified.0.5/opam
@@ -1,0 +1,14 @@
+opam-version: "1.1"
+maintainer: "Max Mouratov <mmouratov@gmail.com>"
+homepage: "https://github.com/cakeplus/pa_qualified/"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [["ocamlfind" "remove" "pa_qualified"]]
+depends: [
+  "ocamlfind"
+  "camlp4"
+]

--- a/packages/pa_qualified/pa_qualified.0.5/url
+++ b/packages/pa_qualified/pa_qualified.0.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cakeplus/pa_qualified/archive/0.5.tar.gz"
+checksum: "52c40a4c3967c17a97896168ab69fa3e"

--- a/packages/pa_qualified/pa_qualified.0.5/url
+++ b/packages/pa_qualified/pa_qualified.0.5/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/cakeplus/pa_qualified/archive/0.5.tar.gz"
-checksum: "52c40a4c3967c17a97896168ab69fa3e"
+checksum: "ae26fa6f0f4814a58fdbe2d852c41bff"


### PR DESCRIPTION
Pa_qualified adds support for fully qualified module references to OCaml. If a module reference (in any possible context) starts with "Q.", then the rest of the reference denotes a context-independent globally unique path (as if the reference was located at the very beginning of the file). Qualified references can never be shadowed by other definitions (warranty void if "Q" is defined explicitly somewhere).