### PR TITLE
macaque.0.7.4 - via opam-publish

### DIFF
--- a/packages/macaque/macaque.0.7.4/descr
+++ b/packages/macaque/macaque.0.7.4/descr
@@ -1,0 +1,3 @@
+Macaque (Macros for Caml Queries) is a DSL for OCaml, which produces
+SQL requests from a comprehension syntax. Macaque can build queries
+from simpler components, using phantom types to ensure safety.

--- a/packages/macaque/macaque.0.7.4/opam
+++ b/packages/macaque/macaque.0.7.4/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "gabriel.scherer@gmail.com"
+authors: "gabriel.scherer@gmail.com"
+homepage: "https://github.com/ocsigen/macaque"
+bug-reports: "https://github.com/ocsigen/macaque/issues"
+dev-repo: "https://github.com/ocsigen/macaque.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "macaque"]
+depends: [
+  "ocamlfind" {build}
+  "pgocaml" {>= "2.2"}
+  "oasis" {>= "0.4.4"}
+  "camlp4"
+]

--- a/packages/macaque/macaque.0.7.4/url
+++ b/packages/macaque/macaque.0.7.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/macaque/archive/0.7.4.tar.gz"
+checksum: "5c7e0c9526146d94bae34e3a065bede9"


### PR DESCRIPTION
Macaque (Macros for Caml Queries) is a DSL for OCaml, which produces
SQL requests from a comprehension syntax. Macaque can build queries
from simpler components, using phantom types to ensure safety.


---
* Homepage: https://github.com/ocsigen/macaque
* Source repo: https://github.com/ocsigen/macaque.git
* Bug tracker: https://github.com/ocsigen/macaque/issues

---

Pull-request generated by opam-publish v0.3.1