### PR TITLE
ocplib-endian requires cppo at least 1.1.0 for -V support

### DIFF
--- a/packages/ocplib-endian/ocplib-endian.0.8/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.8/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "ocplib-endian"]
 depends: [
   "base-bytes"
   "ocamlfind"
-  "cppo" {>= "0.8"}
+  "cppo" {>= "1.1.0"}
 ]
 dev-repo: "https://github.com/OCamlPro/ocplib-endian.git"
 bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"


### PR DESCRIPTION
I spaced in #4007 and put the wrong package's version. :-(