### PR TITLE
lo.0.1.1 - via opam-publish

### DIFF
--- a/packages/lo/lo.0.1.1/opam
+++ b/packages/lo/lo.0.1.1/opam
@@ -3,7 +3,8 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-lo"
 build: [
-  ["./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
   [make]
 ]
 install: [
@@ -14,6 +15,7 @@ depends: ["ocamlfind"]
 depexts: [
  [["ubuntu"]["liblo-dev"]]
  [["debian"]["liblo-dev"]]
+ [["osx" "homebrew"] ["liblo"]]
 ]
 bug-reports: "https://github.com/savonet/ocaml-lo/issues"
 dev-repo: "https://github.com/savonet/ocaml-lo.git"

--- a/packages/lo/lo.0.1.1/url
+++ b/packages/lo/lo.0.1.1/url
@@ -1,2 +1,3 @@
-archive: "https://github.com/savonet/ocaml-lo/releases/download/0.1.1/ocaml-lo-0.1.1.tar.gz"
+http:
+  "https://github.com/savonet/ocaml-lo/releases/download/0.1.1/ocaml-lo-0.1.1.tar.gz"
 checksum: "8534c358aa497e96e6af033a20ba0fc4"


### PR DESCRIPTION
Bindings for the lo library which provides functions for communicating with input controls using the OSC protocol


---
* Homepage: https://github.com/savonet/ocaml-lo
* Source repo: https://github.com/savonet/ocaml-lo.git
* Bug tracker: https://github.com/savonet/ocaml-lo/issues

---
### opam-lint failures
- **WARNING** 92 extra file "findlib"
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1