### PR TITLE
ocal.0.1.2 - via opam-publish

### DIFF
--- a/packages/ocal/ocal.0.1.2/descr
+++ b/packages/ocal/ocal.0.1.2/descr
@@ -1,0 +1,4 @@
+Unix `cal` replacement
+A replacement for the standard Unix `cal` utility. Partly because I
+could, partly because I'd become too irritated with its command line
+interface.

--- a/packages/ocal/ocal.0.1.2/opam
+++ b/packages/ocal/ocal.0.1.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Richard Mortier <mort@cantab.net>"
+authors: "Richard Mortier"
+homepage: "https://github.com/mor1/ocal"
+bug-reports: "https://github.com/mor1/ocal/issues"
+license: "ISC"
+dev-repo: "https://github.com/mor1/ocal.git"
+build: [
+  [make "configure"]
+  [make "build"]
+]
+depends: [
+  "astring" {build}
+  "calendar" {build}
+  "cmdliner" {build}
+  "ocamlfind" {build}
+]

--- a/packages/ocal/ocal.0.1.2/url
+++ b/packages/ocal/ocal.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mor1/ocal/archive/0.1.2.tar.gz"
+checksum: "c746604a320d54a35eb4d3bb2ba6fc94"


### PR DESCRIPTION
Unix `cal` replacement
A replacement for the standard Unix `cal` utility. Partly because I
could, partly because I'd become too irritated with its command line
interface.


---
* Homepage: https://github.com/mor1/ocal
* Source repo: https://github.com/mor1/ocal.git
* Bug tracker: https://github.com/mor1/ocal/issues

---

Pull-request generated by opam-publish v0.3.1