### PR TITLE
Fix compilation of Uri

### DIFF
--- a/packages/uri/uri.1.9.1/opam
+++ b/packages/uri/uri.1.9.1/opam
@@ -37,6 +37,6 @@ depends: [
   "sexplib" {>="109.53.00"}
   "base-bytes"
   "type_conv"
-  "stringext"
+  "stringext" {>="1.4.0"}
   "ounit" {test & >="1.0.2"}
 ]


### PR DESCRIPTION
Uri use `Stringext.find_form` but this function is available in Stringext >= 1.4.0