### PR TITLE
mustache.2.1.0 - via opam-publish

### DIFF
--- a/packages/mustache/mustache.2.1.0/descr
+++ b/packages/mustache/mustache.2.1.0/descr
@@ -1,0 +1,3 @@
+Mustache logic-less templates in OCaml
+
+Read and write mustache templates and render them by providing a json object

--- a/packages/mustache/mustache.2.1.0/opam
+++ b/packages/mustache/mustache.2.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/ocaml-mustache"
+bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
+dev-repo: "https://github.com/rgrinberg/ocaml-mustache.git"
+doc: "http://mustache.github.io/mustache.5.html"
+
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--disable-cli"]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: ["ocaml" "setup.ml" "-install"]
+
+remove: [
+  ["ocamlfind" "remove" "mustache"]
+]
+
+build-doc: ["ocaml" "setup.ml" "-doc"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build & >= "0.4.0"}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mustache/mustache.2.1.0/url
+++ b/packages/mustache/mustache.2.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ocaml-mustache/archive/v2.1.0.tar.gz"
+checksum: "d7545f4b0b3088afd1c62a77225b4f61"


### PR DESCRIPTION
Mustache logic-less templates in OCaml

Read and write mustache templates and render them by providing a json object

---
* Homepage: https://github.com/rgrinberg/ocaml-mustache
* Source repo: https://github.com/rgrinberg/ocaml-mustache.git
* Bug tracker: https://github.com/rgrinberg/ocaml-mustache/issues

---

Pull-request generated by opam-publish v0.3.1