### PR TITLE
Fix Cohttp version in Ketrew package

### DIFF
--- a/packages/ketrew/ketrew.1.0.0/opam
+++ b/packages/ketrew/ketrew.1.0.0/opam
@@ -20,6 +20,6 @@ depends: [
   "trakeva" "sqlite3" "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"
   "ppx_deriving" "ppx_deriving_yojson" {>= "2.3"} "ppx_include" "ppx_blob"
-  "cohttp" "lwt" "ssl"
+  "cohttp" {= "0.17.2"} "lwt" "ssl"
   "conduit"
   ]


### PR DESCRIPTION
The API changes in `0.18.0` break the build.