### PR TITLE
oasis2opam.0.6.1 - via opam-publish

### DIFF
--- a/packages/oasis2opam/oasis2opam.0.6.1/descr
+++ b/packages/oasis2opam/oasis2opam.0.6.1/descr
@@ -1,0 +1,5 @@
+Tool to convert OASIS metadata to OPAM package descriptions
+Generate OPAM files from _oasis. Most of the metadata supported by
+oasis is translated to OPAM. A simple .install file is written to
+handle executables (until oasis supports the functionality itself).
+

--- a/packages/oasis2opam/oasis2opam.0.6.1/opam
+++ b/packages/oasis2opam/oasis2opam.0.6.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "GPL-3 with OCaml linking exception"
+homepage: "https://github.com/ocaml/oasis2opam"
+dev-repo: "https://github.com/ocaml/oasis2opam.git"
+bug-reports: "https://github.com/ocaml/oasis2opam/issues"
+tags: [ "build" "install"  ]
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "base-unix" {build}
+  "oasis" {build & >= "0.4.4"}
+  "ocamlfind" {build}
+  "ounit" {test & >= "2.0.0"}
+  "qcheck" {test & >= "0.4"}
+]

--- a/packages/oasis2opam/oasis2opam.0.6.1/url
+++ b/packages/oasis2opam/oasis2opam.0.6.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/oasis2opam/archive/0.6.1.tar.gz"
+checksum: "e301c93c79e2b05dc0879d5a421119d5"


### PR DESCRIPTION
Tool to convert OASIS metadata to OPAM package descriptions
Generate OPAM files from _oasis. Most of the metadata supported by
oasis is translated to OPAM. A simple .install file is written to
handle executables (until oasis supports the functionality itself).


---
* Homepage: https://github.com/ocaml/oasis2opam
* Source repo: https://github.com/ocaml/oasis2opam.git
* Bug tracker: https://github.com/ocaml/oasis2opam/issues

---
Pull-request generated by opam-publish v0.2.1