### PR TITLE
Update charrua-core and charrua-unix to v0.2

### DIFF
--- a/packages/charrua-core/charrua-core.0.2/descr
+++ b/packages/charrua-core/charrua-core.0.2/descr
@@ -1,0 +1,36 @@
+Charrua DHCP core library.
+
+[charrua-core](http://www.github.com/haesbaert/charrua-core) is an
+_ISC-licensed_ DHCP library implementation in ocaml.
+
+It provides basically two modules, a `Dhcp` responsible for parsing and
+constructing DHCP messages and a `Dhcp_server` module used for constructing DHCP
+servers.
+
+[charrua-unix](http://www.github.com/haesbaert/charrua-unix) is a Unix DHCP
+server based on charrua-core.
+
+[charrua-mirage](http://www.github.com/haesbaert/charrua-mirage) is a Mirage
+DHCP server based on charrua-core.
+
+You can browse the API for [charrua-core] at
+http://haesbaert.github.io/charrua-core/api
+
+Features
+
+* Dhcp_server supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old dhcpd.conf.
+* Support for multiple interfaces/subnets.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage VM or anything else.
+* Functorizes over Logging functions.
+* Code is purely functional with the exception of Dhcp Leases.
+* With `charrua-mirage` you can run a server directly on top of Xen, without a
+  full operating system.
+* It's in ocaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+
+This project became one of the [Mirage Pioneer]
+(https://github.com/mirage/mirage-www/wiki/Pioneer-Projects) projects.

--- a/packages/charrua-core/charrua-core.0.2/opam
+++ b/packages/charrua-core/charrua-core.0.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "charrua-core"
+version: "0.2"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/haesbaert/charrua-core"
+bug-reports: "https://github.com/haesbaert/charrua-core/issues"
+license: "ISC"
+dev-repo: "https://github.com/haesbaert/charrua-core.git"
+available: [ocaml-version >= "4.01"]
+build: [
+  ["sh" "build.sh"]
+]
+depends: [
+  "ocamlfind" {build} "cstruct" "sexplib" "menhir" "ipaddr" "tcpip"
+]

--- a/packages/charrua-core/charrua-core.0.2/url
+++ b/packages/charrua-core/charrua-core.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/haesbaert/charrua-core/archive/v0.2.tar.gz"
+checksum: "77fe7dcba4cd0f452d9abb89f838a512"

--- a/packages/charrua-unix/charrua-unix.0.2/descr
+++ b/packages/charrua-unix/charrua-unix.0.2/descr
@@ -1,0 +1,15 @@
+Charrua DHCP Unix Server
+
+[charrua-unix](http://www.github.com/haesbaert/charrua-unix) is an _ISC-licensed_
+Unix DHCP daemon based on
+[charrua-core](http://www.github.com/haesbaert/charrua-core).
+
+Features
+
+* Supports a stripped down ISC dhcpd.conf. A configuration sample can be found
+[here](https://github.com/haesbaert/charrua-core/blob/master/sample/dhcpd.conf)
+* Priviledge dropping, the daemon doesn't run as root.
+* Almost purely-functional code.
+* Support for multiple interfaces/subnets.
+
+Try `charruad --help` for options.

--- a/packages/charrua-unix/charrua-unix.0.2/opam
+++ b/packages/charrua-unix/charrua-unix.0.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "charrua-unix"
+version: "0.2"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/haesbaert/charrua-unix"
+bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
+license: "ISC"
+dev-repo: "https://github.com/haesbaert/charrua-unix.git"
+available: [ocaml-version >= "4.02"]
+build: [
+  ["sh" "build.sh"]
+]
+depends: [
+  "ocamlfind" {build} "lwt" "charrua-core" "cmdliner" "rawlink"
+]

--- a/packages/charrua-unix/charrua-unix.0.2/url
+++ b/packages/charrua-unix/charrua-unix.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/haesbaert/charrua-unix/archive/v0.2.tar.gz"
+checksum: "4916733da35cbb668404c6c5d7b93cb4"


### PR DESCRIPTION
charrua-unix depends on the updated charrua-core, I'm not sure if this is doable, if not, I can break into two separate pull requests.