### PR TITLE
ocp-indent.1.5.2 requires cmdliner.0.9.8

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.5.2/opam
+++ b/packages/ocp-indent/ocp-indent.1.5.2/opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocp-build" {>= "1.99.6-beta"}
-  "cmdliner"
+  "cmdliner" {>= "0.9.8"}
 ]
 post-messages: [
   "


### PR DESCRIPTION
ocp-indent.1.5.2 does not compile with previous versions of cmdliner.