### PR TITLE
ocaml-systemd.1.1 - via opam-publish

### DIFF
--- a/packages/ocaml-systemd/ocaml-systemd.1.1/descr
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/descr
@@ -1,0 +1,6 @@
+OCaml module for native access to the systemd facilities
+
+* Logging to the Journal
+* Socket activation
+* Watchdog
+* Notifications

--- a/packages/ocaml-systemd/ocaml-systemd.1.1/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/opam
@@ -12,3 +12,5 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "systemd"]
 depends: "ocamlfind"
+ocaml-version: [ >= "4.02.0" ]
+

--- a/packages/ocaml-systemd/ocaml-systemd.1.1/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/opam
@@ -13,4 +13,9 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "systemd"]
 depends: "ocamlfind"
 ocaml-version: [ >= "4.02.0" ]
+depexts: [
+ [ ["debian"] ["libsystemd-dev"] ]
+ [ ["ubuntu"] ["libsystemd-dev"] ]
+ [ ["centos"] ["systemd-devel"] ]
+]
 

--- a/packages/ocaml-systemd/ocaml-systemd.1.1/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Juergen Hoetzel <juergen@archlinux.org>"
+authors: "Juergen Hoetzel <juergen@archlinux.org>"
+homepage: "https://github.com/juergenhoetzel/ocaml-systemd/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+license: "LGPL-3 with OCaml linking exception"
+dev-repo: "https://github.com/juergenhoetzel/ocaml-systemd.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "systemd"]
+depends: "ocamlfind"

--- a/packages/ocaml-systemd/ocaml-systemd.1.1/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "Juergen Hoetzel <juergen@archlinux.org>"
 authors: "Juergen Hoetzel <juergen@archlinux.org>"
 homepage: "https://github.com/juergenhoetzel/ocaml-systemd/"
-bug-reports: "https://github.com/mirage/mirage/issues/"
+bug-reports: "https://github.com/juergenhoetzel/ocaml-systemd/issues/"
 license: "LGPL-3 with OCaml linking exception"
 dev-repo: "https://github.com/juergenhoetzel/ocaml-systemd.git"
 build: [

--- a/packages/ocaml-systemd/ocaml-systemd.1.1/url
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/juergenhoetzel/ocaml-systemd/archive/1.1.tar.gz"
+checksum: "4179c7a16571a5495e92a5b36791aa12"


### PR DESCRIPTION
OCaml module for native access to the systemd facilities

* Logging to the Journal
* Socket activation
* Watchdog
* Notifications

---
* Homepage: https://github.com/juergenhoetzel/ocaml-systemd/
* Source repo: https://github.com/juergenhoetzel/ocaml-systemd.git
* Bug tracker: https://github.com/mirage/mirage/issues/

---
Pull-request generated by opam-publish v0.2.1