### PR TITLE
usbmux.0.9 - via opam-publish

### DIFF
--- a/packages/usbmux/usbmux.0.9/descr
+++ b/packages/usbmux/usbmux.0.9/descr
@@ -1,0 +1,20 @@
+Control port remapping for iOS devices
+
+Talk to jailbroken iDevices over USB with the CLI, gandalf.
+
+Basically this lets you do:
+
+ssh -p <some_port> root@localhost
+
+for an iPhone/iPod/iDevice.
+
+Example usage:
+
+sudo `which gandalf` --mappings etc/mapping --daemonize --verbose
+
+See uptime, tunnels and other metadata with:
+
+gandalf --status
+
+Check out the man page or see the README at:
+https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.org

--- a/packages/usbmux/usbmux.0.9/files/_oasis_remove_.ml
+++ b/packages/usbmux/usbmux.0.9/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/usbmux/usbmux.0.9/files/usbmux.install
+++ b/packages/usbmux/usbmux.0.9/files/usbmux.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/usbmux/usbmux.0.9/opam
+++ b/packages/usbmux/usbmux.0.9/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/onlinemediagroup/ocaml-usbmux"
+bug-reports: "https://github.com/onlinemediagroup/ocaml-usbmux/issues"
+license: "BSD-3"
+dev-repo: "https://github.com/onlinemediagroup/ocaml-usbmux.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/usbmux/_oasis_remove_.ml" "%{etc}%/usbmux"]
+depends: [
+  "ANSITerminal"
+  "cmdliner" {build}
+  "cohttp"
+  "lwt" {>= "2.5.1"}
+  "ocamlfind" {build}
+  "plist"
+  "stringext"
+  "yojson"
+]
+depexts: [
+  [["debian"] ["usbmuxd"]]
+  [["ubuntu"] ["usbmuxd"]]
+]
+available: [ocaml-version >= "4.02.0"]
+post-messages: [
+  "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."
+  "Simple invocation:"
+  "sudo `which gandalf` --mappings etc/mapping --daemonize --verbose"
+  "where etc/mapping is a file of the format <udid>:<localport>:<device_port>"
+  "See uptime, tunnels and other metadata with:"
+  "gandalf --status"
+  "Note that with over 13 devices usbmuxd will start to buck"
+  "because of threading issue with libplist."
+  "Use the custom one provided at https://github.com/onlinemediagroup/libplist"
+  ""
+  "The Linux kernel will also have trouble with many USB3.0 devices, ie over 15ish"
+  "Fix that issue by turning off USB3.0 support in your BIOS"
+  "For this and other issues, be sure to check the README"
+]

--- a/packages/usbmux/usbmux.0.9/url
+++ b/packages/usbmux/usbmux.0.9/url
@@ -1,0 +1,2 @@
+http: "https://github.com/onlinemediagroup/ocaml-usbmux/archive/v0.9.tar.gz"
+checksum: "bd81dfef35f61dddf2fbc7bac867048d"


### PR DESCRIPTION
Control port remapping for iOS devices

Talk to jailbroken iDevices over USB with the CLI, gandalf.

Basically this lets you do:

ssh -p <some_port> root@localhost

for an iPhone/iPod/iDevice.

Example usage:

sudo `which gandalf` --mappings etc/mapping --daemonize --verbose

See uptime, tunnels and other metadata with:

gandalf --status

Check out the man page or see the README at:
https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.org


---
* Homepage: https://github.com/onlinemediagroup/ocaml-usbmux
* Source repo: https://github.com/onlinemediagroup/ocaml-usbmux.git
* Bug tracker: https://github.com/onlinemediagroup/ocaml-usbmux/issues

---

Pull-request generated by opam-publish v0.3.1

Apologies again on the other PR, I will get to it, stalled because I had to change some code there for that release.