### PR TITLE
+depext.0.9.1

### DIFF
--- a/packages/depext/depext.0.9.1/descr
+++ b/packages/depext/depext.0.9.1/descr
@@ -1,0 +1,7 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can perform OS and
+distribution detection, query OPAM for the right external dependencies on a set
+of packages, and call the OS's package manager in the appropriate way to install
+them.

--- a/packages/depext/depext.0.9.1/opam
+++ b/packages/depext/depext.0.9.1/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+tags: "flags:plugin"
+dev-repo: "https://github.com/ocaml/opam-depext.git"
+build: [
+  [
+    "ocamlopt"
+    "-I"
+    cmdliner:lib
+    "unix.cmxa"
+    "cmdliner.cmxa"
+    "-o"
+    "opam-depext"
+    "depext.ml"
+  ]
+    {ocaml-native}
+  [
+    "ocamlc"
+    "-I"
+    cmdliner:lib
+    "unix.cma"
+    "cmdliner.cma"
+    "-o"
+    "opam-depext"
+    "depext.ml"
+  ]
+    {!ocaml-native}
+]
+depends: [
+  "cmdliner" {build}
+]
+available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.0.9.1/url
+++ b/packages/depext/depext.0.9.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam-depext/archive/v0.9.1.tar.gz"
+checksum: "dd3d5c03ca7953c16f00d7e6727756fa"


### PR DESCRIPTION
* Do not assume that `bash` is installed for source depexts (ocaml/opam-depext#35).
* Add support for Red Hat Enterprise Linux via `rhel` tag (ocaml/opam-depext#32).
* Add multi-distro Docker-based Travis file.