### PR TITLE
inotify: update some metadata and add test support

### DIFF
--- a/packages/inotify/inotify.2.1/opam
+++ b/packages/inotify/inotify.2.1/opam
@@ -1,14 +1,20 @@
 opam-version: "1.2"
 maintainer: "whitequark <whitequark@whitequark.org>"
 authors: [ "whitequark <whitequark@whitequark.org>" ]
-license: "LGPL-2.1"
+license: "LGPL-2.1 with OCaml linking exception"
 homepage: "https://github.com/whitequark/ocaml-inotify"
 doc: "http://whitequark.github.io/ocaml-inotify"
 bug-reports: "https://github.com/whitequark/ocaml-inotify/issues"
-dev-repo: "git://github.com/whitequark/ocaml-inotify.git"
+dev-repo: "https://github.com/whitequark/ocaml-inotify.git"
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure"
+   "--%{lwt:enable}%-lwt" "--prefix" prefix "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
 ]
 install: [
   ["ocaml" "setup.ml" "-install"]
@@ -21,6 +27,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "fileutils" {test}
 ]
 depopts: ["lwt"]
 available: [os = "linux" | os = "darwin"]


### PR DESCRIPTION
This is a stripped down version of #5622 which doesn't remove the `darwin` from the support platform list and so doesn't break dependent packages that need `inotify` to install but be non-functional on OS X.