### PR TITLE
tree_layout.0.1.0 - via opam-publish

### DIFF
--- a/packages/tree_layout/tree_layout.0.1.0/descr
+++ b/packages/tree_layout/tree_layout.0.1.0/descr
@@ -1,0 +1,1 @@
+Algorithms to layout trees in a pretty manner.

--- a/packages/tree_layout/tree_layout.0.1.0/opam
+++ b/packages/tree_layout/tree_layout.0.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+authors: "Gabriel Radanne"
+homepage: "https://github.com/Drup/tree_layout"
+bug-reports: "https://github.com/Drup/tree_layout/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/Drup/tree_layout.git"
+doc: "https://drup.github.io/tree_layout/0.1.0/"
+build: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--enable-tests" {test}
+    "--enable-benchmark" {test}
+    "--prefix"
+    prefix
+  ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: ["ocaml" "setup.ml" "-test"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "tree_layout"]
+depends: [
+  "ocamlfind" {build}
+  "tyxml" {test}
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/tree_layout/tree_layout.0.1.0/url
+++ b/packages/tree_layout/tree_layout.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Drup/tree_layout/archive/0.1.0.tar.gz"
+checksum: "eaf12c96b8d60b53d535434e8439c417"


### PR DESCRIPTION
Algorithms to layout trees in a pretty manner.


---
* Homepage: https://github.com/Drup/tree_layout
* Source repo: git+https://github.com/Drup/tree_layout.git
* Bug tracker: https://github.com/Drup/tree_layout/issues

---
first release, wouhou ~~

---

Pull-request generated by opam-publish v0.3.1