### PR TITLE
nebula.0.2.1 - via opam-publish

### DIFF
--- a/packages/nebula/nebula.0.2.1/opam
+++ b/packages/nebula/nebula.0.2.1/opam
@@ -1,20 +1,20 @@
 opam-version: "1.2"
 maintainer: "Jesse Haber-Kucharsky <jesse@haberkucharsky.com>"
 authors: "Jesse Haber-Kucharsky <jesse@haberkucharsky.com>"
-homepage: "https://github.com:hakuch/Nebula"
-bug-reports: "https://github.com:hakuch/Nebula"
+homepage: "https://github.com/hakuch/Nebula"
+bug-reports: "https://github.com/hakuch/Nebula"
 license: "Apache 2.0"
 dev-repo: "git://github.com/hakuch/Nebula.git"
 build: [make]
 build-doc: [make "doc"]
 depends: [
-  "cmdliner" {= "0.9.7"}
-  "ctypes" {= "0.4.1"}
-  "ctypes-foreign" {= "0.4.0"}
-  "ocamlfind" {build & = "1.5.5"}
-  "ounit" {test & = "2.0.0"}
-  "ppx_deriving" {= "2.2"}
-  "tsdl" {= "0.8.1"}
-  "utop" {= "1.18"}
+  "cmdliner" {>= "0.9.7"}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign" {>= "0.4.0"}
+  "ocamlfind" {build & >= "1.5.5"}
+  "ounit" {test & >= "2.0.0"}
+  "ppx_deriving" {>= "2.2"}
+  "tsdl" {>= "0.8.1"}
+  "utop" {>= "1.18"}
 ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
DCPU-16 emulator.

Nebula is a complete DCPU-16 emulator including simulated hardware devices.

---
* Homepage: https://github.com/hakuch/Nebula
* Source repo: git://github.com/hakuch/Nebula.git
* Bug tracker: https://github.com/hakuch/Nebula

---

Pull-request generated by opam-publish v0.3.0