### PR TITLE
mirage-net-unix.2.2.1 - via opam-publish

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.2.2.1/descr
+++ b/packages/mirage-net-unix/mirage-net-unix.2.2.1/descr
@@ -1,0 +1,7 @@
+Ethernet network driver for Mirage, using tuntap
+
+Unix implementation of the Mirage NETWORK interface.
+
+This interface exposes raw Ethernet frames using `ocaml-tuntap`,
+suitable for use with an OCaml network stack such as the one
+found at <https://github.com/mirage/mirage-tcpip>.

--- a/packages/mirage-net-unix/mirage-net-unix.2.2.1/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      [
+  "Anil Madhavapeddy"
+  "David Scott"
+  "Thomas Gazagnaire"
+  "Hannes Mehnert"
+]
+homepage:    "https://github.com/mirage/mirage-net-unix"
+bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
+dev-repo:    "https://github.com/mirage/mirage-net-unix.git"
+license:     "ISC"
+
+build:   [make]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "mirage-net-unix"]
+depends: [
+  "cstruct" {>= "1.0.1"}
+  "ocamlfind"
+  "lwt" {>= "2.4.3"}
+  "mirage-types" {>= "2.3.0"}
+  "io-page" {>= "1.0.1"}
+  "tuntap" {>= "0.7.0"}
+  "ounit" {test}
+]
+available: [ ocaml-version >= "4.00.0"]

--- a/packages/mirage-net-unix/mirage-net-unix.2.2.1/url
+++ b/packages/mirage-net-unix/mirage-net-unix.2.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-net-unix/archive/v2.2.1.tar.gz"
+checksum: "cada7347761084278fec970d3a7cc97d"


### PR DESCRIPTION
Ethernet network driver for Mirage, using tuntap

Unix implementation of the Mirage NETWORK interface.

This interface exposes raw Ethernet frames using `ocaml-tuntap`,
suitable for use with an OCaml network stack such as the one
found at <https://github.com/mirage/mirage-tcpip>.

---
* Homepage: https://github.com/mirage/mirage-net-unix
* Source repo: https://github.com/mirage/mirage-net-unix.git
* Bug tracker: https://github.com/mirage/mirage-net-unix/issues

---
Pull-request generated by opam-publish v0.2.1