### PR TITLE
rdr.2.0.1 - via opam-publish

### DIFF
--- a/packages/rdr/rdr.2.0.1/descr
+++ b/packages/rdr/rdr.2.0.1/descr
@@ -1,0 +1,25 @@
+Rdr is a cross-platform binary analysis and reverse engineering library,
+utilizing a unique symbol map for global analysis.
+
+`rdr` is an OCaml tool/library for doing cross-platform analysis of binaries,
+by printing headers, locating entry points, showing import and export
+symbols, their binary offsets and size, etc.
+
+It also features a symbol map which allows fast lookups for arbitrary
+symbols, and their associated data, on your system
+(the default search location are binaries in /usr/lib).
+
+The latest release also makes `rdr` a package which you can link against
+and use in your own projects.
+
+See the README at http://github.com/m4b/rdr for more details.
+
+Features:
+
+* 64-bit Linux and Mach-o binary analysis
+* Searchable symbol-map of all the symbols on your system, including binary
+  offset, size, and exporting library
+* Print imports and exports of binaries
+* Make pretty graphs, at the binary or symbol map level
+* Byte Coverage algorithm which marks byte sequences as understood (or not)
+  and provides other meta-data

--- a/packages/rdr/rdr.2.0.1/opam
+++ b/packages/rdr/rdr.2.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "m4b <m4b.github.io@gmail.com>"
+authors: "m4b <m4b.github.io@gmail.com>"
+homepage: "http://www.m4b.io"
+bug-reports: "m4b.github.io@gmail.com"
+license: "BSD"
+dev-repo: "git://github.com/m4b/rdr"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "rdr"]
+  ["rm" "-f" "%{bin}%/rdr"]
+]
+depends: "ocamlfind" {build}
+available: [ocaml-version >= "4.02"]

--- a/packages/rdr/rdr.2.0.1/url
+++ b/packages/rdr/rdr.2.0.1/url
@@ -1,0 +1,2 @@
+http: "http://github.com/m4b/rdr/archive/v2.0.1.tar.gz"
+checksum: "5d963556379e7f6192513d76f9b32b44"


### PR DESCRIPTION
Rdr is a cross-platform binary analysis and reverse engineering library,
utilizing a unique symbol map for global analysis.

`rdr` is an OCaml tool/library for doing cross-platform analysis of binaries,
by printing headers, locating entry points, showing import and export
symbols, their binary offsets and size, etc.

It also features a symbol map which allows fast lookups for arbitrary
symbols, and their associated data, on your system
(the default search location are binaries in /usr/lib).

The latest release also makes `rdr` a package which you can link against
and use in your own projects.

See the README at http://github.com/m4b/rdr for more details.

Features:

* 64-bit Linux and Mach-o binary analysis
* Searchable symbol-map of all the symbols on your system, including binary
  offset, size, and exporting library
* Print imports and exports of binaries
* Make pretty graphs, at the binary or symbol map level
* Byte Coverage algorithm which marks byte sequences as understood (or not)
  and provides other meta-data
---
* Homepage: http://www.m4b.io
* Source repo: git://github.com/m4b/rdr
* Bug tracker: m4b.github.io@gmail.com

---
Pull-request generated by opam-publish v0.2.1