### PR TITLE
hex.1.0.0 - via opam-publish

### DIFF
--- a/packages/hex/hex.1.0.0/descr
+++ b/packages/hex/hex.1.0.0/descr
@@ -1,0 +1,12 @@
+Minimal library providing hexadecimal converters.
+
+```ocaml
+#require "hex";;
+# Hex.of_string "Hello world!";;
+- : Hex.t = "48656c6c6f20776f726c6421"
+# Hex.to_string "dead-beef";;
+- : string = "ޭ��"
+# Hex.hexdump (Hex.of_string "Hello world!\n")
+00000000: 4865 6c6c 6f20 776f 726c 6421 0a        Hello world!.
+- : unit = ()
+```

--- a/packages/hex/hex.1.0.0/opam
+++ b/packages/hex/hex.1.0.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Trevor Summers Smith"]
+homepage:     "https://github.com/mirage/ocaml-hex"
+bug-reports:  "https://github.com/mirage/ocaml-hex/issues"
+dev-repo:     "https://github.com/mirage/ocaml-hex.git"
+license:      "ISC"
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+build-test: [
+  ["./configure" "--prefix" prefix "--enable-tests"]
+  [make "test"]
+]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "hex"]
+depends: [
+  "ocamlfind" {build}
+  "cstruct" {>= "1.7.0"}
+]

--- a/packages/hex/hex.1.0.0/url
+++ b/packages/hex/hex.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-hex/archive/1.0.0.tar.gz"
+checksum: "e8af07c37b54076dc33a86e203b0c0d3"


### PR DESCRIPTION
Minimal library providing hexadecimal converters.

```ocaml
#require "hex";;
# Hex.of_string "Hello world!";;
- : Hex.t = "48656c6c6f20776f726c6421"
# Hex.to_string "dead-beef";;
- : string = "ޭ��"
# Hex.hexdump (Hex.of_string "Hello world!\n")
00000000: 4865 6c6c 6f20 776f 726c 6421 0a        Hello world!.
- : unit = ()
```

---
* Homepage: https://github.com/mirage/ocaml-hex
* Source repo: https://github.com/mirage/ocaml-hex.git
* Bug tracker: https://github.com/mirage/ocaml-hex/issues

---

Pull-request generated by opam-publish v0.3.0