### PR TITLE
slap: does not work with latest versions of lacaml

### DIFF
--- a/packages/slap/slap.0.0.0/opam
+++ b/packages/slap/slap.0.0.0/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]

--- a/packages/slap/slap.0.1.0/opam
+++ b/packages/slap/slap.0.1.0/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]

--- a/packages/slap/slap.0.2.0/opam
+++ b/packages/slap/slap.0.2.0/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]

--- a/packages/slap/slap.0.2.1/opam
+++ b/packages/slap/slap.0.2.1/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]

--- a/packages/slap/slap.0.2.2/opam
+++ b/packages/slap/slap.0.2.2/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]

--- a/packages/slap/slap.0.2.3/opam
+++ b/packages/slap/slap.0.2.3/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]

--- a/packages/slap/slap.1.0.0/opam
+++ b/packages/slap/slap.1.0.0/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]

--- a/packages/slap/slap.1.0.1/opam
+++ b/packages/slap/slap.1.0.1/opam
@@ -14,7 +14,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml"
+  "lacaml" {< "7.2.2"}
   "ocamlfind"
   "cppo"
 ]


### PR DESCRIPTION
The latest two versions of `lacaml` have an API change tha breaks `slap`.
