### PR TITLE
fix ppx_deriving on opam 1.2.0

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.2.1/url
+++ b/packages/ppx_deriving/ppx_deriving.2.1/url
@@ -1,2 +1,2 @@
-http: "https://github.com/whitequark/ppx_deriving/archive/v2.1.tar.gz"
-checksum: "6b48d4d1f64813977b684ba1f9f74fea"
+http: "https://github.com/whitequark/ppx_deriving/archive/v2.1.1.tar.gz"
+checksum: "c0fcaa6552eaaa3ded86f561c59bc173"


### PR DESCRIPTION
using experimental features of opam (libexec) isn't that great for users with older versions.