### PR TITLE
usbmux.0.6 - via opam-publish

### DIFF
--- a/packages/usbmux/usbmux.0.6/descr
+++ b/packages/usbmux/usbmux.0.6/descr
@@ -1,0 +1,13 @@
+Control port remapping for iOS devices
+
+Talk to jailbroken iDevices over USB with the CLI, gandalf.
+
+Basically this lets you do:
+
+ssh -p <some_port> root@localhost
+
+for an iPhone/iPod/iDevice.
+
+Example usage:
+
+sudo `which gandalf` --mappings etc/mapping --daemonize --verbose

--- a/packages/usbmux/usbmux.0.6/files/_oasis_remove_.ml
+++ b/packages/usbmux/usbmux.0.6/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/usbmux/usbmux.0.6/files/usbmux.install
+++ b/packages/usbmux/usbmux.0.6/files/usbmux.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/usbmux/usbmux.0.6/opam
+++ b/packages/usbmux/usbmux.0.6/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/onlinemediagroup/ocaml-usbmux"
+bug-reports: "https://github.com/onlinemediagroup/ocaml-usbmux/issues"
+license: "BSD-3"
+dev-repo: "https://github.com/onlinemediagroup/ocaml-usbmux.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/usbmux/_oasis_remove_.ml" "%{etc}%/usbmux"]
+depends: [
+  "ANSITerminal"
+  "cmdliner" {build}
+  "cohttp"
+  "lwt" {>= "2.5.1"}
+  "ocamlfind" {build}
+  "plist"
+  "stringext"
+  "yojson"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/usbmux/usbmux.0.6/url
+++ b/packages/usbmux/usbmux.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/onlinemediagroup/ocaml-usbmux/archive/v0.6.tar.gz"
+checksum: "0f92644f19a22815b30fad8d708f88a9"


### PR DESCRIPTION
Control port remapping for iOS devices

Talk to jailbroken iDevices over USB with the CLI, gandalf.

Basically this lets you do:

ssh -p <some_port> root@localhost

for an iPhone/iPod/iDevice.

Example usage:

sudo `which gandalf` --mappings etc/mapping --daemonize --verbose

---
* Homepage: https://github.com/onlinemediagroup/ocaml-usbmux
* Source repo: https://github.com/onlinemediagroup/ocaml-usbmux.git
* Bug tracker: https://github.com/onlinemediagroup/ocaml-usbmux/issues

---

Pull-request generated by opam-publish v0.3.1