### PR TITLE
mirage-http.2.5.1 - via opam-publish

### DIFF
--- a/packages/mirage-http/mirage-http.2.5.1/descr
+++ b/packages/mirage-http/mirage-http.2.5.1/descr
@@ -1,0 +1,1 @@
+MirageOS HTTP client and server driver

--- a/packages/mirage-http/mirage-http.2.5.1/opam
+++ b/packages/mirage-http/mirage-http.2.5.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/mirage-http"
+bug-reports:  "https://github.com/mirage/mirage-http/issues/"
+dev-repo:     "https://github.com/mirage/mirage-http.git"
+
+build:    [make]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "mirage-http"]
+depends: [
+  "ocamlfind" {build}
+  "mirage-types-lwt" {>= "2.0.0"}
+  "mirage-conduit" {>= "2.2.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp" {>= "0.18.0"}
+  "sexplib"
+  "channel"
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/mirage-http/mirage-http.2.5.1/url
+++ b/packages/mirage-http/mirage-http.2.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-http/archive/v2.5.1.tar.gz"
+checksum: "2b603bc6a49e9c5003b749942b9704ba"


### PR DESCRIPTION
MirageOS HTTP client and server driver


---
* Homepage: https://github.com/mirage/mirage-http
* Source repo: https://github.com/mirage/mirage-http.git
* Bug tracker: https://github.com/mirage/mirage-http/issues/

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.0