### PR TITLE
+cstruct.1.8.0

### DIFF
--- a/packages/cstruct/cstruct.1.8.0/descr
+++ b/packages/cstruct/cstruct.1.8.0/descr
@@ -1,0 +1,19 @@
+access C structures via a camlp4 extension
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the Bigarray module.
+
+An example pcap description is:
+
+```
+cstruct pcap_header {
+  uint32_t magic_number;   (* magic number *)
+  uint16_t version_major;  (* major version number *)
+  uint16_t version_minor;  (* minor version number *)
+  uint32_t thiszone;       (* GMT to local correction *)
+  uint32_t sigfigs;        (* accuracy of timestamps *)
+  uint32_t snaplen;        (* max length of captured packets, in octets *)
+  uint32_t network         (* data link type *)
+} as little_endian
+```

--- a/packages/cstruct/cstruct.1.8.0/opam
+++ b/packages/cstruct/cstruct.1.8.0/opam
@@ -1,0 +1,61 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["./configure"
+      "--prefix" prefix
+      "--%{lwt:enable}%-lwt"
+      "--%{camlp4:enable}%-camlp4"
+      "--%{ppx_tools:enable}%-ppx"
+      "--%{async:enable}%-async"
+      "--%{base-unix:enable}%-unix"]
+  [make]
+]
+build-test: [
+  ["./configure"
+      "--prefix" prefix
+      "--%{lwt:enable}%-lwt"
+      "--%{camlp4:enable}%-camlp4"
+      "--%{ppx_tools:enable}%-ppx"
+      "--%{async:enable}%-async"
+      "--%{base-unix:enable}%-unix"
+      "--enable-tests"]
+  [make]
+  ["./test.sh"]
+]
+install: [
+  [make "install"]
+  [make "js-install"]
+]
+remove:  [
+  [make "js-uninstall"]
+  ["ocamlfind" "remove" "cstruct"]
+]
+depends: [
+  "ocamlfind" {build}
+  "type_conv" {build}
+  "ounit"     {test}
+  "ocplib-endian"
+  "sexplib"
+  "base-bytes"
+]
+depopts: [
+  "camlp4"
+  "ppx_tools"
+  "async"
+  "lwt"
+]
+available: [ocaml-version >= "4.01.0"]
+depexts: [
+  [ ["debian"] ["time"] ]
+  [ ["ubuntu"] ["time"] ]
+]

--- a/packages/cstruct/cstruct.1.8.0/url
+++ b/packages/cstruct/cstruct.1.8.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cstruct/archive/v1.8.0.tar.gz"
+checksum: "61de655438620caebb0e011cd96d5bf9"


### PR DESCRIPTION
* Add support for `-safe-string` in OCaml 4.02 upwards.
  The main change is to rename `blit_to_string` to `blit_to_bytes` and
  change its type so that it writes to bytes rather than string
  (mirage/ocaml-cstruct#74 by @yallop).
* Remove strong build-time dependency on `camlp4` in the base library.
  The `sexplib` functions were only used in the interface, so replace them
  with manually written ones.  This also enables compatibility with latest
  Core that has switched to ppx.
* Add multi-distro testing via Travis/Docker containers.