### PR TITLE
modelica_ml.0.2.0 - via opam-publish

### DIFF
--- a/packages/modelica_ml/modelica_ml.0.2.0/descr
+++ b/packages/modelica_ml/modelica_ml.0.2.0/descr
@@ -1,0 +1,7 @@
+Modelica abstract syntax and parser
+Modelica_ml is a Modelica frontend implemented in OCaml. It is written
+with compilation in mind, but should also be useful for other
+applications. Modelica_ml currently supports abstract syntax, parsing,
+pretty printing and a form of lookup analysis (class normalization).
+Patches welcome!
+

--- a/packages/modelica_ml/modelica_ml.0.2.0/files/modelica.ml.install
+++ b/packages/modelica_ml/modelica_ml.0.2.0/files/modelica.ml.install
@@ -1,0 +1,14 @@
+bin: [
+  "?_build/test/modclread.byte" {"modclread"}
+  "?_build/test/modclread.native" {"modclread"}
+  "?_build/test/modcl.byte" {"modcl"}
+  "?_build/test/modcl.native" {"modcl"}
+  "?_build/test/modclc.byte" {"modclc"}
+  "?_build/test/modclc.native" {"modclc"}
+  "?_build/test/parse_package.byte" {"parse_pkg"}
+  "?_build/test/parse_package.native" {"parse_pkg"}
+  "?_build/test/parse_modelica.byte" {"parse_modelica"}
+  "?_build/test/parse_modelica.native" {"parse_modelica"}
+  "?_build/test/modelica_frontend_tests.byte" {"modelica_frontend_tests"}
+  "?_build/test/modelica_frontend_tests.native" {"modelica_frontend_tests"}
+]

--- a/packages/modelica_ml/modelica_ml.0.2.0/opam
+++ b/packages/modelica_ml/modelica_ml.0.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "\"Christoph Höger <christoph.hoeger@tu-berlin.de>\""
+authors: "\"Christoph Höger <christoph.hoeger@tu-berlin.de>\""
+homepage: "http://github.com/choeger/modelica.ml"
+license: "BSD-3-clause"
+bug-reports: "https://github.com/choeger/modelica.ml/issues"
+dev-repo: "https://github.com/choeger/modelica.ml.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "modelica_ml"]
+depends: [
+  "batteries"
+  "menhir"
+  "ocamlfind"
+  "ocamlgraph"
+  "ppx_deriving" {= "1.0"}
+  "ppx_deriving_yojson" {= "2.0"}
+  "ppx_import"
+  "ppx_monadic"
+  "sedlex"
+]
+depopts: "ounit"
+available: [ocaml-version >= "4.02.1"]

--- a/packages/modelica_ml/modelica_ml.0.2.0/url
+++ b/packages/modelica_ml/modelica_ml.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/choeger/modelica.ml/archive/v0.2.0.tar.gz"
+checksum: "5c1780b0a016f106ccc256b0a6f0b388"


### PR DESCRIPTION
Modelica abstract syntax and parser
Modelica_ml is a Modelica frontend implemented in OCaml. It is written
with compilation in mind, but should also be useful for other
applications. Modelica_ml currently supports abstract syntax, parsing,
pretty printing and a form of lookup analysis (class normalization).
Patches welcome!


---
* Homepage: http://github.com/choeger/modelica.ml
* Source repo: https://github.com/choeger/modelica.ml.git
* Bug tracker: https://github.com/choeger/modelica.ml/issues

---
Pull-request generated by opam-publish v0.2.1