### PR TITLE
Refine uuseg.0.8.0 constraints.

### DIFF
--- a/packages/uuseg/uuseg.0.8.0/opam
+++ b/packages/uuseg/uuseg.0.8.0/opam
@@ -9,7 +9,7 @@ tags: [ "segmentation" "text" "unicode" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0"]
 depends: [ "ocamlfind"
-           "uucp" {>= "0.9.1"} ]
+           "uucp" {>= "0.9.1" & < "1.0.0"} ]
 depopts: [ "uutf"
            "cmdliner"
            "uutf" {test}


### PR DESCRIPTION
Data dependency. Do not allow to use uuseg 0.8.0 with Unicode 8.0.0 data.