### PR TITLE
+sibylfs-lem.0.4.0 because lem has never been released

### DIFF
--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/descr
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/descr
@@ -1,0 +1,15 @@
+SibylFS fork of Lightweight Executable Mathematics for large-scale semantics
+
+Lem is a tool for lightweight executable mathematics, for writing,
+managing, and publishing large-scale portable semantic definitions, with
+export to LaTeX, executable code (currently OCaml) and interactive
+theorem provers (currently Coq, HOL4, and Isabelle/HOL).
+
+It is also intended as an intermediate language for generating
+definitions from domain-specific tools, and for porting definitions
+between interactive theorem proving systems.
+
+Lem is under active development and has been used in several
+applications, some of which can be found in the examples directory. It
+is made available under the BSD 3-clause license, with the exception of
+a few files derived from OCaml, which are under the GNU Library GPL.

--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/files/generate_install_manifest.sh
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/files/generate_install_manifest.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -ex
+
+echo "bin: ["                                  > sibylfs-lem.install
+echo "  \"src/main.native\" {\"lem\"}"        >> sibylfs-lem.install
+echo "]\nlib: ["                              >> sibylfs-lem.install
+
+ls -1 library/*.* hol-lib/*.* isabelle-lib/*.* coq-lib/*.* ocaml-lib/*.* \
+| sed -e "s/\\(.*\\)/  \"\1\" \{ \"\1\" \}/"  >> sibylfs-lem.install
+echo "]"                                      >> sibylfs-lem.install

--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/files/ocamlfind_install.sh
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/files/ocamlfind_install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -ex
+
+ocamlfind install sibylfs-lem ocaml-lib/META \
+  ocaml-lib/_build/extract.a \
+  ocaml-lib/_build/extract.cma \
+  ocaml-lib/_build/extract.cmxa \
+  ocaml-lib/_build/*.mli \
+  ocaml-lib/_build/*.cmi

--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/opam
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+homepage: "https://bitbucket.org/Peter_Sewell/lem"
+maintainer: "tom.j.ridge@googlemail.com"
+authors: [
+  "The Lem Team"
+]
+dev-repo: "https://bitbucket.org/dsheets/lem.git"
+build-env: [
+  [BUILD_DIR = "%{lib}%/sibylfs-lem"]
+]
+build: [
+  [make "-e"]
+  [make "ocaml-libs"]
+  [make "coq-libs"] {"%{coq:installed}%"}
+  ["./generate_install_manifest.sh"]
+]
+install: [
+  ["./ocamlfind_install.sh"]
+]
+remove: [
+  ["rm" "-r" "%{sibylfs-lem:lib}%"]
+]
+conflicts: [
+  "lem"
+]
+depends: [
+  "ocamlfind"
+]
+depopts: [
+  "coq"
+]

--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/url
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://bitbucket.org/dsheets/lem/get/0.4.0.tar.gz"
+checksum: "9306b3bdc99638d5895156c840033b86"


### PR DESCRIPTION
Also, SibylFS uses a fork of lem for an unknown reason and SibylFS needs to be released.