### PR TITLE
gg.0.9.1 - via opam-publish

### DIFF
--- a/packages/gg/gg.0.9.1/descr
+++ b/packages/gg/gg.0.9.1/descr
@@ -1,0 +1,11 @@
+Basic types for computer graphics in OCaml
+
+Gg is an OCaml module providing basic types for computer graphics.
+
+It defines types and functions for floats, vectors, points, sizes,
+matrices, quaternions, axis-aligned boxes, colors, color spaces, and
+raster data.
+
+Gg is made of a single module, depends on bigarrays, and is
+distributed under the BSD3 license.
+

--- a/packages/gg/gg.0.9.1/opam
+++ b/packages/gg/gg.0.9.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/gg"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/gg/doc/Gg"
+dev-repo: "http://erratique.ch/repos/gg.git"
+bug-reports: "https://github.com/dbuenzli/gg/issues"
+tags: [ "matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
+license: "BSD-3-Clause"
+depends: ["ocamlfind" "base-bigarray"]
+available: [ ocaml-version >= "4.01.0" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%" ]
+]

--- a/packages/gg/gg.0.9.1/url
+++ b/packages/gg/gg.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/gg/releases/gg-0.9.1.tbz"
+checksum: "07911ce33ee68f871a08f98d1712df94"


### PR DESCRIPTION
Basic types for computer graphics in OCaml

Gg is an OCaml module providing basic types for computer graphics.

It defines types and functions for floats, vectors, points, sizes,
matrices, quaternions, axis-aligned boxes, colors, color spaces, and
raster data.

Gg is made of a single module, depends on bigarrays, and is
distributed under the BSD3 license.



---
* Homepage: http://erratique.ch/software/gg
* Source repo: http://erratique.ch/repos/gg.git
* Bug tracker: https://github.com/dbuenzli/gg/issues

---

Pull-request generated by opam-publish v0.3.0