### PR TITLE
quickcheck.1.0.0: makes deprecation warning fatal, restrict to < 4.02

### DIFF
--- a/packages/quickcheck/quickcheck.1.0.0/opam
+++ b/packages/quickcheck/quickcheck.1.0.0/opam
@@ -11,4 +11,5 @@ depends: [
   "optcomp"
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.02.0" ]
 dev-repo: "git://github.com/avsm/ocaml-quickcheck"


### PR DESCRIPTION
Fixes the compatibility issue found in #5673.