### PR TITLE
cstruct.1.7.0 - via opam-publish

### DIFF
--- a/packages/cstruct/cstruct.1.7.0/descr
+++ b/packages/cstruct/cstruct.1.7.0/descr
@@ -1,0 +1,19 @@
+access C structures via a camlp4 extension
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the Bigarray module.
+
+An example pcap description is:
+
+```
+cstruct pcap_header {
+  uint32_t magic_number;   (* magic number *)
+  uint16_t version_major;  (* major version number *)
+  uint16_t version_minor;  (* minor version number *)
+  uint32_t thiszone;       (* GMT to local correction *)
+  uint32_t sigfigs;        (* accuracy of timestamps *)
+  uint32_t snaplen;        (* max length of captured packets, in octets *)
+  uint32_t network         (* data link type *)
+} as little_endian
+```

--- a/packages/cstruct/cstruct.1.7.0/opam
+++ b/packages/cstruct/cstruct.1.7.0/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      "Anil Madhavapeddy"
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["./configure"
+      "--prefix" prefix
+      "--%{lwt:enable}%-lwt"
+      "--%{camlp4:enable}%-camlp4"
+      "--%{async:enable}%-async"
+      "--%{base-unix:enable}%-unix"
+      "--%{ounit:enable}%-tests"]
+  [make]
+]
+build-test: [
+  ["./configure"
+      "--prefix" prefix
+      "--%{lwt:enable}%-lwt"
+      "--%{camlp4:enable}%-camlp4"
+      "--%{async:enable}%-async"
+      "--%{base-unix:enable}%-unix"
+      "--%{ounit:enable}%-tests"]
+  [make]
+  ["./test.sh"]
+]
+install: [
+  [make "install"]
+  [make "js-install"]
+]
+remove:  [
+  [make "js-uninstall"]
+  ["ocamlfind" "remove" "cstruct"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ounit" {test}
+  "type_conv" {build}
+  "ocplib-endian"
+  "sexplib"
+]
+depopts: [
+  "camlp4"
+  "async"
+  "lwt"
+]
+available: [ocaml-version >= "4.01.0"]
+depexts: [
+  [ ["debian"] ["time"] ]
+  [ ["ubuntu"] ["time"] ]
+]

--- a/packages/cstruct/cstruct.1.7.0/url
+++ b/packages/cstruct/cstruct.1.7.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cstruct/archive/v1.7.0.tar.gz"
+checksum: "3178d5ef2cf6cd1aa4fa5e897adf5456"


### PR DESCRIPTION
access C structures via a camlp4 extension

Cstruct is a library and syntax extension to make it easier to access C-like
structures directly from OCaml. It supports both reading and writing to these
structures, and they are accessed via the Bigarray module.

An example pcap description is:

```
cstruct pcap_header {
  uint32_t magic_number;   (* magic number *)
  uint16_t version_major;  (* major version number *)
  uint16_t version_minor;  (* minor version number *)
  uint32_t thiszone;       (* GMT to local correction *)
  uint32_t sigfigs;        (* accuracy of timestamps *)
  uint32_t snaplen;        (* max length of captured packets, in octets *)
  uint32_t network         (* data link type *)
} as little_endian
```

---
* Homepage: https://github.com/mirage/ocaml-cstruct
* Source repo: https://github.com/mirage/ocaml-cstruct.git
* Bug tracker: https://github.com/mirage/ocaml-cstruct/issues

---
Pull-request generated by opam-publish v0.2.1