### PR TITLE
Fix ssl on OS X 10.11 to include the homebrew openssl include dir

### DIFF
--- a/packages/ssl/ssl.0.5.2/opam
+++ b/packages/ssl/ssl.0.5.2/opam
@@ -5,7 +5,8 @@ homepage: "https://github.com/savonet/ocaml-ssl"
 dev-repo: "https://github.com/savonet/ocaml-ssl.git"
 bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
 build: [
-  ["./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["./configure" "--prefix" prefix "CFLAGS=-I/usr/local/opt/openssl/include"] { os = "darwin" }
   [make]
 ]
 install: [[make "install"]]


### PR DESCRIPTION
This may cause issues with OS X older than 10.11. In particular, the header and the library may be mismatched on older versions of OS X. A patch of this sort is required to use `opam publish` on OS X 10.11+.

@rgrinberg your async_ssl patch is similar so you may have experience with this.

cc @avsm 