### PR TITLE
Add maxminddb package, final and correct

### DIFF
--- a/packages/maxminddb/maxminddb.0.2/descr
+++ b/packages/maxminddb/maxminddb.0.2/descr
@@ -1,0 +1,10 @@
+Bindings to Maxmind.com's libmaxminddb library, think geoip2
+
+Maxminddb provides OCaml bindings to MaxMind's libmaxminddb C
+library, libmaxminddb is the database powering GeoIP2.  GeoIP2
+provides geographical/geolocation information about ip addresses
+like city of origin, country of origin and more. This library comes
+with the the free GeoLite2 City and Country MaxMindDB files.
+
+This product includes GeoLite2 data created by MaxMind, available
+from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.

--- a/packages/maxminddb/maxminddb.0.2/findlib
+++ b/packages/maxminddb/maxminddb.0.2/findlib
@@ -1,0 +1,1 @@
+maxminddb

--- a/packages/maxminddb/maxminddb.0.2/opam
+++ b/packages/maxminddb/maxminddb.0.2/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "maxminddb"
+version: "0.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "http://hyegar.com"
+bug-reports: "https://github.com/fxfactorial/ocaml-maxminddb/issues"
+dev-repo: "http://github.com/fxfactorial/ocaml-maxmindddb.git"
+tags: [ "clib:maxminddb"  ]
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "maxminddb"]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/maxminddb/maxminddb.0.2/url
+++ b/packages/maxminddb/maxminddb.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-maxminddb/archive/v0.2.tar.gz"
+checksum: "bb7b1361999b206d6b9815b7e7be93dd"


### PR DESCRIPTION
Bindings to Maxmind.com's libmaxminddb library, think geoip2

Maxminddb provides OCaml bindings to MaxMind's libmaxminddb C
library, libmaxminddb is the database powering GeoIP2.  GeoIP2
provides geographical/geolocation information about ip addresses
like city of origin, country of origin and more. This library comes
with the the free GeoLite2 City and Country MaxMindDB files.

This product includes GeoLite2 data created by MaxMind, available
from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.

The travis build will probably fail because the machine doesn't have the libmaxmind C library. 