### PR TITLE
rdbg.1.0 - via opam-publish

### DIFF
--- a/packages/rdbg/rdbg.1.0/descr
+++ b/packages/rdbg/rdbg.1.0/descr
@@ -1,0 +1,5 @@
+RDBG: a reactive programs debugger.
+The library rdbg-plugin contains all the necessary ocaml modules
+needed to add a rdbg plugin. Such a plugin allows ocaml-interpreted
+languages to be executed (à la Lurette) or/and debugged (with rdbg).
+

--- a/packages/rdbg/rdbg.1.0/files/rdbg.install
+++ b/packages/rdbg/rdbg.1.0/files/rdbg.install
@@ -1,0 +1,10 @@
+bin: [
+  "?_build/src/gnuplotrif.byte" {"gnuplot-rif"}
+  "?_build/src/gnuplotrif.native" {"gnuplot-rif"}
+  "?_build/src/rdbgbatch.byte" {"rdbg-batch"}
+  "?_build/src/rdbgbatch.native" {"rdbg-batch"}
+  "?_build/src/rdbgstart.byte" {"rdbg-top"}
+  "?_build/src/rdbgstart.native" {"rdbg-top"}
+  "?_build/src/rdbg.byte" {"rdbg"}
+  "?_build/src/rdbg.native" {"rdbg"}
+]

--- a/packages/rdbg/rdbg.1.0/opam
+++ b/packages/rdbg/rdbg.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "erwan.jahier@imag.fr"
+bug-reports: "erwan.jahier@imag.fr"
+authors: [ "Erwan Jahier" ]
+license: "GPL-3"
+homepage: "http://rdbg.forge.imag.fr/"
+dev-repo: "https://forge.imag.fr/anonscm/git/rdbg/rdbg.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "rdbg-plugin"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "base-unix"
+  "camlp4"
+  ("oasis" {>= "0.4"} | "oasis-mirage" {>= "0.4"})
+  "ocamlfind"
+]
+available: [ ocaml-version >= "4.01" ]

--- a/packages/rdbg/rdbg.1.0/url
+++ b/packages/rdbg/rdbg.1.0/url
@@ -1,0 +1,2 @@
+archive: "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/rdbg/rdbg.tgz"
+checksum: "751ad98f972e7b1d17a53eab6ab87ce1"


### PR DESCRIPTION
RDBG: a reactive programs debugger.
The library rdbg-plugin contains all the necessary ocaml modules
needed to add a rdbg plugin. Such a plugin allows ocaml-interpreted
languages to be executed (à la Lurette) or/and debugged (with rdbg).



---
* Homepage: http://rdbg.forge.imag.fr/
* Source repo: https://forge.imag.fr/anonscm/git/rdbg/rdbg.git
* Bug tracker: erwan.jahier@imag.fr

---

Pull-request generated by opam-publish v0.3.0