### PR TITLE
argon2.0.1 - via opam-publish

### DIFF
--- a/packages/argon2/argon2.0.1/descr
+++ b/packages/argon2/argon2.0.1/descr
@@ -1,0 +1,3 @@
+OCaml bindings to Argon2
+
+Original C implementation: https://github.com/P-H-C/phc-winner-argon2

--- a/packages/argon2/argon2.0.1/opam
+++ b/packages/argon2/argon2.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocaml-argon2"
+bug-reports: "https://github.com/Khady/ocaml-argon2/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Khady/ocaml-argon2.git"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-doc: [make "doc"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign"
+  "result"
+  "ppx_deriving" {>= "2.0"}
+]
+available: [ocaml-version >= "4.02.1"]

--- a/packages/argon2/argon2.0.1/url
+++ b/packages/argon2/argon2.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Khady/ocaml-argon2/archive/v0.1.zip"
+checksum: "d43b1d27ce45e6ea284586832e8bec8c"


### PR DESCRIPTION
OCaml bindings to Argon2

Original C implementation: https://github.com/P-H-C/phc-winner-argon2


---
* Homepage: https://github.com/Khady/ocaml-argon2
* Source repo: git+https://github.com/Khady/ocaml-argon2.git
* Bug tracker: https://github.com/Khady/ocaml-argon2/issues

---

Pull-request generated by opam-publish v0.3.1