### PR TITLE
schroedinger.0.1.1 - via opam-publish

### DIFF
--- a/packages/schroedinger/schroedinger.0.1.1/opam
+++ b/packages/schroedinger/schroedinger.0.1.1/opam
@@ -3,7 +3,8 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-schroedinger"
 build: [
-  ["./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
   [make]
 ]
 install: [

--- a/packages/schroedinger/schroedinger.0.1.1/url
+++ b/packages/schroedinger/schroedinger.0.1.1/url
@@ -1,2 +1,3 @@
-archive: "https://github.com/savonet/ocaml-schroedinger/releases/download/0.1.1/ocaml-schroedinger-0.1.1.tar.gz"
+http:
+  "https://github.com/savonet/ocaml-schroedinger/releases/download/0.1.1/ocaml-schroedinger-0.1.1.tar.gz"
 checksum: "fa6974277a389d0ef5e4a92cbcf416f0"


### PR DESCRIPTION
Bindings for the schroedinger library to decode video files in Dirac format


---
* Homepage: https://github.com/savonet/ocaml-schroedinger
* Source repo: https://github.com/savonet/ocaml-schroedinger.git
* Bug tracker: https://github.com/savonet/ocaml-schroedinger/issues

---
### opam-lint failures
- **WARNING** 92 extra file "findlib"
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1