### PR TITLE
records.0.1.0 - via opam-publish

### DIFF
--- a/packages/records/records.0.1.0/descr
+++ b/packages/records/records.0.1.0/descr
@@ -1,0 +1,4 @@
+Dynamic records
+
+This library makes it possible to create first-class record types and fields.
+These can be defined at runtime and provide efficient access.

--- a/packages/records/records.0.1.0/opam
+++ b/packages/records/records.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/records"
+bug-reports: "https://github.com/cryptosense/records/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/records.git"
+build: [make]
+install: [make "install"]
+build-test: [make "check"]
+remove: ["ocamlfind" "remove" "records"]
+depends: [
+  "bisect_ppx" {test}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "yojson"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/records/records.0.1.0/url
+++ b/packages/records/records.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/cryptosense/records/archive/v0.1.0.tar.gz"
+checksum: "81621f380af1e1bee85e2022903569d7"


### PR DESCRIPTION
Dynamic records

This library makes it possible to create first-class record types and fields.
These can be defined at runtime and provide efficient access.


---
* Homepage: https://github.com/cryptosense/records
* Source repo: https://github.com/cryptosense/records.git
* Bug tracker: https://github.com/cryptosense/records/issues

---

Pull-request generated by opam-publish v0.3.0