### PR TITLE
skkserv-lite.2.0.1 - via opam-publish

### DIFF
--- a/packages/skkserv-lite/skkserv-lite.2.0.1/descr
+++ b/packages/skkserv-lite/skkserv-lite.2.0.1/descr
@@ -1,0 +1,5 @@
+SKK server using sqlite3 dictionaries
+skkserv-lite is a SKK server that uses a sqlite3 database as a
+dictionary. It can use multiple dictionaries and respond to a
+completion request.
+

--- a/packages/skkserv-lite/skkserv-lite.2.0.1/files/_oasis_remove_.ml
+++ b/packages/skkserv-lite/skkserv-lite.2.0.1/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/skkserv-lite/skkserv-lite.2.0.1/files/skkserv-lite.install
+++ b/packages/skkserv-lite/skkserv-lite.2.0.1/files/skkserv-lite.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/skkserv-lite/skkserv-lite.2.0.1/opam
+++ b/packages/skkserv-lite/skkserv-lite.2.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "INAJIMA Daisuke <inajima@sopht.jp>"
+authors: [ "INAJIMA Daisuke <inajima@sopht.jp>" ]
+license: "MIT"
+homepage: "https://github.com/anyakichi/ocaml-skkserv-lite"
+dev-repo: "https://github.com/anyakichi/ocaml-skkserv-lite.git"
+bug-reports: "https://github.com/anyakichi/ocaml-skkserv-lite/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocaml" "%{etc}%/skkserv-lite/_oasis_remove_.ml" "%{etc}%/skkserv-lite"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "base-unix" {build}
+  "camomile" {build}
+  "lwt" {build}
+  "ocamlfind" {build}
+  ("sqlite3" {build & >= "4.0.0"} | "sqlite3" {build & = "3.0.0"} | "sqlite3" {build & = "2.0.9"} | "sqlite3" {build & = "2.0.8"} | "sqlite3" {build & = "2.0.7"} | "sqlite3" {build & = "2.0.6"} | "sqlite3" {build & = "2.0.5"} | "sqlite3" {build & = "2.0.4"} | "sqlite3" {build & = "2.0.3"})
+]
+available: [ ocaml-version >= "4.01" ]

--- a/packages/skkserv-lite/skkserv-lite.2.0.1/url
+++ b/packages/skkserv-lite/skkserv-lite.2.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/anyakichi/ocaml-skkserv-lite/archive/2.0.1.tar.gz"
+checksum: "abd9d5c7253959c82bbece0d0981539b"


### PR DESCRIPTION
SKK server using sqlite3 dictionaries
skkserv-lite is a SKK server that uses a sqlite3 database as a
dictionary. It can use multiple dictionaries and respond to a
completion request.



---
* Homepage: https://github.com/anyakichi/ocaml-skkserv-lite
* Source repo: https://github.com/anyakichi/ocaml-skkserv-lite.git
* Bug tracker: https://github.com/anyakichi/ocaml-skkserv-lite/issues

---

Pull-request generated by opam-publish v0.3.1