### PR TITLE
Newest packages for Apron (with OSX support) & mlgmpidl (1.2.1)

### DIFF
--- a/packages/apron/apron.20150820/descr
+++ b/packages/apron/apron.20150820/descr
@@ -1,0 +1,1 @@
+APRON numerical abstract domain library

--- a/packages/apron/apron.20150820/opam
+++ b/packages/apron/apron.20150820/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+authors: ["Bertrant Jeannet" "Antoine Miné"]
+homepage: "http://apron.cri.ensmp.fr/library/"
+maintainer: "Nicolas Berthier <m@nberth.space>"
+bug-reports: "https://gforge.inria.fr/tracker/?atid=8946&group_id=2625&func=browse"
+license: "LGPL-2.1"
+build: [
+  ["sh" "./configure" "--prefix" "%{apron:share}%"
+  		      "--no-ppl" {! conf-ppl:installed}
+		      "--no-java"
+		      "--absolute-dylibs" { os = "darwin" } ]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "apron"]
+  ["rm" "-r" "-f" "%{apron:share}%"]
+]
+tags: [ "flags:light-uninstall" ]
+depends: [
+  "ocamlfind"
+  "camlidl"
+# ("mlgmpidl" | "mlgmp") <- mlgmp does not seem to install anything...
+  "mlgmpidl"
+]
+depopts: [
+  "conf-ppl"
+]
+available: [ os = "linux" | os = "freebsd" | os = "osx" | os = "darwin" ]

--- a/packages/apron/apron.20150820/opam
+++ b/packages/apron/apron.20150820/opam
@@ -28,6 +28,5 @@ depopts: [
   "conf-ppl"
 ]
 available: [
-  opam-version >= "1.2" &
-  (os = "linux" | os = "freebsd" | os = "osx" | os = "darwin")
+  opam-version >= "1.2"
 ]

--- a/packages/apron/apron.20150820/opam
+++ b/packages/apron/apron.20150820/opam
@@ -22,10 +22,12 @@ tags: [ "flags:light-uninstall" ]
 depends: [
   "ocamlfind"
   "camlidl"
-# ("mlgmpidl" | "mlgmp") <- mlgmp does not seem to install anything...
   "mlgmpidl"
 ]
 depopts: [
   "conf-ppl"
 ]
-available: [ os = "linux" | os = "freebsd" | os = "osx" | os = "darwin" ]
+available: [
+  opam-version >= "1.2" &
+  (os = "linux" | os = "freebsd" | os = "osx" | os = "darwin")
+]

--- a/packages/apron/apron.20150820/opam
+++ b/packages/apron/apron.20150820/opam
@@ -2,6 +2,8 @@ opam-version: "1.2"
 authors: ["Bertrant Jeannet" "Antoine Miné"]
 homepage: "http://apron.cri.ensmp.fr/library/"
 maintainer: "Nicolas Berthier <m@nberth.space>"
+# Commented out as svn does not seem supported (yet?).
+# dev-repo: "svn://scm.gforge.inria.fr/svnroot/apron/"
 bug-reports: "https://gforge.inria.fr/tracker/?atid=8946&group_id=2625&func=browse"
 license: "LGPL-2.1"
 build: [

--- a/packages/apron/apron.20150820/url
+++ b/packages/apron/apron.20150820/url
@@ -1,0 +1,2 @@
+archive: "http://apron.gforge.inria.fr/apron-20150820.tar.gz"
+checksum: "9bb307e5d783981e0c8d85bcaba72533"

--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -26,3 +26,6 @@ conflicts: [
   "apron" {= "20140725"}
   "apron" {= "20150518"}
 ]
+available: [
+  ocaml-version < "4.03"
+]

--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -1,5 +1,7 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+authors: ["David Monniaux"]
+maintainer: "Nicolas Berthier <m@nberth.space>"
+homepage: "http://www-verimag.imag.fr/~monniaux/download/"
 build: [
   ["sh" "-c" "rm -f *.cmo *.cmi *.cma *.cmxa *.o *.a *.cmx *.cmxs"]
   ["oasis" "setup"]
@@ -7,9 +9,13 @@ build: [
   ["mkdir" "-p" "_build"]
   ["cp" "conversions.c" "_build/conversions.c"]
   ["ocaml" "setup.ml" "-build"]
+]
+install: [
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [["ocamlfind" "remove" "gmp"]]
+remove: [
+  ["ocamlfind" "remove" "gmp"]
+]
 depends: [
   "conf-gmp"
   "conf-mpfr"

--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -17,5 +17,6 @@ depends: [
   "ocamlfind"
 ]
 conflicts: [
-  "apron"
+  "apron" {= "20140725"}
+  "apron" {= "20150518"}
 ]

--- a/packages/mlgmpidl/mlgmpidl.1.2.1/descr
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/descr
@@ -1,0 +1,1 @@
+OCaml interface to the GMP library

--- a/packages/mlgmpidl/mlgmpidl.1.2.1/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/opam
@@ -1,8 +1,9 @@
-opam-version: "1"
+opam-version: "1.2"
 authors: ["Bertrant Jeannet"]
 maintainer: "Nicolas Berthier <m@nberth.space>"
 dev-repo: "https://github.com/nberth/mlgmpidl.git"
 bug-reports: "https://github.com/nberth/mlgmpidl/issues"
+homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlgmpidl/"
 license: "LGPL-2.1"
 build: [
   ["./configure"]

--- a/packages/mlgmpidl/mlgmpidl.1.2.1/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1"
+authors: ["Bertrant Jeannet"]
+maintainer: "Nicolas Berthier <m@nberth.space>"
+dev-repo: "https://github.com/nberth/mlgmpidl.git"
+bug-reports: "https://github.com/nberth/mlgmpidl/issues"
+license: "LGPL-2.1"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "gmp"]
+]
+depends: ["ocamlfind" "camlidl" "conf-gmp" "conf-mpfr"]
+conflicts: [
+  "mlgmp"
+  "apron" {= "20140725"}
+  "apron" {= "20150518"}
+]

--- a/packages/mlgmpidl/mlgmpidl.1.2.1/url
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/nberth/mlgmpidl/archive/1.2.1.tar.gz"
+checksum: "5e43e58a14847020aff03271779ffdd5"


### PR DESCRIPTION
The new package 'mlgmpidl' installs a binding to GNU MP and GNU MPFR
that does not match the one provided by 'mlgmp'. It can also be
considered more lightweight as it does not depend on 'oasis'.

The 'mlgmp' package is also marked as conflicting with earlier
versions of 'apron', as the 'mlgmpidl' library was previously included
and installed by this package.