### PR TITLE
mlbdd.0.4 - via opam-publish

### DIFF
--- a/packages/mlbdd/mlbdd.0.4/descr
+++ b/packages/mlbdd/mlbdd.0.4/descr
@@ -1,0 +1,5 @@
+A high performance BDD implementation in OCaml
+
+The mlbdd library provides a simple, easy-to-use, easy-to-extend implementation of binary decision diagrams (BDDs) in OCaml. It is well tested and well documented. The library itself has no dependencies and is thus easy to include in applications that might, for example, be compiled with js_of_ocaml or other tools that rely on pure OCaml. It is also easier to integrate with existing projects due to its lack of dependencies.
+
+Critically, this BDD implementation uses a garbage-collection-aware hashing scheme, so that unused nodes can be collected.  Additionally, this implementation uses complement edges to significantly improve performance over the simplest BDD implementations.

--- a/packages/mlbdd/mlbdd.0.4/opam
+++ b/packages/mlbdd/mlbdd.0.4/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Arlen Cox <arlencox@gmail.com>"
+authors: "Arlen Cox <arlencox@gmail.com>"
+homepage: "https://github.com/arlencox/mlbdd"
+bug-reports: "https://github.com/arlencox/mlbdd/issues"
+license: "MIT"
+dev-repo: "https://github.com/arlencox/mlbdd.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mlbdd"]
+depends: ["ocamlfind" {build}]

--- a/packages/mlbdd/mlbdd.0.4/url
+++ b/packages/mlbdd/mlbdd.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/arlencox/mlbdd/archive/v0.4.tar.gz"
+checksum: "f9288299c170e26f9d49ee3a05e7ae0a"


### PR DESCRIPTION
A high performance BDD implementation in OCaml

The mlbdd library provides a simple, easy-to-use, easy-to-extend implementation of binary decision diagrams (BDDs) in OCaml. It is well tested and well documented. The library itself has no dependencies and is thus easy to include in applications that might, for example, be compiled with js_of_ocaml or other tools that rely on pure OCaml. It is also easier to integrate with existing projects due to its lack of dependencies.

Critically, this BDD implementation uses a garbage-collection-aware hashing scheme, so that unused nodes can be collected.  Additionally, this implementation uses complement edges to significantly improve performance over the simplest BDD implementations.

---
* Homepage: https://github.com/arlencox/mlbdd
* Source repo: https://github.com/arlencox/mlbdd.git
* Bug tracker: https://github.com/arlencox/mlbdd/issues

---
Pull-request generated by opam-publish v0.2.1