### PR TITLE
FreeBSD compatibility

### DIFF
--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -2,7 +2,10 @@ opam-version: "1"
 maintainer: "francois.berenger@inria.fr"
 homepage: "http://zeromq.org/"
 license: "LGPL"
-build: [["cc" "test.c" "-lzmq"]]
+build: [
+  ["cc" "test.c" "-lzmq"] { os != "freebsd" }
+  ["cc" "test.c" "-lzmq" "-I/usr/local/include" "-L/usr/local/lib"] { os = "freebsd" }
+]
 depexts: [
   [["debian"] ["libzmq3-dev"]]
   [["ubuntu"] ["libzmq3-dev"]]


### PR DESCRIPTION
Hello,
When you install zmq with the FreeBSD port, the header file is installed in /usr/local/include and the library in /usr/local/lib. With this patch, the compilation test is able to pass.

See also https://github.com/ocaml/opam-repository/pull/5008 (sic !)