### PR TITLE
xss_filters.0.1 - via opam-publish

### DIFF
--- a/packages/xss_filters/xss_filters.0.1/descr
+++ b/packages/xss_filters/xss_filters.0.1/descr
@@ -1,0 +1,9 @@
+js_of_ocaml bindings for npm's xss-filters
+
+Sanitize user data with Yahoo's xss-filters npm package.
+
+open Nodejs
+
+let () =
+  Xss_filters.in_html_data "<script>edgar</script>"
+  |> print_endline

--- a/packages/xss_filters/xss_filters.0.1/opam
+++ b/packages/xss_filters/xss_filters.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/bean-code/ocaml-npm-xss-filters"
+bug-reports: "https://github.com/bean-code/ocaml-npm-xss-filters/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/bean-code/ocaml-npm-xss-filters.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "xss_filters"]
+depends: [
+  "nodejs" {>= "0.5"}
+  "ocamlfind" {build}
+]
+post-messages: [
+  "Sanitize user input with Yahoo's xss-filters npm package"
+  "
+open Nodejs
+
+let () =
+  Xss_filters.in_html_data \"<script>edgar</script>\"
+  |> print_endline
+  "
+  "Compile with:"
+  "ocamlfind ocamlc code.ml -linkpkg -package xss_filters -o T.out"
+  "js_of_ocaml T.out"
+  "node T.js"
+]

--- a/packages/xss_filters/xss_filters.0.1/url
+++ b/packages/xss_filters/xss_filters.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/bean-code/ocaml-npm-xss-filters/archive/v0.1.tar.gz"
+checksum: "e714d15e74df04f1c0ebf9ce352d3635"


### PR DESCRIPTION
js_of_ocaml bindings for npm's xss-filters

Sanitize user data with Yahoo's xss-filters npm package.
```ocaml
open Nodejs

let () =
  Xss_filters.in_html_data "<script>edgar</script>"
  |> print_endline
```

---
* Homepage: https://github.com/bean-code/ocaml-npm-xss-filters
* Source repo: https://github.com/bean-code/ocaml-npm-xss-filters.git
* Bug tracker: https://github.com/bean-code/ocaml-npm-xss-filters/issues

---

Pull-request generated by opam-publish v0.3.1