### PR TITLE
bisect_ppx.0.2.4 - via opam-publish

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.0.2.4/descr
+++ b/packages/bisect_ppx/bisect_ppx.0.2.4/descr
@@ -1,0 +1,4 @@
+Bisect code coverage instrumentation via ppx.
+
+A fork of the original Bisect code to solely work with ppx, with a few
+bug fixes and improvements.

--- a/packages/bisect_ppx/bisect_ppx.0.2.4/files/bisect_ppx.install
+++ b/packages/bisect_ppx/bisect_ppx.0.2.4/files/bisect_ppx.install
@@ -1,0 +1,4 @@
+bin: [
+  "_build/src/report/report.byte" {"bisect-ppx-report"}
+  "?_build/src/report/report.native" {"bisect-ppx-report"}
+]

--- a/packages/bisect_ppx/bisect_ppx.0.2.4/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.4/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/rleonid/bisect_ppx"
+bug-reports: "https://github.com/rleonid/bisect_ppx/issues"
+dev-repo: "https://github.com/rleonid/bisect_ppx.git"
+build: [
+  ["sh" "configure"]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "bisect_ppx"]
+depends: [
+  "ocamlfind"
+  "ppx_tools" {build}
+]

--- a/packages/bisect_ppx/bisect_ppx.0.2.4/url
+++ b/packages/bisect_ppx/bisect_ppx.0.2.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rleonid/bisect_ppx/archive/0.2.4.tar.gz"
+checksum: "8723d55f4d58f2328d11baab86763a97"


### PR DESCRIPTION
Bisect code coverage instrumentation via ppx.

A fork of the original Bisect code to solely work with ppx, with a few
bug fixes and improvements.


---
* Homepage: https://github.com/rleonid/bisect_ppx
* Source repo: https://github.com/rleonid/bisect_ppx.git
* Bug tracker: https://github.com/rleonid/bisect_ppx/issues

---

Pull-request generated by opam-publish v0.3.0