### PR TITLE
uchar.0.0.1 - via opam-publish

### DIFF
--- a/packages/uchar/uchar.0.0.1/descr
+++ b/packages/uchar/uchar.0.0.1/descr
@@ -1,0 +1,10 @@
+Compatibility library for OCaml's Uchar module
+
+The `uchar` package provides a compatibility library for the
+[`Uchar`][1] module introduced in OCaml 4.03.
+
+The `uchar` package is distributed under the license of the OCaml
+compiler. See [LICENSE](LICENSE) for details.
+
+[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html
+

--- a/packages/uchar/uchar.0.0.1/opam
+++ b/packages/uchar/uchar.0.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://ocaml.org"
+doc: "https://ocaml.github.io/uchar/"
+dev-repo: "https://github.com/ocaml/uchar.git"
+bug-reports: "https://github.com/ocaml/uchar/issues"
+tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
+license: "typeof OCaml system"
+available: [ ocaml-version >= "3.12.0" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"]
+]

--- a/packages/uchar/uchar.0.0.1/url
+++ b/packages/uchar/uchar.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/uchar/releases/download/v0.0.1/uchar-0.0.1.tbz"
+checksum: "3a7e5de4c4f7f25f55d50693f92f1960"


### PR DESCRIPTION
Compatibility library for OCaml's Uchar module

The `uchar` package provides a compatibility library for the
[`Uchar`][1] module introduced in OCaml 4.03.

The `uchar` package is distributed under the license of the OCaml
compiler. See [LICENSE](LICENSE) for details.

[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html



---
* Homepage: http://ocaml.org
* Source repo: https://github.com/ocaml/uchar.git
* Bug tracker: https://github.com/ocaml/uchar/issues

---

Pull-request generated by opam-publish v0.3.1