### PR TITLE
ppx_deriving.{2.0..3.0}: constrain ocam-version >= "4.02.2".

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.2.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.0/opam
@@ -17,4 +17,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version = "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version = "4.02.2" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.1/opam
@@ -17,4 +17,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version >= "4.02.2" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.2/opam
@@ -17,4 +17,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version >= "4.02.2" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.3.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.0/opam
@@ -28,4 +28,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version >= "4.02.2" & opam-version >= "1.2"]


### PR DESCRIPTION
Per https://github.com/whitequark/ppx_deriving/issues/42.