### PR TITLE
xstrp4: fix version in META file to match package version

### DIFF
--- a/packages/xstrp4/xstrp4.1.8/files/version.patch
+++ b/packages/xstrp4/xstrp4.1.8/files/version.patch
@@ -1,0 +1,8 @@
+--- a/META	2010-11-30 16:36:03.000000000 +0200
++++ b/META	2015-05-10 23:04:48.960009677 +0300
+@@ -1,4 +1,4 @@
+-version = "1.7"
++version = "1.8"
+ requires = "camlp4"
+ 
+ # This line counts when the compiler is invoked with

--- a/packages/xstrp4/xstrp4.1.8/opam
+++ b/packages/xstrp4/xstrp4.1.8/opam
@@ -6,4 +6,5 @@ build: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "xstrp4"]]
+patches: ["version.patch"]
 depends: ["ocamlfind" "camlp4"]


### PR DESCRIPTION
FWIW the Debian package for xstrp4 has 1.8 in the META file too.