### PR TITLE
ocplib-json-typed.0.1 - via opam-publish

### DIFF
--- a/packages/ocplib-json-typed/ocplib-json-typed.0.1/descr
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.1/descr
@@ -1,0 +1,9 @@
+Type-aware JSON and JSON schema utilities
+
+This library currently contains three modules:
+
+- Json_encoding: mapping between OCaml types and JSON schemas.
+- Json_schema: manipulation of JSON schemas.
+- Json_repr: manipulation and conversion of JSON data.
+
+Shares types with ezjsonm, yojson compatibility translators provided.

--- a/packages/ocplib-json-typed/ocplib-json-typed.0.1/opam
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "https://github.com/ocamlpro/ocplib-json-typed.git"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "uri" {>= "1.9.0"}
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/ocplib-json-typed/ocplib-json-typed.0.1/url
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.1.tar.gz"
+checksum: "d2455be9dd96731a364f90f01aff08f5"


### PR DESCRIPTION
Type-aware JSON and JSON schema utilities

This library currently contains three modules:

- Json_encoding: mapping between OCaml types and JSON schemas.
- Json_schema: manipulation of JSON schemas.
- Json_repr: manipulation and conversion of JSON data.

Shares types with ezjsonm, yojson compatibility translators provided.

---
* Homepage: https://github.com/ocamlpro/ocplib-json-typed
* Source repo: https://github.com/ocamlpro/ocplib-json-typed.git
* Bug tracker: https://github.com/ocamlpro/ocplib-json-typed/issues

---

Pull-request generated by opam-publish v0.3.1