### PR TITLE
speex.0.2.1 - via opam-publish

### DIFF
--- a/packages/speex/speex.0.2.1/opam
+++ b/packages/speex/speex.0.2.1/opam
@@ -3,7 +3,8 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-speex"
 build: [
-  ["./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
   [make]
 ]
 install: [
@@ -17,6 +18,7 @@ depends: [
 depexts: [
   [["ubuntu"] ["libspeex-dev"]]
   [["debian"] ["libspeex-dev"]]
+  [["osx" "homebrew"] ["speex"]]
 ]
 
 bug-reports: "https://github.com/savonet/ocaml-speex/issues"

--- a/packages/speex/speex.0.2.1/url
+++ b/packages/speex/speex.0.2.1/url
@@ -1,2 +1,3 @@
-archive: "https://github.com/savonet/ocaml-speex/releases/download/0.2.1/ocaml-speex-0.2.1.tar.gz"
+http:
+  "https://github.com/savonet/ocaml-speex/releases/download/0.2.1/ocaml-speex-0.2.1.tar.gz"
 checksum: "68e3596edc35ce7c4fa010e44abc8770"


### PR DESCRIPTION
Bindings for the speex library to decode audio files in speex format


---
* Homepage: https://github.com/savonet/ocaml-speex
* Source repo: https://github.com/savonet/ocaml-speex.git
* Bug tracker: https://github.com/savonet/ocaml-speex/issues

---
### opam-lint failures
- **WARNING** 92 extra file "findlib"
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1