### PR TITLE
uri.1.9.1 - via opam-publish

### DIFF
--- a/packages/uri/uri.1.9.1/descr
+++ b/packages/uri/uri.1.9.1/descr
@@ -1,0 +1,3 @@
+RFC3986 URI/URL parsing library
+
+RFC3986 URI/URL parsing library

--- a/packages/uri/uri.1.9.1/opam
+++ b/packages/uri/uri.1.9.1/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "https://github.com/mirage/ocaml-uri.git"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: [
+  "url"
+  "uri"
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{ounit:enable}%-tests"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: [
+  ["ocaml" "setup.ml" "-doc"]
+]
+remove: [
+  ["ocamlfind" "remove" "uri"]
+]
+depends: [
+  "ocamlfind" {build}
+  "re"
+  "sexplib" {>="109.53.00"}
+  "base-bytes"
+  "type_conv"
+  "stringext"
+  "ounit" {test & >="1.0.2"}
+]

--- a/packages/uri/uri.1.9.1/url
+++ b/packages/uri/uri.1.9.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-uri/archive/v1.9.1.tar.gz"
+checksum: "44a36ed3da245f1fdd5623d17f3d16c5"


### PR DESCRIPTION
RFC3986 URI/URL parsing library

RFC3986 URI/URL parsing library


---
* Homepage: https://github.com/mirage/ocaml-uri
* Source repo: https://github.com/mirage/ocaml-uri.git
* Bug tracker: https://github.com/mirage/ocaml-uri/issues

---
Pull-request generated by opam-publish v0.3.0