### PR TITLE
Rewrite constrained depopts properly as conflicts

### DIFF
--- a/packages/batsh/batsh.0.0.4/opam
+++ b/packages/batsh/batsh.0.0.4/opam
@@ -16,8 +16,8 @@ depends: [
   "menhir" {>= "20130912"}
   "cmdliner" {>= "0.9.2"}
 ]
-depopts: [
-  "ounit"
-  "core" {>= "109.42.00"}
-]
+depopts: ["ounit" "core"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "core" {< "109.42.00"}
+]

--- a/packages/batsh/batsh.0.0.6/opam
+++ b/packages/batsh/batsh.0.0.6/opam
@@ -20,8 +20,8 @@ depends: [
   "dlist" {>= "0.0.3"}
   "cmdliner" {>= "0.9.2"}
 ]
-depopts: [
-  "ounit"
-  "core" {>= "109.47.00"}
-]
+depopts: ["ounit" "core"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "core" {< "109.47.00"}
+]

--- a/packages/cohttp/cohttp.0.9.1/opam
+++ b/packages/cohttp/cohttp.0.9.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "anil@recoil.org"
 tags: [
   "org:mirage"
@@ -16,8 +16,9 @@ depends: [
   "ounit"
   "cstruct" {< "0.6.0"}
 ]
-depopts: [
-  "async" {= "108.00.02"}
-  "lwt" {>= "2.4.1" & <"2.4.7"}
-  "mirage-net"
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {!= "108.00.02"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.2/opam
+++ b/packages/cohttp/cohttp.0.9.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "anil@recoil.org"
 tags: [
   "org:mirage"
@@ -17,9 +17,9 @@ depends: [
   "ounit"
   "cstruct" {< "0.6.0"}
 ]
-depopts: [
-  "async" {= "108.00.02"}
-  "lwt" {>= "2.4.1" & <"2.4.7"}
-  "mirage-net"
-  "ssl"
+depopts: ["async" "lwt" "mirage-net" "ssl"]
+conflicts: [
+  "async" {!= "108.00.02"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.3/opam
+++ b/packages/cohttp/cohttp.0.9.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "anil@recoil.org"
 tags: [
   "org:mirage"
@@ -16,8 +16,9 @@ depends: [
   "ounit"
   "cstruct" {< "0.6.0"}
 ]
-depopts: [
-  "async" {= "108.00.02"}
-  "lwt" {>= "2.4.1" & <"2.4.7"}
-  "mirage-net"
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {!= "108.00.02"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.4/opam
+++ b/packages/cohttp/cohttp.0.9.4/opam
@@ -16,8 +16,10 @@ depends: [
   "ounit"
   "cstruct" {< "0.6.0"}
 ]
-depopts: [
-  "async" {>= "108.07.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.1" & <"2.4.7"}
-  "mirage-net"
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "108.07.00"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.1"}
 ]

--- a/packages/cohttp/cohttp.0.9.5/opam
+++ b/packages/cohttp/cohttp.0.9.5/opam
@@ -15,8 +15,11 @@ depends: [
   "uri" {>= "1.3.2" & <"1.5.0"}
   "ounit"
 ]
-depopts: [
-  "async" {>= "108.07.00" & <= "109.53.02" }
-  "lwt" {>= "2.4.1" & <"2.4.7"}
-  "mirage-net" {>= "0.5.0"}
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "108.07.00"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.1"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.6/opam
+++ b/packages/cohttp/cohttp.0.9.6/opam
@@ -15,8 +15,11 @@ depends: [
   "uri" {>= "1.3.2" & <"1.5.0"}
   "ounit"
 ]
-depopts: [
-  "async" {>= "109.12.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.1" & <"2.4.7"}
-  "mirage-net" {>= "0.5.0"}
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.12.00"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.1"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.7/opam
+++ b/packages/cohttp/cohttp.0.9.7/opam
@@ -16,8 +16,11 @@ depends: [
   "ounit"
   "cstruct"
 ]
-depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3" & <"2.4.7"}
-  "mirage-net" {>= "0.5.0"}
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.8/opam
+++ b/packages/cohttp/cohttp.0.9.8/opam
@@ -16,8 +16,11 @@ depends: [
   "ounit"
   "cstruct"
 ]
-depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3" & <"2.4.7"}
-  "mirage-net" {>= "0.5.0"}
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.9.9/opam
+++ b/packages/cohttp/cohttp.0.9.9/opam
@@ -16,8 +16,11 @@ depends: [
   "ounit"
   "cstruct"
 ]
-depopts: [
-  "async" {>= "109.15.00" & <= "109.53.02"}
-  "lwt" {>= "2.4.3" & <"2.4.7"}
-  "mirage-net" {>= "0.5.0"}
+depopts: ["async" "lwt" "mirage-net"]
+conflicts: [
+  "async" {> "109.53.02"}
+  "async" {< "109.15.00"}
+  "lwt" {>= "2.4.7"}
+  "lwt" {< "2.4.3"}
+  "mirage-net" {< "0.5.0"}
 ]

--- a/packages/cubicle/cubicle.1.0.1/opam
+++ b/packages/cubicle/cubicle.1.0.1/opam
@@ -13,4 +13,7 @@ build: [
   [make "install" "MANDIR=%{man}%"]
 ]
 depends: ["ocamlfind"]
-depopts: ["functory" {>= "0.5"}]
+depopts: ["functory"]
+conflicts: [
+  "functory" {< "0.5"}
+]

--- a/packages/cubicle/cubicle.1.0.2/opam
+++ b/packages/cubicle/cubicle.1.0.2/opam
@@ -13,4 +13,7 @@ build: [
   [make "install" "MANDIR=%{man}%"]
 ]
 depends: ["ocamlfind"]
-depopts: ["functory" {>= "0.5"}]
+depopts: ["functory"]
+conflicts: [
+  "functory" {< "0.5"}
+]

--- a/packages/cubicle/cubicle.1.0/opam
+++ b/packages/cubicle/cubicle.1.0/opam
@@ -13,8 +13,11 @@ build: [
   [make "install" "MANDIR=%{man}%"]
 ]
 depends: ["ocamlfind"]
-depopts: ["functory" {>= "0.5"}]
+depopts: ["functory"]
 depexts: [
   [["debian"] ["graphviz"]]
   [["ubuntu"] ["graphviz"]]
+]
+conflicts: [
+  "functory" {< "0.5"}
 ]

--- a/packages/deriving-ocsigen/deriving-ocsigen.0.3c/opam
+++ b/packages/deriving-ocsigen/deriving-ocsigen.0.3c/opam
@@ -6,4 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "deriving-ocsigen"]]
 depends: ["ocamlfind" "camlp4"]
-depopts: ["type_conv" {< "108.07.00"}]
+depopts: ["type_conv"]
+conflicts: [
+  "type_conv" {>= "108.07.00"}
+]

--- a/packages/deriving-ocsigen/deriving-ocsigen.0.5/opam
+++ b/packages/deriving-ocsigen/deriving-ocsigen.0.5/opam
@@ -10,4 +10,7 @@ depends: [
   "optcomp"
   "camlp4"
 ]
-depopts: ["type_conv" {>= "108.07.00"}]
+depopts: ["type_conv"]
+conflicts: [
+  "type_conv" {< "108.07.00"}
+]

--- a/packages/deriving/deriving.0.5/opam
+++ b/packages/deriving/deriving.0.5/opam
@@ -10,5 +10,8 @@ depends: [
   "optcomp" {>= "1.6"}
   "camlp4"
 ]
-depopts: ["type_conv" {>= "108.07.00"}]
+depopts: ["type_conv"]
 ocaml-version: [<= "4.01.0"]
+conflicts: [
+  "type_conv" {< "108.07.00"}
+]

--- a/packages/dlist/dlist.0.0.1/opam
+++ b/packages/dlist/dlist.0.0.1/opam
@@ -10,9 +10,9 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dlist"]]
 depends: ["ocamlfind" {>= "1.3.2"}]
-depopts: [
-  "core" {>= "109.42.00"}
-  "core_bench" {>= "109.41.00"}
-  "ounit"
-]
+depopts: ["core" "core_bench" "ounit"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "core" {< "109.42.00"}
+  "core_bench" {< "109.41.00"}
+]

--- a/packages/dlist/dlist.0.0.2/opam
+++ b/packages/dlist/dlist.0.0.2/opam
@@ -10,9 +10,9 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dlist"]]
 depends: ["ocamlfind" {>= "1.3.2"}]
-depopts: [
-  "core" {>= "109.42.00"}
-  "core_bench" {>= "109.41.00"}
-  "ounit"
-]
+depopts: ["core" "core_bench" "ounit"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "core" {< "109.42.00"}
+  "core_bench" {< "109.41.00"}
+]

--- a/packages/dlist/dlist.0.0.3/opam
+++ b/packages/dlist/dlist.0.0.3/opam
@@ -14,8 +14,8 @@ remove: [
   ["ocp-build" "uninstall"]
 ]
 depends: ["ocp-build" {>= "1.99.6-beta"}]
-depopts: [
-  "core_bench" {>= "109.41.00"}
-  "ounit"
-]
+depopts: ["core_bench" "ounit"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "core_bench" {< "109.41.00"}
+]

--- a/packages/dlist/dlist.0.1.0/opam
+++ b/packages/dlist/dlist.0.1.0/opam
@@ -16,8 +16,8 @@ remove: [
 depends: [
   "ocp-build" {>= "1.99.6-beta"}
 ]
-depopts: [
-  "core_bench" {>= "109.41.00"}
-  "ounit"
-]
+depopts: ["core_bench" "ounit"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "core_bench" {< "109.41.00"}
+]

--- a/packages/dns/dns.0.11.0/opam
+++ b/packages/dns/dns.0.11.0/opam
@@ -29,10 +29,7 @@ depends: [
   "ipaddr" {>= "2.2.0"}
   "base64" {< "2.0.0"}
 ]
-depopts: [
-  ("mirage-types" & "tcpip")
-  "async"
-]
+depopts: ["mirage-types" "tcpip" "async"]
 conflicts: [
   "mirage-types" {<"1.2.0"}
   "async" {<"109.21.00"}

--- a/packages/dns/dns.0.12.0/opam
+++ b/packages/dns/dns.0.12.0/opam
@@ -29,10 +29,7 @@ depends: [
   "ipaddr" {>= "2.2.0"}
   "base64" {>= "2.0.0"}
 ]
-depopts: [
-  ("mirage-types" & "tcpip")
-  "async"
-]
+depopts: ["mirage-types" "tcpip" "async"]
 conflicts: [
   "mirage-types" {<"1.2.0"}
   "async" {<"109.21.00"}

--- a/packages/dns/dns.0.5.0/opam
+++ b/packages/dns/dns.0.5.0/opam
@@ -17,8 +17,8 @@ depends: [
   "re"
   "uri"
 ]
-depopts: [
-  "lwt" {>= "2.4.1"}
-  "mirage-net"
-]
+depopts: ["lwt" "mirage-net"]
 ocaml-version: [>= "4.0.0"]
+conflicts: [
+  "lwt" {< "2.4.1"}
+]

--- a/packages/dns/dns.0.5.1/opam
+++ b/packages/dns/dns.0.5.1/opam
@@ -17,8 +17,9 @@ depends: [
   "re"
   "uri"
 ]
-depopts: [
-  "lwt" {>= "2.4.1"}
-  "mirage-net" {<= "0.9.4"}
-]
+depopts: ["lwt" "mirage-net"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "lwt" {< "2.4.1"}
+  "mirage-net" {> "0.9.4"}
+]

--- a/packages/dns/dns.0.6.0/opam
+++ b/packages/dns/dns.0.6.0/opam
@@ -18,7 +18,9 @@ depends: [
   "uri"
   "cmdliner"
 ]
-depopts: [
-  "lwt" {>= "2.4.1"}
-  "mirage-net" {>= "0.5.2" & <= "0.9.4"} 
+depopts: ["lwt" "mirage-net"]
+conflicts: [
+  "lwt" {< "2.4.1"}
+  "mirage-net" {> "0.9.4"}
+  "mirage-net" {< "0.5.2"}
 ]

--- a/packages/dns/dns.0.6.1/opam
+++ b/packages/dns/dns.0.6.1/opam
@@ -19,5 +19,9 @@ depends: [
   "uri"
   "cmdliner"
 ]
-depopts: ["mirage-net" {>= "0.5.2" & <= "0.9.4"} ]
+depopts: ["mirage-net"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mirage-net" {> "0.9.4"}
+  "mirage-net" {< "0.5.2"}
+]

--- a/packages/dns/dns.0.6.2/opam
+++ b/packages/dns/dns.0.6.2/opam
@@ -27,5 +27,9 @@ depends: [
   "uri"
   "cmdliner"
 ]
-depopts: ["mirage-net" {>= "0.5.2" & <= "0.9.4"} ]
+depopts: ["mirage-net"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mirage-net" {> "0.9.4"}
+  "mirage-net" {< "0.5.2"}
+]

--- a/packages/dns/dns.0.7.0/opam
+++ b/packages/dns/dns.0.7.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"
@@ -28,5 +28,8 @@ depends: [
   "cmdliner"
   "ipaddr" {>= "0.2.2" & < "2.0.0"}
 ]
-depopts: ["mirage-net" {= "0.9.4"}]
+depopts: ["mirage-net"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mirage-net" {!= "0.9.4"}
+]

--- a/packages/frenetic/frenetic.2.0.0/opam
+++ b/packages/frenetic/frenetic.2.0.0/opam
@@ -18,7 +18,9 @@ depends: [
   "sexplib"
   "topology"    {>= "0.1.0"}
 ]
-depopts: [
-  ("async" & "topology" {>= "0.1.0"} & "cstruct" {>= "1.0.1"} & "packet" {>= "0.2.1"})
-  "quickcheck"
+depopts: ["async" "topology" "cstruct" "packet" "quickcheck"]
+conflicts: [
+  "cstruct" {< "1.0.1"}
+  "packet" {< "0.2.1"}
+  "topology" {< "0.1.0"}
 ]

--- a/packages/frenetic/frenetic.3.0.0/opam
+++ b/packages/frenetic/frenetic.3.0.0/opam
@@ -19,12 +19,10 @@ depends: [
   "sexplib"
   "topology"    {>= "0.1.0" & < "0.4.0"}
 ]
-depopts: [
-  ( "async"
-  & "cmdliner"  {>= "0.9.5"}
-  & "cstruct"   {>= "1.0.1"}
-  & "packet"    {>= "0.2.1"}
-  & "topology"  {>= "0.1.0"}
-  )
-  "quickcheck"
+depopts: ["async" "cmdliner" "cstruct" "packet" "topology" "quickcheck"]
+conflicts: [
+  "cmdliner" {< "0.9.5"}
+  "cstruct" {< "1.0.1"}
+  "packet" {< "0.2.1"}
+  "topology" {< "0.1.0"}
 ]

--- a/packages/frenetic/frenetic.3.1.0/opam
+++ b/packages/frenetic/frenetic.3.1.0/opam
@@ -19,12 +19,10 @@ depends: [
   "sexplib"
   "topology"    {>= "0.1.0"}
 ]
-depopts: [
-  ( "async"
-  & "cmdliner"  {>= "0.9.5"}
-  & "cstruct"   {>= "1.0.1"}
-  & "packet"    {>= "0.2.1"}
-  & "topology"  {>= "0.1.0"}
-  )
-  "quickcheck"
+depopts: ["async" "cmdliner" "cstruct" "packet" "topology" "quickcheck"]
+conflicts: [
+  "cmdliner" {< "0.9.5"}
+  "cstruct" {< "1.0.1"}
+  "packet" {< "0.2.1"}
+  "topology" {< "0.1.0"}
 ]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.6/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.6/opam
@@ -21,9 +21,7 @@ depends: [
   "ctypes-foreign"
   "lwt" {>= "2.4"}
 ]
-depopts: [
-  "ocp-index" {>= "1.0.1"} 
-]
+depopts: ["ocp-index"]
 depexts: [
   [["debian"] ["libzmq3-dev"]]
   [["ubuntu"] ["libzmq3-dev"]]
@@ -31,3 +29,6 @@ depexts: [
   [["centos"] ["zeromq3-devel"]]
 ]
 ocaml-version: [ >= "4.00.1" ]
+conflicts: [
+  "ocp-index" {< "1.0.1"}
+]

--- a/packages/liquidsoap/liquidsoap.1.1.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.1.0/opam
@@ -22,7 +22,7 @@ depopts: [
   "alsa"
   "pulseaudio"
   "bjack"
-  "taglib" {>= "0.3.0"}
+  "taglib"
   "lame"
   "aacplus"
   "ogg"
@@ -46,7 +46,10 @@ depopts: [
   "lo"
   "inotify"
 ]
-conflicts: ["inotify" {>= "2.0"}]
+conflicts: [
+  "inotify" {>= "2.0"}
+  "taglib" {< "0.3.0"}
+]
 depexts: [
   [["debian"] ["libao-dev" "libfaad-dev" "libflac-dev" "libgavl-dev" "libgstreamer-plugins-base0.10-dev" "libgstreamer0.10-dev" "libgstreamer1.0-dev" "liblo-dev" "libmp3lame-dev" "libogg-dev" "libsamplerate-dev" "libschroedinger-dev" "libsoundtouch-dev" "libspeex-dev" "libtheora-dev" "libvo-aacenc-dev" "libvorbis-dev" "portaudio19-dev"]]
   [["ubuntu"] ["libao-dev" "libfaad-dev" "libflac-dev" "libgavl-dev" "libgstreamer-plugins-base0.10-dev" "libgstreamer0.10-dev" "libgstreamer1.0-dev" "liblo-dev" "libmp3lame-dev" "libogg-dev" "libsamplerate-dev" "libschroedinger-dev" "libsoundtouch-dev" "libspeex-dev" "libtheora-dev" "libvo-aacenc-dev" "libvorbis-dev" "portaudio19-dev"]]

--- a/packages/liquidsoap/liquidsoap.1.1.1/opam
+++ b/packages/liquidsoap/liquidsoap.1.1.1/opam
@@ -19,13 +19,13 @@ depends: [
   "mad"
 ]
 depopts: [
-  "cry" {>= "0.3.0"}
+  "cry"
   "ao"
   "portaudio"
   "alsa"
   "pulseaudio"
   "bjack"
-  "taglib" {>= "0.3.0"}
+  "taglib"
   "lame"
   "aacplus"
   "ogg"
@@ -49,7 +49,11 @@ depopts: [
   "lo"
   "inotify"
 ]
-conflicts: ["inotify" {>= "2.0"}]
+conflicts: [
+  "inotify" {>= "2.0"}
+  "cry" {< "0.3.0"}
+  "taglib" {< "0.3.0"}
+]
 depexts: [
   [["debian"] ["libao-dev" "libfaad-dev" "libflac-dev" "libgavl-dev" "libgstreamer-plugins-base0.10-dev" "libgstreamer0.10-dev" "libgstreamer1.0-dev" "liblo-dev" "libmp3lame-dev" "libogg-dev" "libsamplerate-dev" "libschroedinger-dev" "libsoundtouch-dev" "libspeex-dev" "libtheora-dev" "libvo-aacenc-dev" "libvorbis-dev" "portaudio19-dev"]]
   [["ubuntu"] ["libao-dev" "libfaad-dev" "libflac-dev" "libgavl-dev" "libgstreamer-plugins-base0.10-dev" "libgstreamer0.10-dev" "libgstreamer1.0-dev" "liblo-dev" "libmp3lame-dev" "libogg-dev" "libsamplerate-dev" "libschroedinger-dev" "libsoundtouch-dev" "libspeex-dev" "libtheora-dev" "libvo-aacenc-dev" "libvorbis-dev" "portaudio19-dev"]]

--- a/packages/lwt/lwt.2.3.2/opam
+++ b/packages/lwt/lwt.2.3.2/opam
@@ -8,10 +8,5 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "lwt"]]
 depends: ["ocamlfind" "camlp4"]
-depopts: [
-  "base-threads"
-  "base-unix"
-  "conf-libev"
-  "react" {< "1.0.0" }
-]
+depopts: ["base-threads" "base-unix" "conf-libev" "react"]
 conflicts: [ "react" {>="1.0.0"} ]

--- a/packages/mirage-console/mirage-console.2.0.0/opam
+++ b/packages/mirage-console/mirage-console.2.0.0/opam
@@ -16,10 +16,9 @@ depends: [
   "mirage-types-lwt"
   "mirage-unix" {>="1.1.0"}
 ]
-depopts: [
-  "mirage-xen" {>="1.1.0"}
-]
+depopts: ["mirage-xen"]
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
+  "mirage-xen" {< "1.1.0"}
 ]

--- a/packages/mirage-console/mirage-console.2.1.0/opam
+++ b/packages/mirage-console/mirage-console.2.1.0/opam
@@ -16,10 +16,9 @@ depends: [
   "mirage-types-lwt"
   "mirage-unix" {>="1.1.0"}
 ]
-depopts: [
-  "mirage-xen" {>="1.1.0"}
-]
+depopts: ["mirage-xen"]
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
+  "mirage-xen" {< "1.1.0"}
 ]

--- a/packages/mirage-console/mirage-console.2.1.1/opam
+++ b/packages/mirage-console/mirage-console.2.1.1/opam
@@ -16,10 +16,9 @@ depends: [
   "mirage-types-lwt"
   "mirage-unix" {>="1.1.0"}
 ]
-depopts: [
-  "mirage-xen" {>="1.1.0"}
-]
+depopts: ["mirage-xen"]
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
+  "mirage-xen" {< "1.1.0"}
 ]

--- a/packages/mirage-types/mirage-types.1.1.0/opam
+++ b/packages/mirage-types/mirage-types.1.1.0/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.00.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.1.1.1/opam
+++ b/packages/mirage-types/mirage-types.1.1.1/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {> "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.00.0"]
+conflicts: [
+  "ipaddr" {<= "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.1.1.2/opam
+++ b/packages/mirage-types/mirage-types.1.1.2/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.00.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.1.1.3/opam
+++ b/packages/mirage-types/mirage-types.1.1.3/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.00.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.1.2.0/opam
+++ b/packages/mirage-types/mirage-types.1.2.0/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.00.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.2.0.0/opam
+++ b/packages/mirage-types/mirage-types.2.0.0/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.01.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.2.0.1/opam
+++ b/packages/mirage-types/mirage-types.2.0.1/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.01.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.2.1.0/opam
+++ b/packages/mirage-types/mirage-types.2.1.0/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.01.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.2.1.1/opam
+++ b/packages/mirage-types/mirage-types.2.1.1/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "0.2.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.01.0"]
+conflicts: [
+  "ipaddr" {< "0.2.0"}
+]

--- a/packages/mirage-types/mirage-types.2.2.0/opam
+++ b/packages/mirage-types/mirage-types.2.2.0/opam
@@ -9,7 +9,8 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: ["ocamlfind" "sexplib"]
-depopts: [
- ("lwt" & "cstruct" & "io-page" & "ipaddr" {>= "2.0.0"})
-]
+depopts: ["lwt" "cstruct" "io-page" "ipaddr"]
 ocaml-version: [>="4.01.0"]
+conflicts: [
+  "ipaddr" {< "2.0.0"}
+]

--- a/packages/ocamleditor/ocamleditor.1.12.0/opam
+++ b/packages/ocamleditor/ocamleditor.1.12.0/opam
@@ -12,5 +12,8 @@ depends: [
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
-depopts: ["ocurl" {>= "0.6"}]
+depopts: ["ocurl"]
 ocaml-version: [= "4.01.0"]
+conflicts: [
+  "ocurl" {< "0.6"}
+]

--- a/packages/ocamleditor/ocamleditor.1.13.1/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.1/opam
@@ -11,8 +11,9 @@ depends: [
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
-depopts: [
-  "ocurl" {>= "0.6"}
-  "ocamldiff" {>= "1.1"}
-]
+depopts: ["ocurl" "ocamldiff"]
 ocaml-version: [= "4.01.0"]
+conflicts: [
+  "ocamldiff" {< "1.1"}
+  "ocurl" {< "0.6"}
+]

--- a/packages/ocamleditor/ocamleditor.1.13.2/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.2/opam
@@ -11,8 +11,9 @@ depends: [
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
-depopts: [
-  "ocurl" {>= "0.6"}
-  "ocamldiff" {>= "1.1"}
-]
+depopts: ["ocurl" "ocamldiff"]
 ocaml-version: [= "4.01.0"]
+conflicts: [
+  "ocamldiff" {< "1.1"}
+  "ocurl" {< "0.6"}
+]

--- a/packages/ocamleditor/ocamleditor.1.9.0-2/opam
+++ b/packages/ocamleditor/ocamleditor.1.9.0-2/opam
@@ -12,5 +12,8 @@ depends: [
   "lablgtk" {>= "2.16.0"}
   "xml-light" {>= "2.2"}
 ]
-depopts: ["ocurl" {>= "0.5.5"}]
+depopts: ["ocurl"]
 ocaml-version: [>= "4.00.0" & <= "4.00.1"]
+conflicts: [
+  "ocurl" {< "0.5.5"}
+]

--- a/packages/ocamlnet/ocamlnet.3.5.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.5.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 build: [
   ["./configure" "-bindir" bin "-%{lablgtk:enable}%-gtk2" "-%{ssl:enable}%-ssl" "-%{camlzip:enable}%-zip" "-%{cryptokit:enable}%-crypto" "-with-nethttpd"]
@@ -37,11 +37,8 @@ depends: [
   "pcre"
   "camlp4"
 ]
-depopts: [
-  "lablgtk"
-  "pcre"
-  "ssl"
-  "camlzip" {= "1.04"}
-  "cryptokit"
-]
+depopts: ["lablgtk" "pcre" "ssl" "camlzip" "cryptokit"]
 ocaml-version: [< "4.00.0"]
+conflicts: [
+  "camlzip" {!= "1.04"}
+]

--- a/packages/ocsigenserver/ocsigenserver.2.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "dev@ocsigen.org"
 build: [
   ["sh" "configure" "--prefix" prefix "--ocsigen-user" user "--ocsigen-group" group "--commandpipe" "%{lib}%/ocsigenserver/var/run/ocsigenserver_command" "--logdir" "%{lib}%/ocsigenserver/var/log/ocsigenserver" "--mandir" "%{man}%/man1" "--docdir" "%{lib}%/ocsigenserver/share/doc/ocsigenserver" "--commandpipe" "%{lib}%/ocsigenserver/var/run/ocsigenserver_command" "--staticpagesdir" "%{lib}%/ocsigenserver/var/www" "--datadir" "%{lib}%/ocsigenserver/var/lib/ocsigenserver" "--sysconfdir" "%{lib}%/ocsigenserver/etc/ocsigenserver"]
@@ -17,7 +17,7 @@ depends: [
   "tyxml" {< "3.2"}
   "dbm"
 ]
-depopts: [
-  "sqlite3"
-  "camlzip" {= "1.04"}
+depopts: ["sqlite3" "camlzip"]
+conflicts: [
+  "camlzip" {!= "1.04"}
 ]

--- a/packages/ocsigenserver/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.2.0/opam
@@ -17,5 +17,8 @@ depends: [
   "tyxml" {< "3.0.0"}
   ("dbm" | "sqlite3")
 ]
-depopts: ["camlzip" {>= "1.04"}]
+depopts: ["camlzip"]
 patches: ["use_netstring-pcre.patch"]
+conflicts: [
+  "camlzip" {< "1.04"}
+]

--- a/packages/ocsigenserver/ocsigenserver.2.3.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.3.1/opam
@@ -19,4 +19,7 @@ depends: [
   "tyxml" {>= "3.0.0" & < "3.2"}
   ("dbm" | "sqlite3")
 ]
-depopts: ["camlzip" {>= "1.04"}]
+depopts: ["camlzip"]
+conflicts: [
+  "camlzip" {< "1.04"}
+]

--- a/packages/rdf/rdf.0.2/opam
+++ b/packages/rdf/rdf.0.2/opam
@@ -14,8 +14,8 @@ depends: [
   "xmlm" {>= "1.1.1"}
   "ocamlnet"
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.3/opam
+++ b/packages/rdf/rdf.0.3/opam
@@ -14,8 +14,8 @@ depends: [
   "xmlm" {>= "1.1.1"}
   "ocamlnet"
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.4/opam
+++ b/packages/rdf/rdf.0.4/opam
@@ -14,8 +14,8 @@ depends: [
   "xmlm" {>= "1.1.1"}
   "ocamlnet" {>= "3.6"}
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.5/opam
+++ b/packages/rdf/rdf.0.5/opam
@@ -27,8 +27,8 @@ depends: [
   "ulex" {>= "1.1"}
   "menhir" {>= "20120123"}
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.6.0/opam
+++ b/packages/rdf/rdf.0.6.0/opam
@@ -27,8 +27,8 @@ depends: [
   "cryptokit" {>= "1.7"}
   "pcre" {>= "7.0.2"}
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.7.0/opam
+++ b/packages/rdf/rdf.0.7.0/opam
@@ -29,8 +29,8 @@ depends: [
   "cryptokit" {>= "1.7"}
   "pcre" {>= "7.0.2"}
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.7.1/opam
+++ b/packages/rdf/rdf.0.7.1/opam
@@ -29,8 +29,8 @@ depends: [
   "cryptokit" {>= "1.7"}
   "pcre" {>= "7.0.2"}
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.8.0/opam
+++ b/packages/rdf/rdf.0.8.0/opam
@@ -29,8 +29,8 @@ depends: [
   "cryptokit" {>= "1.7"}
   "pcre" {>= "7.0.2"}
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-]
+depopts: ["mysql" "postgresql"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "mysql" {< "1.1.1"}
+]

--- a/packages/rdf/rdf.0.9.0/opam
+++ b/packages/rdf/rdf.0.9.0/opam
@@ -30,10 +30,10 @@ depends: [
   "pcre" {>= "7.0.2"}
   "yojson" {>= "1.1.8"}
 ]
-depopts: [
-  "mysql" {>= "1.1.1"}
-  "postgresql"
-  "cohttp" {>= "0.11.2"}
-  "lwt" {>= "2.4.5"}
-]
+depopts: ["mysql" "postgresql" "cohttp" "lwt"]
 ocaml-version: [>= "4.02.0"]
+conflicts: [
+  "cohttp" {< "0.11.2"}
+  "lwt" {< "2.4.5"}
+  "mysql" {< "1.1.1"}
+]

--- a/packages/sexplib/sexplib.112.06.01/opam
+++ b/packages/sexplib/sexplib.112.06.01/opam
@@ -11,10 +11,10 @@ remove: [
   ["ocamlfind" "remove" "sexplib_unix"]
 ]
 depends: ["ocamlfind"]
-depopts: ["camlp4" {>= "4.02.0+1"}
-          "type_conv"]
+depopts: ["camlp4" "type_conv"]
 conflicts: [
   "type_conv" {< "112.01.00"}
   "type_conv" {>= "112.02.00"}
+  "camlp4" {< "4.02.0+1"}
 ]
 ocaml-version: [>= "4.02.0"]

--- a/packages/stog/stog.0.13.0/opam
+++ b/packages/stog/stog.0.13.0/opam
@@ -20,13 +20,13 @@ depends: [
   "ocamlnet" {>= "3.6"}
   "higlo" { >= "0.4" }
 ]
-depopts: [
-  "js_of_ocaml" { >= "2.5"}
-  "xmldiff" { >= "0.3.0" }
-  "lwt" { >= "2.4.5" }
-  "websocket" { >= "0.8.1" }
-  "cstruct" { >= "0.3.1" }
-  "crunch" { >= "1.1.0" }
-]
-
+depopts: ["js_of_ocaml" "xmldiff" "lwt" "websocket" "cstruct" "crunch"]
 ocaml-version: [>= "4.02.0"]
+conflicts: [
+  "crunch" {< "1.1.0"}
+  "cstruct" {< "0.3.1"}
+  "js_of_ocaml" {< "2.5"}
+  "lwt" {< "2.4.5"}
+  "websocket" {< "0.8.1"}
+  "xmldiff" {< "0.3.0"}
+]

--- a/packages/stog/stog.0.14.0/opam
+++ b/packages/stog/stog.0.14.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "zoggy@bat8.org"
 authors: ["Maxence Guesdon"]
 homepage: "http://zoggy.github.io/stog/"
@@ -21,13 +21,15 @@ depends: [
   "higlo" { >= "0.4" }
 ]
 depopts: [
-  "js_of_ocaml" { >= "2.5"}
-  "xmldiff" { >= "0.5.0" }
-  "lwt" { >= "2.4.5" }
-  "websocket" { = "0.8.1" }
-  "cstruct" { >= "0.3.1" }
-  "crunch" { >= "1.1.0" }
-  "ojs-base" { >= "0.2" }
+  "js_of_ocaml" "xmldiff" "lwt" "websocket" "cstruct" "crunch" "ojs-base"
 ]
-
 ocaml-version: [>= "4.02.1"]
+conflicts: [
+  "crunch" {< "1.1.0"}
+  "cstruct" {< "0.3.1"}
+  "js_of_ocaml" {< "2.5"}
+  "lwt" {< "2.4.5"}
+  "ojs-base" {< "0.2"}
+  "websocket" {!= "0.8.1"}
+  "xmldiff" {< "0.5.0"}
+]

--- a/packages/themoviedb/themoviedb.0.8.1/opam
+++ b/packages/themoviedb/themoviedb.0.8.1/opam
@@ -16,6 +16,7 @@ depends: [
   "yojson"
   "lwt"
 ]
-depopts: [
-  "ounit" {>= "2.0.0" }
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "2.0.0"}
 ]

--- a/packages/themoviedb/themoviedb.0.8/opam
+++ b/packages/themoviedb/themoviedb.0.8/opam
@@ -16,6 +16,7 @@ depends: [
   "yojson"
   "lwt"
 ]
-depopts: [
-  "ounit" {>= "2.0.0" }
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "2.0.0"}
 ]

--- a/packages/uri/uri.1.3.10/opam
+++ b/packages/uri/uri.1.3.10/opam
@@ -22,4 +22,7 @@ depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.3.11/opam
+++ b/packages/uri/uri.1.3.11/opam
@@ -22,4 +22,7 @@ depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.3.12/opam
+++ b/packages/uri/uri.1.3.12/opam
@@ -22,4 +22,7 @@ depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.3.13/opam
+++ b/packages/uri/uri.1.3.13/opam
@@ -24,4 +24,7 @@ depends: [
   "sexplib" {>="109.53.00"}
   "type_conv"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.3.6/opam
+++ b/packages/uri/uri.1.3.6/opam
@@ -22,5 +22,8 @@ depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
 ocaml-version: [>= "4.00.0"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.3.8/opam
+++ b/packages/uri/uri.1.3.8/opam
@@ -22,5 +22,8 @@ depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
 ocaml-version: [>= "4.0.0"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.3.9/opam
+++ b/packages/uri/uri.1.3.9/opam
@@ -22,4 +22,7 @@ depends: [
   "ocamlfind"
   "re"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.4.0/opam
+++ b/packages/uri/uri.1.4.0/opam
@@ -24,4 +24,7 @@ depends: [
   "sexplib" {>="109.53.00"}
   "type_conv"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/uri/uri.1.5.0/opam
+++ b/packages/uri/uri.1.5.0/opam
@@ -26,4 +26,7 @@ depends: [
   "type_conv"
   "stringext"
 ]
-depopts: ["ounit" {>= "1.0.2"}]
+depopts: ["ounit"]
+conflicts: [
+  "ounit" {< "1.0.2"}
+]

--- a/packages/vchan/vchan.2.0.0/opam
+++ b/packages/vchan/vchan.2.0.0/opam
@@ -24,9 +24,8 @@ depends: [
   "cmdliner"
   "ounit"
 ]
-depopts: [
-  "xen-evtchn" {>= "1.0.3"}
-  "xen-gnt"
-  "mirage-xen"
-]
+depopts: ["xen-evtchn" "xen-gnt" "mirage-xen"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "xen-evtchn" {< "1.0.3"}
+]

--- a/packages/vchan/vchan.2.0.1/opam
+++ b/packages/vchan/vchan.2.0.1/opam
@@ -24,9 +24,8 @@ depends: [
   "cmdliner"
   "ounit"
 ]
-depopts: [
-  "xen-evtchn" {>= "1.0.3"}
-  "xen-gnt"
-  "mirage-xen"
-]
+depopts: ["xen-evtchn" "xen-gnt" "mirage-xen"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "xen-evtchn" {< "1.0.3"}
+]

--- a/packages/vchan/vchan.2.0.2/opam
+++ b/packages/vchan/vchan.2.0.2/opam
@@ -24,9 +24,8 @@ depends: [
   "cmdliner"
   "ounit"
 ]
-depopts: [
-  "xen-evtchn" {>= "1.0.3"}
-  "xen-gnt"
-  "mirage-xen"
-]
+depopts: ["xen-evtchn" "xen-gnt" "mirage-xen"]
 ocaml-version: [>= "4.00.1"]
+conflicts: [
+  "xen-evtchn" {< "1.0.3"}
+]

--- a/packages/why3/why3.0.81/opam
+++ b/packages/why3/why3.0.81/opam
@@ -31,11 +31,12 @@ depends: [
   "lablgtk"
   "conf-gtksourceview"
 ]
-depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.3"}
-]
+depopts: ["ocamlgraph" "coq"]
 patches: [
   "configure.patch"
   "Makefile.patch"
+]
+conflicts: [
+  "coq" {< "8.3"}
+  "ocamlgraph" {< "1.8.2"}
 ]

--- a/packages/why3/why3.0.82/opam
+++ b/packages/why3/why3.0.82/opam
@@ -31,10 +31,11 @@ depends: [
   "lablgtk"
   "conf-gtksourceview"
 ]
-depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.3"}
-]
+depopts: ["ocamlgraph" "coq"]
 patches: [
   "Makefile.patch"
+]
+conflicts: [
+  "coq" {< "8.3"}
+  "ocamlgraph" {< "1.8.2"}
 ]

--- a/packages/why3/why3.0.83/opam
+++ b/packages/why3/why3.0.83/opam
@@ -31,7 +31,8 @@ depends: [
   "lablgtk"
   "conf-gtksourceview"
 ]
-depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.3"}
+depopts: ["ocamlgraph" "coq"]
+conflicts: [
+  "coq" {< "8.3"}
+  "ocamlgraph" {< "1.8.2"}
 ]

--- a/packages/why3/why3.0.84/opam
+++ b/packages/why3/why3.0.84/opam
@@ -33,7 +33,8 @@ depends: [
   "camlzip"
   "zarith"
 ]
-depopts: [
-  "ocamlgraph" {>= "1.8.2"}
-  "coq" {>= "8.4"}
+depopts: ["ocamlgraph" "coq"]
+conflicts: [
+  "coq" {< "8.4"}
+  "ocamlgraph" {< "1.8.2"}
 ]

--- a/packages/xapi-xenopsd/xapi-xenopsd.0.9.44.1/opam
+++ b/packages/xapi-xenopsd/xapi-xenopsd.0.9.44.1/opam
@@ -28,5 +28,8 @@ depends: [
   "oclock"
   "xapi-inventory"
 ]
-depopts: "libvirt" {> "0.6.1.2"}
+depopts: ["libvirt"]
 ocaml-version: [>= "4.01.0"]
+conflicts: [
+  "libvirt" {<= "0.6.1.2"}
+]

--- a/packages/xen-api-client/xen-api-client.0.9.3/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.3/opam
@@ -19,5 +19,5 @@ depends: [
   "xmlm"
   "rpc" {>= "1.3.0"}
 ]
-depopts: ["async" {>= "109.15.00"}]
+depopts: ["async"]
 conflicts: ["async" {< "109.15.00"} "async" {>= "111.13.00"}]

--- a/packages/xen-block-driver/xen-block-driver.0.2.2/opam
+++ b/packages/xen-block-driver/xen-block-driver.0.2.2/opam
@@ -18,5 +18,8 @@ depends: [
   "mirage-xen" {>= "0.9.4" & < "0.9.8"}
   "mirage" {>= "0.9.4" & < "0.9.8"}
 ]
-depopts: ["xenctrl" {>= "0.9.8"}]
+depopts: ["xenctrl"]
 ocaml-version: [ < "4.02.0" ]
+conflicts: [
+  "xenctrl" {< "0.9.8"}
+]

--- a/packages/xmldiff/xmldiff.0.3.0/opam
+++ b/packages/xmldiff/xmldiff.0.3.0/opam
@@ -17,8 +17,8 @@ depends: [
   "xmlm" {>= "1.1.0" }
   "camlp4"
 ]
-depopts: [
-  "js_of_ocaml" {>= "2.4.0" }
-]
+depopts: ["js_of_ocaml"]
 ocaml-version: [>= "4.02.0"]
-
+conflicts: [
+  "js_of_ocaml" {< "2.4.0"}
+]

--- a/packages/xmldiff/xmldiff.0.4.0/opam
+++ b/packages/xmldiff/xmldiff.0.4.0/opam
@@ -17,8 +17,8 @@ depends: [
   "xmlm" {>= "1.1.0" }
   "camlp4"
 ]
-depopts: [
-  "js_of_ocaml" {>= "2.4.0" }
-]
+depopts: ["js_of_ocaml"]
 ocaml-version: [>= "4.02.0"]
-
+conflicts: [
+  "js_of_ocaml" {< "2.4.0"}
+]

--- a/packages/xmldiff/xmldiff.0.5.0/opam
+++ b/packages/xmldiff/xmldiff.0.5.0/opam
@@ -16,8 +16,8 @@ depends: [
   "ocamlfind"
   "xmlm" {>= "1.1.0" }
 ]
-depopts: [
-  "js_of_ocaml" {>= "2.4.0" }
-]
+depopts: ["js_of_ocaml"]
 ocaml-version: [>= "4.02.0"]
-
+conflicts: [
+  "js_of_ocaml" {< "2.4.0"}
+]

--- a/packages/zbar/zbar.0.9/opam
+++ b/packages/zbar/zbar.0.9/opam
@@ -9,7 +9,7 @@ remove: [
   ["ocamlfind" "remove" "zbar_ctypes"]
 ]
 depends: ["lwt"]
-depopts: [("ctypes" & "ctypes-foreign")]
+depopts: ["ctypes" "ctypes-foreign"]
 depexts: [
 [ ["ubuntu"] ["libzbar-dev"] ]
 [ ["debian"] ["libzbar-dev"] ]


### PR DESCRIPTION
This uses the new opam-admin by-field preserving rewrite (unpushed yet)

We need this conversion first because currently opam 1.2 won't reprint files
with depopts constraints.

Rewrite done by means of opam.git/admin-scripts/depopts-to-conflicts.ml