### PR TITLE
restricted upper bound of core_kernel version

### DIFF
--- a/packages/bap/bap.0.9.9/opam
+++ b/packages/bap/bap.0.9.9/opam
@@ -41,7 +41,7 @@ depends: [
     "camlzip"
     "cmdliner" {>= "0.9.6"}
     "cohttp" {>= "0.15.0"}
-    "core_kernel" {>= "111.28.0"}
+    "core_kernel" {>= "111.28.0" & <= "112.35.0"}
     "ezjsonm" {>= "0.4.0"}
     "faillib"
     "fileutils"


### PR DESCRIPTION
This is a retroactive update. The library is not changed, only opam file, to confront the breaking changes in `core_kernel` library. 