### PR TITLE
Add compilers down to ocaml 3 07

### DIFF
--- a/compilers/3.07/3.07/3.07.comp
+++ b/compilers/3.07/3.07/3.07.comp
@@ -1,0 +1,20 @@
+opam-version: "1"
+version: "3.07"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
+patches:
+  # ensure sed is not interpreting characters >= 128
+  ["file:///home/herbelin/remove_DEBUG.patch"]
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.07/3.07/3.07.descr
+++ b/compilers/3.07/3.07/3.07.descr
@@ -1,0 +1,1 @@
+Official 3.07 release

--- a/compilers/3.07/3.07/files/remove_DEBUG.patch
+++ b/compilers/3.07/3.07/files/remove_DEBUG.patch
@@ -1,0 +1,13 @@
+*** /home/herbelin/.opam/3.07/build/ocaml/ocamldoc/remove_DEBUG	2003-07-27 11:13:43.000000000 +0200
+--- a	2015-11-30 08:09:39.000000000 +0100
+***************
+*** 5,8 ****
+  # respecting the cpp # line annotation conventions
+  
+  echo "# 1 \"$1\""
+! sed -e '/DEBUG/s/.*//' "$1"
+--- 5,8 ----
+  # respecting the cpp # line annotation conventions
+  
+  echo "# 1 \"$1\""
+! LC_ALL=C sed -e '/DEBUG/s/.*//' "$1"

--- a/compilers/3.08.0/3.08.0/3.08.0.comp
+++ b/compilers/3.08.0/3.08.0/3.08.0.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.08.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.0/3.08.0/3.08.0.descr
+++ b/compilers/3.08.0/3.08.0/3.08.0.descr
@@ -1,0 +1,1 @@
+Official 3.08.0 release

--- a/compilers/3.08.1/3.08.1/3.08.1.comp
+++ b/compilers/3.08.1/3.08.1/3.08.1.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.08.1"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.1/3.08.1/3.08.1.descr
+++ b/compilers/3.08.1/3.08.1/3.08.1.descr
@@ -1,0 +1,1 @@
+Official 3.08.1 release

--- a/compilers/3.08.2/3.08.2/3.08.2.comp
+++ b/compilers/3.08.2/3.08.2/3.08.2.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.08.2"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.2/3.08.2/3.08.2.descr
+++ b/compilers/3.08.2/3.08.2/3.08.2.descr
@@ -1,0 +1,1 @@
+Official 3.08.2 release

--- a/compilers/3.08.3/3.08.3/3.08.3.comp
+++ b/compilers/3.08.3/3.08.3/3.08.3.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.08.3"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.3/3.08.3/3.08.3.descr
+++ b/compilers/3.08.3/3.08.3/3.08.3.descr
@@ -1,0 +1,1 @@
+Official 3.08.3 release

--- a/compilers/3.08.4/3.08.4/3.08.4.comp
+++ b/compilers/3.08.4/3.08.4/3.08.4.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.08.4"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.4/3.08.4/3.08.4.descr
+++ b/compilers/3.08.4/3.08.4/3.08.4.descr
@@ -1,0 +1,1 @@
+Official 3.08.4 release

--- a/compilers/3.09.0/3.09.0/3.09.0.comp
+++ b/compilers/3.09.0/3.09.0/3.09.0.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.09.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.0/3.09.0/3.09.0.descr
+++ b/compilers/3.09.0/3.09.0/3.09.0.descr
@@ -1,0 +1,1 @@
+Official 3.09.0 release

--- a/compilers/3.09.1/3.09.1/3.09.1.comp
+++ b/compilers/3.09.1/3.09.1/3.09.1.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.09.1"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.1/3.09.1/3.09.1.descr
+++ b/compilers/3.09.1/3.09.1/3.09.1.descr
@@ -1,0 +1,1 @@
+Official 3.09.1 release

--- a/compilers/3.09.2/3.09.2/3.09.2.comp
+++ b/compilers/3.09.2/3.09.2/3.09.2.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.09.2"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.2/3.09.2/3.09.2.descr
+++ b/compilers/3.09.2/3.09.2/3.09.2.descr
@@ -1,0 +1,1 @@
+Official 3.09.2 release

--- a/compilers/3.09.3/3.09.3/3.09.3.comp
+++ b/compilers/3.09.3/3.09.3/3.09.3.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.09.3"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.3/3.09.3/3.09.3.descr
+++ b/compilers/3.09.3/3.09.3/3.09.3.descr
@@ -1,0 +1,1 @@
+Official 3.09.3 release

--- a/compilers/3.10.0/3.10.0/3.10.0.comp
+++ b/compilers/3.10.0/3.10.0/3.10.0.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.10.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.10.0/3.10.0/3.10.0.descr
+++ b/compilers/3.10.0/3.10.0/3.10.0.descr
@@ -1,0 +1,1 @@
+Official 3.10.0 release

--- a/compilers/3.10.1/3.10.1/3.10.1.comp
+++ b/compilers/3.10.1/3.10.1/3.10.1.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.10.1"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.10.1/3.10.1/3.10.1.descr
+++ b/compilers/3.10.1/3.10.1/3.10.1.descr
@@ -1,0 +1,1 @@
+Official 3.10.1 release

--- a/compilers/3.10.2/3.10.2/3.10.2.comp
+++ b/compilers/3.10.2/3.10.2/3.10.2.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.10.2"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.2.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.10.2/3.10.2/3.10.2.descr
+++ b/compilers/3.10.2/3.10.2/3.10.2.descr
@@ -1,0 +1,1 @@
+Official 3.10.2 release

--- a/compilers/3.11.0/3.11.0/3.11.0.comp
+++ b/compilers/3.11.0/3.11.0/3.11.0.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.11.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.11.0/3.11.0/3.11.0.descr
+++ b/compilers/3.11.0/3.11.0/3.11.0.descr
@@ -1,0 +1,1 @@
+Official 3.11.0 release

--- a/compilers/3.11.1/3.11.1/3.11.1.comp
+++ b/compilers/3.11.1/3.11.1/3.11.1.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.11.1"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.11.1/3.11.1/3.11.1.descr
+++ b/compilers/3.11.1/3.11.1/3.11.1.descr
@@ -1,0 +1,1 @@
+Official 3.11.1 release

--- a/compilers/3.12.0/3.12.0/3.12.0.comp
+++ b/compilers/3.12.0/3.12.0/3.12.0.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "3.12.0"
+src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.12.0/3.12.0/3.12.0.descr
+++ b/compilers/3.12.0/3.12.0/3.12.0.descr
@@ -1,0 +1,1 @@
+Official 3.12.0 release

--- a/packages/lablgtk/lablgtk.2.14.2-oasis8/opam
+++ b/packages/lablgtk/lablgtk.2.14.2-oasis8/opam
@@ -5,6 +5,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
 ]
+available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
 depends: ["ocamlfind" "camlp4"]
 depexts: [

--- a/packages/lablgtk/lablgtk.2.16.0/opam
+++ b/packages/lablgtk/lablgtk.2.16.0/opam
@@ -6,8 +6,9 @@ build: [
   [make "world"]
   [make "install"]
 ]
+available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" "camlp4"]
+depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
 depopts: [
   "conf-gtksourceview"
   "conf-gnomecanvas"

--- a/packages/lablgtk/lablgtk.2.18.2/opam
+++ b/packages/lablgtk/lablgtk.2.18.2/opam
@@ -6,8 +6,9 @@ build: [
   [make "world"]
   [make "install"]
 ]
+available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" "camlp4"]
+depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
 depopts: [
   "conf-gtksourceview"
   "conf-gnomecanvas"

--- a/packages/lablgtk/lablgtk.2.18.3/opam
+++ b/packages/lablgtk/lablgtk.2.18.3/opam
@@ -6,8 +6,9 @@ build: [
   [make "world"]
   [make "install"]
 ]
+available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" "camlp4"]
+depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
 depopts: [
   "conf-gtksourceview"
   "conf-gnomecanvas"

--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -6,7 +6,7 @@ build: [
   [make "opt"]
   [make "install"]
 ]
-ocaml-version: [< "3.12.2"]
+available: [(ocaml-version >= "3.08") & (ocaml-version < "3.12.2")]
 depexts: [
   [ ["debian"] ["m4"] ]
   [ ["ubuntu"] ["m4"] ] 

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -7,7 +7,7 @@ build: [
   [make "install"]
   ["ocamlfind" "remove" "dbm"]
 ]
-ocaml-version: [<= "4.01.0"]
+available: [(ocaml-version >= "3.08") & (ocaml-version <= "4.01.0")] # ocamlfind uses Arg.align of 3.08
 depexts: [
   [ ["debian"] ["m4"] ]
   [ ["ubuntu"] ["m4"] ] 

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -14,3 +14,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -14,3 +14,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -19,3 +19,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.10.0"] # needs ocamldep -modules

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -19,3 +19,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.10.0"] # needs ocamldep -modules

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -19,3 +19,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.10.0"] # needs ocamldep -modules

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -20,3 +20,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -23,3 +23,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -23,3 +23,4 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
+available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs


### PR DESCRIPTION
Hi, for testing purpose, I created packages for older versions of OCaml. I'm advertising them in case it might be useful for others.

I just adapted the model made for the 3.12.1 package, making the assumption that the build and install process for 3.12.1 was similarly relevant for versions prior to 3.12.1 (+ a patch for 3.07). At least, I could use these versions of OCaml without apparent problems.

I also added the corresponding necessary constraints over ocaml versions for ocamlfind and lablgtk.