### PR TITLE
stb_image.0.1 - via opam-publish

### DIFF
--- a/packages/stb_image/stb_image.0.1/descr
+++ b/packages/stb_image/stb_image.0.1/descr
@@ -1,0 +1,7 @@
+OCaml bindings to stb_image, a public domain image loader 
+
+Stb_image is an OCaml binding to stb_image from Sean Barrett, [Nothings](http://nothings.org/):
+
+  stb_image.h: public domain C image loading library
+
+The OCaml binding is released under CC-0 license.  It has no dependency beside working OCaml and C compilers (stb_image is self-contained).

--- a/packages/stb_image/stb_image.0.1/opam
+++ b/packages/stb_image/stb_image.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/def-lkb/stb_image"
+bug-reports: "https://github.com/def-lkb/stb_image"
+license: "CC0"
+dev-repo: "https://github.com/def-lkb/stb_image.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "stb_image"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ ocaml-version != "4.01.0" ]

--- a/packages/stb_image/stb_image.0.1/url
+++ b/packages/stb_image/stb_image.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/def-lkb/stb_image/archive/v0.1.tar.gz"
+checksum: "7105586140b4c0dfbc346429349ce1ec"


### PR DESCRIPTION
OCaml bindings to stb_image, a public domain image loader 

Stb_image is an OCaml binding to stb_image from Sean Barrett, [Nothings](http://nothings.org/):

  stb_image.h: public domain C image loading library

The OCaml binding is released under CC-0 license.  It has no dependency beside working OCaml and C compilers (stb_image is self-contained).


---
* Homepage: https://github.com/def-lkb/stb_image
* Source repo: https://github.com/def-lkb/stb_image.git
* Bug tracker: https://github.com/def-lkb/stb_image

---

Pull-request generated by opam-publish v0.3.1