### PR TITLE
irmin-chunk.1.0.0 - via opam-publish

### DIFF
--- a/packages/irmin-chunk/irmin-chunk.1.0.0/descr
+++ b/packages/irmin-chunk/irmin-chunk.1.0.0/descr
@@ -1,0 +1,5 @@
+Irmin backend to store raw contents into chunks
+
+Allow to store raw contents into a well-balanced rope-like structure, where
+leafs are chunk of all the same size. Also provides a functor to do it while
+keeping the store keys stable.

--- a/packages/irmin-chunk/irmin-chunk.1.0.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.1.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin-chunk"
+bug-reports:  "https://github.com/mirage/irmin-chunk/issues"
+dev-repo:     "https://github.com/mirage/irmin-chunk.git"
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "irmin-chunk"]
+
+depends: [
+  "ocamlfind" {build}
+  "irmin" {>= "0.9.10"}
+  "lwt"
+  "alcotest"  {test & >="0.4.1"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-chunk/irmin-chunk.1.0.0/url
+++ b/packages/irmin-chunk/irmin-chunk.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/irmin-chunk/archive/1.0.0.tar.gz"
+checksum: "4a7374a29e245563c48590e56c7c8da9"


### PR DESCRIPTION
Irmin backend to store raw contents into chunks

Allow to store raw contents into a well-balanced rope-like structure, where
leafs are chunk of all the same size. Also provides a functor to do it while
keeping the store keys stable.

---
* Homepage: https://github.com/mirage/irmin-chunk
* Source repo: https://github.com/mirage/irmin-chunk.git
* Bug tracker: https://github.com/mirage/irmin-chunk/issues

---

Pull-request generated by opam-publish v0.3.0