### PR TITLE
get package for bisect_ppx to pass opam lint (currently causing opam update to fail)

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.0.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.1/opam
@@ -3,7 +3,8 @@ name: "bisect_ppx"
 version: "0.1"
 maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
 authors: "Leonid Rozenberg <leonidr@gmail.com>"
-dev-repo: "https://github.com/rleonid/bisect_ppx"
+homepage: "https://github.com/rleonid/bisect_ppx"
+dev-repo: "https://github.com/rleonid/bisect_ppx.git"
 bug-reports: "https://github.com/rleonid/bisect_ppx/issues"
 build: [
   ["sh" "configure"]


### PR DESCRIPTION
i tried to `opam update` this evening and was unable to due to the following error message

```ocaml
Updating ~/.opam/packages/ ...
[ERROR] At ~/.opam/repo/default/packages/bisect_ppx/bisect_ppx.0.1/opam:6:48:
  Not a recognised version-control URL
```

i was a bit surprised by this because the url was `"https://github.com/rleonid/bisect_ppx"` but looking at the values of other packages revealed they all had the `.git` extension. i ran `opam lint` once more and saw that the package was missing a homepage. i took the liberty of pointing the homepage to the github repository. after that `opam lint` passed.