### PR TITLE
brozip.0.1 - via opam-publish

### DIFF
--- a/packages/brozip/brozip.0.1/descr
+++ b/packages/brozip/brozip.0.1/descr
@@ -1,0 +1,4 @@
+CLI to concurrently compress, decompress files using the Brotli algorithm
+
+brozip is a command line tool to compress and decompress files using
+the Brotli algorithm, it uses OCaml bindings to the Google Brotli library.

--- a/packages/brozip/brozip.0.1/files/_oasis_remove_.ml
+++ b/packages/brozip/brozip.0.1/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/brozip/brozip.0.1/files/brozip.install
+++ b/packages/brozip/brozip.0.1/files/brozip.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/brozip/brozip.0.1/opam
+++ b/packages/brozip/brozip.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "http://hyegar.com"
+bug-reports: "http://hyegar.com"
+dev-repo: "https://github.com/fxfactorial/brozip.git"
+license: "BSD-3-clause"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/brozip/_oasis_remove_.ml" "%{etc}%/brozip"]
+depends: [
+  "brotli" {build}
+  "cmdliner" {build}
+  "lwt" {build}
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/brozip/brozip.0.1/url
+++ b/packages/brozip/brozip.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/brozip/archive/v1.0.tar.gz"
+checksum: "3d4b66f730d340a48055fa5a4dcfd28c"


### PR DESCRIPTION
CLI to concurrently compress, decompress files using the Brotli algorithm

brozip is a command line tool to compress and decompress files using
the Brotli algorithm, it uses OCaml bindings to the Google Brotli library.

---
* Homepage: http://hyegar.com
* Source repo: https://github.com/fxfactorial/brozip.git
* Bug tracker: http://hyegar.com

---

Pull-request generated by opam-publish v0.3.1