### PR TITLE
added captureio.0.1.2

### DIFF
--- a/packages/captureio/captureio.0.1.2/descr
+++ b/packages/captureio/captureio.0.1.2/descr
@@ -1,0 +1,4 @@
+Capture output to Stderr and Stdout
+
+This library enables you to capture print outs to stdout and stderr with minimal effort.
+

--- a/packages/captureio/captureio.0.1.2/opam
+++ b/packages/captureio/captureio.0.1.2/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+name: "captureio"
+version: "0.1.2"
+maintainer: "Adriaan Larmuseau <adriaan.larmuseau@gmail.com>"
+authors: "Adriaan Larmuseau <adriaan.larmuseau@gmail.com>"
+homepage: "https://github.com/sylvarant/captureio"
+bug-reports: "https://github.com/sylvarant/captureio/issues"
+license: "Artistic 2.0"
+dev-repo: "https://github.com/sylvarant/captureio.git"
+build: [make "library"]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "captureio"]
+depends: [
+  "ocamlfind" {build}
+  "testsimple" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/captureio/captureio.0.1.2/url
+++ b/packages/captureio/captureio.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/sylvarant/captureio/archive/v0.1.2.tar.gz"
+checksum: "238638ade7342e1b4a75677abf43fe4f"


### PR DESCRIPTION
Added the ability to capture file descriptors, as requested.

A previous request failed on the Travis-CI, due to the .4 build failing with:
```
W: Failed to fetch mirror://mirrors.ubuntu.com/mirrors.txt/dists/trusty/main/source/Sources  404  Not Found [Mirror: http://mirror.htnshost.com/ubuntu/]
W: Failed to fetch mirror://mirrors.ubuntu.com/mirrors.txt/dists/trusty/restricted/source/Sources  404  Not Found [Mirror: http://mirror.htnshost.com/ubuntu/]
W: Failed to fetch mirror://mirrors.ubuntu.com/mirrors.txt/dists/trusty/universe/source/Sources  404  Not Found [Mirror: http://mirror.htnshost.com/ubuntu/]
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command "bash -e .travis-ci-install.sh" failed and exited with 100 during .
```
Which I don't think, I caused.