### PR TITLE
New ocamlfind.

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.5.6/descr
+++ b/packages/ocamlfind/ocamlfind.1.5.6/descr
@@ -1,0 +1,6 @@
+A library manager for OCaml
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.

--- a/packages/ocamlfind/ocamlfind.1.5.6/files/ocamlfind.install
+++ b/packages/ocamlfind/ocamlfind.1.5.6/files/ocamlfind.install
@@ -1,0 +1,6 @@
+bin: [
+  "src/findlib/ocamlfind" {"ocamlfind"}
+  "?src/findlib/ocamlfind_opt" {"ocamlfind"}
+  "?tools/safe_camlp4"
+]
+toplevel: ["src/findlib/topfind"]

--- a/packages/ocamlfind/ocamlfind.1.5.6/findlib
+++ b/packages/ocamlfind/ocamlfind.1.5.6/findlib
@@ -1,0 +1,14 @@
+bigarray
+bytes
+compiler-libs
+dynlink
+findlib
+graphics
+labltk
+num
+num-top
+ocamlbuild
+stdlib
+str
+threads
+unix

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "mailto:gerd@gerd-stolpmann.de"
+dev-repo:     "https://github.com/whitequark/ocaml-findlib.git"
+
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
+  [make "all"]
+  [make "opt"] { ocaml-native }
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "bytes"]
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
+  [make "uninstall"]
+]
+depexts: [
+  [["debian"] ["m4" "ncurses-dev"]]
+  [["ubuntu"] ["m4" "ncurses-dev"]]
+]
+post-messages: [
+  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+]

--- a/packages/ocamlfind/ocamlfind.1.5.6/url
+++ b/packages/ocamlfind/ocamlfind.1.5.6/url
@@ -1,0 +1,2 @@
+archive: "http://download.camlcity.org/download/findlib-1.5.6.tar.gz"
+checksum: "91585dd5459cb69bfd9a0689bf222403"


### PR DESCRIPTION
I don't understand. This should make the new ocamlfind available, but still opam insists on saying "ocamlfind.1.5.6 is not available". Is there some special treatment for this package?

Thanks,

Jonathan