### PR TITLE
conduit.0.6.0: missing conflict with async_ssl upper bound

### DIFF
--- a/packages/conduit/conduit.0.6.0/opam
+++ b/packages/conduit/conduit.0.6.0/opam
@@ -29,6 +29,7 @@ conflicts: [
   "async" {<"109.15.00"}
   "lwt" {<"2.4.3"}
   "async_ssl" {<"111.21.00"}
+  "async_ssl" {>="112.24.00"}
   "mirage-types" {<"2.0.0"}
   "dns" {<"0.10.0"}
 ]


### PR DESCRIPTION
This was present in 0.6.1 and 0.5.x, so this specific version got missed

fixes mirage/ocaml-conduit#58