### PR TITLE
taglog.0.3.0 - via opam-publish

### DIFF
--- a/packages/taglog/taglog.0.3.0/descr
+++ b/packages/taglog/taglog.0.3.0/descr
@@ -1,0 +1,1 @@
+Logging library using levels and tags to determine what to log.

--- a/packages/taglog/taglog.0.3.0/opam
+++ b/packages/taglog/taglog.0.3.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/ocaml-taglog/"
+bug-reports: "https://github.com/zoggy/ocaml-taglog/issues"
+license: "GNU Lesser General Public License version 3"
+doc: "http://zoggy.github.io/ocaml-taglog/doc.html"
+tags: "log"
+dev-repo: "https://github.com/zoggy/ocaml-taglog.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "taglog"]
+depends: [
+  "ocamlfind"
+  "ocf" {>= "0.4.0"}
+]
+available: [ocaml-version >= "4.02.1"]

--- a/packages/taglog/taglog.0.3.0/url
+++ b/packages/taglog/taglog.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://zoggy.github.io/ocaml-taglog/taglog-0.3.0.tar.gz"
+checksum: "5a92b93659cdb1b0bdd657e1ff9ae2b9"


### PR DESCRIPTION
Logging library using levels and tags to determine what to log.


---
* Homepage: http://zoggy.github.io/ocaml-taglog/
* Source repo: https://github.com/zoggy/ocaml-taglog.git
* Bug tracker: https://github.com/zoggy/ocaml-taglog/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1