### PR TITLE
mtime.0.8.3 - via opam-publish

### DIFF
--- a/packages/mtime/mtime.0.8.3/descr
+++ b/packages/mtime/mtime.0.8.3/descr
@@ -1,0 +1,12 @@
+Monotonic wall-clock time for OCaml
+
+Mtime is an OCaml module to access monotonic wall-clock time. It
+allows to measure time spans without being subject to operating system
+calendar time adjustments.
+
+Mtime depends only on your platform system library. The optional
+JavaScript support depends on [js_of_ocaml][1]. It is distributed
+under the BSD3 license.
+
+[1]: http://ocsigen.org/js_of_ocaml/
+

--- a/packages/mtime/mtime.0.8.3/opam
+++ b/packages/mtime/mtime.0.8.3/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/mtime"
+doc: "http://erratique.ch/software/mtime"
+dev-repo: "http://erratique.ch/repos/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+tags: [ "time" "monotonic" "system" "org:erratique" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.01.0"]
+depends:
+[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+depopts: [ "js_of_ocaml" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "jsoo=%{js_of_ocaml:installed}%" ]
+]

--- a/packages/mtime/mtime.0.8.3/url
+++ b/packages/mtime/mtime.0.8.3/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/mtime/releases/mtime-0.8.3.tbz"
+checksum: "e3577e065a4c09d73b27f5625e321003"


### PR DESCRIPTION
Monotonic wall-clock time for OCaml

Mtime is an OCaml module to access monotonic wall-clock time. It
allows to measure time spans without being subject to operating system
calendar time adjustments.

Mtime depends only on your platform system library. The optional
JavaScript support depends on [js_of_ocaml][1]. It is distributed
under the BSD3 license.

[1]: http://ocsigen.org/js_of_ocaml/



---
* Homepage: http://erratique.ch/software/mtime
* Source repo: http://erratique.ch/repos/mtime.git
* Bug tracker: https://github.com/dbuenzli/mtime/issues

---

Pull-request generated by opam-publish v0.3.1