### PR TITLE
Add Jitsu

### DIFF
--- a/packages/jitsu/jitsu.0.2/descr
+++ b/packages/jitsu/jitsu.0.2/descr
@@ -1,0 +1,7 @@
+A forwarding DNS server that automatically starts unikernels on demand
+
+Jitsu - or Just-in-Time Summoning of Unikernels - is a prototype DNS server that can boot unikernels on demand. When Jitsu receives a DNS query, a unikernel is booted automatically before the query response is sent back to the client. To the client it will look like it was on the whole time.
+
+This version supports MirageOS and Rumprun unikernels and new backends to manage the unikernel VMs (libvirt, Xapi, libxl). Metadata and internal state is stored in Irmin and the DNS server is implemented on top of ocaml-dns.
+
+Jitsu is experimental software. Please report bugs in the bug tracker.

--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 name: "jitsu"
 maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
 homepage: "https://github.com/mirage/jitsu"
 bug-reports: "https://github.com/mirage/jitsu/issues/"
 dev-repo: "https://github.com/mirage/jitsu.git"

--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+name: "jitsu"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/jitsu"
+bug-reports: "https://github.com/mirage/jitsu/issues/"
+dev-repo: "https://github.com/mirage/jitsu.git"
+license: "ISC"
+build: [
+  [make]
+]
+build-test: [
+  [make "test"]
+]
+depends: [  "lwt"
+            "dns"  { >= "0.15.3" }
+            "xenstore"
+            "xenstore_transport"
+            "cmdliner"
+            "libvirt"
+            "ipaddr"
+            "ezxmlm"
+            "conduit"
+            "vchan"
+            "uuidm"
+            "irmin-unix"
+            "irmin" { >= "0.9.7" }
+            "git"
+            "xen-api-client"
+            "xenctrl"
+            "alcotest" ]
+depexts: [
+  [["debian"] ["libvirt-bin" "libvirt-dev" "libxen-dev"]]
+  [["ubuntu"] ["libvirt-bin" "libvirt-dev" "libxen-dev"]]
+  [["osx" "homebrew"] ["libvirt"]]
+]

--- a/packages/jitsu/jitsu.0.2/url
+++ b/packages/jitsu/jitsu.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/jitsu/archive/0.2.0.tar.gz"
+checksum: "5adbfbb9e9eddafacaa3bed2f488ca1a"


### PR DESCRIPTION
A forwarding DNS server that automatically starts unikernels on demand

Jitsu - or Just-in-Time Summoning of Unikernels - is a prototype DNS server that can boot unikernels on demand. When Jitsu receives a DNS query, a unikernel is booted automatically before the query response is sent back to the client. To the client it will look like it was on the whole time.

This version supports MirageOS and Rumprun unikernels and new backends to manage the unikernel VMs (libvirt, Xapi, libxl). Metadata and internal state is stored in Irmin and the DNS server is implemented on top of ocaml-dns.

Jitsu is experimental software. Please report bugs in the bug tracker.