### PR TITLE
mirage-xen-posix.2.3.4 - via opam-publish

### DIFF
--- a/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/descr
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/descr
@@ -1,0 +1,5 @@
+MirageOS library for posix headers
+
+This package contains the header files to pretend a posix
+system (required to compile the OCaml runtime), plus minilibc and
+float formating.

--- a/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-posix-build"]
+install: [make "xen-posix-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-posix-uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "mirage-xen-minios" {>= "0.7.0"}
+  "conf-pkg-config"
+]
+available: [ocaml-version >= "4.01.0" & os = "linux"]

--- a/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/url
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v2.3.4.tar.gz"
+checksum: "00402709acf64d7405091c587a81e4eb"


### PR DESCRIPTION
MirageOS library for posix headers

This package contains the header files to pretend a posix
system (required to compile the OCaml runtime), plus minilibc and
float formating.

---
* Homepage: https://github.com/mirage/mirage-platform
* Source repo: https://github.com/mirage/mirage-platform.git
* Bug tracker: https://github.com/mirage/mirage-platform/issues/

---

Pull-request generated by opam-publish v0.3.0