### PR TITLE
key-parsers.0.2.0 - via opam-publish

### DIFF
--- a/packages/key-parsers/key-parsers.0.2.0/descr
+++ b/packages/key-parsers/key-parsers.0.2.0/descr
@@ -1,0 +1,4 @@
+Parsers for multiple key formats
+
+This library provides parsers for several encodings of RSA, DSA or Elliptic
+curve public and private keys.

--- a/packages/key-parsers/key-parsers.0.2.0/opam
+++ b/packages/key-parsers/key-parsers.0.2.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+author: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/key-parsers.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "key-parsers"]
+depends: [
+  "ocamlfind" {build}
+  "asn1-combinators"
+  "zarith"
+]

--- a/packages/key-parsers/key-parsers.0.2.0/url
+++ b/packages/key-parsers/key-parsers.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/cryptosense/key-parsers/archive/v0.2.0.tar.gz"
+checksum: "942796681079bfad01e675b7cb266b89"


### PR DESCRIPTION
Parsers for multiple key formats

This library provides parsers for several encodings of RSA, DSA or Elliptic
curve public and private keys.


---
* Homepage: https://github.com/cryptosense/key-parsers
* Source repo: https://github.com/cryptosense/key-parsers.git
* Bug tracker: https://github.com/cryptosense/key-parsers/issues

---

Pull-request generated by opam-publish v0.3.1