### PR TITLE
iri.0.1.0 - via opam-publish

### DIFF
--- a/packages/iri/iri.0.1.0/descr
+++ b/packages/iri/iri.0.1.0/descr
@@ -1,0 +1,5 @@
+IRI (RFC3987) native OCaml implementation.
+
+OCaml implementation of Internationalized Resource Identifiers (IRIs).
+This implementation does not depend on regular expression library. Is is implemented using
+Sedlex, thus it will be usable in Javascript (with Js_of_ocaml).

--- a/packages/iri/iri.0.1.0/opam
+++ b/packages/iri/iri.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: ["Maxence Guesdon"]
+homepage: "http://zoggy.github.io/ocaml-iri/"
+license: "GNU Lesser General Public License version 3"
+doc: ["http://zoggy.github.io/ocaml-iri/doc.html"]
+dev-repo: "https://github.com/zoggy/ocaml-iri.git"
+bug-reports: "https://github.com/zoggy/ocaml-iri/issues"
+tags: ["web" "iri" "rfc3987"]
+
+build: [
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "iri"]]
+depends: [
+  "ocamlfind"
+  "sedlex" {>= "1.99.2"}
+  "uutf" {>= "0.9.4" }
+  "uunf" {>= "1.0"}
+]
+available: [ocaml-version >= "4.02.2"]

--- a/packages/iri/iri.0.1.0/url
+++ b/packages/iri/iri.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/ocaml-iri/archive/0.1.0.tar.gz"
+checksum: "d345a473366c0ce29199188908d711f6"


### PR DESCRIPTION
IRI (RFC3987) native OCaml implementation.

OCaml implementation of Internationalized Resource Identifiers (IRIs).
This implementation does not depend on regular expression library. Is is implemented using
Sedlex, thus it will be usable in Javascript (with Js_of_ocaml).

---
* Homepage: http://zoggy.github.io/ocaml-iri/
* Source repo: https://github.com/zoggy/ocaml-iri.git
* Bug tracker: https://github.com/zoggy/ocaml-iri/issues

---

Pull-request generated by opam-publish v0.3.1