### PR TITLE
humane-re.0.1.1 - via opam-publish

### DIFF
--- a/packages/humane-re/humane-re.0.1.1/descr
+++ b/packages/humane-re/humane-re.0.1.1/descr
@@ -1,0 +1,5 @@
+A human friendly interface to regular expressions in OCaml
+
+Humane-re attempts to provide a more convenient regex API on top of re.  The
+main goal of this library is to make common tasks involving regexes as painless
+as possible.

--- a/packages/humane-re/humane-re.0.1.1/opam
+++ b/packages/humane-re/humane-re.0.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "LGPL-2.0 with OCaml linking exception"
+
+homepage: "https://github.com/rgrinberg/humane-re"
+bug-reports: "https://github.com/rgrinberg/humane-re/issues"
+dev-repo: "https://github.com/rgrinberg/humane-re.git"
+
+
+build: [
+  [make "configure-no-tests"]
+  [make "build"]
+]
+
+install: [make "install"]
+
+remove: [
+  ["ocamlfind" "remove" "humane_re"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "re"
+]
+
+available: [ocaml-version >= "4.02.0"]

--- a/packages/humane-re/humane-re.0.1.1/url
+++ b/packages/humane-re/humane-re.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/humane-re/archive/v0.1.1.tar.gz"
+checksum: "3babb6e4980cb8e0228451f869828ad5"


### PR DESCRIPTION
A human friendly interface to regular expressions in OCaml

Humane-re attempts to provide a more convenient regex API on top of re.  The
main goal of this library is to make common tasks involving regexes as painless
as possible.

---
* Homepage: https://github.com/rgrinberg/humane-re
* Source repo: https://github.com/rgrinberg/humane-re.git
* Bug tracker: https://github.com/rgrinberg/humane-re/issues

---

Pull-request generated by opam-publish v0.3.0