### PR TITLE
github.1.0.0: update metadata including uri dep version constraint

### DIFF
--- a/packages/github/github.1.0.0/opam
+++ b/packages/github/github.1.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "anil@recoil.org"
+maintainer: "sheets@alum.mit.edu"
 authors: [
   "Anil Madhavapeddy"
   "David Sheets"
@@ -8,21 +8,25 @@ authors: [
 ]
 homepage: "https://github.com/mirage/ocaml-github"
 bug-reports: "https://github.com/mirage/ocaml-github/issues"
+dev-repo: "https://github.com/mirage/ocaml-github.git"
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-dev-repo: "https://github.com/mirage/ocaml-github.git"
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{base-unix:enable}%-unix" "--%{js_of_ocaml:enable}%-js" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-install: ["ocaml" "setup.ml" "-install"]
-remove: ["ocamlfind" "remove" "github"]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "github"]
+]
 depends: [
   "ocamlfind"
   "ssl"
-  "uri" {>= "1.5.0"}
+  "uri" {>= "1.9.0"}
   "cohttp" {>= "0.17.0"}
   "lwt" {>= "2.4.4"}
   "atdgen" {>= "1.5.0"}
@@ -32,5 +36,9 @@ depends: [
   "cmdliner"
   "base-unix"
 ]
-depopts: "js_of_ocaml"
-conflicts: "js_of_ocaml" {< "2.4.0"}
+depopts: [
+  "js_of_ocaml"
+]
+conflicts: [
+  "js_of_ocaml" {< "2.4.0"}
+]


### PR DESCRIPTION
I am still unclear about which opam metadata file opam-publish will automatically populate a release. @AltGr

I believe the previous release was with a pinned version of the new library which had this updated file. Someone needs to do some testing of `opam publish prepare` to make sure this is straightforward.