### PR TITLE
Add upper bounds on ocp-indent for cmdliner.

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.2.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.2.0/opam
@@ -13,6 +13,6 @@ remove: [
 ]
 depends: [
   "ocp-build" {>= "1.99.4-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]
 patches: ["warnings.patch"]

--- a/packages/ocp-indent/ocp-indent.1.2.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.2.1/opam
@@ -13,5 +13,5 @@ remove: [
 ]
 depends: [
   "ocp-build" {>= "1.99.4-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]

--- a/packages/ocp-indent/ocp-indent.1.2.2/opam
+++ b/packages/ocp-indent/ocp-indent.1.2.2/opam
@@ -13,5 +13,5 @@ remove: [
 ]
 depends: [
   "ocp-build" {>= "1.99.4-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]

--- a/packages/ocp-indent/ocp-indent.1.3.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.3.0/opam
@@ -13,5 +13,5 @@ remove: [
 ]
 depends: [
   "ocp-build" {= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]

--- a/packages/ocp-indent/ocp-indent.1.3.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.3.1/opam
@@ -13,5 +13,5 @@ remove: [
 ]
 depends: [
   "ocp-build" {= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]

--- a/packages/ocp-indent/ocp-indent.1.3.2/opam
+++ b/packages/ocp-indent/ocp-indent.1.3.2/opam
@@ -13,5 +13,5 @@ remove: [
 ]
 depends: [
   "ocp-build" {= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]

--- a/packages/ocp-indent/ocp-indent.1.4.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.4.0/opam
@@ -13,7 +13,7 @@ remove: [
 ]
 depends: [
   "ocp-build" {= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]
 post-messages: [
   "OCP-INDENT installed.

--- a/packages/ocp-indent/ocp-indent.1.4.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.4.1/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocp-build" {= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]
 post-messages: [
   "OCP-INDENT installed.

--- a/packages/ocp-indent/ocp-indent.1.4.2/opam
+++ b/packages/ocp-indent/ocp-indent.1.4.2/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocp-build" {>= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]
 post-messages: "OCP-INDENT installed.
 

--- a/packages/ocp-indent/ocp-indent.1.5.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.5.1/opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocp-build" {>= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]
 post-messages: [
   "

--- a/packages/ocp-indent/ocp-indent.1.5/opam
+++ b/packages/ocp-indent/ocp-indent.1.5/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocp-build" {>= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {<= "0.9.7"}
 ]
 post-messages: [
   "To use from emacs, add the following to your .emacs:


### PR DESCRIPTION
ocp-indent is incompatible with the upcoming cmdliner release. 

See https://github.com/OCamlPro/ocp-indent/pull/192