### PR TITLE
Add package javalib.2.3a with a patch to fix a restriction on classna…

### DIFF
--- a/packages/javalib/javalib.2.3a/descr
+++ b/packages/javalib/javalib.2.3a/descr
@@ -1,0 +1,4 @@
+Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files.
+
+Thus it stands for a good starting point for people who want to develop static analyses for
+Java byte-code programs, benefiting from the strength of OCaml language.

--- a/packages/javalib/javalib.2.3a/files/patch-javalib.diff
+++ b/packages/javalib/javalib.2.3a/files/patch-javalib.diff
@@ -1,0 +1,12 @@
+diff -uNr javalib-2.3/src/jBasics.ml javalib-2.3a/src/jBasics.ml
+--- javalib-2.3/src/jBasics.ml	2013-10-30 08:35:30.000000000 +0100
++++ javalib-2.3a/src/jBasics.ml	2015-06-18 15:36:17.000000000 +0200
+@@ -278,8 +278,6 @@
+       with _ ->
+ 	let cni = cnt.cni_next in
+         let new_cn = (cni,cn) in
+-	  if not (Str.string_match valid_class_name cn 0)
+-	  then invalid_arg ("Error : " ^ cn ^ " is not a valid name for a class");
+ 	  cnt.cni_map <- ClassNameMap.add cn new_cn cnt.cni_map;
+ 	  cnt.cni_next <- cni + 1;
+ 	  new_cn

--- a/packages/javalib/javalib.2.3a/findlib
+++ b/packages/javalib/javalib.2.3a/findlib
@@ -1,0 +1,2 @@
+javalib
+ptrees

--- a/packages/javalib/javalib.2.3a/opam
+++ b/packages/javalib/javalib.2.3a/opam
@@ -1,0 +1,21 @@
+opam-version: "1"
+maintainer: "sawja@inria.fr"
+build: [
+  ["./configure.sh"]
+  [make "ptrees"]
+  [make "installptrees"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "javalib"]
+  ["ocamlfind" "remove" "ptrees"]
+]
+depends: [
+  "ocamlfind"
+  "camlzip" {= "1.05"}
+  ("extlib" {>= "1.5.1" & <= "1.6.0"} | "extlib-compat")
+]
+patches: [
+  "patch-javalib.diff"
+]

--- a/packages/javalib/javalib.2.3a/url
+++ b/packages/javalib/javalib.2.3a/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/33090/javalib-2.3.tar.bz2"
+checksum: "9b79ea9cfd2b30e0e6c2c655b989532f"

--- a/packages/sawja/sawja.1.5/opam
+++ b/packages/sawja/sawja.1.5/opam
@@ -8,5 +8,5 @@ build: [
 remove: [["ocamlfind" "remove" "sawja"]]
 depends: [
   "ocamlfind"
-  "javalib" {= "2.3"}
+  "javalib" {>= "2.3"}
 ]


### PR DESCRIPTION
…mes.

Currently javalib.2.3 fails on class names containing $dollars, and some java 8 artifacts, which are widely used by annotation processors.
There's no need to restrict the name of classes to be loaded. This change removes the restriction.