### PR TITLE
ssl.0.5.0: patch META file to add bytes package

### DIFF
--- a/packages/ssl/ssl.0.5.0/files/fix-meta.diff
+++ b/packages/ssl/ssl.0.5.0/files/fix-meta.diff
@@ -1,0 +1,14 @@
+diff --git a/src/META.in b/src/META.in
+index 5c46a2b..afbd88e 100644
+--- a/src/META.in
++++ b/src/META.in
+@@ -1,7 +1,7 @@
+ name="Ssl"
+ version="@VERSION@"
+ description="OCaml bindings to libssl"
+-requires="unix"
++requires="unix bytes"
+ archive(byte) = "ssl.cma"
+ archive(native) = "ssl.cmxa"
+ archive(mt,byte) = "ssl_threads.cma"
+

--- a/packages/ssl/ssl.0.5.0/opam
+++ b/packages/ssl/ssl.0.5.0/opam
@@ -6,6 +6,7 @@ build: [
   [make]
   [make "install"]
 ]
+patches: ["fix-meta.diff"]
 remove: [["ocamlfind" "remove" "ssl"]]
 depends: ["ocamlfind"]
 depexts: [


### PR DESCRIPTION
This fixes the build on older versions of OCaml.
Submitted upstream in savonet/ocaml-ssl#20