### PR TITLE
nodemailer.0.2 - via opam-publish

### DIFF
--- a/packages/nodemailer/nodemailer.0.2/descr
+++ b/packages/nodemailer/nodemailer.0.2/descr
@@ -1,0 +1,35 @@
+js_of_ocaml bindings for npm's nodemailer
+
+These are js_of_ocaml bindings to npm's nodemailer package, to be used
+with NodeJS, easily create nodejs based applications that can send mail.
+Possibily the easiest way to send an email in OCaml.
+
+open Nodejs
+open Node_mailer
+
+let () =
+  let mailer = new Node_mailer.node_mailer in
+  let m_opts =
+    with_simple_defaults
+      ~from:"Some Name <some_one@gmail.com>"
+      ~to_:["another_person@gmail.com"]
+      ~subject:(Some "Greeting from OCaml code!")
+      (Some "Some silly body to show off")
+  in
+  let t_opts =
+    {service = Gmail;
+     auth = {user = "some_one@gmail.com"; pass = "some_password"}}
+  in
+  let our_transporter = mailer#create_transport t_opts in
+  our_transporter#send_mail m_opts ~on_done:begin fun error info ->
+    Js.Opt.case error
+      (* This means there was no error *)
+      begin fun () ->
+        print_endline info.envelope.from
+      end
+      (* There was an error oh no *)
+      begin fun e ->
+        print_int e#code
+      end
+
+  end

--- a/packages/nodemailer/nodemailer.0.2/opam
+++ b/packages/nodemailer/nodemailer.0.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/bean-code/ocaml-npm-nodemailer"
+bug-reports: "https://github.com/bean-code/ocaml-npm-nodemailer/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/bean-code/ocaml-npm-nodemailer.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "nodemailer"]
+depends: [
+  "nodejs" {>= "0.5"}
+  "ocamlfind" {build}
+]

--- a/packages/nodemailer/nodemailer.0.2/url
+++ b/packages/nodemailer/nodemailer.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bean-code/ocaml-npm-nodemailer/archive/v0.2.tar.gz"
+checksum: "126e10b6dbbe7191a5606e925cfe541f"


### PR DESCRIPTION
js_of_ocaml bindings for npm's nodemailer

These are js_of_ocaml bindings to npm's nodemailer package, to be used
with NodeJS, easily create nodejs based applications that can send mail.
Possibily the easiest way to send an email in OCaml.

```ocaml
open Nodejs
open Node_mailer

let () =
  let mailer = new Node_mailer.node_mailer in
  let m_opts =
    with_simple_defaults
      ~from:"Some Name <some_one@gmail.com>"
      ~to_:["another_person@gmail.com"]
      ~subject:(Some "Greeting from OCaml code!")
      (Some "Some silly body to show off")
  in
  let t_opts =
    {service = Gmail;
     auth = {user = "some_one@gmail.com"; pass = "some_password"}}
  in
  let our_transporter = mailer#create_transport t_opts in
  our_transporter#send_mail m_opts ~on_done:begin fun error info ->
    Js.Opt.case error
      (* This means there was no error *)
      begin fun () ->
        print_endline info.envelope.from
      end
      (* There was an error oh no *)
      begin fun e ->
        print_int e#code
      end

  end
```

---
* Homepage: https://github.com/bean-code/ocaml-npm-nodemailer
* Source repo: https://github.com/bean-code/ocaml-npm-nodemailer.git
* Bug tracker: https://github.com/bean-code/ocaml-npm-nodemailer/issues

---

Pull-request generated by opam-publish v0.3.1