### PR TITLE
adding build dependencies on ocamlfind/ocamlbuild

### DIFF
--- a/packages/safa/safa.1.3/opam
+++ b/packages/safa/safa.1.3/opam
@@ -8,5 +8,8 @@ license: "GNU LGPL v3"
 build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
-depends: "ocamlfind"
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ ocaml-version >= "4.02.0"]

--- a/packages/safa/safa.1.4/opam
+++ b/packages/safa/safa.1.4/opam
@@ -8,5 +8,8 @@ license: "GNU LGPL v3"
 build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
-depends: "ocamlfind"
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ ocaml-version >= "4.02.0"]

--- a/packages/symkat/symkat.1.4/opam
+++ b/packages/symkat/symkat.1.4/opam
@@ -10,7 +10,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [make "PREFIX=%{prefix}%" "uninstall"]
 depends: [
   "ocamlfind" {build}
-  "safa" {= "1.4"}
+  "safa" {>= "1.4"}
   "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.02.0"]


### PR DESCRIPTION
Please check whether it's fine for safa, which uses ocamlbuild to make, and ocamlfind to (un)install.