### PR TITLE
grenier.0.1 - via opam-publish

### DIFF
--- a/packages/grenier/grenier.0.1/descr
+++ b/packages/grenier/grenier.0.1/descr
@@ -1,0 +1,10 @@
+Collection of algorithms (HyperLogLog, order maintenance, ...)
+
+Included:
+- baltree : Generic balanced-tree
+- trope : Track objects accross rope-like operations
+- orderme : Order-maintenance problem
+- doubledouble : Floating points with around 107-bits precision
+- hll : HyperLogLog
+- jmphash : Jump consistent hashing
+- physh : Physical hashtable

--- a/packages/grenier/grenier.0.1/opam
+++ b/packages/grenier/grenier.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/def-lkb/grenier"
+bug-reports: "https://github.com/def-lkb/grenier"
+license: "CC0"
+dev-repo: "https://github.com/def-lkb/grenier.git"
+build: [
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "grenier"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/grenier/grenier.0.1/url
+++ b/packages/grenier/grenier.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/def-lkb/grenier/archive/v0.1.tar.gz"
+checksum: "db6fd95a65b52e4320062c50cc069fb3"


### PR DESCRIPTION
Collection of algorithms (HyperLogLog, order maintenance, ...)

Included:
- baltree : Generic balanced-tree
- trope : Track objects accross rope-like operations
- orderme : Order-maintenance problem
- doubledouble : Floating points with around 107-bits precision
- hll : HyperLogLog
- jmphash : Jump consistent hashing
- physh : Physical hashtable


---
* Homepage: https://github.com/def-lkb/grenier
* Source repo: https://github.com/def-lkb/grenier.git
* Bug tracker: https://github.com/def-lkb/grenier

---

Pull-request generated by opam-publish v0.3.1