### PR TITLE
fix distfile url in depexts

### DIFF
--- a/packages/conf-libuv/conf-libuv.1/opam
+++ b/packages/conf-libuv/conf-libuv.1/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "andreas@ml.ignorelist.com"
+maintainer: "andreashauptmann@t-online.de"
 homepage: "https://github.com/libuv/libuv"
 license: "MIT"
 bug-reports: "https://github.com/libuv/libuv/issues"
@@ -12,8 +12,9 @@ depexts: [
 #  not available in any mainstream distro at the momement
 #  [["debian"] ["pkg-config" "libuv-dev"]]
 #  [["ubuntu"] ["pkg-config" "libuv-dev"]]
+  [["osx" "homebrew"] ["libuv" "pkg-config"]]
   [["freebsd"] ["pkgconf" "libuv"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/fdopen/cbfb14114f4ec423a1a4/raw/09d2f8139950447f3c6fccaaa8483cfddc1ccb24/install-libuv.sh"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/fdopen/cbfb14114f4ec423a1a4/raw/1d4144f16aa2c65d39a1be5aae39911dc5e53ef6/install-libuv.sh"]]
 ]
 post-messages: [
   "This package requires libuv 1.x development packages installed on your system" {failure}


### PR DESCRIPTION
the depext-script points to an URL that is not longer available.
I've just changed it to the current location: https://gist.github.com/fdopen/cbfb14114f4ec423a1a4/revisions
