### PR TITLE
ppx_deriving_morphism.0.1 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/descr
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/descr
@@ -1,0 +1,5 @@
+Morphism generator for OCaml >=4.02
+
+ppx_deriving_morphism is a ppx_deriving plugin that provides
+a generator for records implementing openly recursive map and fold routines
+for arbitrary data structures.

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/files/ppx_deriving_morphism.install
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/files/ppx_deriving_morphism.install
@@ -1,0 +1,18 @@
+doc: [
+  "_build/CHANGELOG.md" {"CHANGELOG.md"}
+  "_build/LICENSE" {"LICENSE"}
+  "_build/README.md" {"README.md"} ]
+lib: [
+  "_build/pkg/META" {"META"}
+  "_build/src/ppx_deriving_folder.a" {"ppx_deriving_folder.a"}
+  "_build/src/ppx_deriving_folder.cma" {"ppx_deriving_folder.cma"}
+  "_build/src/ppx_deriving_folder.cmxa" {"ppx_deriving_folder.cmxa"}
+  "_build/src/ppx_deriving_folder.cmxs" {"ppx_deriving_folder.cmxs"}
+  "_build/src/ppx_deriving_mapper.a" {"ppx_deriving_mapper.a"}
+  "_build/src/ppx_deriving_mapper.cma" {"ppx_deriving_mapper.cma"}
+  "_build/src/ppx_deriving_mapper.cmxa" {"ppx_deriving_mapper.cmxa"}
+  "_build/src/ppx_deriving_mapper.cmxs" {"ppx_deriving_mapper.cmxs"}
+  "_build/src/ppx_deriving_morphism.a" {"ppx_deriving_morphism.a"}
+  "_build/src/ppx_deriving_morphism.cma" {"ppx_deriving_morphism.cma"}
+  "_build/src/ppx_deriving_morphism.cmxa" {"ppx_deriving_morphism.cmxa"}
+  "_build/src/ppx_deriving_morphism.cmxs" {"ppx_deriving_morphism.cmxs"} ]

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Christoph Höger <christoph.hoeger@tu-berlin.de>"
+authors: "Christoph Höger <christoph.hoeger@tu-berlin.de>"
+homepage: "https://github.com/choeger/ppx_deriving_morphism"
+bug-reports: "https://github.com/choeger/ppx_deriving_morphism/issues"
+license: "BSD"
+tags: "syntax"
+dev-repo: "git://github.com/choeger/ppx_deriving_morphism.git"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_ppx_morphism.byte"
+  "--"
+]
+depends: [
+  "ppx_deriving" {>= "3.0" & < "4.0"}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "ppx_import" {test}
+]

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/url
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/choeger/ppx_deriving_morphism/archive/v0.1.1.tar.gz"
+checksum: "152ac739a1dfe21a44c9a76e49232c22"


### PR DESCRIPTION
Morphism generator for OCaml >=4.02

ppx_deriving_morphism is a ppx_deriving plugin that provides
a generator for records implementing openly recursive map and fold routines
for arbitrary data structures.


---
* Homepage: https://github.com/choeger/ppx_deriving_morphism
* Source repo: git://github.com/choeger/ppx_deriving_morphism.git
* Bug tracker: https://github.com/choeger/ppx_deriving_morphism/issues

---

Pull-request generated by opam-publish v0.3.1