### PR TITLE
restrict mirage-xen to cstruct<1.6.0 due to introduction of new symbols

### DIFF
--- a/packages/mirage-xen/mirage-xen.2.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.0.0/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.0.1/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.0/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.1/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.2/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.3/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.3/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.0/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.2.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.1/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.2.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.2/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "xen-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.3.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.0/opam
@@ -8,7 +8,7 @@ build: [make "xen-build"]
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 remove: [make "xen-uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.3.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.1/opam
@@ -8,7 +8,7 @@ build: [make "xen-build"]
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 remove: [make "xen-uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"1.6.0"}
   "ocamlfind"
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}


### PR DESCRIPTION
bug reported on mirageos-devel@lists.xenproject.org by Magnus Therning