### PR TITLE
setr.0.1 - via opam-publish

### DIFF
--- a/packages/setr/setr.0.1/descr
+++ b/packages/setr/setr.0.1/descr
@@ -1,0 +1,7 @@
+Abstract domain library for sets
+
+SETr is an interface for set abstractions. It defines common infrastructure for
+abstracting set constraints for use in an abstract interpreter. Built upon this
+interface, it provides a number of included abstractions usable as libraries.
+These included abstractions are tuned for high-performance, symbolic (no known
+constants), relational (constraints over multiple variables) constraints.

--- a/packages/setr/setr.0.1/opam
+++ b/packages/setr/setr.0.1/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Arlen Cox <arlencox@gmail.com>"
+authors: "Arlen Cox <arlencox@gmail.com>"
+homepage: "https://github.com/arlencox/SETr"
+bug-reports: "https://github.com/arlencox/SETr/issues"
+license: "MIT"
+dev-repo: "https://github.com/arlencox/SETr.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "setr"]
+depends: [ "ocamlfind" {build} "cppo" {build} "mlbdd" ]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/setr/setr.0.1/url
+++ b/packages/setr/setr.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/arlencox/SETr/archive/v0.1.tar.gz"
+checksum: "56618f3f7a90e8eb9885a094fd306b8c"


### PR DESCRIPTION
Abstract domain library for sets

SETr is an interface for set abstractions. It defines common infrastructure for
abstracting set constraints for use in an abstract interpreter. Built upon this
interface, it provides a number of included abstractions usable as libraries.
These included abstractions are tuned for high-performance, symbolic (no known
constants), relational (constraints over multiple variables) constraints.


---
* Homepage: https://github.com/arlencox/SETr
* Source repo: https://github.com/arlencox/SETr.git
* Bug tracker: https://github.com/arlencox/SETr/issues

---

Pull-request generated by opam-publish v0.3.0