### PR TITLE
Clean-up Irmin 0.9.*'s opam files.

### DIFF
--- a/packages/irmin/irmin.0.9.0/opam
+++ b/packages/irmin/irmin.0.9.0/opam
@@ -11,11 +11,13 @@ build: [
       "--prefix" prefix
       "--%{cohttp:enable}%-http"
       "--%{git:enable}%-git"
-      "--%{base-unix:enable}%-unix"
-      "--%{cohttp+git+alcotest:enable}%-tests"]
+      "--%{base-unix:enable}%-unix"]
   [make]
 ]
-build-test: [make "test"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
 install: [make "install"]
 remove: [
   ["ocamlfind" "remove" "irmin"]
@@ -37,9 +39,15 @@ depends: [
   "re"
   "cmdliner"
   "crunch"
-  "git" {test}
-  "cohttp" {test}
-  "alcotest" {test}
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & <= "0.3.3"}
+]
+depopts: [
+  "base-unix"
+  "git"
+  "cohttp"
 ]
 conflicts: [
   "git"    {!= "1.4.3"}

--- a/packages/irmin/irmin.0.9.1/opam
+++ b/packages/irmin/irmin.0.9.1/opam
@@ -11,11 +11,13 @@ build: [
       "--prefix" prefix
       "--%{cohttp:enable}%-http"
       "--%{git:enable}%-git"
-      "--%{base-unix:enable}%-unix"
-      "--%{cohttp+git+alcotest:enable}%-tests"]
+      "--%{base-unix:enable}%-unix"]
   [make]
 ]
-build-test: [make "test"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
 install: [make "install"]
 remove: [
   ["ocamlfind" "remove" "irmin"]
@@ -37,11 +39,13 @@ depends: [
   "re"
   "cmdliner"
   "crunch"
-  "git" {test}
-  "cohttp" {test}
-  "alcotest" {test}
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & <= "0.3.3"}
 ]
 depopts: [
+  "base-unix"
   "git"
   "cohttp"
 ]

--- a/packages/irmin/irmin.0.9.2/opam
+++ b/packages/irmin/irmin.0.9.2/opam
@@ -6,11 +6,18 @@ bug-reports: "https://github.com/mirage/irmin/issues"
 license: "ISC"
 dev-repo: "https://github.com/mirage/irmin.git"
 build: [
-  ["./configure" "--prefix" prefix "--%{cohttp:enable}%-http" "--%{git:enable}%-git" "--%{base-unix:enable}%-unix" "--%{cohttp+git+alcotest:enable}%-tests"]
+  ["./configure"
+      "--prefix" prefix
+      "--%{cohttp:enable}%-http"
+      "--%{git:enable}%-git"
+      "--%{base-unix:enable}%-unix"]
   [make]
 ]
 install: [make "install"]
-build-test: [make "test"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
 remove: [
   ["ocamlfind" "remove" "irmin"]
   ["rm" "-f" "%{bin}%/irmin"]
@@ -30,11 +37,13 @@ depends: [
   "re"
   "cmdliner"
   "crunch"
-  "git" {test}
-  "cohttp" {test}
-  "alcotest" {test}
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & <= "0.3.3"}
 ]
 depopts: [
+  "base-unix"
   "git"
   "cohttp"
 ]

--- a/packages/irmin/irmin.0.9.3/opam
+++ b/packages/irmin/irmin.0.9.3/opam
@@ -6,11 +6,18 @@ bug-reports: "https://github.com/mirage/irmin/issues"
 license: "ISC"
 dev-repo: "https://github.com/mirage/irmin.git"
 build: [
-  ["./configure" "--prefix" prefix "--%{cohttp:enable}%-http" "--%{git:enable}%-git" "--%{base-unix:enable}%-unix" "--%{cohttp+git+alcotest:enable}%-tests"]
+  ["./configure"
+      "--prefix" prefix
+      "--%{cohttp:enable}%-http"
+      "--%{git:enable}%-git"
+      "--%{base-unix:enable}%-unix"]
   [make]
 ]
 install: [make "install"]
-build-test: [make "test"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
 remove: [
   ["ocamlfind" "remove" "irmin"]
   ["rm" "-f" "%{bin}%/irmin"]
@@ -30,11 +37,13 @@ depends: [
   "re"
   "cmdliner"
   "crunch"
-  "git" {test}
-  "cohttp" {test}
-  "alcotest" {test}
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & <= "0.3.3"}
 ]
 depopts: [
+  "base-unix"
   "git"
   "cohttp"
 ]

--- a/packages/irmin/irmin.0.9.4/opam
+++ b/packages/irmin/irmin.0.9.4/opam
@@ -11,12 +11,13 @@ build: [
       "--prefix" prefix
       "--%{cohttp:enable}%-http"
       "--%{git:enable}%-git"
-      "--%{base-unix:enable}%-unix"
-      "--%{cohttp+git+alcotest:enable}%-tests"
-      "--%{cohttp+git+alcotest:enable}%-examples"]
+      "--%{base-unix:enable}%-unix"]
   [make]
 ]
-build-test: [make "test"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
 install: [make "install"]
 remove: [
   ["ocamlfind" "remove" "irmin"]
@@ -37,9 +38,10 @@ depends: [
   "re"
   "cmdliner"
   "crunch"
-  "git" {test}
-  "cohttp" {test}
-  "alcotest" {test}
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & <= "0.3.3"}
 ]
 depopts: [
   "git"

--- a/packages/irmin/irmin.0.9.5/opam
+++ b/packages/irmin/irmin.0.9.5/opam
@@ -11,8 +11,7 @@ build: [
       "--prefix" prefix
       "--%{cohttp:enable}%-http"
       "--%{git:enable}%-git"
-      "--%{base-unix:enable}%-unix"
-      "--%{cohttp+git+alcotest:enable}%-examples"]
+      "--%{base-unix:enable}%-unix"]
   [make]
 ]
 build-test: [
@@ -39,11 +38,13 @@ depends: [
   "re"
   "cmdliner"
   "crunch"
-  "git" {test}
-  "cohttp" {test}
-  "alcotest" {test}
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & <= "0.3.3"}
 ]
 depopts: [
+  "base-unix"
   "git"
   "cohttp"
   "nocrypto"


### PR DESCRIPTION
Main change is adding a constraint to alcotest <= 0.3.3