### PR TITLE
vg.0.8.2 - via opam-publish

### DIFF
--- a/packages/vg/vg.0.8.2/descr
+++ b/packages/vg/vg.0.8.2/descr
@@ -1,0 +1,22 @@
+Declarative 2D vector graphics for OCaml
+
+Vg is an OCaml module for declarative 2D vector graphics. In Vg,
+images are values that denote functions mapping points of the
+cartesian plane to colors. The module provides combinators to define
+and compose these values.
+
+Renderers for PDF, SVG, Cairo and the HTML canvas are distributed with the
+module. An API allows to implement new renderers.
+     
+Vg depends only on [Gg][1]. The SVG renderer has no dependency, the
+PDF renderer depends on [Uutf][2] and [Otfm][3], the HTML canvas
+renderer depends on [js_of_ocaml][4], the Cairo renderer depends on
+[cairo2][5]. Vg and its renderers are distributed under the BSD3
+license.
+     
+[1]: http://erratique.ch/software/gg
+[2]: http://erratique.ch/software/uutf
+[3]: http://erratique.ch/software/otfm
+[4]: http://ocsigen.org/js_of_ocaml/ 
+[5]: https://forge.ocamlcore.org/projects/cairo/
+

--- a/packages/vg/vg.0.8.2/opam
+++ b/packages/vg/vg.0.8.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/vg"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/vg/doc/Vg"
+dev-repo: "http://erratique.ch/repos/vg.git"
+bug-reports: "https://github.com/dbuenzli/vg/issues"
+tags: [ "pdf" "svg" "html-canvas" "declarative" "graphics" "org:erratique" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.02.0"]
+depends: [ "ocamlfind" "gg" {>= "0.9.0"} ]
+depopts: [ "uutf" "otfm" "js_of_ocaml" "cairo2" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "uutf=%{uutf:installed}%"
+                           "otfm=%{otfm:installed}%"
+                           "cairo2=%{cairo2:installed}%"
+                           "jsoo=%{js_of_ocaml:installed}%" ]
+]

--- a/packages/vg/vg.0.8.2/url
+++ b/packages/vg/vg.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/vg/releases/vg-0.8.2.tbz"
+checksum: "f8e7efd20d6ffd5f50ea78f993d28b9e"


### PR DESCRIPTION
Declarative 2D vector graphics for OCaml

Vg is an OCaml module for declarative 2D vector graphics. In Vg,
images are values that denote functions mapping points of the
cartesian plane to colors. The module provides combinators to define
and compose these values.

Renderers for PDF, SVG, Cairo and the HTML canvas are distributed with the
module. An API allows to implement new renderers.
     
Vg depends only on [Gg][1]. The SVG renderer has no dependency, the
PDF renderer depends on [Uutf][2] and [Otfm][3], the HTML canvas
renderer depends on [js_of_ocaml][4], the Cairo renderer depends on
[cairo2][5]. Vg and its renderers are distributed under the BSD3
license.
     
[1]: http://erratique.ch/software/gg
[2]: http://erratique.ch/software/uutf
[3]: http://erratique.ch/software/otfm
[4]: http://ocsigen.org/js_of_ocaml/ 
[5]: https://forge.ocamlcore.org/projects/cairo/



---
* Homepage: http://erratique.ch/software/vg
* Source repo: http://erratique.ch/repos/vg.git
* Bug tracker: https://github.com/dbuenzli/vg/issues

---

Pull-request generated by opam-publish v0.3.0