### PR TITLE
mirage-http.2.5.0 - via opam-publish

### DIFF
--- a/packages/mirage-http/mirage-http.2.5.0/descr
+++ b/packages/mirage-http/mirage-http.2.5.0/descr
@@ -1,0 +1,1 @@
+Mirage HTTP client and server driver

--- a/packages/mirage-http/mirage-http.2.5.0/opam
+++ b/packages/mirage-http/mirage-http.2.5.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/mirage-http"
+bug-reports:  "https://github.com/mirage/mirage-http/issues/"
+dev-repo:     "https://github.com/mirage/mirage-http.git"
+
+build:    [make]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "mirage-http"]
+depends: [
+  "ocamlfind" {build}
+  "mirage-types-lwt" {>= "2.0.0"}
+  "mirage-conduit" {>= "2.2.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp" {>= "0.18.0"}
+  "sexplib"
+  "channel"
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/mirage-http/mirage-http.2.5.0/url
+++ b/packages/mirage-http/mirage-http.2.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-http/archive/v2.5.0.tar.gz"
+checksum: "d9391f983182c7de9a8e9ddc1275c4cc"


### PR DESCRIPTION
Mirage HTTP client and server driver

---
* Homepage: https://github.com/mirage/mirage-http
* Source repo: https://github.com/mirage/mirage-http.git
* Bug tracker: https://github.com/mirage/mirage-http/issues/

---
Pull-request generated by opam-publish v0.2.1