### PR TITLE
unix-errno.0.2.0 - via opam-publish

### DIFF
--- a/packages/unix-errno/unix-errno.0.2.0/descr
+++ b/packages/unix-errno/unix-errno.0.2.0/descr
@@ -1,0 +1,10 @@
+Unix errno types, maps, and support
+
+unix-errno provides an errno variant similar to Unix.error but including
+POSIX 2008 and Linux-specific constructors. A macro definition type,
+defns is also provided in order to transport a specific errno-integer
+map as is the case with FUSE. The types and their functions reside in
+Errno and are independent of any Unix bindings. This makes the library's
+types usable from MirageOS on top of Xen. Errno_unix provides maps to
+and from Unix.error, the present host's errno map, an errno exception
+Error, and higher-order errno checking functions.

--- a/packages/unix-errno/unix-errno.0.2.0/opam
+++ b/packages/unix-errno/unix-errno.0.2.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets <sheets@alum.mit.edu>"
+homepage: "https://github.com/dsheets/ocaml-unix-errno"
+bug-reports: "https://github.com/dsheets/ocaml-unix-errno/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/ocaml-unix-errno.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ctypes" {>= "0.4.0"}
+  "rresult"
+]

--- a/packages/unix-errno/unix-errno.0.2.0/url
+++ b/packages/unix-errno/unix-errno.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-errno/archive/0.2.0.tar.gz"
+checksum: "afda858f0936c37043c1f6fce04cf315"


### PR DESCRIPTION
Unix errno types, maps, and support

unix-errno provides an errno variant similar to Unix.error but including
POSIX 2008 and Linux-specific constructors. A macro definition type,
defns is also provided in order to transport a specific errno-integer
map as is the case with FUSE. The types and their functions reside in
Errno and are independent of any Unix bindings. This makes the library's
types usable from MirageOS on top of Xen. Errno_unix provides maps to
and from Unix.error, the present host's errno map, an errno exception
Error, and higher-order errno checking functions.


---
* Homepage: https://github.com/dsheets/ocaml-unix-errno
* Source repo: https://github.com/dsheets/ocaml-unix-errno.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-errno/issues

---

Pull-request generated by opam-publish v0.3.0