### PR TITLE
Allow eliom.4.1.0 to build against newer Lwt.

### DIFF
--- a/packages/eliom/eliom.4.1.0/files/build-against-newer-lwt.diff
+++ b/packages/eliom/eliom.4.1.0/files/build-against-newer-lwt.diff
@@ -1,0 +1,71 @@
+From f557bbcd771faa98ee746e1bf43dba53181beb5f Mon Sep 17 00:00:00 2001
+From: Mauricio Fernandez <mfp@acm.org>
+Date: Sun, 26 Apr 2015 13:06:05 +0200
+Subject: [PATCH] Build against newer Lwt, where Lwt_util has been removed.
+
+---
+ src/lib/eliom_state.server.ml            | 2 +-
+ src/lib/server/eliommod_gc.ml            | 2 +-
+ src/lib/server/eliommod_persess.ml       | 6 +++---
+ src/lib/server/eliommod_sessiongroups.ml | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/lib/eliom_state.server.ml b/src/lib/eliom_state.server.ml
+index f7ea0ca..3523fc3 100644
+--- a/src/lib/eliom_state.server.ml
++++ b/src/lib/eliom_state.server.ml
+@@ -561,7 +561,7 @@ let set_persistent_data_session_group ?set_max
+     ?set_max
+     (fst sitedata.Eliom_common.max_persistent_data_sessions_per_group)
+     c.Eliom_common.pc_value !grp n in
+-  lwt () = Lwt_util.iter
++  lwt () = Lwt_list.iter_p
+     (Eliommod_persess.close_persistent_state2
+        ~scope:(scope:>Eliom_common.user_scope) sitedata None) l in
+   grp := n;
+diff --git a/src/lib/server/eliommod_gc.ml b/src/lib/server/eliommod_gc.ml
+index 8167d64..bf6133b 100644
+--- a/src/lib/server/eliommod_gc.ml
++++ b/src/lib/server/eliommod_gc.ml
+@@ -133,7 +133,7 @@ let gc_timeouted_services now tables =
+               Lwt.return ()
+         end
+   in
+-  Lwt_util.iter_serial
++  Lwt_list.iter_s
+     (fun (_gen, _prio, t) -> empty_one t) tables.Eliom_common.table_services
+   >>= fun () ->
+   tables.Eliom_common.table_services <-
+diff --git a/src/lib/server/eliommod_persess.ml b/src/lib/server/eliommod_persess.ml
+index 18c0f5b..cba6b17 100644
+--- a/src/lib/server/eliommod_persess.ml
++++ b/src/lib/server/eliommod_persess.ml
+@@ -152,9 +152,9 @@ let rec find_or_create_persistent_cookie_
+       ?set_max:set_max_in_group
+       (fst sitedata.Eliom_common.max_persistent_data_sessions_per_group)
+       c fullsessgrp >>= fun l ->
+-    Lwt_util.iter (close_persistent_state2
+-                     ~scope:(cookie_scope :> Eliom_common.user_scope)
+-                     sitedata None) l
++    Lwt_list.iter_p (close_persistent_state2
++                       ~scope:(cookie_scope :> Eliom_common.user_scope)
++                       sitedata None) l
+     >>= fun () ->
+     Lwt.return
+       { Eliom_common.pc_value= c;
+diff --git a/src/lib/server/eliommod_sessiongroups.ml b/src/lib/server/eliommod_sessiongroups.ml
+index e69a62a..b7eb8f7 100644
+--- a/src/lib/server/eliommod_sessiongroups.ml
++++ b/src/lib/server/eliommod_sessiongroups.ml
+@@ -475,7 +475,7 @@ module Pers = struct
+         (* First we close all sessions in the group *)
+ 
+         find sess_grp >>= fun cl ->
+-        Lwt_util.iter
++        Lwt_list.iter_p
+           (close_persistent_session2
+              ~cookie_level:(match cookie_level with
+                | `Client_process _ -> `Client_process | `Session -> `Session)
+-- 
+1.8.5.2
+

--- a/packages/eliom/eliom.4.1.0/opam
+++ b/packages/eliom/eliom.4.1.0/opam
@@ -19,3 +19,6 @@ depends: [
   "reactiveData"
 ]
 available: [ ocaml-version >= "4.00.0" ]
+patches: [
+  "build-against-newer-lwt.diff"
+]


### PR DESCRIPTION
Replace `Lwt_util.iter(_serial)` with `Lwt_list.iter_(p|s)`.