### PR TITLE
tyxml.3.5.0 - via opam-publish

### DIFF
--- a/packages/tyxml/tyxml.3.5.0/descr
+++ b/packages/tyxml/tyxml.3.5.0/descr
@@ -1,0 +1,6 @@
+A simple library for building valid HTML5 and SVG documents.
+
+TyXML allows you to build HTML5 and SVG trees whose validity is ensured by the typechecker.
+It provides a printer for said XML trees, along with a syntax extensions.
+Finally it also provides a functorial interface to choose your XML datastructure.
+It's part of the ocsigen project and is used in js_of_ocaml and eliom.

--- a/packages/tyxml/tyxml.3.5.0/opam
+++ b/packages/tyxml/tyxml.3.5.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "dev@ocsigen.org"
+author: "The ocsigen team"
+homepage: "https://ocsigen.org/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tyxml"]
+depends: [
+  "ocamlfind" {build}
+  "uutf"
+  "base-bytes"
+]
+depopts: "camlp4"

--- a/packages/tyxml/tyxml.3.5.0/url
+++ b/packages/tyxml/tyxml.3.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/tyxml/archive/3.5.0.tar.gz"
+checksum: "8207a40c70c36a7f81ed56474aa0e03e"


### PR DESCRIPTION
A simple library for building valid HTML5 and SVG documents.

TyXML allows you to build HTML5 and SVG trees whose validity is ensured by the typechecker.
It provides a printer for said XML trees, along with a syntax extensions.
Finally it also provides a functorial interface to choose your XML datastructure.
It's part of the ocsigen project and is used in js_of_ocaml and eliom.

---
* Homepage: https://ocsigen.org/tyxml/
* Source repo: https://github.com/ocsigen/tyxml.git
* Bug tracker: https://github.com/ocsigen/tyxml/issues

---

Pull-request generated by opam-publish v0.3.0

---

Version 3.5.0
* Add Tyxml_name, which allows to derive tyxml identifiers from HTML
  elements and attributes.
* Internally build the tool `autoname`, which applies the aftermentionned
  transformation for the given elements/attributes.
* Fix typo in `datetime-local`.
* Add download attributes for area and tags.
* Add various svg `text` attributes.
* Fix namespaces issues related to svg elements inside html.