### PR TITLE
semver.0.1.0 - via opam-publish

### DIFF
--- a/packages/semver/semver.0.1.0/descr
+++ b/packages/semver/semver.0.1.0/descr
@@ -1,0 +1,4 @@
+Semantic versioning module
+
+Provides a single module `Semver` that can parse, compare, and manipulate
+software versions of the form x.x.x. See http://semver.org/ 

--- a/packages/semver/semver.0.1.0/opam
+++ b/packages/semver/semver.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: [
+  "Tikhon Jelvis"
+  "Rudi Grinberg"
+]
+homepage: "https://github.com/rgrinberg/ocaml-semver"
+bug-reports: "https://github.com/rgrinberg/ocaml-semver/issues"
+license: "BSD3"
+dev-repo: "https://github.com/rgrinberg/ocaml-semver.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "semver"]
+depends: [
+  "ocamlfind" {build}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/semver/semver.0.1.0/url
+++ b/packages/semver/semver.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ocaml-semver/archive/v0.1.0.tar.gz"
+checksum: "ce6614ba2f91754028b29a12989f9da6"


### PR DESCRIPTION
Semantic versioning module

Provides a single module `Semver` that can parse, compare, and manipulate
software versions of the form x.x.x. See http://semver.org/ 


---
* Homepage: https://github.com/rgrinberg/ocaml-semver
* Source repo: https://github.com/rgrinberg/ocaml-semver.git
* Bug tracker: https://github.com/rgrinberg/ocaml-semver/issues

---
Pull-request generated by opam-publish v0.2.1