### PR TITLE
Update Frama-C-E-ACSL to support newer Frama-C

### DIFF
--- a/packages/frama-c-e-acsl/frama-c-e-acsl.0.5/opam
+++ b/packages/frama-c-e-acsl/frama-c-e-acsl.0.5/opam
@@ -43,7 +43,7 @@ build-doc: [
 ]
 
 depends: [
-  "frama-c-base" { = "20150201" }
+  "frama-c-base" { >= "20150201" }
 ]
 
 available: [ ocaml-version >= "3.12" & ocaml-version != "4.02.0" ]


### PR DESCRIPTION
A new version of Frama-C came out, yet the E-ACSL plug-in is still at version 0.5.
Consequently, now it is impossible to install it.