### PR TITLE
macaque.0.7.3 - via opam-publish

### DIFF
--- a/packages/macaque/macaque.0.7.3/descr
+++ b/packages/macaque/macaque.0.7.3/descr
@@ -1,0 +1,3 @@
+Macaque (Macros for Caml Queries) is a DSL for OCaml, which produces
+SQL requests from a comprehension syntax. Macaque can build queries
+from simpler components, using phantom types to ensure safety.

--- a/packages/macaque/macaque.0.7.3/files/fix-configure.patch
+++ b/packages/macaque/macaque.0.7.3/files/fix-configure.patch
@@ -1,0 +1,24 @@
+diff --git a/configure b/configure
+index d2a26d1..3985b43 100755
+--- a/configure
++++ b/configure
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ 
+ # OASIS_START
+-# DO NOT EDIT (digest: 6f7b8221311e800a7093dc3b793f67ca)
++# DO NOT EDIT (digest: 67dd0def14e1d99625d2485f6a4d5df1)
+ set -e
+ 
+ FST=true
+@@ -23,5 +23,9 @@ for i in "$@"; do
+   esac
+ done
+ 
+-make configure CONFIGUREFLAGS="$*"
++if [ ! -e setup.exe ] || [ _oasis -nt setup.exe ] || [ setup.ml -nt setup.exe ] || [ configure -nt setup.exe ]; then
++  ocamlfind ocamlopt -o setup.exe setup.ml || ocamlfind ocamlc -o setup.exe setup.ml || exit 1
++  rm -f setup.cmi setup.cmo setup.cmx setup.o
++fi
++./setup.exe -configure "$@"
+ # OASIS_STOP

--- a/packages/macaque/macaque.0.7.3/opam
+++ b/packages/macaque/macaque.0.7.3/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "gabriel.scherer@gmail.com"
+authors: "gabriel.scherer@gmail.com"
+homepage: "https://github.com/ocsigen/macaque"
+bug-reports: "https://github.com/ocsigen/macaque/issues"
+dev-repo: "https://github.com/ocsigen/macaque.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "macaque"]
+depends: [
+  "ocamlfind" {build}
+  "pgocaml" {>= "2.2"}
+  "oasis" {>= "0.4.4"}
+  "camlp4"
+]

--- a/packages/macaque/macaque.0.7.3/url
+++ b/packages/macaque/macaque.0.7.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/macaque/archive/0.7.3.tar.gz"
+checksum: "9262a9651d52ee1ecfcef6f50464753c"


### PR DESCRIPTION
Macaque (Macros for Caml Queries) is a DSL for OCaml, which produces
SQL requests from a comprehension syntax. Macaque can build queries
from simpler components, using phantom types to ensure safety.


---
* Homepage: https://github.com/ocsigen/macaque
* Source repo: https://github.com/ocsigen/macaque
* Bug tracker: https://github.com/ocsigen/macaque/issues

---

Pull-request generated by opam-publish v0.3.1