### PR TITLE
If async is installed, cohttp 0.11.0 will try to use async_ssl.

### DIFF
--- a/packages/cohttp/cohttp.0.11.0/opam
+++ b/packages/cohttp/cohttp.0.11.0/opam
@@ -24,6 +24,6 @@ depopts: [
   "lwt"
 ]
 conflicts: [
-  "async" {<"109.15.00"}
+  "async"
   "lwt" {<"2.4.3"}
 ]


### PR DESCRIPTION
Just disable async support for this version.