### PR TITLE
Fixing url of patch file for ocaml 3.07 which was a link to local filesystem

### DIFF
--- a/compilers/3.07/3.07/3.07.comp
+++ b/compilers/3.07/3.07/3.07.comp
@@ -3,7 +3,7 @@ version: "3.07"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
 patches:
   # ensure sed is not interpreting characters >= 128
-  ["file:///home/herbelin/remove_DEBUG.patch"]
+  ["https://raw.githubusercontent.com/ocaml/opam-repository/master/compilers/3.07/3.07/files/remove_DEBUG.patch"]
 build: [
   ["./configure" "-prefix" prefix]
   [make "world"]


### PR DESCRIPTION
This implements @yallop suggestion in https://github.com/ocaml/opam-repository/pull/5425 to fix the url of the patch file needed for ocaml 3.07 in the presence of a locale such as utf-8.