### PR TITLE
Added ocaml-monadic 0.1.0

### DIFF
--- a/packages/ocaml-monadic/ocaml-monadic.0.1.0/descr
+++ b/packages/ocaml-monadic/ocaml-monadic.0.1.0/descr
@@ -1,0 +1,3 @@
+Lightweight monadic syntax extension.
+This project contains a lightweight PPX extension for OCaml to support natural monadic syntax.
+

--- a/packages/ocaml-monadic/ocaml-monadic.0.1.0/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name: "ocaml-monadic"
+version: "0.1.0"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "BSD-3-clause"
+homepage: "https://github.com/zepalmer/ocaml-monadic"
+dev-repo: "https://github.com/zepalmer/ocaml-monadic.git"
+bug-reports: "https://github.com/zepalmer/ocaml-monadic/issues"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]

--- a/packages/ocaml-monadic/ocaml-monadic.0.1.0/url
+++ b/packages/ocaml-monadic/ocaml-monadic.0.1.0/url
@@ -1,0 +1,3 @@
+archive: "https://github.com/zepalmer/ocaml-monadic/archive/0.1.0.tar.gz"
+checksum: "961670352bd9d55b578c1738b671e215"
+


### PR DESCRIPTION
First release of a PPX extension for lightweight monadic syntax meant to blend well with OCaml's syntax.