### PR TITLE
Shell invocations should error on non-zero exit codes

### DIFF
--- a/compilers/4.00.1/4.00.1+mirage-xen/4.00.1+mirage-xen.comp
+++ b/compilers/4.00.1/4.00.1+mirage-xen/4.00.1+mirage-xen.comp
@@ -6,7 +6,7 @@ build: [
   [make "world"]
   [make "world.opt"]
   [make "install"]
-  ["sh" "-c" "rm %{lib}%/ocaml/bigarray.*"]
+  ["sh" "-exc" "rm %{lib}%/ocaml/bigarray.*"]
 ]
 packages: [
   "lwt"

--- a/packages/ancient/ancient.0.9.0/opam
+++ b/packages/ancient/ancient.0.9.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
 build: [
-  ["sh" "-c" "cd mmalloc && ./configure"]
+  ["sh" "-exc" "cd mmalloc && ./configure"]
   [make]
   [make "install" "DESTDIR=%{lib}%"]
 ]

--- a/packages/baardskeerder/baardskeerder.0.5.1/opam
+++ b/packages/baardskeerder/baardskeerder.0.5.1/opam
@@ -3,8 +3,8 @@ maintainer: "romain.slootmaekers@incubaid.com"
 homepage: "http://incubaid.github.io/baardskeerder/"
 license: "LGPL v3"
 build: [
-  ["sh" "-c" "cd src && %{make}%"]
-  ["sh" "-c" "cd src && %{make}% install"]
+  ["sh" "-exc" "cd src && %{make}%"]
+  ["sh" "-exc" "cd src && %{make}% install"]
 ]
 remove: [["ocamlfind" "remove" "baardskeerder"]]
 depends: [

--- a/packages/baardskeerder/baardskeerder.0.5.2/opam
+++ b/packages/baardskeerder/baardskeerder.0.5.2/opam
@@ -3,8 +3,8 @@ maintainer: "romain.slootmaekers@incubaid.com"
 homepage: "http://incubaid.github.io/baardskeerder/"
 license: "LGPL v3"
 build: [
-  ["sh" "-c" "cd src && %{make}%"]
-  ["sh" "-c" "cd src && %{make}% install"]
+  ["sh" "-exc" "cd src && %{make}%"]
+  ["sh" "-exc" "cd src && %{make}% install"]
 ]
 remove: [["ocamlfind" "remove" "baardskeerder"]]
 depends: [

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [
-  ["sh" "-c" "cc -c $CFLAGS -I/usr/local/include test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
 ]
 depexts: [
   [["debian"] ["libgmp-dev"]]

--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -5,7 +5,7 @@ homepage: "http://bugseng.com/products/ppl/"
 bug-reports: "http://bugseng.com/products/ppl/bugs"
 license: "GPL"
 build: [
-  ["sh" "-c"
+  ["sh" "-exc"
 	"cc test.c -lppl_c -lppl" {os != "freebsd" & os != "openbsd"}
 	"cc test.c -I/usr/local/include -L/usr/local/lib -lppl_c -lppl" {os = "freebsd" | os = "openbsd"}]
 ]

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -2,8 +2,8 @@ opam-version: "1"
 maintainer: "kakadu.hafanana@gmail.com"
 
 build: [
-    ["bash" "-c" "echo \"Your Qt version is `qmake -query QT_VERSION`\"" ]
-    ["bash" "-c" "min=\"5.2.1\"; cur=`qmake -query QT_VERSION`; res=`echo -e \"$min\\n$cur\" | sort | head -n 1`; [ \"$res\" = \"$min\" ]"
+    ["bash" "-exc" "echo \"Your Qt version is `qmake -query QT_VERSION`\"" ]
+    ["bash" "-exc" "min=\"5.2.1\"; cur=`qmake -query QT_VERSION`; res=`echo -e \"$min\\n$cur\" | sort | head -n 1`; [ \"$res\" = \"$min\" ]"
     ]
 ]
 

--- a/packages/flowcaml/flowcaml.1.07/opam
+++ b/packages/flowcaml/flowcaml.1.07/opam
@@ -1,11 +1,11 @@
 opam-version: "1"
 maintainer: "prashanth.mundkur@gmail.com"
 build: [
-  ["sh" "-c" "cd src-flowcaml && ./configure --prefix %{prefix}% --with-runlib=%{lib}%/flowcaml"]
-  ["sh" "-c" "cd src-flowcaml && %{make}% world"]
-  ["sh" "-c" "cd src-flowcaml && %{make}% install"]
+  ["sh" "-exc" "cd src-flowcaml && ./configure --prefix %{prefix}% --with-runlib=%{lib}%/flowcaml"]
+  ["sh" "-exc" "cd src-flowcaml && %{make}% world"]
+  ["sh" "-exc" "cd src-flowcaml && %{make}% install"]
 ]
 remove: [
-  ["sh" "-c" "cd src-flowcaml && ./configure --prefix %{prefix}% --with-runlib=%{lib}%/flowcaml"]
-  ["sh" "-c" "cd src-flowcaml && %{make}% uninstall"]
+  ["sh" "-exc" "cd src-flowcaml && ./configure --prefix %{prefix}% --with-runlib=%{lib}%/flowcaml"]
+  ["sh" "-exc" "cd src-flowcaml && %{make}% uninstall"]
 ]

--- a/packages/hkdf/hkdf.1.0.1/opam
+++ b/packages/hkdf/hkdf.1.0.1/opam
@@ -15,7 +15,7 @@ build-test: [
   ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                           "native-dynlink=%{ocaml-native-dynlink}%"
                           "alcotest=true"]
-  ["sh" "-c" "if test -f ./rfctests.native; then ./rfctests.native; else ./rfctests.byte; fi"]
+  ["sh" "-exc" "if test -f ./rfctests.native; then ./rfctests.native; else ./rfctests.byte; fi"]
 ]
 depends: [
   "ocamlfind" {build}

--- a/packages/lablqt/lablqt.0.2/opam
+++ b/packages/lablqt/lablqt.0.2/opam
@@ -3,7 +3,7 @@ maintainer: "kakadu.hafanana@gmail.com"
 build: [
   ["./configure"]
   [make "generator"]
-  ["bash" "-c" "cd lablqml && ./configure --datarootdir=%{lib}% && %{make}%" ]
+  ["bash" "-exc" "cd lablqml && ./configure --datarootdir=%{lib}% && %{make}%" ]
   [make "opam.install" ]
 ]
 remove: [

--- a/packages/lablqt/lablqt.0.3/opam
+++ b/packages/lablqt/lablqt.0.3/opam
@@ -3,7 +3,7 @@ maintainer: "kakadu.hafanana@gmail.com"
 build: [
   ["./configure"]
   [make "generator"]
-  ["bash" "-c" "cd lablqml && ./configure --datarootdir=%{lib}% && %{make}%" ]
+  ["bash" "-exc" "cd lablqml && ./configure --datarootdir=%{lib}% && %{make}%" ]
   [make "opam.install" ]
 ]
 remove: [

--- a/packages/libres3/libres3.0.2/opam
+++ b/packages/libres3/libres3.0.2/opam
@@ -4,9 +4,9 @@ authors: [ "edwin@skylable.com" ]
 license: "GPL-2.0 with OpenSSL exception"
 homepage: "http://www.skylable.com/products/libres3"
 build: [
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -distclean"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -build"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -distclean"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -build"]
 ]
 depends: [
   "base-threads"
@@ -25,6 +25,6 @@ depends: [
 ]
 depopts:["ounit"]
 build-test: [
-    ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]
+    ["sh" "-exc" "cd libres3 && ocaml setup.ml -test"]
 ]
 ocaml-version: [ >= "3.12.1" ]

--- a/packages/libres3/libres3.0.3/opam
+++ b/packages/libres3/libres3.0.3/opam
@@ -4,9 +4,9 @@ authors: [ "edwin@skylable.com" ]
 license: "GPL-2.0 with OpenSSL exception"
 homepage: "http://www.skylable.com/products/libres3"
 build: [
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -distclean"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -build"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -distclean"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -build"]
 ]
 depends: [
   "base-threads"
@@ -27,6 +27,6 @@ depends: [
 ]
 depopts:["ounit"]
 build-test: [
-    ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]
+    ["sh" "-exc" "cd libres3 && ocaml setup.ml -test"]
 ]
 ocaml-version: [ >= "4.00.0" ]

--- a/packages/libres3/libres3.0.9/opam
+++ b/packages/libres3/libres3.0.9/opam
@@ -5,9 +5,9 @@ license: "GPL-2.0 with OpenSSL exception"
 homepage: "http://www.skylable.com/products/libres3"
 bug-reports: "https://bugzilla.skylable.com/"
 build: [
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -distclean"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -build"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -distclean"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -build"]
 ]
 depends: [
   "base-threads"
@@ -27,6 +27,6 @@ depends: [
   "ocamlbuild"
 ]
 build-test: [
-    ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]
+    ["sh" "-exc" "cd libres3 && ocaml setup.ml -test"]
 ]
 ocaml-version: [ >= "4.00.0" ]

--- a/packages/libres3/libres3.1.0/opam
+++ b/packages/libres3/libres3.1.0/opam
@@ -5,9 +5,9 @@ license: "GPL-2.0 with OpenSSL exception"
 homepage: "http://www.skylable.com/products/libres3"
 bug-reports: "https://bugzilla.skylable.com/"
 build: [
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -distclean"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs --override ocamlbuildflags '-j 0'"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -build"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -distclean"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs --override ocamlbuildflags '-j 0'"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -build"]
 ]
 depends: [
   "base-threads"
@@ -27,6 +27,6 @@ depends: [
   "ocamlbuild"
 ]
 build-test: [
-    ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]
+    ["sh" "-exc" "cd libres3 && ocaml setup.ml -test"]
 ]
 available: [ ocaml-version >= "4.00.0" ]

--- a/packages/libres3/libres3.1.1/opam
+++ b/packages/libres3/libres3.1.1/opam
@@ -6,9 +6,9 @@ homepage: "http://www.skylable.com/products/libres3"
 bug-reports: "https://bugzilla.skylable.com/"
 dev-repo: "http://git.skylable.com/libres3.git"
 build: [
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -distclean"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs --override ocamlbuildflags '-j 0'"]
-  ["sh" "-c" "cd libres3 && ocaml setup.ml -build"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -distclean"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -configure --prefix %{prefix}% --%{ounit:enable}%-tests --disable-docs --override ocamlbuildflags '-j 0'"]
+  ["sh" "-exc" "cd libres3 && ocaml setup.ml -build"]
 ]
 depends: [
   "base-threads"
@@ -28,6 +28,6 @@ depends: [
   "ocamlbuild"
 ]
 build-test: [
-    ["sh" "-c" "cd libres3 && ocaml setup.ml -test"]
+    ["sh" "-exc" "cd libres3 && ocaml setup.ml -test"]
 ]
 available: [ ocaml-version >= "4.00.0" & (ocaml-version < "4.02.2" | ocaml-version > "4.02.2") ]

--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -3,7 +3,7 @@ authors: ["David Monniaux"]
 maintainer: "Nicolas Berthier <m@nberth.space>"
 homepage: "http://www-verimag.imag.fr/~monniaux/download/"
 build: [
-  ["sh" "-c" "rm -f *.cmo *.cmi *.cma *.cmxa *.o *.a *.cmx *.cmxs"]
+  ["sh" "-exc" "rm -f *.cmo *.cmi *.cma *.cmxa *.o *.a *.cmx *.cmxs"]
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["mkdir" "-p" "_build"]

--- a/packages/oasis/oasis.0.4.5/opam
+++ b/packages/oasis/oasis.0.4.5/opam
@@ -15,7 +15,7 @@ remove: [
   # If _oasis_remove_.ml is not present, this is an old installation
   # and one needs to perform the removal "manually".  The next version of
   # the package will use the first method only.
-  ["/bin/sh" "-c" "if [ -e '%{etc}%/oasis/_oasis_remove_.ml' ]; then ocaml '%{etc}%/oasis/_oasis_remove_.ml' '%{etc}%/oasis'; else ocamlfind remove plugin-loader; ocamlfind remove userconf; ocamlfind remove oasis; rm '%{bin}%/oasis'; fi"]
+  ["/bin/sh" "-exc" "if [ -e '%{etc}%/oasis/_oasis_remove_.ml' ]; then ocaml '%{etc}%/oasis/_oasis_remove_.ml' '%{etc}%/oasis'; else ocamlfind remove plugin-loader; ocamlfind remove userconf; ocamlfind remove oasis; rm '%{bin}%/oasis'; fi"]
 ]
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"

--- a/packages/ocp-index/ocp-index.0.1.0/opam
+++ b/packages/ocp-index/ocp-index.0.1.0/opam
@@ -5,7 +5,7 @@ build: [
   ["ocp-build" "-init"]
   ["ocp-build" "ocp-index-lib" "ocp-index" "ocp-browser" {"%{curses:installed}%"}]
   ["ocp-build" "install" "-install-lib" "%{lib}%/ocp-index" "-install-bin" bin "-install-data" "%{prefix}%/share/typerex" "ocp-index-lib" "ocp-index" "ocp-browser" {"%{curses:installed}%"}]
-  ["sh" "-c" "./_obuild/ocp-index/ocp-index.asm --help=groff > %{man}%/man1/ocp-index.1"]
+  ["sh" "-exc" "./_obuild/ocp-index/ocp-index.asm --help=groff > %{man}%/man1/ocp-index.1"]
 ]
 remove: [
   ["ocp-build" "-init"]

--- a/packages/ocp-index/ocp-index.0.2.0/opam
+++ b/packages/ocp-index/ocp-index.0.2.0/opam
@@ -5,7 +5,7 @@ build: [
   ["ocp-build" "-init"]
   ["ocp-build" "ocp-index-lib" "ocp-index" "ocp-browser" {"%{curses:installed}%"}]
   ["ocp-build" "install" "-install-lib" "%{lib}%/ocp-index" "-install-bin" bin "-install-data" "%{prefix}%/share/typerex" "ocp-index-lib" "ocp-index" "ocp-browser" {"%{curses:installed}%"}]
-  ["sh" "-c" "./_obuild/ocp-index/ocp-index.asm --help=groff > %{man}%/man1/ocp-index.1"]
+  ["sh" "-exc" "./_obuild/ocp-index/ocp-index.asm --help=groff > %{man}%/man1/ocp-index.1"]
 ]
 remove: [
   ["ocp-build" "-init"]

--- a/packages/ocp-index/ocp-index.0.3.0/opam
+++ b/packages/ocp-index/ocp-index.0.3.0/opam
@@ -6,7 +6,7 @@ build: [
   ["ocp-build" "-init"]
   ["ocp-build" "ocp-index-lib" "ocp-index" "ocp-browser" {"%{curses:installed}%"}]
   ["ocp-build" "install" "-install-lib" "%{lib}%/ocp-index" "-install-bin" bin "-install-data" "%{prefix}%/share/typerex" "ocp-index-lib" "ocp-index" "ocp-browser" {"%{curses:installed}%"}]
-  ["sh" "-c" "./_obuild/ocp-index/ocp-index.asm --help=groff > %{man}%/man1/ocp-index.1"]
+  ["sh" "-exc" "./_obuild/ocp-index/ocp-index.asm --help=groff > %{man}%/man1/ocp-index.1"]
 ]
 remove: [
   ["ocp-build" "-init"]

--- a/packages/omake-mode/omake-mode.1.1.1/opam
+++ b/packages/omake-mode/omake-mode.1.1.1/opam
@@ -6,7 +6,7 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-install"]
-  ["sh" "-c" "cd %{prefix}%/share/omake-mode && make"]
+  ["sh" "-exc" "cd %{prefix}%/share/omake-mode && make"]
 ]
 remove: [
   [ "rm" "-rf" "%{share}%/omake-mode" ]

--- a/packages/otr/otr.0.3.0/opam
+++ b/packages/otr/otr.0.3.0/opam
@@ -14,7 +14,7 @@ build: [
 build-test: [
   ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                           "native-dynlink=%{ocaml-native-dynlink}%"]
-  ["sh" "-c" "if test -f ./feedback.native; then ./feedback.native; else ./feedback.byte; fi"]
+  ["sh" "-exc" "if test -f ./feedback.native; then ./feedback.native; else ./feedback.byte; fi"]
 ]
 
 depends: [

--- a/packages/pprint/pprint.20130131/opam
+++ b/packages/pprint/pprint.20130131/opam
@@ -1,8 +1,8 @@
 opam-version: "1"
 maintainer: "jonathan.protzenko@gmail.com"
 build: [
-  ["sh" "-c" "cd src && %{make}%"]
-  ["sh" "-c" "cd src && %{make}% install"]
+  ["sh" "-exc" "cd src && %{make}%"]
+  ["sh" "-exc" "cd src && %{make}% install"]
 ]
 remove: [["ocamlfind" "remove" "pprint"]]
 depends: ["ocamlfind"]

--- a/packages/pprint/pprint.20130324/opam
+++ b/packages/pprint/pprint.20130324/opam
@@ -1,8 +1,8 @@
 opam-version: "1"
 maintainer: "jonathan.protzenko@gmail.com"
 build: [
-  ["sh" "-c" "cd src && %{make}%"]
-  ["sh" "-c" "cd src && %{make}% install"]
+  ["sh" "-exc" "cd src && %{make}%"]
+  ["sh" "-exc" "cd src && %{make}% install"]
 ]
 remove: [["ocamlfind" "remove" "pprint"]]
 depends: ["ocamlfind"]

--- a/packages/tlstunnel/tlstunnel.0.1.2/opam
+++ b/packages/tlstunnel/tlstunnel.0.1.2/opam
@@ -10,7 +10,7 @@ license:      "BSD2"
 build: [
   [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                            "native-dynlink=%{ocaml-native-dynlink}%" ]
-  ["sh" "-c" "if test -f ./tlstunnel.native; then ./tlstunnel.native --help > _build/tlstunnel.1; else ./tlstunnel.byte --help > _build/tlstunnel.1; fi"]
+  ["sh" "-exc" "if test -f ./tlstunnel.native; then ./tlstunnel.native --help > _build/tlstunnel.1; else ./tlstunnel.byte --help > _build/tlstunnel.1; fi"]
 ]
 depends: [
   "ocamlfind" {build}


### PR DESCRIPTION
`sh` execution is non-interactive so -e is necessary to notify opam that
a package step has failed. Also adds -x to print the actual command executed
to the log to make debugging through the shell's interpreter layer easier.

I realized that this could be a common source of unexplained installation and removal issues when developing #5650. Most of these invocations don't *need* the `-x` flag but it doesn't hurt. I welcome discussion about this change.