### PR TITLE
irmin.0.9.7 - via opam-publish

### DIFF
--- a/packages/irmin/irmin.0.9.7/descr
+++ b/packages/irmin/irmin.0.9.7/descr
@@ -1,0 +1,9 @@
+Irmin, the database that never forgets
+
+Irmin is a distributed database with built-in snapshot, branch and
+revert mechanisms. It is designed to use a large variety of backends,
+although it is optimized for append-only store.
+
+Irmin is written in pure OCaml. It can thus be compiled to Javascript
+-- and run in the browsers; or into a Mirage unikernel -- and run directly
+on top of Xen.

--- a/packages/irmin/irmin.0.9.7/opam
+++ b/packages/irmin/irmin.0.9.7/opam
@@ -1,0 +1,53 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+
+build: [
+  ["./configure" "--prefix" prefix
+      "--%{cohttp:enable}%-http"
+      "--%{git:enable}%-git"
+      "--%{base-unix:enable}%-unix"]
+  [make]
+]
+build-test: [
+  ["./configure" "--enable-tests" "--enable-examples"]
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "irmin"]
+
+depends: [
+  "ocamlfind" {build}
+  "ezjsonm" {>= "0.4.0"}
+  "ocamlgraph"
+  "lwt" {>= "2.4.7"}
+  "dolog" {>= "0.4"}
+  "cstruct" {>= "1.0.1"}
+  "mirage-tc" {>= "0.3.0"}
+  "mstruct"
+  "uri" {>= "1.3.12"}
+  "stringext" {>= "1.1.0"}
+  "hex"
+  "re"
+  "cmdliner"
+  "crunch"
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & >="0.4.1"}
+]
+depopts: [
+  "base-unix"
+  "git"
+  "cohttp"
+]
+conflicts: [
+  "cohttp" {< "0.14.0"}
+  "cohttp" {= "0.16.1"}
+  "git"    {<= "1.5.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin/irmin.0.9.7/url
+++ b/packages/irmin/irmin.0.9.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/irmin/archive/0.9.7.tar.gz"
+checksum: "27dce94256a2fd1ad3b6b5bd47c15824"


### PR DESCRIPTION
Irmin, the database that never forgets

Irmin is a distributed database with built-in snapshot, branch and
revert mechanisms. It is designed to use a large variety of backends,
although it is optimized for append-only store.

Irmin is written in pure OCaml. It can thus be compiled to Javascript
-- and run in the browsers; or into a Mirage unikernel -- and run directly
on top of Xen.

---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---
Pull-request generated by opam-publish v0.2.1