### PR TITLE
nodejs.0.8 - via opam-publish

### DIFF
--- a/packages/nodejs/nodejs.0.8/url
+++ b/packages/nodejs/nodejs.0.8/url
@@ -1,2 +1,2 @@
-http: "https://github.com/fxfactorial/ocaml-nodejs/archive/v0.8.tar.gz"
-checksum: "2a41141a879aac49054a51e15e83dc5e"
+http: "https://github.com/fxfactorial/ocaml-nodejs/archive/v0.9.tar.gz"
+checksum: "1f2eb3552ba0191af9d535391a5265e9"


### PR DESCRIPTION
js_of_ocaml bindings for nodejs

Write OCaml, run on node; these are js_of_ocaml bindings to the node
JavaScript API. Get all the power of the node ecosystem with the type
safety of OCaml.

Here's how easy it is to make a server.

(* Example assuming file name of c.ml *)
open Nodejs 

let () = 

  let server =
  Http.create_server begin fun incoming response ->

    Fs.read_file ~path:"./client.html" begin fun err data ->
      response#write_head ~status_code:200 [("Content-type", "text/html")];
      response#end_ ~data:(String data) ()

      end
   end
  in
  ignore begin
    server#listen ~port:8080 begin fun () ->
      Printf.sprintf "Started Server and Running node: %s" (new process#version)
      |> print_endline
    end
  end

Compile, run with:

$ ocamlfind ocamlc c.ml -linkpkg -package nodejs -o T.out
$ js_of_ocaml T.out
$ node T.js

---
* Homepage: https://github.com/fxfactorial/ocaml-nodejs
* Source repo: https://github.com/fxfactorial/ocaml-nodejs.git
* Bug tracker: https://github.com/fxfactorial/ocaml-nodejs/issues

---

Pull-request generated by opam-publish v0.3.1