### PR TITLE
publish.0.3.1 - via opam-publish

### DIFF
--- a/packages/publish/publish.0.3.1/descr
+++ b/packages/publish/publish.0.3.1/descr
@@ -1,0 +1,4 @@
+A tool to ease contributions to opam repositories.
+
+Opam-publish helps gather metadata to form an OPAM package and submit it
+to a remote repository.

--- a/packages/publish/publish.0.3.1/opam
+++ b/packages/publish/publish.0.3.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+]
+homepage: "http://opam.ocaml.org"
+bug-reports: "https://github.com/OCamlPro/opam-publish/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+tags: "flags:plugin"
+dev-repo: "https://github.com/OCamlPro/opam-publish.git"
+build: [make]
+depends: [
+  "opam-lib" {build & = "1.2.2"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  "github" {build & >= "1.0.0"}
+]

--- a/packages/publish/publish.0.3.1/url
+++ b/packages/publish/publish.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/opam-publish/archive/0.3.1.tar.gz"
+checksum: "a2b8b27a20bbaf918101103ce76abe68"


### PR DESCRIPTION
A tool to ease contributions to opam repositories.

Opam-publish helps gather metadata to form an OPAM package and submit it
to a remote repository.


---
* Homepage: http://opam.ocaml.org
* Source repo: https://github.com/OCamlPro/opam-publish.git
* Bug tracker: https://github.com/OCamlPro/opam-publish/issues

---

Pull-request generated by opam-publish v0.3.1