### PR TITLE
faad.0.3.3 - via opam-publish

### DIFF
--- a/packages/faad/faad.0.3.3/opam
+++ b/packages/faad/faad.0.3.3/opam
@@ -3,7 +3,8 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-faad"
 build: [
-  ["./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
   [make]
 ]
 install: [
@@ -14,6 +15,7 @@ depends: ["ocamlfind"]
 depexts: [
   [["debian"] ["libfaad-dev"]]
   [["ubuntu"] ["libfaad-dev"]]
+  [["osx" "homebrew"] ["faad2"]]
 ]
 
 bug-reports: "https://github.com/savonet/ocaml-faad/issues"

--- a/packages/faad/faad.0.3.3/url
+++ b/packages/faad/faad.0.3.3/url
@@ -1,2 +1,3 @@
-archive: "https://github.com/savonet/ocaml-faad/releases/download/0.3.3/ocaml-faad-0.3.3.tar.gz"
+http:
+  "https://github.com/savonet/ocaml-faad/releases/download/0.3.3/ocaml-faad-0.3.3.tar.gz"
 checksum: "70b3bea8fc805255ff2a7f9aafe55d8c"


### PR DESCRIPTION
Bindings for the faad library which provides functions for decoding AAC audio files


---
* Homepage: https://github.com/savonet/ocaml-faad
* Source repo: https://github.com/savonet/ocaml-faad.git
* Bug tracker: https://github.com/savonet/ocaml-faad/issues

---
### opam-lint failures
- **WARNING** 92 extra file "findlib"
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1