### PR TITLE
libudev.0.1.1 - via opam-publish

### DIFF
--- a/packages/libudev/libudev.0.1.1/descr
+++ b/packages/libudev/libudev.0.1.1/descr
@@ -1,0 +1,1 @@
+Bindings to libudev for OCaml

--- a/packages/libudev/libudev.0.1.1/opam
+++ b/packages/libudev/libudev.0.1.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Armael <armael@isomorphis.me>"
+authors: "Armael <armael@isomorphis.me>"
+homepage: "https://github.com/Armael/ocaml-libudev"
+bug-reports: "https://github.com/Armael/ocaml-libudev/issues"
+license: "MIT"
+dev-repo: "https://github.com/Armael/ocaml-libudev.git"
+available: [ ocaml-version >= "4.01.0" ]
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign"
+  "stdint"
+]
+depexts: [
+  [["debian"] ["libudev-dev"]]
+  [["ubuntu"] ["libudev-dev"]]
+]

--- a/packages/libudev/libudev.0.1.1/url
+++ b/packages/libudev/libudev.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Armael/ocaml-libudev/archive/v0.1.1.zip"
+checksum: "e592e3789e8f6c82652e65880c8bdab4"


### PR DESCRIPTION
Bindings to libudev for OCaml

-- Fixed the version of the installed META file
   (previously the "%%VERSION%%" wasn't actually substituted...)

---
* Homepage: https://github.com/Armael/ocaml-libudev
* Source repo: https://github.com/Armael/ocaml-libudev.git
* Bug tracker: https://github.com/Armael/ocaml-libudev/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1