### PR TITLE
Lambdoc 1.0-beta4 must have Tyxml < 3.6

### DIFF
--- a/packages/lambdoc/lambdoc.1.0-beta4/opam
+++ b/packages/lambdoc/lambdoc.1.0-beta4/opam
@@ -27,7 +27,7 @@ depends: [
   "pcre"
   "pxp"
   "xstrp4"
-  "tyxml" {>= "3.2" & < "4"}
+  "tyxml" {>= "3.2" & < "3.6"}
   "omd" {>= "1.0.0"}
   "blahcaml"
   "camlhighlight" {>= "3.0" & < "4"}


### PR DESCRIPTION
Tyxml 3.6 has some backwards-incompatible changes that broke Lambdoc.