### PR TITLE
Set an explicit upper bound for a core_kernel.

### DIFF
--- a/packages/bap/bap.0.9.8/opam
+++ b/packages/bap/bap.0.9.8/opam
@@ -41,7 +41,7 @@ depends: [
     "camlzip"
     "cmdliner" {>= "0.9.6"}
     "cohttp" {>= "0.15.0"}
-    "core_kernel" {>= "111.28.0"}
+    "core_kernel" {>= "111.28.0" & < "112.35.0"}
     "ezjsonm" {>= "0.4.0"}
     "faillib"
     "fileutils"


### PR DESCRIPTION
Version 112.35.0 introduces incompatible changes to a monad interface.