### PR TITLE
nodejs.0.9 - via opam-publish

### DIFF
--- a/packages/nodejs/nodejs.0.9/descr
+++ b/packages/nodejs/nodejs.0.9/descr
@@ -1,0 +1,35 @@
+js_of_ocaml bindings for nodejs
+
+Write OCaml, run on node; these are js_of_ocaml bindings to the node
+JavaScript API. Get all the power of the node ecosystem with the type
+safety of OCaml.
+
+Here's how easy it is to make a server.
+
+(* Example assuming file name of c.ml *)
+open Nodejs 
+
+let () = 
+
+  let server =
+  Http.create_server begin fun incoming response ->
+
+    Fs.read_file ~path:"./client.html" begin fun err data ->
+      response#write_head ~status_code:200 [("Content-type", "text/html")];
+      response#end_ ~data:(String data) ()
+
+      end
+   end
+  in
+  ignore begin
+    server#listen ~port:8080 begin fun () ->
+      Printf.sprintf "Started Server and Running node: %s" (new process#version)
+      |> print_endline
+    end
+  end
+
+Compile, run with:
+
+$ ocamlfind ocamlc c.ml -linkpkg -package nodejs -o T.out
+$ js_of_ocaml T.out
+$ node T.js

--- a/packages/nodejs/nodejs.0.9/opam
+++ b/packages/nodejs/nodejs.0.9/opam
@@ -1,0 +1,62 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-nodejs"
+bug-reports: "https://github.com/fxfactorial/ocaml-nodejs/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-nodejs.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "nodejs"]
+depends: [
+  "js_of_ocaml" {>= "2.7"}
+  "lwt" {>= "2.5.1"}
+  "magic-mime"
+  "ocamlfind" {build}
+  "yojson"
+]
+depexts: [
+  [["debian"] ["nodejs"]]
+  [["homebrew" "osx"] ["node"]]
+  [["ubuntu"] ["nodejs"]]
+]
+available: [ocaml-version >= "4.02.0"]
+post-messages: [
+  "Now you can write OCaml and execute on node."
+  "Example assuming file name of c.ml:"
+  "
+open Nodejs
+
+let () =
+
+  let server =
+    (* Throw away the incoming_message *)
+    Http.create_server begin fun _ response ->
+      (* Read the file sync *)
+      (match Fs.read_file_sync \"./client.html\" with
+       | String data ->
+         response#write_head ~status_code:200 [(\"Content-type\", \"text/html\")];
+         response#end_ ~data:(String data) ()
+       | Buffer _ -> ())
+    end
+  in
+  ignore begin
+    server#listen ~port:8080 begin fun () ->
+
+      Printf.sprintf \"Started Server and Running node: %s\" (new process#version)
+      |> print_endline
+    end
+  end
+  "
+  "ocamlfind ocamlc c.ml -linkpkg -package nodejs -o T.out"
+  "js_of_ocaml T.out"
+  "node T.js"
+]

--- a/packages/nodejs/nodejs.0.9/url
+++ b/packages/nodejs/nodejs.0.9/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-nodejs/archive/v0.9.tar.gz"
+checksum: "feeb6e3b342375754de760c2a8c2280c"


### PR DESCRIPTION
js_of_ocaml bindings for nodejs

Write OCaml, run on node; these are js_of_ocaml bindings to the node
JavaScript API. Get all the power of the node ecosystem with the type
safety of OCaml.

Here's how easy it is to make a server.

(* Example assuming file name of c.ml *)
open Nodejs 

let () = 

  let server =
  Http.create_server begin fun incoming response ->

    Fs.read_file ~path:"./client.html" begin fun err data ->
      response#write_head ~status_code:200 [("Content-type", "text/html")];
      response#end_ ~data:(String data) ()

      end
   end
  in
  ignore begin
    server#listen ~port:8080 begin fun () ->
      Printf.sprintf "Started Server and Running node: %s" (new process#version)
      |> print_endline
    end
  end

Compile, run with:

$ ocamlfind ocamlc c.ml -linkpkg -package nodejs -o T.out
$ js_of_ocaml T.out
$ node T.js

---
* Homepage: https://github.com/fxfactorial/ocaml-nodejs
* Source repo: https://github.com/fxfactorial/ocaml-nodejs.git
* Bug tracker: https://github.com/fxfactorial/ocaml-nodejs/issues

---

Pull-request generated by opam-publish v0.3.1