### PR TITLE
+ minios-xen.0.9

### DIFF
--- a/packages/minios-xen/minios-xen.0.9/descr
+++ b/packages/minios-xen/minios-xen.0.9/descr
@@ -1,0 +1,5 @@
+A minimal OS for running under the Xen hypervisor
+
+Mini-OS provides architecture-specific boot code, a stack, malloc, an interrupt
+handler, a console driver, and some basic C functions. It can be used as a
+library to build unikernels such as Mirage.

--- a/packages/minios-xen/minios-xen.0.9/opam
+++ b/packages/minios-xen/minios-xen.0.9/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "mirageos-devel@lists.openmirage.org"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/talex5/mini-os"
+bug-reports: "https://github.com/mirage/mini-os/issues"
+license: "BSD + some optional GPL components"
+dev-repo: "https://github.com/talex5/mini-os.git"
+build: [
+  [make "debug=n" "CONFIG_VERBOSE_BOOT=n"]
+]
+install: [
+  [make "install" "LIBDIR=%{prefix}%/lib" "INCLUDEDIR=%{prefix}%/include"]
+]
+remove: [
+  ["rm" "-r"
+    "%{prefix}%/lib/minios-xen"
+    "%{prefix}%/lib/pkgconfig/libminios-xen.pc"
+    "%{prefix}%/include/minios-xen"
+  ]
+]

--- a/packages/minios-xen/minios-xen.0.9/url
+++ b/packages/minios-xen/minios-xen.0.9/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/talex5/mini-os/archive/v0.9.tar.gz"
+checksum: "8f30d651d16f9e7b6b0f2296cd71cec0"


### PR DESCRIPTION
- Provide stats on memory pages used (`minios_heap_pages_total` and `minios_heap_pages_used`).
- Block when writing to a full console. Before, we simply discarded the remaining output when the console ring was full. Now, we sleep for 10ms and retry. This avoids losing the final error or exception when a busy domain crashes.
