### PR TITLE
riakc_ppx.3.1.3 - via opam-publish

### DIFF
--- a/packages/riakc_ppx/riakc_ppx.3.1.3/descr
+++ b/packages/riakc_ppx/riakc_ppx.3.1.3/descr
@@ -1,0 +1,3 @@
+An OCaml riak client with ppx extensions
+
+An OCaml library that provides type safe caching extensions to riakc using ppx deriving

--- a/packages/riakc_ppx/riakc_ppx.3.1.3/opam
+++ b/packages/riakc_ppx/riakc_ppx.3.1.3/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "carmelo.piccione+riakc_ppx@gmail.com"
+authors: "Carmelo Piccione carmelo.piccione+riakc_ppx@gmail.com"
+homepage: "https://github.com/struktured/riakc_ppx"
+bug-reports: "https://github.com/struktured/riakc_ppx/issues"
+dev-repo: "https://github.com/struktured/riakc_ppx.git"
+build: ["omake" "-j2"]
+install: ["omake" "install"]
+remove: ["ocamlfind" "remove" "riakc_ppx"]
+depends: [
+  "ocamlfind"
+  "core" {>= "109.12.00"}
+  "async"
+  "ppx_deriving_protobuf" {>= "2.0"}
+  "bitstring" {>= "2.0.4"}
+  "omake" {build}
+]
+available: [ocaml-version >= "4.02.2"]

--- a/packages/riakc_ppx/riakc_ppx.3.1.3/url
+++ b/packages/riakc_ppx/riakc_ppx.3.1.3/url
@@ -1,0 +1,2 @@
+http: "http://github.com/struktured/riakc_ppx/archive/3.1.3.zip"
+checksum: "acaa64e2331db904b9d72101b7e693ca"


### PR DESCRIPTION
An OCaml riak client with ppx extensions

An OCaml library that provides type safe caching extensions to riakc using ppx deriving


---
* Homepage: https://github.com/struktured/riakc_ppx
* Source repo: https://github.com/struktured/riakc_ppx.git
* Bug tracker: https://github.com/struktured/riakc_ppx/issues

---
Pull-request generated by opam-publish v0.3.0