### PR TITLE
Yojson: support bytecode-only systems

### DIFF
--- a/packages/yojson/yojson.1.0.3/opam
+++ b/packages/yojson/yojson.1.0.3/opam
@@ -1,7 +1,8 @@
 opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all"] {!ocaml-native}
   [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]

--- a/packages/yojson/yojson.1.0.3/opam
+++ b/packages/yojson/yojson.1.0.3/opam
@@ -1,8 +1,14 @@
 opam-version: "1.2"
-maintainer: "contact@ocamlpro.com"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/yojson.html"
+bug-reports: "https://github.com/mjambon/yojson/issues"
+dev-repo: "https://github.com/mjambon/yojson.git"
 build: [
   [make] {ocaml-native}
   [make "all"] {!ocaml-native}
+]
+install: [
   [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]

--- a/packages/yojson/yojson.1.1.3/opam
+++ b/packages/yojson/yojson.1.1.3/opam
@@ -1,7 +1,8 @@
 opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all"] {!ocaml-native}
   [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]

--- a/packages/yojson/yojson.1.1.3/opam
+++ b/packages/yojson/yojson.1.1.3/opam
@@ -1,8 +1,14 @@
 opam-version: "1.2"
-maintainer: "contact@ocamlpro.com"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/yojson.html"
+bug-reports: "https://github.com/mjambon/yojson/issues"
+dev-repo: "https://github.com/mjambon/yojson.git"
 build: [
   [make] {ocaml-native}
   [make "all"] {!ocaml-native}
+]
+install: [
   [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [["ocamlfind" "remove" "yojson"]]

--- a/packages/yojson/yojson.1.2.3/opam
+++ b/packages/yojson/yojson.1.2.3/opam
@@ -5,7 +5,8 @@ homepage: "http://mjambon.com/yojson.html"
 bug-reports: "https://github.com/mjambon/yojson/issues"
 dev-repo: "https://github.com/mjambon/yojson.git"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all"] {!ocaml-native}
 ]
 install: [
   [make "install-lib"]


### PR DESCRIPTION
For targets that use opam but do not have a native code compiler (and hence have `ocaml-native = false`), this makes it possible to install this library.

Cc @mjambon 