### PR TITLE
mirage-bootvar-xen 0.3.1

### DIFF
--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/descr
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/descr
@@ -1,0 +1,1 @@
+Library for reading MirageOS unikernel boot parameters in Xen

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/descr
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/descr
@@ -1,1 +1,5 @@
 Library for reading MirageOS unikernel boot parameters in Xen
+
+This library contains functions for reading parameters passed as boot parameter to a unikernel in Xen. The parameters can be passed as key/value pairs in the `extra=` field in an .xl-file or on the command line when starting a unikernel with the `xl` utility.
+
+Boot parameters are read from the VM's `cmdline` key in Xenstore. If this key does not exist the parameters will be read from `OS.Start_info.cmd_line`.

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-bootvar-xen"
+bug-reports: "https://github.com/mirage/mirage-bootvar-xen/issues/"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-bootvar-xen.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-bootvar"]
+depends: [
+  "mirage-xen" {>= "2.2.0"}
+  "mirage-types"
+  "ipaddr"
+  "re"
+]

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/url
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-bootvar-xen/archive/0.3.1.tar.gz"
+checksum: "d21a6a8b022523a76935e4393d75edbd"


### PR DESCRIPTION
Library for reading MirageOS unikernel boot parameters in Xen

This library contains functions for reading parameters passed as boot parameter to a unikernel in Xen. The parameters can be passed as key/value pairs in the `extra=` field in an .xl-file or on the command line when starting a unikernel with the `xl` utility.

Boot parameters are read from the VM's `cmdline` key in Xenstore. If this key does not exist the parameters will be read from `OS.Start_info.cmd_line`.