### PR TITLE
mirage-http conflicts with cohttp 0.18

### DIFF
--- a/packages/mirage-http/mirage-http.2.2.0/opam
+++ b/packages/mirage-http/mirage-http.2.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "mirage-types-lwt" {>= "2.0.0"}
   "mirage-conduit"
   "lwt" {>= "2.4.3"}
-  "cohttp" {>= "0.16.0"}
+  "cohttp" {>= "0.16.0" & < "0.18"}
   "camlp4"
   "sexplib"
 ]


### PR DESCRIPTION
Error was:

    Error: Signature mismatch:
    [...]
       The field `sexp_of_ctx' is required but not provided
       The field `close' is required but not provided
       The field `close_out' is required but not provided
       The field `close_in' is required but not provided
       The field `connect_uri' is required but not provided
       The field `default_ctx' is required but not provided
       The field `ctx' is required but not provided