### PR TITLE
An explicit package for OCamlbuild base

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0/descr
+++ b/packages/ocamlbuild/ocamlbuild.0/descr
@@ -1,0 +1,1 @@
+Build system distributed with the OCaml compiler since OCaml 3.10.0

--- a/packages/ocamlbuild/ocamlbuild.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: [
+  "Nicolas Pouillard"
+  "Berke Durak"
+]
+license: "LGPL-2 with OCaml linking exception"
+
+homepage: "https://github.com/ocaml/ocaml"
+dev-repo: "https://github.com/ocaml/ocaml.git"
+bug-reports: "http://caml.inria.fr/mantis/"
+
+doc: [
+  "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
+  "https://github.com/gasche/manual-ocamlbuild/blob/master/manual.md"
+]
+
+available: [ocaml-version >= "3.10"]


### PR DESCRIPTION
In the future, ocamlbuild will be released and distributed separately
from the OCaml compiler. To ensure a smooth transition, we should let
ocamlbuild users indicate the dependency explicitly in their OPAM
metadata.

We use "version 0" for the included versions, and will start
versioning 1.0 and upward after the split.