### PR TITLE
FreeBSD fixes for zarith: env perl and CC=cc

### DIFF
--- a/packages/zarith/zarith.1.3/files/z_pp.pl.patch
+++ b/packages/zarith/zarith.1.3/files/z_pp.pl.patch
@@ -1,0 +1,11 @@
+diff -ur zarith-1.3.orig/z_pp.pl zarith-1.3/z_pp.pl
+--- zarith-1.3.orig/z_pp.pl	2013-07-30 17:49:15.000000000 +0100
++++ zarith-1.3/z_pp.pl	2015-10-17 23:05:41.944161000 +0100
+@@ -1,4 +1,6 @@
+-#!/usr/bin/perl -W
++#!/usr/bin/env perl
++
++use warnings "all" ;
+ 
+ # Simple preprocessor to fix @ASM directives in z.mlp and z.mlip, and
+ # generate z.ml and z.mli

--- a/packages/zarith/zarith.1.3/opam
+++ b/packages/zarith/zarith.1.3/opam
@@ -4,7 +4,7 @@ authors: "Xavier Leroy"
 homepage: "https://forge.ocamlcore.org/projects/zarith"
 build: [
   ["./configure"] { os != "openbsd" & os != "freebsd" }
-  ["env" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "./configure"] { os = "openbsd" | os = "freebsd" }
+  ["env" "LDFLAGS=-L/usr/local/lib" "CC=cc" "CFLAGS=-I/usr/local/include -O3 -Wall -Wextra" "./configure"] { os = "openbsd" | os = "freebsd" }
   [make]
   [make "install"]
 ]
@@ -13,3 +13,4 @@ depends: [
   "ocamlfind"
   "conf-gmp"
 ]
+patches: [ "z_pp.pl.patch" ]


### PR DESCRIPTION
on FreeBSD, there is no longer any /usr/bin/perl, but rather /usr/local/bin/perl
(also, passing -W to env is not supported, but perl behaves the same with
use warnings "all";)

also, there is no gcc anymore; rather an executable called cc (manually
setting CFLAGS to those from configure to avoid unoptimised code).