### PR TITLE
Quickfix for ocp-indent's .el file

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.5.1/files/elisp-hotfix.patch
+++ b/packages/ocp-indent/ocp-indent.1.5.1/files/elisp-hotfix.patch
@@ -1,0 +1,14 @@
+diff --git a/tools/ocp-indent.el b/tools/ocp-indent.el
+index fdb70aa..7516245 100644
+--- a/tools/ocp-indent.el
++++ b/tools/ocp-indent.el
+@@ -113,7 +113,8 @@ are blanks."
+ ;;;###autoload
+ (defun ocp-setup-indent ()
+   (interactive nil)
+-  (unless (string= (file-name-extension (buffer-file-name)) "mly")
++  (unless (and (buffer-file-name)
++               (string= (file-name-extension (buffer-file-name)) "mly"))
+     (unless ocp-indent-allow-tabs (set 'indent-tabs-mode nil))
+     (set (make-local-variable 'indent-line-function) #'ocp-indent-line)
+     (set (make-local-variable 'indent-region-function) #'ocp-indent-region)))

--- a/packages/ocp-indent/ocp-indent.1.5.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.5.1/opam
@@ -33,3 +33,4 @@ This package requires additional configuration for use in editors.
   "
     {success & !user-setup:installed}
 ]
+patches: "elisp-hotfix.patch"


### PR DESCRIPTION
Not worth a release, but annoying