### PR TITLE
hkdf-1.0.0 - via opam-publish

### DIFF
--- a/packages/hkdf-1/hkdf-1.0.0/descr
+++ b/packages/hkdf-1/hkdf-1.0.0/descr
@@ -1,0 +1,3 @@
+HMAC-based Extract-and-Expand Key Derivation Function (HKDF), RFC5869
+
+An implementation of HKDF, including test cases from RFC 5869, in OCaml.  This is used in various protocols, including IKEv2, PANA, EAP-AKA.

--- a/packages/hkdf-1/hkdf-1.0.0/opam
+++ b/packages/hkdf-1/hkdf-1.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+homepage: "https://github.com/hannesm/ocaml-hkdf"
+bug-reports: "https://github.com/hannesm/ocaml-hkdf/issues"
+license: "BSD2"
+dev-repo: "https://github.com/hannesm/ocaml-hkdf.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+build-test: [
+  ["./configure" "--%{alcotest:enable}%-tests"]
+  [make "test"]
+]
+remove: ["ocamlfind" "remove" "hkdf"]
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.6.0"}
+  "nocrypto" {>= "0.5.0"}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/hkdf-1/hkdf-1.0.0/url
+++ b/packages/hkdf-1/hkdf-1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hannesm/ocaml-hkdf/archive/1.0.0.tar.gz"
+checksum: "c6012ebf7bb23fb8155d90a01e3679e2"


### PR DESCRIPTION
HMAC-based Extract-and-Expand Key Derivation Function (HKDF), RFC5869

An implementation of HKDF, including test cases from RFC 5869, in OCaml.  This is used in various protocols, including IKEv2, PANA, EAP-AKA.

---
* Homepage: https://github.com/hannesm/ocaml-hkdf
* Source repo: https://github.com/hannesm/ocaml-hkdf.git
* Bug tracker: https://github.com/hannesm/ocaml-hkdf/issues

---

Pull-request generated by opam-publish v0.3.1