### PR TITLE
+xen-gnt.2.2.1

### DIFF
--- a/packages/xen-gnt/xen-gnt.2.2.1/descr
+++ b/packages/xen-gnt/xen-gnt.2.2.1/descr
@@ -1,0 +1,5 @@
+Xen grant table bindings
+
+These allow your program (running either in userspace or in kernelspace
+via MirageOS) to read and write memory exported by other VMs on the same host.
+These APIs are the foundation of all inter-VM communication on Xen.

--- a/packages/xen-gnt/xen-gnt.2.2.1/opam
+++ b/packages/xen-gnt/xen-gnt.2.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "john.else@citrix.com"
+homepage:      "https://github.com/mirage/ocaml-gnt"
+bug-reports:   "https://github.com/mirage/ocaml-gnt/issues"
+dev-repo:      "https://github.com/mirage/ocaml-gnt.git"
+build: [
+  [make]
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
+depends: [
+  "ounit"
+  "cstruct" {>= "1.0.1"}
+  "io-page"
+  "lwt" {>= "2.4.3"}
+  "cmdliner"
+  "mirage-profile" {>= "0.3"}
+  "ocamlbuild" {build}
+]
+depexts: [
+  [["debian"] ["libxen-dev"]]
+  [["ubuntu"] ["libxen-dev"]]
+]
+ocaml-version: [>="4.00.0"]

--- a/packages/xen-gnt/xen-gnt.2.2.1/opam
+++ b/packages/xen-gnt/xen-gnt.2.2.1/opam
@@ -1,10 +1,13 @@
 opam-version: "1.2"
 maintainer: "john.else@citrix.com"
+authors: [ "Anil Madhavapeddy" "Dave Scott" "John Else" "Thomas Leonard" ]
 homepage:      "https://github.com/mirage/ocaml-gnt"
 bug-reports:   "https://github.com/mirage/ocaml-gnt/issues"
 dev-repo:      "https://github.com/mirage/ocaml-gnt.git"
 build: [
   [make]
+]
+install: [
   [make "PREFIX=%{prefix}%" "install"]
 ]
 remove: [
@@ -23,4 +26,4 @@ depexts: [
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
 ]
-ocaml-version: [>="4.00.0"]
+available: [ ocaml-version >= "4.00.0" ]

--- a/packages/xen-gnt/xen-gnt.2.2.1/url
+++ b/packages/xen-gnt/xen-gnt.2.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-gnt/archive/v2.2.1.tar.gz"
+checksum: "2c043c42a298ff163ff0e58d5da3c71e"


### PR DESCRIPTION
2.2.1 (16-Dec-2015):
* Start `gntref` counter at zero. (#19)
  Before, the initialisation code decreased the counter for each
  page added to the free list, causing the counter to start negative.
