### PR TITLE
colors_js.0.1 - via opam-publish

### DIFF
--- a/packages/colors_js/colors_js.0.1/descr
+++ b/packages/colors_js/colors_js.0.1/descr
@@ -1,0 +1,15 @@
+js_of_ocaml bindings for npm's colors.js
+
+Easily create cross platform colored output code, run on node.
+
+let () =
+  let styled =
+    Colors_js.colorize ~msg:"Hello World"
+      ~styles:Colors_js.([Blue; Underline; White_bg])
+      []
+  in
+  let with_actions =
+    Colors_js.colorize ~msg:"Foo Bar Baz" ~styles:[] [Colors_js.America]
+  in
+  print_endline styled;
+  print_endline with_actions

--- a/packages/colors_js/colors_js.0.1/opam
+++ b/packages/colors_js/colors_js.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/bean-code/ocaml-npm-colors-js"
+bug-reports: "https://github.com/bean-code/ocaml-npm-colors-js/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/bean-code/ocaml-npm-colors.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "nodemailer"]
+depends: [
+  "nodejs" {>= "0.4"}
+  "ocamlfind" {build}
+]
+
+post-messages: [
+  "Easily create colored output with OCaml compiled for node."
+  "let () =
+   let styled =
+     Colors_js.colorize ~msg:\"Hello World\"
+        ~styles:Colors_js.([Blue; Underline; White_bg])
+        []
+    in
+    let with_actions =
+      Colors_js.colorize ~msg:\"Foo Bar Baz\" ~styles:[] [Colors_js.America]
+    in
+    print_endline styled;
+    print_endline with_actions"
+    "Compile with: "
+    "ocamlfind ocamlc code.ml -linkpkg -package colors_js -o T.out"
+    "js_of_ocaml T.out"
+    "node T.js"
+]

--- a/packages/colors_js/colors_js.0.1/url
+++ b/packages/colors_js/colors_js.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bean-code/ocaml-npm-colors-js/archive/v0.1.tar.gz"
+checksum: "d267b039183cab83bc633a34eb45bf76"


### PR DESCRIPTION
js_of_ocaml bindings for npm's colors.js

Easily create cross platform colored output code, run on node.

```ocaml
let () =
  let styled =
    Colors_js.colorize ~msg:"Hello World"
      ~styles:Colors_js.([Blue; Underline; White_bg])
      []
  in
  let with_actions =
    Colors_js.colorize ~msg:"Foo Bar Baz" ~styles:[] [Colors_js.America]
  in
  print_endline styled;
  print_endline with_actions
```

---
* Homepage: https://github.com/bean-code/ocaml-npm-colors-js
* Source repo: https://github.com/bean-code/ocaml-npm-colors.git
* Bug tracker: https://github.com/bean-code/ocaml-npm-colors-js/issues

---

Pull-request generated by opam-publish v0.3.1