### PR TITLE
remove base-ocamlbuild from base packages for 4.03

### DIFF
--- a/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
+++ b/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
@@ -11,6 +11,5 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
-  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]


### PR DESCRIPTION
via @dsheets in ocaml/opam-repository#5578