### PR TITLE
dht.0.2.0 - via opam-publish

### DIFF
--- a/packages/dht/dht.0.2.0/descr
+++ b/packages/dht/dht.0.2.0/descr
@@ -1,0 +1,2 @@
+OCaml bindings for Juliusz Chroboczek's dht C library
+found at <https://www.github.com/jech/dht>

--- a/packages/dht/dht.0.2.0/opam
+++ b/packages/dht/dht.0.2.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+authors: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+homepage: "https://www.github.com/nojb/ocaml-dht"
+bug-reports: "https://www.github.com/nojb/ocaml-dht/issues"
+license: "MIT"
+dev-repo: "https://www.github.com/nojb/ocaml-dht.git"
+available: [ ocaml-version >= "4.02.0" ]
+build: [make "lib"]
+depends:
+[
+  "base-bytes"
+  "ocamlfind" {build}
+]

--- a/packages/dht/dht.0.2.0/url
+++ b/packages/dht/dht.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nojb/ocaml-dht/archive/0.2.0.tar.gz"
+checksum: "8a1364aa280d2402bfb9c9e120abaa58"


### PR DESCRIPTION
OCaml bindings for Juliusz Chroboczek's dht C library
found at <https://www.github.com/jech/dht>


---
* Homepage: https://www.github.com/nojb/ocaml-dht
* Source repo: https://www.github.com/nojb/ocaml-dht.git
* Bug tracker: https://www.github.com/nojb/ocaml-dht/issues

---

Pull-request generated by opam-publish v0.3.1