### PR TITLE
dns.0.15.1 - via opam-publish

### DIFF
--- a/packages/dns/dns.0.15.1/descr
+++ b/packages/dns/dns.0.15.1/descr
@@ -1,0 +1,5 @@
+DNS client and server implementation
+
+This is a pure OCaml implementation of the DNS protocol. It is intended to be a
+reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.

--- a/packages/dns/dns.0.15.1/opam
+++ b/packages/dns/dns.0.15.1/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "
+LGPL-2.0 &
+   LGPL-2.1 with OCaml linking exception &
+   ISC
+         "
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+dev-repo: "https://github.com/mirage/ocaml-dns.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{base-unix:enable}%-lwt" "--%{mirage-types:enable}%-mirage"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{base-unix:enable}%-lwt" "--%{mirage-types:enable}%-mirage" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test" "-runner" "sequential"]
+]
+remove: ["ocamlfind" "remove" "dns"]
+depends: [
+  "base-bytes"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.1"}
+  "ocamlfind"
+  "re"
+  "cmdliner"
+  "ipaddr" {>= "2.6.0"}
+  "uri" {>= "1.7.0"}
+  "base64" {>= "2.0.0"}
+  "ounit"
+  "pcap-format" {test}
+  "mirage-profile"
+]
+depopts: [
+  "tcpip"
+  "async"
+]
+conflicts: [
+  "mirage-types" {< "1.2.0"}
+  "async" {< "112.24.00"}
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/dns/dns.0.15.1/url
+++ b/packages/dns/dns.0.15.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-dns/archive/v0.15.1.tar.gz"
+checksum: "2466edb1a52425496641fb6699b180d9"


### PR DESCRIPTION
DNS client and server implementation

This is a pure OCaml implementation of the DNS protocol. It is intended to be a
reasonably high-performance implementation, but clarity is preferred rather
than low-level performance hacks.


---
* Homepage: https://github.com/mirage/ocaml-dns
* Source repo: https://github.com/mirage/ocaml-dns.git
* Bug tracker: https://github.com/mirage/ocaml-dns/issues

---
Pull-request generated by opam-publish v0.3.0