### PR TITLE
mirage.2.7.0 - via opam-publish

### DIFF
--- a/packages/mirage/mirage.2.7.0/descr
+++ b/packages/mirage/mirage.2.7.0/descr
@@ -1,0 +1,12 @@
+The MirageOS library operating system
+
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.

--- a/packages/mirage/mirage.2.7.0/opam
+++ b/packages/mirage/mirage.2.7.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
+]
+homepage: "https://mirage.io/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/mirage.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--bindir" bin]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["rm" "-f" "%{bin}%/mirage"]
+  ["ocamlfind" "remove" "mirage"]
+]
+depends: [
+  "ipaddr" {>= "2.6.0"}
+  "functoria"
+]
+conflicts: [
+  "nocrypto" {< "0.4.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage/mirage.2.7.0/url
+++ b/packages/mirage/mirage.2.7.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage/archive/v2.7.0.tar.gz"
+checksum: "f1547f5de31192dd51bb1fde82006a41"


### PR DESCRIPTION
The MirageOS library operating system

MirageOS is a library operating system that constructs unikernels for
secure, high-performance network applications across a variety of
cloud computing and mobile platforms. Code can be developed on a
normal OS such as Linux or MacOS X, and then compiled into a
fully-standalone, specialised unikernel that runs under the Xen
hypervisor.

Since Xen powers most public cloud computing infrastructure such as
Amazon EC2 or Rackspace, this lets your servers run more cheaply,
securely and with finer control than with a full software stack.


---
* Homepage: https://mirage.io/
* Source repo: https://github.com/mirage/mirage.git
* Bug tracker: https://github.com/mirage/mirage/issues/

---

Pull-request generated by opam-publish v0.3.1