### PR TITLE
alcotest.0.3.1 - via opam-publish

### DIFF
--- a/packages/alcotest/alcotest.0.3.1/descr
+++ b/packages/alcotest/alcotest.0.3.1/descr
@@ -1,0 +1,12 @@
+Alcotest is a lightweight and colourful test framework, based on OUnit.
+
+Alcotest exposes a much more restricted interface than OUnit, as you can
+only pass to `Alcotest.run` a tree of callbacks of depth 2, and the
+callbacks are `unit -> unit` functions that you can build using the
+usual `OUnit.assert_*` functions or any other means (including
+Quickcheck-like test generators).
+
+This limitation enables Alcotest to provide a quiet and colorful
+output where only faulty runs are fully displayed at the end of the
+run (with the full logs ready to inspect), with a simple (yet
+expressive) query language to select the tests to run.

--- a/packages/alcotest/alcotest.0.3.1/opam
+++ b/packages/alcotest/alcotest.0.3.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/samoht/alcotest/"
+dev-repo:    "https://github.com/samoht/alcotest.git"
+bug-reports: "https://github.com/samoht/alcotest/issues/"
+
+license: "ISC"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "alcotest"]
+depends: [
+  "ocamlfind"
+  "ounit" {>= "1.1.2"}
+  "re"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/alcotest/alcotest.0.3.1/url
+++ b/packages/alcotest/alcotest.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/samoht/alcotest/archive/0.3.1.tar.gz"
+checksum: "6ace09e1ae26e3da9f6f8c0dbc6b5f7c"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework, based on OUnit.

Alcotest exposes a much more restricted interface than OUnit, as you can
only pass to `Alcotest.run` a tree of callbacks of depth 2, and the
callbacks are `unit -> unit` functions that you can build using the
usual `OUnit.assert_*` functions or any other means (including
Quickcheck-like test generators).

This limitation enables Alcotest to provide a quiet and colorful
output where only faulty runs are fully displayed at the end of the
run (with the full logs ready to inspect), with a simple (yet
expressive) query language to select the tests to run.

---
* Homepage: https://github.com/samoht/alcotest/
* Source repo: https://github.com/samoht/alcotest.git
* Bug tracker: https://github.com/samoht/alcotest/issues/

---
Pull-request generated by opam-publish v0.2.1