### PR TITLE
Use ocamlfind directly to remove package

### DIFF
--- a/packages/ocephes/ocephes.0.1/opam
+++ b/packages/ocephes/ocephes.0.1/opam
@@ -7,7 +7,7 @@ license: "Apache 2.0"
 dev-repo: "https://github.com/rleonid/Ocephes.git"
 build: [make]
 install: [make "install"]
-remove: [make "uninstall"]
+remove: ["ocamlfind" "remove" "ocephes"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}


### PR DESCRIPTION
I'm not certain why the Oasis provided default isn't working for other people. This change will avoid issuing a new version.