### PR TITLE
alcotest.0.4.5 - via opam-publish

### DIFF
--- a/packages/alcotest/alcotest.0.4.5/descr
+++ b/packages/alcotest/alcotest.0.4.5/descr
@@ -1,0 +1,11 @@
+Alcotest is a lightweight and colourful test framework.
+
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple `TESTABLE` module type, a `check` function to assert test
+predicates and a `run` function to perform a list of `unit -> unit`
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.

--- a/packages/alcotest/alcotest.0.4.5/opam
+++ b/packages/alcotest/alcotest.0.4.5/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+
+license: "ISC"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "alcotest"]
+depends: [
+  "ocamlfind"
+  "stringext"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/alcotest/alcotest.0.4.5/url
+++ b/packages/alcotest/alcotest.0.4.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/alcotest/archive/0.4.5.tar.gz"
+checksum: "850459d7f7196da38c684b4c2adc1d31"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework.

Alcotest exposes simple interface to perform unit tests. It exposes
a simple `TESTABLE` module type, a `check` function to assert test
predicates and a `run` function to perform a list of `unit -> unit`
test callbacks.

Alcotest provides a quiet and colorful output where only faulty runs
are fully displayed at the end of the run (with the full logs ready to
inspect), with a simple (yet expressive) query language to select the
tests to run.


---
* Homepage: https://github.com/mirage/alcotest/
* Source repo: https://github.com/mirage/alcotest.git
* Bug tracker: https://github.com/mirage/alcotest/issues/

---

Pull-request generated by opam-publish v0.3.0