### PR TITLE
usbmux.0.3 - via opam-publish

### DIFF
--- a/packages/usbmux/usbmux.0.3/descr
+++ b/packages/usbmux/usbmux.0.3/descr
@@ -1,0 +1,3 @@
+Control port remapping for iOS devices
+Talk to jailbroken iDevices over USB.
+

--- a/packages/usbmux/usbmux.0.3/files/_oasis_remove_.ml
+++ b/packages/usbmux/usbmux.0.3/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/usbmux/usbmux.0.3/files/usbmux.install
+++ b/packages/usbmux/usbmux.0.3/files/usbmux.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/usbmux/usbmux.0.3/opam
+++ b/packages/usbmux/usbmux.0.3/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/onlinemediagroup/ocaml-usbmux"
+dev-repo: "https://github.com/onlinemediagroup/ocaml-usbmux.git"
+bug-reports: "https://github.com/onlinemediagroup/ocaml-usbmux/issues"
+license: "BSD-3"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/usbmux/_oasis_remove_.ml" "%{etc}%/usbmux"]
+depends: [
+  "ANSITerminal"
+  "cmdliner" {build}
+  "cohttp"
+  "lwt" {>= "2.5.1"}
+  "ocamlfind" {build}
+  "plist"
+  "stringext"
+  "yojson"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/usbmux/usbmux.0.3/url
+++ b/packages/usbmux/usbmux.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/onlinemediagroup/ocaml-usbmux/archive/v0.3.tar.gz"
+checksum: "d3111c4f11e525670b478a1ac8d80c0b"


### PR DESCRIPTION
Control port remapping for iOS devices
Talk to jailbroken iDevices over USB.



---
* Homepage: https://github.com/onlinemediagroup/ocaml-usbmux
* Source repo: https://github.com/onlinemediagroup/ocaml-usbmux.git
* Bug tracker: https://github.com/onlinemediagroup/ocaml-usbmux/issues

---

Pull-request generated by opam-publish v0.3.1