### PR TITLE
let `ocamlfind` depends on `conf-m4`

### DIFF
--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -9,4 +9,7 @@ depexts: [
   [["debian"] ["m4"]]
   [["ubuntu"] ["m4"]]
   [["nixpkgs"] ["m4"]]
+  [["fedora"] ["m4"]]
+  [["centos"] ["m4"]]
+  [["alpine"] ["m4"]]
 ]

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -11,4 +11,5 @@ depexts: [
   [["debian"] ["ncurses-dev"]]
   [["ubuntu"] ["ncurses-dev"]]
   [["nixpkgs"] ["ncurses"]]
+  [["alpine"] ["ncurses-dev"]]
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -8,6 +8,6 @@ build: [
 ]
 available: [(ocaml-version >= "3.08") & (ocaml-version < "3.12.2")]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -7,13 +7,7 @@ build: [
   [make "install"]
 ]
 available: [(ocaml-version >= "3.08") & (ocaml-version < "3.12.2")]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -8,6 +8,6 @@ build: [
 ]
 ocaml-version: [> "3.12.2"]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -7,13 +7,7 @@ build: [
   [make "install"]
 ]
 ocaml-version: [> "3.12.2"]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -8,13 +8,7 @@ build: [
   ["ocamlfind" "remove" "dbm"]
 ]
 available: [(ocaml-version >= "3.08") & (ocaml-version <= "4.01.0")] # ocamlfind uses Arg.align of 3.08
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -9,6 +9,6 @@ build: [
 ]
 available: [(ocaml-version >= "3.08") & (ocaml-version <= "4.01.0")] # ocamlfind uses Arg.align of 3.08
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -7,7 +7,7 @@ build: [
   [make "install"]
 ]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -6,14 +6,8 @@ build: [
   [make "opt"]
   [make "install"]
 ]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -7,7 +7,7 @@ build: [
   [make "install"]
 ]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -6,14 +6,8 @@ build: [
   [make "opt"]
   [make "install"]
 ]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -11,15 +11,9 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -12,7 +12,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -11,15 +11,9 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -12,7 +12,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -11,15 +11,9 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -12,7 +12,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -13,7 +13,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "conf-m4" {build}
+  "conf-m4"
   "conf-ncurses"
 ]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -12,14 +12,8 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-depexts: [
-  [["debian"] ["m4"]]
-  [["ubuntu"] ["m4"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -16,14 +16,8 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -16,14 +16,8 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-depexts: [
-  [["debian"] ["m4" "ncurses-dev"]]
-  [["ubuntu"] ["m4" "ncurses-dev"]]
-  [["fedora"] ["m4"]]
-  [["centos"] ["m4"]]
-  [["alpine"] ["m4" "ncurses-dev"]]
-]
-post-messages: [
-  "Could not build ocamlfind. The most common reason for that is a missing 'm4' system package." {failure}
-]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
+]

--- a/packages/ocamlfind/ocamlfind.1.6.1/descr
+++ b/packages/ocamlfind/ocamlfind.1.6.1/descr
@@ -1,0 +1,6 @@
+A library manager for OCaml
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.

--- a/packages/ocamlfind/ocamlfind.1.6.1/files/ocamlfind.install
+++ b/packages/ocamlfind/ocamlfind.1.6.1/files/ocamlfind.install
@@ -1,0 +1,6 @@
+bin: [
+  "src/findlib/ocamlfind" {"ocamlfind"}
+  "?src/findlib/ocamlfind_opt" {"ocamlfind"}
+  "?tools/safe_camlp4"
+]
+toplevel: ["src/findlib/topfind"]

--- a/packages/ocamlfind/ocamlfind.1.6.1/findlib
+++ b/packages/ocamlfind/ocamlfind.1.6.1/findlib
@@ -1,0 +1,14 @@
+bigarray
+bytes
+compiler-libs
+dynlink
+findlib
+graphics
+labltk
+num
+num-top
+ocamlbuild
+stdlib
+str
+threads
+unix

--- a/packages/ocamlfind/ocamlfind.1.6.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "mailto:gerd@gerd-stolpmann.de"
+dev-repo:     "https://github.com/whitequark/ocaml-findlib.git"
+
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
+  [make "all"]
+  [make "opt"] { ocaml-native }
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "bytes"]
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
+  [make "uninstall"]
+]
+available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+depends: [
+  "conf-m4" {build}
+  "conf-ncurses"
+]

--- a/packages/ocamlfind/ocamlfind.1.6.1/url
+++ b/packages/ocamlfind/ocamlfind.1.6.1/url
@@ -1,0 +1,2 @@
+archive: "http://download.camlcity.org/download/findlib-1.6.1.tar.gz"
+checksum: "50a900451dbaa67c6985a09c905f94a7"


### PR DESCRIPTION
With the recent introduction of  `conf-m4`, this patch replaces the `depext` field in `ocamlfind` by a dependency on `conf-m4`. This also removes the `post-message`: 
 
```
The most common reason for that is a missing 'm4' system package.") as the failing package will now be `conf-m4`
```

The failing package should now be `conf-m4` and it fails with:
 
```
This package relies on external (system) dependencies that may be missing. `opam depext conf-m4' may help you find the correct installation for your system.
```

If this PRs is approved, I'm willing to write PRs for others `conf-*` and to regroup `depext` into `conf-package`. This might helps "centralizing" some `depext` information and this should avoid duplication.

