### PR TITLE
+ mirage-qubes.0.1

### DIFF
--- a/packages/mirage-qubes/mirage-qubes.0.1/desc
+++ b/packages/mirage-qubes/mirage-qubes.0.1/desc
@@ -1,0 +1,9 @@
+Implementations of various QubesOS protocols:
+
+- `Qubes.RExec`: provide services to other VMs
+- `Qubes.GUI`: just enough of the GUI protocol so that Qubes accepts the AppVM
+- `Qubes.DB`: read and write the VM's QubesDB database
+
+See [qubes-mirage-skeleton][] for an example using this library.
+
+[qubes-mirage-skeleton]: https://github.com/talex5/qubes-mirage-skeleton

--- a/packages/mirage-qubes/mirage-qubes.0.1/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/talex5/mirage-qubes"
+bug-reports:  "https://github.com/talex5/mirage-qubes/issues"
+dev-repo:     "https://github.com/talex5/mirage-qubes.git"
+
+build: [
+  ["./configure"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-qubes"]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cstruct"
+  "vchan"
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen"
+  "lwt"
+  "mirage-types"
+  "logs"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-qubes/mirage-qubes.0.1/url
+++ b/packages/mirage-qubes/mirage-qubes.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/talex5/mirage-qubes/archive/v0.1.tar.gz"
+checksum: "a7a5672afc6c1f04c976539827f5c1dc"


### PR DESCRIPTION
This library can be used to make unikernel VMs for Qubes. For an example, see http://roscidus.com/blog/blog/2016/01/01/a-unikernel-firewall-for-qubesos/