### PR TITLE
irmin.0.9.10 - via opam-publish

### DIFF
--- a/packages/irmin/irmin.0.9.10/descr
+++ b/packages/irmin/irmin.0.9.10/descr
@@ -1,0 +1,9 @@
+Irmin, the database that never forgets
+
+Irmin is a distributed database with built-in snapshot, branch and
+revert mechanisms. It is designed to use a large variety of backends,
+although it is optimized for append-only store.
+
+Irmin is written in pure OCaml. It can thus be compiled to Javascript
+-- and run in the browsers; or into a MirageOS unikernel -- and run directly
+on top of Xen.

--- a/packages/irmin/irmin.0.9.10/opam
+++ b/packages/irmin/irmin.0.9.10/opam
@@ -1,0 +1,54 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+
+build: [
+  ["./configure" "--prefix" prefix
+      "--%{cohttp:enable}%-http"
+      "--%{git:enable}%-git"
+      "--%{base-unix:enable}%-unix"
+      "--%{mirage-git:enable}%-mirage"]
+  [make]
+]
+build-test: [
+  ["./configure" "--enable-tests" "--enable-examples"]
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "irmin"]
+
+depends: [
+  "ocamlfind" {build}
+  "ezjsonm" {>= "0.4.2"}
+  "ocamlgraph"
+  "lwt" {>= "2.4.7"}
+  "dolog" {>= "0.4"}
+  "cstruct" {>= "1.0.1"}
+  "mirage-tc" {>= "0.3.0"}
+  "mstruct"
+  "uri" {>= "1.3.12"}
+  "stringext" {>= "1.1.0"}
+  "hex"
+  "re"
+  "cmdliner"
+  "crunch"
+  "base-unix" {test}
+  "git"       {test}
+  "cohttp"    {test}
+  "alcotest"  {test & >="0.4.1"}
+]
+depopts: [
+  "base-unix"
+  "git"
+  "cohttp"
+  "mirage-git"
+]
+conflicts: [
+  "cohttp" {< "0.18.3"}
+  "git"    {< "1.7.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin/irmin.0.9.10/url
+++ b/packages/irmin/irmin.0.9.10/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/irmin/archive/0.9.10.tar.gz"
+checksum: "4df65e9fe984406b4a1eeb873e55a09b"


### PR DESCRIPTION
Irmin, the database that never forgets

Irmin is a distributed database with built-in snapshot, branch and
revert mechanisms. It is designed to use a large variety of backends,
although it is optimized for append-only store.

Irmin is written in pure OCaml. It can thus be compiled to Javascript
-- and run in the browsers; or into a MirageOS unikernel -- and run directly
on top of Xen.


---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---

Pull-request generated by opam-publish v0.3.0