### PR TITLE
bisect_ppx.0.2.6 - via opam-publish

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.0.2.6/descr
+++ b/packages/bisect_ppx/bisect_ppx.0.2.6/descr
@@ -1,0 +1,4 @@
+Bisect code coverage instrumentation via ppx.
+
+A fork of the original Bisect code to solely work with ppx, with a few
+bug fixes and improvements.

--- a/packages/bisect_ppx/bisect_ppx.0.2.6/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.6/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/rleonid/bisect_ppx"
+bug-reports: "https://github.com/rleonid/bisect_ppx/issues"
+dev-repo: "https://github.com/rleonid/bisect_ppx.git"
+build: [
+  ["sh" "configure"]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "bisect_ppx"]
+depends: [
+  "ocamlfind"
+  "ppx_tools" {build}
+]

--- a/packages/bisect_ppx/bisect_ppx.0.2.6/url
+++ b/packages/bisect_ppx/bisect_ppx.0.2.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rleonid/bisect_ppx/archive/0.2.6.tar.gz"
+checksum: "fbf18a7efe55bb632b87ae4355fd8a8c"


### PR DESCRIPTION
Bisect code coverage instrumentation via ppx.

A fork of the original Bisect code to solely work with ppx, with a few
bug fixes and improvements.


---
* Homepage: https://github.com/rleonid/bisect_ppx
* Source repo: https://github.com/rleonid/bisect_ppx.git
* Bug tracker: https://github.com/rleonid/bisect_ppx/issues

---

Pull-request generated by opam-publish v0.3.1