### PR TITLE
Add `nixpkgs` depexts and some missing dependencies

### DIFF
--- a/packages/biniou/biniou.1.0.9/opam
+++ b/packages/biniou/biniou.1.0.9/opam
@@ -11,3 +11,6 @@ depends: [
   "ocamlfind"
   "easy-format"
 ]
+depexts: [
+  [["nixpkgs"] ["which"]]
+]

--- a/packages/camomile/camomile.0.8.5/opam
+++ b/packages/camomile/camomile.0.8.5/opam
@@ -13,4 +13,4 @@ build: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "camomile"]]
-depends: ["ocamlfind"]
+depends: ["ocamlfind" "camlp4"]

--- a/packages/cryptokit/cryptokit.1.10/opam
+++ b/packages/cryptokit/cryptokit.1.10/opam
@@ -13,4 +13,5 @@ depexts: [
   [["debian"] ["zlib1g-dev"]]
   [["ubuntu"] ["zlib1g-dev"]]
   [["centos"] ["zlib-devel"]]
+  [["nixpkgs"] ["zlib"]]
 ]

--- a/packages/cudf/cudf.0.7/opam
+++ b/packages/cudf/cudf.0.7/opam
@@ -12,3 +12,6 @@ depends: [
   ("extlib" | "extlib-compat")
   "ocamlbuild" {build}
 ]
+depexts: [
+ [["nixkgs"] ["perl"]]
+]

--- a/packages/dose/dose.3.3/opam
+++ b/packages/dose/dose.3.3/opam
@@ -37,6 +37,9 @@ depends: [
   "re" {>= "1.2.0"}
   "ocamlbuild" {build}
 ]
+depexts: [
+  [["nixpkgs"] ["perl"]]
+]
 patches: [
   "0001-Removed-hard-failure-cases-in-favor-of-finer-diagnos.patch"
   "0002-ocamlgraph-1.8.6.diff" {ocamlgraph:version >= "1.8.6"}

--- a/packages/minios-xen/minios-xen.0.7/opam
+++ b/packages/minios-xen/minios-xen.0.7/opam
@@ -18,3 +18,6 @@ remove: [
     "%{prefix}%/include/minios-xen"
   ]
 ]
+depexts: [
+  [["nixpkgs"] ["perl"]]
+]

--- a/packages/mirage-unix/mirage-unix.2.3.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.3.1/opam
@@ -17,4 +17,7 @@ depends: [
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}
 ]
+depexts: [
+  [["nixpkgs"] ["which"]]
+]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
@@ -10,6 +10,7 @@ remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "mirage-xen-posix"
   "conf-pkg-config"
+  "ocamlfind"
   "ocaml-src"
   "ocamlbuild" {build}
 ]

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -19,6 +19,7 @@ remove: [
 depexts: [
   [["debian"] ["m4" "ncurses-dev"]]
   [["ubuntu"] ["m4" "ncurses-dev"]]
+  [["nixpkgs"] ["m4" "ncurses"]]
 ]
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -19,6 +19,7 @@ remove: [
 depexts: [
   [["debian"] ["m4" "ncurses-dev"]]
   [["ubuntu"] ["m4" "ncurses-dev"]]
+  [["nixpkgs"] ["m4" "ncurses"]]
 ]
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}

--- a/packages/ocurl/ocurl.0.7.5/opam
+++ b/packages/ocurl/ocurl.0.7.5/opam
@@ -24,4 +24,5 @@ depexts: [
   [["debian"] ["libcurl4-gnutls-dev"]]
   [["ubuntu"] ["libcurl4-gnutls-dev"]]
   [["centos"] ["libcurl-devel" "openssl-devel"]]
+  [["nixpkgs"] ["curl" "openssl"]]
 ]

--- a/packages/opam-lib/opam-lib.1.2.2/opam
+++ b/packages/opam-lib/opam-lib.1.2.2/opam
@@ -23,6 +23,7 @@ depends: [
   "cmdliner"
   "dose" {>= "3.2.2+opam" & < "4"}
   "cudf"
+  "extlib"
   "re" {>= "1.2.0"}
   "ocamlfind" {build}
   "jsonm"

--- a/packages/opam-lib/opam-lib.1.2.2/opam
+++ b/packages/opam-lib/opam-lib.1.2.2/opam
@@ -29,3 +29,6 @@ depends: [
   "jsonm"
   "ocamlbuild" {build}
 ]
+depexts: [
+  [["nixpkgs"] ["curl"]]
+]

--- a/packages/zarith/zarith.1.3/opam
+++ b/packages/zarith/zarith.1.3/opam
@@ -13,4 +13,7 @@ depends: [
   "ocamlfind"
   "conf-gmp"
 ]
+depexts: [
+  [["nixpkgs"] ["perl"]]
+]
 patches: [ "z_pp.pl.patch" ]

--- a/packages/zarith/zarith.1.4.1/opam
+++ b/packages/zarith/zarith.1.4.1/opam
@@ -11,6 +11,9 @@ install: [
   [make "install"]
 ]
 remove:  ["ocamlfind" "remove" "zarith"]
+depexts: [
+  [["nixpkgs"] ["perl"]]
+]
 depends: [
   "ocamlfind"
   "conf-gmp"


### PR DESCRIPTION
Working on [opam2nix](https://github.com/timbertson/opam2nix), I've encountered a number of packages which don't compile due to missing dependencies. I've added a `nixpkgs` depext to track external dependency names in [nixpkgs](https://github.com/NixOS/nixpkgs/).

I also encountered a number of dependencies which needed to be added to get certain packages to compile - my assumption is that these dependencies are implicitly provided by transitive dependencies. In `opam2nix` only explicit direct dependencies are visible to the package being compiled, which explains why they would fail under this mode (whereas in normal opam operation, I believe a package can use any package which happens to be installed, even if it doesn't declare a dependency on it).