### PR TITLE
Newest packages for Apron (with OSX support) & mlgmpidl (1.2.1)

### DIFF
--- a/packages/apron/apron.20150820/descr
+++ b/packages/apron/apron.20150820/descr
@@ -1,0 +1,1 @@
+APRON numerical abstract domain library

--- a/packages/apron/apron.20150820/opam
+++ b/packages/apron/apron.20150820/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+authors: ["Bertrant Jeannet" "Antoine Miné"]
+homepage: "http://apron.cri.ensmp.fr/library/"
+maintainer: "Nicolas Berthier <m@nberth.space>"
+dev-repo: "https://gforge.inria.fr/scm/?group_id=2625"
+bug-reports: "https://gforge.inria.fr/tracker/?atid=8946&group_id=2625&func=browse"
+license: "LGPL-2.1"
+build: [
+  ["sh" "./configure" "--prefix" "%{apron:share}%"
+  		      "--no-ppl" {! conf-ppl:installed}
+		      "--no-java"
+		      "--absolute-dylibs" { os = "darwin" } ]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "apron"]
+  ["rm" "-r" "-f" "%{apron:share}%"]
+]
+tags: [ "flags:light-uninstall" ]
+depends: [
+  "ocamlfind"
+  "camlidl"
+# ("mlgmpidl" | "mlgmp") <- mlgmp does not seem to install anything...
+  "mlgmpidl"
+]
+depopts: [
+  "conf-ppl"
+]
+available: [ os = "linux" | os = "freebsd" | os = "osx" | os = "darwin" ]

--- a/packages/apron/apron.20150820/url
+++ b/packages/apron/apron.20150820/url
@@ -1,0 +1,2 @@
+archive: "http://apron.gforge.inria.fr/apron-20150820.tar.gz"
+checksum: "9bb307e5d783981e0c8d85bcaba72533"

--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -17,5 +17,6 @@ depends: [
   "ocamlfind"
 ]
 conflicts: [
-  "apron"
+  "apron" {= "20140725"}
+  "apron" {= "20150518"}
 ]

--- a/packages/mlgmpidl/mlgmpidl.1.2.1/descr
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/descr
@@ -1,0 +1,1 @@
+OCaml interface to the GMP library

--- a/packages/mlgmpidl/mlgmpidl.1.2.1/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1"
+authors: ["Bertrant Jeannet"]
+maintainer: "Nicolas Berthier <m@nberth.space>"
+dev-repo: "https://github.com/nberth/mlgmpidl"
+bug-reports: "https://github.com/nberth/mlgmpidl/issues"
+license: "LGPL-2.1"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "gmp"]
+]
+depends: ["ocamlfind" "camlidl" "conf-gmp" "conf-mpfr"]
+conflicts: [
+  "mlgmp"
+  "apron" {= "20140725"}
+  "apron" {= "20150518"}
+]

--- a/packages/mlgmpidl/mlgmpidl.1.2.1/url
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/nberth/mlgmpidl/archive/1.2.1.tar.gz"
+checksum: "5e43e58a14847020aff03271779ffdd5"


### PR DESCRIPTION
The new package `mlgmpidl' installs a binding to GNU MP and GNU MPFR
that does not match the one provided by `mlgmp'. It can also be
considered more lightweight as it does not depend on `oasis'.

The `mlgmp' package is also marked as conflicting with earlier
versions of `apron', as the `mlgmpidl' library was previously included
and installed by apron.