### PR TITLE
why: move dependencies from why3/frama-c to their -base versions

### DIFF
--- a/packages/why/why.2.35/opam
+++ b/packages/why/why.2.35/opam
@@ -27,6 +27,6 @@ build: [
   [make "install"]
 ]
 depends: [
-  "why3" {>= "0.84"}
-  "frama-c" {>= "20150201"}
+  "why3-base" {>= "0.84"}
+  "frama-c-base" {>= "20150201"}
 ]


### PR DESCRIPTION
Now that why3 and frama-c have been split into base and full packages, I think `why` should depend on the base versions, unless I missed something?
