### PR TITLE
sociaml-facebook-api version 0.4.1

### DIFF
--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/descr
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/descr
@@ -1,0 +1,2 @@
+Facebook Graph API Client Library for OCaml
+Access version 1.0 of the Facebook Graph API in OCaml applications.

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 name: "sociaml-facebook-api"
 version: "0.4.1"
 maintainer: "dominic.price@nottingham.ac.uk"
@@ -6,6 +6,9 @@ homepage: "https://github.com/dominicjprice/sociaml-facebook-api"
 authors: [ "Dominic Price" ]
 license: "ISC"
 ocaml-version: [ >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" ]
+bug-reports: "https://github.com/dominicjprice/sociaml-facebook-api/issues"
+dev-repo: "https://github.com/dominicjprice/sociaml-facebook-api"
 build: [
   ["oasis" "setup"]
   ["./configure" "--prefix" prefix]

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
@@ -5,7 +5,6 @@ maintainer: "dominic.price@nottingham.ac.uk"
 homepage: "https://github.com/dominicjprice/sociaml-facebook-api"
 authors: [ "Dominic Price" ]
 license: "ISC"
-ocaml-version: [ >= "4.02.1" ]
 available: [ ocaml-version >= "4.02.1" ]
 bug-reports: "https://github.com/dominicjprice/sociaml-facebook-api/issues"
 dev-repo: "https://github.com/dominicjprice/sociaml-facebook-api"

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
@@ -1,0 +1,34 @@
+opam-version: "1"
+name: "sociaml-facebook-api"
+version: "0.4.1"
+maintainer: "dominic.price@nottingham.ac.uk"
+homepage: "https://github.com/dominicjprice/sociaml-facebook-api"
+authors: [ "Dominic Price" ]
+license: "ISC"
+ocaml-version: [ >= "4.02.1" ]
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix" prefix]
+  [make "build"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  [make "uninstall"]
+  ["ocamlfind" "remove" "sociaml_facebook_api"]
+  ["ocamlfind" "remove" "endpoints"]
+]
+depends: [
+  "calendar"
+  "cohttp" { >= "0.18.0" }
+  "core_kernel"
+  "csv"
+  "lwt"
+  "oasis"
+  "ppx_meta_conv"
+  "ssl"
+  "tiny_json"
+  "tiny_json_conv"
+  "uri"
+]

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
@@ -7,7 +7,7 @@ authors: [ "Dominic Price" ]
 license: "ISC"
 available: [ ocaml-version >= "4.02.1" ]
 bug-reports: "https://github.com/dominicjprice/sociaml-facebook-api/issues"
-dev-repo: "https://github.com/dominicjprice/sociaml-facebook-api"
+dev-repo: "https://github.com/dominicjprice/sociaml-facebook-api.git"
 build: [
   ["oasis" "setup"]
   ["./configure" "--prefix" prefix]

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/url
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dominicjprice/sociaml-facebook-api/archive/v0.4.1.tar.gz"
+checksum: "5ccb8fbeb4128ceee8c541d80364e156"


### PR DESCRIPTION
This version has been updated to be compatible with cohttp 0.18+,
previous versions of cohttp are no longer supported.
Support for meta_conv has been dropped in favour of ppx_meta_conv, the
follow-on effect of this is that an ocaml version greater than or equal
to 4.02 is required.