### PR TITLE
dropbox.0.1~772c4a6 - via opam-publish

### DIFF
--- a/packages/dropbox/dropbox.0.1~772c4a6/descr
+++ b/packages/dropbox/dropbox.0.1~772c4a6/descr
@@ -1,0 +1,1 @@
+Binding to the Dropbox Remote API

--- a/packages/dropbox/dropbox.0.1~772c4a6/opam
+++ b/packages/dropbox/dropbox.0.1~772c4a6/opam
@@ -9,5 +9,6 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "dropbox"]
 depends: [
-  "ocamlfind" "lwt" "ssl" "cohttp" "uri" "atdgen"
+  "ocamlfind" "oasis" "lwt" "ssl" "cohttp" "uri" "atdgen"
 ]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/dropbox/dropbox.0.1~772c4a6/opam
+++ b/packages/dropbox/dropbox.0.1~772c4a6/opam
@@ -9,5 +9,5 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "dropbox"]
 depends: [
-  "ocamlfind" {build}
+  "ocamlfind" "lwt" "ssl" "cohttp" "uri" "atdgen"
 ]

--- a/packages/dropbox/dropbox.0.1~772c4a6/opam
+++ b/packages/dropbox/dropbox.0.1~772c4a6/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
-homepage: "https://github.com/Chris00/ocaml-docker"
+homepage: "https://github.com/Chris00/ocaml-dropbox"
 bug-reports: "https://github.com/Chris00/ocaml-dropbox/issues"
 license: "LGPL-3.0 with OCaml linking exception"
 dev-repo: "https://github.com/Chris00/ocaml-dropbox.git"

--- a/packages/dropbox/dropbox.0.1~772c4a6/opam
+++ b/packages/dropbox/dropbox.0.1~772c4a6/opam
@@ -11,4 +11,4 @@ remove: ["ocamlfind" "remove" "dropbox"]
 depends: [
   "ocamlfind" "oasis" "lwt" "ssl" "cohttp" "uri" "atdgen"
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/dropbox/dropbox.0.1~772c4a6/opam
+++ b/packages/dropbox/dropbox.0.1~772c4a6/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+homepage: "https://github.com/Chris00/ocaml-docker"
+bug-reports: "https://github.com/Chris00/ocaml-dropbox/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/Chris00/ocaml-dropbox.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "dropbox"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/dropbox/dropbox.0.1~772c4a6/url
+++ b/packages/dropbox/dropbox.0.1~772c4a6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/toots/ocaml-dropbox/archive/opam-0.1.tar.gz"
+checksum: "32510c91c595a9f361cb5f5be0351f77"


### PR DESCRIPTION
Binding to the Dropbox Remote API


---
* Homepage: https://github.com/Chris00/ocaml-docker
* Source repo: https://github.com/Chris00/ocaml-dropbox.git
* Bug tracker: https://github.com/Chris00/ocaml-dropbox/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.0