### PR TITLE
add ocamlnet.4.0.4 / human verification requested (unless machine verification fails)

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.0.4/descr
+++ b/packages/ocamlnet/ocamlnet.4.0.4/descr
@@ -1,0 +1,9 @@
+Internet protocols (http, cgi, email etc.) and helper data structures (mail messages, character sets, etc.)
+Ocamlnet is an enhanced system platform library for Ocaml. As the name
+suggests, large parts of it have to do with network programming, but
+it is actually not restricted to this. Other parts deal with the
+management of multiple worker processes, and the interaction with
+other programs running on the same machine. You can also view Ocamlnet
+as an extension of the system interface as provided by the Unix module
+of the standard library.
+

--- a/packages/ocamlnet/ocamlnet.4.0.4/files/ocamlnet.install
+++ b/packages/ocamlnet/ocamlnet.4.0.4/files/ocamlnet.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/rpc-generator/ocamlrpcgen"
+  "src/netplex/netplex-admin"
+]

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -8,6 +8,7 @@ build: [
   [make "opt"]
   [make "install"]
 ]
+authors: ["Gerd Stolpmann"]
 remove: [
   ["ocamlfind" "remove" "equeue"]
   ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
@@ -42,4 +43,4 @@ depopts: [
   "pcre"
   "camlzip"
 ]
-ocaml-version: [>="4.00.0"]
+available: [ ocaml-version >= "4.00.0"]

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "vb@luminar.eu.org"
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.4/doc/html-main/index.html"]
+build: [
+  ["./configure" "-bindir" bin "-%{conf-gssapi:enable}%-gssapi" "-%{conf-gnutls:enable}%-gnutls" "-%{pcre:enable}%-pcre" "-%{lablgtk:enable}%-gtk2" "-%{camlzip:enable}%-zip" "-with-nethttpd"]
+  [make "all"]
+  [make "opt"]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "equeue"]
+  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
+  ["ocamlfind" "remove" "netcamlbox"]
+  ["ocamlfind" "remove" "netcgi2"]
+  ["ocamlfind" "remove" "netcgi2-plex"]
+  ["ocamlfind" "remove" "netclient"]
+  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
+  ["ocamlfind" "remove" "nethttpd"]
+  ["ocamlfind" "remove" "netmulticore"]
+  ["ocamlfind" "remove" "netplex"]
+  ["ocamlfind" "remove" "netshm"]
+  ["ocamlfind" "remove" "netstring"]
+  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
+  ["ocamlfind" "remove" "netsys"]
+  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
+  ["ocamlfind" "remove" "netunidata"]
+  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
+  ["ocamlfind" "remove" "pop"]
+  ["ocamlfind" "remove" "rpc"]
+  ["ocamlfind" "remove" "rpc-auth-local"]
+  ["ocamlfind" "remove" "rpc-generator"]
+  ["ocamlfind" "remove" "shell"]
+  ["ocamlfind" "remove" "smtp"]
+
+]
+depends: ["ocamlfind" {build}]
+depopts: [
+  "conf-gnutls"
+  "conf-gssapi"
+  "lablgtk"
+  "pcre"
+  "camlzip"
+]
+ocaml-version: [>="4.00.0"]

--- a/packages/ocamlnet/ocamlnet.4.0.4/url
+++ b/packages/ocamlnet/ocamlnet.4.0.4/url
@@ -1,0 +1,2 @@
+archive: "http://download.camlcity.org/download/ocamlnet-4.0.4.tar.gz"
+checksum: "3196b85e1e329bfb0665f54723e0dffb"


### PR DESCRIPTION
I copied `ocamlnet.4.0.2`  and made it work with `ocamlnet.4.0.4` by changing the file `url`.

I needed `ocamlnet.4.0.4` because `ocamlnet.4.0.2` failed to compile on my machine (some compilation clash with `conf-gnutls`, which has only a single version). So, it seems to me that `conf-gnutls` and `ocamlnet.4.0.2` are not compatible; but I'm not sure.