### PR TITLE
flac.0.1.2 - via opam-publish

### DIFF
--- a/packages/flac/flac.0.1.2/opam
+++ b/packages/flac/flac.0.1.2/opam
@@ -3,7 +3,8 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-flac"
 build: [
-  ["./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
   [make]
 ]
 install: [
@@ -14,6 +15,7 @@ depends: ["ocamlfind" "ogg"]
 depexts: [
   [["debian"] ["libflac-dev"]]
   [["ubuntu"] ["libflac-dev"]]
+  [["osx" "homebrew"] ["flac"]]
 ]
 bug-reports: "https://github.com/savonet/ocaml-flac/issues"
 dev-repo: "https://github.com/savonet/ocaml-flac.git"

--- a/packages/flac/flac.0.1.2/url
+++ b/packages/flac/flac.0.1.2/url
@@ -1,2 +1,3 @@
-archive: "https://github.com/savonet/ocaml-flac/releases/download/0.1.2/ocaml-flac-0.1.2.tar.gz"
+http:
+  "https://github.com/savonet/ocaml-flac/releases/download/0.1.2/ocaml-flac-0.1.2.tar.gz"
 checksum: "00944c4f2f2016770fa6e8f948561669"


### PR DESCRIPTION
Interface for the Free Lossless Audio Codec otherwise known as FLAC


---
* Homepage: https://github.com/savonet/ocaml-flac
* Source repo: https://github.com/savonet/ocaml-flac.git
* Bug tracker: https://github.com/savonet/ocaml-flac/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1