### PR TITLE
tptp.0.3.2 - via opam-publish

### DIFF
--- a/packages/tptp/tptp.0.3.2/descr
+++ b/packages/tptp/tptp.0.3.2/descr
@@ -1,0 +1,1 @@
+Library for reading and writing FOF and CNF formulas in TPTP format

--- a/packages/tptp/tptp.0.3.2/opam
+++ b/packages/tptp/tptp.0.3.2/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Radek Micek <radek.micek@gmail.com>"
+authors: "Radek Micek <radek.micek@gmail.com>"
+homepage: "https://github.com/radekm/ocaml-tptp"
+license: "MIT"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "tptp"]
+depends: ["ocamlfind" "zarith" "pprint" "menhir"]

--- a/packages/tptp/tptp.0.3.2/url
+++ b/packages/tptp/tptp.0.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/radekm/ocaml-tptp/archive/0.3.2.tar.gz"
+checksum: "9e3bb9d827bfc22f7d55202b1e722cb4"


### PR DESCRIPTION
Library for reading and writing FOF and CNF formulas in TPTP format


---
* Homepage: https://github.com/radekm/ocaml-tptp
* Source repo: 
* Bug tracker: 

---
### opam-lint failures
- **WARNING** 37 Missing field 'dev-repo'
- **WARNING** 36 Missing field 'bug-reports'
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1