### PR TITLE
socket_io.0.1 - via opam-publish

### DIFF
--- a/packages/socket_io/socket_io.0.1/descr
+++ b/packages/socket_io/socket_io.0.1/descr
@@ -1,0 +1,4 @@
+OCaml js_of_ocaml bindings for npm's socket.io
+These are OCaml bindings to npm's socket.io package To be used with
+NodeJS, easily create nodejs based servers
+

--- a/packages/socket_io/socket_io.0.1/opam
+++ b/packages/socket_io/socket_io.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-npm-socket-io"
+bug-reports: "https://github.com/fxfactorial/ocaml-npm-socket-io/issues"
+dev-repo: "https://github.com/fxfactorial/ocaml-npm-socket-io.git"
+license: "BSD-3-clause"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "socket_io"]
+depends: [
+  "js_of_ocaml"
+  "nodejs" {>= "0.3"}
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]

--- a/packages/socket_io/socket_io.0.1/url
+++ b/packages/socket_io/socket_io.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/fxfactorial/ocaml-npm-socket-io/archive/v0.1.tar.gz"
+checksum: "a682847101049430ac6a6e961ecab46c"


### PR DESCRIPTION
OCaml js_of_ocaml bindings for npm's socket.io
These are OCaml bindings to npm's socket.io package To be used with
NodeJS, easily create nodejs based servers



---
* Homepage: https://github.com/fxfactorial/ocaml-npm-socket-io
* Source repo: https://github.com/fxfactorial/ocaml-npm-socket-io.git
* Bug tracker: https://github.com/fxfactorial/ocaml-npm-socket-io/issues

---

Pull-request generated by opam-publish v0.3.1