### PR TITLE
Fix ./configure for `cairo`

### DIFF
--- a/packages/cairo/cairo.1.2.0/files/configure_fontconfig.patch
+++ b/packages/cairo/cairo.1.2.0/files/configure_fontconfig.patch
@@ -1,0 +1,23 @@
+diff --git a/configure.ac b/configure.ac
+index 6c8c4e9..b539ca6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -32,6 +32,18 @@ PKG_CHECK_MODULES(LIBSVG_CAIRO, libsvg-cairo, use_libsvg_cairo=yes, use_libsvg_c
+ # Optional pango-cairo support
+ PKG_CHECK_MODULES(LIBPANGOCAIRO, pangocairo, use_libpangocairo=yes, use_libpangocairo=no)
+ 
++# Optional fontconfig support
++CFLAGS=$CAIRO_CFLAGS
++AC_CHECK_DECL(CAIRO_HAS_FT_FONT,
++              [require_fontconfig=yes],[require_fontconfig=no],
++              [[#include <cairo.h>]])
++
++if test $require_fontconfig = yes ; then
++  unset CAIRO_LIBS
++  unset CAIRO_CFLAGS
++  PKG_CHECK_MODULES(CAIRO, cairo >= 1.2 freetype2 fontconfig)
++fi
++
+ echo
+ echo "  GTK+         support: $use_gtk"
+ echo "  libsvg-cairo support: $use_libsvg_cairo"

--- a/packages/cairo/cairo.1.2.0/opam
+++ b/packages/cairo/cairo.1.2.0/opam
@@ -6,8 +6,10 @@ build: [
   ["autoconf"]
   ["./configure" "LABLGTKDIR=%{lib}%/lablgtk2" "--prefix" prefix "--sbindir=%{lib}%/cairo/sbin" "--libexecdir=%{lib}%/cairo/libexec" "--sysconfdir=%{lib}%/cairo/etc" "--sharedstatedir=%{lib}%/cairo/com" "--localstatedir=%{lib}%/cairo/var" "--libdir=%{lib}%/cairo/lib" "--includedir=%{lib}%/cairo/include" "--datarootdir=%{lib}%/cairo/share"]
   [make]
-  [make "install"]
   ["ocamlopt.opt" "-shared" "-linkall" "-I" "src" "-ccopt" "-I/usr/include/cairo" "-ccopt" "-I/usr/include/glib-2.0" "-ccopt" "-I/usr/lib/x86_64-linux-gnu/glib-2.0/include" "-ccopt" "-I/usr/include/pixman-1" "-ccopt" "-I/usr/include/freetype2" "-ccopt" "-I/usr/include/libpng12" "-o" "src/cairo.cmxs" "-cclib" "-Lsrc/" "-cclib" "-lcairo" "src/cairo.cmxa"]
+]
+install: [
+  [make "install"]
   ["cp" "src/cairo.cmxs" "%{lib}%/cairo"]
   ["cp" "META" "%{lib}%/cairo"]
 ]
@@ -20,4 +22,7 @@ depexts: [
   [["debian"] ["autoconf" "libcairo2-dev"]]
   [["ubuntu"] ["autoconf" "libcairo2-dev"]]
 ]
-patches: ["opam.patch"]
+patches: [
+  "opam.patch"
+  "configure_fontconfig.patch"
+]

--- a/packages/cairo/cairo.1.2.0/opam
+++ b/packages/cairo/cairo.1.2.0/opam
@@ -1,5 +1,5 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: "gregoire.henry@ocamlpro.com"
 substs: ["opam.patch"]
 build: [
   ["aclocal" "-I" "support"]
@@ -26,3 +26,10 @@ patches: [
   "opam.patch"
   "configure_fontconfig.patch"
 ]
+authors: [
+  "Olivier Andrieu"
+  "Richard Jones"
+]
+homepage: "http://cairographics.org/cairo-ocaml/"
+dev-repo: "git+http://anongit.freedesktop.org/git/cairo-ocaml.git"
+bug-reports: "https://bugs.freedesktop.org/buglist.cgi?quicksearch=cairo%20ocaml"


### PR DESCRIPTION
It tries to detect wether libcairo has fontconfig support or not. This is a quick fix for #5162.