### PR TITLE
ocp-index: 0.2.0 and 0.3.0 also fail to install with recent ocp-build

### DIFF
--- a/packages/ocp-index/ocp-index.0.2.0/opam
+++ b/packages/ocp-index/ocp-index.0.2.0/opam
@@ -13,7 +13,7 @@ remove: [
   ["rm" "%{man}%/man1/ocp-index.1"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.4-beta"}
+  "ocp-build" {>= "1.99.4-beta" & <= "1.99.8-beta"}
   "cmdliner"
 ]
 depopts: ["curses"]

--- a/packages/ocp-index/ocp-index.0.3.0/opam
+++ b/packages/ocp-index/ocp-index.0.3.0/opam
@@ -14,7 +14,7 @@ remove: [
   ["rm" "%{man}%/man1/ocp-index.1"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.4-beta"}
+  "ocp-build" {>= "1.99.4-beta" & <= "1.99.8-beta"}
   "cmdliner"
 ]
 depopts: ["curses"]


### PR DESCRIPTION
Adding `-build` causes these packages to build with ocp-build 9 or later but fail with 8. Uninstallation with 9 or later then fails.

Upstream issues:

OCamlPro/ocp-build#5
OCamlPro/ocp-build#6
OCamlPro/ocp-index#83

/cc @lefessan