### PR TITLE
ptime.0.8.0 - via opam-publish

### DIFF
--- a/packages/ptime/ptime.0.8.0/descr
+++ b/packages/ptime/ptime.0.8.0/descr
@@ -1,0 +1,21 @@
+POSIX time for OCaml
+
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][1] and pretty printing to a
+human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime depends on the `result` compatibility package. Ptime_clock
+depends on your system library. Ptime_clock's optional JavaScript
+support depends on [js_of_ocaml][2]. Ptime and its libraries are
+distributed under the BSD3 license.
+
+[1]: http://tools.ietf.org/html/rfc3339
+[2]: http://ocsigen.org/js_of_ocaml/
+

--- a/packages/ptime/ptime.0.8.0/opam
+++ b/packages/ptime/ptime.0.8.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/ptime"
+doc: "http://erratique.ch/software/ptime"
+dev-repo: "http://erratique.ch/repos/ptime.git"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+tags: [ "time" "posix" "system" "org:erratique" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "result"
+]
+depopts: [ "js_of_ocaml" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "jsoo=%{js_of_ocaml:installed}%"]
+]

--- a/packages/ptime/ptime.0.8.0/url
+++ b/packages/ptime/ptime.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/ptime/releases/ptime-0.8.0.tbz"
+checksum: "9d5ad46d4bbf19f2419fa121bf6c111a"


### PR DESCRIPTION
POSIX time for OCaml

Ptime has platform independent POSIX time support in pure OCaml. It
provides a type to represent a well-defined range of POSIX timestamps
with picosecond precision, conversion with date-time values,
conversion with [RFC 3339 timestamps][1] and pretty printing to a
human-readable, locale-independent representation.

The additional Ptime_clock library provides access to a system POSIX
clock and to the system's current time zone offset.

Ptime is not a calendar library.

Ptime depends on the `result` compatibility package. Ptime_clock
depends on your system library. Ptime_clock's optional JavaScript
support depends on [js_of_ocaml][2]. Ptime and its libraries are
distributed under the BSD3 license.

[1]: http://tools.ietf.org/html/rfc3339
[2]: http://ocsigen.org/js_of_ocaml/



---
* Homepage: http://erratique.ch/software/ptime
* Source repo: http://erratique.ch/repos/ptime.git
* Bug tracker: https://github.com/dbuenzli/ptime/issues

---

Pull-request generated by opam-publish v0.3.1