### PR TITLE
[opam-publish] hdf5.0.1

### DIFF
--- a/packages/hdf5/hdf5.0.1/descr
+++ b/packages/hdf5/hdf5.0.1/descr
@@ -1,0 +1,5 @@
+Manages HDF5 files used for storing large amounts of data
+
+The library manages reading and writing to HDF5 files. HDF5 file format is used for
+storing and organizing large amounts of data. Also provided is a fast way of working with
+large arrays of records, much faster than OCaml arrays of records.

--- a/packages/hdf5/hdf5.0.1/opam
+++ b/packages/hdf5/hdf5.0.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Vladimir Brankov <vbrankov@janestreet.com>"
+authors: "Vladimir Brankov <vbrankov@janestreet.com>"
+homepage: "https://github.com/vbrankov/hdf5-ocaml"
+bug-reports: "https://github.com/vbrankov/hdf5-ocaml/issues"
+license: "MIT"
+dev-repo: "git@github.com:vbrankov/hdf5-ocaml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "hdf5_caml"]
+  ["ocamlfind" "remove" "hdf5_raw"]
+]
+depends: "ocamlfind" {build}

--- a/packages/hdf5/hdf5.0.1/url
+++ b/packages/hdf5/hdf5.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vbrankov/hdf5-ocaml/archive/v0.1-alpha.tar.gz"
+checksum: "81b08d0ef1cfca8d5e81289fd8f3360a"


### PR DESCRIPTION
Pull-request generated by opam-publish v0.2

---
Manages HDF5 files used for storing large amounts of data

The library manages reading and writing to HDF5 files. HDF5 file format is used for
storing and organizing large amounts of data. Also provided is a fast way of working with
large arrays of records, much faster than OCaml arrays of records.

---
* Homepage: https://github.com/vbrankov/hdf5-ocaml
* Source repo: git@github.com:vbrankov/hdf5-ocaml.git
* Bug tracker: https://github.com/vbrankov/hdf5-ocaml/issues
