### PR TITLE
Jitsu v0.2: Fix irmin dependency after API change

### DIFF
--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -24,7 +24,7 @@ depends: [  "lwt"
             "vchan"
             "uuidm"
             "irmin-unix"
-            "irmin" { >= "0.9.7" }
+            "irmin" { >= "0.9.7" & < "0.9.10" }
             "git"
             "xen-api-client"
             "xenctrl"


### PR DESCRIPTION
Jitsu v0.2 will not compile with Irmin 0.9.10 or newer