### PR TITLE
enumerators.0.1.1 - via opam-publish

### DIFF
--- a/packages/enumerators/enumerators.0.1.1/descr
+++ b/packages/enumerators/enumerators.0.1.1/descr
@@ -1,0 +1,5 @@
+Finite lazy enumerators
+
+This library enables you to work with large sequences of elements.  It provides
+constructors and combinators to build finite sequences that can be iterated through with a
+low memory footprint.

--- a/packages/enumerators/enumerators.0.1.1/opam
+++ b/packages/enumerators/enumerators.0.1.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Bertrand Bonnefoy-Claudet <bertrand@cryptosense.com>"
+authors: "Bertrand Bonnefoy-Claudet <bertrand@cryptosense.com>"
+homepage: "https://github.com/cryptosense/enumerators"
+bug-reports: "https://github.com/cryptosense/enumerators/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/enumerators.git"
+build: [
+    [make] {ocaml-native}
+    [make "byte"] {!ocaml-native}
+]
+install: [make "install"]
+build-test: [make "check"]
+remove: ["ocamlfind" "remove" "enumerators"]
+depends: [
+  "ocamlfind" {build}
+  "ounit" {test}
+]
+depopts: [
+  "bisect_ppx" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/enumerators/enumerators.0.1.1/url
+++ b/packages/enumerators/enumerators.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/cryptosense/enumerators/archive/v0.1.1.tar.gz"
+checksum: "8e5c1392d4aa12e0baf49076cf650c9b"


### PR DESCRIPTION
Finite lazy enumerators

This library enables you to work with large sequences of elements.  It provides
constructors and combinators to build finite sequences that can be iterated through with a
low memory footprint.


---
* Homepage: https://github.com/cryptosense/enumerators
* Source repo: https://github.com/cryptosense/enumerators.git
* Bug tracker: https://github.com/cryptosense/enumerators/issues

---

Pull-request generated by opam-publish v0.3.1