### PR TITLE
Dose 3.4.1 requires extlib 1.7.0.

### DIFF
--- a/packages/dose/dose.3.4.1/opam
+++ b/packages/dose/dose.3.4.1/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocamlgraph" {= "1.8.6"}
   "cudf" {>= "0.7"}
-  ("extlib" {<= "1.7.0"} | "extlib-compat" {<= "1.7.0"})
+  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
   "ocamlbuild" {build}
   "cppo" {build}


### PR DESCRIPTION
The `OptParse` interface changed in extlib 1.7.0:

https://github.com/ygrek/ocaml-extlib/commit/3ea0e045f37872a06b743fa3acdad60cd7b8f366

See:

https://github.com/ocaml/opam-repository/pull/5364#issuecomment-169964167