### PR TITLE
ocaml-git's tests need mirage-fs-unix **=** 1.1.4

### DIFF
--- a/packages/git/git.1.5.0/opam
+++ b/packages/git/git.1.5.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"        {>= "2.4.7"}
   "hex"
   "alcotest"         {test}
-  "mirage-fs-unix"   {test & >="1.1.4"}
+  "mirage-fs-unix"   {test & ="1.1.4"}
   "mirage-types-lwt" {test}
   "cohttp"           {test}
   "conduit"          {test}

--- a/packages/git/git.1.5.1/opam
+++ b/packages/git/git.1.5.1/opam
@@ -32,7 +32,7 @@ depends: [
   "lwt"        {>= "2.4.7"}
   "hex"
   "alcotest"         {test & <="0.3.3"}
-  "mirage-fs-unix"   {test & >="1.1.4"}
+  "mirage-fs-unix"   {test & ="1.1.4"}
   "mirage-types-lwt" {test}
   "cohttp"           {test}
   "conduit"          {test}

--- a/packages/git/git.1.5.2/opam
+++ b/packages/git/git.1.5.2/opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-types-lwt" {test}
   "mirage-flow"      {test}
   "mirage-http"      {test}
-  "mirage-fs-unix"   {test & >="1.1.4"}
+  "mirage-fs-unix"   {test & ="1.1.4"}
   "cohttp"           {test}
   "conduit"          {test}
   "base-unix"        {test}

--- a/packages/git/git.1.5.3/opam
+++ b/packages/git/git.1.5.3/opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-types-lwt" {test}
   "mirage-flow"      {test}
   "mirage-http"      {test}
-  "mirage-fs-unix"   {test & >="1.1.4"}
+  "mirage-fs-unix"   {test & ="1.1.4"}
   "cohttp"           {test}
   "conduit"          {test}
   "base-unix"        {test}

--- a/packages/git/git.1.6.0/opam
+++ b/packages/git/git.1.6.0/opam
@@ -35,7 +35,7 @@ depends: [
   "mirage-types-lwt" {test}
   "mirage-flow"      {test}
   "mirage-http"      {test}
-  "mirage-fs-unix"   {test & >="1.1.4"}
+  "mirage-fs-unix"   {test & ="1.1.4"}
   "cohttp"           {test}
   "conduit"          {test}
   "base-unix"        {test}

--- a/packages/git/git.1.6.1/opam
+++ b/packages/git/git.1.6.1/opam
@@ -35,7 +35,7 @@ depends: [
   "mirage-types-lwt" {test}
   "mirage-flow"      {test}
   "mirage-http"      {test}
-  "mirage-fs-unix"   {test & >="1.1.4"}
+  "mirage-fs-unix"   {test & ="1.1.4"}
   "cohttp"           {test}
   "conduit"          {test}
   "base-unix"        {test}

--- a/packages/git/git.1.6.2/opam
+++ b/packages/git/git.1.6.2/opam
@@ -35,7 +35,7 @@ depends: [
   "mirage-types-lwt" {test}
   "mirage-flow"      {test}
   "mirage-http"      {test}
-  "mirage-fs-unix"   {test & >="1.1.4"}
+  "mirage-fs-unix"   {test & ="1.1.4"}
   "cohttp"           {test}
   "conduit"          {test}
   "base-unix"        {test}


### PR DESCRIPTION
This should fix https://github.com/mirage/ocaml-git/issues/116