### PR TITLE
why 2.35 does not recognize why3 0.86.1

### DIFF
--- a/packages/why/why.2.35/opam
+++ b/packages/why/why.2.35/opam
@@ -27,6 +27,6 @@ build: [
   [make "install"]
 ]
 depends: [
-  "why3" {>= "0.84"}
+  "why3" {>= "0.84" & <= "0.86" }
   "frama-c" {>= "20150201"}
 ]


### PR DESCRIPTION
,should only be compiled with 0.84, 0.85 or 0.86