### PR TITLE
Mirage 2.4.0 needs crunch >= 1.4.0 for connect

### DIFF
--- a/packages/mirage/mirage.2.4.0/opam
+++ b/packages/mirage/mirage.2.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "io-page" {>= "1.4.0"}
-  "crunch" {>= "1.2.2"}
+  "crunch" {>= "1.4.0"}
   "sexplib"
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
crunch 1.3.0 doesn't have connect when a new `KV_RO` signature is used which doesn't have connect. 1.4.0 explicitly added connect back.