### PR TITLE
uunf.1.0.0 - via opam-publish

### DIFF
--- a/packages/uunf/uunf.1.0.0/descr
+++ b/packages/uunf/uunf.1.0.0/descr
@@ -1,0 +1,14 @@
+Unicode text normalization for OCaml
+
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms][1]. The library is independent from any
+IO mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf has no dependency. It may optionally depend on [Uutf][2] for
+support on OCaml UTF-X encoded strings. It is distributed under the
+BSD3 license.
+
+[1]: http://www.unicode.org/reports/tr15/
+[2]: http://erratique.ch/software/uutf
+

--- a/packages/uunf/uunf.1.0.0/opam
+++ b/packages/uunf/uunf.1.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uunf"
+doc: "http://erratique.ch/software/uunf/doc/Uunf"
+dev-repo: "http://erratique.ch/repos/uunf.git"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+tags: [ "unicode" "text" "normalization" "org:erratique" ]
+license: "BSD3"
+available: [ ocaml-version >= "4.01.0" ]
+depends: [ "ocamlfind" ]
+depopts: [ "uutf" "cmdliner" ]
+build: 
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "uutf=%{uutf:installed}%"
+                           "cmdliner=%{cmdliner:installed}%" ]
+]

--- a/packages/uunf/uunf.1.0.0/url
+++ b/packages/uunf/uunf.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uunf/releases/uunf-1.0.0.tbz"
+checksum: "019a0f195dc59f1a9befb2857544e16a"


### PR DESCRIPTION
Unicode text normalization for OCaml

Uunf is an OCaml library for normalizing Unicode text. It supports all
Unicode [normalization forms][1]. The library is independent from any
IO mechanism or Unicode text data structure and it can process text
without a complete in-memory representation.

Uunf has no dependency. It may optionally depend on [Uutf][2] for
support on OCaml UTF-X encoded strings. It is distributed under the
BSD3 license.

[1]: http://www.unicode.org/reports/tr15/
[2]: http://erratique.ch/software/uutf


---
* Homepage: http://erratique.ch/software/uunf
* Source repo: http://erratique.ch/repos/uunf.git
* Bug tracker: https://github.com/dbuenzli/uunf/issues

---
Pull-request generated by opam-publish v0.2.1