### PR TITLE
ocp-build: remove old unbuildable versions

### DIFF
--- a/packages/ocp-build/ocp-build.0.1/descr
+++ b/packages/ocp-build/ocp-build.0.1/descr
@@ -1,1 +1,0 @@
-Project manager for OCaml

--- a/packages/ocp-build/ocp-build.0.1/files/ocp-build.install
+++ b/packages/ocp-build/ocp-build.0.1/files/ocp-build.install
@@ -1,1 +1,0 @@
-bin: ["_obuild/ocp-build/ocp-build.asm" {"ocp-build"}]

--- a/packages/ocp-build/ocp-build.0.1/findlib
+++ b/packages/ocp-build/ocp-build.0.1/findlib
@@ -1,1 +1,0 @@
-ocp-build

--- a/packages/ocp-build/ocp-build.0.1/opam
+++ b/packages/ocp-build/ocp-build.0.1/opam
@@ -1,4 +1,0 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
-build: [[make]]
-conflicts: ["typerex"]

--- a/packages/ocp-build/ocp-build.0.1/url
+++ b/packages/ocp-build/ocp-build.0.1/url
@@ -1,2 +1,0 @@
-archive: "http://www.ocamlpro.com/pub/ocp-build.tar.gz"
-checksum: "32a37a0c1f5ee2dd65b7e19c6f874996"

--- a/packages/ocp-build/ocp-build.1.99-beta/descr
+++ b/packages/ocp-build/ocp-build.1.99-beta/descr
@@ -1,1 +1,0 @@
-Project manager for OCaml

--- a/packages/ocp-build/ocp-build.1.99-beta/findlib
+++ b/packages/ocp-build/ocp-build.1.99-beta/findlib
@@ -1,1 +1,0 @@
-ocp-build

--- a/packages/ocp-build/ocp-build.1.99-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99-beta/opam
@@ -1,3 +1,0 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
-depends: ["typerex" {>= "1.99"}]


### PR DESCRIPTION
ocp-build 0.1 is missing its archive and ocp-build 1.99-beta is missing the dependency `typerex`.

/cc @lefessan