### PR TITLE
ocveralls.0.2.1 also needs a minimum ezjsonm

### DIFF
--- a/packages/ocveralls/ocveralls.0.2.1/opam
+++ b/packages/ocveralls/ocveralls.0.2.1/opam
@@ -15,6 +15,6 @@ remove:  [ "rm" "-f" "%{bin}%/ocveralls" ]
 
 depends: [
   "ocamlfind" { build }
-  "ezjsonm" { build }
+  "ezjsonm" { build & >="0.4.0" }
   "bisect" { build }
 ]


### PR DESCRIPTION
ocoveralls 0.2.0 and earlier already had this constraint