### PR TITLE
mirage-flow: --enable-tests if we have both ounit and alcotest

### DIFF
--- a/packages/mirage-flow/mirage-flow.1.0.3/opam
+++ b/packages/mirage-flow/mirage-flow.1.0.3/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/mirage/mirage-flow/issues/"
 license: "ISC"
 dev-repo: "https://github.com/mirage/mirage-flow.git"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--%{alcotest:enable}%-tests"]
+  ["./configure" "--prefix=%{prefix}%" "--%{alcotest+ounit:enable}%-tests"]
   [make]
 ]
 build-test: [make "test"]


### PR DESCRIPTION
Fixes #4966

/cc @samoht -- does this look reasonable?

Signed-off-by: David Scott <dave.scott@unikernel.com>