### PR TITLE
dose 3.4.1 is not compatible with 3.3 which breaks opam-lib.1.2.2

### DIFF
--- a/packages/opam-lib/opam-lib.1.2.2/opam
+++ b/packages/opam-lib/opam-lib.1.2.2/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocamlgraph"
   "cmdliner"
-  "dose" {>= "3.2.2+opam" & < "4"}
+  "dose" {>= "3.2.2+opam" & < "3.4.0"}
   "cudf"
   "re" {>= "1.2.0"}
   "ocamlfind" {build}


### PR DESCRIPTION
Fixes #5395.