### PR TITLE
Easy-format: support bytecode-only systems

### DIFF
--- a/packages/easy-format/easy-format.1.1.0/opam
+++ b/packages/easy-format/easy-format.1.1.0/opam
@@ -5,7 +5,8 @@ homepage: "http://mjambon.com/easy-format.html"
 bug-reports: "https://github.com/mjambon/easy-format/issues"
 dev-repo: "https://github.com/mjambon/easy-format.git"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all"] {!ocaml-native}
 ]
 install: [
   [make "install"]

--- a/packages/easy-format/easy-format.1.2.0/opam
+++ b/packages/easy-format/easy-format.1.2.0/opam
@@ -5,7 +5,8 @@ homepage: "http://mjambon.com/easy-format.html"
 bug-reports: "https://github.com/mjambon/easy-format/issues"
 dev-repo: "https://github.com/mjambon/easy-format.git"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "all"] {!ocaml-native}
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
For targets that use opam but do not have a native code compiler, this makes it
possible to install this library.

This mechanism is not available on opam <1.2, so it applies only to the versions
with a opam-version: "1".

Thanks!

(I only have a couple more like these and I'm done :))