### PR TITLE
async-mvar.0.1.0 - via opam-publish

### DIFF
--- a/packages/async-mvar/async-mvar.0.1.0/descr
+++ b/packages/async-mvar/async-mvar.0.1.0/descr
@@ -1,0 +1,4 @@
+Async-mvar is a port of Lwt's Lwt_mvar
+
+This package provides a single module - `Async_mvar`. It it analagous to
+Lwt's `Lwt_mvar`.

--- a/packages/async-mvar/async-mvar.0.1.0/opam
+++ b/packages/async-mvar/async-mvar.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/async-mvar"
+bug-reports: "https://github.com/rgrinberg/async-mvar/issues"
+dev-repo: "https://github.com/rgrinberg/async-mvar.git"
+
+build: [
+  ["obuild" "configure"]
+  ["obuild" "build"]
+]
+
+install: ["obuild" "install"]
+
+remove: [
+  ["ocamlfind" "remove" "async_mvar"]
+]
+
+build-test: [
+  ["obuild" "configure" "--enable-tests"]
+  ["obuild" "build"]
+  ["obuild" "test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "obuild" {build}
+  "core_kernel"
+  "async_kernel"
+  "core" {test}
+  "async" {test}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/async-mvar/async-mvar.0.1.0/url
+++ b/packages/async-mvar/async-mvar.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/async-mvar/archive/v0.1.0.tar.gz"
+checksum: "0ca7827c947b1ce59690f215121550cf"


### PR DESCRIPTION
Async-mvar is a port of Lwt's Lwt_mvar

This package provides a single module - `Async_mvar`. It it analagous to
Lwt's `Lwt_mvar`.


---
* Homepage: https://github.com/rgrinberg/async-mvar
* Source repo: https://github.com/rgrinberg/async-mvar.git
* Bug tracker: https://github.com/rgrinberg/async-mvar/issues

---
Pull-request generated by opam-publish v0.3.0