### PR TITLE
mirage-vnetif.0.1.0 - via opam-publish

### DIFF
--- a/packages/mirage-vnetif/mirage-vnetif.0.1.0/descr
+++ b/packages/mirage-vnetif/mirage-vnetif.0.1.0/descr
@@ -1,0 +1,6 @@
+Virtual network interface and software switch for Mirage.
+
+Provides the module Vnetif which can be used as a replacement for the
+regular Netif implementation in Xen and Unix. Stacks built using
+Vnetif are connected to a software switch that allows the stacks to
+communicate as if they were connected to the same LAN.

--- a/packages/mirage-vnetif/mirage-vnetif.0.1.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/MagnusS/mirage-vnetif"
+bug-reports: "https://github.com/MagnusS/mirage-vnetif/issues/"
+license: "ISC"
+dev-repo: "https://github.com/MagnusS/mirage-vnetif.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-vnetif"]
+depends: [
+  "lwt"
+  "mirage-types"
+  "cstruct"
+  "ipaddr"
+  "io-page"
+  "mirage-profile"
+]

--- a/packages/mirage-vnetif/mirage-vnetif.0.1.0/url
+++ b/packages/mirage-vnetif/mirage-vnetif.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/MagnusS/mirage-vnetif/archive/0.1.tar.gz"
+checksum: "2a68bf60f3b8b0e88746bf2647aeafa8"


### PR DESCRIPTION
Virtual network interface and software switch for Mirage.

Provides the module Vnetif which can be used as a replacement for the
regular Netif implementation in Xen and Unix. Stacks built using
Vnetif are connected to a software switch that allows the stacks to
communicate as if they were connected to the same LAN.

---
* Homepage: https://github.com/MagnusS/mirage-vnetif
* Source repo: https://github.com/MagnusS/mirage-vnetif.git
* Bug tracker: https://github.com/MagnusS/mirage-vnetif/issues/

---
Pull-request generated by opam-publish v0.2.1