### PR TITLE
rawlink.0.1 - via opam-publish

### DIFF
--- a/packages/rawlink/rawlink.0.1/descr
+++ b/packages/rawlink/rawlink.0.1/descr
@@ -1,0 +1,28 @@
+A portable library to read and write raw packets.
+
+Rawlink is an ocaml library for sending and receiving raw packets at the link
+layer level. Sometimes you need to have full control of the packet, including
+building the full ethernet frame.
+
+The API is platform independent, it uses BPF on real UNIXes and AF_SOCKET on
+linux. Some functionality is sacrificed so that the API is portable enough. 
+
+Currently BPF and AF_PACKET are implemented, including filtering capabilities.
+Writing a BPF program is a pain in the ass, so no facilities are provided for
+it. If you need a BPF filter, I suggest you write a small .c file with a
+function that returns the BPF program as a string, check `rawlink_stubs.c` for
+an example.
+
+Both normal blocking functions as well as `Lwt` monadic variants are provided.
+
+A typical code for receiving all packets and just sending them back on an
+specified interface are detailed below:
+
+```
+let link = Rawlink.open_link "eth0" in
+let buf = Rawlink.read_packet link in
+Printf.printf "got a packet with %d bytes.\n%!" (Cstruct.len buf);
+Rawlink.send_packet link buf
+```
+
+Check the mli interface for more options.

--- a/packages/rawlink/rawlink.0.1/opam
+++ b/packages/rawlink/rawlink.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/haesbaert/rawlink"
+bug-reports: "https://github.com/haesbaert/rawlink/issues"
+license: "ISC"
+dev-repo: "https://github.com/haesbaert/rawlink.git"
+build: ["sh" "build.sh"]
+depends: [
+  "ocamlfind" {build}
+  "lwt"
+  "cstruct"
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/rawlink/rawlink.0.1/url
+++ b/packages/rawlink/rawlink.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/haesbaert/rawlink/archive/v0.1.tar.gz"
+checksum: "1c600ed9fcb47617daa7431991e9e00f"


### PR DESCRIPTION
A portable library to read and write raw packets.

Rawlink is an ocaml library for sending and receiving raw packets at the link
layer level.  Sometimes you need to have full control of the packet, including
building the a full ethernet frame.

The API is platform independent and it uses BPF on real UNIXes and AF_SOCKET on
linux. Some functionality is sacrificed so that the API is portable
enough.

Currently BPF AF are implemented, including receiving filtering
capabilities. Writing a BPF program is a pain in the ass, so no facilities are
provided for writing a BPF program. If you need a BPF filter, I suggest you
write a small .c file with a function that returns the BPF program as a string,
check `rawlink_stubs.c` for an example.

Both normal blocking functions as well as `Lwt` monadic variants are provided.

A tipical code for receiving all packets and just sending them back on an
especified interface are detailed below:

```
let link = Rawlink.open_link "eth0" in
let buf = Rawlink.read_packet link in
Printf.printf "got a packet with %d bytes.\n%!" (Cstruct.len buf);
Rawlink.send_packet link buf
```

Check the mli interface for more options.


---
* Homepage: https://github.com/haesbaert/rawlink
* Source repo: https://github.com/haesbaert/rawlink.git
* Bug tracker: https://github.com/haesbaert/rawlink/issues

---

Pull-request generated by opam-publish v0.3.0