### PR TITLE
mirage-xen-ocaml.2.3.4 - via opam-publish

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/descr
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/descr
@@ -1,0 +1,3 @@
+MirageOS headers for the OCaml runtime
+
+The package contains the OCaml runtime patches and build system.

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-ocaml-build"]
+install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+depends: ["mirage-xen-posix" "conf-pkg-config" "ocaml-src"]
+available: [ocaml-version >= "4.01.0" & os = "linux"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/url
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v2.3.4.tar.gz"
+checksum: "00402709acf64d7405091c587a81e4eb"


### PR DESCRIPTION
MirageOS headers for the OCaml runtime

The package contains the OCaml runtime patches and build system.


---
* Homepage: https://github.com/mirage/mirage-platform
* Source repo: https://github.com/mirage/mirage-platform.git
* Bug tracker: https://github.com/mirage/mirage-platform/issues/

---

Pull-request generated by opam-publish v0.3.0