### PR TITLE
Fixing dependency of ocamlfind 1.5.1 to 1.5.3 into not using ocaml 3.11

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -21,4 +21,7 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
-available: [ocaml-version >= "3.10.0"] # needs ocamldep -modules
+# needs 3.10.0 for ocamldep -modules but for some reason, when using
+# 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0
+available: [ (ocaml-version >= "3.12.0") |
+             ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0")) ]

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -21,4 +21,7 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
-available: [ocaml-version >= "3.10.0"] # needs ocamldep -modules
+# needs 3.10.0 for ocamldep -modules but for some reason, when using
+# 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0
+available: [ (ocaml-version >= "3.12.0") |
+             ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0")) ]

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -21,4 +21,7 @@ depexts: [
 post-messages: [
   "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
 ]
-available: [ocaml-version >= "3.10.0"] # needs ocamldep -modules
+# needs 3.10.0 for ocamldep -modules but for some reason, when using
+# 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0
+available: [ (ocaml-version >= "3.12.0") |
+             ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0")) ]


### PR DESCRIPTION
For some reason, some test of the ocamlfind test-suite needs cmxs (available from 3.12) when using ocaml 3.11 but not when using ocaml 3.10. This PR fixes the dependency (this was noticed by Soichi Sumi on caml-list).

