### PR TITLE
Fix sociaml-facebook-api cohttp dep for 0.18.0 breakage

### DIFF
--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
@@ -19,7 +19,7 @@ remove: [
 ]
 depends: [
   "calendar"
-  "cohttp" { >= "0.12.0" }
+  "cohttp" { >= "0.12.0" & < "0.18.0" }
   "core_kernel"
   "csv"
   "lwt"

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
@@ -1,15 +1,17 @@
-opam-version: "1"
-name: "sociaml-facebook-api"
-version: "0.4.0"
+opam-version: "1.2"
 maintainer: "dominic.price@nottingham.ac.uk"
 homepage: "https://github.com/dominicjprice/sociaml-facebook-api"
+bug-reports: "https://github.com/dominicjprice/sociaml-facebook-api/issues"
+dev-repo: "https://github.com/dominicjprice/sociaml-facebook-api.git"
 authors: [ "Dominic Price" ]
 license: "ISC"
-ocaml-version: [ >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" ]
 build: [
   ["oasis" "setup"]
   ["./configure" "--prefix" prefix]
   [make "build"]
+]
+install: [
   [make "install"]
 ]
 remove: [


### PR DESCRIPTION
@dominicjprice, an update which works with cohttp 0.18+ might be nice.