### PR TITLE
ocephes.0.0.1 - via opam-publish

### DIFF
--- a/packages/ocephes/ocephes.0.0.1/descr
+++ b/packages/ocephes/ocephes.0.0.1/descr
@@ -1,0 +1,4 @@
+Bindings to special math functions from the Cephes library.
+
+Ctypes bindings to some of the functions in this common C
+mathematical functions library.

--- a/packages/ocephes/ocephes.0.0.1/opam
+++ b/packages/ocephes/ocephes.0.0.1/opam
@@ -7,5 +7,9 @@ license: "Apache 2.0"
 dev-repo: "https://github.com/rleonid/Ocephes.git"
 build: [make]
 install: [make "install"]
-remove: ["make uninstall"]
-depends: ["ocamlfind" "ctypes"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "ctypes"
+  ]

--- a/packages/ocephes/ocephes.0.0.1/opam
+++ b/packages/ocephes/ocephes.0.0.1/opam
@@ -4,7 +4,7 @@ authors: "Leonid Rozenberg <leonidr@gmail.com>"
 homepage: "https://github.com/rleonid/Ocephes"
 bug-reports: "https://github.com/rleonid/Ocephes/issues"
 license: "Apache 2.0"
-dev-repo: "https://github.com/rleonid/Ocephes"
+dev-repo: "https://github.com/rleonid/Ocephes.git"
 build: [make]
 install: [make "install"]
 remove: ["make uninstall"]

--- a/packages/ocephes/ocephes.0.0.1/opam
+++ b/packages/ocephes/ocephes.0.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/rleonid/Ocephes"
+bug-reports: "https://github.com/rleonid/Ocephes/issues"
+license: "Apache 2.0"
+dev-repo: "https://github.com/rleonid/Ocephes"
+build: [make]
+install: [make "install"]
+remove: ["make uninstall"]
+depends: ["ocamlfind" "ctypes"]

--- a/packages/ocephes/ocephes.0.0.1/url
+++ b/packages/ocephes/ocephes.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rleonid/Ocephes/archive/v0.0.1.tar.gz"
+checksum: "0b1dd698aee6524fd7260477404cde41"


### PR DESCRIPTION
Bindings to special math functions from the Cephes library.

Ctypes bindings to some of the functions in this common C
mathematical functions library.


---
* Homepage: https://github.com/rleonid/Ocephes
* Source repo: https://github.com/rleonid/Ocephes
* Bug tracker: https://github.com/rleonid/Ocephes/issues

---

Pull-request generated by opam-publish v0.3.0