### PR TITLE
unix-type-representations.0.1.0 - via opam-publish

### DIFF
--- a/packages/unix-type-representations/unix-type-representations.0.1.0/descr
+++ b/packages/unix-type-representations/unix-type-representations.0.1.0/descr
@@ -1,0 +1,1 @@
+Functions that expose the underlying types of some abstract types in the Unix module.

--- a/packages/unix-type-representations/unix-type-representations.0.1.0/opam
+++ b/packages/unix-type-representations/unix-type-representations.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Jeremy Yallop <yallop@gmail.com>"
+authors: "Jeremy Yallop <yallop@gmail.com>"
+homepage: "https://github.com/yallop/ocaml-unix-type-representations"
+bug-reports:
+  "https://github.com/yallop/ocaml-unix-type-representations/issues"
+license: "MIT"
+dev-repo: "https://github.com/yallop/ocaml-unix-type-representations.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  [make "test"]
+]
+remove: ["ocamlfind" "remove" "unix-type-representations"]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+  "ctypes" {test}
+  "ctypes-foreign" {test}
+  "ounit" {test}
+]

--- a/packages/unix-type-representations/unix-type-representations.0.1.0/url
+++ b/packages/unix-type-representations/unix-type-representations.0.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/yallop/ocaml-unix-type-representations/archive/0.1.0.tar.gz"
+checksum: "ed8b6597b8fd7975d3f1f4b60fbf05f8"


### PR DESCRIPTION
Functions that expose the underlying types of some abstract types in the Unix module.


---
* Homepage: https://github.com/yallop/ocaml-unix-type-representations
* Source repo: https://github.com/yallop/ocaml-unix-type-representations.git
* Bug tracker: https://github.com/yallop/ocaml-unix-type-representations/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1