### PR TITLE
ocaml-monadic.0.3.1 - via opam-publish

### DIFF
--- a/packages/ocaml-monadic/ocaml-monadic.0.3.1/descr
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.1/descr
@@ -1,0 +1,3 @@
+Lightweight monadic syntax extension.
+This project contains a lightweight PPX extension for OCaml to support natural monadic syntax.
+

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.1/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+homepage: "https://github.com/zepalmer/ocaml-monadic"
+bug-reports: "https://github.com/zepalmer/ocaml-monadic/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/zepalmer/ocaml-monadic.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+available: [
+  ocaml-version >= "4.02.0" & ocaml-version < "4.03.0" &
+  opam-version >= "1.2"
+]

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.1/url
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zepalmer/ocaml-monadic/archive/0.3.1.tar.gz"
+checksum: "cc43d76bfe8f9ce45c125ff8db4f3225"


### PR DESCRIPTION
Lightweight monadic syntax extension.
This project contains a lightweight PPX extension for OCaml to support natural monadic syntax.



---
* Homepage: https://github.com/zepalmer/ocaml-monadic
* Source repo: https://github.com/zepalmer/ocaml-monadic.git
* Bug tracker: https://github.com/zepalmer/ocaml-monadic/issues

---

Pull-request generated by opam-publish v0.3.1