### PR TITLE
Add ocamlbuild dep:  detect plugins

### DIFF
--- a/packages/bap/bap.0.9.6/opam
+++ b/packages/bap/bap.0.9.6/opam
@@ -55,7 +55,7 @@ depends: [
   "utop"
   "zarith"
   "piqi" {>= "0.7.4"}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depexts: [
     [["ubuntu"] [

--- a/packages/bap/bap.0.9.7/opam
+++ b/packages/bap/bap.0.9.7/opam
@@ -54,7 +54,7 @@ depends: [
   "utop"
   "zarith"
   "piqi" {>= "0.7.4"}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depexts: [
     [["ubuntu"] [

--- a/packages/bap/bap.0.9.8/opam
+++ b/packages/bap/bap.0.9.8/opam
@@ -55,7 +55,7 @@ depends: [
   "zarith"
   "piqi" {>= "0.7.4"}
   "uuidm"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depexts: [
     [["ubuntu"] [

--- a/packages/bap/bap.0.9.9/opam
+++ b/packages/bap/bap.0.9.9/opam
@@ -55,7 +55,7 @@ depends: [
   "zarith"
   "piqi" {>= "0.7.4"}
   "uuidm"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depexts: [
     [["ubuntu"] [

--- a/packages/cppo/cppo.0.9.4/opam
+++ b/packages/cppo/cppo.0.9.4/opam
@@ -11,7 +11,4 @@ remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
 
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.0.0/opam
+++ b/packages/cppo/cppo.1.0.0/opam
@@ -10,7 +10,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.0.1/opam
+++ b/packages/cppo/cppo.1.0.1/opam
@@ -10,7 +10,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.1.0/opam
+++ b/packages/cppo/cppo.1.1.0/opam
@@ -10,7 +10,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.1.1/opam
+++ b/packages/cppo/cppo.1.1.1/opam
@@ -10,7 +10,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.1.2/opam
+++ b/packages/cppo/cppo.1.1.2/opam
@@ -10,7 +10,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.2.2/opam
+++ b/packages/cppo/cppo.1.2.2/opam
@@ -12,7 +12,4 @@ build: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.3.0/opam
+++ b/packages/cppo/cppo.1.3.0/opam
@@ -14,7 +14,4 @@ install: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/cppo/cppo.1.3.1/opam
+++ b/packages/cppo/cppo.1.3.1/opam
@@ -14,7 +14,4 @@ install: [
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/eliom/eliom.4.0.0/opam
+++ b/packages/eliom/eliom.4.0.0/opam
@@ -20,5 +20,5 @@ depends: [
   "ocsigenserver" {>= "2.4.0" & < "2.6"}
   "camlp4"
   "ipaddr" {>= "2.1"}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/eliom/eliom.4.1.0/opam
+++ b/packages/eliom/eliom.4.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocsigenserver" {= "2.5"}
   "ipaddr" {>= "2.1"}
   "reactiveData"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 available: [ ocaml-version >= "4.00.0" ]
 patches: [

--- a/packages/eliom/eliom.4.2.0/opam
+++ b/packages/eliom/eliom.4.2.0/opam
@@ -15,6 +15,6 @@ depends: [
   "ocsigenserver" {>= "2.6"}
   "ipaddr" {>= "2.1"}
   "reactiveData"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 available: [ ocaml-version >= "4.00.0" ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4"}
   "menhir"
   "camlp4"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depopts: ["deriving"]
 conflicts: ["deriving" {< "0.6"}]

--- a/packages/js_of_ocaml/js_of_ocaml.2.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.1/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4"}
   "menhir"
   "camlp4"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depopts: ["deriving"]
 conflicts: ["deriving" {< "0.6"}]

--- a/packages/js_of_ocaml/js_of_ocaml.2.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.2/opam
@@ -9,13 +9,7 @@ build: [
 remove: [
   ["ocamlfind" "remove" "js_of_ocaml"]
 ]
-depends: [
-  "ocamlfind"
-  "lwt"
-  "menhir"
-  "camlp4"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "lwt" "menhir" "camlp4" "ocamlbuild"]
 depopts: ["deriving"]
 conflicts: [
   "deriving" {< "0.6"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.3/opam
@@ -9,13 +9,7 @@ build: [
 remove: [
   ["ocamlfind" "remove" "js_of_ocaml"]
 ]
-depends: [
-  "ocamlfind"
-  "lwt"
-  "menhir"
-  "camlp4"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "lwt" "menhir" "camlp4" "ocamlbuild"]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 
 conflicts: [

--- a/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
@@ -9,14 +9,7 @@ build: [
 remove: [
   ["ocamlfind" "remove" "js_of_ocaml"]
 ]
-depends: [
-  "base-unix"
-  "ocamlfind"
-  "lwt"
-  "menhir"
-  "camlp4"
-  "ocamlbuild" {build}
-]
+depends: ["base-unix" "ocamlfind" "lwt" "menhir" "camlp4" "ocamlbuild"]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 
 conflicts: [

--- a/packages/js_of_ocaml/js_of_ocaml.2.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4/opam
@@ -9,14 +9,7 @@ build: [
 remove: [
   ["ocamlfind" "remove" "js_of_ocaml"]
 ]
-depends: [
-  "base-unix"
-  "ocamlfind"
-  "lwt"
-  "menhir"
-  "camlp4"
-  "ocamlbuild" {build}
-]
+depends: ["base-unix" "ocamlfind" "lwt" "menhir" "camlp4" "ocamlbuild"]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 
 conflicts: [

--- a/packages/js_of_ocaml/js_of_ocaml.2.5/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.5/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt" {>= "2.4.4"}
   "menhir"
   "camlp4"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 

--- a/packages/js_of_ocaml/js_of_ocaml.2.6/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.6/opam
@@ -19,7 +19,7 @@ depends: [
   "camlp4"
   "base64"
   ("base-no-ppx" | "ppx_tools")
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 

--- a/packages/libres3/libres3.0.9/opam
+++ b/packages/libres3/libres3.0.9/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlnet" {>= "3.7.4" & < "4.0.0"}
   "lwt" {>= "2.4.2"}
   "ocsigenserver" {>= "2.5"}
-  "sqlite3"
+  "sqlite3" # for ocsigenserver, choose sqlite3 as dbm doesn't build
   "dns" {>= "0.9.0"}
   "re"
   "ounit"

--- a/packages/libres3/libres3.0.9/opam
+++ b/packages/libres3/libres3.0.9/opam
@@ -20,11 +20,11 @@ depends: [
   "ocamlnet" {>= "3.7.4" & < "4.0.0"}
   "lwt" {>= "2.4.2"}
   "ocsigenserver" {>= "2.5"}
-  "sqlite3" # for ocsigenserver, choose sqlite3 as dbm doesn't build
+  "sqlite3"
   "dns" {>= "0.9.0"}
   "re"
   "ounit"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 build-test: [
     ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]

--- a/packages/libres3/libres3.1.0/opam
+++ b/packages/libres3/libres3.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlnet" {>= "3.7.4" & < "4.0.0"}
   "lwt" {>= "2.4.2"}
   "ocsigenserver" {>= "2.5"}
-  "sqlite3"
+  "sqlite3" # for ocsigenserver, choose sqlite3 as dbm doesn't build
   "dns" {>= "0.10.0"}
   "re"
   "ounit"

--- a/packages/libres3/libres3.1.0/opam
+++ b/packages/libres3/libres3.1.0/opam
@@ -20,11 +20,11 @@ depends: [
   "ocamlnet" {>= "3.7.4" & < "4.0.0"}
   "lwt" {>= "2.4.2"}
   "ocsigenserver" {>= "2.5"}
-  "sqlite3" # for ocsigenserver, choose sqlite3 as dbm doesn't build
+  "sqlite3"
   "dns" {>= "0.10.0"}
   "re"
   "ounit"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 build-test: [
     ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]

--- a/packages/libres3/libres3.1.1/opam
+++ b/packages/libres3/libres3.1.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlnet" {>= "3.7.4" & < "4.0.0"}
   "lwt" {>= "2.4.2"}
   "ocsigenserver" {>= "2.5"}
-  "sqlite3"
+  "sqlite3" # for ocsigenserver, choose sqlite3 as dbm doesn't build
   "dns" {>= "0.10.0"}
   "re"
   "ounit"

--- a/packages/libres3/libres3.1.1/opam
+++ b/packages/libres3/libres3.1.1/opam
@@ -21,11 +21,11 @@ depends: [
   "ocamlnet" {>= "3.7.4" & < "4.0.0"}
   "lwt" {>= "2.4.2"}
   "ocsigenserver" {>= "2.5"}
-  "sqlite3" # for ocsigenserver, choose sqlite3 as dbm doesn't build
+  "sqlite3"
   "dns" {>= "0.10.0"}
   "re"
   "ounit"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 build-test: [
     ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]

--- a/packages/mezzo/mezzo.0.0.m8/opam
+++ b/packages/mezzo/mezzo.0.0.m8/opam
@@ -3,14 +3,7 @@ maintainer: "jonathan.protzenko@inria.fr"
 homepage: "http://protz.github.io/mezzo/"
 license: "GPL-2"
 depends: [
-  "ocamlfind"
-  "yojson"
-  "ulex"
-  "menhir"
-  "fix"
-  "functory"
-  "pprint"
-  "ocamlbuild" {build}
+  "ocamlfind" "yojson" "ulex" "menhir" "fix" "functory" "pprint" "ocamlbuild"
 ]
 patches: [
   "no-deprecated-fatal-warning.patch"

--- a/packages/mybuild/mybuild.1/opam
+++ b/packages/mybuild/mybuild.1/opam
@@ -15,5 +15,5 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/mybuild/mybuild.2/opam
+++ b/packages/mybuild/mybuild.2/opam
@@ -19,5 +19,5 @@ remove: [
 depends: [
   "ocamlfind" {build}
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/mybuild/mybuild.3/opam
+++ b/packages/mybuild/mybuild.3/opam
@@ -19,5 +19,5 @@ remove: [
 depends: [
   "ocamlfind" {build}
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/oasis-mirage/oasis-mirage.0.3.0/opam
+++ b/packages/oasis-mirage/oasis-mirage.0.3.0/opam
@@ -20,6 +20,6 @@ depends: [
   "ocaml-data-notation"
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 conflicts: ["oasis"]

--- a/packages/oasis-mirage/oasis-mirage.0.3.0a/opam
+++ b/packages/oasis-mirage/oasis-mirage.0.3.0a/opam
@@ -20,6 +20,6 @@ depends: [
   "ocaml-data-notation"
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 conflicts: ["oasis"]

--- a/packages/oasis/oasis.0.2.0/opam
+++ b/packages/oasis/oasis.0.2.0/opam
@@ -19,5 +19,5 @@ depends: [
   "ocaml-data-notation"
   "pcre"
   "expect"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/oasis/oasis.0.3.0/opam
+++ b/packages/oasis/oasis.0.3.0/opam
@@ -11,9 +11,5 @@ remove: [
   ["ocamlfind" "remove" "oasis"]
 ]
 depends: [
-  "ocamlfind"
-  "ocaml-data-notation"
-  "ocamlify"
-  "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlfind" "ocaml-data-notation" "ocamlify" "ocamlmod" "ocamlbuild"
 ]

--- a/packages/oasis/oasis.0.4.0/opam
+++ b/packages/oasis/oasis.0.4.0/opam
@@ -15,5 +15,5 @@ depends: [
   "ocaml-data-notation" {>= "0.0.11"}
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/oasis/oasis.0.4.1/opam
+++ b/packages/oasis/oasis.0.4.1/opam
@@ -15,5 +15,5 @@ depends: [
   "ocaml-data-notation" {>= "0.0.11"}
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/oasis/oasis.0.4.2/opam
+++ b/packages/oasis/oasis.0.4.2/opam
@@ -15,5 +15,5 @@ depends: [
   "ocaml-data-notation" {>= "0.0.11"}
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/oasis/oasis.0.4.3/opam
+++ b/packages/oasis/oasis.0.4.3/opam
@@ -15,5 +15,5 @@ depends: [
   "ocaml-data-notation" {>= "0.0.11"}
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/oasis/oasis.0.4.4/opam
+++ b/packages/oasis/oasis.0.4.4/opam
@@ -15,5 +15,5 @@ depends: [
   "ocaml-data-notation" {>= "0.0.11"}
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]

--- a/packages/oasis/oasis.0.4.5/opam
+++ b/packages/oasis/oasis.0.4.5/opam
@@ -34,7 +34,7 @@ depends: [
   "ocamlmod" {build}
   "ounit" {test & >= "2.0.0"}
   "pcre" {test}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 conflicts: [
   "oasis-mirage" {= "0.3.0a"}

--- a/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/opam
+++ b/packages/ocamlbuild-atdgen/ocamlbuild-atdgen.0.1.0/opam
@@ -18,6 +18,6 @@ remove: [
 
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/ocamlnet/ocamlnet.3.7.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.5/opam
@@ -35,10 +35,7 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.6/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.6/opam
@@ -35,10 +35,7 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -35,10 +35,7 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.4.0.1/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.1/opam
@@ -36,7 +36,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depopts: [
   "conf-gnutls"

--- a/packages/ocamlnet/ocamlnet.4.0.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.2/opam
@@ -36,7 +36,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depopts: [
   "conf-gnutls"

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -37,7 +37,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild"
 ]
 depopts: [
   "conf-gnutls"

--- a/packages/otags/otags.3.12.5/opam
+++ b/packages/otags/otags.3.12.5/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "sebastien.fricker@gmail.com"
 build: [
   ["./configure" "--prefix" prefix]
@@ -6,3 +6,4 @@ build: [
   [make "install"]
 ]
 ocaml-version: [< "4.00.0"]
+depends: ["ocamlbuild"]

--- a/packages/otags/otags.4.00.1/opam
+++ b/packages/otags/otags.4.00.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "sebastien.fricker@gmail.com"
 build: [
   ["./configure" "--prefix" prefix]
@@ -6,3 +6,4 @@ build: [
   [make "install"]
 ]
 ocaml-version: [>= "4.00.0" & < "4.01.0"]
+depends: ["ocamlbuild"]

--- a/packages/otags/otags.4.01.1/opam
+++ b/packages/otags/otags.4.01.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "tews@os.inf.tu-dresden.de"
 build: [
   ["./configure" "--prefix" prefix]
@@ -6,3 +6,4 @@ build: [
   [make "install"]
 ]
 ocaml-version: [= "4.01.0"]
+depends: ["ocamlbuild"]

--- a/packages/rml/rml.1.08.04/opam
+++ b/packages/rml/rml.1.08.04/opam
@@ -7,6 +7,4 @@ build: [
 ]
 remove: [[make "uninstall"]]
 ocaml-version: [<= "4.00.1"]
-depends: [
-  "ocamlbuild" {build}
-]
+depends: ["ocamlbuild"]

--- a/packages/rml/rml.1.08.05/opam
+++ b/packages/rml/rml.1.08.05/opam
@@ -8,6 +8,4 @@ build: [
 ]
 remove: [[make "uninstall"]]
 ocaml-version: [<= "4.00.1"]
-depends: [
-  "ocamlbuild" {build}
-]
+depends: ["ocamlbuild"]

--- a/packages/rml/rml.1.08.06/opam
+++ b/packages/rml/rml.1.08.06/opam
@@ -8,6 +8,4 @@ build: [
 ]
 remove: [[make "uninstall"]]
 ocaml-version: [<= "4.00.1"]
-depends: [
-  "ocamlbuild" {build}
-]
+depends: ["ocamlbuild"]

--- a/packages/rml/rml.1.09.00/opam
+++ b/packages/rml/rml.1.09.00/opam
@@ -7,7 +7,4 @@ build: [
   [make "install"]
 ]
 remove: [[make "uninstall"]]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/rml/rml.1.09.01/opam
+++ b/packages/rml/rml.1.09.01/opam
@@ -7,7 +7,4 @@ build: [
   [make "install"]
 ]
 remove: [[make "uninstall"]]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/rml/rml.1.09.02/opam
+++ b/packages/rml/rml.1.09.02/opam
@@ -9,7 +9,4 @@ build: [
 remove: [
 [make "uninstall"]
 ]
-depends: [
-  "ocamlfind"
-  "ocamlbuild" {build}
-]
+depends: ["ocamlfind" "ocamlbuild"]

--- a/packages/rml/rml.1.09.03/opam
+++ b/packages/rml/rml.1.09.03/opam
@@ -10,6 +10,4 @@ remove: [
  ["./configure" "--prefix" "%{prefix}%"]
  [make "uninstall"]
 ]
-depends: [
-  "ocamlbuild" {build}
-]
+depends: ["ocamlbuild"]


### PR DESCRIPTION
This PR builds on top of the not-yet-merged #5226, but #5226 is very simple and this one relies on a considerably more sophisticated logic, so I thought it would be good to split the two.

The present PR implements a suggestion of @Drup to detect packages that use ocamlbuild not only as their build system (build-time dependency), but actually distribute libraries or executables linked with ocamlbuild libraries (typically, ocamlbuild plugins). The idea is to look for uses of the `Ocamlbuild_plugin` module appearing in source code inside the package. It needed a lot of additional refinements to work, but it now has zero false positives over opam-repository packages (I checked). 65 packages are updated to have a full dependency over ocamlbuild, which validates the guess that it is a minority of packages (around 3000 packages have a build-time dependency).

The heuristics used to test this are a bit too complex for their own good and thus a bit fragile (see the [updated script](https://github.com/gasche/opam/commit/85b897fad8291230e8f72b23980382a0c9284039) which gained a lot of complexity), but the resulting diff against opam-repository is small and can be easily checked to contain no false positives. (In my script there is a comment listing the packages I was surprised to find in the list, and why they deserve to be in it.) I thus think that this PR is actually rather safe, and could be merged right now.