### PR TITLE
ao.0.2.1 - via opam-publish

### DIFF
--- a/packages/ao/ao.0.2.1/descr
+++ b/packages/ao/ao.0.2.1/descr
@@ -1,0 +1,1 @@
+Bindings for the AO library which provides high-level functions for using soundcards

--- a/packages/ao/ao.0.2.1/opam
+++ b/packages/ao/ao.0.2.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "smimram@gmail.com"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "ao"]
+depends: "ocamlfind"
+depexts: [
+  [["debian"] ["libao-dev"]]
+  [["ubuntu"] ["libao-dev"]]
+]

--- a/packages/ao/ao.0.2.1/url
+++ b/packages/ao/ao.0.2.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/savonet/ocaml-ao/releases/download/0.2.1/ocaml-ao-0.2.1.tar.gz"
+checksum: "7f763e8c47e8369274ee400c640532d4"


### PR DESCRIPTION
Bindings for the AO library which provides high-level functions for using soundcards


---
* Homepage: https://github.com/savonet
* Source repo: 
* Bug tracker: 

---
### opam-lint failures
- **WARNING** 37 Missing field 'dev-repo'
- **WARNING** 36 Missing field 'bug-reports'
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.0