### PR TITLE
channel.1.0.0 - via opam-publish

### DIFF
--- a/packages/channel/channel.1.0.0/descr
+++ b/packages/channel/channel.1.0.0/descr
@@ -1,0 +1,3 @@
+Mirage channels
+
+An implementation of MirageOS' V1.CHANNEL using page aligned buffers.

--- a/packages/channel/channel.1.0.0/opam
+++ b/packages/channel/channel.1.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "https://github.com/mirage/mirage-channel"
+bug-reports:  "https://github.com/mirage/mirage-channel/issues"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-channel.git"
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "channel"]
+
+depends: [
+  "ocamlfind" {build}
+  "mirage-types-lwt"
+  "io-page"
+  "lwt"
+  "cstruct"
+  "alcotest"    {test}
+  "ounit"       {test}
+  "mirage-flow" {test}
+]

--- a/packages/channel/channel.1.0.0/url
+++ b/packages/channel/channel.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-channel/archive/1.0.0.tar.gz"
+checksum: "74478e4fa322d9a196b270deb1920af9"


### PR DESCRIPTION
Mirage channels

An implementation of MirageOS' V1.CHANNEL using page aligned buffers.

---
* Homepage: https://github.com/mirage/mirage-channel
* Source repo: https://github.com/mirage/mirage-channel.git
* Bug tracker: https://github.com/mirage/mirage-channel/issues

---
Pull-request generated by opam-publish v0.2.1