### PR TITLE
stb_truetype.0.1 - via opam-publish

### DIFF
--- a/packages/stb_truetype/stb_truetype.0.1/descr
+++ b/packages/stb_truetype/stb_truetype.0.1/descr
@@ -1,0 +1,8 @@
+OCaml bindings to stb_truetype, a public domain font rasterizer
+
+Stb_truetype is an OCaml binding to stb_truetype from Sean Barrett, [Nothings](http://nothings.org/):
+
+  stb_truetype.h: public domain C truetype rasterization library 
+
+The OCaml binding is released under CC-0 license.  It has no dependency beside
+working OCaml and C compilers (stb_truetype is self-contained).

--- a/packages/stb_truetype/stb_truetype.0.1/opam
+++ b/packages/stb_truetype/stb_truetype.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/def-lkb/stb_truetype"
+bug-reports: "https://github.com/def-lkb/stb_truetype"
+license: "CC0"
+dev-repo: "https://github.com/def-lkb/stb_truetype.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "stb_truetype"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/stb_truetype/stb_truetype.0.1/url
+++ b/packages/stb_truetype/stb_truetype.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/def-lkb/stb_truetype/archive/v0.1.tar.gz"
+checksum: "50f342f0b6b330dc9875dfe22f8f6b97"


### PR DESCRIPTION
OCaml bindings to stb_truetype, a public domain font rasterizer

Stb_truetype is an OCaml binding to stb_truetype from Sean Barrett, [Nothings](http://nothings.org/):

  stb_truetype.h: public domain C truetype rasterization library 

The OCaml binding is released under CC-0 license.  It has no dependency beside
working OCaml and C compilers (stb_truetype is self-contained).


---
* Homepage: https://github.com/def-lkb/stb_truetype
* Source repo: https://github.com/def-lkb/stb_truetype.git
* Bug tracker: https://github.com/def-lkb/stb_truetype

---

Pull-request generated by opam-publish v0.3.1