### PR TITLE
Fix typo: cpmf-mpfr ~> conf-mpfr.

### DIFF
--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -12,7 +12,7 @@ build: [
 remove: [["ocamlfind" "remove" "gmp"]]
 depends: [
   "conf-gmp"
-  "cpmf-mpfr"
+  "conf-mpfr"
   "oasis"
   "ocamlfind"
 ]


### PR DESCRIPTION
[Thanks](https://github.com/ocaml/opam-repository/commit/6140a423bf7a7e303b48e6655733cafc31df560d#commitcomment-10952228), @piotrm0!