### PR TITLE
mirror.0.0.1 - via opam-publish

### DIFF
--- a/packages/mirror/mirror.0.0.1/descr
+++ b/packages/mirror/mirror.0.0.1/descr
@@ -1,0 +1,15 @@
+Mirror upstream OPAM package distribution files
+
+This is a tool that mirrors original upstream distribution files in OPAM
+packages. It places them into a `distfiles/` directory that follows a similar
+structure to the existing `archives/` directory.
+
+Assuming that you have an OPAM checkout in `~/git/opam-repository`, do:
+
+    opam mirror-show-urls ~/git/opam-repository > package-list
+    opam mirror-fetch-urls package-list
+
+or
+
+    opam mirror-fetch-urls - | opam mirror-show-urls ~git/opam-repository
+

--- a/packages/mirror/mirror.0.0.1/opam
+++ b/packages/mirror/mirror.0.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/avsm/opam-mirror"
+bug-reports: "https://github.com/avsm/opam-mirror/issues"
+license: "ISC"
+tags: ["org:ocamllabs" "org:mirage" "flags:plugin"]
+dev-repo: "https://github.com/avsm/opam-mirror.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: []
+depends: [
+  "ocamlfind" {build}
+  "cmdliner"
+  "cohttp" {>= "0.15.2"}
+  "lwt" {>= "2.4.3"}
+  "opam-lib" {>= "1.2.0"}
+  "tls"
+  "lambda-term"
+]

--- a/packages/mirror/mirror.0.0.1/url
+++ b/packages/mirror/mirror.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/avsm/opam-mirror/archive/v0.0.1.tar.gz"
+checksum: "cffb46c09512369c5f13f9ee2012ce40"


### PR DESCRIPTION
Mirror upstream OPAM package distribution files

This is a tool that mirrors original upstream distribution files in OPAM
packages. It places them into a `distfiles/` directory that follows a similar
structure to the existing `archives/` directory.

Assuming that you have an OPAM checkout in `~/git/opam-repository`, do:

    opam mirror-show-urls ~/git/opam-repository > package-list
    opam mirror-fetch-urls package-list

or

    opam mirror-fetch-urls - | opam mirror-show-urls ~git/opam-repository



---
* Homepage: https://github.com/avsm/opam-mirror
* Source repo: https://github.com/avsm/opam-mirror.git
* Bug tracker: https://github.com/avsm/opam-mirror/issues

---

Pull-request generated by opam-publish v0.3.0