### PR TITLE
camlp4 does not actually use or need ocamlfind directly

### DIFF
--- a/packages/camlp4/camlp4.4.02+6/opam
+++ b/packages/camlp4/camlp4.4.02+6/opam
@@ -7,7 +7,6 @@ build: [
   [make "all"]
 ]
 depends: [
-  "ocamlfind"
   "ocamlbuild" {build}
 ]
 install: [

--- a/packages/camlp4/camlp4.4.03/opam
+++ b/packages/camlp4/camlp4.4.03/opam
@@ -7,7 +7,6 @@ build: [
   [make "all"]
 ]
 depends: [
-  "ocamlfind"
   "ocamlbuild" {build}
 ]
 install: [


### PR DESCRIPTION
This keeps the base dependencies for ocaml and camlp4 simpler,
since findlib needs m4 to build as well

/cc @gasche as this may affect ocamlbuild packaging.