### PR TITLE
conduit.0.8.3 - via opam-publish

### DIFF
--- a/packages/conduit/conduit.0.8.3/descr
+++ b/packages/conduit/conduit.0.8.3/descr
@@ -1,0 +1,15 @@
+Network connection library for TCP and SSL
+
+The `conduit` library takes care of establishing and listening for TCP and
+SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways to bind to
+a library (e.g. the C FFI, or the Ctypes library), as well as well as which
+library is used (either OpenSSL or a native OCaml TLS implementation).
+
+If you are using the `Lwt_unix` version of the library, you can set two
+environment variables to control the behaviour of the library:
+
+- `CONDUIT_DEBUG=1` will output debug information to standard error.
+- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.

--- a/packages/conduit/conduit.0.8.3/opam
+++ b/packages/conduit/conduit.0.8.3/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+]
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+tags: "org:mirage"
+dev-repo: "https://github.com/mirage/ocaml-conduit.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "conduit"]
+depends: [
+  "ocamlfind"
+  "sexplib" {>= "109.15.00"}
+  "stringext"
+  "uri"
+  "cstruct" {>= "1.0.1"}
+  "ipaddr" {>= "2.5.0"}
+]
+depopts: [
+  "async"
+  "lwt"
+  "ssl"
+  "async_ssl"
+  "mirage-dns"
+  "vchan"
+  "tls"
+]
+conflicts: [
+  "lwt" {< "2.4.4"}
+  "async_ssl" {< "112.24.00"}
+  "mirage-types" {< "2.0.0"}
+  "dns" {< "0.10.0"}
+  "tls" {< "0.4.0"}
+  "vchan" {< "2.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/conduit/conduit.0.8.3/url
+++ b/packages/conduit/conduit.0.8.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-conduit/archive/v0.8.3.tar.gz"
+checksum: "b748bf258b55c1ec35d4adaf5d9278be"


### PR DESCRIPTION
Network connection library for TCP and SSL

The `conduit` library takes care of establishing and listening for TCP and
SSL/TLS connections for the Lwt and Async libraries.

The reason this library exists is to provide a degree of abstraction
from the precise SSL library used, since there are a variety of ways to bind to
a library (e.g. the C FFI, or the Ctypes library), as well as well as which
library is used (either OpenSSL or a native OCaml TLS implementation).

If you are using the `Lwt_unix` version of the library, you can set two
environment variables to control the behaviour of the library:

- `CONDUIT_DEBUG=1` will output debug information to standard error.
- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.

---
* Homepage: https://github.com/mirage/ocaml-conduit
* Source repo: https://github.com/mirage/ocaml-conduit.git
* Bug tracker: https://github.com/mirage/ocaml-conduit/issues

---
Pull-request generated by opam-publish v0.2.1