### PR TITLE
Constrain zmq.4.* to OCaml < 4.03.0

### DIFF
--- a/packages/zmq/zmq.4.0-1/opam
+++ b/packages/zmq/zmq.4.0-1/opam
@@ -13,3 +13,4 @@ depexts: [
   [ ["source" "linux"] ["https://gist.githubusercontent.com/andersfugmann/11168509/raw"] ]
 ]
 conflicts: ["ocaml-zmq"]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/zmq/zmq.4.0-2/opam
+++ b/packages/zmq/zmq.4.0-2/opam
@@ -13,3 +13,4 @@ depexts: [
   [ ["source" "linux"] ["https://gist.github.com/hcarty/77e32afdecbf09af0213/raw"] ]
 ]
 conflicts: ["ocaml-zmq"]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/zmq/zmq.4.0-3/opam
+++ b/packages/zmq/zmq.4.0-3/opam
@@ -21,3 +21,4 @@ depends: [
 conflicts: [
   "ocaml-zmq"
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/zmq/zmq.4.0-4/opam
+++ b/packages/zmq/zmq.4.0-4/opam
@@ -25,3 +25,4 @@ depends: [
 conflicts: [
   "ocaml-zmq"
 ]
+available: [ ocaml-version < "4.03.0" ]


### PR DESCRIPTION
The `zmq.4.*` packages [don't build with OCaml trunk (4.03)](https://travis-ci.org/ocaml/opam-repository/jobs/77262855#L834-L836) because of the [switch to C99 integer types](https://github.com/ocaml/ocaml/commit/b868c05ec91a7ee193010a421de768a3b1a80952).

/cc @frejsoya @andersfugmann
