### PR TITLE
nodejs.0.4 - via opam-publish

### DIFF
--- a/packages/nodejs/nodejs.0.4/descr
+++ b/packages/nodejs/nodejs.0.4/descr
@@ -1,0 +1,5 @@
+js_of_ocaml bindings for nodejs
+
+Write OCaml, run on node These are js_of_ocaml bindings to the node
+JavaScript API. Get all the power of the node ecosystem with the type
+safety of OCaml.

--- a/packages/nodejs/nodejs.0.4/opam
+++ b/packages/nodejs/nodejs.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-nodejs"
+bug-reports: "https://github.com/fxfactorial/ocaml-nodejs/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-nodejs.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "nodejs"]
+depends: [
+  "js_of_ocaml"
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+  "yojson"
+]
+
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/nodejs/nodejs.0.4/url
+++ b/packages/nodejs/nodejs.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-nodejs/archive/v0.4.tar.gz"
+checksum: "1d55d1bcc1b0d75386315184b27fbc87"


### PR DESCRIPTION
js_of_ocaml bindings for nodejs

Write OCaml, run on node These are js_of_ocaml bindings to the node
JavaScript API. Get all the power of the node ecosystem with the type
safety of OCaml.


---
* Homepage: https://github.com/fxfactorial/ocaml-nodejs
* Source repo: https://github.com/fxfactorial/ocaml-nodejs.git
* Bug tracker: https://github.com/fxfactorial/ocaml-nodejs/issues

---

Pull-request generated by opam-publish v0.3.1