### PR TITLE
base-ocamlbuild: update to work with opam 1.1.2

### DIFF
--- a/packages/base-ocamlbuild/base-ocamlbuild.base/opam
+++ b/packages/base-ocamlbuild/base-ocamlbuild.base/opam
@@ -1,4 +1,4 @@
 opam-version: "1"
 maintainer: "gabriel.scherer@gmail.com"
 
-available: [ocaml-version >= "3.10" & ocaml-version < "4.03"]
+ocaml-version: [>= "3.10" & < "4.03"]


### PR DESCRIPTION
We will drop support for opam 1.1.2 when 1.3 comes out most likely but until then, this causes CI failures because it is a base package and it used a 1.2-only feature of `available`.