### PR TITLE
update lwt dependency for new camlp4 numbering scheme

### DIFF
--- a/packages/lwt/lwt.2.4.4/opam
+++ b/packages/lwt/lwt.2.4.4/opam
@@ -6,7 +6,7 @@ build: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "lwt"]]
-depends: ["ocamlfind" "camlp4" {< "4.02.0"}]
+depends: ["ocamlfind" "camlp4" {< "4.02"}]
 depopts: [
   "base-threads"
   "base-unix"


### PR DESCRIPTION
It looks like `camlp4` dropped the last part of the version number, and `4.02`  is smaller than `4.02.0`, so opam tries to install `lwt.2.4.4` on OCaml `4.02.2`, which fails.
