### PR TITLE
trv.0.1.1 - via opam-publish

### DIFF
--- a/packages/trv/trv.0.1.1/descr
+++ b/packages/trv/trv.0.1.1/descr
@@ -1,0 +1,6 @@
+Basic bootstrapping library for ocaml projects
+
+This contains a set of 'base' commands for supporting builds. It
+also includes a library of useful utilities that supports commands
+in general. This may or may not be useful in the general case.
+

--- a/packages/trv/trv.0.1.1/opam
+++ b/packages/trv/trv.0.1.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Afiniate, Inc."
+author: "Afiniate, Inc."
+homepage: "https://github.com/afiniate/trv"
+bug-reports: "https://github.com/afiniate/trv/issues"
+license: "OSI Approved :: Apache Software License v2.0"
+dev-repo: "git@github.com:afiniate/trv.git"
+available: [ ocaml-version >= "4.01" ]
+
+build: [
+    [make]
+]
+
+install: [
+    [make "install" "PREFIX=%{prefix}%" "SEMVER=%{trv:version}"]
+]
+
+remove: [
+    [make "remove" "PREFIX=%{prefix}%"]
+]
+
+
+depends: [ "core"   {>= "112.24.00"}  
+           "async_kernel" {>= "112.24.00"}  
+           "async" {>= "112.24.00"}  
+           "async_extra" {>= "112.24.00" }
+           "core_extended"  
+           "uri"  
+           "cohttp"  
+           "async_shell"  
+           "async_find"  
+           "cohttp" ]

--- a/packages/trv/trv.0.1.1/url
+++ b/packages/trv/trv.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/afiniate/trv/archive/0.1.1.tar.gz"
+checksum: "24abda45d4f3c97169e1d90b2273e9be"


### PR DESCRIPTION
Basic bootstrapping library for ocaml projects

This contains a set of 'base' commands for supporting builds. It
also includes a library of useful utilities that supports commands
in general. This may or may not be useful in the general case.



---
* Homepage: https://github.com/afiniate/trv
* Source repo: git@github.com:afiniate/trv.git
* Bug tracker: https://github.com/afiniate/trv/issues

---

Pull-request generated by opam-publish v0.3.1