### PR TITLE
Explicitely specify binaries path in biniou and yojson

### DIFF
--- a/packages/biniou/biniou.1.0.5/opam
+++ b/packages/biniou/biniou.1.0.5/opam
@@ -4,7 +4,7 @@ homepage: "http://mjambon.com/biniou.html"
 license: "BSD-3-Clause"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "biniou"]]
 depends: [

--- a/packages/biniou/biniou.1.0.6/opam
+++ b/packages/biniou/biniou.1.0.6/opam
@@ -4,7 +4,7 @@ homepage: "http://mjambon.com/biniou.html"
 license: "BSD-3-Clause"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "biniou"]]
 depends: [

--- a/packages/biniou/biniou.1.0.9/opam
+++ b/packages/biniou/biniou.1.0.9/opam
@@ -4,7 +4,7 @@ homepage: "http://mjambon.com/biniou.html"
 license: "BSD-3-Clause"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "biniou"]]
 depends: [

--- a/packages/yojson/yojson.1.0.3/opam
+++ b/packages/yojson/yojson.1.0.3/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]
 depends: [

--- a/packages/yojson/yojson.1.1.3/opam
+++ b/packages/yojson/yojson.1.1.3/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]
 depends: [

--- a/packages/yojson/yojson.1.1.6/opam
+++ b/packages/yojson/yojson.1.1.6/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]
 depends: [

--- a/packages/yojson/yojson.1.1.8/opam
+++ b/packages/yojson/yojson.1.1.8/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]
 depends: [

--- a/packages/yojson/yojson.1.2.0/opam
+++ b/packages/yojson/yojson.1.2.0/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "martin@mjambon.com"
 build: [
   [make]
-  [make "install"]
+  [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]
 depends: [


### PR DESCRIPTION
If no PREFIX or BINDIR is specified, biniou's Makefile tries to compute a
decent one, using in particular the 'which' primitive. However, if
/bin/sh is minimal, 'which' may not exist, thus leading to PREFIX
being empty and BINDIR being /bin, which is incorrect.

As opam can provide an explicit path for BINDIR, providing it is a way
to solve the problem.