### PR TITLE
Add package for PGOCaml 2.3

### DIFF
--- a/packages/pgocaml/pgocaml.2.3/descr
+++ b/packages/pgocaml/pgocaml.2.3/descr
@@ -1,0 +1,9 @@
+Interface to PostgreSQL databases
+PG'OCaml provides an interface to PostgreSQL databases for OCaml
+applications. It uses Camlp4 to extend the OCaml syntax, enabling one
+to directly embed SQL statements inside the OCaml code. Moreover, it
+uses the describe feature of PostgreSQL to obtain type information
+about the database. This allows PG'OCaml to check at compile-time if
+the program is indeed consistent with the database structure. This
+type-safe database access is the primary advantage that PG'OCaml has
+over other PostgreSQL bindings for OCaml.

--- a/packages/pgocaml/pgocaml.2.3/findlib
+++ b/packages/pgocaml/pgocaml.2.3/findlib
@@ -1,0 +1,1 @@
+pgocaml

--- a/packages/pgocaml/pgocaml.2.3/opam
+++ b/packages/pgocaml/pgocaml.2.3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Dario Teixeira <dario.teixeira@nleyten.com>"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "http://pgocaml.forge.ocamlcore.org/"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0 with OCaml linking exception"
+build: [
+  ["./configure" "--%{camlp4:enable}%-p4" "--prefix" prefix "--docdir" "%{doc}%/pgocaml"]
+  [make]
+  [make "doc"]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "pgocaml"]]
+depends: [
+  "base-bytes"
+  "calendar"
+  "csv"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "re"
+]
+
+depopts: [ "camlp4" ]

--- a/packages/pgocaml/pgocaml.2.3/opam
+++ b/packages/pgocaml/pgocaml.2.3/opam
@@ -5,6 +5,7 @@ homepage: "http://pgocaml.forge.ocamlcore.org/"
 bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
 dev-repo: "https://github.com/darioteixeira/pgocaml.git"
 license: "LGPL-2.0 with OCaml linking exception"
+available: [ocaml-version >= "4.01.0"]
 build: [
   ["./configure" "--%{camlp4:enable}%-p4" "--prefix" prefix "--docdir" "%{doc}%/pgocaml"]
   [make]

--- a/packages/pgocaml/pgocaml.2.3/url
+++ b/packages/pgocaml/pgocaml.2.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/darioteixeira/pgocaml/archive/v2.3.tar.gz"
+checksum: "0f26e179c7c2ad32140ecb69a5f6c8a1"


### PR DESCRIPTION
The project migrated from PCRE to OCaml-re, and Camlp4 is now an optional dependency.  Hopefully the transition will be smooth OPAM-wise...