### PR TITLE
receive-mail.0.1.2: does not work with core >= 113.24.00

### DIFF
--- a/packages/receive-mail/receive-mail.0.1.2/opam
+++ b/packages/receive-mail/receive-mail.0.1.2/opam
@@ -5,7 +5,7 @@ maintainer: "dominic.price@nottingham.ac.uk"
 homepage: "https://github.com/dominicjprice/receive-mail"
 authors: [ "Dominic Price" ]
 license: "GPL-3"
-ocaml-version: [ >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" ]
 build: [
   ["oasis" "setup"]
   ["./configure" "--prefix" prefix]
@@ -18,7 +18,7 @@ remove: [
 ]
 depends: [
   "bolt"
-  "core"
+  "core" {< "113.24.00"}
   "lwt"
   "oasis"
   "ocamlnet"


### PR DESCRIPTION
@dominicjprice, `receive-mail` is not compatible with the newest versions of `core`.