### PR TITLE
+depext.0.5

### DIFF
--- a/packages/depext/depext.0.5/descr
+++ b/packages/depext/depext.0.5/descr
@@ -1,0 +1,7 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can perform OS and
+distribution detection, query OPAM for the right external dependencies on a set
+of packages, and call the OS's package manager in the appropriate way to install
+them.

--- a/packages/depext/depext.0.5/opam
+++ b/packages/depext/depext.0.5/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
+          "Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml/opam-depext.git"
+build: [
+  ["ocamlopt" "-I" cmdliner:lib "unix.cmxa" "cmdliner.cmxa"
+     "-o" "opam-depext" "depext.ml"]
+    { ocaml-native }
+  ["ocamlc" "-I" cmdliner:lib "unix.cma" "cmdliner.cma"
+     "-o" "opam-depext" "depext.ml"]
+    { !ocaml-native }
+]
+depends: [ "cmdliner" {build} ]

--- a/packages/depext/depext.0.5/url
+++ b/packages/depext/depext.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam-depext/archive/0.5.tar.gz"
+checksum: "9811e468fff6ddfc3e6b2078e5c3bd83"


### PR DESCRIPTION
* Do not let `yum upgrade` go interactive.
* Print commands before `sudo` so that they can be cut-and-pasted.
* Double-check the installation of multiple RPMs as the exit code
  can be unreliable.
* Add support for Gentoo and Arch Linux.
* Add Travis CI scripts.
