### PR TITLE
sibylfs.0.5.0 - via opam-publish

### DIFF
--- a/packages/sibylfs/sibylfs.0.5.0/descr
+++ b/packages/sibylfs/sibylfs.0.5.0/descr
@@ -1,0 +1,9 @@
+formal specification and oracle-based testing for POSIX file systems
+
+SibylFS is a formal specification in Lem of the POSIX file system API
+and its real-world variations as found in Linux, OS X, and FreeBSD. The
+specification is executable so that the more than 20,000 test cases do
+not require inclusion of expected behavior -- the expectation envelope
+can be automatically extracted and checked against a real file system!
+SibylFS has found numerous bugs in many different file system, VFS, and
+libc configurations.

--- a/packages/sibylfs/sibylfs.0.5.0/opam
+++ b/packages/sibylfs/sibylfs.0.5.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "tom.j.ridge@googlemail.com"
+authors: [
+  "Tom Ridge <tom.j.ridge@googlemail.com>"
+  "Thomas Tuerk <tt291@cl.cam.ac.uk>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Andrea Giugliano <agiugliano@live.it>"
+]
+homepage: "http://sibylfs.io/"
+bug-reports: "https://github.com/sibylfs/sibylfs_src/issues"
+dev-repo: "https://github.com/sibylfs/sibylfs_src.git"
+build: [
+  ["mkdir" "-p" "src_ext/lem/ocaml-lib"]
+  ["ln" "-s" sibylfs-lem:lib "src_ext/lem/ocaml-lib/_build"]
+  ["ln" "-s" "%{sibylfs-lem:bin}%/lem" "src_ext/lem/lem"]
+  [make]
+]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlfind" {build}
+  "sibylfs-lem" {build}
+  "cppo" {build}
+  "sha"
+  "cmdliner"
+  "fd-send-recv"
+  "camlp4"
+  "sexplib"
+  "menhir"
+  "cow"
+  "unix-fcntl" {>= "0.2.0"}
+]

--- a/packages/sibylfs/sibylfs.0.5.0/url
+++ b/packages/sibylfs/sibylfs.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/sibylfs/sibylfs_src/archive/0.5.0.tar.gz"
+checksum: "3ec26e4dcd63041162473cb15f563a48"


### PR DESCRIPTION
formal specification and oracle-based testing for POSIX file systems

SibylFS is a formal specification in Lem of the POSIX file system API
and its real-world variations as found in Linux, OS X, and FreeBSD. The
specification is executable so that the more than 20,000 test cases do
not require inclusion of expected behavior -- the expectation envelope
can be automatically extracted and checked against a real file system!
SibylFS has found numerous bugs in many different file system, VFS, and
libc configurations.


---
* Homepage: http://sibylfs.io/
* Source repo: https://github.com/sibylfs/sibylfs_src.git
* Bug tracker: https://github.com/sibylfs/sibylfs_src/issues

---

Pull-request generated by opam-publish v0.3.1