### PR TITLE
Constrain dog to Irmin <= "0.9.9".

### DIFF
--- a/packages/dog/dog.0.2.0/opam
+++ b/packages/dog/dog.0.2.0/opam
@@ -19,6 +19,7 @@ remove: ["ocamlfind" "remove" "dog"]
 depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.4.5"}
+  "irmin" {>= "0.9.5" & <= "0.9.9"}
   "irmin-unix" {>= "0.9.5" & <= "0.9.9"}
   "git" {>= "1.4.10"}
   "cohttp"

--- a/packages/dog/dog.0.2.0/opam
+++ b/packages/dog/dog.0.2.0/opam
@@ -19,7 +19,7 @@ remove: ["ocamlfind" "remove" "dog"]
 depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.4.5"}
-  "irmin" {>= "0.9.5" & <= "0.9.9"}
+  "irmin-unix" {>= "0.9.5" & <= "0.9.9"}
   "git" {>= "1.4.10"}
   "cohttp"
   "re"

--- a/packages/dog/dog.0.2.0/opam
+++ b/packages/dog/dog.0.2.0/opam
@@ -19,7 +19,7 @@ remove: ["ocamlfind" "remove" "dog"]
 depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.4.5"}
-  "irmin" {>= "0.9.5"}
+  "irmin" {>= "0.9.5" & <= "0.9.9"}
   "git" {>= "1.4.10"}
   "cohttp"
   "re"


### PR DESCRIPTION
With Irmin 0.9.10:

```
# File "lib/dog_misc.mli", line 26, characters 14-34:
# Error: Unbound type constructor Irmin.basic
# Command exited with code 2.
# Makefile:8: recipe for target 'build' failed
```

/cc @samoht 