### PR TITLE
Fix wrong dependency for mirage-tcpip-xen

### DIFF
--- a/packages/mirage-tcpip-xen/mirage-tcpip-xen.0.9.5/opam
+++ b/packages/mirage-tcpip-xen/mirage-tcpip-xen.0.9.5/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
-  "io-page" {<"1.3.0"}
+  "io-page-xen"
   "mirage-types" {= "0.5.0"}
   "mirage-xen" {= "0.9.9"}
   "mirage-clock-xen" {>= "1.0.0"}


### PR DESCRIPTION
(spotted by ows)