### PR TITLE
flowtype v0.22.0 requires >= 4.01.0

### DIFF
--- a/packages/flowtype/flowtype.0.22.0/opam
+++ b/packages/flowtype/flowtype.0.22.0/opam
@@ -18,7 +18,7 @@ depends: [
   "base-bytes"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.01.0"]
 build: [ [ make ] ]
 depexts: [
  [ ["debian"] ["libelf-dev"] ]


### PR DESCRIPTION
We had to bump the requirement for v0.21.0 due to a bug, but v0.22.0 only needs 4.01.0