### PR TITLE
msat.0.2 - via opam-publish

### DIFF
--- a/packages/msat/msat.0.2/descr
+++ b/packages/msat/msat.0.2/descr
@@ -1,0 +1,8 @@
+Modular sat/smt solver
+
+This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
+- proof output
+- push/pop operations
+- CNF transformation tools
+
+This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.

--- a/packages/msat/msat.0.2/opam
+++ b/packages/msat/msat.0.2/opam
@@ -19,3 +19,4 @@ depends: [
   "ocamlfind" {build}
   "base-unix"
 ]
+available: [ocaml-version >= "4.02.1"]

--- a/packages/msat/msat.0.2/opam
+++ b/packages/msat/msat.0.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes@inria.fr"]
+authors: [
+  "Sylvain Conchon"
+  "Alain Mebsout"
+  "Stephane Lecuyer"
+  "Simon Cruanes"
+  "Guillaume Bury"
+]
+homepage: "https://github.com/Gbury/mSAT"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+license: "Apache"
+tags: ["sat" "smt"]
+dev-repo: "https://github.com/Gbury/mSAT.git"
+build: [[make "disable_log"] [make "lib"]]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "msat"]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+]

--- a/packages/msat/msat.0.2/url
+++ b/packages/msat/msat.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Gbury/mSAT/archive/v0.2.tar.gz"
+checksum: "1dcb6fa0dad9caf83a8b1d5bb4ab7f57"


### PR DESCRIPTION
Modular sat/smt solver

This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
- proof output
- push/pop operations
- CNF transformation tools

This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.


---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---

Pull-request generated by opam-publish v0.3.1