### PR TITLE
crunch.1.4.1 - via opam-publish

### DIFF
--- a/packages/crunch/crunch.1.4.1/descr
+++ b/packages/crunch/crunch.1.4.1/descr
@@ -1,0 +1,1 @@
+Convert a filesystem into a static OCaml module

--- a/packages/crunch/crunch.1.4.1/opam
+++ b/packages/crunch/crunch.1.4.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/ocaml-crunch"
+bug-reports:  "https://github.com/mirage/ocaml-crunch/issues"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-crunch.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["rm" "-f" "%{bin}%/ocaml-crunch"]
+  ["ocamlfind" "remove" "crunch"]
+]
+depends: [
+  "ocamlfind"
+  "cmdliner"
+  "ocamlbuild" {build}
+]

--- a/packages/crunch/crunch.1.4.1/url
+++ b/packages/crunch/crunch.1.4.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-crunch/archive/v1.4.1.tar.gz"
+checksum: "ee49cc396eb21d472057c25cb37e1d79"


### PR DESCRIPTION
Convert a filesystem into a static OCaml module


---
* Homepage: https://github.com/mirage/ocaml-crunch
* Source repo: https://github.com/mirage/ocaml-crunch.git
* Bug tracker: https://github.com/mirage/ocaml-crunch/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.0