### PR TITLE
ocaml-amqp.0.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-amqp/ocaml-amqp.0.0.1/descr
+++ b/packages/ocaml-amqp/ocaml-amqp.0.0.1/descr
@@ -1,0 +1,6 @@
+Amqp client library
+
+Library providing high level bindings for amqp.
+The library is tested against rabbitmq,
+but should work against other amqp servers.
+The library is written in pure OCaml.

--- a/packages/ocaml-amqp/ocaml-amqp.0.0.1/descr
+++ b/packages/ocaml-amqp/ocaml-amqp.0.0.1/descr
@@ -1,6 +1,5 @@
 Amqp client library
 
-Library providing high level bindings for amqp.
-The library is tested against rabbitmq,
-but should work against other amqp servers.
+This library provides high level client bindings for amqp.
+The library is tested against rabbitmq, but should work against other amqp servers.
 The library is written in pure OCaml.

--- a/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
+++ b/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
@@ -4,7 +4,7 @@ authors: "Anders Fugmann <anders@fugmann.net>"
 homepage: "https://github.com/andersfugmann/ocaml-amqp"
 bug-reports: "https://github.com/andersfugmann/ocaml-amqp"
 license: "BSD"
-dev-repo: "git@github.com:andersfugmann/ocaml-amqp"
+dev-repo: "https://github.com/andersfugmann/ocaml-amqp.git"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "ocaml-amqp"]
@@ -16,3 +16,4 @@ depends: [
   "async_unix"
   "ocplib-endian"
 ]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
+++ b/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann <anders@fugmann.net>"
+homepage: "https://github.com/andersfugmann/ocaml-amqp"
+bug-reports: "https://github.com/andersfugmann/ocaml-amqp"
+license: "BSD"
+dev-repo: "https://github.com/andersfugmann/ocaml-amqp"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ocaml-amqp"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
+++ b/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
@@ -4,7 +4,7 @@ authors: "Anders Fugmann <anders@fugmann.net>"
 homepage: "https://github.com/andersfugmann/ocaml-amqp"
 bug-reports: "https://github.com/andersfugmann/ocaml-amqp"
 license: "BSD"
-dev-repo: "https://github.com/andersfugmann/ocaml-amqp"
+dev-repo: "git@github.com:andersfugmann/ocaml-amqp"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "ocaml-amqp"]

--- a/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
+++ b/packages/ocaml-amqp/ocaml-amqp.0.0.1/opam
@@ -10,4 +10,9 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "ocaml-amqp"]
 depends: [
   "ocamlfind" {build}
+  "omake" {build}
+  "xml-light" {build}
+  "async"
+  "async_unix"
+  "ocplib-endian"
 ]

--- a/packages/ocaml-amqp/ocaml-amqp.0.0.1/url
+++ b/packages/ocaml-amqp/ocaml-amqp.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andersfugmann/ocaml-amqp/archive/0.0.1.tar.gz"
+checksum: "e5b86c836573514085f61ca62b349247"


### PR DESCRIPTION
Amqp client library

Library providing high level bindings for amqp.
The library is tested against rabbitmq,
but should work against other amqp servers.
The library is written in pure OCaml.


---
* Homepage: https://github.com/andersfugmann/ocaml-amqp
* Source repo: https://github.com/andersfugmann/ocaml-amqp
* Bug tracker: https://github.com/andersfugmann/ocaml-amqp

---

Pull-request generated by opam-publish v0.3.1