### PR TITLE
express.0.1 - via opam-publish

### DIFF
--- a/packages/express/express.0.1/descr
+++ b/packages/express/express.0.1/descr
@@ -1,0 +1,12 @@
+js_of_ocaml bindings for npm's express
+
+These are OCaml bindings to npm's express package, easily
+create networked applications with middleware logic.
+
+open Nodejs
+
+let () =
+  let app = new Express.app ~existing:None in
+  let express = new Express.express in
+  app#use (express#static "public");
+  app#listen ~port:8080

--- a/packages/express/express.0.1/opam
+++ b/packages/express/express.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-npm-socket-io"
+bug-reports: "https://github.com/fxfactorial/ocaml-npm-socket-io/issues"
+dev-repo: "https://github.com/fxfactorial/ocaml-npm-socket-io.git"
+license: "BSD-3-clause"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "express"]
+depends: [
+  "nodejs" {>= "0.6"}
+  "ocamlfind" {build}
+]
+post-messages: [
+  "Example assuming file name of c.ml:"
+  "
+open Nodejs
+
+let () =
+  let app = new Express.app ~existing:None in
+  let express = new Express.express in
+  app#use (express#static \"public\");
+  app#listen ~port:8080
+  "
+  "ocamlfind ocamlc c.ml -linkpkg -package express -o T.out"
+  "js_of_ocaml T.out"
+  "node T.js"
+]

--- a/packages/express/express.0.1/url
+++ b/packages/express/express.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bean-code/ocaml-npm-express/archive/v0.1.tar.gz"
+checksum: "35b1b844efe5459bf3c83fa69a945d5e"


### PR DESCRIPTION
js_of_ocaml bindings for npm's express

These are OCaml bindings to npm's express package, easily
create networked applications with middleware logic.

```ocaml
open Nodejs

let () =
  let app = new Express.app ~existing:None in
  let express = new Express.express in
  app#use (express#static "public");
  app#listen ~port:8080
```

---
* Homepage: https://github.com/fxfactorial/ocaml-npm-socket-io
* Source repo: https://github.com/fxfactorial/ocaml-npm-socket-io.git
* Bug tracker: https://github.com/fxfactorial/ocaml-npm-socket-io/issues

---

Pull-request generated by opam-publish v0.3.1