### PR TITLE
telegraml.1.0 - via opam-publish

### DIFF
--- a/packages/telegraml/telegraml.1.0/descr
+++ b/packages/telegraml/telegraml.1.0/descr
@@ -1,0 +1,5 @@
+Telegram Bot API for OCaml
+An implementation of the Telegram Bot API in 100% OCaml,
+using Lwt for asynchronous operations and Cohttp for networking.
+Implements most basic functionality present in the API, plus
+convenience modules for error handling and defining commands.

--- a/packages/telegraml/telegraml.1.0/opam
+++ b/packages/telegraml/telegraml.1.0/opam
@@ -11,6 +11,7 @@ build: [
 ]
 install: [make "install"]
 remove: [make "uninstall"]
+available: [ocaml-version >= "4.02"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}

--- a/packages/telegraml/telegraml.1.0/opam
+++ b/packages/telegraml/telegraml.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/telegraml"
+bug-reports: "https://github.com/nv-vn/telegraml/issues"
+license: "MIT"
+dev-repo: "https://github.com/nv-vn/telegraml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "lwt" {>= "2.5.0"}
+  "cohttp" {>= "0.19.0"}
+  "yojson" {>= "1.3.0"}
+  "batteries" {>= "2.4.0"}
+]

--- a/packages/telegraml/telegraml.1.0/url
+++ b/packages/telegraml/telegraml.1.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/nv-vn/TelegraML/archive/1.0.tar.gz"
-checksum: "c85cb2b0b70a870ee1e9168737db7f8d"
+checksum: "d9b252080407b7e6d2e6bc1c72648862"

--- a/packages/telegraml/telegraml.1.0/url
+++ b/packages/telegraml/telegraml.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/TelegraML/archive/1.0.tar.gz"
+checksum: "c85cb2b0b70a870ee1e9168737db7f8d"


### PR DESCRIPTION
Telegram Bot API for OCaml
An implementation of the Telegram Bot API in 100% OCaml,
using Lwt for asynchronous operations and Cohttp for networking.
Implements most basic functionality present in the API, plus
convenience modules for error handling and defining commands.


---
* Homepage: https://github.com/nv-vn/telegraml
* Source repo: https://github.com/nv-vn/telegraml.git
* Bug tracker: https://github.com/nv-vn/telegraml/issues

---

Pull-request generated by opam-publish v0.3.1