### PR TITLE
mirage-net-xen uses `with sexplib` camlp4

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.1.5.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.5.0/opam
@@ -1,10 +1,11 @@
 opam-version: "1.2"
-authors: "The MirageOS team"
-maintainer: "anil@recoil.org"
-homepage: "https://github.com/mirage/mirage-net-xen"
-bug-reports: "https://github.com/mirage/mirage-net-xen/issues"
-dev-repo: "https://github.com/mirage/mirage-net-xen.git"
-build: [make]
+maintainer:   "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
+
+build:   [make]
 install: [make "install"]
 remove: [
   ["ocamlfind" "remove" "mirage-net-xen"]
@@ -20,6 +21,7 @@ depends: [
   "ipaddr" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "shared-memory-ring" {>= "1.1.1"}
+  "sexplib" {< "113.01.00"}
   "result"
 ]
 available: [ ocaml-version >= "4.01.0" ]


### PR DESCRIPTION
So it needs an older version of sexplib.