### PR TITLE
tsdl.0.8.2 - via opam-publish

### DIFF
--- a/packages/tsdl/tsdl.0.8.2/descr
+++ b/packages/tsdl/tsdl.0.8.2/descr
@@ -1,0 +1,11 @@
+Thin bindings to SDL for OCaml
+
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.1][1] C library (or later) and
+[ocaml-ctypes][2]. Tsdl is distributed under the BSD3 license.
+
+[1]: http://www.libsdl.org/
+[2]: https://github.com/ocamllabs/ocaml-ctypes
+

--- a/packages/tsdl/tsdl.0.8.2/opam
+++ b/packages/tsdl/tsdl.0.8.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/tsdl"
+doc: "http://erratique.ch/software/tsdl/doc/Tsdl"
+dev-repo: "http://erratique.ch/repos/tsdl.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.00.1" ]
+depends: [ "ocamlfind" "ctypes" {>= "0.4.1"} "ctypes-foreign" ]
+depexts: [
+ [["debian"] ["libsdl2-dev"]]
+ [["ubuntu"] ["libsdl2-dev"]]
+ [["mageia"] ["libsdl2.0-devel"]]
+ [["osx" "homebrew"] ["sdl2"]]
+]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%" ]
+]

--- a/packages/tsdl/tsdl.0.8.2/url
+++ b/packages/tsdl/tsdl.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/tsdl/releases/tsdl-0.8.2.tbz"
+checksum: "37d15a4f7bd09ff4674eb7429241341f"


### PR DESCRIPTION
Thin bindings to SDL for OCaml

Tsdl is an OCaml library providing thin bindings to the cross-platform
SDL C library.

Tsdl depends on the [SDL 2.0.1][1] C library (or later) and
[ocaml-ctypes][2]. Tsdl is distributed under the BSD3 license.

[1]: http://www.libsdl.org/
[2]: https://github.com/ocamllabs/ocaml-ctypes



---
* Homepage: http://erratique.ch/software/tsdl
* Source repo: http://erratique.ch/repos/tsdl.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---

Pull-request generated by opam-publish v0.3.1