### PR TITLE
reactiveData.0.2 - via opam-publish

### DIFF
--- a/packages/reactiveData/reactiveData.0.2/descr
+++ b/packages/reactiveData/reactiveData.0.2/descr
@@ -1,0 +1,6 @@
+Functional reactive programming with incremental changes in data structures
+
+ReactiveData is an OCaml module for functional reactive
+programming (FRP) based on React. It adds support to incremental
+changes in data structures by reasoning on patches instead of absolute
+values.

--- a/packages/reactiveData/reactiveData.0.2/opam
+++ b/packages/reactiveData/reactiveData.0.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+
+maintainer: "Hugo Heuzard <hugo.heuzard@gmail.com>"
+authors: ["Hugo Heuzard <hugo.heuzard@gmail.com>"]
+homepage: "https://github.com/ocsigen/reactiveData"
+dev-repo: "https://github.com/ocsigen/reactiveData.git"
+bug-reports: "https://github.com/ocsigen/reactiveData/issues"
+
+doc:"http://ocsigen.github.io/reactiveData/0.2/"
+
+tags: [ "reactive" "declarative" "signal" "event" "frp" ]
+license: "LGPL-3.0 with OCaml linking exception"
+
+depends: ["ocamlfind" "react"]
+build:
+[
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native}%" ]
+]
+build-doc: ["ocamlbuild" "-use-ocamlfind" "src/api.docdir/index.html"]
+
+available: ocaml-version >= "3.11.0"

--- a/packages/reactiveData/reactiveData.0.2/url
+++ b/packages/reactiveData/reactiveData.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/reactiveData/archive/0.2.tar.gz"
+checksum: "02c61c421c8bf02310acee73f4beafdd"


### PR DESCRIPTION
Functional reactive programming with incremental changes in data structures

ReactiveData is an OCaml module for functional reactive
programming (FRP) based on React. It adds support to incremental
changes in data structures by reasoning on patches instead of absolute
values.


---
* Homepage: https://github.com/ocsigen/reactiveData
* Source repo: https://github.com/ocsigen/reactiveData.git
* Bug tracker: https://github.com/ocsigen/reactiveData/issues

---

Pull-request generated by opam-publish v0.3.1