### PR TITLE
pkg-config openssl doesn't return anything on BSDs (but exit code 1)

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -3,7 +3,9 @@ maintainer: "David Sheets <sheets@alum.mit.edu>"
 authors: ["The OpenSSL Project"]
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
-build: [["pkg-config" "openssl"]]
+build: [
+  ["pkg-config" "openssl"] {os != "freebsd" & os != "openbsd"}
+]
 depends: ["conf-pkg-config"]
 depexts: [
   [["debian"] ["libssl-dev"]]


### PR DESCRIPTION
this fixes the partial work of #5334 and makes `conf-openssl` installable on FreeBSD and OpenBSD