### PR TITLE
uucp.1.0.0 - via opam-publish

### DIFF
--- a/packages/uucp/uucp.1.0.0/descr
+++ b/packages/uucp/uucp.1.0.0/descr
@@ -1,0 +1,11 @@
+Unicode character properties for OCaml
+Unicode version %%UNICODE_VERSION%%
+
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the BSD3 license.
+
+[1]: http://www.unicode.org/reports/tr44/
+

--- a/packages/uucp/uucp.1.0.0/opam
+++ b/packages/uucp/uucp.1.0.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uucp"
+doc: "http://erratique.ch/software/uucp/doc/Uucp"
+dev-repo: "http://erratique.ch/repos/uucp.git"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+tags: [ "unicode" "text" "character" "org:erratique" ]
+license: "BSD3"
+depends: [ "ocamlfind" "base-bytes" ]
+available: [ ocaml-version >= "4.01.0" ]
+build: 
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native}%" ]
+]

--- a/packages/uucp/uucp.1.0.0/url
+++ b/packages/uucp/uucp.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uucp/releases/uucp-1.0.0.tbz"
+checksum: "229455ecbee6cd4b7d6082371307fd01"


### PR DESCRIPTION
Unicode character properties for OCaml
Unicode version %%UNICODE_VERSION%%

Uucp is an OCaml library providing efficient access to a selection of
character properties of the [Unicode character database][1].

Uucp is independent from any Unicode text data structure and has no
dependencies. It is distributed under the BSD3 license.

[1]: http://www.unicode.org/reports/tr44/


---
* Homepage: http://erratique.ch/software/uucp
* Source repo: http://erratique.ch/repos/uucp.git
* Bug tracker: https://github.com/dbuenzli/uucp/issues

---
Pull-request generated by opam-publish v0.2.1