### PR TITLE
Fix Jitsu xen-api-client dependency

### DIFF
--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -26,7 +26,7 @@ depends: [  "lwt"
             "irmin-unix"
             "irmin" { >= "0.9.7" & < "0.9.10" }
             "git"
-            "xen-api-client"
+            "xen-api-client" { <= "0.9.8" }
             "xenctrl" { <= "0.9.26" }
             "alcotest" ]
 depexts: [


### PR DESCRIPTION
Depend on xen-api-client <= 0.9.8 as api changed in 0.9.10. 

(Travis will fail for this PR with Ubuntu Trusty, as the Xen version is too old)