### PR TITLE
fmt.0.7.0 - via opam-publish

### DIFF
--- a/packages/fmt/fmt.0.7.0/descr
+++ b/packages/fmt/fmt.0.7.0/descr
@@ -1,0 +1,9 @@
+OCaml Format pretty-printer combinators
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional Fmt_tty
+library that allows to setup formatters for terminal color output
+depends on the Unix library. Fmt is distributed under the BSD3
+license.
+

--- a/packages/fmt/fmt.0.7.0/opam
+++ b/packages/fmt/fmt.0.7.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/fmt"
+doc: "http://erratique.ch/software/fmt"
+dev-repo: "http://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.01.0"]
+depends: [ "ocamlfind" ]
+depopts: [ "base-unix" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "unix=%{base-unix:installed}%" ]
+]

--- a/packages/fmt/fmt.0.7.0/url
+++ b/packages/fmt/fmt.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/fmt/releases/fmt-0.7.0.tbz"
+checksum: "5097baf454eed813a56fbef2a994dc71"


### PR DESCRIPTION
OCaml Format pretty-printer combinators

Fmt exposes combinators to devise `Format` pretty-printing functions.

Fmt depends only on the OCaml standard library. The optional Fmt_tty
library that allows to setup formatters for terminal color output
depends on the Unix library. Fmt is distributed under the BSD3
license.



---
* Homepage: http://erratique.ch/software/fmt
* Source repo: http://erratique.ch/repos/fmt.git
* Bug tracker: https://github.com/dbuenzli/fmt/issues

---

Pull-request generated by opam-publish v0.3.1