### PR TITLE
add jitsu 0.3.0

### DIFF
--- a/packages/jitsu/jitsu.0.3.0/descr
+++ b/packages/jitsu/jitsu.0.3.0/descr
@@ -1,0 +1,9 @@
+A forwarding DNS server that automatically starts unikernels on demand
+
+Jitsu - or Just-in-Time Summoning of Unikernels - is a prototype DNS server that can boot unikernels on demand. When Jitsu receives a DNS query, a unikernel is booted automatically before the query response is sent back to the client. To the client it will look like it was on the whole time.
+
+This version supports MirageOS and Rumprun unikernels and new backends to manage the unikernel VMs (libvirt, Xapi, libxl). Metadata and internal state is stored in Irmin and the DNS server is implemented on top of ocaml-dns. 
+
+Backends have to be installed separately. Currently supported libraries are xenctrl, xen-api-client and libvirt.
+
+Jitsu is experimental software. Please report bugs in the bug tracker.

--- a/packages/jitsu/jitsu.0.3.0/opam
+++ b/packages/jitsu/jitsu.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "1.2"
+name: "jitsu"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/jitsu"
+bug-reports: "https://github.com/mirage/jitsu/issues/"
+dev-repo: "https://github.com/mirage/jitsu.git"
+license: "ISC"
+
+build: [
+  [make]
+]
+
+build-test: [
+  [make "test"]
+]
+
+depends: [  "ocamlfind"
+            "lwt"
+            "dns"  { >= "0.15.3" }
+            "xenstore"
+            "xenstore_transport"
+            "cmdliner"
+            "ipaddr"
+            "ezxmlm"
+            "conduit"
+            "vchan"
+            "uuidm"
+            "irmin-unix"
+            "irmin" { >= "0.10.0" }
+            "git"
+            "alcotest" ]
+
+depopts: [
+    "xenctrl"
+    "xen-api-client"
+    "libvirt"
+]
+
+conflicts: [
+    "xenctrl" { < "0.9.29" }
+    "xen-api-client"  { < "0.9.10" }
+]
+

--- a/packages/jitsu/jitsu.0.3.0/url
+++ b/packages/jitsu/jitsu.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/jitsu/archive/0.3.0.tar.gz"
+checksum: "60f971b294bbb6609d18e794d99e5802"


### PR DESCRIPTION
Changes since previous release in opam:

- Support for modular backends. Only available backends are now compiled in by default.
- Virtual packages for jitsu-libvirt, jitsu-libxl, jitsu-xapi
- Support for xenctrl > 0.9.26
- Support for xen-api-client > 0.9.8
- Add/fix support for multiple DNS entries per VM
- Updated storage backend with support for latest Irmin API (0.10.0)
- Add VERSION file to track version in builds and releases
- Update README with links to paper and recent blog posts + new installation instructions