### PR TITLE
mirage-xen.2.3.3 - via opam-publish

### DIFF
--- a/packages/mirage-xen/mirage-xen.2.3.3/descr
+++ b/packages/mirage-xen/mirage-xen.2.3.3/descr
@@ -1,0 +1,3 @@
+MirageOS library for Xen
+
+This library consists of the OCaml `OS` module and its various C bindings.

--- a/packages/mirage-xen/mirage-xen.2.3.3/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-build"]
+install: [make "xen-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "cstruct" {>= "1.0.1"}
+  "ocamlfind"
+  "io-page" {>= "1.5.0"}
+  "mirage-clock-xen" {>= "1.0.0"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring" {>= "1.0.0"}
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "xen-gnt" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "conf-pkg-config"
+  "mirage-profile" {>= "0.3"}
+  "mirage-xen-ocaml"
+]
+available: [ocaml-version >= "4.01.0" & os = "linux"]

--- a/packages/mirage-xen/mirage-xen.2.3.3/url
+++ b/packages/mirage-xen/mirage-xen.2.3.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v2.3.3.tar.gz"
+checksum: "5746cfe4d3d16844c5ce81a357ffd9a0"


### PR DESCRIPTION
MirageOS library for Xen

This library consists of the OCaml `OS` module and its various C bindings.

---
* Homepage: https://github.com/mirage/mirage-platform
* Source repo: https://github.com/mirage/mirage-platform.git
* Bug tracker: https://github.com/mirage/mirage-platform/issues/

---
Pull-request generated by opam-publish v0.2.1