### PR TITLE
ezjsonm.0.4.2 - via opam-publish

### DIFF
--- a/packages/ezjsonm/ezjsonm.0.4.2/descr
+++ b/packages/ezjsonm/ezjsonm.0.4.2/descr
@@ -1,0 +1,9 @@
+An easy interface on top of the Jsonm library
+
+This version provides more convenient (but far less flexible)
+input and output functions that go to and from [string] values.
+This avoids the need to write signal code, which is useful for
+quick scripts that manipulate JSON.
+
+More advanced users should go straight to the Jsonm library and
+use it directly, rather than be saddled with the Ezjsonm interface.

--- a/packages/ezjsonm/ezjsonm.0.4.2/opam
+++ b/packages/ezjsonm/ezjsonm.0.4.2/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ezjsonm"
+bug-reports:  "https://github.com/mirage/ezjsonm/issues"
+dev-repo:     "https://github.com/mirage/ezjsonm.git"
+tags: [
+  "org:mirage"
+  "org:ocamllabs"
+]
+
+build: [
+  ["./configure" "--prefix" prefix "--%{lwt:enable}%-lwt"]
+  [make]
+]
+build-test: [
+  ["./configure" "--prefix" prefix "--enable-tests"]
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ezjsonm"]
+depends: [
+  "ocamlfind" {build}
+  "alcotest" {test & >= "0.4.0"}
+  "lwt"      {test}
+  "jsonm" {>= "0.9.1"}
+  "sexplib"
+  "hex"
+]
+depopts: ["lwt"]

--- a/packages/ezjsonm/ezjsonm.0.4.2/url
+++ b/packages/ezjsonm/ezjsonm.0.4.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ezjsonm/archive//0.4.2.tar.gz"
+checksum: "109cd6f44d26a4a9893118bd25be150c"


### PR DESCRIPTION
An easy interface on top of the Jsonm library

This version provides more convenient (but far less flexible)
input and output functions that go to and from [string] values.
This avoids the need to write signal code, which is useful for
quick scripts that manipulate JSON.

More advanced users should go straight to the Jsonm library and
use it directly, rather than be saddled with the Ezjsonm interface.


---
* Homepage: https://github.com/mirage/ezjsonm
* Source repo: https://github.com/mirage/ezjsonm.git
* Bug tracker: https://github.com/mirage/ezjsonm/issues

---

Pull-request generated by opam-publish v0.3.0