### PR TITLE
cppo: support bytecode-only systems

### DIFF
--- a/packages/cppo/cppo.1.2.2/opam
+++ b/packages/cppo/cppo.1.2.2/opam
@@ -8,6 +8,8 @@ license: "BSD-3-Clause"
 build: [
   [make] {ocaml-native}
   [make "all" "ocamlbuild"] {!ocaml-native}
+]
+install: [
   [make "install-lib"]
 ]
 remove: [

--- a/packages/cppo/cppo.1.2.2/opam
+++ b/packages/cppo/cppo.1.2.2/opam
@@ -6,7 +6,8 @@ dev-repo: "https://github.com/mjambon/cppo.git"
 bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all" "ocamlbuild"] {!ocaml-native}
   [make "install-lib"]
 ]
 remove: [

--- a/packages/cppo/cppo.1.3.0/opam
+++ b/packages/cppo/cppo.1.3.0/opam
@@ -6,7 +6,8 @@ dev-repo: "https://github.com/mjambon/cppo.git"
 bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all" "ocamlbuild"] {!ocaml-native}
 ]
 install: [
   [make "install-lib"]

--- a/packages/cppo/cppo.1.3.1/opam
+++ b/packages/cppo/cppo.1.3.1/opam
@@ -6,7 +6,8 @@ dev-repo: "https://github.com/mjambon/cppo.git"
 bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all" "ocamlbuild"] {!ocaml-native}
 ]
 install: [
   [make "install-lib"]


### PR DESCRIPTION
For targets that use opam but do not have a native code compiler, this makes it
possible to install this library.

This mechanism is not available on opam <1.2, so it applies only to the versions
with a opam-version: "1".

cc @mjambon 

Thanks!