### PR TITLE
mirage-seal.0.3.0 - via opam-publish

### DIFF
--- a/packages/mirage-seal/mirage-seal.0.3.0/descr
+++ b/packages/mirage-seal/mirage-seal.0.3.0/descr
@@ -1,0 +1,4 @@
+Short description
+
+Long
+description

--- a/packages/mirage-seal/mirage-seal.0.3.0/descr
+++ b/packages/mirage-seal/mirage-seal.0.3.0/descr
@@ -1,4 +1,4 @@
-Short description
+Serve static files over HTTPS, using Mirage+ocaml-TLS.
 
-Long
-description
+Use this tool to seal the contents of a directory into a static unikernel,
+serving its contents over HTTPS.

--- a/packages/mirage-seal/mirage-seal.0.3.0/opam
+++ b/packages/mirage-seal/mirage-seal.0.3.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "https://github.com/mirage/mirage-seal"
+bug-reports:  "https://github.com/mirage/mirage-seal/issues/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-seal.git"
+
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+depends: [
+  "mirage" {build & >= "2.5.0"}
+  "cmdliner"
+  "dolog"
+  "crunch"
+]

--- a/packages/mirage-seal/mirage-seal.0.3.0/url
+++ b/packages/mirage-seal/mirage-seal.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-seal/archive/0.3.0.tar.gz"
+checksum: "f584a4978a68be46ec4978b58920a5cb"


### PR DESCRIPTION
Serve static files over HTTPS, using Mirage+ocaml-TLS.

Use this tool to seal the contents of a directory into a static unikernel,
serving its contents over HTTPS.

---
* Homepage: https://github.com/mirage/mirage-seal
* Source repo: https://github.com/mirage/mirage-seal.git
* Bug tracker: https://github.com/mirage/mirage-seal/issues/

---
Pull-request generated by opam-publish v0.2.1