### PR TITLE
fdkaac.0.2.1 - via opam-publish

### DIFF
--- a/packages/fdkaac/fdkaac.0.2.1/descr
+++ b/packages/fdkaac/fdkaac.0.2.1/descr
@@ -1,0 +1,4 @@
+Fraunhofer FDK AAC Codec Library
+
+The FDK AAC Codec Library For Android contains an encoder implementation of the
+Advanced Audio Coding (AAC) audio codec.

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-fdkaac"
+bug-reports: "https://github.com/savonet/ocaml-fdkaac/issues"
+license: "GPL-2.0"
+dev-repo: "https://github.com/savonet/ocaml-fdkaac.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"] { os != "darwin"}
+  ["./configure" "OCAMLFLAGS='-cclib -L/usr/local/lib'" "--prefix=%{prefix}%"] { os = "darwin"}
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "fdkaac"]
+depends: [
+  "ocamlfind" {build}
+]
+depexts: [
+  [["debian"] ["libfdk-aac-dev"]]
+  [["ubuntu"] ["libfdk-aac-dev"]]
+  [["osx" "homebrew"] ["fdk-aac"]]
+]

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -6,8 +6,8 @@ bug-reports: "https://github.com/savonet/ocaml-fdkaac/issues"
 license: "GPL-2.0"
 dev-repo: "https://github.com/savonet/ocaml-fdkaac.git"
 build: [
-  ["./configure" "--prefix=%{prefix}%"] { os != "darwin"}
-  ["./configure" "OCAMLFLAGS=-cclib -L/usr/local/lib" "--prefix=%{prefix}%"] { os = "darwin"}
+  ["./configure" "--prefix=%{prefix}%"] { os != "darwin" }
+  ["./configure" "OCAMLFLAGS=-cclib -L/usr/local/lib" "--prefix=%{prefix}%"] { os = "darwin" }
   [make]
 ]
 install: [make "install"]

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -7,7 +7,7 @@ license: "GPL-2.0"
 dev-repo: "https://github.com/savonet/ocaml-fdkaac.git"
 build: [
   ["./configure" "--prefix=%{prefix}%"] { os != "darwin"}
-  ["./configure" "OCAMLFLAGS='-cclib -L/usr/local/lib'" "--prefix=%{prefix}%"] { os = "darwin"}
+  ["./configure" "OCAMLFLAGS=-cclib -L/usr/local/lib" "--prefix=%{prefix}%"] { os = "darwin"}
   [make]
 ]
 install: [make "install"]

--- a/packages/fdkaac/fdkaac.0.2.1/url
+++ b/packages/fdkaac/fdkaac.0.2.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/savonet/ocaml-fdkaac/releases/download/0.2.1/ocaml-fdkaac-0.2.1.tar.gz"
+checksum: "fff652fa282b4954d2f504ca1c2a70e9"

--- a/packages/liquidsoap/liquidsoap.1.2.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "romain.beauxis@gmail.com"
 homepage: "https://github.com/savonet/liquidsoap"
-authors: "The Savonet Team <savonet-users@lists.sourceforge.net"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 build: [
   ["./configure" "--prefix" prefix "--sbindir=%{lib}%/liquidsoap/sbin" "--libexecdir=%{lib}%/liquidsoap/libexec" "--sysconfdir=%{lib}%/liquidsoap/etc" "--sharedstatedir=%{lib}%/liquidsoap/com" "--localstatedir=%{lib}%/liquidsoap/var" "--libdir=%{lib}%/liquidsoap/lib" "--includedir=%{lib}%/liquidsoap/include" "--datarootdir=%{lib}%/liquidsoap/share" "--disable-graphics" "--with-user=dummy" "--with-group=dummy"]
   [make]
@@ -20,7 +20,6 @@ depends: [
   "dtools"
   "duppy" {>= "0.5.0"}
   "mm" {>= "0.2.1"}
-  "mad"
 ]
 depopts: [
   "cry"
@@ -38,10 +37,12 @@ depopts: [
   "opus"
   "faad"
   "flac"
+  "fdkaac"
   "speex"
   "schroedinger"
   "voaacenc"
   "ladspa"
+  "mad"
   "samplerate"
   "soundtouch"
   "gavl"


### PR DESCRIPTION
Fraunhofer FDK AAC Codec Library

The FDK AAC Codec Library For Android contains an encoder implementation of the
Advanced Audio Coding (AAC) audio codec.


---
* Homepage: https://github.com/savonet/ocaml-fdkaac
* Source repo: https://github.com/savonet/ocaml-fdkaac.git
* Bug tracker: https://github.com/savonet/ocaml-fdkaac/issues

---

Pull-request generated by opam-publish v0.3.1