### PR TITLE
+ irmin-indexeddb 0.1

### DIFF
--- a/packages/irmin-indexeddb/irmin-indexeddb.0.1/descr
+++ b/packages/irmin-indexeddb/irmin-indexeddb.0.1/descr
@@ -1,0 +1,3 @@
+This is an Irmin backend that stores the data in the web-browser's IndexedDB store.
+
+For more information, see <http://roscidus.com/blog/blog/2015/06/22/cuekeeper-internals-irmin/>

--- a/packages/irmin-indexeddb/irmin-indexeddb.0.1/opam
+++ b/packages/irmin-indexeddb/irmin-indexeddb.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/talex5/irmin-indexeddb"
+bug-reports: "https://github.com/talex5/irmin-indexeddb/issues"
+license: "ISC"
+dev-repo: "https://github.com/talex5/irmin-indexeddb.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "irmin-indexeddb"]
+depends: [
+  "base64"
+  "irmin"
+  "js_of_ocaml"
+  "lwt"
+]

--- a/packages/irmin-indexeddb/irmin-indexeddb.0.1/url
+++ b/packages/irmin-indexeddb/irmin-indexeddb.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/talex5/irmin-indexeddb/archive/v0.1.tar.gz"
+checksum: "68965847817741d92f020e12995ea65c"


### PR DESCRIPTION
This is an Irmin backend that stores the data in the web-browser's IndexedDB store.

For more information, see <http://roscidus.com/blog/blog/2015/06/22/cuekeeper-internals-irmin/>