### PR TITLE
Update checksum for sundialsml

### DIFF
--- a/packages/sundialsml/sundialsml.2.5.0p2/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p2/opam
@@ -37,7 +37,7 @@ depopts: [
 depexts: [
     [["debian"] ["libsundials-serial-dev"]]
     [["ubuntu"] ["libsundials-serial-dev"]]
-    [["osx" "homebrew"] ["sundials"]]
+    [["osx" "homebrew"] ["homebrew/science/sundials"]]
     [["osx" "macports"] ["sundials"]]
 ]
 ocaml-version: [>= "3.12.1"]

--- a/packages/sundialsml/sundialsml.2.5.0p2/url
+++ b/packages/sundialsml/sundialsml.2.5.0p2/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/inria-parkas/sundialsml/archive/v2.5.0p2.zip"
-checksum: "ca87b44cf825f537f9ae02c07093bdd1"
+checksum: "479095cc1cd4d9988cfe2e4848496b98"


### PR DESCRIPTION
The checksum on the github archived zip seems to have changed, but a diff -r
against its contents and sundialsml:master shows no differences.