### PR TITLE
Add result 1.0

### DIFF
--- a/packages/result/result.1.0/opam
+++ b/packages/result/result.1.0/opam
@@ -1,0 +1,8 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/result"
+dev-repo: "https://github.com/janestreet/result.git"
+bug-reports: "https://github.com/janestreet/result/issues"
+license: "BSD3"
+build: [[make]]

--- a/packages/result/result.1.0/url
+++ b/packages/result/result.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/result/archive/1.0.tar.gz"
+checksum: "01391a66385ab1a43f90455dfb5c6843"


### PR DESCRIPTION
Compatibility `Result` module for the `Pervasives.result` type introduced in ocaml/ocaml@19a5d5eb50fa5c5661a33343cded8ec1442703be