### PR TITLE
unix-fcntl.0.2.0 - via opam-publish

### DIFF
--- a/packages/unix-fcntl/unix-fcntl.0.2.0/descr
+++ b/packages/unix-fcntl/unix-fcntl.0.2.0/descr
@@ -1,0 +1,9 @@
+Unix fcntl.h types, maps, and support
+
+unix-fcntl provides types for manipulating concepts expressed in
+fcntl.h. A macro definition type, defns is provided for open flags in
+order to transport a specific openflag-integer map as is the case with
+FUSE. The types and their functions reside in Fcntl and are independent
+of any Unix bindings. This makes the library's types usable from
+MirageOS on top of Xen. Fcntl_unix provides maps to and from
+Unix.open_flag, the present host's open flag map, and similar.

--- a/packages/unix-fcntl/unix-fcntl.0.2.0/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.2.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets <sheets@alum.mit.edu>"
+homepage: "https://github.com/dsheets/ocaml-unix-fcntl"
+bug-reports: "https://github.com/dsheets/ocaml-unix-fcntl/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/ocaml-unix-fcntl.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ctypes" {>= "0.4.0"}
+  "unix-errno" {>= "0.2.0"}
+]

--- a/packages/unix-fcntl/unix-fcntl.0.2.0/url
+++ b/packages/unix-fcntl/unix-fcntl.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-fcntl/archive/0.2.0.tar.gz"
+checksum: "b0e7c850d093fe462041beb13827e5ba"


### PR DESCRIPTION
Unix fcntl.h types, maps, and support

unix-fcntl provides types for manipulating concepts expressed in
fcntl.h. A macro definition type, defns is provided for open flags in
order to transport a specific openflag-integer map as is the case with
FUSE. The types and their functions reside in Fcntl and are independent
of any Unix bindings. This makes the library's types usable from
MirageOS on top of Xen. Fcntl_unix provides maps to and from
Unix.open_flag, the present host's open flag map, and similar.


---
* Homepage: https://github.com/dsheets/ocaml-unix-fcntl
* Source repo: https://github.com/dsheets/ocaml-unix-fcntl.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-fcntl/issues

---

Pull-request generated by opam-publish v0.3.0