### PR TITLE
irmin 0.9.[0-4] are not compatible with OCaml 4.02.2

### DIFF
--- a/packages/irmin/irmin.0.9.0/opam
+++ b/packages/irmin/irmin.0.9.0/opam
@@ -46,4 +46,4 @@ conflicts: [
   "cohttp" {< "0.13.0"}
   "cohttp" {>= "0.14.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.02.2"]

--- a/packages/irmin/irmin.0.9.1/opam
+++ b/packages/irmin/irmin.0.9.1/opam
@@ -49,4 +49,4 @@ conflicts: [
   "git"    {!= "1.4.3"}
   "cohttp" {< "0.15.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.02.2"]

--- a/packages/irmin/irmin.0.9.2/opam
+++ b/packages/irmin/irmin.0.9.2/opam
@@ -43,4 +43,4 @@ conflicts: [
   "git" {> "1.4.5"}
   "cohttp" {< "0.15.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.02.2"]

--- a/packages/irmin/irmin.0.9.3/opam
+++ b/packages/irmin/irmin.0.9.3/opam
@@ -43,4 +43,4 @@ conflicts: [
   "git" {> "1.4.10"}
   "cohttp" {< "0.14.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.02.2"]

--- a/packages/irmin/irmin.0.9.4/opam
+++ b/packages/irmin/irmin.0.9.4/opam
@@ -49,4 +49,4 @@ conflicts: [
   "git"    {< "1.4.10"}
   "cohttp" {< "0.14.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.02.2"]


### PR DESCRIPTION
because of `-warn-error A`