### PR TITLE
tftp.0.1.3 - via opam-publish

### DIFF
--- a/packages/tftp/tftp.0.1.3/descr
+++ b/packages/tftp/tftp.0.1.3/descr
@@ -1,0 +1,5 @@
+A TFTP library and Mirage unikernel
+
+A basic implementation of the [Trivial FTP](https://tools.ietf.org/html/rfc1350)
+protocol. Provides separate wire parsing and server libraries, plus a
+[MirageOS](https://mirage.io/) unikernel server implementation.

--- a/packages/tftp/tftp.0.1.3/opam
+++ b/packages/tftp/tftp.0.1.3/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "mort@cantab.net"
+authors: "Richard Mortier <mort@cantab.net>"
+homepage: "https://github.com/mor1/ocaml-tftp"
+bug-reports: "https://github.com/mor1/ocaml-tftp/issues"
+license: "ISC"
+dev-repo: "https://github.com/mor1/ocaml-tftp.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--%{alcotest:enable}%-tests"]
+  [make "build"]
+  ["cp" "./tftp.opam/install" "./tftp.install"]
+]
+install: [
+  [make "install"]
+  [make "tftpd" "FS=direct" "NET=socket" "MIRFLAGS=--no-depext --no-opam"]
+]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "tftp"]
+depends: [
+  "ocamlfind" {build}
+  "camlp4"
+  "lwt" {>= "2.4.7"}
+  "cstruct" {>= "1.0.1"}
+  "mirage" {>= "2.5.0"}
+  "io-page"
+  "mirage-console"
+  "mirage-fs-unix"
+  "tcpip"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/tftp/tftp.0.1.3/url
+++ b/packages/tftp/tftp.0.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mor1/ocaml-tftp/archive/0.1.3.tar.gz"
+checksum: "b2f676c7c042cd8ec75865636cafdaa6"


### PR DESCRIPTION
A TFTP library and Mirage unikernel

A basic implementation of the [Trivial FTP](https://tools.ietf.org/html/rfc1350)
protocol. Provides separate wire parsing and server libraries, plus a
[MirageOS](https://mirage.io/) unikernel server implementation.


---
* Homepage: https://github.com/mor1/ocaml-tftp
* Source repo: https://github.com/mor1/ocaml-tftp.git
* Bug tracker: https://github.com/mor1/ocaml-tftp/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them

---

Pull-request generated by opam-publish v0.3.0