### PR TITLE
Update oasis 0.4.5

### DIFF
--- a/packages/oasis/oasis.0.4.5/descr
+++ b/packages/oasis/oasis.0.4.5/descr
@@ -1,7 +1,22 @@
 Architecture for building OCaml libraries and applications
-OASIS is a tool to integrate a configure, build and install system in
-your OCaml project. It helps to create standard entry points in your
-build system and allows external tools to analyse your project easily.
+OASIS generates a full configure, build and install system for your
+application. It starts with a simple `_oasis` file at the toplevel of
+your project and creates everything required.
+It uses external tools like OCamlbuild and it can be considered as the
+glue between various subsystems that do the job. It should support the
+following tools:
 
-OASIS first target is OCamlbuild, but other build system support is
-planned.
+
+* OCamlbuild
+* OMake (todo)
+* OCamlMakefile (todo),
+* ocaml-autoconf (todo)
+
+
+It also features a do-it-yourself command line invocation and an
+internal configure/install scheme. Libraries are managed through
+findlib. It has been tested on GNU Linux and Windows.
+It also allows to have standard entry points and description. It helps
+to integrates your libraries and software with third parties tools
+like GODI.
+

--- a/packages/oasis/oasis.0.4.5/files/_oasis_remove_.ml
+++ b/packages/oasis/oasis.0.4.5/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/oasis/oasis.0.4.5/files/oasis.install
+++ b/packages/oasis/oasis.0.4.5/files/oasis.install
@@ -1,1 +1,6 @@
-bin: ["_build/src/cli/Main.byte" {"oasis"}]
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/oasis/oasis.0.4.5/opam
+++ b/packages/oasis/oasis.0.4.5/opam
@@ -1,18 +1,43 @@
-opam-version: "1"
-maintainer: "sylvain@le-gall.net"
+opam-version: "1.2"
+maintainer: "Sylvain Le Gall <gildor@ocamlcore.org>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "http://oasis.forge.ocamlcore.org/"
+dev-repo: "git://github.com/gildor478/oasis.git"
+bug-reports: "http://oasis.forge.ocamlcore.org/"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix
+    "--%{gettext:enable}%-gettext"]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
 ]
+install: ["ocaml" "setup.ml" "-install"]
 remove: [
-  ["ocamlfind" "remove" "plugin-loader"]
-  ["ocamlfind" "remove" "userconf"]
-  ["ocamlfind" "remove" "oasis"]
+  ["ocaml" "%{etc}%/oasis/_oasis_remove_.ml" "%{etc}%/oasis"]
 ]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"
+    "--%{gettext:enable}%-gettext"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
-  "ocamlfind" {>= "1.3.1"}
+  "base-unix"
+  "expect" {test & >= "0.0.4"}
+  "fileutils" {test & >= "0.4.2"}
   "ocaml-data-notation" {>= "0.0.11"}
-  "ocamlify"
-  "ocamlmod"
+  "ocamlfind" {>= "1.3.1"}
+  "ounit" {test & >= "2.0.0"}
+  "pcre" {test}
+  "ocamlify" {build}
+  "ocamlmod" {build}
 ]
+conflicts: [
+  "oasis-mirage" {= "0.3.0a"}
+  "oasis-mirage" {= "0.3.0"}
+  "oasis-mirage" {= "0.3.0a"}
+  "oasis-mirage" {= "0.3.0"}
+  "oasis-mirage" {= "0.3.0a"}
+  "oasis-mirage" {= "0.3.0"}
+]
+available: [ ocaml-version >= "3.11.2" ]

--- a/packages/oasis/oasis.0.4.5/opam
+++ b/packages/oasis/oasis.0.4.5/opam
@@ -27,16 +27,12 @@ depends: [
   "fileutils" {test & >= "0.4.2"}
   "ocaml-data-notation" {>= "0.0.11"}
   "ocamlfind" {>= "1.3.1"}
-  "ounit" {test & >= "2.0.0"}
-  "pcre" {test}
   "ocamlify" {build}
   "ocamlmod" {build}
+  "ounit" {test & >= "2.0.0"}
+  "pcre" {test}
 ]
 conflicts: [
-  "oasis-mirage" {= "0.3.0a"}
-  "oasis-mirage" {= "0.3.0"}
-  "oasis-mirage" {= "0.3.0a"}
-  "oasis-mirage" {= "0.3.0"}
   "oasis-mirage" {= "0.3.0a"}
   "oasis-mirage" {= "0.3.0"}
 ]


### PR DESCRIPTION
The new installation procedure makes it possible to install the package on Windows (with Cygwin).

See https://ci.appveyor.com/project/Chris00/opam-repository-appveyor/build/1.0.7