### PR TITLE
libudev.0.2 - via opam-publish

### DIFF
--- a/packages/libudev/libudev.0.2/descr
+++ b/packages/libudev/libudev.0.2/descr
@@ -1,0 +1,1 @@
+Bindings to libudev for OCaml

--- a/packages/libudev/libudev.0.2/opam
+++ b/packages/libudev/libudev.0.2/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Armael <armael@isomorphis.me>"
+authors: "Armael <armael@isomorphis.me>"
+homepage: "https://github.com/Armael/ocaml-libudev"
+bug-reports: "https://github.com/Armael/ocaml-libudev/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Armael/ocaml-libudev.git"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign"
+  "stdint"
+]
+depexts: [
+  [["debian"] ["libudev-dev"]]
+  [["ubuntu"] ["libudev-dev"]]
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/libudev/libudev.0.2/url
+++ b/packages/libudev/libudev.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Armael/ocaml-libudev/archive/v0.2.zip"
+checksum: "7dc001bc3b0a0d10df6be1f0dd970f9a"


### PR DESCRIPTION
Bindings to libudev for OCaml

Fixed some bugs & compilation stuff.
v0.2 because the `Libudev` module has been renamed to `Udev`, so that ocaml's compilation objects (especially the .a) do not conflict with the C library.

---
* Homepage: https://github.com/Armael/ocaml-libudev
* Source repo: git+https://github.com/Armael/ocaml-libudev.git
* Bug tracker: https://github.com/Armael/ocaml-libudev/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1