### PR TITLE
why3-base: small bug fixes released

### DIFF
--- a/packages/why3-base/why3-base.0.86/url
+++ b/packages/why3-base/why3-base.0.86/url
@@ -1,2 +1,2 @@
-archive: "https://gforge.inria.fr/frs/download.php/file/34775/why3-0.86.tar.gz"
-checksum: "4521da929108a7329d3945a7cc5bca92"
+archive: "https://gforge.inria.fr/frs/download.php/file/34795/why3-0.86.1.tar.gz"
+checksum: "428110ba368038498a01f25222b9dc6b"


### PR DESCRIPTION
update opam package for why3-base 0.86 to integrate small bug fixes