### PR TITLE
brotli.0.1 - via opam-publish

### DIFF
--- a/packages/brotli/brotli.0.1/descr
+++ b/packages/brotli/brotli.0.1/descr
@@ -1,0 +1,6 @@
+Bindings to Google's Brotli compresion algorithm
+
+Source: https://github.com/google/brotli/
+RFC: http://www.ietf.org/id/draft-alakuijala-brotli
+
+Comes with command line tool called brozip

--- a/packages/brotli/brotli.0.1/files/_oasis_remove_.ml
+++ b/packages/brotli/brotli.0.1/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/brotli/brotli.0.1/files/brotli.install
+++ b/packages/brotli/brotli.0.1/files/brotli.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/brotli/brotli.0.1/opam
+++ b/packages/brotli/brotli.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "http://hyegar.com"
+bug-reports: "https://github.com/fxfactorial/ocaml-brotli/issues"
+license: "BSD-3-clause"
+tags: ["clib:stdc" "clib:brotli"]
+dev-repo: "https://github.com/fxfactorial/ocaml-brotli.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/brotli/_oasis_remove_.ml" "%{etc}%/brotli"]
+depends: [
+  "cmdliner" {build}
+  "lwt" {build}
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/brotli/brotli.0.1/url
+++ b/packages/brotli/brotli.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-brotli/archive/v0.1.tar.gz"
+checksum: "5dbcba4df3ca2603a613d79562d3990e"


### PR DESCRIPTION
Bindings to Google's Brotli compresion algorithm

Source: https://github.com/google/brotli/
RFC: http://www.ietf.org/id/draft-alakuijala-brotli

Comes with command line tool called brozip

---
* Homepage: http://hyegar.com
* Source repo: https://github.com/fxfactorial/ocaml-brotli.git
* Bug tracker: https://github.com/fxfactorial/ocaml-brotli/issues

---

Pull-request generated by opam-publish v0.3.1