### PR TITLE
Add the install files, and build dependencies, for bisect_ppx 0.2.6

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.0.2.6/files/bisect_ppx.install
+++ b/packages/bisect_ppx/bisect_ppx.0.2.6/files/bisect_ppx.install
@@ -1,0 +1,4 @@
+bin: [
+  "_build/src/report/report.byte" {"bisect-ppx-report"}
+  "?_build/src/report/report.native" {"bisect-ppx-report"}
+]

--- a/packages/bisect_ppx/bisect_ppx.0.2.6/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.6/opam
@@ -11,6 +11,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ppx_tools" {build}
+  "ocamlbuild" {build}
 ]


### PR DESCRIPTION
I forgot to add the .install file necessary for installing `bisect-ppx-report`. Also added the build dependency on `ocamlfind`, and a correct `ocamlbuild` dependency.

My apologies for missing these. When I used `opam-publish` for 0.2.5 it "Just Worked" and I didn't check again.