### PR TITLE
polyglot.1.0.0 - via opam-publish

### DIFF
--- a/packages/polyglot/polyglot.1.0.0/descr
+++ b/packages/polyglot/polyglot.1.0.0/descr
@@ -1,0 +1,4 @@
+Filters to convert XHTML into polyglot HTML5
+
+polyglot is a filter to convert XHTML into polyglot HTML5. It's a
+command and a MirageOS-compatible OCaml library.

--- a/packages/polyglot/polyglot.1.0.0/opam
+++ b/packages/polyglot/polyglot.1.0.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/polyglot"
+bug-reports: "https://github.com/dsheets/polyglot/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/polyglot.git"
+substs: ["lib/META" "polyglot.version"]
+build: [
+  [make "lib"]
+  [make "tool"] {cmdliner:installed & base-unix:installed}
+]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "polyglot"]
+depends: [
+  "ocamlfind" {build}
+  "xmlm"
+  "alcotest" {test}
+]
+depopts: ["cmdliner" "base-unix"]
+available: [ocaml-version >= "4.00.0" & opam-version >= "1.2"]

--- a/packages/polyglot/polyglot.1.0.0/url
+++ b/packages/polyglot/polyglot.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/polyglot/archive/1.0.0.tar.gz"
+checksum: "9c65e6ba5bb4538410b01d553d5651e3"


### PR DESCRIPTION
Filters to convert XHTML into polyglot HTML5

polyglot is a filter to convert XHTML into polyglot HTML5. It's a
command and a MirageOS-compatible OCaml library.


---
* Homepage: https://github.com/dsheets/polyglot
* Source repo: https://github.com/dsheets/polyglot.git
* Bug tracker: https://github.com/dsheets/polyglot/issues

---

Pull-request generated by opam-publish v0.3.0