### PR TITLE
ppx_custom_printf

### DIFF
--- a/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/descr
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/descr
@@ -1,0 +1,2 @@
+Printf-style format-strings for user-defined string conversion
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_custom_printf"
+bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
+dev-repo: "https://github.com/janestreet/ppx_custom_printf.git"
+license: "Apache-2.0"
+build: [[make]]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "ppx_custom_printf"]]
+build-doc: [[make "doc"]]
+depends: [ "ocamlfind" {>= "1.3.2"}
+           "ppx_sexp_conv"
+           "ppx_core"
+           "ppx_deriving"
+           "ppx_tools"
+           "ppx_driver" ]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/url
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/ppx_custom_printf/archive/113.09.00.tar.gz"
+checksum: "ab756fa5444432dea3c98a515ec78de0"

--- a/packages/ppx_tools/ppx_tools.0.99.3/descr
+++ b/packages/ppx_tools/ppx_tools.0.99.3/descr
@@ -1,0 +1,1 @@
+Tools for authors of ppx rewriters and other syntactic tools

--- a/packages/ppx_tools/ppx_tools.0.99.3/findlib
+++ b/packages/ppx_tools/ppx_tools.0.99.3/findlib
@@ -1,0 +1,1 @@
+ppx_tools

--- a/packages/ppx_tools/ppx_tools.0.99.3/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.3/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "alain.frisch@lexifi.com"
+authors: ["Alain Frisch <alain.frisch@lexifi.com>"]
+homepage: "https://github.com/alainfrisch/ppx_tools"
+bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
+dev-repo: "https://github.com/alainfrisch/ppx_tools.git"
+build: [[make "all"]]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "ppx_tools"]]
+depends: ["ocamlfind" {>= "1.5.0"}]
+available: [ (ocaml-version >= "4.02.0") & (ocaml-version < "4.03.0") ]

--- a/packages/ppx_tools/ppx_tools.0.99.3/url
+++ b/packages/ppx_tools/ppx_tools.0.99.3/url
@@ -1,0 +1,2 @@
+archive: "http://github.com/diml/ppx_tools/archive/ppx_tools_0.99.3.tar.gz"
+checksum: "eeda1c5b2d790c4f566aeed5b960b910"

--- a/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
@@ -11,7 +11,7 @@ remove: [["ocamlfind" "remove" "ppx_type_conv"]]
 build-doc: [[make "doc"]]
 depends: [ "ocamlfind" {>= "1.3.2"}
            "ppx_core"
-           "ppx_deriving"
+           "ppx_deriving" {>= "3.0"}
            "ppx_tools"
            "ppx_driver" ]
 available: [ ocaml-version >= "4.02.2" ]


### PR DESCRIPTION
First release of ppx\_custom\_printf.

This pull request contains a minor release of ppx\_tools, which includes some patches backported for OCaml 4.02 that are required by ppx\_custom\_printf (see alainfrisch/ppx_tools#26).