### PR TITLE
ppx_const.1.1 - via opam-publish

### DIFF
--- a/packages/ppx_const/ppx_const.1.1/descr
+++ b/packages/ppx_const/ppx_const.1.1/descr
@@ -1,0 +1,7 @@
+Compile-time "if" statement for conditional inclusion of code.
+
+This is a ppx extension which adds `if#const` and `match#const` constructs to
+OCaml. They behave like normal `if` and `const`, but conditions are evaluated
+at compile time and AST sections not selected are excluded from the program
+completely. In conjunction with ppx_getenv, this can be used for conditional
+compilation of code.

--- a/packages/ppx_const/ppx_const.1.1/opam
+++ b/packages/ppx_const/ppx_const.1.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Andi McClure <andi.m.mcclure@gmail.com>"
+authors: "Andi McClure <andi.m.mcclure@gmail.com>"
+homepage: "https://github.com/mcclure/ppx_const"
+bug-reports: "https://github.com/mcclure/ppx_const/issues"
+license: "Creative Commons Zero"
+tags: "syntax"
+dev-repo: "git://github.com/mcclure/ppx_const.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+build-test: ["ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_const.byte" "--"]
+depends: [
+  "ppx_tools" {>= "0.99.1"}
+  "ounit" {test}
+  "ocamlfind" {test}
+]
+available: [ocaml-version >= "4.02.0" & opam-version >= "1.2"]

--- a/packages/ppx_const/ppx_const.1.1/url
+++ b/packages/ppx_const/ppx_const.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mcclure/ppx_const/archive/ppx_const-1.1.tar.gz"
+checksum: "53f811ffb931d9b8242ee1ddf9bf4e47"


### PR DESCRIPTION
Compile-time "if" statement for conditional inclusion of code.

This is a ppx extension which adds `if#const` and `match#const` constructs to
OCaml. They behave like normal `if` and `const`, but conditions are evaluated
at compile time and AST sections not selected are excluded from the program
completely. In conjunction with ppx_getenv, this can be used for conditional
compilation of code.

---
* Homepage: https://github.com/mcclure/ppx_const
* Source repo: git://github.com/mcclure/ppx_const.git
* Bug tracker: https://github.com/mcclure/ppx_const/issues

---
Pull-request generated by opam-publish v0.2.1