### PR TITLE
Add the 4.03 build to `allow_failures`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     env: OCAML_VERSION=4.02 OPAM_VERSION=1.2.2
   allow_failures:
   - os: osx
+  - env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2
 notifications:
   email:
   - opam-commits@lists.ocaml.org


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/4663#issuecomment-131079929

Some 4.03 features are still in flux, so it seems reasonable to allow packages to fail with 4.03 for now.