### PR TITLE
opam-lib.1.2.1 - via opam-publish

### DIFF
--- a/packages/opam-lib/opam-lib.1.2.1/descr
+++ b/packages/opam-lib/opam-lib.1.2.1/descr
@@ -1,0 +1,5 @@
+The OPAM library
+
+OPAM is The OCaml PAckage Manager. This package contains the OPAM
+libraries, that may be used by external tools to access OPAM
+installation, state and data.

--- a/packages/opam-lib/opam-lib.1.2.1/files/fix-wait.diff
+++ b/packages/opam-lib/opam-lib.1.2.1/files/fix-wait.diff
@@ -1,0 +1,19 @@
+diff --git a/src/core/opamProcess.ml b/src/core/opamProcess.ml
+index ca64c89..320c42c 100644
+--- a/src/core/opamProcess.ml
++++ b/src/core/opamProcess.ml
+@@ -175,9 +175,13 @@ let read_lines f =
+     List.rev !lines
+   with Sys_error _ -> []
+ 
++let rec waitpid p = try Unix.waitpid [] p with
++  | Unix.Unix_error (Unix.EINTR,_,_) -> waitpid p
++  | Unix.Unix_error (Unix.ECHILD,_,_) -> p, Unix.WEXITED 256
++
+ let wait p =
+   let rec iter () =
+-    let _, status = Unix.waitpid [] p.p_pid in
++    let _, status = waitpid p.p_pid in
+     match status with
+     | Unix.WEXITED code ->
+       let duration = Unix.gettimeofday () -. p.p_time in

--- a/packages/opam-lib/opam-lib.1.2.1/opam
+++ b/packages/opam-lib/opam-lib.1.2.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+homepage:     "https://opam.ocaml.org/"
+dev-repo:     "https://github.com/ocaml/opam.git"
+bug-reports:  "https://github.com/ocaml/opam/issues"
+authors: [
+   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+   "Anil Madhavapeddy   <anil@recoil.org>"
+   "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+   "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+   "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+   "Vincent Bernardoff  <vb@luminar.eu.org>"
+   "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+build: [
+  ["./configure"]
+  [make]
+  [make "-C" "src" "../opam-lib.install"]
+]
+depends: [
+  "ocamlgraph"
+  "cmdliner"
+  "dose" {>= "3.2.2+opam" & < "4"}
+  "cudf"
+  "re" {>= "1.2.0"}
+  "ocamlfind" {build}
+  "jsonm"
+]

--- a/packages/opam-lib/opam-lib.1.2.1/url
+++ b/packages/opam-lib/opam-lib.1.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/1.2.1.tar.gz"
+checksum: "6f69a4dcaead73d1685c45647c71e063"


### PR DESCRIPTION
The OPAM library

OPAM is The OCaml PAckage Manager. This package contains the OPAM
libraries, that may be used by external tools to access OPAM
installation, state and data.


---
* Homepage: https://opam.ocaml.org/
* Source repo: https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---

Pull-request generated by opam-publish v0.3.0