### PR TITLE
tcpip.2.4.2 - via opam-publish

### DIFF
--- a/packages/tcpip/tcpip.2.4.2/descr
+++ b/packages/tcpip/tcpip.2.4.2/descr
@@ -1,0 +1,4 @@
+Userlevel TCP/IP stack
+
+The library provides a networking stack for the Mirage operating
+system that supports IPv4, IPv6, ARPv4, DHCPv4 and TCP/IP.

--- a/packages/tcpip/tcpip.2.4.2/opam
+++ b/packages/tcpip/tcpip.2.4.2/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+authors: [
+  "Anil Madhavapeddy"
+  "Balraj Singh"
+  "Richard Mortier"
+  "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire"
+]
+tags: ["org:mirage"]
+
+build: [
+  ["./configure" "--prefix" prefix
+      "--%{mirage-flow+alcotest:enable}%-tests"
+      "--%{mirage-xen:enable}%-xen"
+  ]
+  [make]
+]
+build-test: [make "test"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "tcpip"]
+depends: [
+  "ocamlfind" {build}
+  "cstruct" {>= "1.0.1"}
+  "mirage-types" {>= "2.0.0"}
+  "mirage-unix" {>= "1.1.0"}
+  "mirage-console"
+  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-net-unix" {>= "1.1.0"}
+  "ipaddr" {>= "2.2.0"}
+  "mirage-profile"
+  "mirage-flow" {test}
+  "alcotest" {test}
+]
+depopts: [
+  "mirage-xen"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/tcpip/tcpip.2.4.2/url
+++ b/packages/tcpip/tcpip.2.4.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-tcpip/archive/v2.4.2.tar.gz"
+checksum: "a0806a884441de94a5c2cb904ecae229"


### PR DESCRIPTION
Userlevel TCP/IP stack

The library provides a networking stack for the Mirage operating
system that supports IPv4, IPv6, ARPv4, DHCPv4 and TCP/IP.

---
* Homepage: https://github.com/mirage/mirage-tcpip
* Source repo: https://github.com/mirage/mirage-tcpip.git
* Bug tracker: https://github.com/mirage/mirage-tcpip/issues

---
Pull-request generated by opam-publish v0.2.1