### PR TITLE
mirage-flow.1.0.3 - via opam-publish

### DIFF
--- a/packages/mirage-flow/mirage-flow.1.0.3/descr
+++ b/packages/mirage-flow/mirage-flow.1.0.3/descr
@@ -1,0 +1,4 @@
+Various implementations of the MirageOS FLOW interface
+
+- `Fflow` uses input/output functions to build a flow
+- `Lwt_io_flow` uses `Lwt_io.channel`

--- a/packages/mirage-flow/mirage-flow.1.0.3/opam
+++ b/packages/mirage-flow/mirage-flow.1.0.3/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage: "https://github.com/mirage/mirage-flow"
+bug-reports: "https://github.com/mirage/mirage-flow/issues/"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-flow.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--%{alcotest:enable}%-tests"]
+  [make]
+]
+build-test: [make "test"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-flow"]
+depends: [
+  "ocamlfind" {build}
+  "mirage-types-lwt"
+  "cstruct"
+  "lwt" {>= "2.5.0"}
+  "alcotest" {test}
+  "ounit"    {test}
+]

--- a/packages/mirage-flow/mirage-flow.1.0.3/url
+++ b/packages/mirage-flow/mirage-flow.1.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-flow/archive/1.0.3.tar.gz"
+checksum: "0e1e6964b4400adcc4866b135d288828"


### PR DESCRIPTION
Various implementations of the MirageOS FLOW interface

- `Fflow` uses input/output functions to build a flow
- `Lwt_io_flow` uses `Lwt_io.channel`


---
* Homepage: https://github.com/mirage/mirage-flow
* Source repo: https://github.com/mirage/mirage-flow.git
* Bug tracker: https://github.com/mirage/mirage-flow/issues/

---

Pull-request generated by opam-publish v0.3.0