### PR TITLE
Update lemonade to v0.4.0

### DIFF
--- a/packages/lemonade/lemonade.0.4.0/descr
+++ b/packages/lemonade/lemonade.0.4.0/descr
@@ -1,0 +1,3 @@
+A monad library with bubbles
+
+WWW: https://github.com/michipili/lemonade

--- a/packages/lemonade/lemonade.0.4.0/opam
+++ b/packages/lemonade/lemonade.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "michipili@gmail.com"
+authors: "Michael Grünewald"
+version: "0.4.0"
+license: "CeCILL-B"
+homepage: "https://github.com/michipili/lemonade"
+bug-reports: "https://github.com/michipili/lemonade/issues"
+dev-repo: "https://github.com/michipili/lemonade.git"
+tags: [
+  "pattern"
+  "monad"
+]
+build: [
+  ["./configure"
+    "--prefix" prefix
+    "--%{ppx_tools:enable}%-ppx-rewriter"]
+  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
+  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+]
+install: [
+  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
+  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+]
+remove: [
+  ["ocamlfind" "remove" "lemonade"]
+  ["rm" "-rf" "%{share}%/doc/lemonade"]
+]
+available: [
+  ocaml-version >= "4.00.1"
+]
+depends: [
+  "broken" {>= "0.4.2"}
+  "bsdowl" {>= "3.0.0"}
+  "mixture"{>= "1.0.0"}
+  "ocamlfind"
+]
+depexts: [
+  [["debian"] ["bmake"]]
+  [["ubuntu"] ["bmake"]]
+  [["osx" "macports"] ["bmake"]]
+]

--- a/packages/lemonade/lemonade.0.4.0/url
+++ b/packages/lemonade/lemonade.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/michipili/lemonade/releases/download/v0.4.0/lemonade-0.4.0.tar.xz"
+checksum: "b626960c77f8e9fde0ccac0aab34a10d"


### PR DESCRIPTION
We can expect the usual CI failures bound to the use of **bmake** :)