### PR TITLE
async-zmq.0.2.0 - via opam-publish

### DIFF
--- a/packages/async-zmq/async-zmq.0.2.0/descr
+++ b/packages/async-zmq/async-zmq.0.2.0/descr
@@ -1,0 +1,3 @@
+Async wrapper for OCaml's zeromq bindings
+
+A faithful port of lwt-zmq

--- a/packages/async-zmq/async-zmq.0.2.0/opam
+++ b/packages/async-zmq/async-zmq.0.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+license: "MIT"
+authors: [ "Rudi Grinberg" ]
+
+homepage: "https://github.com/rgrinberg/async-zmq"
+bug-reports: "https://github.com/rgrinberg/async-zmq/issues"
+dev-repo: "https://github.com/rgrinberg/async-zmq.git"
+
+build: [
+  [make "configure"]
+  [make "all"]
+]
+
+install: [make "install"]
+
+remove: [["ocamlfind" "remove" "async_zmq"]]
+
+depends: [
+  "ocamlfind" {build}
+  "obuild" {build}
+  "core"
+  "async"
+  "sexplib"
+  "zmq"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/async-zmq/async-zmq.0.2.0/url
+++ b/packages/async-zmq/async-zmq.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/async-zmq/archive/v0.2.0.tar.gz"
+checksum: "018b28f083b38486ef4929f229130961"


### PR DESCRIPTION
Async wrapper for OCaml's zeromq bindings

A faithful port of lwt-zmq


---
* Homepage: https://github.com/rgrinberg/async-zmq
* Source repo: https://github.com/rgrinberg/async-zmq.git
* Bug tracker: https://github.com/rgrinberg/async-zmq/issues

---

Pull-request generated by opam-publish v0.3.0