### PR TITLE
olmi.1.0 - via opam-publish

### DIFF
--- a/packages/olmi/olmi.1.0/descr
+++ b/packages/olmi/olmi.1.0/descr
@@ -1,0 +1,3 @@
+Olmi provide functor to generate monadic combinators with a minimal interface
+
+Olmi for OCaml Lightweight Monadic Interface provide some functors to build all monadic combinators with a minimal interface.

--- a/packages/olmi/olmi.1.0/opam
+++ b/packages/olmi/olmi.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "xvw <xavier.vdw@gmail.com>"
+authors: "xvw <xavier.vdw@gmail.com>"
+homepage: "https://github.com/xvw/olmi"
+bug-reports: "https://github.com/xvw/olmi/issues"
+license: "GPLv3"
+dev-repo: "https://github.com/xvw/olmi.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "olmi"]
+available: [ocaml-version >= "4.00.0"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/olmi/olmi.1.0/url
+++ b/packages/olmi/olmi.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/xvw/olmi/releases/download/v1.0/olmi.tar.gz"
+checksum: "d82dae00b83488d93e7138831c2bc351"


### PR DESCRIPTION
Olmi provide functor to generate monadic combinators with a minimal interface

Olmi for OCaml Lightweight Monadic Interface provide some functors to build all monadic combinators with a minimal interface.

---
* Homepage: https://github.com/xvw/olmi
* Source repo: https://github.com/xvw/olmi.git
* Bug tracker: https://github.com/xvw/olmi/issues

---

Pull-request generated by opam-publish v0.3.1