### PR TITLE
ppx_sexp.0.3.0 - via opam-publish

### DIFF
--- a/packages/ppx_sexp/ppx_sexp.0.3.0/descr
+++ b/packages/ppx_sexp/ppx_sexp.0.3.0/descr
@@ -1,0 +1,29 @@
+ppx_sexp is a ppx preprocessor for embedding S-expressions in OCaml programs.
+
+For example, this:
+
+    [%sexp (define a "hi there!")]
+
+is translated into:
+
+    `List [`Symbol "define"; `Symbol "a"; `String "hi there"]
+
+You can unquote, or insert regular OCaml expressions inside of the S-expression that will be evaluated instead of converted to atoms (e.g. `List`, `Symbol`) using the `[%in ...]` syntax:
+
+    let a = [%sexp (title "Hello, world!")] in
+    [%sexp (html
+              (head
+                 [%in a])
+              (body
+                 (p "Hi there!")))]
+
+When inserting values, you must make sure to contain them in the appropriate polymorphic variant (the names correspond directly to OCaml's AST constant types, with the exception of Bool):
+
+     [%sexp (print [%in `String "S-expressions: abbreviated sexp"])]
+
+The `%in` syntax is intended to be used for embedding other S-expressions. 
+If you are embedding atoms, there is a streamlined syntax:
+
+     [%sexp (print [%string "S-expressions: sexp"])]
+
+Unquote-splicing is also supported.

--- a/packages/ppx_sexp/ppx_sexp.0.3.0/opam
+++ b/packages/ppx_sexp/ppx_sexp.0.3.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Jonathan Chan <jyc@fastmail.fm>"
+authors: "Jonathan Chan <jyc@fastmail.fm>"
+homepage: "https://bitbucket.org/jyc/ppx_sexp"
+bug-reports:
+  "https://bitbucket.org/jyc/ppx_sexp/issues"
+license: "BSD 2-Clause"
+dev-repo: "hg://https://bitbucket.org/jyc/ppx_sexp"
+build: ["./build"]
+install: ["./install"]
+remove: ["./uninstall"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ (ocaml-version >= "4.02.0") & (ocaml-version < "4.03.0") ]

--- a/packages/ppx_sexp/ppx_sexp.0.3.0/url
+++ b/packages/ppx_sexp/ppx_sexp.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://bitbucket.org/jyc/ppx_sexp/get/0.3.0.tar.gz"
+checksum: "afbfb6e6c9eca9032234464703b83588"


### PR DESCRIPTION
ppx_sexp is a ppx preprocessor for embedding S-expressions in OCaml programs.

For example, this:

    [%sexp (define a "hi there!")]

is translated into:

    `List [`Symbol "define"; `Symbol "a"; `String "hi there"]

You can unquote, or insert regular OCaml expressions inside of the S-expression that will be evaluated instead of converted to atoms (e.g. `List`, `Symbol`) using the `[%in ...]` syntax:

    let a = [%sexp (title "Hello, world!")] in
    [%sexp (html
              (head
                 [%in a])
              (body
                 (p "Hi there!")))]

When inserting values, you must make sure to contain them in the appropriate polymorphic variant (the names correspond directly to OCaml's AST constant types, with the exception of Bool):

     [%sexp (print [%in `String "S-expressions: abbreviated sexp"])]

The `%in` syntax is intended to be used for embedding other S-expressions. 
If you are embedding atoms, there is a streamlined syntax:

     [%sexp (print [%string "S-expressions: sexp"])]

Unquote-splicing is also supported.


---
* Homepage: https://bitbucket.org/jyc/ppx_sexp
* Source repo: hg://https://bitbucket.org/jyc/ppx_sexp
* Bug tracker: https://bitbucket.org/jyc/ppx_sexp/issues

---

Pull-request generated by opam-publish v0.3.0