### PR TITLE
Version 1.1.2d fixes script incompatibility with Bourne shell.

### DIFF
--- a/packages/libra-tk/libra-tk.1.1.2/url
+++ b/packages/libra-tk/libra-tk.1.1.2/url
@@ -1,2 +1,2 @@
-http: "http://libra.cs.uoregon.edu/libra-tk-1.1.2b.tar.gz"
-checksum: "ba144d4b69b118d7fc38dc216437f232"
+http: "http://libra.cs.uoregon.edu/libra-tk-1.1.2d.tar.gz"
+checksum: "3bd733fe53c8532f1deb4cc9b941575d"

--- a/packages/libra-tk/libra-tk.1.1.2/url
+++ b/packages/libra-tk/libra-tk.1.1.2/url
@@ -1,2 +1,2 @@
 http: "http://libra.cs.uoregon.edu/libra-tk-1.1.2d.tar.gz"
-checksum: "3bd733fe53c8532f1deb4cc9b941575d"
+checksum: "a53e35d844ba391d5053416696c48168"


### PR DESCRIPTION
This is a very minor bug fix update.  There are a few documentation updates and one script has been modified to support the standard Bourne shell (sh).  (One test that used [[ ]] was changed to the more universal [ ].)