### PR TITLE
lwt 2.4.{6,7,8} are not available for OCaml 4.02.1+BER

### DIFF
--- a/packages/lwt/lwt.2.4.6/opam
+++ b/packages/lwt/lwt.2.4.6/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "jeremie@dimino.org"
 build: [
   ["./configure"
@@ -34,3 +34,4 @@ conflicts: [
 patches: [
   "patch-ocsigen-lwt-101.diff" {os = "darwin"}
 ]
+available: [compiler != "4.02.1+BER"]

--- a/packages/lwt/lwt.2.4.7/opam
+++ b/packages/lwt/lwt.2.4.7/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "jeremie@dimino.org"
 build: [
   ["./configure"
@@ -31,4 +31,4 @@ depopts: [
 conflicts: [
  "react" {<"1.0.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & compiler != "4.02.1+BER"]

--- a/packages/lwt/lwt.2.4.8/opam
+++ b/packages/lwt/lwt.2.4.8/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "jerome.vouillon@pps.univ-paris-diderot.fr"
 build: [
   ["./configure"
@@ -31,4 +31,4 @@ depopts: [
 conflicts: [
  "react" {<"1.0.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & compiler != "4.02.1+BER"]


### PR DESCRIPTION
Recent versions of lwt don't build with MetaOCaml.  (See [here](https://github.com/andrewray/iocamljs/issues/7#issuecomment-76972955) for an example of this causing problems.)  Here's the log from a failed build:

```
#=== ERROR while installing lwt.2.4.8 =========================================#
# opam-version 1.2.1~rc2
# os           linux
# command      make build
# path         /home/jeremy/.opam/4.02.1+BER/build/lwt.2.4.8
# compiler     4.02.1+BER
# exit-code    2
# env-file     /home/jeremy/.opam/4.02.1+BER/build/lwt.2.4.8/lwt-4923-05296d.env
# stdout-file  /home/jeremy/.opam/4.02.1+BER/build/lwt.2.4.8/lwt-4923-05296d.out
# stderr-file  /home/jeremy/.opam/4.02.1+BER/build/lwt.2.4.8/lwt-4923-05296d.err
### stdout ###
# [...]
# findlib: [WARNING] Interface trx.cmi occurs in several directories: /home/jeremy/.opam/4.02.1+BER/lib/ocaml, /home/jeremy/.opam/4.02.1+BER/lib/ocaml/compiler-libs
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/jeremy/.opam/4.02.1+BER/lib/ocaml, /home/jeremy/.opam/4.02.1+BER/lib/ocaml/compiler-libs
# /home/jeremy/.opam/4.02.1+BER/bin/ocamlfind ocamlopt -a ppx/ppx_lwt.cmx -o ppx/ppx.cmxa
# /home/jeremy/.opam/4.02.1+BER/bin/ocamlfind ocamlopt -shared ppx/ppx.cmxa ppx/ppx_lwt.cmx -o ppx/ppx.cmxs
# /home/jeremy/.opam/4.02.1+BER/bin/ocamlfind ocamldep -package ppx_tools.metaquot -package compiler-libs.common -modules ppx/ppx_lwt_ex.ml > ppx/ppx_lwt_ex.ml.depends
# + /home/jeremy/.opam/4.02.1+BER/bin/ocamlfind ocamldep -package ppx_tools.metaquot -package compiler-libs.common -modules ppx/ppx_lwt_ex.ml > ppx/ppx_lwt_ex.ml.depends
# File "ppx/ppx_lwt_ex.ml", line 346, characters 44-45:
# Error: Syntax error: operator expected.
# Command exited with code 2.
# Makefile:27: recipe for target 'build' failed
### stderr ###
# ocamlfind: Package `wikidoc' not found
# E: Failure("Command ''/home/jeremy/.opam/4.02.1+BER/bin/ocamlbuild' src/core/lwt.cma src/core/lwt.cmxa src/core/lwt.a src/core/lwt.cmxs src/logger/lwt-log.cma src/logger/lwt-log.cmxa src/logger/lwt-log.a src/logger/lwt-log.cmxs src/unix/liblwt-unix_stubs.a src/unix/dlllwt-unix_stubs.so src/unix/lwt-unix.cma src/unix/lwt-unix.cmxa src/unix/lwt-unix.a src/unix/lwt-unix.cmxs src/simple_top/lwt-simple-top.cma src/simple_top/lwt-simple-top.cmxa src/simple_top/lwt-simple-top.a src/simple_top/lwt-simple-top.cmxs src/react/lwt-react.cma src/react/lwt-react.cmxa src/react/lwt-react.a src/react/lwt-react.cmxs src/preemptive/lwt-preemptive.cma src/preemptive/lwt-preemptive.cmxa src/preemptive/lwt-preemptive.a src/preemptive/lwt-preemptive.cmxs src/ssl/lwt-ssl.cma src/ssl/lwt-ssl.cmxa src/ssl/lwt-ssl.a src/ssl/lwt-ssl.cmxs syntax/lwt-syntax.cma syntax/lwt-syntax.cmxa syntax/lwt-syntax.a syntax/lwt-syntax.cmxs syntax/lwt-syntax-options.cma syntax/lwt-syntax-options.cmxa syntax/lwt-syntax-options.a syntax/lwt-syntax-options.cmxs syntax/lwt-syntax-log.cma syntax/lwt-syntax-log.cmxa syntax/lwt-syntax-log.a syntax/lwt-syntax-log.cmxs ppx/ppx.cma ppx/ppx.cmxa ppx/ppx.a ppx/ppx.cmxs ppx/ppx_lwt_ex.native examples/unix/logging.native examples/unix/relay.native examples/unix/parallelize.native -use-ocamlfind -tag debug' terminated with error code 10")
# make: *** [build] Error 1
```

/cc @vouillon