### PR TITLE
Add availability constraint for Blahcaml 2.1 (anything but OSX)

### DIFF
--- a/packages/blahcaml/blahcaml.2.1/opam
+++ b/packages/blahcaml/blahcaml.2.1/opam
@@ -5,6 +5,7 @@ homepage: "http://blahcaml.forge.ocamlcore.org/"
 bug-reports: "https://github.com/darioteixeira/blahcaml/issues"
 dev-repo: "https://github.com/darioteixeira/blahcaml.git"
 license: "GPL-2.0"
+available: [os != "darwin"]
 build: [[make]]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "blahcaml"]]


### PR DESCRIPTION
I don't have access to an OSX machine, but I'll see if I can get Blahcaml to compile on OSX anyway.  But in the meantime it's better to fix the OPAM package.