### PR TITLE
ppx_json_types.0.1 - via opam-publish

### DIFF
--- a/packages/ppx_json_types/ppx_json_types.0.1/descr
+++ b/packages/ppx_json_types/ppx_json_types.0.1/descr
@@ -1,0 +1,4 @@
+JSON type providers
+A solution for dynamically creating JSON-based types from Web-hosted
+type information, providing the tools necessary to work with values
+of the type at compile-time.

--- a/packages/ppx_json_types/ppx_json_types.0.1/opam
+++ b/packages/ppx_json_types/ppx_json_types.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/otp"
+bug-reports: "https://github.com/nv-vn/otp/issues"
+license: "GPL"
+dev-repo: "https://github.com/nv-vn/otp"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ppx_json_types"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/ppx_json_types/ppx_json_types.0.1/url
+++ b/packages/ppx_json_types/ppx_json_types.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/otp/archive/0.1.tar.gz"
+checksum: "b8adbab728a64ceb776946a45059e6b1"


### PR DESCRIPTION
JSON type providers
A solution for dynamically creating JSON-based types from Web-hosted
type information, providing the tools necessary to work with values
of the type at compile-time.


---
* Homepage: https://github.com/nv-vn/otp
* Source repo: https://github.com/nv-vn/otp
* Bug tracker: https://github.com/nv-vn/otp/issues

---

Pull-request generated by opam-publish v0.3.1