### PR TITLE
libvirt: add osx homebrew depext

### DIFF
--- a/packages/libvirt/libvirt.0.6.1.2/opam
+++ b/packages/libvirt/libvirt.0.6.1.2/opam
@@ -15,4 +15,5 @@ depends: ["ocamlfind"]
 depexts: [
   [["debian"] ["libvirt-dev"]]
   [["ubuntu"] ["libvirt-dev"]]
+  [["osx" "homebrew"] ["libvirt"]]
 ]

--- a/packages/libvirt/libvirt.0.6.1.2/opam
+++ b/packages/libvirt/libvirt.0.6.1.2/opam
@@ -1,5 +1,8 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "dave.scott@eu.citrix.com"
+homepage: "https://libvirt.org/ocaml/"
+bug-reports: "http://libvirt.org/bugs.html"
+authors: "Richard W.M. Jones"
 tags: [
   "org:mirage"
   "org:xapi-project"


### PR DESCRIPTION
- Add libvirt as depext in OS X
- Fix lint errors (update opam version, add author, bug-reports, homepage)