### PR TITLE
ppx_core: OCaml minimum version is 4.02.3

### DIFF
--- a/packages/ppx_core/ppx_core.113.09.00/opam
+++ b/packages/ppx_core/ppx_core.113.09.00/opam
@@ -12,4 +12,4 @@ build-doc: [[make "doc"]]
 depends: [ "ocamlfind" {>= "1.3.2"}
            "ppx_tools"
            "ppx_deriving" ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.3" ]


### PR DESCRIPTION
Installing ppx_core fails on OCaml 4.02.2 due to a 4.02.3 requirement in the oasis file:
https://github.com/janestreet/ppx_core/blob/master/_oasis#L2