### PR TITLE
why3 0.86.1: URL and checksum have changed

### DIFF
--- a/packages/why3-base/why3-base.0.86/url
+++ b/packages/why3-base/why3-base.0.86/url
@@ -1,2 +1,2 @@
-archive: "https://gforge.inria.fr/frs/download.php/file/34795/why3-0.86.1.tar.gz"
-checksum: "428110ba368038498a01f25222b9dc6b"
+archive: "https://gforge.inria.fr/frs/download.php/file/34797/why3-0.86.1.tar.gz"
+checksum: "43ab4c224b025c2e3dd5526fa6bef181"


### PR DESCRIPTION
I'm assuming the new version of the archive is compatible with the old one...
