### PR TITLE
msgpack.1.2.1 - via opam-publish

### DIFF
--- a/packages/msgpack/msgpack.1.2.1/descr
+++ b/packages/msgpack/msgpack.1.2.1/descr
@@ -1,0 +1,4 @@
+Msgpack library for OCaml
+
+MessagePack is an efficient binary serialization format.
+If meta_conv is installed, conv module will be installed.

--- a/packages/msgpack/msgpack.1.2.1/opam
+++ b/packages/msgpack/msgpack.1.2.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "mzp <mzp.ppp@gmail.com>"
+author: "mzp <mzp.ppp@gmail.com>"
+homepage: "http://github.com/msgpack/msgpack-ocaml/"
+dev-repo: "https://github.com/msgpack/msgpack-ocaml.git"
+bug-reports: "https://github.com/msgpack/msgpack-ocaml/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--enable-core" "--%{meta_conv:enable}%-conv"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "msgpack"]
+]
+depends: ["ocamlfind" "camlp4"]
+
+depopts: ["meta_conv"]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/msgpack/msgpack.1.2.1/url
+++ b/packages/msgpack/msgpack.1.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/msgpack/msgpack-ocaml/archive/1.2.1.tar.gz"
+checksum: "7043759dada3e988eca65d965c7c3483"


### PR DESCRIPTION
Msgpack library for OCaml

MessagePack is an efficient binary serialization format.
If meta_conv is installed, conv module will be installed.


---
* Homepage: http://github.com/msgpack/msgpack-ocaml/
* Source repo: https://github.com/msgpack/msgpack-ocaml.git
* Bug tracker: https://github.com/msgpack/msgpack-ocaml/issues

---

Pull-request generated by opam-publish v0.3.1