### PR TITLE
electron.0.1 - via opam-publish

### DIFF
--- a/packages/electron/electron.0.1/descr
+++ b/packages/electron/electron.0.1/descr
@@ -1,0 +1,10 @@
+js_of_ocaml bindings for electron
+
+js_of_ocaml bindings to electron, build electron based
+cross-platform applications with all the latest and greatest web
+technologies along with the type safety and joy of OCaml.
+
+Use the package electron.main_process for your main processing code
+and the package eletron.renderer for your render side code. The root
+package electron contains modules allowed in both the main and
+renderer processes.

--- a/packages/electron/electron.0.1/opam
+++ b/packages/electron/electron.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-electron"
+bug-reports: "https://github.com/fxfactorial/ocaml-electron/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-electron.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "electron"]
+depends: [
+  "nodejs" {>= "0.3"}
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]

--- a/packages/electron/electron.0.1/url
+++ b/packages/electron/electron.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-electron/archive/v0.1.tar.gz"
+checksum: "5f2005914a71b32f552182b4eab252b8"


### PR DESCRIPTION
js_of_ocaml bindings for electron

js_of_ocaml bindings to electron, build electron based
cross-platform applications with all the latest and greatest web
technologies along with the type safety and joy of OCaml.

Use the package electron.main_process for your main processing code
and the package eletron.renderer for your render side code. The root
package electron contains modules allowed in both the main and
renderer processes.


---
* Homepage: https://github.com/fxfactorial/ocaml-electron
* Source repo: https://github.com/fxfactorial/ocaml-electron.git
* Bug tracker: https://github.com/fxfactorial/ocaml-electron/issues

---

Pull-request generated by opam-publish v0.3.1