### PR TITLE
Fix the build of 3.12.1 due to missing patch

### DIFF
--- a/compilers/3.12.1/3.12.1/3.12.1.comp
+++ b/compilers/3.12.1/3.12.1/3.12.1.comp
@@ -1,7 +1,6 @@
 opam-version: "1"
 version: "3.12.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
-patches: ["https://github.com/hhugo/ocaml/compare/3.12.1...fix-3.12.1.diff"]
 build: [
   ["./configure" "-prefix" prefix]
   [make "world"]


### PR DESCRIPTION
Fixes #5328 but reverts #1813 which probably regresses natdynlink support on OSX.