### PR TITLE
Update to bsdowl-3.0.0-20150401

### DIFF
--- a/packages/bsdowl/bsdowl.3.0.0-20150401/descr
+++ b/packages/bsdowl/bsdowl.3.0.0-20150401/descr
@@ -1,0 +1,33 @@
+This collection of BSD Make directives aims at providing a highly
+portable build system targetting modern UNIX systems and supporting
+common or less command languages.  This is a build system, which means
+that it can be used to organise fairly complex projects.
+
+BSD Owl Scripts assists developers in the production, installation and
+distribution of projects comprising the following types of products:
+
+ - C programs, compiled for several targets
+ - C libraries, static and shared, compiled for several targets
+ - Shell scripts
+ - Python scripts
+ - OCaml programs
+ - OCaml libraries, with ocamldoc documentation
+ - OCaml plugins
+ - TeX documents, prepared for several printing devices
+ - METAPOST figures, with output as PDF, PS, SVG or PNG,
+   either as part of a TeX document or as standalone documents
+
+BSD Owl Scripts offers developers a rich set of features easing
+project management:
+
+ - Support of compilation profiles
+ - Support of the parallel mode (at the directory level)
+ - Support of separate trees for sources and objects
+ - Support of architecture-dependant compilation options
+ - Support GNU autoconf
+ - Production of GPG-signed tarballs
+ - Developer subshell, empowered with project-specific scripts
+ - Literate programming using noweb
+ - Preprocessing with m4
+
+WWW: https://github.com/michipili/bsdowl

--- a/packages/bsdowl/bsdowl.3.0.0-20150401/files/remove.sh
+++ b/packages/bsdowl/bsdowl.3.0.0-20150401/files/remove.sh
@@ -1,0 +1,5 @@
+# Usage: remove PREFIX
+#  Remove BSD Owl Scripts
+find "$1/share/bsdowl" "$1/bin" -type f \
+    | xargs grep -l 'This file is part of BSD Owl Scripts' \
+    | xargs rm -v -f

--- a/packages/bsdowl/bsdowl.3.0.0-20150401/opam
+++ b/packages/bsdowl/bsdowl.3.0.0-20150401/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "michipili@gmail.com"
+authors: "Michael Grünewald"
+license: "CeCILL-B"
+homepage: "https://github.com/michipili/bsdowl"
+bug-reports: "https://github.com/michipili/bsdowl/issues"
+dev-repo: "https://github.com/michipili/bsdowl.git"
+tags: [
+  "bsd"
+  "bmake"
+  "build"
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  ["bmake" "-r" "build"] {os != "freebsd"}
+  ["make" "-r" "build"]  {os  = "freebsd"}
+]
+install: [
+  ["bmake" "install"] {os != "freebsd"}
+  ["make" "install"]  {os  = "freebsd"}
+]
+remove: [
+  ["sh" "%{build}%/opam/files/remove.sh" prefix]
+]
+depends: ["ocamlfind"]
+depexts: [
+  [["debian"] ["bmake"]]
+  [["ubuntu"] ["bmake"]]
+  [["osx" "macports"] ["bmake"]]
+]

--- a/packages/bsdowl/bsdowl.3.0.0-20150401/url
+++ b/packages/bsdowl/bsdowl.3.0.0-20150401/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/michipili/bsdowl/releases/download/v3.0.0-20150401/bsdowl-3.0.0-20150401.tar.gz"
+checksum: "2c92358b7c5c6d802e7b953bd955d757"


### PR DESCRIPTION
This is an upgrade of BSD Owl.

I took advantage of filters to use native's FreeBSD **make** instead of relying on a third-party package. I also used a more flexible installation procedure as in 2.2 so that opam conventions are respected.

 If the environment defines `MAKEFLAGS` the package will not build nor install. Any thoughts about this?