### PR TITLE
mirage-fs-unix.1.2.0 - via opam-publish

### DIFF
--- a/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/descr
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/descr
@@ -1,0 +1,1 @@
+MirageOS filesystem passthrough driver for Unix

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
+                "Thomas Gazagnaire" ]
+maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org"]
+homepage:     "https://github.com/mirage/mirage-fs-unix"
+dev-repo:     "https://github.com/mirage/mirage-fs-unix.git"
+bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
+tags: [ "org:mirage" ]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+build-test: [
+  ["./configure" "--prefix" prefix "--enable-tests"]
+  [make "test" ]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-fs-unix"]
+depends: [
+  "ocamlfind" {build}
+  "cstruct" {>= "1.4.0"}
+  "mirage-types-lwt"
+  "mirage-clock-unix" {test}
+  "alcotest"          {test}
+  "ounit"             {test}
+]
+available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/url
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-fs-unix/archive/v1.2.0.tar.gz"
+checksum: "3a95a7d4d3557cd405e9f2a3f005c76c"


### PR DESCRIPTION
MirageOS filesystem passthrough driver for Unix


---
* Homepage: https://github.com/mirage/mirage-fs-unix
* Source repo: https://github.com/mirage/mirage-fs-unix.git
* Bug tracker: https://github.com/mirage/mirage-fs-unix/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.0