### PR TITLE
+ mirage-profile.0.6.1

### DIFF
--- a/packages/mirage-profile/mirage-profile.0.6.1/descr
+++ b/packages/mirage-profile/mirage-profile.0.6.1/descr
@@ -1,0 +1,6 @@
+Collect profiling information
+
+This library can be used to trace execution of OCaml/Lwt programs (such as
+MirageOS unikernels) at the level of Lwt threads. The traces can be viewed using
+JavaScript or GTK viewers provided by mirage-trace-viewer or processed by tools
+supporting the Common Trace Format (CTF).

--- a/packages/mirage-profile/mirage-profile.0.6.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.6.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+available: [ ocaml-version >= "4.00" ]
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/mirage/mirage-profile"
+dev-repo: "https://github.com/mirage/mirage-profile.git"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+license: "BSD-2-clause"
+build: [
+	["./configure"
+	  "--prefix" prefix
+	  "--%{mirage-xen-minios:enable}%-xen"
+	]
+	[make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-profile"]
+depends: [
+  "ocamlfind" {build}
+  "cstruct"
+  "ocplib-endian"
+  "io-page"
+  "lwt"
+  "ocamlbuild" {build}
+]
+depopts: [
+	"mirage-xen-minios"
+]

--- a/packages/mirage-profile/mirage-profile.0.6.1/url
+++ b/packages/mirage-profile/mirage-profile.0.6.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-profile/archive/v0.6.1.tar.gz"
+checksum: "deddb93d576a763e4c524533976624c4"


### PR DESCRIPTION
The previous release broke the build on OS X (sorry). This should fix it.

(Travis detected the problem, but it was marked as an acceptable failure)