### PR TITLE
added packages/clangml/clangml.3.6.0.1

### DIFF
--- a/packages/clangml/clangml.3.6.0.1/descr
+++ b/packages/clangml/clangml.3.6.0.1/descr
@@ -1,0 +1,1 @@
+clang OCaml bindings

--- a/packages/clangml/clangml.3.6.0.1/files/clangml.install
+++ b/packages/clangml/clangml.3.6.0.1/files/clangml.install
@@ -1,0 +1,3 @@
+bin: [
+  "_build/consumer/processor.native" {"clangml-processor"}
+]

--- a/packages/clangml/clangml.3.6.0.1/opam
+++ b/packages/clangml/clangml.3.6.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+authors: ["Pippijn van Steenhoven"]
+maintainer: "francois.berenger@inria.fr"
+homepage: "https://github.com/Antique-team/clangml"
+bug-reports: "https://github.com/Antique-team/clangml/issues"
+dev-repo: "https://github.com/Antique-team/clangml.git"
+build: [
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  [make "uninstall"]
+]
+depends: [
+  "batteries"
+  "deriving"
+  "ANSITerminal"
+  "base-unix"
+  "camlp4"
+  "ocamlfind"
+]
+depexts: [
+  [["debian"] ["libboost-dev" "llvm-3.6-dev" "clang-3.6" "libclang-3.6-dev" "binutils-dev"]]
+  [["ubuntu"] ["libboost-dev" "llvm-3.6-dev" "clang-3.6" "libclang-3.6-dev" "binutils-dev"]]
+  [["gentoo"] ["dev-libs/boost" "sys-devel/binutils"]]
+  [["archlinux"] ["boost" "binutils"]]
+]
+available: [
+  ocaml-version >= "4.02.3" & !preinstalled
+]

--- a/packages/clangml/clangml.3.6.0.1/url
+++ b/packages/clangml/clangml.3.6.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Antique-team/clangml/archive/v3.6.0.1.tar.gz"
+checksum: "135ea97a3e166009d1c16155d34f1ac6"


### PR DESCRIPTION
clangml was fixed to work out of the box on Gentoo and Archlinux