### PR TITLE
ppx_deriving_yojson.2.3 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/url
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/url
@@ -1,2 +1,2 @@
 http: "https://github.com/whitequark/ppx_deriving_yojson/archive/v2.3.tar.gz"
-checksum: "55ca357dbf59b9fcc81009ba3fd1c0cd"
+checksum: "ef4f247f645457f129ff1e66400ff077"


### PR DESCRIPTION
JSON codec generator for OCaml >=4.02

ppx_deriving_yojson is a ppx_deriving plugin that provides
a JSON codec generator.

---
* Homepage: https://github.com/whitequark/ppx_deriving_yojson
* Source repo: git://github.com/whitequark/ppx_deriving_yojson.git
* Bug tracker: https://github.com/whitequark/ppx_deriving_yojson/issues

---
Pull-request generated by opam-publish v0.2.1