### PR TITLE
Add freebsd support for ocamlidl build script

### DIFF
--- a/packages/camlidl/camlidl.1.05/opam
+++ b/packages/camlidl/camlidl.1.05/opam
@@ -4,7 +4,7 @@ authors: ["Xavier Leroy"]
 homepage: "http://caml.inria.fr/pub/old_caml_site/camlidl/"
 license: "QPL-1.0 and LGPL-2 with exceptions"
 build: [
-  ["mv" "config/Makefile.unix" "config/Makefile"] {(os = "darwin") | ((os = "linux") | ((os = "bsd") | ((os = "bsd") | ((os = "unix") | (os = "cygwin")))))}
+  ["mv" "config/Makefile.unix" "config/Makefile"] {(os = "darwin") | ((os = "linux") | ((os = "freebsd") | ((os = "bsd") | ((os = "unix") | (os = "cygwin")))))}
   ["mv" "config/Makefile.win32" "config/Makefile"] {os = "win32"}
   ["mkdir" "-p" bin "%{lib}%/camlidl" "%{lib}%/camlidl/caml"]
   [make "all"]


### PR DESCRIPTION
Looks like a typo in the build script had 'bsd' twice.  Not sure if 'bsd' is actually valid for not for an OS.