### PR TITLE
ssl: now installable on OS X 10.11 with macports

### DIFF
--- a/packages/ssl/ssl.0.5.2/opam
+++ b/packages/ssl/ssl.0.5.2/opam
@@ -8,11 +8,7 @@ bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
 build: [
   ["./configure" "--prefix" prefix] { os != "darwin" }
   ["sh" "-exc"
-   "./configure --prefix %{prefix}% \
-    CPPFLAGS=\"$CPPFLAGS \
-      -I/opt/local/include \
-      -I/usr/local/opt/openssl/include \
-    \""
+   "./configure --prefix %{prefix}% CPPFLAGS=\"$CPPFLAGS -I/opt/local/include -I/usr/local/opt/openssl/include\""
   ] { os = "darwin" }
   [make]
 ]

--- a/packages/ssl/ssl.0.5.2/opam
+++ b/packages/ssl/ssl.0.5.2/opam
@@ -7,7 +7,13 @@ bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
 
 build: [
   ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "--prefix" prefix "CFLAGS=-I/usr/local/opt/openssl/include"] { os = "darwin" }
+  ["sh" "-exc"
+   "./configure --prefix %{prefix}% \
+    CPPFLAGS=\"$CPPFLAGS \
+      -I/opt/local/include \
+      -I/usr/local/opt/openssl/include \
+    \""
+  ] { os = "darwin" }
   [make]
 ]
 install: [[make "install"]]


### PR DESCRIPTION
Also, use CPPFLAGS for -I instead of CFLAGS (-I is preprocessor whereas
CFLAGS is for compiler only) and don't force an override of the CPPFLAGS
environment variable.

Fixes #5512.