### PR TITLE
mirage-bootvar-xen.0.3 - via opam-publish

### DIFF
--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3/descr
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3/descr
@@ -1,0 +1,1 @@
+Library for reading MirageOS unikernel boot parameters in Xen

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-bootvar-xen"
+bug-reports: "https://github.com/mirage/mirage-bootvar-xen/issues/"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-bootvar-xen.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-bootvar"]
+depends: [
+  "mirage-xen" {>= "2.2.0"}
+  "mirage-types"
+  "ipaddr"
+  "re"
+]

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3/url
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-bootvar-xen/archive/0.3.tar.gz"
+checksum: "ce5281d7b1d454a68d8679b9729f3072"


### PR DESCRIPTION
Library for reading MirageOS unikernel boot parameters in Xen


---
* Homepage: https://github.com/mirage/mirage-bootvar-xen
* Source repo: https://github.com/mirage/mirage-bootvar-xen.git
* Bug tracker: https://github.com/mirage/mirage-bootvar-xen/issues/

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.0