### PR TITLE
Add Maxminddb library

### DIFF
--- a/packages/maxminddb/maxminddb.0.1/descr
+++ b/packages/maxminddb/maxminddb.0.1/descr
@@ -1,0 +1,10 @@
+Bindings to Maxmind.com's libmaxminddb library.
+
+Maxminddb provides OCaml bindings to MaxMind's libmaxminddb C
+library, libmaxminddb is the database powering GeoIP2.  GeoIP2
+provides geographical/geolocation information about ip addresses
+like city of origin, country of origin and more. This library comes
+with the the free GeoLite2 City and Country MaxMindDB files.
+
+This product includes GeoLite2 data created by MaxMind, available
+from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.

--- a/packages/maxminddb/maxminddb.0.1/findlib
+++ b/packages/maxminddb/maxminddb.0.1/findlib
@@ -1,0 +1,1 @@
+maxminddb

--- a/packages/maxminddb/maxminddb.0.1/opam
+++ b/packages/maxminddb/maxminddb.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "maxminddb"
+version: "0.1"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "http://hyegar.com"
+bug-reports: "https://github.com/fxfactorial/ocaml-maxminddb/issues"
+dev-repo: "http://github.com/fxfactorial/ocaml-maxmindddb.git"
+tags: [ "clib:maxminddb"  ]
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "maxminddb"]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/maxminddb/maxminddb.0.1/url
+++ b/packages/maxminddb/maxminddb.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-maxminddb/archive/v0.0.1.tar.gz"
+checksum: "e1656b608fcedfff4e403b77d39ee309"


### PR DESCRIPTION
Bindings to Maxmind.com's libmaxminddb library.

Maxminddb provides OCaml bindings to MaxMind's libmaxminddb C
library, libmaxminddb is the database powering GeoIP2.  GeoIP2
provides geographical/geolocation information about ip addresses
like city of origin, country of origin and more. This library comes
with the the free GeoLite2 City and Country MaxMindDB files.

This product includes GeoLite2 data created by MaxMind, available
from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.

Expect travis build to fail as it probably won't have the libmaxminddb library.