### PR TITLE
mirage-seal.0.3.1 - via opam-publish

### DIFF
--- a/packages/mirage-seal/mirage-seal.0.3.1/descr
+++ b/packages/mirage-seal/mirage-seal.0.3.1/descr
@@ -1,0 +1,4 @@
+Serve static files over HTTPS, using Mirage+ocaml-TLS.
+
+Use this tool to seal the contents of a directory into a static unikernel,
+serving its contents over HTTPS.

--- a/packages/mirage-seal/mirage-seal.0.3.1/opam
+++ b/packages/mirage-seal/mirage-seal.0.3.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "https://github.com/mirage/mirage-seal"
+bug-reports:  "https://github.com/mirage/mirage-seal/issues/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-seal.git"
+
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+depends: [
+  "mirage" {build & >= "2.5.0"}
+  "cmdliner"
+  "dolog"
+  "crunch"
+]

--- a/packages/mirage-seal/mirage-seal.0.3.1/url
+++ b/packages/mirage-seal/mirage-seal.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-seal/archive/0.3.1.tar.gz"
+checksum: "8fbb6847d5511324c3f1bfa5aa8593cd"


### PR DESCRIPTION
Serve static files over HTTPS, using Mirage+ocaml-TLS.

Use this tool to seal the contents of a directory into a static unikernel,
serving its contents over HTTPS.

---
* Homepage: https://github.com/mirage/mirage-seal
* Source repo: https://github.com/mirage/mirage-seal.git
* Bug tracker: https://github.com/mirage/mirage-seal/issues/

---
Pull-request generated by opam-publish v0.2.1