### PR TITLE
OASIS has deprecation warning as error, fails on 4.03.0

### DIFF
--- a/packages/oasis/oasis.0.2.0/opam
+++ b/packages/oasis/oasis.0.2.0/opam
@@ -21,3 +21,4 @@ depends: [
   "expect"
   "ocamlbuild"
 ]
+available: [ ocaml-version < "4.00.0" ]

--- a/packages/oasis/oasis.0.3.0/opam
+++ b/packages/oasis/oasis.0.3.0/opam
@@ -13,3 +13,4 @@ remove: [
 depends: [
   "ocamlfind" "ocaml-data-notation" "ocamlify" "ocamlmod" "ocamlbuild"
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/oasis/oasis.0.4.0/opam
+++ b/packages/oasis/oasis.0.4.0/opam
@@ -17,3 +17,4 @@ depends: [
   "ocamlmod"
   "ocamlbuild"
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/oasis/oasis.0.4.1/opam
+++ b/packages/oasis/oasis.0.4.1/opam
@@ -17,3 +17,4 @@ depends: [
   "ocamlmod"
   "ocamlbuild"
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/oasis/oasis.0.4.2/opam
+++ b/packages/oasis/oasis.0.4.2/opam
@@ -17,3 +17,4 @@ depends: [
   "ocamlmod"
   "ocamlbuild"
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/oasis/oasis.0.4.3/opam
+++ b/packages/oasis/oasis.0.4.3/opam
@@ -17,3 +17,4 @@ depends: [
   "ocamlmod"
   "ocamlbuild"
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/oasis/oasis.0.4.4/opam
+++ b/packages/oasis/oasis.0.4.4/opam
@@ -17,3 +17,4 @@ depends: [
   "ocamlmod"
   "ocamlbuild"
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/oasis/oasis.0.4.5/opam
+++ b/packages/oasis/oasis.0.4.5/opam
@@ -40,4 +40,4 @@ conflicts: [
   "oasis-mirage" {= "0.3.0a"}
   "oasis-mirage" {= "0.3.0"}
 ]
-available: [ ocaml-version >= "3.11.2" ]
+available: [ ocaml-version >= "3.11.2" & ocaml-version < "4.03.0" ]


### PR DESCRIPTION
Also, removed oasis 0.2.0 as no mainstream OCaml back to 3.12.0 can install it.

/cc @gildor478