### PR TITLE
Install BER MetaOCaml from the github.com/metaocaml repository.

### DIFF
--- a/compilers/4.02.1/4.02.1+BER/4.02.1+BER.comp
+++ b/compilers/4.02.1/4.02.1+BER/4.02.1+BER.comp
@@ -1,9 +1,6 @@
 opam-version: "1"
 version: "4.02.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
-patches:[
-  "https://gist.githubusercontent.com/yallop/7d7e471ece10f5893642/raw/18b0937472780970ccaf18df35b0c824b5ca478a/ber-n102.patch"
-]
+src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-n102.tar.gz"
 build: [
   ["./configure" "-prefix" "%{prefix}%"]
   ["%{make}%" "world" "bootstrap" "opt" "opt.opt"]


### PR DESCRIPTION
Use the [organisation repository](https://github.com/metaocaml/ber-metaocaml/releases/tag/ber-n102) rather than a gist-hosted patch.