### PR TITLE
Fix checksum of cubicle.1.0.1: altered upstream

### DIFF
--- a/packages/cubicle/cubicle.1.0.1/url
+++ b/packages/cubicle/cubicle.1.0.1/url
@@ -1,2 +1,2 @@
 archive: "http://cubicle.lri.fr/cubicle-1.0.1.tar.gz"
-checksum: "74684b8ca5c797984905af52602831f2"
+checksum: "a13b45e48ba6bfa35f38ed52cb639c13"


### PR DESCRIPTION
/cc @mebsout : the upstream 1.0.1 tarfile has changed, and it looks like 1.0 has disappeared. Would it be possible to restore the older releases so that OPAM installations continue to work?