### PR TITLE
libssh.0.1 - via opam-publish

### DIFF
--- a/packages/libssh/libssh.0.1/descr
+++ b/packages/libssh/libssh.0.1/descr
@@ -1,0 +1,4 @@
+Bindings to libssh
+
+Bindings to libssh, https://www.libssh.org. This library exposes both
+the Client and Server side implementations of ssh.

--- a/packages/libssh/libssh.0.1/opam
+++ b/packages/libssh/libssh.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "http://hyegar.com"
+bug-reports: "https://github.com/fxfactorial/ocaml-libssh/issues"
+license: "BSD-3-clause"
+tags: "clib:ssh"
+dev-repo: "https://github.com/fxfactorial/ocaml-libssh.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "ssh"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+depexts: [
+  [["centos"] ["libssh-devel"]]
+  [["debian"] ["libssh-dev"]]
+  [["homebrew" "osx"] ["libssh"]]
+  [["ubuntu"] ["libssh-dev"]]
+]
+available: [ocaml-version >= "4.02.3"]
+post-messages: [
+  "This package requires libssh https://www.libssh.org on your system"
+    {failure}
+]

--- a/packages/libssh/libssh.0.1/url
+++ b/packages/libssh/libssh.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-libssh/archive/v0.1.tar.gz"
+checksum: "5eea8bf42523058cd1a6c9bada7f5b3f"


### PR DESCRIPTION
Bindings to libssh

Bindings to libssh, https://www.libssh.org. This library exposes both
the Client and Server side implementations of ssh.

---
* Homepage: http://hyegar.com
* Source repo: https://github.com/fxfactorial/ocaml-libssh.git
* Bug tracker: https://github.com/fxfactorial/ocaml-libssh/issues

---

Pull-request generated by opam-publish v0.3.1