### PR TITLE
tallgeese.0.1 - via opam-publish

### DIFF
--- a/packages/tallgeese/tallgeese.0.1/descr
+++ b/packages/tallgeese/tallgeese.0.1/descr
@@ -1,0 +1,5 @@
+Enhanced SSH on OS X
+Enhanced SSH experience on OS X using native Cocoa tallgeese is an
+OCaml/Objective-C application that makes the SSH experience more
+enjoyable on OS X.
+

--- a/packages/tallgeese/tallgeese.0.1/files/_oasis_remove_.ml
+++ b/packages/tallgeese/tallgeese.0.1/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/tallgeese/tallgeese.0.1/files/tallgeese.install
+++ b/packages/tallgeese/tallgeese.0.1/files/tallgeese.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/tallgeese/tallgeese.0.1/opam
+++ b/packages/tallgeese/tallgeese.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "http://hyegar.com"
+bug-reports: "http://hyegar.com"
+license: "BSD-3-clause"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/tallgeese/_oasis_remove_.ml" "%{etc}%/tallgeese"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+depopts: [
+  "cmdliner" {build}
+  "maxminddb" {build}
+  "ssh" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/tallgeese/tallgeese.0.1/url
+++ b/packages/tallgeese/tallgeese.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/tallgeese/archive/v0.1.tar.gz"
+checksum: "eb3c32c189fcde13a632cda732ea7700"


### PR DESCRIPTION
Enhanced SSH on OS X
Enhanced SSH experience on OS X using native Cocoa tallgeese is an
OCaml/Objective-C application that makes the SSH experience more
enjoyable on OS X.



---
* Homepage: http://hyegar.com
* Source repo: 
* Bug tracker: http://hyegar.com

---
### opam-lint failures
- **WARNING** 37 Missing field 'dev-repo'

---

Pull-request generated by opam-publish v0.3.1