### PR TITLE
transmission-rpc.1.0 - via opam-publish

### DIFF
--- a/packages/transmission-rpc/transmission-rpc.1.0/descr
+++ b/packages/transmission-rpc/transmission-rpc.1.0/descr
@@ -1,0 +1,8 @@
+A client library for the Transmission Bittorrent client RPC
+An OCaml client library for the Transmission Bittorrent client RPC
+supporting all the available methods while remaining voluntarily close
+to the interface specification. To each specified method corresponds a
+function which take advantages of some OCaml niceties: labelled
+arguments, optional arguments for optional parameters and variant
+types.
+

--- a/packages/transmission-rpc/transmission-rpc.1.0/opam
+++ b/packages/transmission-rpc/transmission-rpc.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Benoit Bataille <benoit.bataille@gmail.com>"
+authors: [ "Benoit Bataille <benoit.bataille@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/bataille/ocaml-transmission-rpc"
+bug-reports: "https://github.com/bataille/ocaml-transmission-rpc/issues"
+dev-repo: "https://github.com/bataille/ocaml-transmission-rpc.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "transmission-rpc"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "cohttp"
+  "lwt"
+  "ocamlfind" {build}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "2.0"}
+  "rresult"
+  "yojson"
+]

--- a/packages/transmission-rpc/transmission-rpc.1.0/url
+++ b/packages/transmission-rpc/transmission-rpc.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/bataille/ocaml-transmission-rpc/archive/1.0.tar.gz"
+checksum: "a1fd3f45728686185203c09d5d6c50f2"


### PR DESCRIPTION
A client library for the Transmission Bittorrent client RPC
An OCaml client library for the Transmission Bittorrent client RPC
supporting all the available methods while remaining voluntarily close
to the interface specification. To each specified method corresponds a
function which take advantages of some OCaml niceties: labelled
arguments, optional arguments for optional parameters and variant
types.



---
* Homepage: https://github.com/bataille/ocaml-transmission-rpc
* Source repo: https://github.com/bataille/ocaml-transmission-rpc.git
* Bug tracker: https://github.com/bataille/ocaml-transmission-rpc/issues

---

Pull-request generated by opam-publish v0.3.1