### PR TITLE
opus.0.1.1 - via opam-publish

### DIFF
--- a/packages/opus/opus.0.1.1/opam
+++ b/packages/opus/opus.0.1.1/opam
@@ -3,7 +3,8 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-opus"
 build: [
-  ["./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
   [make]
 ]
 install: [
@@ -17,6 +18,7 @@ depends: [
 depexts: [
   [["debian"] ["libavutil-dev" "libopus-dev"]]
   [["ubuntu"] ["libavutil-dev" "libopus-dev"]]
+  [["osx" "homebrew"] ["opus"]]
 ]
 bug-reports: "https://github.com/savonet/ocaml-opus/issues"
 dev-repo: "https://github.com/savonet/ocaml-opus.git"

--- a/packages/opus/opus.0.1.1/url
+++ b/packages/opus/opus.0.1.1/url
@@ -1,2 +1,3 @@
-archive: "https://github.com/savonet/ocaml-opus/releases/download/0.1.1/ocaml-opus-0.1.1.tar.gz"
+http:
+  "https://github.com/savonet/ocaml-opus/releases/download/0.1.1/ocaml-opus-0.1.1.tar.gz"
 checksum: "c58b1ff9859ce31b56f5cba9d22f91a2"


### PR DESCRIPTION
Bindings for the opus library to decode audio files in opus format


---
* Homepage: https://github.com/savonet/ocaml-opus
* Source repo: https://github.com/savonet/ocaml-opus.git
* Bug tracker: https://github.com/savonet/ocaml-opus/issues

---
### opam-lint failures
- **WARNING** 92 extra file "findlib"
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1