### PR TITLE
Fix opam 1.2.0 warning by commenting-out a dev-repo

### DIFF
--- a/packages/pxp/pxp.1.2.7/opam
+++ b/packages/pxp/pxp.1.2.7/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "codinuum@me.com"
 homepage: "http://projects.camlcity.org/projects/pxp.html"
-dev-repo: "https://godirepo.camlcity.org/svn/lib-pxp"
+# dev-repo: "https://godirepo.camlcity.org/svn/lib-pxp"
 bug-reports: "ocaml-pxp-users@orcaware.com"
 authors: [
   "Gerd Stolpmann <gerd@gerd-stolpmann.de>"


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/issues/4511

@AltGr is there a better solution with the rewrites?