### PR TITLE
add dose.3.4.2 (new upstream release)

### DIFF
--- a/packages/dose/dose.3.4.2/descr
+++ b/packages/dose/dose.3.4.2/descr
@@ -1,0 +1,1 @@
+Dose library (part of Mancoosi tools)

--- a/packages/dose/dose.3.4.2/opam
+++ b/packages/dose/dose.3.4.2/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "pietro.abate@pps.univ-paris-diderot.fr"
+authors: [
+  "Pietro Abate"
+  "Jaap Boender"
+  "Roberto Di Cosmo"
+  "Johannes Schauer"
+  "Ralf Treinen"
+  "Stefano Zacchiroli"
+  "Jakub Zwolakowski"
+  "Olivier Rosello"
+]
+homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
+license: "LGPL-v3+ with OCaml linking exception"
+dev-repo: "https://gforge.inria.fr/git/dose/dose.git"
+build: [
+  ["./configure" "--with-ocamlgraph"]
+  [make printconf]
+  [make]
+]
+install: [make "installlib"]
+remove: [
+  ["./configure" "--with-ocamlgraph"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlgraph" {= "1.8.6"}
+  "cudf" {>= "0.7"}
+  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
+  "re" {>= "1.2.2"}
+  "ocamlbuild" {build}
+  "cppo" {build & >= "1.1.2"}
+]

--- a/packages/dose/dose.3.4.2/url
+++ b/packages/dose/dose.3.4.2/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/file/35465/dose3-4.2.tar.gz"
+checksum: "99a5c01496165e47d8fda8e3810c62a1"


### PR DESCRIPTION
* Fix META file and other compilation problems (notably on 32 bits architectures)
* Add back the "Enhances" field in the debian printer
* the new yaml format also drops the architecture suffix in the package and unsat-dependency fields 
* Add new function Depsolver.is_consistent and Debian.Debcudf.get_real_name 
* Update the yaml output of outdated (no more cudf-related cruft in package names) 
* bump yaml output-version to 1.1 