### PR TITLE
OpenSSL is included in NetBSD's base system.

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -4,7 +4,7 @@ authors: ["The OpenSSL Project"]
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
 build: [
-  ["pkg-config" "openssl"] {os != "freebsd" & os != "openbsd"}
+  ["pkg-config" "openssl"] {os != "freebsd" & os != "openbsd" & os != "netbsd"}
 ]
 depends: ["conf-pkg-config"]
 depexts: [


### PR DESCRIPTION
Since the addition of `conf-openssl`, all packages with an `ssl` dependency won't build on NetBSD. This patch adds NetBSD with the other BSDs in skipping the `pkg-config` query for OpenSSL.

This builds upon the pull in issue #5389.