### PR TITLE
Add ppx_defer 0.1.0

### DIFF
--- a/packages/ppx_defer/ppx_defer.0.1.0/descr
+++ b/packages/ppx_defer/ppx_defer.0.1.0/descr
@@ -1,0 +1,4 @@
+A syntax extension to provide a somewhat Go-like defer
+
+([%defer e1]; e2) will defer the evaluation of `e1` until after `e2` is
+evaluated.

--- a/packages/ppx_defer/ppx_defer.0.1.0/opam
+++ b/packages/ppx_defer/ppx_defer.0.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "ppx_defer"
+version: "0.1.0"
+maintainer: "Hezekiah M. Carty <hez@0ok.org>"
+authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
+license: "MIT"
+homepage: "https://github.com/hcarty/ppx_defer"
+bug-reports: "https://github.com/hcarty/ppx_defer/issues"
+dev-repo: "https://github.com/hcarty/ppx_defer.git"
+tags: [ "syntax" ]
+build:[
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ppx_tools" {>= "0.99.3"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_defer/ppx_defer.0.1.0/url
+++ b/packages/ppx_defer/ppx_defer.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hcarty/ppx_defer/archive/v0.1.0.tar.gz"
+checksum: "010ce32e79ef4ff23025fc2aac4ce721"


### PR DESCRIPTION
A syntax extension to allow code like:

```ocaml
let () =
  let ic = open_in_bin "some_file" in
  [%defer close_in ic];
  let length = in_channel_length ic in
  let bytes = really_input_string ic length in
  print_endline bytes
```

where `close_in ic` will be evaluated after the following expression.