### PR TITLE
uucd.3.0.0 - via opam-publish

### DIFF
--- a/packages/uucd/uucd.3.0.0/descr
+++ b/packages/uucd/uucd.3.0.0/descr
@@ -1,0 +1,15 @@
+Unicode character database decoder for OCaml
+Unicode version 8.0.0
+
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][3] and is distributed
+under the BSD3 license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[3]: http://erratique.ch/software/xmlm 
+

--- a/packages/uucd/uucd.3.0.0/opam
+++ b/packages/uucd/uucd.3.0.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uucd"
+dev-repo: "http://erratique.ch/repos/uucd.git"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+doc: "http://erratique.ch/software/uucd/doc/Uucd"
+tags: [ "unicode" "database" "decoder" "org:erratique" ]
+license: "BSD3"
+available: [ ocaml-version >= "4.00.0"]
+depends: [ "ocamlfind" "xmlm" ]
+build: 
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%" 
+                           "native-dynlink=%{ocaml-native-dynlink}%" ]
+]

--- a/packages/uucd/uucd.3.0.0/url
+++ b/packages/uucd/uucd.3.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uucd/releases/uucd-3.0.0.tbz"
+checksum: "31eb8244924de06693563d6523ad43f4"


### PR DESCRIPTION
Unicode character database decoder for OCaml
Unicode version 8.0.0

Uucd is an OCaml module to decode the data of the [Unicode character 
database][1] from its XML [representation][2]. It provides high-level 
(but not necessarily efficient) access to the data so that efficient 
representations can be extracted.

Uucd is made of a single module, depends on [Xmlm][3] and is distributed
under the BSD3 license.

[1]: http://www.unicode.org/reports/tr44/
[2]: http://www.unicode.org/reports/tr42/
[3]: http://erratique.ch/software/xmlm 


---
* Homepage: http://erratique.ch/software/uucd
* Source repo: http://erratique.ch/repos/uucd.git
* Bug tracker: https://github.com/dbuenzli/uucd/issues

---
Pull-request generated by opam-publish v0.2.1