### PR TITLE
Older versions of Lwt are incompatible with ssl.0.5.0 safestring

### DIFF
--- a/packages/lwt/lwt.2.4.0/opam
+++ b/packages/lwt/lwt.2.4.0/opam
@@ -13,6 +13,9 @@ depopts: [
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: [
+  "react" {>="1.0.0"}
+  "ssl" {>="0.5.0"}
+]

--- a/packages/lwt/lwt.2.4.1/opam
+++ b/packages/lwt/lwt.2.4.1/opam
@@ -13,6 +13,9 @@ depopts: [
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: [
+  "react" {>="1.0.0"}
+  "ssl" {>="0.5.0"}
+]

--- a/packages/lwt/lwt.2.4.2/opam
+++ b/packages/lwt/lwt.2.4.2/opam
@@ -13,7 +13,10 @@ depopts: [
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
   "lablgtk"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: [
+  "react" {>="1.0.0"}
+  "ssl" {>="0.5.0"}
+]

--- a/packages/lwt/lwt.2.4.3/opam
+++ b/packages/lwt/lwt.2.4.3/opam
@@ -13,9 +13,12 @@ depopts: [
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
   "lablgtk"
   "text"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: [
+  "react" {>="1.0.0"}
+  "ssl" {>="0.5.0"}
+]
 ocaml-version: [<"4.02.0"]

--- a/packages/lwt/lwt.2.4.4/opam
+++ b/packages/lwt/lwt.2.4.4/opam
@@ -12,8 +12,11 @@ depopts: [
   "base-unix"
   "conf-libev"
   "ssl"
-  "react" {< "1.0.0" }
+  "react"
   "lablgtk"
   "text"
 ]
-conflicts: [ "react" {>="1.0.0"} ]
+conflicts: [
+  "react" {>="1.0.0"}
+  "ssl" {>="0.5.0"}
+]

--- a/packages/lwt/lwt.2.4.5/opam
+++ b/packages/lwt/lwt.2.4.5/opam
@@ -18,4 +18,5 @@ depopts: [
 ]
 conflicts: [
  "react" {<"1.0.0"}
+ "ssl" {>="0.5.0"}
 ]

--- a/packages/lwt/lwt.2.4.6/opam
+++ b/packages/lwt/lwt.2.4.6/opam
@@ -30,6 +30,7 @@ depopts: [
 ]
 conflicts: [
  "react" {<"1.0.0"}
+ "ssl" {>="0.5.0"}
 ]
 patches: [
   "patch-ocsigen-lwt-101.diff" {os = "darwin"}


### PR DESCRIPTION
e.g. http://opam.ocaml.org/builds/2a72f37d26c92576db2d8baf59b517fb6112887f/logs/local-ubuntu-14.04-ocaml-4.01.0/raw/mirage-http-unix.html#bottom