### PR TITLE
Rename opam-publish to 'publish'

### DIFF
--- a/packages/opam-publish/opam-publish.0.3.0+transition/descr
+++ b/packages/opam-publish/opam-publish.0.3.0+transition/descr
@@ -1,0 +1,4 @@
+opam-publish transition package
+
+The package has been renamed to just 'publish'. You can safely remove this
+package.

--- a/packages/opam-publish/opam-publish.0.3.0+transition/opam
+++ b/packages/opam-publish/opam-publish.0.3.0+transition/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+]
+homepage: "http://opam.ocaml.org"
+bug-reports: "https://github.com/OCamlPro/opam-publish/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/OCamlPro/opam-publish.git"
+depends: "publish"

--- a/packages/publish/publish.0.3.0/descr
+++ b/packages/publish/publish.0.3.0/descr
@@ -1,0 +1,4 @@
+A tool to ease contributions to opam repositories.
+
+Opam-publish helps gather metadata to form an OPAM package and submit it
+to a remote repository.

--- a/packages/publish/publish.0.3.0/opam
+++ b/packages/publish/publish.0.3.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+]
+homepage: "http://opam.ocaml.org"
+bug-reports: "https://github.com/OCamlPro/opam-publish/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/OCamlPro/opam-publish.git"
+build: [make]
+depends: [
+  "opam-lib" {build & = "1.2.2"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  "github" {build & >= "1.0.0"}
+]
+tags: [ "flags:plugin" ]

--- a/packages/publish/publish.0.3.0/url
+++ b/packages/publish/publish.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/opam-publish/archive/0.3.0.tar.gz"
+checksum: "e0c500e5fb0918269d729b0575033c48"


### PR DESCRIPTION
allowing the 'plugin' auto-install trick. An upgrade opam-publish transition package
is provided so that 'opam upgrade' automatically picks up 'publish'