### PR TITLE
Heptagon version 1.03.00

### DIFF
--- a/packages/heptagon/heptagon.1.03.00/descr
+++ b/packages/heptagon/heptagon.1.03.00/descr
@@ -1,0 +1,10 @@
+Compiler for the Heptagon/BZR synchronous programming language
+Heptagon/BZR is a synchronous dataflow language whose syntax and
+semantics is inspired from Lustre, with a syntax allowing the
+expression of control structures (e.g., switch or mode automata).
+Heptagon/BZR is a research compiler, whose aim is to facilitate
+experimentation. The current version of the compiler includes the
+following features:
+- Inclusion of discrete controller synthesis within the compilation
+- Expression and compilation of array values with modular memory optimization
+See http://bzr.inria.fr for further informations.

--- a/packages/heptagon/heptagon.1.03.00/files/heptagon.install
+++ b/packages/heptagon/heptagon.1.03.00/files/heptagon.install
@@ -1,0 +1,19 @@
+bin: [
+  "compiler/_build/main/heptc.byte" {"heptc"}
+  "?compiler/_build/main/hepts.byte" {"hepts"}
+  "?compiler/_build/main/ctrl2ept.byte" {"ctrl2ept"}
+  "?compiler/_build/main/heptc.native" {"heptc.opt"}
+  "?compiler/_build/main/hepts.native" {"hepts.opt"}
+  "?compiler/_build/main/ctrl2ept.native" {"ctrl2ept.opt"}
+]
+lib: [
+  "lib/c/math.c" {"c/math.c"}
+  "lib/c/math.h" {"c/math.h"}
+  "lib/c/pervasives.h" {"c/pervasives.h"}
+  "lib/iostream.epci" {"iostream.epci"}
+  "lib/iostream.epi" {"iostream.epi"}
+  "lib/math.epci" {"math.epci"}
+  "lib/math.epi" {"math.epi"}
+  "lib/pervasives.epci" {"pervasives.epci"}
+  "lib/pervasives.epi" {"pervasives.epi"}
+]

--- a/packages/heptagon/heptagon.1.03.00/opam
+++ b/packages/heptagon/heptagon.1.03.00/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "gwenael.delaval@inria.fr"
+authors: "Gwenaël Delaval"
+homepage: "http://bzr.inria.fr"
+dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/heptagon/heptagon.git"
+build: [
+   ["./configure" "--prefix" prefix]
+   [make]
+]
+tags: [ "flags:light-uninstall" ]
+depends: [
+  "ocamlfind"
+  "menhir" {>= "20141215"}
+  "ocamlgraph"
+  "camlp4"
+  "ocamlbuild" {build}
+]
+depopts: ["lablgtk"]

--- a/packages/heptagon/heptagon.1.03.00/url
+++ b/packages/heptagon/heptagon.1.03.00/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/file/35466/heptagon-1.03.00.tar.gz"
+checksum: "84c930f50e1c758e9a58b642de76745c"


### PR DESCRIPTION
Heptagon 1.03.00

 - -deadcode option, improvement of deadcode removal
 - graphical simulator handles type aliasing