### PR TITLE
Disable the tests for latest versions of Irmin

### DIFF
--- a/packages/irmin/irmin.0.9.6/opam
+++ b/packages/irmin/irmin.0.9.6/opam
@@ -13,10 +13,10 @@ build: [
       "--%{base-unix:enable}%-unix"]
   [make]
 ]
-build-test: [
-  ["./configure" "--enable-tests" "--enable-examples"]
-  [make "test"]
-]
+#build-test: [
+#  ["./configure" "--enable-tests" "--enable-examples"]
+#  [make "test"]
+#]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "irmin"]
 

--- a/packages/irmin/irmin.0.9.7/opam
+++ b/packages/irmin/irmin.0.9.7/opam
@@ -13,10 +13,10 @@ build: [
       "--%{base-unix:enable}%-unix"]
   [make]
 ]
-build-test: [
-  ["./configure" "--enable-tests" "--enable-examples"]
-  [make "test"]
-]
+#build-test: [
+#  ["./configure" "--enable-tests" "--enable-examples"]
+#  [make "test"]
+#]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "irmin"]
 

--- a/packages/irmin/irmin.0.9.8/opam
+++ b/packages/irmin/irmin.0.9.8/opam
@@ -14,10 +14,10 @@ build: [
       "--%{mirage-git:enable}%-mirage"]
   [make]
 ]
-build-test: [
-  ["./configure" "--enable-tests" "--enable-examples"]
-  [make "test"]
-]
+#build-test: [
+#  ["./configure" "--enable-tests" "--enable-examples"]
+#  [make "test"]
+#]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "irmin"]
 


### PR DESCRIPTION
The HTTP tests are broken because of https://github.com/ocsigen/lwt/issues/136,
so they need lwt 1.5.0 to pass (but we don't have a release of cohttp compatible
with that version of lwt yet).