### PR TITLE
callipyge.0.1 - via opam-publish

### DIFF
--- a/packages/callipyge/callipyge.0.1/descr
+++ b/packages/callipyge/callipyge.0.1/descr
@@ -1,0 +1,3 @@
+Curve25519 in OCaml
+
+Curve25519 in OCaml

--- a/packages/callipyge/callipyge.0.1/opam
+++ b/packages/callipyge/callipyge.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/oklm-wsh/Callipyge"
+bug-reports: "https://github.com/oklm-wsh/Callipyge/issues"
+license: "MIT"
+dev-repo: "https://github.com/oklm-wsh/Callipyge.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+build-test: [
+  ["./configure" "--enable-tests" "--prefix=%{prefix}%"]
+  [make "test"]
+]
+remove: ["ocamlfind" "remove" "callipyge"]
+depends: [
+  "oasis" {build}
+  "base-bytes"
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/callipyge/callipyge.0.1/url
+++ b/packages/callipyge/callipyge.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/oklm-wsh/Callipyge/archive/0.1.tar.gz"
+checksum: "37d16e36c5830a0864cb4331e6b13a43"


### PR DESCRIPTION
Curve25519 in OCaml

Curve25519 in OCaml


---
* Homepage: https://github.com/oklm-wsh/Callipyge
* Source repo: https://github.com/oklm-wsh/Callipyge.git
* Bug tracker: https://github.com/oklm-wsh/Callipyge/issues

---

Pull-request generated by opam-publish v0.3.1