### PR TITLE
podge.0.4 - via opam-publish

### DIFF
--- a/packages/podge/podge.0.4/descr
+++ b/packages/podge/podge.0.4/descr
@@ -1,0 +1,19 @@
+Shortcuts and helpers for common tasks in OCaml ecosystem
+
+If you're doing any modern OCaml then you're doubtlessly annoyed by
+the state of libraries and committing to one of the big ones can be
+restricting. Podge is a single module containing specialized modules
+for their respectives usages for seemingly common tasks.
+
+Some conveniences with Podge:
+1) Web: Simple HTTP get/put requests that return Yojson objects
+2) Yojson: Pretty printing, updating keys, and removing key-value pairs
+   from Yojson objects
+3) Unix: Read output of a process, simple daemonize.
+4) Xml: Simple reading of node content given a path.
+5) ANSITerminal: Create a colored string for the shell,
+   with or without current time.
+6) Other modules: Math, Html5, Analyze, Cohttp, Printf, Debugging,
+   and List.
+
+Podge is especially useful for Hackathons and prototyping.

--- a/packages/podge/podge.0.4/files/_oasis_remove_.ml
+++ b/packages/podge/podge.0.4/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/podge/podge.0.4/files/podge.install
+++ b/packages/podge/podge.0.4/files/podge.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/podge/podge.0.4/opam
+++ b/packages/podge/podge.0.4/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "http://hyegar.com"
+bug-reports: "https://github.com/fxfactorial/podge/issues"
+dev-repo: "http://github.com/fxfactorial/podge.git"
+license: "BSD-3-clause"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/podge/_oasis_remove_.ml" "%{etc}%/podge"]
+depends: [
+  "ANSITerminal"
+  "base-unix"
+  "cohttp"
+  "ezxmlm"
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+  "re"
+  "tyxml"
+  "yojson"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/podge/podge.0.4/url
+++ b/packages/podge/podge.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/podge/archive/v0.0.4.tar.gz"
+checksum: "a2755ba37df9af3709270a5bf6c33ed8"


### PR DESCRIPTION
Shortcuts and helpers for common tasks in OCaml ecosystem

If you're doing any modern OCaml then you're doubtlessly annoyed by
the state of libraries and committing to one of the big ones can be
restricting. Podge is a single module containing specialized modules
for their respectives usages for seemingly common tasks.

Some conveniences with Podge:
1) Web: Simple HTTP get/put requests that return Yojson objects
2) Yojson: Pretty printing, updating keys, and removing key-value pairs
   from Yojson objects
3) Unix: Read output of a process, simple daemonize.
4) Xml: Simple reading of node content given a path.
5) ANSITerminal: Create a colored string for the shell,
   with or without current time.
6) Other modules: Math, Html5, Analyze, Cohttp, Printf, Debugging,
   and List.

Podge is especially useful for Hackathons and prototyping.


---
* Homepage: http://hyegar.com
* Source repo: http://github.com/fxfactorial/podge.git
* Bug tracker: https://github.com/fxfactorial/podge/issues

---

Pull-request generated by opam-publish v0.3.0