### PR TITLE
ppx_where.1.0 - via opam-publish

### DIFF
--- a/packages/ppx_where/ppx_where.1.0/descr
+++ b/packages/ppx_where/ppx_where.1.0/descr
@@ -1,0 +1,6 @@
+Haskell-style `where` clauses as a PPX syntax extension
+ppx_where allows for the use of `where` clauses after expressions
+by rewriting the `where` syntax into `let ... in` syntax at
+compile-time. Additionally, ppx_where allows for some limited
+pattern matching such as that allowed in-place for arguments
+in normal function bindings.

--- a/packages/ppx_where/ppx_where.1.0/opam
+++ b/packages/ppx_where/ppx_where.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/ppx_where"
+bug-reports: "https://github.com/nv-vn/ppx_where/issues"
+license: "MIT"
+dev-repo: "https://github.com/nv-vn/ppx_where.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+available: [ocaml-version >= "4.02"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+]

--- a/packages/ppx_where/ppx_where.1.0/url
+++ b/packages/ppx_where/ppx_where.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/nv-vn/ppx_where/archive/1.0.tar.gz"
+checksum: "cdb1d702a42d4b61d02012bf146286f2"


### PR DESCRIPTION
Haskell-style `where` clauses as a PPX syntax extension
ppx_where allows for the use of `where` clauses after expressions
by rewriting the `where` syntax into `let ... in` syntax at
compile-time. Additionally, ppx_where allows for some limited
pattern matching such as that allowed in-place for arguments
in normal function bindings.


---
* Homepage: https://github.com/nv-vn/ppx_where
* Source repo: https://github.com/nv-vn/ppx_where.git
* Bug tracker: https://github.com/nv-vn/ppx_where/issues

---

Pull-request generated by opam-publish v0.3.1