### PR TITLE
Add typerex-attic.1.0.0

### DIFF
--- a/packages/typerex-attic/typerex-attic.1.0.0/descr
+++ b/packages/typerex-attic/typerex-attic.1.0.0/descr
@@ -1,0 +1,20 @@
+A set of simple tools and libraries that we developed over the years
+for temporary OCaml projects. Most of them are only
+maintained/improved when we need them for a task.
+
+ OCaml Tools
+
+* ocp-check-globals: display global mutable values stored in the modules
+    of an application.
+* ocp-check-poly: display the use of polymorphic functions, that can
+    sometimes be dangerous (polymorphic comparisons, etc.)
+* ocp-manager: wrappers around OCaml binaries to automatically choose
+    the correct opam switch.
+* ocp-check-crcs: check the consistency of binary files in an OCaml
+    distribution.
+* ocp-check-headers: print the headers of all files in a project, can be
+    used to add/replace headers.
+* ocp-imports: print values imported by a module. Can also display imports
+    by set of modules, to get the architecture of a project.
+* ocp-pack: pack several OCaml source files into one source file, to get
+   a result similar to the one of -pack

--- a/packages/typerex-attic/typerex-attic.1.0.0/findlib
+++ b/packages/typerex-attic/typerex-attic.1.0.0/findlib
@@ -1,0 +1,1 @@
+typerex-attic

--- a/packages/typerex-attic/typerex-attic.1.0.0/opam
+++ b/packages/typerex-attic/typerex-attic.1.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+authors: [
+  "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+  ]
+homepage: "http://www.typerex.org/"
+dev-repo: "https://github.com/OCamlPro/typerex-attic.git"
+bug-reports: "https://github.com/OCamlPro/typerex-attic/issues"
+build: [
+  [ "./configure" "--prefix" "%{prefix}%"  ]
+  [ make ]
+]
+install: [
+  [ make "install" ]
+]
+remove: [
+  [ "rm" "-f" "%{prefix}%/bin/ocp-check-crcs" ]
+  [ "rm" "-f" "%{prefix}%/bin/ocp-check-poly" ]
+  [ "rm" "-f" "%{prefix}%/bin/ocp-check-global" ]
+  [ "rm" "-f" "%{prefix}%/bin/ocp-check-headers" ]
+  [ "rm" "-f" "%{prefix}%/bin/ocp-imports" ]
+  [ "rm" "-f" "%{prefix}%/bin/ocp-manager" ]
+  [ "rm" "-f" "%{prefix}%/man/man1/ocp-manager.1" ]
+  [ "rm" "-f" "%{prefix}%/bin/ocp-pack" ]
+]
+depends: [
+    "ocp-build" {>= "1.99.11-beta"}
+  ]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/typerex-attic/typerex-attic.1.0.0/url
+++ b/packages/typerex-attic/typerex-attic.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://github.com/OCamlPro/typerex-attic/archive/1.0.0.tar.gz"
+checksum: "f46a8b0c1ac41322bd8fedfec027f962"


### PR DESCRIPTION
A set of simple tools and libraries that we developed over the years
for temporary OCaml projects. Most of them are only
maintained/improved when we need them for a task.

 OCaml Tools

* ocp-check-globals: display global mutable values stored in the modules
    of an application.
* ocp-check-poly: display the use of polymorphic functions, that can
    sometimes be dangerous (polymorphic comparisons, etc.)
* ocp-manager: wrappers around OCaml binaries to automatically choose
    the correct opam switch.
* ocp-check-crcs: check the consistency of binary files in an OCaml
    distribution.
* ocp-check-headers: print the headers of all files in a project, can be
    used to add/replace headers.
* ocp-imports: print values imported by a module. Can also display imports
    by set of modules, to get the architecture of a project.
* ocp-pack: pack several OCaml source files into one source file, to get
   a result similar to the one of -pack