### PR TITLE
Add patch for compilation of OCaml 3.12.0 with binutils >= 2.21.

### DIFF
--- a/compilers/3.12.0/3.12.0/3.12.0.comp
+++ b/compilers/3.12.0/3.12.0/3.12.0.comp
@@ -1,6 +1,9 @@
 opam-version: "1"
 version: "3.12.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.0.tar.gz"
+patches:
+  # S. Glondu's patch for binutils >= 2.21 (see bug report #5237)
+  ["http://caml.inria.fr/mantis/file_download.php?file_id=418&type=bug"]
 build: [
   ["./configure" "-prefix" prefix]
   [make "world"]


### PR DESCRIPTION
This fixes the compilation of OCaml 3.12.0 in the presence of binutils >= 2.21 (see OCaml bug #5237).

I refer to the patch by its link to the bug tracker, hoping it is sustainable enough.

By the way, is there a way to use local patches for compilers the same way as it is possible for packages?

In particular, I realized I made a mistake in https://github.com/ocaml/opam-repository/commit/bb299af43c59d7f113283a0397d265d74f924f38 by referring to a local patch file of the form "file:///..." which is obviously not universal. But I don't know what existing url to give for this patch.