### PR TITLE
Remove base-ocamlbuild from all 4.03 compilers

### DIFF
--- a/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
+++ b/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
@@ -11,6 +11,5 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
-  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
+++ b/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
@@ -11,6 +11,5 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
-  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
+++ b/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
@@ -11,6 +11,5 @@ packages: [
   "base-unix"
   "base-bigarray"
   "base-threads"
-  "base-ocamlbuild"
 ]
 env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]


### PR DESCRIPTION
This is a followup of https://github.com/ocaml/opam-repository/pull/5616 that removed it only from the default one.