### PR TITLE
logs.0.4.2 - via opam-publish

### DIFF
--- a/packages/logs/logs.0.4.2/descr
+++ b/packages/logs/logs.0.4.2/descr
@@ -1,0 +1,22 @@
+Logging infrastructure for OCaml
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` depends only on the `result` compatibility package. The
+optional `Logs_stdo` reporter on standard outputs depends
+on [Fmt][1].  The `Logs_browser` reporter that reports to the web
+browser console depends on [js_of_ocaml][2]. The optional `Logs_cli`
+library that provides command line support for controlling Logs
+depends on [`Cmdliner`][3].
+
+Logs and its reporters are distributed under the BSD3 license.
+
+[1]: http://ocsigen.org/js_of_ocaml/
+[2]: http://erratique.ch/software/fmt
+[3]: http://erratique.ch/software/cmdliner
+

--- a/packages/logs/logs.0.4.2/opam
+++ b/packages/logs/logs.0.4.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/logs"
+doc: "http://erratique.ch/software/logs"
+dev-repo: "http://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.02.0"]
+depends: [ "ocamlfind" {build} "ocamlbuild" {build} "result" ]
+depopts: [ "js_of_ocaml" "fmt" "cmdliner" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "jsoo=%{js_of_ocaml:installed}%"
+                           "fmt=%{fmt:installed}%"
+                           "cmdliner=%{cmdliner:installed}%" ]
+]

--- a/packages/logs/logs.0.4.2/url
+++ b/packages/logs/logs.0.4.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/logs/releases/logs-0.4.2.tbz"
+checksum: "ca937a070ade70ac58ab2d5402af5f72"


### PR DESCRIPTION
Logging infrastructure for OCaml

Logs provides a logging infrastructure for OCaml. Logging is performed
on sources whose reporting level can be set independently. Log message
report is decoupled from logging and is handled by a reporter.

A few optional log reporters are distributed with the base library and
the API easily allows to implement your own.

`Logs` depends only on the `result` compatibility package. The
optional `Logs_stdo` reporter on standard outputs depends
on [Fmt][1].  The `Logs_browser` reporter that reports to the web
browser console depends on [js_of_ocaml][2]. The optional `Logs_cli`
library that provides command line support for controlling Logs
depends on [`Cmdliner`][3].

Logs and its reporters are distributed under the BSD3 license.

[1]: http://ocsigen.org/js_of_ocaml/
[2]: http://erratique.ch/software/fmt
[3]: http://erratique.ch/software/cmdliner



---
* Homepage: http://erratique.ch/software/logs
* Source repo: http://erratique.ch/repos/logs.git
* Bug tracker: https://github.com/dbuenzli/logs/issues

---

Pull-request generated by opam-publish v0.3.1