### PR TITLE
Ocaml-expat build

### DIFF
--- a/packages/ocaml-expat/ocaml-expat.0.9.1/files/Makefile.patch
+++ b/packages/ocaml-expat/ocaml-expat.0.9.1/files/Makefile.patch
@@ -1,0 +1,21 @@
+diff --git a/Makefile b/Makefile
+index b32f906..e428fa5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -25,6 +25,7 @@ OCAMLDEP=ocamldep
+ OCAMLMKLIB=ocamlmklib 
+ OCAMLDOC=ocamldoc
+ OCAMLFIND=ocamlfind
++OCAMLDIR:=$(shell ocamlfind query stdlib)
+ 
+ .PHONY: all
+ all: $(ARCHIVE)
+@@ -32,7 +33,7 @@ all: $(ARCHIVE)
+ allopt:  $(XARCHIVE)
+ 
+ depend: *.c *.ml *.mli
+-	gcc -MM *.c > depend	
++	gcc -I $(OCAMLDIR) -MM *.c > depend
+ 	$(OCAMLDEP) *.mli *.ml >> depend
+ 
+ ## Library creation

--- a/packages/ocaml-expat/ocaml-expat.0.9.1/opam
+++ b/packages/ocaml-expat/ocaml-expat.0.9.1/opam
@@ -6,9 +6,10 @@ build: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "expat"]]
-depends: ["ocamlfind"]
+depends: ["ocamlfind" {build}]
 depexts: [
  [["debian"] ["libexpat1-dev"]]
  [["ubuntu"] ["libexpat1-dev"]]
  [["osx" "homebrew"] ["expat"]]
 ]
+patches: [ "Makefile.patch" ]

--- a/packages/ocaml-expat/ocaml-expat.0.9.1/opam
+++ b/packages/ocaml-expat/ocaml-expat.0.9.1/opam
@@ -1,5 +1,7 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
+authors: "Maas-Maarten Zeeman"
+homepage: "http://mmzeeman.home.xs4all.nl/ocaml/"
 build: [
   [make "all"]
   [make "allopt"]


### PR DESCRIPTION
Patch the Makefile to include a link to the ocaml stdlib via ocamlfind. This addresses #4310 but in a different way.
I also tried to add more fields to the original `opam` file to satisfy the linter, but it is still complaining
```
error 24: Field 'maintainer' set to the old default value
```
I couldn't find what the new default value should be.