### PR TITLE
Allow ocsigenserver.2.5 to build against newer Lwt.

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.2.5/files/build-against-recent-lwt.diff
+++ b/packages/ocsigenserver/ocsigenserver.2.5/files/build-against-recent-lwt.diff
@@ -1,0 +1,39 @@
+From dcf9988313f4e3110c12065ea889a1ee2a9badd8 Mon Sep 17 00:00:00 2001
+From: Mauricio Fernandez <mfp@acm.org>
+Date: Sun, 26 Apr 2015 12:42:47 +0200
+Subject: [PATCH] Fix build against recent Lwt.
+
+---
+ src/extensions/ocsigen_comet.ml | 2 +-
+ src/server/ocsigen_server.ml    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/extensions/ocsigen_comet.ml b/src/extensions/ocsigen_comet.ml
+index ad7d9dd..ccc0719 100644
+--- a/src/extensions/ocsigen_comet.ml
++++ b/src/extensions/ocsigen_comet.ml
+@@ -468,7 +468,7 @@ end = struct
+            Lwt.choose
+              [ (choosed >|= fun x -> Some x);
+                (Lwt_unix.sleep (get_timeout ()) >|= fun () -> None);
+-               (Lwt_event.next Security.kill >>= fun () -> Lwt.fail Kill);
++               (Lwt_react.E.next Security.kill >>= fun () -> Lwt.fail Kill);
+              ] >|= fun x ->
+            List.iter (fun c -> Channels.send_listeners c (-1)) active ;
+            let s = Messages.encode_downgoing ended x in
+diff --git a/src/server/ocsigen_server.ml b/src/server/ocsigen_server.ml
+index c5563a6..e548f5e 100644
+--- a/src/server/ocsigen_server.ml
++++ b/src/server/ocsigen_server.ml
+@@ -1040,7 +1040,7 @@ let rec wait_connection use_ssl port socket =
+          >>= decr_connected
+        in
+ 
+-       Lwt_util.iter handle_one l >>= fun () ->
++       Lwt_list.iter_p handle_one l >>= fun () ->
+        match e with
+        | Some e -> handle_exn e
+        | None -> Lwt.return ())
+-- 
+1.8.5.2
+

--- a/packages/ocsigenserver/ocsigenserver.2.5/files/fix-build-with-ocsipersist-sqlite.diff
+++ b/packages/ocsigenserver/ocsigenserver.2.5/files/fix-build-with-ocsipersist-sqlite.diff
@@ -1,0 +1,47 @@
+From 42eef0caa729a39467fdac61e4120a5cefabd4e4 Mon Sep 17 00:00:00 2001
+From: Mauricio Fernandez <mfp@acm.org>
+Date: Sun, 26 Apr 2015 17:22:56 +0200
+Subject: [PATCH] Check against lwt.preemptive instead of lwt.extra in
+ configure script.
+
+---
+ Makefile.options | 2 +-
+ configure        | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.options b/Makefile.options
+index bd3a8fa..060cdbe 100644
+--- a/Makefile.options
++++ b/Makefile.options
+@@ -26,7 +26,7 @@ endif
+ ## but also to generate src/baselib/ocsigen_config.ml and src/files/META
+ 
+ ifeq "$(PREEMPTIVE)" "YES"
+-LWT_EXTRA_PACKAGE:=lwt.extra
++LWT_EXTRA_PACKAGE:=lwt.preemptive
+ endif
+ 
+ BASE_PACKAGE := lwt ipaddr
+diff --git a/configure b/configure
+index 2e786ed..cec8fe7 100755
+--- a/configure
++++ b/configure
+@@ -454,12 +454,12 @@ if [ "$with_camlzip" -gt 0 ]; then
+     fi
+ fi
+ 
+-# Check Lwt.extra
++# Check lwt.preemptive
+ if [ "$with_preempt" -gt 0 ]; then
+-    if test_library lwt.extra; then
++    if test_library lwt.preemptive; then
+ 	echo -n
+     elif [ "$with_preempt" -gt 1 ]; then
+-	fail_library lwt.extra "Missing support for 'extra' in lwt."
++	fail_library lwt.extra "Missing support for 'preemptive' in lwt."
+     else
+ 	with_preempt=0
+     fi
+-- 
+1.8.5.2
+

--- a/packages/ocsigenserver/ocsigenserver.2.5/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.5/opam
@@ -31,4 +31,5 @@ depopts: [ "camlzip" ]
 conflicts: [ "camlzip" {< "1.04" } ]
 patches: [
   "build-against-recent-lwt.diff"
+  "fix-build-with-ocsipersist-sqlite.diff"
 ]

--- a/packages/ocsigenserver/ocsigenserver.2.5/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.5/opam
@@ -18,7 +18,7 @@ depends: [
   "base-threads"
   "react"
   "ssl"
-  "lwt" {>= "2.4.0" & < "2.4.7"}
+  "lwt" {>= "2.4.0" }
   "ocamlnet" {>= "3.6.0"}
   "pcre"
   "cryptokit"
@@ -28,3 +28,6 @@ depends: [
 ]
 depopts: [ "camlzip" ]
 conflicts: [ "camlzip" {< "1.04" } ]
+patches: [
+  "build-against-recent-lwt.diff"
+]

--- a/packages/ocsigenserver/ocsigenserver.2.5/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.5/opam
@@ -18,6 +18,7 @@ depends: [
   "base-threads"
   "react"
   "ssl"
+  "camlp4"
   "lwt" {>= "2.4.0" }
   "ocamlnet" {>= "3.6.0"}
   "pcre"


### PR DESCRIPTION
Trivial 1-line changes to build against newer Lwt where `Lwt_util` and `Lwt_event` have been removed.