### PR TITLE
frama-c: turn strong dependencies back into optional

### DIFF
--- a/packages/frama-c/frama-c.20150201/opam
+++ b/packages/frama-c/frama-c.20150201/opam
@@ -63,13 +63,16 @@ build-test: [
 
 depends: [
   "ocamlgraph" { = "1.8.5" | = "1.8.6" }
-  "lablgtk" { >= "2.18.2" } #for ocaml >= 4.02.1
+]
+depopts: [
+  "lablgtk"
   "conf-gtksourceview"
   "conf-gnomecanvas"
 ]
 
 conflicts: [
   "why3" { < "0.85" }
+  "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1
 ]
 
 available: [ ocaml-version >= "3.12" & ocaml-version != "4.02.0" ]


### PR DESCRIPTION
Is there any good reason to turn the GUI stuff into strong dependencies? In `20140301`, they were optional and it worked. I've turned them back to optional in `20150201` and it seems to work.
