### PR TITLE
libudev.0.1 - via opam-publish

### DIFF
--- a/packages/libudev/libudev.0.1/descr
+++ b/packages/libudev/libudev.0.1/descr
@@ -1,0 +1,1 @@
+Bindings to libudev for OCaml

--- a/packages/libudev/libudev.0.1/opam
+++ b/packages/libudev/libudev.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Armael <armael@isomorphis.me>"
+authors: "Armael <armael@isomorphis.me>"
+homepage: "https://github.com/Armael/ocaml-libudev"
+bug-reports: "https://github.com/Armael/ocaml-libudev/issues"
+license: "MIT"
+dev-repo: "https://github.com/Armael/ocaml-libudev.git"
+available: [ ocaml-version >= "4.01.0" ]
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign"
+  "stdint"
+]
+depexts: [
+  [["debian"] ["libudev-dev"]]
+  [["ubuntu"] ["libudev-dev"]]
+]

--- a/packages/libudev/libudev.0.1/url
+++ b/packages/libudev/libudev.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Armael/ocaml-libudev/archive/v0.1.zip"
+checksum: "3668c064e1559b5218d28cc9196c254d"


### PR DESCRIPTION
Bindings to libudev for OCaml


---
* Homepage: https://github.com/Armael/ocaml-libudev
* Source repo: https://github.com/Armael/ocaml-libudev.git
* Bug tracker: https://github.com/Armael/ocaml-libudev/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1