### PR TITLE
alcotest.0.3.3 - via opam-publish

### DIFF
--- a/packages/alcotest/alcotest.0.3.3/descr
+++ b/packages/alcotest/alcotest.0.3.3/descr
@@ -1,0 +1,12 @@
+Alcotest is a lightweight and colourful test framework, based on OUnit.
+
+Alcotest exposes a much more restricted interface than OUnit, as you can
+only pass to `Alcotest.run` a tree of callbacks of depth 2, and the
+callbacks are `unit -> unit` functions that you can build using the
+usual `OUnit.assert_*` functions or any other means (including
+Quickcheck-like test generators).
+
+This limitation enables Alcotest to provide a quiet and colorful
+output where only faulty runs are fully displayed at the end of the
+run (with the full logs ready to inspect), with a simple (yet
+expressive) query language to select the tests to run.

--- a/packages/alcotest/alcotest.0.3.3/opam
+++ b/packages/alcotest/alcotest.0.3.3/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+
+license: "ISC"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "alcotest"]
+depends: [
+  "ocamlfind"
+  "ounit" {>= "1.1.2"}
+  "re"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/alcotest/alcotest.0.3.3/url
+++ b/packages/alcotest/alcotest.0.3.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/alcotest//archive/0.3.3.tar.gz"
+checksum: "18e0363a5dee713c315af648c7cfde37"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework, based on OUnit.

Alcotest exposes a much more restricted interface than OUnit, as you can
only pass to `Alcotest.run` a tree of callbacks of depth 2, and the
callbacks are `unit -> unit` functions that you can build using the
usual `OUnit.assert_*` functions or any other means (including
Quickcheck-like test generators).

This limitation enables Alcotest to provide a quiet and colorful
output where only faulty runs are fully displayed at the end of the
run (with the full logs ready to inspect), with a simple (yet
expressive) query language to select the tests to run.

---
* Homepage: https://github.com/mirage/alcotest/
* Source repo: https://github.com/mirage/alcotest.git
* Bug tracker: https://github.com/mirage/alcotest/issues/

---
Pull-request generated by opam-publish v0.2.1