### PR TITLE
Constrain yojson 1.0.3 to OCaml >= 4.01.0.

### DIFF
--- a/packages/yojson/yojson.1.0.3/opam
+++ b/packages/yojson/yojson.1.0.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 build: [
   [make]
@@ -11,3 +11,4 @@ depends: [
   "easy-format"
   "biniou"
 ]
+available: [ ocaml-version >= "4.01.0"]


### PR DESCRIPTION
yojson 1.03 requires OCaml 4.01.0 or later.  See https://github.com/ocaml/opam-repository/pull/4038#issuecomment-98701707

/cc @mjambon