### PR TITLE
Constraint on `ppx_deriving` in Ketrew 2.0.0

### DIFF
--- a/packages/ketrew/ketrew.2.0.0/opam
+++ b/packages/ketrew/ketrew.2.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "omake" "ocamlfind" "ocamlify"
   "trakeva" "sqlite3" "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"
-  "ppx_deriving" "ppx_deriving_yojson" {>= "2.3"}
+  "ppx_deriving" {>= "3.0"} "ppx_deriving_yojson" {>= "2.3"}
   "cohttp" {>= "0.17.0" } "lwt" "ssl"
   "conduit"
   "js_of_ocaml" {>= "2.6" } "tyxml" "reactiveData"

--- a/packages/ketrew/ketrew.2.0.0/opam
+++ b/packages/ketrew/ketrew.2.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "trakeva" "sqlite3" "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"
   "ppx_deriving" {>= "3.0"} "ppx_deriving_yojson" {>= "2.3"}
-  "cohttp" {>= "0.17.0" } "lwt" "ssl"
+  "cohttp" {>= "0.17.0" } "lwt" {< "2.5.0" } "ssl"
   "conduit"
   "js_of_ocaml" {>= "2.6" } "tyxml" "reactiveData"
   ]


### PR DESCRIPTION
This fixes the issue
[`hammerlab/ketrew#291`](https://github.com/hammerlab/ketrew/issues/291).