### PR TITLE
Add `Pvem_lwt_unix` version 0.0.2

### DIFF
--- a/packages/pvem_lwt_unix/pvem_lwt_unix.0.0.2/descr
+++ b/packages/pvem_lwt_unix/pvem_lwt_unix.0.0.2/descr
@@ -1,0 +1,4 @@
+Access to the Operating system with Pvem and Lwt_unix
+
+`Pvem_lwt_unix` provides a high-level API on top of `Lwt_unix`, with
+comprehensive error types passing through a `Pvem.Result.t` monad.

--- a/packages/pvem_lwt_unix/pvem_lwt_unix.0.0.2/opam
+++ b/packages/pvem_lwt_unix/pvem_lwt_unix.0.0.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "seb@mondet.org"
+authors: "seb@mondet.org"
+homepage: "http://seb.mondet.org/software/pvem_lwt_unix/"
+dev-repo: "https://bitbucket.org/smondet/pvem_lwt_unix.git"
+bug-reports: "https://bitbucket.org/smondet/pvem_lwt_unix/issues"
+available: [ ocaml-version >= "4.00.0"]
+install: [
+    ["ocaml" "please.ml" "build"]
+    ["ocaml" "please.ml" "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "pvem_lwt_unix"]
+]
+depends: ["ocamlfind" "pvem" "base-unix" "base-threads" "lwt" {>= "2.5.0"}]

--- a/packages/pvem_lwt_unix/pvem_lwt_unix.0.0.2/url
+++ b/packages/pvem_lwt_unix/pvem_lwt_unix.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://bitbucket.org/smondet/pvem_lwt_unix/get/pvem_lwt_unix.0.0.2.tar.gz"
+checksum: "15e69255c8e21d8cd467ed65be1c913c"


### PR DESCRIPTION
This new version is only switching to Lwt ≥ 2.5 in a (hopefully)
backwards compatible way.