### PR TITLE
ocamlbuild-atdgen.0.1.0 - via opam-publish

### DIFF
--- a/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/descr
+++ b/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/descr
@@ -1,0 +1,4 @@
+Atdgen plugin for OCamlbuild
+
+Daniel Weil's original ocamlbuild plugin for atdgen. This plugin will invoke
+atdgen for you to generate Atdgen_{j,v,t} modules automatically.

--- a/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/opam
+++ b/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Daniel Weil" "Hezekiah M. Carty" "Rudi Grinberg"]
+
+homepage: "https://github.com/rgrinberg/ocamlbuild-atdgen"
+bug-reports: "https://github.com/rgrinberg/ocamlbuild-atdgen/issues"
+dev-repo: "https://github.com/rgrinberg/ocamlbuild-atdgen.git"
+
+build: [
+  [make "all"]
+]
+
+install: [make "install"]
+
+remove: [
+  ["ocamlfind" "remove" "ocamlbuild_atdgen"]
+]
+
+depends: [
+  "ocamlfind" {build}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/url
+++ b/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ocamlbuild-atdgen/archive/v0.1.0.tar.gz"
+checksum: "689d9f2f5968a4d8e6f3a072c4c5d298"


### PR DESCRIPTION
Atdgen plugin for OCamlbuild

Daniel Weil's original ocamlbuild plugin for atdgen. This plugin will invoke
atdgen for you to generate Atdgen_{j,v,t} modules automatically.


---
* Homepage: https://github.com/rgrinberg/ocamlbuild-atdgen
* Source repo: https://github.com/rgrinberg/ocamlbuild-atdgen.git
* Bug tracker: https://github.com/rgrinberg/ocamlbuild-atdgen/issues

---
Pull-request generated by opam-publish v0.3.0