### PR TITLE
Update Zenon to version 0.8.0

### DIFF
--- a/packages/zenon/zenon.0.8.0/descr
+++ b/packages/zenon/zenon.0.8.0/descr
@@ -1,0 +1,4 @@
+Automated theorem prover for first order classical logic (with equality), based on the tableau method
+Zenon is an automatic theorem prover written in OCaml. Zenon handles
+first-order logic with equality. Its most important feature is that it
+outputs the proofs of the theorems, in Coq-checkable form.

--- a/packages/zenon/zenon.0.8.0/files/zenon.install
+++ b/packages/zenon/zenon.0.8.0/files/zenon.install
@@ -1,0 +1,4 @@
+bin: [
+  "zenon" {"zenon-0.8.0"}
+  "zenon"
+]

--- a/packages/zenon/zenon.0.8.0/opam
+++ b/packages/zenon/zenon.0.8.0/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+build: [
+  ["mkdir" "-p" "%{lib}%/zenon-0.7.1"]
+  ["./configure" "--prefix" prefix "--tools_prefix" "%{lib}%/zenon-0.7.1"]
+  [make]
+  [make "install"]
+]
+remove: [["rm" "-rf" "%{lib}%/zenon-0.7.1"]]
+depends: ["coq"]

--- a/packages/zenon/zenon.0.8.0/opam
+++ b/packages/zenon/zenon.0.8.0/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
   ["mkdir" "-p" "%{lib}%/zenon-0.8.0"]
-  ["./configure" "--prefix" prefix "--tools_prefix" "%{lib}%/zenon-0.8.0"]
+  ["./configure" "--prefix" prefix "--libdir" "%{lib}%/zenon-0.8.0"]
   [make]
   [make "install"]
 ]

--- a/packages/zenon/zenon.0.8.0/opam
+++ b/packages/zenon/zenon.0.8.0/opam
@@ -1,10 +1,10 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
-  ["mkdir" "-p" "%{lib}%/zenon-0.7.1"]
-  ["./configure" "--prefix" prefix "--tools_prefix" "%{lib}%/zenon-0.7.1"]
+  ["mkdir" "-p" "%{lib}%/zenon-0.8.0"]
+  ["./configure" "--prefix" prefix "--tools_prefix" "%{lib}%/zenon-0.8.0"]
   [make]
   [make "install"]
 ]
-remove: [["rm" "-rf" "%{lib}%/zenon-0.7.1"]]
+remove: [["rm" "-rf" "%{lib}%/zenon-0.8.0"]]
 depends: ["coq"]

--- a/packages/zenon/zenon.0.8.0/url
+++ b/packages/zenon/zenon.0.8.0/url
@@ -1,0 +1,2 @@
+http: "http://zenon-prover.org/zenon-0.8.0.tar.gz"
+checksum: "4d82ae5b6dc498a73ef85a353c5da325"


### PR DESCRIPTION
Hello,

A new version of the ATP Zenon has been released in October.
I updated the OPAM package using the archive file found on Zenon website (http://zenon-prover.org).

This is the first time I request a pull on this repository so I hope I am doing things as expected.

The previous version used an archive hosted by Fedora, if this is better, the url for version 0.8.0 is https://pkgs.fedoraproject.org/repo/pkgs/zenon/zenon-0.8.0.tar.gz/4d82ae5b6dc498a73ef85a353c5da325/zenon-0.8.0.tar.gz

Regards,

-- 
rafoo