### PR TITLE
spreadsheet.0.1 - via opam-publish

### DIFF
--- a/packages/spreadsheet/spreadsheet.0.1/descr
+++ b/packages/spreadsheet/spreadsheet.0.1/descr
@@ -1,0 +1,9 @@
+Functor for parsing and building spreadsheets.
+
+Defines a spreadsheet functor and `RowSpec` module type.
+When given a `RowSpec`, the functor produces a module that will represent a
+spreadsheet backed by a set.
+The programmer must provide a `RowSpec` module, which is essentially:
+- An OCaml type to describe spreadsheet rows.
+- Coercions from the row type to/from `string`.
+- A `string list` title describing each column of the spreadsheet.

--- a/packages/spreadsheet/spreadsheet.0.1/opam
+++ b/packages/spreadsheet/spreadsheet.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Ben Greenman"
+authors: "Ben Greenman"
+homepage: "http://github.com/bennn/spreadsheet"
+bug-reports: "http://github.com/bennn/spreadsheet/issues"
+license: "LGPL"
+doc: "Functor for parsing and building spreadsheets"
+dev-repo: "http://github.com/bennn/spreadsheet.git"
+available: [ocaml-version >= "4.02.0"]
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "spreadsheet"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/spreadsheet/spreadsheet.0.1/url
+++ b/packages/spreadsheet/spreadsheet.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bennn/spreadsheet/archive/0.1.zip"
+checksum: "c3bdce5e5b379f5333d466fcf5e6ac8f"


### PR DESCRIPTION
Functor for parsing and building spreadsheets.

Defines a spreadsheet functor and `RowSpec` module type.
When given a `RowSpec`, the functor produces a module that will represent a
spreadsheet backed by a set.
The programmer must provide a `RowSpec` module, which is essentially:
- An OCaml type to describe spreadsheet rows.
- Coercions from the row type to/from `string`.
- A `string list` title describing each column of the spreadsheet.


---
* Homepage: http://github.com/bennn/spreadsheet
* Source repo: http://github.com/bennn/spreadsheet.git
* Bug tracker: http://github.com/bennn/spreadsheet/issues

---

Pull-request generated by opam-publish v0.3.0