### PR TITLE
ocephes.0.8 - via opam-publish

### DIFF
--- a/packages/ocephes/ocephes.0.8/descr
+++ b/packages/ocephes/ocephes.0.8/descr
@@ -1,0 +1,3 @@
+Bindings to special math functions from the Cephes library.
+
+Easy special math functions in OCaml

--- a/packages/ocephes/ocephes.0.8/opam
+++ b/packages/ocephes/ocephes.0.8/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/rleonid/Ocephes"
+bug-reports: "https://github.com/rleonid/Ocephes/issues"
+license: "BSD 3"
+dev-repo: "https://github.com/rleonid/Ocephes.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ocephes"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "ctypes"
+]

--- a/packages/ocephes/ocephes.0.8/url
+++ b/packages/ocephes/ocephes.0.8/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rleonid/Ocephes/archive/0.8.tar.gz"
+checksum: "f95529322ca97aa08dd3c11d95816b92"


### PR DESCRIPTION
Bindings to special math functions from the Cephes library.

Easy special math functions in OCaml


---
* Homepage: https://github.com/rleonid/Ocephes
* Source repo: https://github.com/rleonid/Ocephes.git
* Bug tracker: https://github.com/rleonid/Ocephes/issues

---

Pull-request generated by opam-publish v0.3.1