### PR TITLE
inotify-event.0.1.0 - via opam-publish

### DIFF
--- a/packages/inotify-event/inotify-event.0.1.0/descr
+++ b/packages/inotify-event/inotify-event.0.1.0/descr
@@ -1,0 +1,7 @@
+inotify event tools
+
+inotify-event provides sexplib constructors and destructors for
+inotify's event type. If cmdliner is installed, inotify-event also
+installs the inotify-events tool which can monitor the current working
+directory for all or a subset of inotify events and print either
+pretty-printed strings or S-expressions to stdout.

--- a/packages/inotify-event/inotify-event.0.1.0/opam
+++ b/packages/inotify-event/inotify-event.0.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-inotify-event"
+bug-reports: "https://github.com/dsheets/ocaml-inotify-event/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/ocaml-inotify-event.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-bytes"
+  "inotify" {>= "2.2"}
+  "sexplib"
+  "ppx_sexp_conv"
+]
+depopts: "cmdliner"

--- a/packages/inotify-event/inotify-event.0.1.0/url
+++ b/packages/inotify-event/inotify-event.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-inotify-event/archive/0.1.0.tar.gz"
+checksum: "1d312b59c7e081cf1593bea37e2055da"


### PR DESCRIPTION
inotify event tools

inotify-event provides sexplib constructors and destructors for
inotify's event type. If cmdliner is installed, inotify-event also
installs the inotify-events tool which can monitor the current working
directory for all or a subset of inotify events and print either
pretty-printed strings or S-expressions to stdout.


---
* Homepage: https://github.com/dsheets/ocaml-inotify-event
* Source repo: https://github.com/dsheets/ocaml-inotify-event.git
* Bug tracker: https://github.com/dsheets/ocaml-inotify-event/issues

---

Pull-request generated by opam-publish v0.3.1