### PR TITLE
+ mirage-xen-minios 0.8.0

### DIFF
--- a/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/descr
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/descr
@@ -1,0 +1,4 @@
+Xen MiniOS guest operating system library
+
+This is used by the MirageOS framework to link OCaml unikernels to run
+directly as Xen guest kernels.

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+homepage: "https://github.com/mirage/mirage-xen-minios/"
+maintainer: "mirageos-devel@lists.openmirage.org"
+bug-reports: "https://github.com/mirage/mirage-xen-minios/issues"
+dev-repo: "https://github.com/mirage/mirage-xen-minios.git"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+]
+tags: [
+  "org:mirage"
+]
+install: [
+  [make "build"]
+]
+remove: []
+available: [os = "linux"]
+depends: ["minios-xen"]

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/url
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-xen-minios/releases/download/v0.8.0/mirage-xen-minios-v0.8.0.tar.bz2"
+checksum: "0a0600f77d147a4b3745d6f5161b7fc6"


### PR DESCRIPTION
* Uses Mini-OS 0.7.
* New releases of Mini-OS will no longer require this package to be updated.

