### PR TITLE
assertions.0.1 - via opam-publish

### DIFF
--- a/packages/assertions/assertions.0.1/descr
+++ b/packages/assertions/assertions.0.1/descr
@@ -1,8 +1,4 @@
-Short
-description
 Basic assert statements
 
-Long
-description
 Provides basic assert statements, like `assert_equal` and `assert_raises`.
 To be used independently or as a supplement to `ounit` or `pa_ounit.

--- a/packages/assertions/assertions.0.1/descr
+++ b/packages/assertions/assertions.0.1/descr
@@ -1,0 +1,8 @@
+Short
+description
+Basic assert statements
+
+Long
+description
+Provides basic assert statements, like `assert_equal` and `assert_raises`.
+To be used independently or as a supplement to `ounit` or `pa_ounit.

--- a/packages/assertions/assertions.0.1/opam
+++ b/packages/assertions/assertions.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Ben Greenman"
+authors: "Ben Greenman"
+homepage: "http://github.com/bennn"
+bug-reports: "https://github.com/bennn/assertions/issues"
+dev-repo: "https://github.com/bennn/assertions.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "assertions"]
+depends: "ocamlfind" {build}

--- a/packages/assertions/assertions.0.1/opam
+++ b/packages/assertions/assertions.0.1/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "Ben Greenman"
 authors: "Ben Greenman"
-homepage: "http://github.com/bennn"
+homepage: "http://github.com/bennn/assertions"
 bug-reports: "https://github.com/bennn/assertions/issues"
 dev-repo: "https://github.com/bennn/assertions.git"
 build: [

--- a/packages/assertions/assertions.0.1/url
+++ b/packages/assertions/assertions.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bennn/assertions/archive/0.1.tar.gz"
+checksum: "2021486112f018aafc818bce8c318a7a"


### PR DESCRIPTION
Short
description
Basic assert statements

Long
description
Provides basic assert statements, like `assert_equal` and `assert_raises`.
To be used independently or as a supplement to `ounit` or `pa_ounit.

---
* Homepage: http://github.com/bennn
* Source repo: https://github.com/bennn/assertions.git
* Bug tracker: https://github.com/bennn/assertions/issues

---
Pull-request generated by opam-publish v0.2.1