### PR TITLE
iso-filesystem.0.1 - via opam-publish

### DIFF
--- a/packages/iso-filesystem/iso-filesystem.0.1/descr
+++ b/packages/iso-filesystem/iso-filesystem.0.1/descr
@@ -1,0 +1,4 @@
+ISO9660 filesystem library
+
+A MirageOS compatible library for providing read-only access to
+ISO9660 filsystems.

--- a/packages/iso-filesystem/iso-filesystem.0.1/opam
+++ b/packages/iso-filesystem/iso-filesystem.0.1/opam
@@ -5,6 +5,7 @@ bug-reports: "https://github.com/jonludlam/ocaml-iso-filesystem/issues"
 dev-repo: "git://github.com/jonludlam/ocaml-iso-filesystem"
 authors: "Jon Ludlam"
 license: "ISC"
+available: [ocaml-version >= "4.01.0"]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/iso-filesystem/iso-filesystem.0.1/opam
+++ b/packages/iso-filesystem/iso-filesystem.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "jonathan.ludlam@citrix.com"
+homepage: "https://github.com/jonludlam/ocaml-iso-filesystem"
+bug-reports: "https://github.com/jonludlam/ocaml-iso-filesystem/issues"
+dev-repo: "git://github.com/jonludlam/ocaml-iso-filesystem"
+authors: "Jon Ludlam"
+license: "ISC"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["lib_test/mkiso.sh"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "iso-filesystem"]
+depends: [
+  "cstruct"
+  "io-page" {build}
+  "lwt"
+  "mirage-block-unix" {build}
+  "mirage-types"
+  "ocamlfind" {build}
+  "ounit" {build}
+  "re"
+  "stringext"
+]

--- a/packages/iso-filesystem/iso-filesystem.0.1/url
+++ b/packages/iso-filesystem/iso-filesystem.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jonludlam/ocaml-iso9660/archive/v0.1.tar.gz"
+checksum: "aa3afc0f7f858f352c07425d4b779dcc"


### PR DESCRIPTION
ISO9660 filesystem library

A MirageOS compatible library for providing read-only access to
ISO9660 filsystems.


---
* Homepage: https://github.com/jonludlam/ocaml-iso-filesystem
* Source repo: git://github.com/jonludlam/ocaml-iso-filesystem
* Bug tracker: https://github.com/jonludlam/ocaml-iso-filesystem/issues

---

Pull-request generated by opam-publish v0.3.1