### PR TITLE
cfstream: fix build instructions

### DIFF
--- a/packages/cfstream/cfstream.1.0.0/opam
+++ b/packages/cfstream/cfstream.1.0.0/opam
@@ -1,5 +1,16 @@
 opam-version: "1.2"
-maintainer: "agarwal1975@gmail.com"
+name: "cfstream"
+version: "1.0.0"
+homepage: "https://github.com/biocaml/cfstream"
+dev-repo: "https://github.com/biocaml/cfstream.git"
+bug-reports: "https://github.com/biocaml/cfstream/issues"
+license: "LGPL + linking exception"
+maintainer: "Ashish Agarwal <agarwal1975@gmail.com>"
+authors: [
+  "Philippe Veber <philippe.veber@gmail.com>"
+  "Ashish Agarwal <agarwal1975@gmail.com>"
+  "Drup <drupyog@zoho.com>"
+]
 build: [
   ["rm" "-f" "configure.om"]
   ["omake"]
@@ -14,5 +25,6 @@ depends: [
   "omake"
   "core"
 ]
-ocaml-version: [>="4.00.0"]
-dev-repo: "git://github.com/biocaml/cfstream"
+available: [
+  ocaml-version >= "4.01.0"
+]

--- a/packages/cfstream/cfstream.1.0.0/opam
+++ b/packages/cfstream/cfstream.1.0.0/opam
@@ -26,5 +26,5 @@ depends: [
   "core"
 ]
 available: [
-  ocaml-version >= "4.01.0"
+  ocaml-version >= "4.00.0"
 ]

--- a/packages/cfstream/cfstream.1.1.1/opam
+++ b/packages/cfstream/cfstream.1.1.1/opam
@@ -1,8 +1,22 @@
 opam-version: "1.2"
-maintainer: "agarwal1975@gmail.com"
+name: "cfstream"
+version: "1.1.1"
+homepage: "https://github.com/biocaml/cfstream"
+dev-repo: "https://github.com/biocaml/cfstream.git"
+bug-reports: "https://github.com/biocaml/cfstream/issues"
+license: "LGPL + linking exception"
+maintainer: "Ashish Agarwal <agarwal1975@gmail.com>"
+authors: [
+  "Philippe Veber <philippe.veber@gmail.com>"
+  "Ashish Agarwal <agarwal1975@gmail.com>"
+  "Drup <drupyog@zoho.com>"
+]
 
 build: [
   ["omake" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
+]
+
+install: [
   ["omake" "install"]
 ]
 
@@ -21,5 +35,6 @@ depends: [
   "core"
 ]
 
-ocaml-version: [>="4.00.1"]
-dev-repo: "git://github.com/biocaml/cfstream"
+available: [
+  ocaml-version >= "4.01.0"
+]

--- a/packages/cfstream/cfstream.1.1.1/opam
+++ b/packages/cfstream/cfstream.1.1.1/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "agarwal1975@gmail.com"
 
 build: [
-  ["omake" "-j2" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
+  ["omake" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
   ["omake" "install"]
 ]
 
@@ -11,7 +11,7 @@ remove: [
 ]
 
 build-doc: [
-  ["omake" "-j2" "doc"]
+  ["omake" "doc"]
   ["omake" "install_doc" "DOC_DIR=%{doc}%/cfstream"]
 ]
 

--- a/packages/cfstream/cfstream.1.1.1/opam
+++ b/packages/cfstream/cfstream.1.1.1/opam
@@ -36,5 +36,5 @@ depends: [
 ]
 
 available: [
-  ocaml-version >= "4.01.0"
+  ocaml-version >= "4.00.1"
 ]

--- a/packages/cfstream/cfstream.1.1.2/opam
+++ b/packages/cfstream/cfstream.1.1.2/opam
@@ -2,7 +2,7 @@ opam-version: "1"
 maintainer: "agarwal1975@gmail.com"
 
 build: [
-  ["omake" "-j2" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
+  ["omake" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
   ["omake" "install"]
 ]
 
@@ -11,7 +11,7 @@ remove: [
 ]
 
 build-doc: [
-  ["omake" "-j2" "doc"]
+  ["omake" "doc"]
   ["omake" "install_doc" "DOC_DIR=%{doc}%/cfstream"]
 ]
 

--- a/packages/cfstream/cfstream.1.1.2/opam
+++ b/packages/cfstream/cfstream.1.1.2/opam
@@ -1,8 +1,22 @@
-opam-version: "1"
-maintainer: "agarwal1975@gmail.com"
+opam-version: "1.2"
+name: "cfstream"
+version: "1.1.2"
+homepage: "https://github.com/biocaml/cfstream"
+dev-repo: "https://github.com/biocaml/cfstream.git"
+bug-reports: "https://github.com/biocaml/cfstream/issues"
+license: "LGPL + linking exception"
+maintainer: "Ashish Agarwal <agarwal1975@gmail.com>"
+authors: [
+  "Philippe Veber <philippe.veber@gmail.com>"
+  "Ashish Agarwal <agarwal1975@gmail.com>"
+  "Drup <drupyog@zoho.com>"
+]
 
 build: [
   ["omake" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
+]
+
+install: [
   ["omake" "install"]
 ]
 
@@ -21,4 +35,6 @@ depends: [
   "core_kernel"
 ]
 
-ocaml-version: [>="4.00.1"]
+available: [
+  ocaml-version >= "4.01.0"
+]

--- a/packages/cfstream/cfstream.1.1.2/opam
+++ b/packages/cfstream/cfstream.1.1.2/opam
@@ -36,5 +36,5 @@ depends: [
 ]
 
 available: [
-  ocaml-version >= "4.01.0"
+  ocaml-version >= "4.00.1"
 ]

--- a/packages/cfstream/cfstream.1.2.0/opam
+++ b/packages/cfstream/cfstream.1.2.0/opam
@@ -12,12 +12,12 @@ authors: [
   "Drup <drupyog@zoho.com>"
 ]
 
-build: ["omake" "-j%{jobs}%" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
+build: ["omake" "PREFIX=%{prefix}%" "COMPILE_TEST=false"]
 install: ["omake" "install"]
 remove: ["ocamlfind" "remove" "cfstream"]
 
 build-doc: [
-  ["omake" "-j%{jobs}%" "doc"]
+  ["omake" "doc"]
   ["omake" "install_doc" "DOC_DIR=%{doc}%/cfstream"]
 ]
 


### PR DESCRIPTION
as noted in #5623, our use of "-j" in `omake` most probably causes
race conditions which in turn lead to build failures (X and Y make
inconsistent assumptions over interface Z). This commit simply removes
the "-j" option from `omake` invocations.