### PR TITLE
oasis2opam.0.6.1 - via opam-publish

### DIFF
--- a/packages/oasis2opam/oasis2opam.0.6.1/descr
+++ b/packages/oasis2opam/oasis2opam.0.6.1/descr
@@ -1,0 +1,6 @@
+Tool to convert OASIS metadata to OPAM package descriptions
+Generate OPAM files from _oasis. Most of the metadata supported by
+oasis is translated to OPAM. A simple .install file is written to
+preserve Oasis setup.{ml,data,log} in order to be able to use oasis
+for removal.
+

--- a/packages/oasis2opam/oasis2opam.0.6.1/files/_oasis_remove_.ml
+++ b/packages/oasis2opam/oasis2opam.0.6.1/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/oasis2opam/oasis2opam.0.6.1/files/oasis2opam.install
+++ b/packages/oasis2opam/oasis2opam.0.6.1/files/oasis2opam.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/oasis2opam/oasis2opam.0.6.1/opam
+++ b/packages/oasis2opam/oasis2opam.0.6.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "GPL-3 with OCaml linking exception"
+homepage: "https://github.com/ocaml/oasis2opam"
+dev-repo: "https://github.com/ocaml/oasis2opam.git"
+bug-reports: "https://github.com/ocaml/oasis2opam/issues"
+tags: [ "build" "install"  ]
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocaml" "%{etc}%/oasis2opam/_oasis_remove_.ml" "%{etc}%/oasis2opam"]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "base-bytes" {build}
+  "base-unix" {build}
+  "oasis" {build & >= "0.4.4"}
+  "ocamlfind" {build & >= "1.5"}
+  "ounit" {test & >= "2.0.0"}
+  "qcheck" {test & >= "0.4"}
+]

--- a/packages/oasis2opam/oasis2opam.0.6.1/url
+++ b/packages/oasis2opam/oasis2opam.0.6.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/oasis2opam/archive/0.6.1.tar.gz"
+checksum: "5e2ee417afac7e0138afb2c955001019"


### PR DESCRIPTION
Tool to convert OASIS metadata to OPAM package descriptions
Generate OPAM files from _oasis. Most of the metadata supported by
oasis is translated to OPAM. A simple .install file is written to
preserve Oasis setup.{ml,data,log} in order to be able to use oasis
for removal.


---
* Homepage: https://github.com/ocaml/oasis2opam
* Source repo: https://github.com/ocaml/oasis2opam.git
* Bug tracker: https://github.com/ocaml/oasis2opam/issues

---
Pull-request generated by opam-publish v0.2.1