### PR TITLE
unison.2.48.3: comment out dev-repo for svn over https

### DIFF
--- a/packages/unison/unison.2.48.3/opam
+++ b/packages/unison/unison.2.48.3/opam
@@ -6,7 +6,7 @@ authors: [
 ]
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "mailto:unison-users@yahoogroups.com "
-dev-repo: "https://webdav.seas.upenn.edu/svn/unison"
+# dev-repo: "https://webdav.seas.upenn.edu/svn/unison"
 build: [[make "install" "OCAMLLIBDIR=%{lib}%" "HOME=%{prefix}%"]]
 depends: ["lablgtk"]
 patches: ["opam.patch"]


### PR DESCRIPTION
opam doesn't support it and it causes problems for 1.2.0 clients
Fixes ocaml/ocaml.org#714.