### PR TITLE
opium.0.14.0 - via opam-publish

### DIFF
--- a/packages/opium/opium.0.14.0/descr
+++ b/packages/opium/opium.0.14.0/descr
@@ -1,0 +1,11 @@
+Sinatra like web toolkit based on Lwt + Cohttp
+
+Opium is a minimalistic library for quickly binding functions
+to http routes. Its features include (but not limited to):
+
+* Middleware system for app independent components
+* A simple router for matching urls and parsing parameters
+* Request/Response pretty printing for easier debugging
+
+Note: This library is still at an early stage so expect breakages
+until 1.0

--- a/packages/opium/opium.0.14.0/opam
+++ b/packages/opium/opium.0.14.0/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/opium"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+dev-repo: "https://github.com/rgrinberg/opium.git"
+
+build: [ [make] ]
+
+install: [make "install"]
+
+remove: [
+  ["ocamlfind" "remove" "opium_rock"]
+  ["ocamlfind" "remove" "opium"]
+]
+
+build-test: [ [make "check"] ]
+
+depends: [
+  "ocamlfind" {build}
+  "omake" {build}
+  "cohttp" {>= "0.15.0"}
+  "ezjsonm" {>= "0.4.0"}
+  "base64" {>= "2.0.0"}
+  "lwt"
+  "core_kernel"
+  "cmdliner"
+  "fieldslib"
+  "sexplib"
+  "re" {>= "1.3.0"}
+  "magic-mime"
+  "ounit" {test}
+  "cow" {test & >= "0.10.0"}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opium/opium.0.14.0/url
+++ b/packages/opium/opium.0.14.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/opium/archive/v0.14.0.tar.gz"
+checksum: "09be6a2006fc1abda8ec0e1547f21503"


### PR DESCRIPTION
Sinatra like web toolkit based on Lwt + Cohttp

Opium is a minimalistic library for quickly binding functions
to http routes. Its features include (but not limited to):

* Middleware system for app independent components
* A simple router for matching urls and parsing parameters
* Request/Response pretty printing for easier debugging

Note: This library is still at an early stage so expect breakages
until 1.0

---
* Homepage: https://github.com/rgrinberg/opium
* Source repo: https://github.com/rgrinberg/opium.git
* Bug tracker: https://github.com/rgrinberg/opium/issues

---

Pull-request generated by opam-publish v0.3.1