### PR TITLE
ipaddr.2.7.0 - via opam-publish

### DIFF
--- a/packages/ipaddr/ipaddr.2.7.0/descr
+++ b/packages/ipaddr/ipaddr.2.7.0/descr
@@ -1,0 +1,23 @@
+IP (and MAC) address representation library
+
+A library for manipulation of IP (and MAC) address representations.
+
+Features:
+
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 CIDR-scoped address support
+ * Ipaddr.V4 and Ipaddr.V4.Prefix modules are Map.OrderedType
+ * Ipaddr.V6 and Ipaddr.V6.Prefix modules are Map.OrderedType
+ * Ipaddr and Ipaddr.Prefix modules are Map.OrderedType
+ * Ipaddr_unix in findlib subpackage ipaddr.unix provides compatibility
+   with the standard library Unix module
+ * Ipaddr_top in findlib subpackage ipaddr.top provides top-level pretty
+   printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * Macaddr is a Map.OrderedType
+ * All types have sexplib serializers/deserializers

--- a/packages/ipaddr/ipaddr.2.7.0/opam
+++ b/packages/ipaddr/ipaddr.2.7.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer:   "sheets@alum.mit.edu"
+authors: [
+              "David Sheets"
+              "Anil Madhavapeddy"
+              "Hugo Heuzard"
+]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-ipaddr"
+bug-reports:  "https://github.com/mirage/ocaml-ipaddr/issues"
+dev-repo:     "https://github.com/mirage/ocaml-ipaddr.git"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{ounit:enable}%-tests"]
+  [make "build"]
+]
+build-test: [
+  [make "test"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "ipaddr"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-bytes"
+  "sexplib"
+  "ppx_sexp_conv"
+  "ounit" {test}
+]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/ipaddr/ipaddr.2.7.0/url
+++ b/packages/ipaddr/ipaddr.2.7.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-ipaddr/archive/2.7.0.tar.gz"
+checksum: "48389ef61662181069de9456c5d3aeb1"


### PR DESCRIPTION
IP (and MAC) address representation library

A library for manipulation of IP (and MAC) address representations.

Features:

 * Depends only on sexplib (conditionalization under consideration)
 * oUnit-based tests
 * IPv4 and IPv6 support
 * IPv4 and IPv6 CIDR prefix support
 * IPv4 and IPv6 CIDR-scoped address support
 * Ipaddr.V4 and Ipaddr.V4.Prefix modules are Map.OrderedType
 * Ipaddr.V6 and Ipaddr.V6.Prefix modules are Map.OrderedType
 * Ipaddr and Ipaddr.Prefix modules are Map.OrderedType
 * Ipaddr_unix in findlib subpackage ipaddr.unix provides compatibility
   with the standard library Unix module
 * Ipaddr_top in findlib subpackage ipaddr.top provides top-level pretty
   printers (requires compiler-libs default since OCaml 4.0)
 * IP address scope classification
 * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
 * MAC-48 (Ethernet) address support
 * Macaddr is a Map.OrderedType
 * All types have sexplib serializers/deserializers


---
* Homepage: https://github.com/mirage/ocaml-ipaddr
* Source repo: https://github.com/mirage/ocaml-ipaddr.git
* Bug tracker: https://github.com/mirage/ocaml-ipaddr/issues

---

Pull-request generated by opam-publish v0.3.1