### PR TITLE
fmt.0.7.1 - via opam-publish

### DIFF
--- a/packages/fmt/fmt.0.7.1/descr
+++ b/packages/fmt/fmt.0.7.1/descr
@@ -1,0 +1,13 @@
+OCaml Format pretty-printer combinators
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][1].
+
+Fmt is distributed under the BSD3 license.
+
+[1]: http://erratique.ch/software/cmdliner
+

--- a/packages/fmt/fmt.0.7.1/opam
+++ b/packages/fmt/fmt.0.7.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/fmt"
+doc: "http://erratique.ch/software/fmt"
+dev-repo: "http://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.01.0"]
+depends: [ "ocamlfind" {build} "ocamlbuild" {build} ]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "unix=%{base-unix:installed}%"
+                           "cmdliner=%{cmdliner:installed}%" ]
+]

--- a/packages/fmt/fmt.0.7.1/url
+++ b/packages/fmt/fmt.0.7.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/fmt/releases/fmt-0.7.1.tbz"
+checksum: "484dd80fbf6a11fed59a71f69b3ec4b1"


### PR DESCRIPTION
OCaml Format pretty-printer combinators

Fmt exposes combinators to devise `Format` pretty-printing functions.

Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
library that allows to setup formatters for terminal color output
depends on the Unix library. The optional `Fmt_cli` library that
provides command line support for Fmt depends on [`Cmdliner`][1].

Fmt is distributed under the BSD3 license.

[1]: http://erratique.ch/software/cmdliner



---
* Homepage: http://erratique.ch/software/fmt
* Source repo: http://erratique.ch/repos/fmt.git
* Bug tracker: https://github.com/dbuenzli/fmt/issues

---

Pull-request generated by opam-publish v0.3.1