### PR TITLE
riakc_ppx: will not work with OCaml 4.02.2

### DIFF
--- a/packages/riakc_ppx/riakc_ppx.3.1.2/opam
+++ b/packages/riakc_ppx/riakc_ppx.3.1.2/opam
@@ -9,7 +9,7 @@ build: [
   ["omake" "install"]
 ]
 
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.02.2" ]
 
 remove: [
   ["ocamlfind" "remove" "riakc_ppx"]


### PR DESCRIPTION
Because of a syntax change in attributes, this version of riakc_ppx will not work on 4.02.2.
