### PR TITLE
travis: require graceful function on OS X with the latest opam and OCaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
   - os: osx
     env: OCAML_VERSION=4.02 OPAM_VERSION=1.2.2
   allow_failures:
-  - os: osx
   - env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2
 notifications:
   email:


### PR DESCRIPTION
Travis's OS X support seems to function better than it used to function with builds happening relatively quickly and without sporadic failures.

I propose making non-graceful function on OS X a failure from the CI perspective. Packages which do not function or fail un-gracefully on OS X should be amended to either exclude OS X in their metadata or should be fixed to work on OS X. Given the number of users and developers on OS X and its similar functionality to Linux and the BSDs, making OS X a primary platform will be good for the community.

Discussion welcome.