### PR TITLE
maxminddb.0.4 - via opam-publish

### DIFF
--- a/packages/maxminddb/maxminddb.0.4/descr
+++ b/packages/maxminddb/maxminddb.0.4/descr
@@ -1,0 +1,10 @@
+Bindings to Maxmind.com's libmaxminddb library, like geoip2
+
+Maxminddb provides OCaml bindings to MaxMind's libmaxminddb C
+library, libmaxminddb is the database powering GeoIP2.  GeoIP2
+provides geographical/geolocation information about ip addresses
+like city of origin, country of origin and more. This library comes
+with the the free GeoLite2 City and Country MaxMindDB files.
+
+This product includes GeoLite2 data created by MaxMind, available
+from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.

--- a/packages/maxminddb/maxminddb.0.4/opam
+++ b/packages/maxminddb/maxminddb.0.4/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "http://hyegar.com"
+bug-reports: "https://github.com/fxfactorial/ocaml-maxminddb/issues"
+license: "BSD-3-clause"
+tags: "clib:maxminddb"
+dev-repo: "http://github.com/fxfactorial/ocaml-maxmindddb.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "maxminddb"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/maxminddb/maxminddb.0.4/url
+++ b/packages/maxminddb/maxminddb.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-maxminddb/archive/v0.4.tar.gz"
+checksum: "d6c0f201ab33afd0d494d914ed5b8f1e"


### PR DESCRIPTION
Bindings to Maxmind.com's libmaxminddb library, like geoip2

Maxminddb provides OCaml bindings to MaxMind's libmaxminddb C
library, libmaxminddb is the database powering GeoIP2.  GeoIP2
provides geographical/geolocation information about ip addresses
like city of origin, country of origin and more. This library comes
with the the free GeoLite2 City and Country MaxMindDB files.

This product includes GeoLite2 data created by MaxMind, available
from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.


---
* Homepage: http://hyegar.com
* Source repo: http://github.com/fxfactorial/ocaml-maxmindddb.git
* Bug tracker: https://github.com/fxfactorial/ocaml-maxminddb/issues

---

Pull-request generated by opam-publish v0.3.0