### PR TITLE
uucp.1.0.0 - via opam-publish

### DIFF
--- a/packages/uucp/uucp.1.0.0/descr
+++ b/packages/uucp/uucp.1.0.0/descr
@@ -1,5 +1,5 @@
 Unicode character properties for OCaml
-Unicode version %%UNICODE_VERSION%%
+Unicode version 8.0.0
 
 Uucp is an OCaml library providing efficient access to a selection of
 character properties of the [Unicode character database][1].


### PR DESCRIPTION
Unicode character properties for OCaml
Unicode version 8.0.0

Uucp is an OCaml library providing efficient access to a selection of
character properties of the [Unicode character database][1].

Uucp is independent from any Unicode text data structure and has no
dependencies. It is distributed under the BSD3 license.

[1]: http://www.unicode.org/reports/tr44/


---
* Homepage: http://erratique.ch/software/uucp
* Source repo: http://erratique.ch/repos/uucp.git
* Bug tracker: https://github.com/dbuenzli/uucp/issues

---
Pull-request generated by opam-publish v0.2.1