### PR TITLE
Constrain OCaml version for Ketrew 1.1.0

### DIFF
--- a/packages/ketrew/ketrew.1.1.0/opam
+++ b/packages/ketrew/ketrew.1.1.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "seb@mondet.org"
 homepage: "http://seb.mondet.org/software/ketrew"
-ocaml-version: [ >= "4.02.0" ]
+ocaml-version: [ >= "4.02.0" & <= "4.02.1" ]
 build: [
   [make "_oasis"]
   ["oasis" "setup" ]


### PR DESCRIPTION

Ketrew was hit by the non-backwards compatible change in PPX attributes syntax (4.02.2).

