### PR TITLE
tsdl-image.0.1.1 - via opam-publish

### DIFF
--- a/packages/tsdl-image/tsdl-image.0.1.1/descr
+++ b/packages/tsdl-image/tsdl-image.0.1.1/descr
@@ -1,0 +1,4 @@
+SDL2_Image bindings to go with Tsdl
+
+Tsdl_image provides bindings to SDL2_Image intended to be used with
+Tsdl.

--- a/packages/tsdl-image/tsdl-image.0.1.1/opam
+++ b/packages/tsdl-image/tsdl-image.0.1.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Julian Squires <julian@cipht.net>"
+authors: "Julian Squires <julian@cipht.net>"
+homepage: "http://github.com/tokenrove/tsdl-image"
+bug-reports: "http://github.com/tokenrove/tsdl-image/issues"
+license: "BSD3"
+tags: ["bindings" "graphics"]
+dev-repo: "https://github.com/tokenrove/tsdl-image.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tsdl_image"]
+depends: [
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "tsdl" {> "0.8.1" & < "0.9.0"}
+  "oasis" {build}
+]
+depexts: [
+  [["debian"] ["libsdl2-image-dev"]]
+  [["homebrew" "osx"] ["sdl2_image"]]
+  [["ubuntu"] ["libsdl2-image-dev"]]
+]

--- a/packages/tsdl-image/tsdl-image.0.1.1/url
+++ b/packages/tsdl-image/tsdl-image.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/tokenrove/tsdl-image/archive/0.1.1.tar.gz"
+checksum: "e5a6c22e5f45c9b53dbbca8ecac98e98"


### PR DESCRIPTION
SDL2_Image bindings to go with Tsdl

Tsdl_image provides bindings to SDL2_Image intended to be used with
Tsdl.


---
* Homepage: http://github.com/tokenrove/tsdl-image
* Source repo: https://github.com/tokenrove/tsdl-image.git
* Bug tracker: http://github.com/tokenrove/tsdl-image/issues

---

Pull-request generated by opam-publish v0.3.1