### PR TITLE
osx-plutil.0.5.0 - via opam-publish

### DIFF
--- a/packages/osx-plutil/osx-plutil.0.5.0/descr
+++ b/packages/osx-plutil/osx-plutil.0.5.0/descr
@@ -1,0 +1,5 @@
+OS X plutil plist manipulation
+
+osx-plutil wraps the OS X plutil command which can be used to lint plist
+files and convert between their XML, binary, and JSON formats. JSON
+pretty-printing and human-readable output are also available.

--- a/packages/osx-plutil/osx-plutil.0.5.0/opam
+++ b/packages/osx-plutil/osx-plutil.0.5.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "David Sheets <sheets@alum.mit.edu>"
+authors: "David Sheets <sheets@alum.mit.edu>"
+homepage: "https://github.com/dsheets/ocaml-osx-plutil"
+bug-reports: "https://github.com/dsheets/ocaml-osx-plutil/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/ocaml-osx-plutil.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "osx-plutil"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-unix"
+  "base-bytes"
+  "result"
+  "process"
+]
+available: [os = "darwin" & ocaml-version >= "4.01.0"]

--- a/packages/osx-plutil/osx-plutil.0.5.0/url
+++ b/packages/osx-plutil/osx-plutil.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-plutil/archive/0.5.0.tar.gz"
+checksum: "5e0bca8642147c799523fcafba5116b9"


### PR DESCRIPTION
OS X plutil plist manipulation

osx-plutil wraps the OS X plutil command which can be used to lint plist
files and convert between their XML, binary, and JSON formats. JSON
pretty-printing and human-readable output are also available.


---
* Homepage: https://github.com/dsheets/ocaml-osx-plutil
* Source repo: https://github.com/dsheets/ocaml-osx-plutil.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-plutil/issues

---

Pull-request generated by opam-publish v0.3.1