### PR TITLE
fix version number

### DIFF
--- a/packages/tlstunnel/tlstunnel.0.1.1/opam
+++ b/packages/tlstunnel/tlstunnel.0.1.1/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name:         "tlstunnel"
-version:      "0.1.0"
+version:      "0.1.1"
 homepage:     "https://github.com/hannesm/tlstunnel"
 dev-repo:     "https://github.com/hannesm/tlstunnel.git"
 bug-reports:  "https://github.com/hannesm/tlstunnel/issues"


### PR DESCRIPTION
as requested by @dsheets https://github.com/ocaml/opam-repository/pull/4360#discussion_r33887345

why do you suggest to not have a name and version number in the opam file? (with our current signing design, each opam file will be required to contain this information (otherwise replay attacks can happen)). I personally think it is a good thing to have this data in one place, rather than implicit via the file system structure..