### PR TITLE
Add the "ocaml-version < 4.03" constraint on all Jane Street packages

### DIFF
--- a/packages/async/async.109.19.00/opam
+++ b/packages/async/async.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.19.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.20.00/opam
+++ b/packages/async/async.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.21.00/opam
+++ b/packages/async/async.109.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.21.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.22.00/opam
+++ b/packages/async/async.109.22.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.21.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.24.00/opam
+++ b/packages/async/async.109.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.24.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.27.00/opam
+++ b/packages/async/async.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.27.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.30.00/opam
+++ b/packages/async/async.109.30.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.30.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.31.00/opam
+++ b/packages/async/async.109.31.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.31.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.32.00/opam
+++ b/packages/async/async.109.32.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.32.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.33.00/opam
+++ b/packages/async/async.109.33.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.32.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.34.00/opam
+++ b/packages/async/async.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.34.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.35.00/opam
+++ b/packages/async/async.109.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "109.35.00" & <= "109.36.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.38.00/opam
+++ b/packages/async/async.109.38.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "109.38.00" & <= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.42.00/opam
+++ b/packages/async/async.109.42.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "109.42.00" & <= "109.47.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.53.00/opam
+++ b/packages/async/async.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "109.53.00" & <= "109.55.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.53.02/opam
+++ b/packages/async/async.109.53.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "109.53.00" & <= "109.55.02"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.58.00/opam
+++ b/packages/async/async.109.58.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.58.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.109.60.00/opam
+++ b/packages/async/async.109.60.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "109.60.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.110.01.00/opam
+++ b/packages/async/async.110.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "110.01.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.111.03.00/opam
+++ b/packages/async/async.111.03.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "111.03.00" & <= "111.08.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.111.11.00/opam
+++ b/packages/async/async.111.11.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "111.11.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.111.13.00/opam
+++ b/packages/async/async.111.13.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {= "111.13.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.111.17.00/opam
+++ b/packages/async/async.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "111.17.00" & <= "111.21.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.111.25.00/opam
+++ b/packages/async/async.111.25.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "111.25.00" & <= "111.28.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.112.01.00/opam
+++ b/packages/async/async.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.112.06.00/opam
+++ b/packages/async/async.112.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "112.06.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.112.17.00/opam
+++ b/packages/async/async.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.112.24.00/opam
+++ b/packages/async/async.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "112.24.00" & < "112.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.112.35.00/opam
+++ b/packages/async/async.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async/async.113.00.00/opam
+++ b/packages/async/async.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "async_unix" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.19.00/opam
+++ b/packages/async_core/async_core.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "sexplib" {= "109.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.20.00/opam
+++ b/packages/async_core/async_core.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.22.00/opam
+++ b/packages/async_core/async_core.109.22.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "zero" {= "109.21.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.24.00/opam
+++ b/packages/async_core/async_core.109.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "zero" {= "109.21.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.27.00/opam
+++ b/packages/async_core/async_core.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "zero" {= "109.27.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.28.00/opam
+++ b/packages/async_core/async_core.109.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.30.00/opam
+++ b/packages/async_core/async_core.109.30.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.32.00/opam
+++ b/packages/async_core/async_core.109.32.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.34.00/opam
+++ b/packages/async_core/async_core.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.35.00/opam
+++ b/packages/async_core/async_core.109.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.36.00/opam
+++ b/packages/async_core/async_core.109.36.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.37.00/opam
+++ b/packages/async_core/async_core.109.37.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.38.00/opam
+++ b/packages/async_core/async_core.109.38.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.40.00/opam
+++ b/packages/async_core/async_core.109.40.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.41.00/opam
+++ b/packages/async_core/async_core.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.42.00/opam
+++ b/packages/async_core/async_core.109.42.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.45.00/opam
+++ b/packages/async_core/async_core.109.45.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.47.00/opam
+++ b/packages/async_core/async_core.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.47.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.53.00/opam
+++ b/packages/async_core/async_core.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {= "109.53.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.55.00/opam
+++ b/packages/async_core/async_core.109.55.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "109.55.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_core/async_core.109.55.02/opam
+++ b/packages/async_core/async_core.109.55.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "109.55.00" & <= "109.55.02"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_core/issues"
+dev-repo: "https://github.com/janestreet/async_core.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.111.17.00/opam
+++ b/packages/async_extended/async_extended.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.111.21.00/opam
+++ b/packages/async_extended/async_extended.111.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.111.28.00/opam
+++ b/packages/async_extended/async_extended.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.112.01.00/opam
+++ b/packages/async_extended/async_extended.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.112.06.00/opam
+++ b/packages/async_extended/async_extended.112.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.112.17.00/opam
+++ b/packages/async_extended/async_extended.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.112.24.00/opam
+++ b/packages/async_extended/async_extended.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.112.35.00/opam
+++ b/packages/async_extended/async_extended.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extended/async_extended.113.00.00/opam
+++ b/packages/async_extended/async_extended.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extended"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "camlzip"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.19.00/opam
+++ b/packages/async_extra/async_extra.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.20.00/opam
+++ b/packages/async_extra/async_extra.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.22.00/opam
+++ b/packages/async_extra/async_extra.109.22.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.24.00/opam
+++ b/packages/async_extra/async_extra.109.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.27.00/opam
+++ b/packages/async_extra/async_extra.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.28.00/opam
+++ b/packages/async_extra/async_extra.109.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.31.00/opam
+++ b/packages/async_extra/async_extra.109.31.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.32.00/opam
+++ b/packages/async_extra/async_extra.109.32.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.33.00/opam
+++ b/packages/async_extra/async_extra.109.33.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.34.00/opam
+++ b/packages/async_extra/async_extra.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.35.00/opam
+++ b/packages/async_extra/async_extra.109.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.38.00/opam
+++ b/packages/async_extra/async_extra.109.38.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.40.00/opam
+++ b/packages/async_extra/async_extra.109.40.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.41.00/opam
+++ b/packages/async_extra/async_extra.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.42.00/opam
+++ b/packages/async_extra/async_extra.109.42.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.45.00/opam
+++ b/packages/async_extra/async_extra.109.45.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.47.00/opam
+++ b/packages/async_extra/async_extra.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.47.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.53.00/opam
+++ b/packages/async_extra/async_extra.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.53.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.55.00/opam
+++ b/packages/async_extra/async_extra.109.55.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.55.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.55.02/opam
+++ b/packages/async_extra/async_extra.109.55.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {>= "109.55.00" & <= "109.55.02"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.58.00/opam
+++ b/packages/async_extra/async_extra.109.58.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.58.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.109.60.00/opam
+++ b/packages/async_extra/async_extra.109.60.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "109.60.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.110.01.00/opam
+++ b/packages/async_extra/async_extra.110.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "110.01.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.03.00/opam
+++ b/packages/async_extra/async_extra.111.03.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.06.00/opam
+++ b/packages/async_extra/async_extra.111.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.08.00/opam
+++ b/packages/async_extra/async_extra.111.08.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.11.00/opam
+++ b/packages/async_extra/async_extra.111.11.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.11.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.13.00/opam
+++ b/packages/async_extra/async_extra.111.13.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.13.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.17.00/opam
+++ b/packages/async_extra/async_extra.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.21.00/opam
+++ b/packages/async_extra/async_extra.111.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.25.00/opam
+++ b/packages/async_extra/async_extra.111.25.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.111.28.00/opam
+++ b/packages/async_extra/async_extra.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.112.01.00/opam
+++ b/packages/async_extra/async_extra.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.112.06.00/opam
+++ b/packages/async_extra/async_extra.112.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {>= "112.06.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.112.17.00/opam
+++ b/packages/async_extra/async_extra.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.112.24.00/opam
+++ b/packages/async_extra/async_extra.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "sexplib" {>= "112.24.00" & < "112.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.112.35.00/opam
+++ b/packages/async_extra/async_extra.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_extra/async_extra.113.00.00/opam
+++ b/packages/async_extra/async_extra.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 patches: [ "patch-errno.diff" ]
 remove: [["ocamlfind" "remove" "async_extra"]]
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+install: [[make "install"]]

--- a/packages/async_find/async_find.111.28.00/opam
+++ b/packages/async_find/async_find.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_find"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_find"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "sexplib" {>= "109.15.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_find/issues"
+dev-repo: "https://github.com/janestreet/async_find.git"
+install: [[make "install"]]

--- a/packages/async_inotify/async_inotify.113.00.00/opam
+++ b/packages/async_inotify/async_inotify.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_inotify"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [
@@ -15,4 +14,7 @@ depends: [
   "async_find" {>= "111.28.00" & < "111.29.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_inotify/issues"
+dev-repo: "https://github.com/janestreet/async_inotify.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.109.58.00/opam
+++ b/packages/async_kernel/async_kernel.109.58.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "109.58.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.109.60.00/opam
+++ b/packages/async_kernel/async_kernel.109.60.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "109.60.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.110.01.00/opam
+++ b/packages/async_kernel/async_kernel.110.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "110.01.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.111.03.00/opam
+++ b/packages/async_kernel/async_kernel.111.03.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.111.06.00/opam
+++ b/packages/async_kernel/async_kernel.111.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.111.08.00/opam
+++ b/packages/async_kernel/async_kernel.111.08.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.111.11.00/opam
+++ b/packages/async_kernel/async_kernel.111.11.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "111.11.00" & <= "111.13.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.111.17.00/opam
+++ b/packages/async_kernel/async_kernel.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.111.25.00/opam
+++ b/packages/async_kernel/async_kernel.111.25.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.111.28.00/opam
+++ b/packages/async_kernel/async_kernel.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.112.01.00/opam
+++ b/packages/async_kernel/async_kernel.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.112.06.00/opam
+++ b/packages/async_kernel/async_kernel.112.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "112.06.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.112.17.00/opam
+++ b/packages/async_kernel/async_kernel.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.112.24.00/opam
+++ b/packages/async_kernel/async_kernel.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "112.24.00" & < "112.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.112.35.00/opam
+++ b/packages/async_kernel/async_kernel.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_kernel/async_kernel.113.00.00/opam
+++ b/packages/async_kernel/async_kernel.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_kernel"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.23.00/opam
+++ b/packages/async_parallel/async_parallel.109.23.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.27.00/opam
+++ b/packages/async_parallel/async_parallel.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.30.00/opam
+++ b/packages/async_parallel/async_parallel.109.30.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.34.00/opam
+++ b/packages/async_parallel/async_parallel.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.35.00/opam
+++ b/packages/async_parallel/async_parallel.109.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.40.00/opam
+++ b/packages/async_parallel/async_parallel.109.40.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.41.00/opam
+++ b/packages/async_parallel/async_parallel.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.47.00/opam
+++ b/packages/async_parallel/async_parallel.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.47.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.53.00/opam
+++ b/packages/async_parallel/async_parallel.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "109.53.00" & <= "109.55.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.53.02/opam
+++ b/packages/async_parallel/async_parallel.109.53.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "109.53.00" & <= "109.55.02"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.58.00/opam
+++ b/packages/async_parallel/async_parallel.109.58.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "109.58.00" & <= "110.01.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.109.58.01/opam
+++ b/packages/async_parallel/async_parallel.109.58.01/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "109.58.00" & <= "111.13.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.111.17.00/opam
+++ b/packages/async_parallel/async_parallel.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.111.25.00/opam
+++ b/packages/async_parallel/async_parallel.111.25.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.111.28.00/opam
+++ b/packages/async_parallel/async_parallel.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "111.25.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.112.17.00/opam
+++ b/packages/async_parallel/async_parallel.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "112.17.00" & < "112.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.112.35.00/opam
+++ b/packages/async_parallel/async_parallel.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_parallel/async_parallel.113.00.00/opam
+++ b/packages/async_parallel/async_parallel.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_parallel"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+install: [[make "install"]]

--- a/packages/async_rpc_kernel/async_rpc_kernel.112.35.00/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_rpc_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_rpc_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_rpc_kernel.git"
+install: [[make "install"]]

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.00.00/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_rpc_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_rpc_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_rpc_kernel.git"
+install: [[make "install"]]

--- a/packages/async_shell/async_shell.109.28.03/opam
+++ b/packages/async_shell/async_shell.109.28.03/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_shell"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_shell"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "core_extended" {>= "109.28.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_shell/issues"
+dev-repo: "https://github.com/janestreet/async_shell.git"
+install: [[make "install"]]

--- a/packages/async_smtp/async_smtp.112.35.00/opam
+++ b/packages/async_smtp/async_smtp.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/async_smtp"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_smtp"]]
 depends: [
@@ -16,3 +15,7 @@ depends: [
   "email_message" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_smtp/issues"
+dev-repo: "https://github.com/janestreet/async_smtp.git"
+install: [[make "install"]]

--- a/packages/async_smtp/async_smtp.113.00.00/opam
+++ b/packages/async_smtp/async_smtp.113.00.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/async_smtp"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_smtp"]]
 depends: [
@@ -18,3 +17,7 @@ depends: [
   "email_message" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_smtp/issues"
+dev-repo: "https://github.com/janestreet/async_smtp.git"
+install: [[make "install"]]

--- a/packages/async_ssl/async_ssl.112.35.00/opam
+++ b/packages/async_ssl/async_ssl.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/async_ssl"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [
@@ -22,9 +21,12 @@ depends: [
   "ctypes" {>= "0.4.0"}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1"& ocaml-version < "4.03" ]
 depexts: [
   [["debian"] ["libssl-dev"]]
   [["ubuntu"] ["libssl-dev"]]
   [["centos"] ["openssl-devel"]]
 ]
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "https://github.com/janestreet/async_ssl.git"
+install: [[make "install"]]

--- a/packages/async_ssl/async_ssl.113.00.00/opam
+++ b/packages/async_ssl/async_ssl.113.00.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/async_ssl"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "ocamlbuild" {build}
   "conf-openssl"
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1"& ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "https://github.com/janestreet/async_ssl.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.19.00/opam
+++ b/packages/async_unix/async_unix.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.20.00/opam
+++ b/packages/async_unix/async_unix.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.21.00/opam
+++ b/packages/async_unix/async_unix.109.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.24.00/opam
+++ b/packages/async_unix/async_unix.109.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.27.00/opam
+++ b/packages/async_unix/async_unix.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.30.00/opam
+++ b/packages/async_unix/async_unix.109.30.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.31.00/opam
+++ b/packages/async_unix/async_unix.109.31.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.32.00/opam
+++ b/packages/async_unix/async_unix.109.32.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.34.00/opam
+++ b/packages/async_unix/async_unix.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.35.00/opam
+++ b/packages/async_unix/async_unix.109.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.36.00/opam
+++ b/packages/async_unix/async_unix.109.36.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.38.00/opam
+++ b/packages/async_unix/async_unix.109.38.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.40.00/opam
+++ b/packages/async_unix/async_unix.109.40.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.41.00/opam
+++ b/packages/async_unix/async_unix.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.42.00/opam
+++ b/packages/async_unix/async_unix.109.42.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.45.00/opam
+++ b/packages/async_unix/async_unix.109.45.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.47.00/opam
+++ b/packages/async_unix/async_unix.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.47.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.53.00/opam
+++ b/packages/async_unix/async_unix.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.53.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.55.00/opam
+++ b/packages/async_unix/async_unix.109.55.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {= "109.55.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.55.02/opam
+++ b/packages/async_unix/async_unix.109.55.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "sexplib" {>= "109.55.00" & <= "109.55.02"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.58.00/opam
+++ b/packages/async_unix/async_unix.109.58.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "109.58.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.109.60.00/opam
+++ b/packages/async_unix/async_unix.109.60.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "109.60.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.110.01.00/opam
+++ b/packages/async_unix/async_unix.110.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "110.01.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.03.00/opam
+++ b/packages/async_unix/async_unix.111.03.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.06.00/opam
+++ b/packages/async_unix/async_unix.111.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.08.00/opam
+++ b/packages/async_unix/async_unix.111.08.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.11.00/opam
+++ b/packages/async_unix/async_unix.111.11.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.11.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.13.00/opam
+++ b/packages/async_unix/async_unix.111.13.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.13.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.17.00/opam
+++ b/packages/async_unix/async_unix.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.21.00/opam
+++ b/packages/async_unix/async_unix.111.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.25.00/opam
+++ b/packages/async_unix/async_unix.111.25.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.111.28.00/opam
+++ b/packages/async_unix/async_unix.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.112.01.00/opam
+++ b/packages/async_unix/async_unix.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.112.06.00/opam
+++ b/packages/async_unix/async_unix.112.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {>= "112.06.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.112.17.00/opam
+++ b/packages/async_unix/async_unix.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.112.24.00/opam
+++ b/packages/async_unix/async_unix.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {>= "112.24.00" & < "112.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.112.35.00/opam
+++ b/packages/async_unix/async_unix.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/async_unix/async_unix.113.00.00/opam
+++ b/packages/async_unix/async_unix.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+install: [[make "install"]]

--- a/packages/bignum/bignum.112.35.00/opam
+++ b/packages/bignum/bignum.112.35.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "bignum"]
@@ -19,4 +18,7 @@ depends: [
   "zarith"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bignum/issues"
+dev-repo: "https://github.com/janestreet/bignum.git"
+install: [[make "install"]]

--- a/packages/bignum/bignum.113.00.00/opam
+++ b/packages/bignum/bignum.113.00.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "bignum"]
@@ -19,4 +18,7 @@ depends: [
   "zarith"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bignum/issues"
+dev-repo: "https://github.com/janestreet/bignum.git"
+install: [[make "install"]]

--- a/packages/bin_prot/bin_prot.109.15.00/opam
+++ b/packages/bin_prot/bin_prot.109.15.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.15.01/opam
+++ b/packages/bin_prot/bin_prot.109.15.01/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {>= "109.15.00" & <= "109.28.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.30.00/opam
+++ b/packages/bin_prot/bin_prot.109.30.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {>= "109.15.00" & <= "109.28.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.41.00/opam
+++ b/packages/bin_prot/bin_prot.109.41.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.42.00/opam
+++ b/packages/bin_prot/bin_prot.109.42.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.45.00/opam
+++ b/packages/bin_prot/bin_prot.109.45.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.47.00/opam
+++ b/packages/bin_prot/bin_prot.109.47.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {= "109.47.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.53.00/opam
+++ b/packages/bin_prot/bin_prot.109.53.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,3 +12,8 @@ depends: [
   "type_conv" {= "109.53.00"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.53.02/opam
+++ b/packages/bin_prot/bin_prot.109.53.02/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 patches: ["fix-arm-double-field.diff"]
 remove: [["ocamlfind" "remove" "bin_prot"]]
@@ -14,4 +13,8 @@ depends: [
   "type_conv" {>= "109.53.00" & <= "109.60.01"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.109.53.03/opam
+++ b/packages/bin_prot/bin_prot.109.53.03/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 patches: ["fix-arm-double-field.diff"]
 remove: [["ocamlfind" "remove" "bin_prot"]]
@@ -14,4 +13,8 @@ depends: [
   "type_conv" {>= "109.53.00" & <= "109.60.01"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.111.03.00/opam
+++ b/packages/bin_prot/bin_prot.111.03.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,4 +12,8 @@ depends: [
   "type_conv" {>= "109.53.00" & <= "111.13.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.112.01.00/opam
+++ b/packages/bin_prot/bin_prot.112.01.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,4 +12,8 @@ depends: [
   "type_conv" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.112.06.00/opam
+++ b/packages/bin_prot/bin_prot.112.06.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,4 +12,8 @@ depends: [
   "type_conv" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.112.06.01/opam
+++ b/packages/bin_prot/bin_prot.112.06.01/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,4 +12,8 @@ depends: [
   "type_conv" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.112.17.00/opam
+++ b/packages/bin_prot/bin_prot.112.17.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,4 +12,8 @@ depends: [
   "type_conv" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.112.24.00/opam
+++ b/packages/bin_prot/bin_prot.112.24.00/opam
@@ -4,7 +4,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -13,4 +12,8 @@ depends: [
   "type_conv" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]

--- a/packages/bin_prot/bin_prot.112.35.00/opam
+++ b/packages/bin_prot/bin_prot.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]

--- a/packages/bin_prot/bin_prot.113.00.00/opam
+++ b/packages/bin_prot/bin_prot.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+install: [[make "install"]]

--- a/packages/comparelib/comparelib.113.00.00/opam
+++ b/packages/comparelib/comparelib.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/comparelib"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/comparelib/issues"
+dev-repo: "https://github.com/janestreet/comparelib.git"
+install: [[make "install"]]

--- a/packages/core/core.109.19.00/opam
+++ b/packages/core/core.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.20.00/opam
+++ b/packages/core/core.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.21.00/opam
+++ b/packages/core/core.109.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.22.00/opam
+++ b/packages/core/core.109.22.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.23.00/opam
+++ b/packages/core/core.109.23.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.24.00/opam
+++ b/packages/core/core.109.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.27.00/opam
+++ b/packages/core/core.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.28.00/opam
+++ b/packages/core/core.109.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.30.00/opam
+++ b/packages/core/core.109.30.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.31.00/opam
+++ b/packages/core/core.109.31.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.32.00/opam
+++ b/packages/core/core.109.32.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.34.00/opam
+++ b/packages/core/core.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.01.0"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0"]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.35.00/opam
+++ b/packages/core/core.109.35.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["patch" "-p1" "-i" "4.01cloexec.diff"] {ocaml-version >= "4.01.0"}
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.36.00/opam
+++ b/packages/core/core.109.36.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["patch" "-p1" "-i" "4.01cloexec.diff"] {ocaml-version >= "4.01.0"}
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.37.00/opam
+++ b/packages/core/core.109.37.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["patch" "-p1" "-i" "4.01cloexec.diff"] {ocaml-version >= "4.01.0"}
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.38.00/opam
+++ b/packages/core/core.109.38.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["patch" "-p1" "-i" "4.01cloexec.diff"] {ocaml-version >= "4.01.0"}
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.40.00/opam
+++ b/packages/core/core.109.40.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["patch" "-p1" "-i" "4.01cloexec.diff"] {ocaml-version >= "4.01.0"}
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.41.00/opam
+++ b/packages/core/core.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.42.00/opam
+++ b/packages/core/core.109.42.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.45.00/opam
+++ b/packages/core/core.109.45.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.47.00/opam
+++ b/packages/core/core.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.53.00/opam
+++ b/packages/core/core.109.53.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.53.01/opam
+++ b/packages/core/core.109.53.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -25,5 +24,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
 dev-repo: "git://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+install: [[make "install"]]

--- a/packages/core/core.109.55.00/opam
+++ b/packages/core/core.109.55.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.55.02/opam
+++ b/packages/core/core.109.55.02/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.58.00/opam
+++ b/packages/core/core.109.58.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.109.60.00/opam
+++ b/packages/core/core.109.60.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.110.01.00/opam
+++ b/packages/core/core.110.01.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.03.00/opam
+++ b/packages/core/core.111.03.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.06.00/opam
+++ b/packages/core/core.111.06.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.08.00/opam
+++ b/packages/core/core.111.08.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.11.00/opam
+++ b/packages/core/core.111.11.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.11.01/opam
+++ b/packages/core/core.111.11.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.13.00/opam
+++ b/packages/core/core.111.13.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.17.00/opam
+++ b/packages/core/core.111.17.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.21.00/opam
+++ b/packages/core/core.111.21.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.25.00/opam
+++ b/packages/core/core.111.25.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.28.00/opam
+++ b/packages/core/core.111.28.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.111.28.01/opam
+++ b/packages/core/core.111.28.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.01.00/opam
+++ b/packages/core/core.112.01.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.01.01/opam
+++ b/packages/core/core.112.01.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.06.00/opam
+++ b/packages/core/core.112.06.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,8 +26,10 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-available: [ os != "darwin" ]
+available: [ os != "darwin" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
 patches: [
   "build_with_trunk.patch"
 ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.06.01/opam
+++ b/packages/core/core.112.06.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,7 +26,10 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
 patches: [
   "build_with_trunk.patch"
 ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.06.02/opam
+++ b/packages/core/core.112.06.02/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.17.00/opam
+++ b/packages/core/core.112.17.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.24.00/opam
+++ b/packages/core/core.112.24.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.24.01/opam
+++ b/packages/core/core.112.24.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -27,4 +26,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.35.00/opam
+++ b/packages/core/core.112.35.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -28,4 +27,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.112.35.01/opam
+++ b/packages/core/core.112.35.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -28,4 +27,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core/core.113.00.00/opam
+++ b/packages/core/core.113.00.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core"]]
 depends: [
@@ -28,4 +27,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+install: [[make "install"]]

--- a/packages/core_bench/core_bench.112.35.00/opam
+++ b/packages/core_bench/core_bench.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/core_bench"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_bench/issues"
+dev-repo: "https://github.com/janestreet/core_bench.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.19.00/opam
+++ b/packages/core_extended/core_extended.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -23,5 +22,7 @@ depends: [
   "sexplib" {= "109.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.20.00/opam
+++ b/packages/core_extended/core_extended.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -23,5 +22,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.21.00/opam
+++ b/packages/core_extended/core_extended.109.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -23,5 +22,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.23.00/opam
+++ b/packages/core_extended/core_extended.109.23.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -23,5 +22,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.24.00/opam
+++ b/packages/core_extended/core_extended.109.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.24.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.27.00/opam
+++ b/packages/core_extended/core_extended.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.24.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.28.00/opam
+++ b/packages/core_extended/core_extended.109.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.24.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.30.00/opam
+++ b/packages/core_extended/core_extended.109.30.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.24.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.31.00/opam
+++ b/packages/core_extended/core_extended.109.31.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.24.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.34.00/opam
+++ b/packages/core_extended/core_extended.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.24.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.35.00/opam
+++ b/packages/core_extended/core_extended.109.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.35.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.36.00/opam
+++ b/packages/core_extended/core_extended.109.36.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.36.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.40.00/opam
+++ b/packages/core_extended/core_extended.109.40.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.36.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.41.00/opam
+++ b/packages/core_extended/core_extended.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.36.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.42.00/opam
+++ b/packages/core_extended/core_extended.109.42.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.36.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.45.00/opam
+++ b/packages/core_extended/core_extended.109.45.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.36.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.47.00/opam
+++ b/packages/core_extended/core_extended.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "109.36.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.53.00/opam
+++ b/packages/core_extended/core_extended.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -25,5 +24,7 @@ depends: [
   "textutils" {= "109.53.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.55.00/opam
+++ b/packages/core_extended/core_extended.109.55.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -25,5 +24,7 @@ depends: [
   "textutils" {= "109.53.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.55.02/opam
+++ b/packages/core_extended/core_extended.109.55.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -25,5 +24,7 @@ depends: [
   "textutils" {>= "109.53.00" & <= "109.53.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.109.58.00/opam
+++ b/packages/core_extended/core_extended.109.58.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {>= "109.53.00" & <= "109.53.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.110.01.00/opam
+++ b/packages/core_extended/core_extended.110.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {>= "109.53.00" & <= "109.53.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.111.03.00/opam
+++ b/packages/core_extended/core_extended.111.03.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.111.06.00/opam
+++ b/packages/core_extended/core_extended.111.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "111.06.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.111.11.00/opam
+++ b/packages/core_extended/core_extended.111.11.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "111.06.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.111.13.00/opam
+++ b/packages/core_extended/core_extended.111.13.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "111.06.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.111.17.00/opam
+++ b/packages/core_extended/core_extended.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "111.06.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.111.25.00/opam
+++ b/packages/core_extended/core_extended.111.25.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.111.28.00/opam
+++ b/packages/core_extended/core_extended.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {= "111.28.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.112.01.00/opam
+++ b/packages/core_extended/core_extended.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,7 @@ depends: [
   "textutils" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
-os: [!"openbsd"]
+available: [ os != "openbsd" & ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.112.06.00/opam
+++ b/packages/core_extended/core_extended.112.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,8 @@ depends: [
   "textutils" {>= "112.06.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
 patches: [ "openbsd-quota-disable.diff" { (os = "openbsd") | (os = "freebsd") } ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.112.17.00/opam
+++ b/packages/core_extended/core_extended.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,8 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
 patches: [ "openbsd-quota-disable.diff" { (os = "openbsd") | (os = "freebsd") } ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.112.24.00/opam
+++ b/packages/core_extended/core_extended.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,8 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
 patches: [ "openbsd-quota-disable.diff" { (os = "openbsd") | (os = "freebsd") } ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.112.35.00/opam
+++ b/packages/core_extended/core_extended.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,8 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
 patches: [ "openbsd-quota-disable.diff" { (os = "openbsd") | (os = "freebsd") } ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_extended/core_extended.113.00.00/opam
+++ b/packages/core_extended/core_extended.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [
@@ -24,5 +23,8 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
 patches: [ "openbsd-quota-disable.diff" { (os = "openbsd") | (os = "freebsd") } ]
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.27.00/opam
+++ b/packages/core_kernel/core_kernel.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.28.00/opam
+++ b/packages/core_kernel/core_kernel.109.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.30.00/opam
+++ b/packages/core_kernel/core_kernel.109.30.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.31.00/opam
+++ b/packages/core_kernel/core_kernel.109.31.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.32.00/opam
+++ b/packages/core_kernel/core_kernel.109.32.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.33.00/opam
+++ b/packages/core_kernel/core_kernel.109.33.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.34.00/opam
+++ b/packages/core_kernel/core_kernel.109.34.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.35.00/opam
+++ b/packages/core_kernel/core_kernel.109.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.35.01/opam
+++ b/packages/core_kernel/core_kernel.109.35.01/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.36.00/opam
+++ b/packages/core_kernel/core_kernel.109.36.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.37.00/opam
+++ b/packages/core_kernel/core_kernel.109.37.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.38.00/opam
+++ b/packages/core_kernel/core_kernel.109.38.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.40.00/opam
+++ b/packages/core_kernel/core_kernel.109.40.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.41.00/opam
+++ b/packages/core_kernel/core_kernel.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.42.00/opam
+++ b/packages/core_kernel/core_kernel.109.42.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.45.00/opam
+++ b/packages/core_kernel/core_kernel.109.45.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.47.00/opam
+++ b/packages/core_kernel/core_kernel.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.53.00/opam
+++ b/packages/core_kernel/core_kernel.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -22,4 +21,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.55.00/opam
+++ b/packages/core_kernel/core_kernel.109.55.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.55.02/opam
+++ b/packages/core_kernel/core_kernel.109.55.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.58.00/opam
+++ b/packages/core_kernel/core_kernel.109.58.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.109.60.00/opam
+++ b/packages/core_kernel/core_kernel.109.60.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.110.01.00/opam
+++ b/packages/core_kernel/core_kernel.110.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.03.00/opam
+++ b/packages/core_kernel/core_kernel.111.03.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -23,4 +22,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.06.00/opam
+++ b/packages/core_kernel/core_kernel.111.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -24,4 +23,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.08.00/opam
+++ b/packages/core_kernel/core_kernel.111.08.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1" & < "4.02.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.11.00/opam
+++ b/packages/core_kernel/core_kernel.111.11.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0" & < "4.02.1"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.13.00/opam
+++ b/packages/core_kernel/core_kernel.111.13.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0" & < "4.02.1"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.17.00/opam
+++ b/packages/core_kernel/core_kernel.111.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0" & < "4.02.1"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.21.00/opam
+++ b/packages/core_kernel/core_kernel.111.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0" & < "4.02.1"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.02.1"]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.25.00/opam
+++ b/packages/core_kernel/core_kernel.111.25.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.111.28.00/opam
+++ b/packages/core_kernel/core_kernel.111.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & <= "109.15.03"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.112.01.00/opam
+++ b/packages/core_kernel/core_kernel.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.112.06.00/opam
+++ b/packages/core_kernel/core_kernel.112.06.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,8 +24,11 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.03" ]
 patches: [
   "build_with_trunk.patch"
   "include_compatibility.patch"
 ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.112.06.02/opam
+++ b/packages/core_kernel/core_kernel.112.06.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.112.17.00/opam
+++ b/packages/core_kernel/core_kernel.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.112.24.00/opam
+++ b/packages/core_kernel/core_kernel.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.112.35.00/opam
+++ b/packages/core_kernel/core_kernel.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_kernel/core_kernel.113.00.00/opam
+++ b/packages/core_kernel/core_kernel.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_kernel"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "variantslib" {>= "109.15.00" & < "109.16.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+install: [[make "install"]]

--- a/packages/core_profiler/core_profiler.112.19.00/opam
+++ b/packages/core_profiler/core_profiler.112.19.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_profiler"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_profiler/issues"
+dev-repo: "https://github.com/janestreet/core_profiler.git"
+install: [[make "install"]]

--- a/packages/core_profiler/core_profiler.112.19.01/opam
+++ b/packages/core_profiler/core_profiler.112.19.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_profiler"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_profiler/issues"
+dev-repo: "https://github.com/janestreet/core_profiler.git"
+install: [[make "install"]]

--- a/packages/core_profiler/core_profiler.112.35.00/opam
+++ b/packages/core_profiler/core_profiler.112.35.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_profiler"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_profiler/issues"
+dev-repo: "https://github.com/janestreet/core_profiler.git"
+install: [[make "install"]]

--- a/packages/core_profiler/core_profiler.113.00.00/opam
+++ b/packages/core_profiler/core_profiler.113.00.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "core_profiler"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "textutils" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/core_profiler/issues"
+dev-repo: "https://github.com/janestreet/core_profiler.git"
+install: [[make "install"]]

--- a/packages/custom_printf/custom_printf.113.00.00/opam
+++ b/packages/custom_printf/custom_printf.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/custom_printf"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "pa_ounit" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/custom_printf/issues"
+dev-repo: "https://github.com/janestreet/custom_printf.git"
+install: [[make "install"]]

--- a/packages/email_message/email_message.112.35.00/opam
+++ b/packages/email_message/email_message.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/email_message"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "email_message"]]
 depends: [
@@ -20,4 +19,7 @@ depends: [
   "fieldslib" {>= "109.20.00" & < "109.21.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/email_message/issues"
+dev-repo: "https://github.com/janestreet/email_message.git"
+install: [[make "install"]]

--- a/packages/email_message/email_message.113.00.00/opam
+++ b/packages/email_message/email_message.113.00.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/email_message"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "email_message"]]
 depends: [
@@ -21,4 +20,7 @@ depends: [
   "fieldslib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/email_message/issues"
+dev-repo: "https://github.com/janestreet/email_message.git"
+install: [[make "install"]]

--- a/packages/enumerate/enumerate.111.08.00/opam
+++ b/packages/enumerate/enumerate.111.08.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "enumerate"]
@@ -17,4 +16,7 @@ depends: [
   "type_conv" {>= "109.60.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.1" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/enumerate/issues"
+dev-repo: "https://github.com/janestreet/enumerate.git"
+install: [[make "install"]]

--- a/packages/fieldslib/fieldslib.109.19.00/opam
+++ b/packages/fieldslib/fieldslib.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "https://github.com/janestreet/fieldslib.git"
+install: [[make "install"]]

--- a/packages/fieldslib/fieldslib.109.20.00/opam
+++ b/packages/fieldslib/fieldslib.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "109.20.00" & <= "109.53.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "https://github.com/janestreet/fieldslib.git"
+install: [[make "install"]]

--- a/packages/fieldslib/fieldslib.109.20.02/opam
+++ b/packages/fieldslib/fieldslib.109.20.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "109.20.00" & <= "109.60.01"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "https://github.com/janestreet/fieldslib.git"
+install: [[make "install"]]

--- a/packages/fieldslib/fieldslib.109.20.03/opam
+++ b/packages/fieldslib/fieldslib.109.20.03/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "109.20.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "https://github.com/janestreet/fieldslib.git"
+install: [[make "install"]]

--- a/packages/fieldslib/fieldslib.113.00.00/opam
+++ b/packages/fieldslib/fieldslib.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "https://github.com/janestreet/fieldslib.git"
+install: [[make "install"]]

--- a/packages/herelib/herelib.112.35.00/opam
+++ b/packages/herelib/herelib.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/herelib"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [
@@ -12,4 +11,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/herelib/issues"
+dev-repo: "https://github.com/janestreet/herelib.git"
+install: [[make "install"]]

--- a/packages/incremental/incremental.112.35.00/opam
+++ b/packages/incremental/incremental.112.35.00/opam
@@ -8,7 +8,6 @@ license: "Apache-2.0"
 build: [
   [make]
 ]
-install: [make "install"]
 remove: [["ocamlfind" "remove" "incremental_lib"]]
 depends: [
   "camlp4"
@@ -21,4 +20,5 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+install: [[make "install"]]

--- a/packages/incremental/incremental.113.00.00/opam
+++ b/packages/incremental/incremental.113.00.00/opam
@@ -8,7 +8,6 @@ license: "Apache-2.0"
 build: [
   [make]
 ]
-install: [make "install"]
 remove: [["ocamlfind" "remove" "incremental_lib"]]
 depends: [
   "camlp4"
@@ -21,4 +20,5 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.19.00/opam
+++ b/packages/jenga/jenga.109.19.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "sexplib" {= "109.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.20.00/opam
+++ b/packages/jenga/jenga.109.20.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.21.00/opam
+++ b/packages/jenga/jenga.109.21.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.22.00/opam
+++ b/packages/jenga/jenga.109.22.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.23.00/opam
+++ b/packages/jenga/jenga.109.23.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.24.00/opam
+++ b/packages/jenga/jenga.109.24.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -25,4 +24,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.27.00/opam
+++ b/packages/jenga/jenga.109.27.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,5 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
-os: ["linux"]
+available: [ os = "linux" & ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.28.00/opam
+++ b/packages/jenga/jenga.109.28.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,5 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
-os: ["linux"]
+available: [ os = "linux" & ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.30.00/opam
+++ b/packages/jenga/jenga.109.30.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.31.00/opam
+++ b/packages/jenga/jenga.109.31.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.32.00/opam
+++ b/packages/jenga/jenga.109.32.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.33.00/opam
+++ b/packages/jenga/jenga.109.33.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.34.00/opam
+++ b/packages/jenga/jenga.109.34.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.35.00/opam
+++ b/packages/jenga/jenga.109.35.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.36.00/opam
+++ b/packages/jenga/jenga.109.36.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.37.00/opam
+++ b/packages/jenga/jenga.109.37.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.38.00/opam
+++ b/packages/jenga/jenga.109.38.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.40.00/opam
+++ b/packages/jenga/jenga.109.40.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "109.20.00" & <= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.41.00/opam
+++ b/packages/jenga/jenga.109.41.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.42.00/opam
+++ b/packages/jenga/jenga.109.42.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.45.00/opam
+++ b/packages/jenga/jenga.109.45.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.41.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.47.00/opam
+++ b/packages/jenga/jenga.109.47.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.47.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.53.00/opam
+++ b/packages/jenga/jenga.109.53.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.53.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.55.00/opam
+++ b/packages/jenga/jenga.109.55.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "109.55.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.55.02/opam
+++ b/packages/jenga/jenga.109.55.02/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "109.55.00" & <= "109.55.02"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.55.03/opam
+++ b/packages/jenga/jenga.109.55.03/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "109.55.00" & <= "109.55.02"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.109.58.00/opam
+++ b/packages/jenga/jenga.109.58.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "109.58.00" & <= "110.01.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.03.00/opam
+++ b/packages/jenga/jenga.111.03.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.06.00/opam
+++ b/packages/jenga/jenga.111.06.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "111.03.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.08.00/opam
+++ b/packages/jenga/jenga.111.08.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "111.03.00" & <= "111.13.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.08.01/opam
+++ b/packages/jenga/jenga.111.08.01/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "111.03.00" & <= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.17.00/opam
+++ b/packages/jenga/jenga.111.17.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.21.00/opam
+++ b/packages/jenga/jenga.111.21.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "111.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.25.00/opam
+++ b/packages/jenga/jenga.111.25.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.111.28.00/opam
+++ b/packages/jenga/jenga.111.28.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {= "111.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.112.01.00/opam
+++ b/packages/jenga/jenga.112.01.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "112.01.00" & < "112.02.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.112.06.00/opam
+++ b/packages/jenga/jenga.112.06.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "112.06.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.112.17.00/opam
+++ b/packages/jenga/jenga.112.17.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.112.24.00/opam
+++ b/packages/jenga/jenga.112.24.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "112.24.00" & < "112.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.112.35.00/opam
+++ b/packages/jenga/jenga.112.35.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/jenga/jenga.113.00.00/opam
+++ b/packages/jenga/jenga.113.00.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "jenga"]]
 depends: [
@@ -26,4 +25,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+install: [[make "install"]]

--- a/packages/ocaml_plugin/ocaml_plugin.112.35.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/ocaml_plugin"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "ocaml_plugin"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "herelib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
+dev-repo: "https://github.com/janestreet/ocaml_plugin.git"
+install: [[make "install"]]

--- a/packages/ocaml_plugin/ocaml_plugin.113.00.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/ocaml_plugin"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "ocaml_plugin"]]
 depends: [
@@ -19,4 +18,7 @@ depends: [
   "herelib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
+dev-repo: "https://github.com/janestreet/ocaml_plugin.git"
+install: [[make "install"]]

--- a/packages/pa_bench/pa_bench.113.00.00/opam
+++ b/packages/pa_bench/pa_bench.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/pa_bench"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pa_bench"]]
 depends: [
@@ -15,4 +14,7 @@ depends: [
   "pa_ounit" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/pa_bench/issues"
+dev-repo: "https://github.com/janestreet/pa_bench.git"
+install: [[make "install"]]

--- a/packages/pa_ounit/pa_ounit.112.35.00/opam
+++ b/packages/pa_ounit/pa_ounit.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/pa_ounit"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/pa_ounit/issues"
+dev-repo: "https://github.com/janestreet/pa_ounit.git"
+install: [[make "install"]]

--- a/packages/pa_ounit/pa_ounit.113.00.00/opam
+++ b/packages/pa_ounit/pa_ounit.113.00.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/pa_ounit"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/pa_ounit/issues"
+dev-repo: "https://github.com/janestreet/pa_ounit.git"
+install: [[make "install"]]

--- a/packages/pa_structural_sexp/pa_structural_sexp.112.35.00/opam
+++ b/packages/pa_structural_sexp/pa_structural_sexp.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/pa_structural_sexp"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pa_structural_sexp"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/pa_structural_sexp/issues"
+dev-repo: "https://github.com/janestreet/pa_structural_sexp.git"
+install: [[make "install"]]

--- a/packages/pa_structural_sexp/pa_structural_sexp.113.00.00/opam
+++ b/packages/pa_structural_sexp/pa_structural_sexp.113.00.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/pa_structural_sexp"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pa_structural_sexp"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/pa_structural_sexp/issues"
+dev-repo: "https://github.com/janestreet/pa_structural_sexp.git"
+install: [[make "install"]]

--- a/packages/pa_test/pa_test.112.24.00/opam
+++ b/packages/pa_test/pa_test.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/pa_test"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "herelib" {>= "109.35.02" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/pa_test/issues"
+dev-repo: "https://github.com/janestreet/pa_test.git"
+install: [[make "install"]]

--- a/packages/patdiff/patdiff.113.00.00/opam
+++ b/packages/patdiff/patdiff.113.00.00/opam
@@ -15,3 +15,6 @@ depends: [
   "pcre"
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/patdiff/issues"
+dev-repo: "https://github.com/janestreet/patdiff.git"

--- a/packages/patience_diff/patience_diff.112.24.00/opam
+++ b/packages/patience_diff/patience_diff.112.24.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "patience_diff"]
@@ -19,4 +18,7 @@ depends: [
   "sexplib" {>= "112.24.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/patience_diff/issues"
+dev-repo: "https://github.com/janestreet/patience_diff.git"
+install: [[make "install"]]

--- a/packages/pipebang/pipebang.113.00.00/opam
+++ b/packages/pipebang/pipebang.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/pipebang"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [
@@ -13,4 +12,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.1" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/pipebang/issues"
+dev-repo: "https://github.com/janestreet/pipebang.git"
+install: [[make "install"]]

--- a/packages/ppx_assert/ppx_assert.113.09.00/opam
+++ b/packages/ppx_assert/ppx_assert.113.09.00/opam
@@ -21,4 +21,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_bench/ppx_bench.113.09.00/opam
+++ b/packages/ppx_bench/ppx_bench.113.09.00/opam
@@ -19,4 +19,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.09.00/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_compare/ppx_compare.113.09.00/opam
+++ b/packages/ppx_compare/ppx_compare.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_conv_func/ppx_conv_func.113.09.00/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_core/ppx_core.113.09.00/opam
+++ b/packages/ppx_core/ppx_core.113.09.00/opam
@@ -15,4 +15,4 @@ depends: [
   "ppx_deriving"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.03" ]

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.09.00/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.09.00/opam
@@ -19,4 +19,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_driver/ppx_driver.113.09.00/opam
+++ b/packages/ppx_driver/ppx_driver.113.09.00/opam
@@ -17,4 +17,4 @@ depends: [
   "ppx_deriving"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_enumerate/ppx_enumerate.113.09.00/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_fail/ppx_fail.113.09.00/opam
+++ b/packages/ppx_fail/ppx_fail.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.09.00/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_here/ppx_here.113.09.00/opam
+++ b/packages/ppx_here/ppx_here.113.09.00/opam
@@ -17,4 +17,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_inline_test/ppx_inline_test.113.09.00/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_optcomp/ppx_optcomp.113.09.00/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.09.00/opam
@@ -16,4 +16,4 @@ depends: [
   "ppx_deriving"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_pipebang/ppx_pipebang.113.09.00/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.09.00/opam
@@ -17,4 +17,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.09.00/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.09.00/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
@@ -17,4 +17,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.09.00/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.09.00/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.09.00/opam
@@ -18,4 +18,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.09.00/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.09.00/opam
@@ -19,4 +19,4 @@ depends: [
   "ppx_driver"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/re2/re2.112.35.00/opam
+++ b/packages/re2/re2.112.35.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/re2"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "pa_ounit" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/re2/issues"
+dev-repo: "https://github.com/janestreet/re2.git"
+install: [[make "install"]]

--- a/packages/re2/re2.113.00.00/opam
+++ b/packages/re2/re2.113.00.00/opam
@@ -4,7 +4,6 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/re2"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "pa_ounit" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/re2/issues"
+dev-repo: "https://github.com/janestreet/re2.git"
+install: [[make "install"]]

--- a/packages/rpc_parallel/rpc_parallel.112.01.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "rpc_parallel"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "sexplib" {>= "112.01.00" & < "112.07.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.1"]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "https://github.com/janestreet/rpc_parallel.git"
+install: [[make "install"]]

--- a/packages/rpc_parallel/rpc_parallel.112.17.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "rpc_parallel"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "sexplib" {>= "112.17.00" & < "112.18.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "https://github.com/janestreet/rpc_parallel.git"
+install: [[make "install"]]

--- a/packages/rpc_parallel/rpc_parallel.112.24.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.24.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "rpc_parallel"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "sexplib" {>= "112.24.00" & < "112.25.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "https://github.com/janestreet/rpc_parallel.git"
+install: [[make "install"]]

--- a/packages/rpc_parallel/rpc_parallel.112.35.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "rpc_parallel"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "https://github.com/janestreet/rpc_parallel.git"
+install: [[make "install"]]

--- a/packages/rpc_parallel/rpc_parallel.113.00.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "rpc_parallel"]]
 depends: [
@@ -16,4 +15,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "https://github.com/janestreet/rpc_parallel.git"
+install: [[make "install"]]

--- a/packages/sexplib/sexplib.112.35.00/opam
+++ b/packages/sexplib/sexplib.112.35.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]
   [make]
-  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "sexplib"]
@@ -21,4 +20,7 @@ conflicts: [
   "type_conv" {< "112.01.00"}
   "type_conv" {>= "112.02.00"}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "https://github.com/janestreet/sexplib.git"
+install: [[make "install"]]

--- a/packages/sexplib/sexplib.113.00.00/opam
+++ b/packages/sexplib/sexplib.113.00.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]
   [make]
-  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "sexplib"]
@@ -21,4 +20,7 @@ conflicts: [
   "type_conv" {< "113.00.00"}
   "type_conv" {>= "113.01.00"}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "https://github.com/janestreet/sexplib.git"
+install: [[make "install"]]

--- a/packages/textutils/textutils.112.17.00/opam
+++ b/packages/textutils/textutils.112.17.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/textutils"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [
@@ -15,4 +14,7 @@ depends: [
   "pa_ounit" {>= "112.17.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/textutils/issues"
+dev-repo: "https://github.com/janestreet/textutils.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.109.28.00/opam
+++ b/packages/type_conv/type_conv.109.28.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.109.41.00/opam
+++ b/packages/type_conv/type_conv.109.41.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.109.47.00/opam
+++ b/packages/type_conv/type_conv.109.47.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.109.53.00/opam
+++ b/packages/type_conv/type_conv.109.53.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.109.53.02/opam
+++ b/packages/type_conv/type_conv.109.53.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.109.60.00/opam
+++ b/packages/type_conv/type_conv.109.60.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.109.60.01/opam
+++ b/packages/type_conv/type_conv.109.60.01/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.111.13.00/opam
+++ b/packages/type_conv/type_conv.111.13.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.112.01.00/opam
+++ b/packages/type_conv/type_conv.112.01.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.112.01.01/opam
+++ b/packages/type_conv/type_conv.112.01.01/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.112.01.02/opam
+++ b/packages/type_conv/type_conv.112.01.02/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -14,4 +13,7 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.113.00.00/opam
+++ b/packages/type_conv/type_conv.113.00.00/opam
@@ -7,7 +7,6 @@ dev-repo: "https://github.com/janestreet/type_conv.git"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "type_conv"]]
@@ -16,4 +15,5 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03" ]
+install: [[make "install"]]

--- a/packages/type_conv/type_conv.113.00.01/opam
+++ b/packages/type_conv/type_conv.113.00.01/opam
@@ -14,4 +14,4 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03" ]

--- a/packages/type_conv/type_conv.113.00.02/opam
+++ b/packages/type_conv/type_conv.113.00.02/opam
@@ -14,4 +14,4 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03" ]

--- a/packages/typerep/typerep.112.35.00/opam
+++ b/packages/typerep/typerep.112.35.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "typerep_lib"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "112.35.00" & < "112.36.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/typerep/issues"
+dev-repo: "https://github.com/janestreet/typerep.git"
+install: [[make "install"]]

--- a/packages/typerep/typerep.113.00.00/opam
+++ b/packages/typerep/typerep.113.00.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "typerep_lib"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/typerep/issues"
+dev-repo: "https://github.com/janestreet/typerep.git"
+install: [[make "install"]]

--- a/packages/typerep_extended/typerep_extended.113.00.00/opam
+++ b/packages/typerep_extended/typerep_extended.113.00.00/opam
@@ -6,7 +6,6 @@ license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "typerep_extended"]]
 depends: [
@@ -18,4 +17,7 @@ depends: [
   "sexplib" {>= "113.00.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/typerep_extended/issues"
+dev-repo: "https://github.com/janestreet/typerep_extended.git"
+install: [[make "install"]]

--- a/packages/variantslib/variantslib.109.15.03/opam
+++ b/packages/variantslib/variantslib.109.15.03/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/variantslib"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [
@@ -14,4 +13,7 @@ depends: [
   "type_conv" {>= "109.15.00" & < "113.01.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/variantslib/issues"
+dev-repo: "https://github.com/janestreet/variantslib.git"
+install: [[make "install"]]

--- a/packages/zero/zero.109.19.00/opam
+++ b/packages/zero/zero.109.19.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "zero"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.17.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/zero/issues"
+dev-repo: "https://github.com/janestreet/zero.git"
+install: [[make "install"]]

--- a/packages/zero/zero.109.20.00/opam
+++ b/packages/zero/zero.109.20.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "zero"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/zero/issues"
+dev-repo: "https://github.com/janestreet/zero.git"
+install: [[make "install"]]

--- a/packages/zero/zero.109.21.00/opam
+++ b/packages/zero/zero.109.21.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "zero"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/zero/issues"
+dev-repo: "https://github.com/janestreet/zero.git"
+install: [[make "install"]]

--- a/packages/zero/zero.109.27.00/opam
+++ b/packages/zero/zero.109.27.00/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [
   [make]
-  [make "install"]
 ]
 remove: [["ocamlfind" "remove" "zero"]]
 depends: [
@@ -17,4 +16,7 @@ depends: [
   "sexplib" {= "109.20.00"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/zero/issues"
+dev-repo: "https://github.com/janestreet/zero.git"
+install: [[make "install"]]

--- a/packages/zero/zero.109.28.00/opam
+++ b/packages/zero/zero.109.28.00/opam
@@ -1,6 +1,8 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
 authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03" ]
+bug-reports: "https://github.com/janestreet/zero/issues"
+dev-repo: "https://github.com/janestreet/zero.git"


### PR DESCRIPTION
Following janestreet/sexplib#17