### PR TITLE
llvm: Explicitly constrain over ocaml >= 4.0

### DIFF
--- a/packages/llvm/llvm.3.6/opam
+++ b/packages/llvm/llvm.3.6/opam
@@ -15,3 +15,4 @@ depexts: [
   [["source" "linux"] ["https://gist.githubusercontent.com/whitequark/cc737ffcb8896e4d7b91/raw/ed2ba05691bc3a0500b1cc2dcd7156dd10c5b652/gistfile1.sh"]]
 ]
 available: [opam-version >= "1.2"] # for "version" variable
+ocaml-version: [>= "4.00.0"]


### PR DESCRIPTION
Required by ctypes.
So that it can be all green in ows.

cc @whitequark