### PR TITLE
socket-daemon.0.1.0 - via opam-publish

### DIFF
--- a/packages/socket-daemon/socket-daemon.0.1.0/descr
+++ b/packages/socket-daemon/socket-daemon.0.1.0/descr
@@ -1,0 +1,6 @@
+Create daemons listening to a socket for stop, restart, ..., orders
+
+Lwt-oriented library to make your server run as a daemon and
+listen to a socket file. Provides a module to create the command-line
+client which send commands (stop, restart, ...) to the server through
+the socket.

--- a/packages/socket-daemon/socket-daemon.0.1.0/opam
+++ b/packages/socket-daemon/socket-daemon.0.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://github.com/zoggy/ocaml-socket-daemon"
+bug-reports: "https://github.com/zoggy/ocaml-socket-daemon/issues"
+license: "GNU General Public License version 3"
+doc: "http://github.com/zoggy/ocaml-socket-daemon"
+tags: ["socket" "daemon" "unix"]
+dev-repo: "https://github.com/zoggy/ocaml-socket-daemon.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "socket-daemon"]
+depends: [
+  "lwt" {>= "2.5"}
+  "ppx_deriving_yojson" {>= "2.4"}
+]
+available: [ocaml-version >= "4.02.2"]

--- a/packages/socket-daemon/socket-daemon.0.1.0/url
+++ b/packages/socket-daemon/socket-daemon.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/ocaml-socket-daemon/archive/0.1.0.tar.gz"
+checksum: "f6b01fb8fe450a61676c4ac745c484a5"


### PR DESCRIPTION
Create daemons listening to a socket for stop, restart, ..., orders

Lwt-oriented library to make your server run as a daemon and
listen to a socket file. Provides a module to create the command-line
client which send commands (stop, restart, ...) to the server through
the socket.


---
* Homepage: http://github.com/zoggy/ocaml-socket-daemon
* Source repo: https://github.com/zoggy/ocaml-socket-daemon.git
* Bug tracker: https://github.com/zoggy/ocaml-socket-daemon/issues

---

Pull-request generated by opam-publish v0.3.1