### PR TITLE
eliom.5.0.0 - via opam-publish

### DIFF
--- a/packages/eliom/eliom.5.0.0/descr
+++ b/packages/eliom/eliom.5.0.0/descr
@@ -1,0 +1,9 @@
+Framework for programming Web sites and client/server Web applications.
+Eliom is a framework for programming Web sites and client/server Web
+applications. It introduces new concepts to simplify programming common
+behaviours and uses advanced static typing features of OCaml to check
+many properties of the Web site at compile time. If you want to write a
+Web application, Eliom makes possible to write the whole application as
+a single program (client and server parts). A syntax extension is used
+to distinguish both parts and the client side is compiled to JS using
+Ocsigen Js_of_ocaml.

--- a/packages/eliom/eliom.5.0.0/opam
+++ b/packages/eliom/eliom.5.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "https://github.com/ocsigen/eliom.git"
+build: [
+  make
+  "PPX=false" {base-no-ppx:installed}
+]
+depends: [
+  "ocamlfind"
+  "deriving" {>= "0.6"}
+  ("base-no-ppx" | "ppx_tools")
+  "js_of_ocaml" {> "2.6"}
+  "tyxml" {> "3.5.0"}
+  "calendar"
+  "ocsigenserver" {>= "2.6"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2"}
+  "base-bytes"
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/eliom/eliom.5.0.0/url
+++ b/packages/eliom/eliom.5.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/eliom/archive/5.0.0.tar.gz"
+checksum: "dcd4c6b7b09a9ac233cb6db4605c233e"


### PR DESCRIPTION
Framework for programming Web sites and client/server Web applications.
Eliom is a framework for programming Web sites and client/server Web
applications. It introduces new concepts to simplify programming common
behaviours and uses advanced static typing features of OCaml to check
many properties of the Web site at compile time. If you want to write a
Web application, Eliom makes possible to write the whole application as
a single program (client and server parts). A syntax extension is used
to distinguish both parts and the client side is compiled to JS using
Ocsigen Js_of_ocaml.


---
* Homepage: http://ocsigen.org/eliom/
* Source repo: https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---

Pull-request generated by opam-publish v0.3.1