### PR TITLE
efl: add OS X depext

### DIFF
--- a/packages/efl/efl.1.17.0/opam
+++ b/packages/efl/efl.1.17.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "Alexis Bernadet <alexis.bernadet at noos.fr>"
 authors: "Alexis Bernadet <alexis.bernadet at noos.fr>"
-ocaml-version: [>= "3.12"]
+available: [ ocaml-version >= "3.12"]
 homepage: "https://forge.ocamlcore.org/projects/ocaml-efl/"
 license: "LGPL with linking exception"
 dev-repo: "https://github.com/axiles/ocaml-efl.git"

--- a/packages/efl/efl.1.17.0/opam
+++ b/packages/efl/efl.1.17.0/opam
@@ -16,5 +16,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
+  [["osx" "homebrew"] ["elementary"]]
   [["source" "linux"] ["https://gist.githubusercontent.com/axiles/6e0f43192045c5f9b460/raw/f7c0668e063e12ded850f9b67fc4432b31ca1a7b/install_efl_1_17_on_ubuntu"]]
 ]


### PR DESCRIPTION
@axiles, I don't know if this actually functions properly but now it at least compiles on OS X. I think homebrew has efl 1.14.2 right now. If this won't work or is somehow bad, please restrict the package with `available: [ os != "darwin" ]`. Thanks!

Fixes #5644 on OS X CI VM.