### PR TITLE
reedsolomon: fix dependencies

### DIFF
--- a/packages/reedsolomon/reedsolomon.0.2/opam
+++ b/packages/reedsolomon/reedsolomon.0.2/opam
@@ -10,5 +10,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "hardcaml"
+  "js_of_ocaml"
 ]
 ocaml-version: [ >= "4.00.1" ]


### PR DESCRIPTION
`reedsolomon` should optionally depend on `hardcaml` and `js_of_ocaml`, but a bug in the Makefile makes it misconfigure when `hardcaml` is present and `js_of_ocaml` absent, and the build fails.

I've sent a [PR](https://github.com/ujamjar/reedsolomon/pull/1) upstream to fix the Makefile but for this version the best solution is probably to add them as hard dependencies.
