### PR TITLE
ppx_deriving_protobuf.2.2 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.2/descr
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.2/descr
@@ -1,0 +1,2 @@
+A Protocol Buffers codec generator for OCaml >=4.02
+A Protocol Buffers codec generator for OCaml >=4.02

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.2/opam
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: "whitequark <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_deriving_protobuf"
+bug-reports: "https://github.com/whitequark/ppx_deriving_protobuf/issues"
+license: "MIT"
+doc: "http://whitequark.github.io/ppx_deriving_protobuf"
+tags: "syntax"
+dev-repo: "git://github.com/whitequark/ppx_deriving_protobuf.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%" "native-dynlink=%{ocaml-native-dynlink}%"]
+build-test: ["ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_protobuf.byte" "--"]
+build-doc: [make "doc"]
+depends: [
+  "ppx_deriving" {>= "2.0" & < "3.0"}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "uint" {test}
+]

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.2/url
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving_protobuf/archive/v2.2.tar.gz"
+checksum: "72f983337e8f7d269417a8e749267ee6"


### PR DESCRIPTION
A Protocol Buffers codec generator for OCaml >=4.02
A Protocol Buffers codec generator for OCaml >=4.02

---
* Homepage: https://github.com/whitequark/ppx_deriving_protobuf
* Source repo: git://github.com/whitequark/ppx_deriving_protobuf.git
* Bug tracker: https://github.com/whitequark/ppx_deriving_protobuf/issues

---
Pull-request generated by opam-publish v0.2.1