### PR TITLE
sodium.0.5.0 - via opam-publish

### DIFF
--- a/packages/sodium/sodium.0.5.0/descr
+++ b/packages/sodium/sodium.0.5.0/descr
@@ -1,0 +1,8 @@
+Binding to libsodium UNAUDITED
+
+Binding to libsodium 0.7.0+, a shared library wrapper for djb's NaCl.
+
+Binding uses ctypes' stub generation system. GNU/Linux, FreeBSD, and OS
+X are supported.
+
+UNAUDITED

--- a/packages/sodium/sodium.0.5.0/opam
+++ b/packages/sodium/sodium.0.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "David Sheets <sheets@alum.mit.edu>"
+  "Peter Zotov <whitequark@whitequark.org>"
+]
+homepage: "https://github.com/dsheets/ocaml-sodium/"
+bug-reports: "https://github.com/dsheets/ocaml-sodium/issues/"
+tags: "org:mirage"
+dev-repo: "https://github.com/dsheets/ocaml-sodium.git"
+build: [
+  [make] {os != "freebsd"}
+  [make "CFLAGS=-I/usr/local/include -L/usr/local/lib"] {os = "freebsd"}
+]
+install: [make "PREFIX=%{prefix}%" "install"]
+build-test: [
+  [make "test"] {os != "freebsd"}
+  [make "CFLAGS=-I/usr/local/include -L/usr/local/lib" "test"] {os = "freebsd"}
+]
+remove: ["ocamlfind" "remove" "sodium"]
+depends: [
+  "base-bigarray"
+  "base-bytes"
+  "ocamlfind"
+  "ctypes" {>= "0.4.0"}
+]
+depexts: [
+  [["debian"] ["libsodium-dev"]]
+  [["freebsd"] ["security/libsodium"]]
+  [["homebrew" "osx"] ["libsodium"]]
+  [["ubuntu"] ["libsodium-dev"]]
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages: [
+  "This package requires installation of libsodium-dev (>= 0.7.0)" {failure & os = "debian"}
+  "This package requires installation of libsodium-dev (>= 0.7.0)" {failure & os = "ubuntu"}
+  "This package requires installation of security/libsodium (>= 0.7.0)" {failure & os = "freebsd"}
+  "This package requires installation of libsodium (>= 0.7.0)" {failure & os = "osx"}
+]

--- a/packages/sodium/sodium.0.5.0/url
+++ b/packages/sodium/sodium.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-sodium/archive/0.5.0.tar.gz"
+checksum: "07c585883270fe5d1eee84d94f26864a"


### PR DESCRIPTION
Binding to libsodium UNAUDITED

Binding to libsodium 0.7.0+, a shared library wrapper for djb's NaCl.

Binding uses ctypes' stub generation system. GNU/Linux, FreeBSD, and OS
X are supported.

UNAUDITED


---
* Homepage: https://github.com/dsheets/ocaml-sodium/
* Source repo: https://github.com/dsheets/ocaml-sodium.git
* Bug tracker: https://github.com/dsheets/ocaml-sodium/issues/

---
Pull-request generated by opam-publish v0.3.0