### PR TITLE
Revert "inotify: osx is not supported, add test info for 2.1"

### DIFF
--- a/packages/inotify/inotify.1.4/opam
+++ b/packages/inotify/inotify.1.4/opam
@@ -10,5 +10,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-os: ["linux"]
+os: ["linux" | "darwin"]
 dev-repo: "git://github.com/whitequark/ocaml-inotify"

--- a/packages/inotify/inotify.1.5/opam
+++ b/packages/inotify/inotify.1.5/opam
@@ -10,5 +10,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-os: ["linux"]
+os: ["linux" | "darwin"]
 dev-repo: "git://github.com/whitequark/ocaml-inotify"

--- a/packages/inotify/inotify.2.0/opam
+++ b/packages/inotify/inotify.2.0/opam
@@ -12,5 +12,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["lwt"]
-os: ["linux"]
+os: ["linux" | "darwin"]
 dev-repo: "git://github.com/whitequark/ocaml-inotify"

--- a/packages/inotify/inotify.2.1/opam
+++ b/packages/inotify/inotify.2.1/opam
@@ -1,20 +1,14 @@
 opam-version: "1.2"
 maintainer: "whitequark <whitequark@whitequark.org>"
 authors: [ "whitequark <whitequark@whitequark.org>" ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1"
 homepage: "https://github.com/whitequark/ocaml-inotify"
 doc: "http://whitequark.github.io/ocaml-inotify"
 bug-reports: "https://github.com/whitequark/ocaml-inotify/issues"
-dev-repo: "https://github.com/whitequark/ocaml-inotify.git"
+dev-repo: "git://github.com/whitequark/ocaml-inotify.git"
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-]
-build-test: [
-  ["ocaml" "setup.ml" "-configure"
-   "--%{lwt:enable}%-lwt" "--prefix" prefix "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
 ]
 install: [
   ["ocaml" "setup.ml" "-install"]
@@ -27,7 +21,6 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "fileutils" {test}
 ]
 depopts: ["lwt"]
-available: [os = "linux"]
+available: [os = "linux" | os = "darwin"]


### PR DESCRIPTION
Reverts ocaml/opam-repository#5622. We need to check the dependent packages that may rely on the non-functional inotify stubs on OS X.