### PR TITLE
+cohttp.0.19.0

### DIFF
--- a/packages/cohttp/cohttp.0.19.0/descr
+++ b/packages/cohttp/cohttp.0.19.0/descr
@@ -1,0 +1,9 @@
+HTTP library for Lwt, Async and Mirage
+
+There are several optional dependencies which activate functionality:
+
+* Lwt: `opam install lwt cohttp`
+* Lwt and SSL: `opam install lwt ssl cohttp`
+* Async: `opam install async cohttp`
+* Async and SSL: `opam install async_ssl cohttp`
+

--- a/packages/cohttp/cohttp.0.19.0/opam
+++ b/packages/cohttp/cohttp.0.19.0/opam
@@ -1,0 +1,63 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [ "Anil Madhavapeddy"
+           "Stefano Zacchiroli"
+           "David Sheets"
+           "Thomas Gazagnaire"
+           "David Scott"
+           "Rudi Grinberg"
+           "Andy Ray" ]
+
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+
+build: [
+  [make "PREFIX=%{prefix}%"]
+]
+
+install: [make "PREFIX=%{prefix}%" "install"]
+
+remove: [["ocamlfind" "remove" "cohttp"]]
+
+depends: [
+  "base-bytes"
+  "ocamlfind" {build}
+  "cmdliner" {build & >= "0.9.4"}
+  "re"
+  "uri" {>= "1.9.0"}
+  "fieldslib" {>= "109.20.00"}
+  "sexplib" {>= "109.53.00"}
+  "conduit" {>= "0.7.0"}
+  "stringext"
+  "base64" {>="2.0.0"}
+  "magic-mime"
+  "ounit" {test}
+  "alcotest" {test}
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+
+depopts: [
+  "async"
+  "lwt"
+  "js_of_ocaml"
+]
+
+conflicts: [
+  "async" {<"111.25.00"}
+  "lwt" {<"2.5.0"}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/cohttp/cohttp.0.19.0/url
+++ b/packages/cohttp/cohttp.0.19.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cohttp/archive/v0.19.0.tar.gz"
+checksum: "54a9498b4d6ec5291ab6f669cae69d30"


### PR DESCRIPTION
Compatibility breaking interface changes:
* Remove `read_form` from the `Request/Response/Header` interfaces
  as this should be done in `Body` handling instead (#401).

New features and bug fixes:
* Remove `IO.write_line` as it was unused in any interfaces.
* Do not use the `lwt` camlp4 extension. No observable external difference.
* Do not return a code stacktrace in the default 500 handler.
* Add `Cohttp.Header.compare` (#411)
* Fix typos in CLI documentation (#413 via @moonlightdrive)
* Use the Lwt 2.5.0 buffer API.
* `Cohttp_lwt.read_response` now has a non-optional `closefn` parameter (#400).
* Add a `Cohttp_lwt_s` module that contains all the Lwt module types
  in one convenient place (#397).
