### PR TITLE
rdr.1.0 - via opam-publish

### DIFF
--- a/packages/rdr/rdr.1.0/descr
+++ b/packages/rdr/rdr.1.0/descr
@@ -1,0 +1,15 @@
+Rdr is a cross-platform binary analysis and reverse engineering tool, utilizing a unique symbol map for global analysis.
+
+`rdr` is an OCaml tool/library for doing cross-platform analysis of binaries, by printing headers, locating entry points, showing import and export symbols, their binary offsets and size, etc.
+
+It also features a symbol map which allows fast lookups for arbitrary symbols, and their associated data, on your system (the default search location are binaries in /usr/lib).
+
+See the README at http://github.com/m4b/rdr for more details.
+
+Features:
+
+* 64-bit Linux and Mach-o binary analysis
+* Searchable symbol-map of all the symbols on your system, including binary offset, size, and exporting library
+* Print imports and exports of binaries
+* Make pretty graphs, at the binary or symbol map level
+

--- a/packages/rdr/rdr.1.0/opam
+++ b/packages/rdr/rdr.1.0/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "m4b <m4b.github.io@gmail.com>"
+authors: "m4b <m4b.github.io@gmail.com>"
+bug-reports: "m4b.github.io@gmail.com"
+dev-repo: "git://github.com/m4b/rdr"
+homepage: "http://www.m4b.io"
+build: [make "build"]
+depends: "ocamlfind" {build}
+available: [ocaml-version >= "4.02"]

--- a/packages/rdr/rdr.1.0/url
+++ b/packages/rdr/rdr.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/m4b/rdr/archive/v1.0.tar.gz"
+checksum: "ed7b7154cc8745434b1db4dae9fd307b"


### PR DESCRIPTION
Rdr is a cross-platform binary analysis and reverse engineering tool, utilizing a unique symbol map for global analysis.

`rdr` is an OCaml tool/library for doing cross-platform analysis of binaries, by printing headers, locating entry points, showing import and export symbols, their binary offsets and size, etc.

It also features a symbol map which allows fast lookups for arbitrary symbols, and their associated data, on your system (the default search location are binaries in /usr/lib).

See the README at http://github.com/m4b/rdr for more details.

Features:

* 64-bit Linux and Mach-o binary analysis
* Searchable symbol-map of all the symbols on your system, including binary offset, size, and exporting library
* Print imports and exports of binaries
* Make pretty graphs, at the binary or symbol map level


---
* Homepage: http://www.m4b.io
* Source repo: git://github.com/m4b/rdr
* Bug tracker: m4b.github.io@gmail.com

---
Pull-request generated by opam-publish v0.2.1