### PR TITLE
upcoming nocrypto no longer provides Cs.equal, while x509-0.4 depends…

### DIFF
--- a/packages/x509/x509.0.4.0/opam
+++ b/packages/x509/x509.0.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "type_conv"
   "sexplib"
   "asn1-combinators" {>= "0.1.1"}
-  "nocrypto" {>= "0.5.0"}
+  "nocrypto" {>= "0.5.0" & < "0.5.2"}
   "ounit" {test}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
… on it