### PR TITLE
olmi.1 - via opam-publish

### DIFF
--- a/packages/olmi/olmi.1/descr
+++ b/packages/olmi/olmi.1/descr
@@ -1,0 +1,4 @@
+Olmi provide functors to generate monadic combinators with a minimal interface
+
+This library provides functors to generate all monadic combinators for a
+Datastruct, using a minimal interface. Check https://github.com/xvw/olmi/README.md for more informations.

--- a/packages/olmi/olmi.1/opam
+++ b/packages/olmi/olmi.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "xvw <xavier.vdw@gmail.com>"
+authors: "xvw <xavier.vdw@gmail.com>"
+homepage: "https://github.com/xvw/olmi"
+bug-reports: "https://github.com/xvw/olmi/issues"
+license: "GPL"
+dev-repo: "https://github.com/xvw/olmi/issues"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "olmi"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/olmi/olmi.1/url
+++ b/packages/olmi/olmi.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/xvw/olmi/releases/download/v1.0/olmi.tar.gz"
+checksum: "900eebabc1eb5ea35ef6d49585b44ec9"


### PR DESCRIPTION
Olmi provide functors to generate monadic combinators with a minimal interface

This library provides functors to generate all monadic combinators for a
Datastruct, using a minimal interface. Check https://github.com/xvw/olmi/README.md for more informations.

---
* Homepage: https://github.com/xvw/olmi
* Source repo: https://github.com/xvw/olmi/issues
* Bug tracker: https://github.com/xvw/olmi/issues

---

Pull-request generated by opam-publish v0.3.1