### PR TITLE
ppx_sexp.0.2.1 - via opam-publish

### DIFF
--- a/packages/ppx_sexp/ppx_sexp.0.2.1/descr
+++ b/packages/ppx_sexp/ppx_sexp.0.2.1/descr
@@ -1,0 +1,27 @@
+ppx_sexp is a ppx preprocessor for embedding S-expressions in OCaml programs.
+
+For example, this:
+
+    [%sexp (define a "hi there!")]
+
+is translated into:
+
+    `List [`Symbol "define"; `Symbol "a"; `String "hi there"]
+
+You can unquote, or insert regular OCaml expressions inside of the S-expression that will be evaluated instead of converted to atoms (e.g. `List`, `Symbol`) using the `[%in ...]` syntax:
+
+    let a = [%sexp (title "Hello, world!")] in
+    [%sexp (html
+              (head
+                 [%in a])
+              (body
+                 (p "Hi there!")))]
+
+When inserting values, you must make sure to contain them in the appropriate polymorphic variant (the names correspond directly to OCaml's AST constant types, with the exception of Bool):
+
+     [%sexp (print [%in `String "S-expressions: abbreviated sexp"])]
+
+The `%in` syntax is intended to be used for embedding other S-expressions. 
+If you are embedding atoms, there is a streamlined syntax:
+
+     [%sexp (print [%string "S-expressions: sexp"])]

--- a/packages/ppx_sexp/ppx_sexp.0.2.1/opam
+++ b/packages/ppx_sexp/ppx_sexp.0.2.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Jonathan Chan <jyc@fastmail.fm>"
+authors: "Jonathan Chan <jyc@fastmail.fm>"
+homepage: "https://bitbucket.org/jyc/ppx_sexp"
+bug-reports:
+  "https://bitbucket.org/jyc/ppx_sexp/issues?status=new&status=open"
+license: "BSD 2-Clause"
+dev-repo: "https://bitbucket.org/jyc/ppx_sexp/src"
+build: ["./build"]
+install: ["./install"]
+remove: ["./uninstall"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/ppx_sexp/ppx_sexp.0.2.1/url
+++ b/packages/ppx_sexp/ppx_sexp.0.2.1/url
@@ -1,0 +1,2 @@
+http: "https://bitbucket.org/jyc/ppx_sexp/get/0.2.1.tar.gz"
+checksum: "fd43a67df61ddfe4f42e997f77f88c5b"


### PR DESCRIPTION
ppx_sexp is a ppx preprocessor for embedding S-expressions in OCaml programs.

For example, this:

    [%sexp (define a "hi there!")]

is translated into:

    `List [`Symbol "define"; `Symbol "a"; `String "hi there"]

You can unquote, or insert regular OCaml expressions inside of the S-expression that will be evaluated instead of converted to atoms (e.g. `List`, `Symbol`) using the `[%in ...]` syntax:

    let a = [%sexp (title "Hello, world!")] in
    [%sexp (html
              (head
                 [%in a])
              (body
                 (p "Hi there!")))]

When inserting values, you must make sure to contain them in the appropriate polymorphic variant (the names correspond directly to OCaml's AST constant types, with the exception of Bool):

     [%sexp (print [%in `String "S-expressions: abbreviated sexp"])]

The `%in` syntax is intended to be used for embedding other S-expressions. 
If you are embedding atoms, there is a streamlined syntax:

     [%sexp (print [%string "S-expressions: sexp"])]


---
* Homepage: https://bitbucket.org/jyc/ppx_sexp
* Source repo: https://bitbucket.org/jyc/ppx_sexp/src
* Bug tracker: https://bitbucket.org/jyc/ppx_sexp/issues?status=new&status=open

---

Pull-request generated by opam-publish v0.3.0