### PR TITLE
Base ocamlbuild package

### DIFF
--- a/compilers/3.07/3.07/3.07.comp
+++ b/compilers/3.07/3.07/3.07.comp
@@ -16,5 +16,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.0/3.08.0/3.08.0.comp
+++ b/compilers/3.08.0/3.08.0/3.08.0.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.1/3.08.1/3.08.1.comp
+++ b/compilers/3.08.1/3.08.1/3.08.1.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.2/3.08.2/3.08.2.comp
+++ b/compilers/3.08.2/3.08.2/3.08.2.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.3/3.08.3/3.08.3.comp
+++ b/compilers/3.08.3/3.08.3/3.08.3.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.08.4/3.08.4/3.08.4.comp
+++ b/compilers/3.08.4/3.08.4/3.08.4.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.0/3.09.0/3.09.0.comp
+++ b/compilers/3.09.0/3.09.0/3.09.0.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.1/3.09.1/3.09.1.comp
+++ b/compilers/3.09.1/3.09.1/3.09.1.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.2/3.09.2/3.09.2.comp
+++ b/compilers/3.09.2/3.09.2/3.09.2.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.09.3/3.09.3/3.09.3.comp
+++ b/compilers/3.09.3/3.09.3/3.09.3.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.10.0/3.10.0/3.10.0.comp
+++ b/compilers/3.10.0/3.10.0/3.10.0.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.10.1/3.10.1/3.10.1.comp
+++ b/compilers/3.10.1/3.10.1/3.10.1.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.10.2/3.10.2/3.10.2.comp
+++ b/compilers/3.10.2/3.10.2/3.10.2.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.11.0/3.11.0/3.11.0.comp
+++ b/compilers/3.11.0/3.11.0/3.11.0.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.11.1/3.11.1/3.11.1.comp
+++ b/compilers/3.11.1/3.11.1/3.11.1.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.11.2/3.11.2/3.11.2.comp
+++ b/compilers/3.11.2/3.11.2/3.11.2.comp
@@ -14,5 +14,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.12.0/3.12.0/3.12.0.comp
+++ b/compilers/3.12.0/3.12.0/3.12.0.comp
@@ -16,5 +16,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/3.12.1/3.12.1/3.12.1.comp
+++ b/compilers/3.12.1/3.12.1/3.12.1.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.0/4.00.0+debug-runtime/4.00.0+debug-runtime.comp
+++ b/compilers/4.00.0/4.00.0+debug-runtime/4.00.0+debug-runtime.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.0/4.00.0+fp/4.00.0+fp.comp
+++ b/compilers/4.00.0/4.00.0+fp/4.00.0+fp.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.0/4.00.0/4.00.0.comp
+++ b/compilers/4.00.0/4.00.0/4.00.0.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+BER/4.00.1+BER.comp
+++ b/compilers/4.00.1/4.00.1+BER/4.00.1+BER.comp
@@ -16,5 +16,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+PIC/4.00.1+PIC.comp
+++ b/compilers/4.00.1/4.00.1+PIC/4.00.1+PIC.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild"]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+alloc-profiling/4.00.1+alloc-profiling.comp
+++ b/compilers/4.00.1/4.00.1+alloc-profiling/4.00.1+alloc-profiling.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+annot/4.00.1+annot.comp
+++ b/compilers/4.00.1/4.00.1+annot/4.00.1+annot.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+french/4.00.1+french.comp
+++ b/compilers/4.00.1/4.00.1+french/4.00.1+french.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+mirage-unix/4.00.1+mirage-unix.comp
+++ b/compilers/4.00.1/4.00.1+mirage-unix/4.00.1+mirage-unix.comp
@@ -10,6 +10,7 @@ build: [
 packages: [
   "base-unix"
   "base-threads"
+  "base-ocamlbuild"
   "base-bigarray"
   "lwt"
   "ocamlfind"

--- a/compilers/4.00.1/4.00.1+open-types/4.00.1+open-types.comp
+++ b/compilers/4.00.1/4.00.1+open-types/4.00.1+open-types.comp
@@ -9,5 +9,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+raspberrypi/4.00.1+raspberrypi.comp
+++ b/compilers/4.00.1/4.00.1+raspberrypi/4.00.1+raspberrypi.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1+short-types/4.00.1+short-types.comp
+++ b/compilers/4.00.1/4.00.1+short-types/4.00.1+short-types.comp
@@ -9,5 +9,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.00.1/4.00.1/4.00.1.comp
+++ b/compilers/4.00.1/4.00.1/4.00.1.comp
@@ -13,5 +13,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+32bit/4.01.0+32bit.comp
+++ b/compilers/4.01.0/4.01.0+32bit/4.01.0+32bit.comp
@@ -12,5 +12,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+BER.comp
+++ b/compilers/4.01.0/4.01.0+BER.comp
@@ -13,7 +13,7 @@ build: [
   ["%{make}%" "-C" "ber-metaocaml-101" "all"]
   ["%{make}%" "-C" "ber-metaocaml-101" "install"]
 ]
-packages : [ "base-unix" "base-bigarray" "base-threads" "base-metaocaml-ocamlfind"]
+packages : [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" "base-metaocaml-ocamlfind"]
 env: [
   [ CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs" ]
 ]

--- a/compilers/4.01.0/4.01.0+PIC/4.01.0+PIC.comp
+++ b/compilers/4.01.0/4.01.0+PIC/4.01.0+PIC.comp
@@ -12,5 +12,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
+++ b/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
@@ -12,5 +12,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.comp
+++ b/compilers/4.01.0/4.01.0+bin-ocp/4.01.0+bin-ocp.comp
@@ -15,5 +15,5 @@ build: [
        [ "rsync" "-auv" "ocaml/man/." "%{prefix}%/man/." ]
        [ "rsync" "-auv" "ocaml/lib/ocaml/." "%{prefix}%/lib/ocaml/." ]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/ocaml/stublibs:%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
+++ b/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
@@ -12,5 +12,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+jocaml/4.01.0+jocaml.comp
+++ b/compilers/4.01.0/4.01.0+jocaml/4.01.0+jocaml.comp
@@ -14,5 +14,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
+++ b/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
@@ -19,6 +19,7 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [
     [LSBCC_LSBVERSION = "4.0"]

--- a/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.comp
+++ b/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.comp
@@ -16,5 +16,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+musl/4.01.0+musl.comp
+++ b/compilers/4.01.0/4.01.0+musl/4.01.0+musl.comp
@@ -14,5 +14,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+open-types/4.01.0+open-types.comp
+++ b/compilers/4.01.0/4.01.0+open-types/4.01.0+open-types.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.01.0/4.01.0+profile/4.01.0+profile.comp
+++ b/compilers/4.01.0/4.01.0+profile/4.01.0+profile.comp
@@ -12,6 +12,7 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [
   [OCAMLPARAM="p=1,g=1,_"]

--- a/compilers/4.01.0/4.01.0/4.01.0.comp
+++ b/compilers/4.01.0/4.01.0/4.01.0.comp
@@ -12,5 +12,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.comp
+++ b/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild"]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.0/4.02.0+improved-errors/4.02.0+improved-errors.comp
+++ b/compilers/4.02.0/4.02.0+improved-errors/4.02.0+improved-errors.comp
@@ -10,7 +10,7 @@ build: [
   ["%{make}%" "world.opt"]
   ["%{make}%" "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild"]
 env: [
   [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
 ]

--- a/compilers/4.02.0/4.02.0+modular-implicits/4.02.0+modular-implicits.comp
+++ b/compilers/4.02.0/4.02.0+modular-implicits/4.02.0+modular-implicits.comp
@@ -7,7 +7,7 @@ build: [
   ["%{make}%" "world.opt"]
   ["%{make}%" "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild"]
 env: [
   [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
 ]

--- a/compilers/4.02.0/4.02.0+rc1/4.02.0+rc1.comp
+++ b/compilers/4.02.0/4.02.0+rc1/4.02.0+rc1.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.0/4.02.0+trunk/4.02.0+trunk.comp
+++ b/compilers/4.02.0/4.02.0+trunk/4.02.0+trunk.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.0/4.02.0/4.02.0.comp
+++ b/compilers/4.02.0/4.02.0/4.02.0.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.1/4.02.1+32bit/4.02.1+32bit.comp
+++ b/compilers/4.02.1/4.02.1+32bit/4.02.1+32bit.comp
@@ -12,5 +12,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.1/4.02.1+BER/4.02.1+BER.comp
+++ b/compilers/4.02.1/4.02.1+BER/4.02.1+BER.comp
@@ -7,7 +7,7 @@ build: [
   ["%{make}%" "-i" "install"]
   ["%{make}%" "-C" "metalib" "all" "install"]
 ]
-packages : [ "base-unix" "base-bigarray" "base-threads" "base-metaocaml-ocamlfind"]
+packages : [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" "base-metaocaml-ocamlfind"]
 env: [
   [ CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs" ]
 ]

--- a/compilers/4.02.1/4.02.1+PIC/4.02.1+PIC.comp
+++ b/compilers/4.02.1/4.02.1+PIC/4.02.1+PIC.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild"]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.1/4.02.1+fp/4.02.1+fp.comp
+++ b/compilers/4.02.1/4.02.1+fp/4.02.1+fp.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.1/4.02.1+modular-implicits-ber/4.02.1+modular-implicits-ber.comp
+++ b/compilers/4.02.1/4.02.1+modular-implicits-ber/4.02.1+modular-implicits-ber.comp
@@ -7,7 +7,7 @@ build: [
   ["%{make}%" "install"]
   ["%{make}%" "-C" "metalib" "all" "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads" "base-metaocaml-ocamlfind"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" "base-metaocaml-ocamlfind"]
 env: [
   [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
 ]

--- a/compilers/4.02.1/4.02.1+musl+static/4.02.1+musl+static.comp
+++ b/compilers/4.02.1/4.02.1+musl+static/4.02.1+musl+static.comp
@@ -16,5 +16,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.1/4.02.1+musl/4.02.1+musl.comp
+++ b/compilers/4.02.1/4.02.1+musl/4.02.1+musl.comp
@@ -14,5 +14,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.1/4.02.1/4.02.1.comp
+++ b/compilers/4.02.1/4.02.1/4.02.1.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.2/4.02.2+rc1/4.02.2+rc1.comp
+++ b/compilers/4.02.2/4.02.2+rc1/4.02.2+rc1.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.2/4.02.2/4.02.2.comp
+++ b/compilers/4.02.2/4.02.2/4.02.2.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3/4.02.3+32bit/4.02.3+32bit.comp
+++ b/compilers/4.02.3/4.02.3+32bit/4.02.3+32bit.comp
@@ -12,5 +12,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3/4.02.3+PIC/4.02.3+PIC.comp
+++ b/compilers/4.02.3/4.02.3+PIC/4.02.3+PIC.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild"]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3/4.02.3+curried-constr/4.02.3+curried-constr.comp
+++ b/compilers/4.02.3/4.02.3+curried-constr/4.02.3+curried-constr.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3/4.02.3+fp/4.02.3+fp.comp
+++ b/compilers/4.02.3/4.02.3+fp/4.02.3+fp.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3/4.02.3+musl+static/4.02.3+musl+static.comp
+++ b/compilers/4.02.3/4.02.3+musl+static/4.02.3+musl+static.comp
@@ -16,5 +16,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3/4.02.3+musl/4.02.3+musl.comp
+++ b/compilers/4.02.3/4.02.3+musl/4.02.3+musl.comp
@@ -14,5 +14,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3/4.02.3/4.02.3.comp
+++ b/compilers/4.02.3/4.02.3/4.02.3.comp
@@ -10,5 +10,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
+++ b/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
+++ b/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr100/4.03.0+pr100.comp
+++ b/compilers/4.03.0/4.03.0+pr100/4.03.0+pr100.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr101/4.03.0+pr101.comp
+++ b/compilers/4.03.0/4.03.0+pr101/4.03.0+pr101.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr102/4.03.0+pr102.comp
+++ b/compilers/4.03.0/4.03.0+pr102/4.03.0+pr102.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr103/4.03.0+pr103.comp
+++ b/compilers/4.03.0/4.03.0+pr103/4.03.0+pr103.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr112/4.03.0+pr112.comp
+++ b/compilers/4.03.0/4.03.0+pr112/4.03.0+pr112.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr113/4.03.0+pr113.comp
+++ b/compilers/4.03.0/4.03.0+pr113/4.03.0+pr113.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr120/4.03.0+pr120.comp
+++ b/compilers/4.03.0/4.03.0+pr120/4.03.0+pr120.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr126/4.03.0+pr126.comp
+++ b/compilers/4.03.0/4.03.0+pr126/4.03.0+pr126.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr146/4.03.0+pr146.comp
+++ b/compilers/4.03.0/4.03.0+pr146/4.03.0+pr146.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr153/4.03.0+pr153.comp
+++ b/compilers/4.03.0/4.03.0+pr153/4.03.0+pr153.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr158/4.03.0+pr158.comp
+++ b/compilers/4.03.0/4.03.0+pr158/4.03.0+pr158.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr163/4.03.0+pr163.comp
+++ b/compilers/4.03.0/4.03.0+pr163/4.03.0+pr163.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr176/4.03.0+pr176.comp
+++ b/compilers/4.03.0/4.03.0+pr176/4.03.0+pr176.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr177/4.03.0+pr177.comp
+++ b/compilers/4.03.0/4.03.0+pr177/4.03.0+pr177.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr180/4.03.0+pr180.comp
+++ b/compilers/4.03.0/4.03.0+pr180/4.03.0+pr180.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr181/4.03.0+pr181.comp
+++ b/compilers/4.03.0/4.03.0+pr181/4.03.0+pr181.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr182/4.03.0+pr182.comp
+++ b/compilers/4.03.0/4.03.0+pr182/4.03.0+pr182.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr185/4.03.0+pr185.comp
+++ b/compilers/4.03.0/4.03.0+pr185/4.03.0+pr185.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr187/4.03.0+pr187.comp
+++ b/compilers/4.03.0/4.03.0+pr187/4.03.0+pr187.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr188/4.03.0+pr188.comp
+++ b/compilers/4.03.0/4.03.0+pr188/4.03.0+pr188.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr195/4.03.0+pr195.comp
+++ b/compilers/4.03.0/4.03.0+pr195/4.03.0+pr195.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr199/4.03.0+pr199.comp
+++ b/compilers/4.03.0/4.03.0+pr199/4.03.0+pr199.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr203/4.03.0+pr203.comp
+++ b/compilers/4.03.0/4.03.0+pr203/4.03.0+pr203.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr217/4.03.0+pr217.comp
+++ b/compilers/4.03.0/4.03.0+pr217/4.03.0+pr217.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr218/4.03.0+pr218.comp
+++ b/compilers/4.03.0/4.03.0+pr218/4.03.0+pr218.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr22/4.03.0+pr22.comp
+++ b/compilers/4.03.0/4.03.0+pr22/4.03.0+pr22.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr230/4.03.0+pr230.comp
+++ b/compilers/4.03.0/4.03.0+pr230/4.03.0+pr230.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr232/4.03.0+pr232.comp
+++ b/compilers/4.03.0/4.03.0+pr232/4.03.0+pr232.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr234/4.03.0+pr234.comp
+++ b/compilers/4.03.0/4.03.0+pr234/4.03.0+pr234.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr236/4.03.0+pr236.comp
+++ b/compilers/4.03.0/4.03.0+pr236/4.03.0+pr236.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr24/4.03.0+pr24.comp
+++ b/compilers/4.03.0/4.03.0+pr24/4.03.0+pr24.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr241/4.03.0+pr241.comp
+++ b/compilers/4.03.0/4.03.0+pr241/4.03.0+pr241.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr244/4.03.0+pr244.comp
+++ b/compilers/4.03.0/4.03.0+pr244/4.03.0+pr244.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr246/4.03.0+pr246.comp
+++ b/compilers/4.03.0/4.03.0+pr246/4.03.0+pr246.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr247/4.03.0+pr247.comp
+++ b/compilers/4.03.0/4.03.0+pr247/4.03.0+pr247.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr253/4.03.0+pr253.comp
+++ b/compilers/4.03.0/4.03.0+pr253/4.03.0+pr253.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr257/4.03.0+pr257.comp
+++ b/compilers/4.03.0/4.03.0+pr257/4.03.0+pr257.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr260/4.03.0+pr260.comp
+++ b/compilers/4.03.0/4.03.0+pr260/4.03.0+pr260.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr278/4.03.0+pr278.comp
+++ b/compilers/4.03.0/4.03.0+pr278/4.03.0+pr278.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr285/4.03.0+pr285.comp
+++ b/compilers/4.03.0/4.03.0+pr285/4.03.0+pr285.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr291/4.03.0+pr291.comp
+++ b/compilers/4.03.0/4.03.0+pr291/4.03.0+pr291.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr292/4.03.0+pr292.comp
+++ b/compilers/4.03.0/4.03.0+pr292/4.03.0+pr292.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr293/4.03.0+pr293.comp
+++ b/compilers/4.03.0/4.03.0+pr293/4.03.0+pr293.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr3/4.03.0+pr3.comp
+++ b/compilers/4.03.0/4.03.0+pr3/4.03.0+pr3.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr301/4.03.0+pr301.comp
+++ b/compilers/4.03.0/4.03.0+pr301/4.03.0+pr301.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr307/4.03.0+pr307.comp
+++ b/compilers/4.03.0/4.03.0+pr307/4.03.0+pr307.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr322/4.03.0+pr322.comp
+++ b/compilers/4.03.0/4.03.0+pr322/4.03.0+pr322.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr324/4.03.0+pr324.comp
+++ b/compilers/4.03.0/4.03.0+pr324/4.03.0+pr324.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr328/4.03.0+pr328.comp
+++ b/compilers/4.03.0/4.03.0+pr328/4.03.0+pr328.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr332/4.03.0+pr332.comp
+++ b/compilers/4.03.0/4.03.0+pr332/4.03.0+pr332.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr335/4.03.0+pr335.comp
+++ b/compilers/4.03.0/4.03.0+pr335/4.03.0+pr335.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr336/4.03.0+pr336.comp
+++ b/compilers/4.03.0/4.03.0+pr336/4.03.0+pr336.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr337/4.03.0+pr337.comp
+++ b/compilers/4.03.0/4.03.0+pr337/4.03.0+pr337.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr342/4.03.0+pr342.comp
+++ b/compilers/4.03.0/4.03.0+pr342/4.03.0+pr342.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr350/4.03.0+pr350.comp
+++ b/compilers/4.03.0/4.03.0+pr350/4.03.0+pr350.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr351/4.03.0+pr351.comp
+++ b/compilers/4.03.0/4.03.0+pr351/4.03.0+pr351.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr366/4.03.0+pr366.comp
+++ b/compilers/4.03.0/4.03.0+pr366/4.03.0+pr366.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr367/4.03.0+pr367.comp
+++ b/compilers/4.03.0/4.03.0+pr367/4.03.0+pr367.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr368/4.03.0+pr368.comp
+++ b/compilers/4.03.0/4.03.0+pr368/4.03.0+pr368.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr370/4.03.0+pr370.comp
+++ b/compilers/4.03.0/4.03.0+pr370/4.03.0+pr370.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr372/4.03.0+pr372.comp
+++ b/compilers/4.03.0/4.03.0+pr372/4.03.0+pr372.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr374/4.03.0+pr374.comp
+++ b/compilers/4.03.0/4.03.0+pr374/4.03.0+pr374.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr375/4.03.0+pr375.comp
+++ b/compilers/4.03.0/4.03.0+pr375/4.03.0+pr375.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr378/4.03.0+pr378.comp
+++ b/compilers/4.03.0/4.03.0+pr378/4.03.0+pr378.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr384/4.03.0+pr384.comp
+++ b/compilers/4.03.0/4.03.0+pr384/4.03.0+pr384.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr386/4.03.0+pr386.comp
+++ b/compilers/4.03.0/4.03.0+pr386/4.03.0+pr386.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr389/4.03.0+pr389.comp
+++ b/compilers/4.03.0/4.03.0+pr389/4.03.0+pr389.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr392/4.03.0+pr392.comp
+++ b/compilers/4.03.0/4.03.0+pr392/4.03.0+pr392.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr401/4.03.0+pr401.comp
+++ b/compilers/4.03.0/4.03.0+pr401/4.03.0+pr401.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr406/4.03.0+pr406.comp
+++ b/compilers/4.03.0/4.03.0+pr406/4.03.0+pr406.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr408/4.03.0+pr408.comp
+++ b/compilers/4.03.0/4.03.0+pr408/4.03.0+pr408.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr414/4.03.0+pr414.comp
+++ b/compilers/4.03.0/4.03.0+pr414/4.03.0+pr414.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr415/4.03.0+pr415.comp
+++ b/compilers/4.03.0/4.03.0+pr415/4.03.0+pr415.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr417/4.03.0+pr417.comp
+++ b/compilers/4.03.0/4.03.0+pr417/4.03.0+pr417.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr427/4.03.0+pr427.comp
+++ b/compilers/4.03.0/4.03.0+pr427/4.03.0+pr427.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr428/4.03.0+pr428.comp
+++ b/compilers/4.03.0/4.03.0+pr428/4.03.0+pr428.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr430/4.03.0+pr430.comp
+++ b/compilers/4.03.0/4.03.0+pr430/4.03.0+pr430.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr435/4.03.0+pr435.comp
+++ b/compilers/4.03.0/4.03.0+pr435/4.03.0+pr435.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr437/4.03.0+pr437.comp
+++ b/compilers/4.03.0/4.03.0+pr437/4.03.0+pr437.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr439/4.03.0+pr439.comp
+++ b/compilers/4.03.0/4.03.0+pr439/4.03.0+pr439.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr6/4.03.0+pr6.comp
+++ b/compilers/4.03.0/4.03.0+pr6/4.03.0+pr6.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr65/4.03.0+pr65.comp
+++ b/compilers/4.03.0/4.03.0+pr65/4.03.0+pr65.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr69/4.03.0+pr69.comp
+++ b/compilers/4.03.0/4.03.0+pr69/4.03.0+pr69.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr71/4.03.0+pr71.comp
+++ b/compilers/4.03.0/4.03.0+pr71/4.03.0+pr71.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+pr98/4.03.0+pr98.comp
+++ b/compilers/4.03.0/4.03.0+pr98/4.03.0+pr98.comp
@@ -7,5 +7,5 @@ build: [
   [make "world.opt"]
   [make "install"]
 ]
-packages: [ "base-unix" "base-bigarray" "base-threads" ]
+packages: [ "base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
+++ b/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
@@ -11,5 +11,6 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
+  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/packages/base-ocamlbuild/base-ocamlbuild.base/descr
+++ b/packages/base-ocamlbuild/base-ocamlbuild.base/descr
@@ -1,0 +1,1 @@
+OCamlbuild binary and libraries distributed with the OCaml compiler

--- a/packages/base-ocamlbuild/base-ocamlbuild.base/opam
+++ b/packages/base-ocamlbuild/base-ocamlbuild.base/opam
@@ -1,0 +1,2 @@
+opam-version: "1"
+maintainer: "gabriel.scherer@gmail.com"


### PR DESCRIPTION
I am preparing the proposal of a PR against ocaml/ocaml to remove ocamlbuild from the standard distribution (in 4.03+dev only). This first requires uploading a separate ocamlbuild package on OPAM (for >= 4.03).

Then it would be natural to strengthen the bound on the current dummy ocamlbuild.0 package to be (< 4.03), but that means pain for the people testing 4.03 today, with trunk versions with ocamlbuild -- they would not have ocamlbuild.0 available anymore, yet not want to install a separate ocamlbuild that conflicts with the preinstalled one.

The solution implemented in this PR is to add a new `base-ocamlbuild` package that signals "this compiler comes with ocamlbuild preinstalled". Then I can enable the separate ocamlbuild package with (>= 4.03) *and* (conflicts base-ocamlbuild). (I can then leave ocamlbuild.0 unchanged; semantically it would be correct to make it depend on base-ocamlbuild, but that would mean breaking switches built from home-made compiler descriptions, so I won't do it in the short term.)

This could even open the door to separate-ocamlbuild distributions of switches for older compiler versions or alternate branches.