### PR TITLE
ocamlbuild bulk deps: add some missing packages

### DIFF
--- a/packages/ackdo-reloaded/ackdo-reloaded.0.3/opam
+++ b/packages/ackdo-reloaded/ackdo-reloaded.0.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 build: [
   [make build]
@@ -9,4 +9,5 @@ depends: [
   "core"
   "sexplib"
   "textutils"
+  "ocamlbuild" {build}
 ]

--- a/packages/ackdo-reloaded/ackdo-reloaded.0.4/opam
+++ b/packages/ackdo-reloaded/ackdo-reloaded.0.4/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 build: [
   [make "build"]
@@ -10,4 +10,5 @@ depends: [
   "sexplib"
   "textutils"
   "kaputt"
+  "ocamlbuild" {build}
 ]

--- a/packages/async_graphics/async_graphics.0.5.1/opam
+++ b/packages/async_graphics/async_graphics.0.5.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Leo White <leo@lpw25.net>"
 authors: ["Leo White <leo@lpw25.net>"]
 license: "LGPL-2.0 with OCaml linking exception"
@@ -11,4 +11,5 @@ remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
   "ocamlfind"
   "async" {>= "109.09.00"}
+  "ocamlbuild" {build}
 ]

--- a/packages/async_graphics/async_graphics.0.5/opam
+++ b/packages/async_graphics/async_graphics.0.5/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Leo White <leo@lpw25.net>"
 authors: ["Leo White <leo@lpw25.net>"]
 license: "LGPL-2.0 with OCaml linking exception"
@@ -11,4 +11,5 @@ remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
   "ocamlfind"
   "async" {>= "109.09.00"}
+  "ocamlbuild" {build}
 ]

--- a/packages/base58/base58.0.1.2/opam
+++ b/packages/base58/base58.0.1.2/opam
@@ -16,5 +16,6 @@ depends: [
   "testsimple" {test}
   "bisect" {test}
   "bisect_ppx" {test}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/bencode/bencode.0.1/opam
+++ b/packages/bencode/bencode.0.1/opam
@@ -1,9 +1,12 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 build: [
   [make "all"]
   [make "install"]
 ]
 remove: [[make "uninstall"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>="4.00.1"]

--- a/packages/bencode/bencode.0.2/opam
+++ b/packages/bencode/bencode.0.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 authors: [ "Rudi Grinberg" "Simon Cruanes" ]
 license: "WTFPL"
@@ -7,5 +7,8 @@ build: [
   [make "install"]
 ]
 remove: [[make "uninstall"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>="4.00.1"]

--- a/packages/bencode/bencode.1.0.0/opam
+++ b/packages/bencode/bencode.1.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 authors: [ "Rudi Grinberg" "Simon Cruanes" ]
 license: "MIT"
@@ -7,5 +7,8 @@ build: [
   [make "install"]
 ]
 remove: [[make "uninstall"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>="4.00.1"]

--- a/packages/bencode/bencode.1.0.1/opam
+++ b/packages/bencode/bencode.1.0.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 authors: [ "Rudi Grinberg" "Simon Cruanes" ]
 license: "MIT"
@@ -9,5 +9,8 @@ build: [
 remove: [
     ["ocamlfind" "remove" "bencode"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>="4.00.1"]

--- a/packages/bencode/bencode.1.0.2/opam
+++ b/packages/bencode/bencode.1.0.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 authors: [ "Rudi Grinberg" "Simon Cruanes" ]
 license: "MIT"
@@ -9,5 +9,8 @@ build: [
 remove: [
     ["ocamlfind" "remove" "bencode"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>="4.00.1"]

--- a/packages/captureio/captureio.0.1.1/opam
+++ b/packages/captureio/captureio.0.1.1/opam
@@ -14,5 +14,6 @@ remove: ["ocamlfind" "remove" "captureio"]
 depends: [
   "ocamlfind" {build}
   "testsimple" {test}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/captureio/captureio.0.1.2/opam
+++ b/packages/captureio/captureio.0.1.2/opam
@@ -14,5 +14,6 @@ remove: ["ocamlfind" "remove" "captureio"]
 depends: [
   "ocamlfind" {build}
   "testsimple" {test}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/cgroups/cgroups.0.1/opam
+++ b/packages/cgroups/cgroups.0.1/opam
@@ -12,6 +12,7 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
   "base-unix"
+  "ocamlbuild" {build}
 ]
 available: [
   ocaml-version >= "4.02.1"

--- a/packages/cmdliner/cmdliner.0.9.4/opam
+++ b/packages/cmdliner/cmdliner.0.9.4/opam
@@ -1,11 +1,14 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/cmdliner"
 authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
 doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
 tags: [ "cli" "system" "declarative" ]
 license: "BSD3"
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "3.12.0"]
 build: 
 [

--- a/packages/cmdliner/cmdliner.0.9.5/opam
+++ b/packages/cmdliner/cmdliner.0.9.5/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/cmdliner"
 #dev-repo: "http://erratique.ch/repos/cmdliner.git"
@@ -6,7 +6,10 @@ authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
 doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
 tags: [ "cli" "system" "declarative" ]
 license: "BSD3"
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "3.12.0"]
 build: 
 [

--- a/packages/cmdliner/cmdliner.0.9.6/opam
+++ b/packages/cmdliner/cmdliner.0.9.6/opam
@@ -7,7 +7,10 @@ dev-repo: "http://erratique.ch/repos/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "BSD3"
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.00.0"]
 build: 
 [

--- a/packages/cmdliner/cmdliner.0.9.7/opam
+++ b/packages/cmdliner/cmdliner.0.9.7/opam
@@ -15,3 +15,6 @@ build:
   ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                           "native-dynlink=%{ocaml-native-dynlink}%" ]
 ]
+depends: [
+  "ocamlbuild" {build}
+]

--- a/packages/cmdliner/cmdliner.0.9.8/opam
+++ b/packages/cmdliner/cmdliner.0.9.8/opam
@@ -14,3 +14,6 @@ build:
   ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                           "native-dynlink=%{ocaml-native-dynlink}%" ]
 ]
+depends: [
+  "ocamlbuild" {build}
+]

--- a/packages/coccinelle/coccinelle.1.0.0-rc24/opam
+++ b/packages/coccinelle/coccinelle.1.0.0-rc24/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 authors: ["Julia Lawall et. al."]
 homepage: "http://coccinelle.lip6.fr/"
 license: "GPL"
@@ -18,6 +18,7 @@ depends: [
   "conf-pkg-config"
   "conf-python-2-7"
   "conf-python-2-7-dev"
+  "ocamlbuild" {build}
 ]
 patches: [
   "opam.patch"

--- a/packages/coccinelle/coccinelle.1.0.2/opam
+++ b/packages/coccinelle/coccinelle.1.0.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 authors: ["Julia Lawall et. al."]
 homepage: "http://coccinelle.lip6.fr/"
 license: "GPL"
@@ -28,4 +28,5 @@ depends: [
   "conf-python-2-7"
   "conf-python-2-7-dev"
   "parmap"
+  "ocamlbuild" {build}
 ]

--- a/packages/cookie-js/cookie-js.1.0.0/opam
+++ b/packages/cookie-js/cookie-js.1.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/ocaml-cookie-js"
 build: [
@@ -11,4 +11,5 @@ remove: [
 depends: [
   "ocamlfind"
   "js_of_ocaml"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.0.9.4/opam
+++ b/packages/cppo/cppo.0.9.4/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
@@ -13,4 +13,5 @@ remove: [
 
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.0.0/opam
+++ b/packages/cppo/cppo.1.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
@@ -12,4 +12,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.0.1/opam
+++ b/packages/cppo/cppo.1.0.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
@@ -12,4 +12,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.1.0/opam
+++ b/packages/cppo/cppo.1.1.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "martin@mjambon.com"
 authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
@@ -12,4 +12,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.1.1/opam
+++ b/packages/cppo/cppo.1.1.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "martin@mjambon.com"
 authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
@@ -12,4 +12,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.1.2/opam
+++ b/packages/cppo/cppo.1.1.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "martin@mjambon.com"
 authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
@@ -12,4 +12,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.2.2/opam
+++ b/packages/cppo/cppo.1.2.2/opam
@@ -14,4 +14,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.3.0/opam
+++ b/packages/cppo/cppo.1.3.0/opam
@@ -16,4 +16,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/cppo/cppo.1.3.1/opam
+++ b/packages/cppo/cppo.1.3.1/opam
@@ -16,4 +16,5 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]

--- a/packages/datalog/datalog.0.1/opam
+++ b/packages/datalog/datalog.0.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/datalog"
 build: [
@@ -9,4 +9,7 @@ remove: [
   ["ocamlfind" "remove" "datalog"]
   ["rm" "%{bin}%/datalog_cli"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]

--- a/packages/datalog/datalog.0.2/opam
+++ b/packages/datalog/datalog.0.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/datalog"
 build: [
@@ -9,4 +9,7 @@ remove: [
   ["ocamlfind" "remove" "datalog"]
   ["rm" "%{bin}%/datalog_cli"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]

--- a/packages/datalog/datalog.0.3.1/opam
+++ b/packages/datalog/datalog.0.3.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/datalog"
 build: [
@@ -9,4 +9,7 @@ remove: [
   ["ocamlfind" "remove" "datalog"]
   ["rm" "%{bin}%/datalog_cli"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]

--- a/packages/datalog/datalog.0.3/opam
+++ b/packages/datalog/datalog.0.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/datalog"
 build: [
@@ -9,4 +9,7 @@ remove: [
   ["ocamlfind" "remove" "datalog"]
   ["rm" "%{bin}%/datalog_cli"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]

--- a/packages/datalog/datalog.0.4.1/opam
+++ b/packages/datalog/datalog.0.4.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/datalog"
 license: "BSD-2-Clause"
@@ -10,4 +10,7 @@ remove: [
   ["ocamlfind" "remove" "datalog"]
   ["rm" "%{bin}%/datalog_cli"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]

--- a/packages/datalog/datalog.0.4/opam
+++ b/packages/datalog/datalog.0.4/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/datalog"
 build: [
@@ -9,4 +9,7 @@ remove: [
   ["ocamlfind" "remove" "datalog"]
   ["rm" "%{bin}%/datalog_cli"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]

--- a/packages/efl/efl.1.12.0/opam
+++ b/packages/efl/efl.1.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer: "Alexis Bernadet <alexis.bernadet at noos.fr>"
-author: "Alexis Bernadet <alexis.bernadet at noos.fr>"
+authors: "Alexis Bernadet <alexis.bernadet at noos.fr>"
 ocaml-version: [>= "3.12"]
 homepage: "https://forge.ocamlcore.org/projects/ocaml-efl/"
 license: "LGPL with linking exception"
@@ -11,8 +11,10 @@ build: [
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "efl"]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depexts: [
   [["source" "linux"] ["https://gist.githubusercontent.com/axiles/7be06b1fac09d99edf9a/raw/e826d3d93753eb0e677e43b4e0b7c066cfc11c4e/install_efl_1_12_on_ubuntu"]]
 ]
-

--- a/packages/efl/efl.1.13.0/opam
+++ b/packages/efl/efl.1.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer: "Alexis Bernadet <alexis.bernadet at noos.fr>"
-author: "Alexis Bernadet <alexis.bernadet at noos.fr>"
+authors: "Alexis Bernadet <alexis.bernadet at noos.fr>"
 ocaml-version: [>= "3.12"]
 homepage: "https://forge.ocamlcore.org/projects/ocaml-efl/"
 license: "LGPL with linking exception"
@@ -11,8 +11,10 @@ build: [
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "efl"]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depexts: [
   [["source" "linux"] ["https://gist.githubusercontent.com/axiles/7be06b1fac09d99edf9a/raw/fc8dc050b5f94d91dd49dda2ba29f3c16815c5a8/install_efl_1_13_on_ubuntu"]]
 ]
-

--- a/packages/eliom/eliom.4.0.0/opam
+++ b/packages/eliom/eliom.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-author: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 homepage: "http://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues/"
@@ -14,10 +14,11 @@ remove: [["rm" "-rf" "%{lib}%/eliom" "%{man}%/man1/eliomc.1" "%{man}%/man1/eliom
 depends: [
   "ocamlfind"
   "deriving"
-  "js_of_ocaml" {>= "2.2" }
+  "js_of_ocaml" {>= "2.2"}
   "calendar"
   "tyxml" {< "3.2"}
   "ocsigenserver" {>= "2.4.0" & < "2.6"}
   "camlp4"
   "ipaddr" {>= "2.1"}
+  "ocamlbuild" {build}
 ]

--- a/packages/eliom/eliom.4.1.0/opam
+++ b/packages/eliom/eliom.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-author: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 homepage: "http://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues/"
@@ -16,6 +16,7 @@ depends: [
   "ocsigenserver" {= "2.5"}
   "ipaddr" {>= "2.1"}
   "reactiveData"
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.00.0" ]
 patches: [

--- a/packages/eliom/eliom.4.2.0/opam
+++ b/packages/eliom/eliom.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-author: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 homepage: "http://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues/"
@@ -15,5 +15,6 @@ depends: [
   "ocsigenserver" {>= "2.6"}
   "ipaddr" {>= "2.1"}
   "reactiveData"
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.00.0" ]

--- a/packages/ezjsonm/ezjsonm.0.4.3/opam
+++ b/packages/ezjsonm/ezjsonm.0.4.3/opam
@@ -23,9 +23,10 @@ remove: ["ocamlfind" "remove" "ezjsonm"]
 depends: [
   "ocamlfind" {build}
   "alcotest" {test & >= "0.4.0"}
-  "lwt"      {test}
+  "lwt" {test}
   "jsonm" {>= "0.9.1"}
   "sexplib"
   "hex"
+  "ocamlbuild" {build}
 ]
 depopts: ["lwt"]

--- a/packages/flowtype/flowtype.0.13.1/opam
+++ b/packages/flowtype/flowtype.0.13.1/opam
@@ -5,7 +5,11 @@ authors: ["Avik Chaudhuri"]
 doc: "http://flowtype.org/docs/getting-started.html"
 dev-repo: "https://github.com/facebook/flow.git"
 license: "BSD3"
-depends: [ "base-unix" "base-bytes" ]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.01.0"]
 build: [ [ make ] ]
 depexts: [

--- a/packages/flowtype/flowtype.0.14.0/opam
+++ b/packages/flowtype/flowtype.0.14.0/opam
@@ -12,7 +12,11 @@ authors: [
 ]
 doc: "http://flowtype.org/docs/getting-started.html"
 license: "BSD3"
-depends: [ "base-unix" "base-bytes" ]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 build: [ [ make ] ]
 depexts: [

--- a/packages/flowtype/flowtype.0.15.0/opam
+++ b/packages/flowtype/flowtype.0.15.0/opam
@@ -12,7 +12,11 @@ authors: [
 ]
 doc: "http://flowtype.org/docs/getting-started.html"
 license: "BSD3"
-depends: [ "base-unix" "base-bytes" ]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 build: [ [ make ] ]
 depexts: [

--- a/packages/flowtype/flowtype.0.17.0/opam
+++ b/packages/flowtype/flowtype.0.17.0/opam
@@ -12,7 +12,11 @@ authors: [
 ]
 doc: "http://flowtype.org/docs/getting-started.html"
 license: "BSD3"
-depends: [ "base-unix" "base-bytes" ]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 build: [ [ make ] ]
 depexts: [

--- a/packages/flowtype/flowtype.0.19.0/opam
+++ b/packages/flowtype/flowtype.0.19.0/opam
@@ -12,7 +12,11 @@ authors: [
 ]
 doc: "http://flowtype.org/docs/getting-started.html"
 license: "BSD3"
-depends: [ "base-unix" "base-bytes" ]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 build: [ [ make ] ]
 depexts: [

--- a/packages/fmt/fmt.0.7.0/opam
+++ b/packages/fmt/fmt.0.7.0/opam
@@ -8,7 +8,10 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "BSD-3-Clause"
 available: [ ocaml-version >= "4.01.0"]
-depends: [ "ocamlfind" ]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: [ "base-unix" ]
 build:
 [

--- a/packages/gg/gg.0.8.0/opam
+++ b/packages/gg/gg.0.8.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
 homepage: "http://erratique.ch/software/gg"
@@ -15,5 +15,8 @@ build: [
   ["./pkg/pkg-git"]
   ["./pkg/build" "true"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.00.0"]

--- a/packages/gg/gg.0.9.0/opam
+++ b/packages/gg/gg.0.9.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/gg"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
@@ -7,7 +7,11 @@ doc: "http://erratique.ch/software/gg/doc/Gg"
 #bug-reports: "https://github.com/dbuenzli/gg/issues"
 tags: [ "matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
 license: "BSD3"
-depends: ["ocamlfind" "base-bigarray"]
+depends: [
+  "ocamlfind"
+  "base-bigarray"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.01.0"]
 build: 
 [

--- a/packages/gg/gg.0.9.1/opam
+++ b/packages/gg/gg.0.9.1/opam
@@ -7,7 +7,11 @@ dev-repo: "http://erratique.ch/repos/gg.git"
 bug-reports: "https://github.com/dbuenzli/gg/issues"
 tags: [ "matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
 license: "BSD-3-Clause"
-depends: ["ocamlfind" "base-bigarray"]
+depends: [
+  "ocamlfind"
+  "base-bigarray"
+  "ocamlbuild" {build}
+]
 available: [ ocaml-version >= "4.01.0" ]
 build:
 [

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.5.19/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.5.19/opam
@@ -17,5 +17,6 @@ depends: [
   "ocamlfind"
   "ocamlfuse"
   "sqlite3"
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "3.12.0"]

--- a/packages/hardcaml-vpi/hardcaml-vpi.0.1.0/opam
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.1.0/opam
@@ -12,6 +12,7 @@ depends: [
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
   "hardcaml"
+  "ocamlbuild" {build}
 ]
 depexts: [
   [["ubuntu"] ["iverilog"]]

--- a/packages/hardcaml-vpi/hardcaml-vpi.0.2/opam
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.2/opam
@@ -12,6 +12,7 @@ depends: [
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
   "hardcaml" {>= "1.1.1"}
+  "ocamlbuild" {build}
 ]
 depexts: [
   [["ubuntu"] ["iverilog"]]

--- a/packages/hardcaml/hardcaml.1.0.0/opam
+++ b/packages/hardcaml/hardcaml.1.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/ujamjar/hardcaml"
 build: [
@@ -13,5 +13,6 @@ depends: [
   "camlp4"
   "lwt"
   "js_of_ocaml"
+  "ocamlbuild" {build}
 ]
 ocaml-version: [ >= "4.01.0" ]

--- a/packages/hevea/hevea.2.01/opam
+++ b/packages/hevea/hevea.2.01/opam
@@ -1,7 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 build: [
   [make "PREFIX=%{prefix}%"]
   [make "install"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]

--- a/packages/hevea/hevea.2.25/opam
+++ b/packages/hevea/hevea.2.25/opam
@@ -13,3 +13,6 @@ remove: [ [ "rm" "-r" "%{lib}%/hevea" ]
 post-messages: [
   "The file 'hevea.sty' has been installed in %{lib}%/hevea but latex won't see it by itself" {success}
 ]
+depends: [
+  "ocamlbuild" {build}
+]

--- a/packages/hkdf/hkdf.1.0.0/opam
+++ b/packages/hkdf/hkdf.1.0.0/opam
@@ -16,6 +16,7 @@ depends: [
   "cstruct" {>= "1.6.0"}
   "nocrypto" {>= "0.5.0"}
   "alcotest" {test}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0"]
 

--- a/packages/imap/imap.0.20.0/opam
+++ b/packages/imap/imap.0.20.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
 authors: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
 license: "MIT"
@@ -10,5 +10,10 @@ build:
                            "native-dynlink=true" # TODO fixme
                            "lwt=%{lwt:installed}%"
                            "ssl=%{ssl:installed}%" ]
-depends: [ "uint" "cryptokit" "uutf" ]
+depends: [
+  "uint"
+  "cryptokit"
+  "uutf"
+  "ocamlbuild" {build}
+]
 depopts: [ "ssl" "lwt" ]

--- a/packages/imap/imap.1.1.0/opam
+++ b/packages/imap/imap.1.1.0/opam
@@ -11,5 +11,6 @@ depends: [
   "uint"
   "base64"
   "uutf"
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/imap/imap.1.1.1/opam
+++ b/packages/imap/imap.1.1.1/opam
@@ -11,5 +11,6 @@ depends: [
   "uint"
   "base64"
   "uutf"
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.0/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.0/opam
@@ -1,10 +1,8 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocaml"
 build: [
   [make "all"]
-]
-remove: [
 ]
 depends: [
   "ocamlfind"
@@ -13,8 +11,9 @@ depends: [
   "uuidm"
   "yojson"
   "atdgen"
-  "ocp-index" {>= "1.0.1"} 
+  "ocp-index" {>= "1.0.1"}
   "zmq" {= "3.2-2"}
+  "ocamlbuild" {build}
 ]
 depexts: [
 [ ["source" "linux"] ["https://gist.github.com/andrewray/179832b0ea39481d0f2c/raw"] ]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.3/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocaml"
 build: [
@@ -15,9 +15,10 @@ depends: [
   "uuidm"
   "yojson"
   "atdgen"
-  "ocp-index" {>= "1.0.1"} 
+  "ocp-index" {>= "1.0.1"}
   "lwt" {>= "2.4"}
   "ctypes" {>= "0.2.3" & < "0.3"}
+  "ocamlbuild" {build}
 ]
 depexts: [
   [["debian"] ["libzmq3-dev"]]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.4/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.4/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocaml"
 build: [
@@ -19,6 +19,7 @@ depends: [
   "lwt" {>= "2.4"}
   "ctypes" {>= "0.4"}
   "ctypes-foreign"
+  "ocamlbuild" {build}
 ]
 depexts: [
   [["debian"] ["libzmq3-dev"]]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.6/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.6/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocaml"
 build: [
@@ -20,6 +20,7 @@ depends: [
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
   "lwt" {>= "2.4"}
+  "ocamlbuild" {build}
 ]
 depopts: ["ocp-index"]
 depexts: [

--- a/packages/iocaml/iocaml.0.4.2/opam
+++ b/packages/iocaml/iocaml.0.4.2/opam
@@ -1,11 +1,9 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocamlserver"
 build: [
   ["cp" "config.darwin.ml" "config.ml"] {os = "darwin"}
   [make "all"]
-]
-remove: [
 ]
 depends: [
   "ocamlfind"
@@ -20,5 +18,6 @@ depends: [
   "crunch"
   "iocaml-kernel" {= "0.4.0"}
   "iocamljs-kernel" {= "0.4.0"}
+  "ocamlbuild" {build}
 ]
 ocaml-version: [ >= "4.01.0" & < "4.02.0" ]

--- a/packages/iocaml/iocaml.0.4.3/opam
+++ b/packages/iocaml/iocaml.0.4.3/opam
@@ -1,11 +1,9 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocamlserver"
 build: [
   ["cp" "config.darwin.ml" "config.ml"] {os = "darwin"}
   [make "all"]
-]
-remove: [
 ]
 depends: [
   "ocamlfind"
@@ -20,5 +18,6 @@ depends: [
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.3"}
   "iocamljs-kernel" {= "0.4.3"}
+  "ocamlbuild" {build}
 ]
 ocaml-version: [ >= "4.01.0" & < "4.02.0" ]

--- a/packages/iocaml/iocaml.0.4.4/opam
+++ b/packages/iocaml/iocaml.0.4.4/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocamlserver"
 build: [
@@ -18,5 +18,6 @@ depends: [
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.4"}
   "iocamljs-kernel" {= "0.4.4"}
+  "ocamlbuild" {build}
 ]
 ocaml-version: [ >= "4.01.0" & < "4.02.0" ]

--- a/packages/iocaml/iocaml.0.4.5/opam
+++ b/packages/iocaml/iocaml.0.4.5/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocamlserver"
 build: [
@@ -18,5 +18,6 @@ depends: [
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.4"}
   "iocamljs-kernel" {= "0.4.5"}
+  "ocamlbuild" {build}
 ]
 ocaml-version: [ >= "4.01.0" & < "4.02.0" ]

--- a/packages/iocaml/iocaml.0.4.6/opam
+++ b/packages/iocaml/iocaml.0.4.6/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocamlserver"
 build: [
@@ -19,5 +19,6 @@ depends: [
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.6"}
   "iocamljs-kernel" {= "0.4.6"}
+  "ocamlbuild" {build}
 ]
 ocaml-version: [ >= "4.00.1" ]

--- a/packages/iocaml/iocaml.0.4.7/opam
+++ b/packages/iocaml/iocaml.0.4.7/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 version: "0.4.7"
-author: "Andrew Ray <andy.ray@ujamjar.com>"
+authors: "Andrew Ray <andy.ray@ujamjar.com>"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/andrewray/iocamlserver"
 dev-repo: "https://github.com/andrewray/iocamlserver.git"
@@ -15,12 +15,13 @@ depends: [
   "yojson"
   "cow"
   "lwt" {>= "2.4"}
-  "websocket" {>= "0.9" & <"1.0"}
+  "websocket" {>= "0.9" & < "1.0"}
   "cohttp" {>= "0.15.0"}
   "crunch"
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.6"}
   "iocamljs-kernel" {= "0.4.6"}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.02.0"  ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.0/opam
@@ -14,8 +14,8 @@ depends: [
   "lwt" {>= "2.4"}
   "menhir"
   "camlp4"
+  "ocamlbuild" {build}
 ]
-
 depopts: ["deriving"]
 conflicts: ["deriving" {< "0.6"}]
 ocaml-version: [<= "4.01.0"]

--- a/packages/js_of_ocaml/js_of_ocaml.2.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.1/opam
@@ -14,8 +14,8 @@ depends: [
   "lwt" {>= "2.4"}
   "menhir"
   "camlp4"
+  "ocamlbuild" {build}
 ]
-
 depopts: ["deriving"]
 conflicts: ["deriving" {< "0.6"}]
 ocaml-version: [<= "4.01.0"]

--- a/packages/js_of_ocaml/js_of_ocaml.2.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.2/opam
@@ -14,8 +14,8 @@ depends: [
   "lwt"
   "menhir"
   "camlp4"
+  "ocamlbuild" {build}
 ]
-
 depopts: ["deriving"]
 conflicts: [
   "deriving" {< "0.6"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.3/opam
@@ -14,6 +14,7 @@ depends: [
   "lwt"
   "menhir"
   "camlp4"
+  "ocamlbuild" {build}
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 

--- a/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
@@ -15,6 +15,7 @@ depends: [
   "lwt"
   "menhir"
   "camlp4"
+  "ocamlbuild" {build}
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 

--- a/packages/js_of_ocaml/js_of_ocaml.2.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4/opam
@@ -15,6 +15,7 @@ depends: [
   "lwt"
   "menhir"
   "camlp4"
+  "ocamlbuild" {build}
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 

--- a/packages/js_of_ocaml/js_of_ocaml.2.5/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.5/opam
@@ -16,6 +16,7 @@ depends: [
   "lwt" {>= "2.4.4"}
   "menhir"
   "camlp4"
+  "ocamlbuild" {build}
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 

--- a/packages/js_of_ocaml/js_of_ocaml.2.6/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.6/opam
@@ -18,9 +18,9 @@ depends: [
   "cppo"
   "camlp4"
   "base64"
-  ( "base-no-ppx" | "ppx_tools" )
+  ("base-no-ppx" | "ppx_tools")
+  "ocamlbuild" {build}
 ]
-
 depopts: ["deriving" "tyxml" "reactiveData" ]
 
 conflicts: [

--- a/packages/key-parsers/key-parsers.0.1.0/opam
+++ b/packages/key-parsers/key-parsers.0.1.0/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer: "Nathan Rebours <nathan@cryptosense.com>"
-author: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Nathan Rebours <nathan@cryptosense.com>"
 homepage: "https://github.com/cryptosense/key-parsers"
 bug-reports: "https://github.com/cryptosense/key-parsers/issues"
 license: "BSD-2"
@@ -12,4 +12,5 @@ depends: [
   "ocamlfind" {build}
   "asn1-combinators"
   "zarith"
+  "ocamlbuild" {build}
 ]

--- a/packages/kinetic-client/kinetic-client.0.0.1/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.1/opam
@@ -16,6 +16,7 @@ depends: [
   "piqi" {build & >= "0.7.1"}
   "lwt"
   "cryptokit"
+  "ocamlbuild" {build}
 ]
 depexts: [
          [["debian"] ["protobuf-compiler"]]

--- a/packages/kinetic-client/kinetic-client.0.0.3/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.3/opam
@@ -16,6 +16,7 @@ depends: [
   "piqi" {build & >= "0.7.1"}
   "lwt"
   "cryptokit"
+  "ocamlbuild" {build}
 ]
 depexts: [
          [["debian"] ["protobuf-compiler"]]

--- a/packages/kinetic-client/kinetic-client.0.0.4/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.4/opam
@@ -16,6 +16,7 @@ depends: [
   "piqi" {build & >= "0.7.1"}
   "lwt"
   "cryptokit"
+  "ocamlbuild" {build}
 ]
 depexts: [
          [["debian"] ["protobuf-compiler"]]

--- a/packages/kinetic-client/kinetic-client.0.0.5/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.5/opam
@@ -16,6 +16,7 @@ depends: [
   "piqi" {build & >= "0.7.1"}
   "lwt"
   "cryptokit"
+  "ocamlbuild" {build}
 ]
 depexts: [
          [["debian"] ["protobuf-compiler"]]

--- a/packages/kinetic-client/kinetic-client.0.0.6/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.6/opam
@@ -17,6 +17,7 @@ depends: [
   "piqi" {build & >= "0.7.1"}
   "lwt"
   "cryptokit"
+  "ocamlbuild" {build}
 ]
 depexts: [
          [["debian"] ["protobuf-compiler"]]
@@ -24,4 +25,3 @@ depexts: [
          [["osx" "homebrew"] ["protobuf"]]
 ]
 available: [ ocaml-version >= "4.02.0" ]
-

--- a/packages/lambdasoup/lambdasoup.0.5/opam
+++ b/packages/lambdasoup/lambdasoup.0.5/opam
@@ -14,4 +14,5 @@ install: [make "ocamlfind-install"]
 remove: ["ocamlfind" "remove" "lambdasoup"]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]

--- a/packages/macaroons/macaroons.0.1.0/opam
+++ b/packages/macaroons/macaroons.0.1.0/opam
@@ -19,6 +19,7 @@ depends: [
   "hex"
   "base64" {>= "2.0.0"}
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]
 depopts: "sodium"
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mlbdd/mlbdd.0.1/opam
+++ b/packages/mlbdd/mlbdd.0.1/opam
@@ -8,4 +8,7 @@ dev-repo: "https://github.com/arlencox/mlbdd.git"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mlbdd"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/mlbdd/mlbdd.0.2/opam
+++ b/packages/mlbdd/mlbdd.0.2/opam
@@ -8,4 +8,7 @@ dev-repo: "https://github.com/arlencox/mlbdd.git"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mlbdd"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/mlbdd/mlbdd.0.3/opam
+++ b/packages/mlbdd/mlbdd.0.3/opam
@@ -8,4 +8,7 @@ dev-repo: "https://github.com/arlencox/mlbdd.git"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mlbdd"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/mlbdd/mlbdd.0.4/opam
+++ b/packages/mlbdd/mlbdd.0.4/opam
@@ -8,4 +8,7 @@ dev-repo: "https://github.com/arlencox/mlbdd.git"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mlbdd"]
-depends: ["ocamlfind" {build}]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/mlbdd/mlbdd.0.5/opam
+++ b/packages/mlbdd/mlbdd.0.5/opam
@@ -8,4 +8,7 @@ dev-repo: "https://github.com/arlencox/mlbdd.git"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mlbdd"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/mlcuddidl/mlcuddidl.2.3.0/opam
+++ b/packages/mlcuddidl/mlcuddidl.2.3.0/opam
@@ -13,4 +13,8 @@ install: [
 remove: [
   ["ocamlfind" "remove" "cudd"]
 ]
-depends: ["ocamlfind" "camlidl"]
+depends: [
+  "ocamlfind"
+  "camlidl"
+  "ocamlbuild" {build}
+]

--- a/packages/msat/msat.0.1/opam
+++ b/packages/msat/msat.0.1/opam
@@ -18,5 +18,6 @@ remove: ["ocamlfind" "remove" "msat"]
 depends: [
   "ocamlfind" {build}
   "base-unix"
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.1"]

--- a/packages/mybuild/mybuild.1/opam
+++ b/packages/mybuild/mybuild.1/opam
@@ -15,4 +15,5 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]

--- a/packages/mybuild/mybuild.2/opam
+++ b/packages/mybuild/mybuild.2/opam
@@ -19,4 +19,5 @@ remove: [
 depends: [
   "ocamlfind" {build}
   "base-unix"
+  "ocamlbuild" {build}
 ]

--- a/packages/mybuild/mybuild.3/opam
+++ b/packages/mybuild/mybuild.3/opam
@@ -19,4 +19,5 @@ remove: [
 depends: [
   "ocamlfind" {build}
   "base-unix"
+  "ocamlbuild" {build}
 ]

--- a/packages/mysql_protocol/mysql_protocol.0.8/opam
+++ b/packages/mysql_protocol/mysql_protocol.0.8/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "stephleg@free.fr"
 build: [
   [make "all"]
@@ -9,5 +9,6 @@ depends: [
   "ocamlfind"
   "cryptokit"
   "bitstring"
+  "ocamlbuild" {build}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/mysql_protocol/mysql_protocol.0.9/opam
+++ b/packages/mysql_protocol/mysql_protocol.0.9/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "stephleg@free.fr"
 build: [
   [make "all"]
@@ -9,5 +9,6 @@ depends: [
   "ocamlfind"
   "cryptokit"
   "bitstring"
+  "ocamlbuild" {build}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/mysql_protocol/mysql_protocol.1.0/opam
+++ b/packages/mysql_protocol/mysql_protocol.1.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "stephleg@free.fr"
 build: [
   [make "all"]
@@ -9,5 +9,6 @@ depends: [
   "ocamlfind"
   "cryptokit"
   "bitstring"
+  "ocamlbuild" {build}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/mysql_protocol/mysql_protocol.1.1/opam
+++ b/packages/mysql_protocol/mysql_protocol.1.1/opam
@@ -16,6 +16,6 @@ depends: [
   "ocamlfind"
   "cryptokit"
   "bitstring"
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.00.0" ]
-

--- a/packages/nanomsg/nanomsg.1.0/opam
+++ b/packages/nanomsg/nanomsg.1.0/opam
@@ -27,8 +27,8 @@ depends: [
   "containers"
   "ipaddr"
   "ppx_deriving"
+  "ocamlbuild" {build}
 ]
-
 depopts: [ "lwt" "ounit" ]
 
 available: [ocaml-version >= "4.02.0"]

--- a/packages/nebula/nebula.0.2.1/opam
+++ b/packages/nebula/nebula.0.2.1/opam
@@ -16,5 +16,6 @@ depends: [
   "ppx_deriving" {>= "2.2"}
   "tsdl" {>= "0.8.1"}
   "utop" {>= "1.18"}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/obeanstalk/obeanstalk.0.1/opam
+++ b/packages/obeanstalk/obeanstalk.0.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "rudi.grinberg@gmail.com"
 build: [[make "opam-install"]]
 remove: [["ocamlfind" "remove" "obeanstalk"]]
@@ -7,4 +7,5 @@ depends: [
   "core" {>= "109.42.00"}
   "async" {>= "109.42.00"}
   "sexplib"
+  "ocamlbuild" {build}
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.5/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.5/doc/html-main/index.html"]
@@ -35,7 +35,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.6/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.6/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.6/doc/html-main/index.html"]
@@ -35,7 +35,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.7/doc/html-main/index.html"]
@@ -35,7 +35,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.4.0.1/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.1/opam
@@ -34,7 +34,10 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 
 ]
-depends: ["ocamlfind" {build}]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 depopts: [
   "conf-gnutls"
   "conf-gssapi"

--- a/packages/ocamlnet/ocamlnet.4.0.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.2/opam
@@ -34,7 +34,10 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 
 ]
-depends: ["ocamlfind" {build}]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 depopts: [
   "conf-gnutls"
   "conf-gssapi"

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -35,7 +35,10 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 
 ]
-depends: ["ocamlfind" {build}]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 depopts: [
   "conf-gnutls"
   "conf-gssapi"

--- a/packages/ocp-indent/ocp-indent.0.1.0/opam
+++ b/packages/ocp-indent/ocp-indent.0.1.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 homepage: "https://github.com/OCamlPro/ocp-indent"
 build: [
@@ -9,4 +9,7 @@ build: [
 remove: [
   ["./configure" "--prefix=%{prefix}%"]
   [make "uninstall"]
+]
+depends: [
+  "ocamlbuild" {build}
 ]

--- a/packages/opa-base/opa-base.1.1.0+4263/opam
+++ b/packages/opa-base/opa-base.1.1.0+4263/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 license: "AGPL"
 build: [
@@ -11,6 +11,7 @@ depends: [
   "ulex"
   "camlzip"
   "ocamlgraph"
+  "ocamlbuild" {build}
 ]
 patches: [
   "configure_notty.patch"

--- a/packages/opam-doc/opam-doc.0.9.0/opam
+++ b/packages/opam-doc/opam-doc.0.9.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 homepage: "https://github.com/ocamllabs/opam-doc"
 tags: [
@@ -12,5 +12,6 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind"
   "cow" {>= "0.8.1"}
+  "ocamlbuild" {build}
 ]
 available: [ preinstalled & (ocaml-version = "4.01.0") ]

--- a/packages/opam-doc/opam-doc.0.9.1/opam
+++ b/packages/opam-doc/opam-doc.0.9.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 homepage: "https://github.com/ocamllabs/opam-doc"
 tags: [
@@ -12,5 +12,6 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind"
   "cow" {>= "0.8.1"}
+  "ocamlbuild" {build}
 ]
 available: [ preinstalled & (ocaml-version = "4.01.0") ]

--- a/packages/opam-doc/opam-doc.0.9.2/opam
+++ b/packages/opam-doc/opam-doc.0.9.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 homepage: "https://github.com/ocamllabs/opam-doc"
 tags: [
@@ -12,5 +12,6 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind"
   "cow" {>= "0.8.1"}
+  "ocamlbuild" {build}
 ]
 available: [ preinstalled & (ocaml-version = "4.01.0") ]

--- a/packages/opam-doc/opam-doc.0.9.3/opam
+++ b/packages/opam-doc/opam-doc.0.9.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 homepage: "https://github.com/ocamllabs/opam-doc"
 tags: [
@@ -12,5 +12,6 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind"
   "cow" {>= "0.8.1"}
+  "ocamlbuild" {build}
 ]
 available: [ preinstalled & (ocaml-version = "4.01.0") ]

--- a/packages/opam-sync-github-prs/opam-sync-github-prs.1.0.0/opam
+++ b/packages/opam-sync-github-prs/opam-sync-github-prs.1.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "anil@recoil.org"
 tags: [
   "org:ocamllabs"
@@ -11,8 +11,9 @@ build: [
 remove: [["rm" "-f" "%{bin}%/opam-sync-github-prs"]]
 depends: [
   "ocamlfind"
-  "core" {>="109.53.01"}
-  "github" {>="0.8.0" & <"1.0.0"}
-  "lwt" {>="2.4.2"}
+  "core" {>= "109.53.01"}
+  "github" {>= "0.8.0" & < "1.0.0"}
+  "lwt" {>= "2.4.2"}
+  "ocamlbuild" {build}
 ]
 ocaml-version: [>="4.01.0"]

--- a/packages/opam-sync-github-prs/opam-sync-github-prs.1.1.0/opam
+++ b/packages/opam-sync-github-prs/opam-sync-github-prs.1.1.0/opam
@@ -16,9 +16,10 @@ install: [
 ]
 remove: [["rm" "-f" "%{bin}%/opam-sync-github-prs"]]
 depends: [
-  "ocamlfind" { build }
-  "core" { build & >="109.53.01"}
-  "github" { build & >="1.0.0" }
-  "lwt" { build & >="2.4.2"}
+  "ocamlfind" {build}
+  "core" {build & >= "109.53.01"}
+  "github" {build & >= "1.0.0"}
+  "lwt" {build & >= "2.4.2"}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/oplay/oplay.1.0.0/opam
+++ b/packages/oplay/oplay.1.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/ujamjar/oplay"
 build: [
@@ -7,4 +7,5 @@ build: [
 depends: [
   "ocamlfind"
   "tsdl"
+  "ocamlbuild" {build}
 ]

--- a/packages/orocksdb/orocksdb.0.1.0/opam
+++ b/packages/orocksdb/orocksdb.0.1.0/opam
@@ -14,11 +14,11 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "rocks"]
 depends: [
   "ocamlfind" {build}
-  "ctypes" { >= "0.4.0" }
-  "ctypes-foreign" { >= "0.4.0"}
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign" {>= "0.4.0"}
   "depext" {build}
+  "ocamlbuild" {build}
 ]
-
 available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
 
 depexts:[
@@ -26,4 +26,3 @@ depexts:[
   [[ "ubuntu"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
   [["source" "linux"] ["https://gist.githubusercontent.com/toolslive/56b9fae64b27d3e00971/raw/60bc8b3f2d8980635500d89bac89e092befac5f9/gistfile1.txt"]]
 ]
-

--- a/packages/orocksdb/orocksdb.0.2.0/opam
+++ b/packages/orocksdb/orocksdb.0.2.0/opam
@@ -14,11 +14,11 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "rocks"]
 depends: [
   "ocamlfind" {build}
-  "ctypes" { >= "0.4.0" }
-  "ctypes-foreign" { >= "0.4.0"}
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign" {>= "0.4.0"}
   "depext" {build}
+  "ocamlbuild" {build}
 ]
-
 available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
 
 depexts:[
@@ -26,4 +26,3 @@ depexts:[
   [[ "ubuntu"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
   [["source" "linux"] ["https://gist.githubusercontent.com/toolslive/22958251b056dcb3131a/raw/14e68d9a0a2480d7be13c31f1fbe126d796c8db3/install.sh"]]
 ]
-

--- a/packages/orocksdb/orocksdb.0.2.1/opam
+++ b/packages/orocksdb/orocksdb.0.2.1/opam
@@ -12,11 +12,11 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "rocks"]
 depends: [
   "ocamlfind" {build}
-  "ctypes" { >= "0.4.0" }
-  "ctypes-foreign" { >= "0.4.0"}
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign" {>= "0.4.0"}
   "depext" {build}
+  "ocamlbuild" {build}
 ]
-
 available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
 
 depexts:[

--- a/packages/otfm/otfm.0.1.0/opam
+++ b/packages/otfm/otfm.0.1.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
 homepage: "http://erratique.ch/software/otfm"
@@ -17,5 +17,6 @@ build: [
 depends: [
   "uutf"
   "ocamlfind"
+  "ocamlbuild" {build}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/otfm/otfm.0.2.0/opam
+++ b/packages/otfm/otfm.0.2.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/otfm"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
@@ -7,7 +7,11 @@ doc: "http://erratique.ch/software/otfm/doc/Otfm"
 #bug-reports: "https://github.com/dbuenzli/otfm/issues"
 tags: [ "OpenType" "ttf" "font" "decoder" "graphics" "org:erratique" ]
 license: "BSD3"
-depends: [ "ocamlfind" "uutf" ]
+depends: [
+  "ocamlfind"
+  "uutf"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.01.0"]
 build: 
 [

--- a/packages/polyglot/polyglot.1.0.0/opam
+++ b/packages/polyglot/polyglot.1.0.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ocamlfind" {build}
   "xmlm"
   "alcotest" {test}
+  "ocamlbuild" {build}
 ]
 depopts: ["cmdliner" "base-unix"]
 available: [ocaml-version >= "4.00.0" & opam-version >= "1.2"]

--- a/packages/rdr/rdr.1.0/opam
+++ b/packages/rdr/rdr.1.0/opam
@@ -5,5 +5,8 @@ bug-reports: "m4b.github.io@gmail.com"
 dev-repo: "git://github.com/m4b/rdr"
 homepage: "http://www.m4b.io"
 build: [make "build"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.02"]

--- a/packages/rdr/rdr.1.1/opam
+++ b/packages/rdr/rdr.1.1/opam
@@ -8,5 +8,8 @@ homepage: "http://www.m4b.io"
 build: [
   [make "build"]
 ]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.02"]

--- a/packages/react/react.1.0.0/opam
+++ b/packages/react/react.1.0.0/opam
@@ -1,11 +1,14 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/react"
 authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
 doc: "http://erratique.ch/software/react/doc/React"
 tags: [ "reactive" "declarative" "signal" "event" "frp" ]
 license: "BSD3"
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "3.11.0"]
 build: 
 [

--- a/packages/react/react.1.0.1/opam
+++ b/packages/react/react.1.0.1/opam
@@ -1,11 +1,14 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/react"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 doc: "http://erratique.ch/software/react/doc/React"
 tags: [ "reactive" "declarative" "signal" "event" "frp" ]
 license: "BSD3"
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "3.11.0"]
 build: 
 [

--- a/packages/react/react.1.1.0/opam
+++ b/packages/react/react.1.1.0/opam
@@ -1,11 +1,14 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/react"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 doc: "http://erratique.ch/software/react/doc/React"
 tags: [ "reactive" "declarative" "signal" "event" "frp" ]
 license: "BSD3"
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "3.11.0"]
 build: 
 [

--- a/packages/react/react.1.2.0/opam
+++ b/packages/react/react.1.2.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/react"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
@@ -7,7 +7,10 @@ doc: "http://erratique.ch/software/react/doc/React"
 #bug-reports: "https://github.com/dbuenzli/react/issues"
 tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
 license: "BSD3"
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.00.0"]
 build: 
 [

--- a/packages/reactiveData/reactiveData.0.1/opam
+++ b/packages/reactiveData/reactiveData.0.1/opam
@@ -1,10 +1,14 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Hugo Heuzard <hugo.heuzard@gmail.com>"
 homepage: "https://github.com/hhugo/reactiveData"
 authors: ["Hugo Heuzard <hugo.heuzard@gmail.com>"]
 tags: [ "reactive" "declarative" "signal" "event" "frp" ]
 license: "LGPL-3.0 with OCaml linking exception"
-depends: ["ocamlfind" "react" {>= "1.0.0"}]
+depends: [
+  "ocamlfind"
+  "react" {>= "1.0.0"}
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "3.11.0"]
 build:
 [

--- a/packages/records/records.0.1.0/opam
+++ b/packages/records/records.0.1.0/opam
@@ -14,5 +14,6 @@ depends: [
   "ocamlfind" {build}
   "ounit" {test}
   "yojson"
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/records/records.0.2.0/opam
+++ b/packages/records/records.0.2.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind" {build}
   "ounit" {test}
   "yojson"
+  "ocamlbuild" {build}
 ]
 depopts: [
   "bisect_ppx" {test}

--- a/packages/records/records.0.3.0/opam
+++ b/packages/records/records.0.3.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind" {build}
   "ounit" {test}
   "yojson"
+  "ocamlbuild" {build}
 ]
 depopts: [
   "bisect_ppx" {test}

--- a/packages/records/records.0.3.1/opam
+++ b/packages/records/records.0.3.1/opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ounit" {test}
   "yojson"
+  "ocamlbuild" {build}
 ]
 depopts: [
   "bisect_ppx" {test}

--- a/packages/rresult/rresult.0.1.0/opam
+++ b/packages/rresult/rresult.0.1.0/opam
@@ -8,7 +8,10 @@ bug-reports: "https://github.com/dbuenzli/rresult/issues"
 tags: [ "result" "error" "declarative" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0"]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 build:
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/rresult/rresult.0.2.0/opam
+++ b/packages/rresult/rresult.0.2.0/opam
@@ -8,7 +8,10 @@ bug-reports: "https://github.com/dbuenzli/rresult/issues"
 tags: [ "result" "error" "declarative" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0"]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 build:
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/rresult/rresult.0.3.0/opam
+++ b/packages/rresult/rresult.0.3.0/opam
@@ -9,8 +9,9 @@ tags: [ "result" "error" "declarative" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0"]
 depends: [
-   "ocamlfind" {build}
-   "result"
+  "ocamlfind" {build}
+  "result"
+  "ocamlbuild" {build}
 ]
 build:
 [

--- a/packages/sgf/sgf.1.0/opam
+++ b/packages/sgf/sgf.1.0/opam
@@ -16,6 +16,6 @@ depends: [
   "sedlex"
   "menhir"
   "rresult"
+  "ocamlbuild" {build}
 ]
-
 available: [ ocaml-version >="4.02.0" ]

--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/opam
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/opam
@@ -25,6 +25,7 @@ conflicts: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]
 depopts: [
   "coq"

--- a/packages/smtp/smtp.0.2/opam
+++ b/packages/smtp/smtp.0.2/opam
@@ -1,9 +1,12 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
 authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
 license: "ISC"
 tags: [ "smtp" ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: ["lwt"]
 build:
 [

--- a/packages/symkat/symkat.1.3/opam
+++ b/packages/symkat/symkat.1.3/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer: "Damien Pous <Damien.Pous@ens-lyon.fr>"
-author: "Damien Pous <Damien.Pous@ens-lyon.fr>"
+authors: "Damien Pous <Damien.Pous@ens-lyon.fr>"
 name: "symkat"
 version: "1.3"
 homepage: "http://perso.ens-lyon.fr/damien.pous/symkat/"
@@ -8,5 +8,9 @@ bug-reports: ""
 license: "GNU LGPL v3"
 build: [make "PREFIX=%{prefix}%" "install"]
 remove: [make "PREFIX=%{prefix}%" "uninstall"]
-depends: ["ocamlfind" {build} "safa" {>= "1.3"}]
+depends: [
+  "ocamlfind" {build}
+  "safa" {>= "1.3"}
+  "ocamlbuild" {build}
+]
 available: [ ocaml-version >= "4.02.0"]

--- a/packages/tree_layout/tree_layout.0.1.0/opam
+++ b/packages/tree_layout/tree_layout.0.1.0/opam
@@ -25,5 +25,6 @@ remove: ["ocamlfind" "remove" "tree_layout"]
 depends: [
   "ocamlfind" {build}
   "tyxml" {test}
+  "ocamlbuild" {build}
 ]
 available: ocaml-version >= "4.01.0"

--- a/packages/tsdl-image/tsdl-image.0.1/opam
+++ b/packages/tsdl-image/tsdl-image.0.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ctypes-foreign"
   "tsdl" {> "0.8.1"}
   "oasis" {build}
+  "ocamlbuild" {build}
 ]
 depexts: [
   [["debian"] ["libsdl2-image-dev"]]

--- a/packages/tsdl/tsdl.0.9.0/opam
+++ b/packages/tsdl/tsdl.0.9.0/opam
@@ -8,7 +8,13 @@ bug-reports: "https://github.com/dbuenzli/tsdl/issues"
 tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci" ]
 license: "BSD-3-Clause"
 available: [ ocaml-version >= "4.00.1" ]
-depends: [ "ocamlfind" {build} "ctypes" {>= "0.4.1"} "ctypes-foreign" "result" ]
+depends: [
+  "ocamlfind" {build}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign"
+  "result"
+  "ocamlbuild" {build}
+]
 depexts: [
  [["debian"] ["libsdl2-dev"]]
  [["ubuntu"] ["libsdl2-dev"]]

--- a/packages/uchar/uchar.0.0.1/opam
+++ b/packages/uchar/uchar.0.0.1/opam
@@ -14,3 +14,6 @@ build:
   [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                            "native-dynlink=%{ocaml-native-dynlink}%"]
 ]
+depends: [
+  "ocamlbuild" {build}
+]

--- a/packages/unix-errno/unix-errno.0.3.0/opam
+++ b/packages/unix-errno/unix-errno.0.3.0/opam
@@ -13,6 +13,7 @@ depends: [
   "alcotest" {test}
   "base-bytes"
   "result"
+  "ocamlbuild" {build}
 ]
 depopts: ["base-unix" "ctypes"]
 conflicts: [

--- a/packages/uucd/uucd.1.0.0/opam
+++ b/packages/uucd/uucd.1.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uucd"
@@ -16,5 +16,6 @@ build: [
 depends: [
   "ocamlfind"
   "xmlm"
+  "ocamlbuild" {build}
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/uucd/uucd.2.0.0/opam
+++ b/packages/uucd/uucd.2.0.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/uucd"
 #dev-repo: "http://erratique.ch/repos/uucd.git"
@@ -7,7 +7,11 @@ doc: "http://erratique.ch/software/uucd/doc/Uucd"
 tags: [ "unicode" "database" "decoder" ]
 license: "BSD3"
 ocaml-version: [>= "4.00.0"]
-depends: [ "ocamlfind" "xmlm" ]
+depends: [
+  "ocamlfind"
+  "xmlm"
+  "ocamlbuild" {build}
+]
 build: 
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/uucd/uucd.3.0.0/opam
+++ b/packages/uucd/uucd.3.0.0/opam
@@ -8,7 +8,11 @@ doc: "http://erratique.ch/software/uucd/doc/Uucd"
 tags: [ "unicode" "database" "decoder" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.00.0"]
-depends: [ "ocamlfind" "xmlm" ]
+depends: [
+  "ocamlfind"
+  "xmlm"
+  "ocamlbuild" {build}
+]
 build: 
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/uucp/uucp.0.9.0/opam
+++ b/packages/uucp/uucp.0.9.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/uucp"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
@@ -6,7 +6,11 @@ doc: "http://erratique.ch/software/uucp/doc/Uucp"
 #dev-repo: "http://erratique.ch/repos/uucp.git"
 tags: [ "unicode" "text" "character" ]
 license: "BSD3"
-depends: [ "ocamlfind" "base-bytes" ]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.00.0"]
 build: 
 [

--- a/packages/uucp/uucp.0.9.1/opam
+++ b/packages/uucp/uucp.0.9.1/opam
@@ -7,7 +7,11 @@ dev-repo: "http://erratique.ch/repos/uucp.git"
 bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "BSD3"
-depends: [ "ocamlfind" "base-bytes" ]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 available: [ ocaml-version >= "4.00.0" ]
 build: 
 [

--- a/packages/uucp/uucp.1.0.0/opam
+++ b/packages/uucp/uucp.1.0.0/opam
@@ -7,7 +7,11 @@ dev-repo: "http://erratique.ch/repos/uucp.git"
 bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "BSD3"
-depends: [ "ocamlfind" "base-bytes" ]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 available: [ ocaml-version >= "4.01.0" ]
 build: 
 [

--- a/packages/uucp/uucp.1.1.0/opam
+++ b/packages/uucp/uucp.1.1.0/opam
@@ -7,7 +7,11 @@ dev-repo: "http://erratique.ch/repos/uucp.git"
 bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "BSD3"
-depends: [ "ocamlfind" "base-bytes" ]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
 available: [ ocaml-version >= "4.00.0" ]
 build:
 [

--- a/packages/uunf/uunf.0.9.2/opam
+++ b/packages/uunf/uunf.0.9.2/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uunf"
@@ -12,6 +12,9 @@ build: [
   ["./pkg/pkg-git"]
   ["./pkg/build" "true" "%{uutf:installed}%"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: ["uutf"]
 ocaml-version: [>= "4.00.0"]

--- a/packages/uunf/uunf.0.9.3/opam
+++ b/packages/uunf/uunf.0.9.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/uunf"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
@@ -8,7 +8,10 @@ tags: [ "unicode" "text" ]
 license: "BSD3"
 depopts: [ "uutf" ]
 ocaml-version: [>= "4.00.0"]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 build: 
 [
   ["./pkg/pkg-git" ]

--- a/packages/uunf/uunf.1.0.0/opam
+++ b/packages/uunf/uunf.1.0.0/opam
@@ -8,7 +8,10 @@ bug-reports: "https://github.com/dbuenzli/uunf/issues"
 tags: [ "unicode" "text" "normalization" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0" ]
-depends: [ "ocamlfind" ]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: [ "uutf" "cmdliner" ]
 build: 
 [

--- a/packages/uuseg/uuseg.0.8.0/opam
+++ b/packages/uuseg/uuseg.0.8.0/opam
@@ -8,8 +8,11 @@ bug-reports: "https://github.com/dbuenzli/uuseg/issues"
 tags: [ "segmentation" "text" "unicode" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0"]
-depends: [ "ocamlfind"
-           "uucp" {>= "0.9.1" & < "1.0.0"} ]
+depends: [
+  "ocamlfind"
+  "uucp" {>= "0.9.1" & < "1.0.0"}
+  "ocamlbuild" {build}
+]
 depopts: [ "uutf"
            "cmdliner"
            "uutf" {test}

--- a/packages/uuseg/uuseg.0.9.0/opam
+++ b/packages/uuseg/uuseg.0.9.0/opam
@@ -8,8 +8,11 @@ bug-reports: "https://github.com/dbuenzli/uuseg/issues"
 tags: [ "segmentation" "text" "unicode" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0"]
-depends: [ "ocamlfind"
-           "uucp" {>= "1.0.0"} ]
+depends: [
+  "ocamlfind"
+  "uucp" {>= "1.0.0"}
+  "ocamlbuild" {build}
+]
 depopts: [ "uutf"
            "cmdliner"
            "uutf" {test}

--- a/packages/uutf/uutf.0.9.3/opam
+++ b/packages/uutf/uutf.0.9.3/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uutf"
@@ -14,5 +14,8 @@ build: [
   ["./pkg/pkg-git"]
   ["./pkg/build" "true"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.00.0"]

--- a/packages/uutf/uutf.0.9.4/opam
+++ b/packages/uutf/uutf.0.9.4/opam
@@ -8,7 +8,10 @@ bug-reports: "https://github.com/dbuenzli/uutf/issues"
 tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.00.0"]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 depopts: ["cmdliner"
           "cmdliner" {test} ]
 conflicts : ["cmdliner" { < "0.9.6" } ]

--- a/packages/vg/vg.0.8.0/opam
+++ b/packages/vg/vg.0.8.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
 homepage: "http://erratique.ch/software/vg"
@@ -18,6 +18,7 @@ build: [
 depends: [
   "ocamlfind"
   "gg" {< "0.9.0"}
+  "ocamlbuild" {build}
 ]
 conflicts: [ "gg" {>= "0.9.0"} ]
 depopts: [

--- a/packages/vg/vg.0.8.1/opam
+++ b/packages/vg/vg.0.8.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/vg"
 authors: ["Daniel Bünzli <daniel.buenzli i@erratique.ch>"]
@@ -8,7 +8,11 @@ doc: "http://erratique.ch/software/vg/doc/Vg"
 tags: [ "pdf" "svg" "html-canvas" "declarative" "graphics" "org:erratique" ]
 license: "BSD3"
 ocaml-version: [>= "4.01.0"]
-depends: [ "ocamlfind" "gg" {>= "0.9.0"} ]
+depends: [
+  "ocamlfind"
+  "gg" {>= "0.9.0"}
+  "ocamlbuild" {build}
+]
 depopts: [ "uutf" "otfm" "js_of_ocaml"  ]
 build: 
 [

--- a/packages/vg/vg.0.8.2/opam
+++ b/packages/vg/vg.0.8.2/opam
@@ -8,7 +8,11 @@ bug-reports: "https://github.com/dbuenzli/vg/issues"
 tags: [ "pdf" "svg" "html-canvas" "declarative" "graphics" "org:erratique" ]
 license: "BSD-3-Clause"
 available: [ ocaml-version >= "4.02.0"]
-depends: [ "ocamlfind" "gg" {>= "0.9.0"} ]
+depends: [
+  "ocamlfind"
+  "gg" {>= "0.9.0"}
+  "ocamlbuild" {build}
+]
 depopts: [ "uutf" "otfm" "js_of_ocaml" "cairo2" ]
 build:
 [

--- a/packages/websocket/websocket.0.9.1/opam
+++ b/packages/websocket/websocket.0.9.1/opam
@@ -12,8 +12,9 @@ tags: [
 build: [make]
 depends: [
   "lwt" {>= "2.4.7"}
-  "tls" {>= "0.2" & <"0.4"}
-  "cohttp" {>= "0.12.0" & <"0.19.0"}
+  "tls" {>= "0.2" & < "0.4"}
+  "cohttp" {>= "0.12.0" & < "0.19.0"}
   "ocplib-endian" {>= "0.4"}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/websocket/websocket.0.9.2/opam
+++ b/packages/websocket/websocket.0.9.2/opam
@@ -12,8 +12,9 @@ tags: [
 build: [make]
 depends: [
   "lwt" {>= "2.4.7"}
-  "tls" {>= "0.2" & <"0.4"}
-  "cohttp" {>= "0.12.0" & <"0.19.0"}
+  "tls" {>= "0.2" & < "0.4"}
+  "cohttp" {>= "0.12.0" & < "0.19.0"}
   "ocplib-endian" {>= "0.4"}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/websocket/websocket.0.9.3/opam
+++ b/packages/websocket/websocket.0.9.3/opam
@@ -13,8 +13,9 @@ tags: [
 build: [make]
 depends: [
   "lwt" {>= "2.4.8"}
-  "tls" {>= "0.4" & <"0.5"}
-  "cohttp" {>= "0.14.0" & <"0.19.0"}
+  "tls" {>= "0.4" & < "0.5"}
+  "cohttp" {>= "0.14.0" & < "0.19.0"}
   "ocplib-endian" {>= "0.8"}
+  "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/websocket/websocket.2.0.0/opam
+++ b/packages/websocket/websocket.2.0.0/opam
@@ -19,11 +19,11 @@ build: [
 depends: [
   "lwt" {>= "2.4.8"}
   "containers" {>= "0.10"}
-  "cohttp" {>= "0.17.1" & <"0.19.0"}
+  "cohttp" {>= "0.17.1" & < "0.19.0"}
   "ocplib-endian" {>= "0.8"}
   "ppx_deriving" {>= "2.0"}
   "nocrypto" {>= "0.4.0"}
   "conduit" {>= "0.8.3"}
+  "ocamlbuild" {build}
 ]
-
 available: [ ocaml-version >="4.02.0" ]

--- a/packages/websocket/websocket.2.1/opam
+++ b/packages/websocket/websocket.2.1/opam
@@ -23,6 +23,6 @@ depends: [
   "ppx_deriving" {>= "2.0"}
   "nocrypto" {>= "0.5.0"}
   "conduit" {>= "0.8.3"}
+  "ocamlbuild" {build}
 ]
-
 available: [ ocaml-version >="4.02.0" ]

--- a/packages/xmlm/xmlm.1.2.0/opam
+++ b/packages/xmlm/xmlm.1.2.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/xmlm"
@@ -12,5 +12,8 @@ build: [
   ["./pkg/pkg-git"]
   ["./pkg/build" "true"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 ocaml-version: [>= "4.00.0"]


### PR DESCRIPTION
Guillaume Bury reported a typo in the ocamlbuild-detection logic: it
looked for a file name "_tag" instead of "_tags", and thus missed some
ocamlbuild users. The present patch is the result of re-running the
script after fixing this: 171 additional packages are detected to use
ocamlbuild (including a few maintained by Guillaume Bury).

The last commit on master at the time the script was re-run was

> commit a939e2dd452c9cd24a55a359cb09faa145f63b32
> Merge: 58e08f2 7016e0b
> Author: yallop <yallop@gmail.com>
> Date:   Tue Dec 1 23:08:32 2015 +0000
>
>     Merge pull request #5221 from gabelevi/flowtype
>
>     +flowtype.0.19.0