### PR TITLE
alcotest.0.3.1 requires ocaml 4.02.0+ due to Bytes

### DIFF
--- a/packages/alcotest/alcotest.0.3.1/opam
+++ b/packages/alcotest/alcotest.0.3.1/opam
@@ -18,4 +18,4 @@ depends: [
   "re"
   "cmdliner"
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
See samoht/alcotest#8 for upstream fix