### PR TITLE
ppx_deriving 2.1

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.1.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.0/opam
@@ -24,4 +24,4 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit"     {test}
 ]
-available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version = "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.1.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.1/opam
@@ -16,4 +16,4 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit" {test}
 ]
-available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version = "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.0/opam
@@ -16,4 +16,4 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit" {test}
 ]
-available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version = "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.1/descr
+++ b/packages/ppx_deriving/ppx_deriving.2.1/descr
@@ -1,0 +1,5 @@
+Type-driven code generation for OCaml >=4.02
+
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.

--- a/packages/ppx_deriving/ppx_deriving.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: ["Peter Zotov <whitequark@whitequark.org>" "Simon Cruanes <simon.cruanes.2007@m4x.org>"]
+authors: "Peter Zotov <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_deriving"
+bug-reports: "https://github.com/whitequark/ppx_deriving/issues"
+license: "MIT"
+doc: "http://whitequark.github.io/ppx_deriving"
+tags: "syntax"
+dev-repo: "git://github.com/whitequark/ppx_deriving.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native-dynlink}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+build-test: ["ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_deriving.byte" "--"]
+build-doc: [make "doc"]
+depends: [
+  "ppx_tools" {>= "0.99.2"}
+  "ocamlfind" {build & >= "1.5.4"}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.1/url
+++ b/packages/ppx_deriving/ppx_deriving.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving/archive/v2.1.tar.gz"
+checksum: "6b48d4d1f64813977b684ba1f9f74fea"


### PR DESCRIPTION
whitequark being busy, here is a new release that fixes `ppx_deriving` for 4.02.2