### PR TITLE
logs.0.5.0 - via opam-publish

### DIFF
--- a/packages/logs/logs.0.5.0/descr
+++ b/packages/logs/logs.0.5.0/descr
@@ -1,0 +1,24 @@
+Logging infrastructure for OCaml
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` depends only on the `result` compatibility package. The
+optional `Logs_fmt` reporter on OCaml formatters depends on [Fmt][1].
+The optional `Logs_browser` reporter that reports to the web browser
+console depends on [js_of_ocaml][2]. The optional `Logs_cli` library
+that provides command line support for controlling Logs depends on
+[`Cmdliner`][3]. The optional `Logs_lwt` library that provides Lwt logging
+functions depends on [`Lwt`][4]
+
+Logs and its reporters are distributed under the BSD3 license.
+
+[1]: http://ocsigen.org/js_of_ocaml/
+[2]: http://erratique.ch/software/fmt
+[3]: http://erratique.ch/software/cmdliner
+[4]: http://ocsigen.org/lwt/
+

--- a/packages/logs/logs.0.5.0/opam
+++ b/packages/logs/logs.0.5.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/logs"
+doc: "http://erratique.ch/software/logs"
+dev-repo: "http://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "BSD-3-Clause"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "mtime" {test}
+  "result" ]
+depopts: [ "js_of_ocaml" "fmt" "cmdliner" "lwt" ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+                           "jsoo=%{js_of_ocaml:installed}%"
+                           "fmt=%{fmt:installed}%"
+                           "cmdliner=%{cmdliner:installed}%"
+                           "lwt=%{lwt:installed}%"
+ ]
+]

--- a/packages/logs/logs.0.5.0/url
+++ b/packages/logs/logs.0.5.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/logs/releases/logs-0.5.0.tbz"
+checksum: "f5a882164b986456c3178d7e50774394"


### PR DESCRIPTION
Logging infrastructure for OCaml

Logs provides a logging infrastructure for OCaml. Logging is performed
on sources whose reporting level can be set independently. Log message
report is decoupled from logging and is handled by a reporter.

A few optional log reporters are distributed with the base library and
the API easily allows to implement your own.

`Logs` depends only on the `result` compatibility package. The
optional `Logs_fmt` reporter on OCaml formatters depends on [Fmt][1].
The optional `Logs_browser` reporter that reports to the web browser
console depends on [js_of_ocaml][2]. The optional `Logs_cli` library
that provides command line support for controlling Logs depends on
[`Cmdliner`][3]. The optional `Logs_lwt` library that provides Lwt logging
functions depends on [`Lwt`][4]

Logs and its reporters are distributed under the BSD3 license.

[1]: http://ocsigen.org/js_of_ocaml/
[2]: http://erratique.ch/software/fmt
[3]: http://erratique.ch/software/cmdliner
[4]: http://ocsigen.org/lwt/



---
* Homepage: http://erratique.ch/software/logs
* Source repo: http://erratique.ch/repos/logs.git
* Bug tracker: https://github.com/dbuenzli/logs/issues

---

Pull-request generated by opam-publish v0.3.1