### PR TITLE
Bring iocaml up-to-date

### DIFF
--- a/packages/iocaml-kernel/iocaml-kernel.0.4.8/descr
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.8/descr
@@ -1,0 +1,1 @@
+An OCaml kernel for the IPython notebook.

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.8/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.8/opam
@@ -33,7 +33,7 @@ depexts: [
   [["osx" "homebrew"] ["zeromq"]]
   [["centos"] ["zeromq3-devel"]]
 ]
-available: [ ocaml_version >= "4.00.1" ]
+available: [ ocaml-version >= "4.02.0"  ]
 conflicts: [
   "ocp-index" {< "1.0.1"}
 ]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.8/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.8/opam
@@ -1,8 +1,13 @@
 opam-version: "1.2"
-maintainer: "andy.ray@ujamjar.com"
+maintainer: "Andy Ray <andy.ray@ujamjar.com>"
+authors: "Andy Ray <andy.ray@ujamjar.com>"
 homepage: "https://github.com/andrewray/iocaml"
+dev-repo: "https://github.com/andrewray/iocaml.git"
+bug-reports: "https://github.com/andrewray/iocaml/issues"
 build: [
   [ make "all" ]
+]
+install: [
   [ make "install" ]
 ]
 remove: [
@@ -28,7 +33,7 @@ depexts: [
   [["osx" "homebrew"] ["zeromq"]]
   [["centos"] ["zeromq3-devel"]]
 ]
-ocaml-version: [ >= "4.00.1" ]
+available: [ ocaml_version >= "4.00.1" ]
 conflicts: [
   "ocp-index" {< "1.0.1"}
 ]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.8/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.8/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocaml"
+build: [
+  [ make "all" ]
+  [ make "install" ]
+]
+remove: [
+  [ make "uninstall" ]
+]
+depends: [
+  "ocamlfind"
+  "optcomp"
+  "ounit"
+  "uint" {>= "1.1.0"}
+  "uuidm"
+  "yojson"
+  "atdgen"
+  "ctypes" {>= "0.3"}
+  "ctypes-foreign"
+  "lwt" {>= "2.4"}
+  "ocamlbuild" {build}
+]
+depopts: ["ocp-index"]
+depexts: [
+  [["debian"] ["libzmq3-dev"]]
+  [["ubuntu"] ["libzmq3-dev"]]
+  [["osx" "homebrew"] ["zeromq"]]
+  [["centos"] ["zeromq3-devel"]]
+]
+ocaml-version: [ >= "4.00.1" ]
+conflicts: [
+  "ocp-index" {< "1.0.1"}
+]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.8/url
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.8/url
@@ -1,3 +1,3 @@
 archive: "https://github.com/andrewray/iocaml/archive/v0.4.8.tar.gz"
-md5sum: "c57e00e60d691034849362bf4db2d8d1"
+checksum: "c57e00e60d691034849362bf4db2d8d1"
 

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.8/url
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.8/url
@@ -1,0 +1,3 @@
+archive: "https://github.com/andrewray/iocaml/archive/v0.4.8.tar.gz"
+md5sum: "c57e00e60d691034849362bf4db2d8d1"
+

--- a/packages/iocaml/iocaml.0.4.8/descr
+++ b/packages/iocaml/iocaml.0.4.8/descr
@@ -1,0 +1,1 @@
+A webserver for iocaml-kernel and iocamljs-kernel.

--- a/packages/iocaml/iocaml.0.4.8/files/iocaml.install
+++ b/packages/iocaml/iocaml.0.4.8/files/iocaml.install
@@ -1,0 +1,3 @@
+bin: [
+  "_build/iocamlserver.byte" { "iocaml" }
+]

--- a/packages/iocaml/iocaml.0.4.8/opam
+++ b/packages/iocaml/iocaml.0.4.8/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+authors: "Andrew Ray <andy.ray@ujamjar.com>"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocamlserver"
+dev-repo: "https://github.com/andrewray/iocamlserver.git"
+bug-reports: "https://github.com/andrewray/iocamlserver/issues"
+build: [
+  [ "cp" "config.darwin.ml" "config.ml" ] {os = "darwin"}
+  [ make "all" ]
+]
+depends: [
+  "ocamlfind"
+  "uuidm"
+  "yojson"
+  "cow"
+  "lwt" {>= "2.4"}
+  "websocket" {>= "2.0"}
+  "cohttp" {>= "0.15.0"}
+  "crunch"
+  "ctypes" {>= "0.3"}
+  "ctypes-foreign"
+  "iocaml-kernel" {= "0.4.8"}
+  "iocamljs-kernel" {= "0.4.8"}
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.02.0"  ]

--- a/packages/iocaml/iocaml.0.4.8/url
+++ b/packages/iocaml/iocaml.0.4.8/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andrewray/iocamlserver/archive/v0.4.8.tar.gz"
+md5sum: "f9a8db4165a24257d26bf03ef0875636"

--- a/packages/iocaml/iocaml.0.4.8/url
+++ b/packages/iocaml/iocaml.0.4.8/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/andrewray/iocamlserver/archive/v0.4.8.tar.gz"
-md5sum: "f9a8db4165a24257d26bf03ef0875636"
+checksum: "f9a8db4165a24257d26bf03ef0875636"

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/descr
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/descr
@@ -1,0 +1,1 @@
+An OCaml javascript kernel for the IPython notebook.

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/files/iocamljs-kernel.install
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/files/iocamljs-kernel.install
@@ -1,0 +1,15 @@
+share: [
+  "static/services/kernels/js/kernel.min.js"  { "profile/static/services/kernels/js/kernel.min.js" }
+  "static/services/kernels/js/kernel.full.js" { "profile/static/services/kernels/js/kernel.full.js" }
+  "static/services/kernels/js/kernel.full.js" { "profile/static/services/kernels/js/kernel.js" }
+  "static/custom/custom.js"                   { "profile/static/custom/custom.js" }
+  "static/custom/iocamljsnblogo.png"          { "profile/static/custom/iocamljsnblogo.png" }
+]
+lib: [
+  "META"
+  "exec.cmi"
+  "iocaml.cmi"
+  "iocaml_main.cmi"
+  "iocamljs.cma"
+  "kernel.js"
+]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
@@ -1,0 +1,14 @@
+opam-version: "1.1"
+maintainer: "andy.ray@ujamjar.com"
+homepage: "https://github.com/andrewray/iocamljs"
+build: [
+  [ make "clean" "min" ]
+  [ make "clean" "full" ]
+]
+depends: [
+  "ocamlfind"
+  "optcomp"
+  "lwt" {>= "2.4"}
+  "js_of_ocaml" {>= "2.6"}
+]
+ocaml-version: [ >= "4.00.1" ]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
@@ -1,6 +1,9 @@
 opam-version: "1.1"
-maintainer: "andy.ray@ujamjar.com"
+maintainer: "Andy Ray <andy.ray@ujamjar.com>"
+authors: "Andy Ray <andy.ray@ujamjar.com>"
 homepage: "https://github.com/andrewray/iocamljs"
+dev-repo: "https://github.com/andrewray/iocamljs.git"
+bug-reports: "https://github.com/andrewray/iocamljs/issues"
 build: [
   [ make "clean" "min" ]
   [ make "clean" "full" ]
@@ -11,4 +14,4 @@ depends: [
   "lwt" {>= "2.4"}
   "js_of_ocaml" {>= "2.6"}
 ]
-ocaml-version: [ >= "4.00.1" ]
+available: [ ocaml_version >= "4.00.1" ]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
@@ -1,4 +1,4 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "Andy Ray <andy.ray@ujamjar.com>"
 authors: "Andy Ray <andy.ray@ujamjar.com>"
 homepage: "https://github.com/andrewray/iocamljs"

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/opam
@@ -14,4 +14,4 @@ depends: [
   "lwt" {>= "2.4"}
   "js_of_ocaml" {>= "2.6"}
 ]
-available: [ ocaml_version >= "4.00.1" ]
+available: [ ocaml-version >= "4.02.0"  ]

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/url
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/andrewray/iocamljs/archive/v0.4.8.tar.gz"
-md5sum: "eb2997a038b854eab821504b42f695a8"
+checksum: "eb2997a038b854eab821504b42f695a8"

--- a/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/url
+++ b/packages/iocamljs-kernel/iocamljs-kernel.0.4.8/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andrewray/iocamljs/archive/v0.4.8.tar.gz"
+md5sum: "eb2997a038b854eab821504b42f695a8"


### PR DESCRIPTION
* iocaml-kernel - compatibilty with Jupyter (ipython 4x) contributed by signalpillar
* iocamljs-kernel - compatibilty with js_of_ocaml 2.6
* iocaml - compatibility with websocket 2.0