### PR TITLE
cgroups.0.1 - via opam-publish

### DIFF
--- a/packages/cgroups/cgroups.0.1/descr
+++ b/packages/cgroups/cgroups.0.1/descr
@@ -1,5 +1,5 @@
-An OCamlinterface for the Linux control groups
+An OCaml interface for the Linux control groups
 
-Cgroups is an OCaml library aimed to provide functions for
+Cgroups is an OCaml library aimed at providing functions for
 interacting with the Linux control group system. Interaction with
 the control groups is done via the filesystem.

--- a/packages/cgroups/cgroups.0.1/descr
+++ b/packages/cgroups/cgroups.0.1/descr
@@ -1,0 +1,5 @@
+An OCamlinterface for the Linux control groups
+
+Cgroups is an OCaml library aimed to provide functions for
+interacting with the Linux control group system. Interaction with
+the control groups is done via the filesystem.

--- a/packages/cgroups/cgroups.0.1/opam
+++ b/packages/cgroups/cgroups.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "guillaume.bury@gmail.com"
+authors: "Guillaume Bury"
+homepage: "https://github.com/Gbury/ocaml-cgroups"
+bug-reports: "https://github.com/Gbury/ocaml-cgroups/issues/"
+license: "BSD"
+tags: "cgroups"
+dev-repo: "https://github.com/Gbury/ocaml-cgroups.git"
+build: [make "lib"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+]

--- a/packages/cgroups/cgroups.0.1/opam
+++ b/packages/cgroups/cgroups.0.1/opam
@@ -13,3 +13,6 @@ depends: [
   "ocamlfind" {build}
   "base-unix"
 ]
+available: [
+  ocaml-version >= "4.02.1"
+  ]

--- a/packages/cgroups/cgroups.0.1/url
+++ b/packages/cgroups/cgroups.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Gbury/ocaml-cgroups/archive/v0.1.tar.gz"
+checksum: "4d2c9c0723061eef4220098e3d3ab790"


### PR DESCRIPTION
An OCamlinterface for the Linux control groups

Cgroups is an OCaml library aimed to provide functions for
interacting with the Linux control group system. Interaction with
the control groups is done via the filesystem.


---
* Homepage: https://github.com/Gbury/ocaml-cgroups
* Source repo: https://github.com/Gbury/ocaml-cgroups.git
* Bug tracker: https://github.com/Gbury/ocaml-cgroups/issues/

---

Pull-request generated by opam-publish v0.3.0