### PR TITLE
Fix for omake build issue on NetBSD

### DIFF
--- a/packages/omake/omake.0.9.8.6-0.rc1/files/netbsd_fam.patch
+++ b/packages/omake/omake.0.9.8.6-0.rc1/files/netbsd_fam.patch
@@ -1,0 +1,26 @@
+$NetBSD: patch-ab,v 1.1.1.1 2010/05/29 10:43:14 obache Exp $
+
+--- src/libmojave-external/cutil/fam_kqueue.c.orig	2010-05-28 09:23:46.000000000 +0000
++++ src/libmojave-external/cutil/fam_kqueue.c
+@@ -181,6 +181,12 @@ static kevent_t *new_kevent() {
+     return ev;
+ }
+ 
++#if defined(__NetBSD__)
++typedef intptr_t kqueue_udata_t;
++#else
++typedef void *kqueue_udata_t;
++#endif
++
+ /*
+  * Start monitoring a directory.
+  * We store the DirInfo pointer as the userdata in the kevent.
+@@ -199,7 +205,7 @@ static int monitor_start(FAMConnection *
+         dir->kevent = kev;
+         /* Register interest in the MON_FLAGS flags of the dir */
+         EV_SET(kev, dir->handle, EVFILT_VNODE, EV_ADD | EV_CLEAR, MON_FLAGS,
+-                (intptr_t) NULL, (void *)dir);
++                (intptr_t) NULL, (kqueue_udata_t) dir);
+         code = kevent(fc->id, kev, 1, NULL, 0, &gTime0);
+ #ifdef FAM_DEBUG
+         fprintf(stderr,

--- a/packages/omake/omake.0.9.8.6-0.rc1/opam
+++ b/packages/omake/omake.0.9.8.6-0.rc1/opam
@@ -10,4 +10,5 @@ patches: [
   "opam.patch"
   "fam.patch"
   "readline.patch"
+  "netbsd_fam.patch"
 ]


### PR DESCRIPTION
Omake fails to build on NetBSD, because the use of a `-Werror` in one compilation step causes a warning about a `kqueue`-related typecast to become an error and aborts build.  The native NetBSD package building framework, `pkgsrc`, contains a patch to workaround this issue.  I copied over this patch to the opam package.  The build succeeded on my dev box.