### PR TITLE
gccjit.0.1.0 - via opam-publish

### DIFF
--- a/packages/gccjit/gccjit.0.1.0/descr
+++ b/packages/gccjit/gccjit.0.1.0/descr
@@ -1,0 +1,17 @@
+Bindings for the GCC 5 `libgccjit` library
+
+`libgccjit` is an embeddable shared library being included in GCC 5 for adding
+compilation to existing programs using GCC as the backend.
+
+In order for compilation to be successful the library `libgccjit` needs to be
+found by the C compiler using the `-lgccjit` flag.  If the `libgccjit` library in
+your system is a non-standard location, please set the `LIBGCCJIT_DIR` environment
+variable before installing this package, like this:
+
+```
+LIBGCCJIT_DIR=<directory where libgccjit lives> opam install gccjit
+```
+
+See https://gcc.gnu.org/wiki/JIT for instructions how to build `libgccjit`.
+
+See the homepage for examples and tutorial.

--- a/packages/gccjit/gccjit.0.1.0/opam
+++ b/packages/gccjit/gccjit.0.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+authors: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+homepage: "https://www.github.com/nojb/ocaml-gccjit"
+bug-reports: "https://www.github.com/nojb/ocaml-gccjit/issues"
+license: "MIT"
+dev-repo: "https://www.github.com/nojb/ocaml-gccjit.git"
+build: [make]
+build-doc: [make "doc"]
+depends: [
+  "ctypes" {>= "0.4"}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.01.0"]
+depexts: [
+  ["linux" "source"]
+  ["https://gist.githubusercontent.com/nojb/774a5debc6ffcc4acb99/raw/e4e57b14826b03a522c08bbd5cfac891aefe649a/install-libgccjit-from-source.sh"]
+]
+post-messages: [
+
+"In order for compilation to be successful the library `libgccjit` needs to be
+found by the C compiler using the `-lgccjit` flag.  If the `libgccjit` library in
+your system is a non-standard location, please set the `LIBGCCJIT_DIR` environment
+variable before installing this package, like this:
+
+```
+LIBGCCJIT_DIR=<directory where libgccjit lives> opam install gccjit
+```
+
+See https://gcc.gnu.org/wiki/JIT for instructions how to build `libgccjit`.
+" {failure}
+
+]

--- a/packages/gccjit/gccjit.0.1.0/url
+++ b/packages/gccjit/gccjit.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nojb/ocaml-gccjit/archive/v0.1.0.tar.gz"
+checksum: "ada9d2557aa8e8d3fd0c241e384c831d"


### PR DESCRIPTION
Bindings for the GCC 5 `libgccjit` library

`libgccjit` is an embeddable shared library being included in GCC 5 for adding
compilation to existing programs using GCC as the backend.

In order for compilation to be successful the library `libgccjit` needs to be
found by the C compiler using the `-lgccjit` flag.  If the `libgccjit` library in
your system is a non-standard location, please set the `LIBGCCJIT_DIR` environment
variable before installing this package, like this:

```
LIBGCCJIT_DIR=<directory where libgccjit lives> opam install gccjit
```

See https://gcc.gnu.org/wiki/JIT for instructions how to build `libgccjit`.

See the homepage for examples and tutorial.

---
* Homepage: https://www.github.com/nojb/ocaml-gccjit
* Source repo: https://www.github.com/nojb/ocaml-gccjit.git
* Bug tracker: https://www.github.com/nojb/ocaml-gccjit/issues

---
Pull-request generated by opam-publish v0.2.1