### PR TITLE
user-setup.0.5 - via opam-publish

### DIFF
--- a/packages/user-setup/user-setup.0.5/descr
+++ b/packages/user-setup/user-setup.0.5/descr
@@ -1,0 +1,14 @@
+Helper for the configuration of editors for the use of OCaml tools
+
+This tool knows about several editors, and several OCaml editing tools existing
+as opam packages. It automates the configuration of these editors, providing
+base templates when appropriate, and suitably installing the editing tools in
+the editor's configuration.
+
+For example, it will configure your emacs or Vim to indent OCaml files using
+[ocp-indent](http://www.typerex.org/ocp-indent.html) if you have that installed.
+
+Opam-user-setup is designed to be suitable both to beginners not wanting to be
+bothered with configuration files, and to people who manage them carefully.
+
+It's customisable and reversible.

--- a/packages/user-setup/user-setup.0.5/opam
+++ b/packages/user-setup/user-setup.0.5/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "ISC"
+tags: "org:ocamlpro"
+homepage: "https://github.com/AltGr/opam-user-setup"
+bug-reports: "https://github.com/AltGr/opam-user-setup/issues"
+depends: [
+  "ocamlfind" {build}
+  "cmdliner"
+  "re"
+]
+depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]
+available: ocaml-version >= "4.00.1"
+build: make
+post-messages:
+  "To setup or update your editors, run 'opam user-setup install'." {success}
+dev-repo: "git+https://github.com/AltGr/opam-user-setup.git"

--- a/packages/user-setup/user-setup.0.5/url
+++ b/packages/user-setup/user-setup.0.5/url
@@ -1,0 +1,2 @@
+src: "https://github.com/OCamlPro/opam-user-setup/archive/0.5.tar.gz"
+checksum: "2139faa7d5d117c0ed0af8f69340e762"


### PR DESCRIPTION
Helper for the configuration of editors for the use of OCaml tools

This tool knows about several editors, and several OCaml editing tools existing
as opam packages. It automates the configuration of these editors, providing
base templates when appropriate, and suitably installing the editing tools in
the editor's configuration.

For example, it will configure your emacs or Vim to indent OCaml files using
[ocp-indent](http://www.typerex.org/ocp-indent.html) if you have that installed.

Opam-user-setup is designed to be suitable both to beginners not wanting to be
bothered with configuration files, and to people who manage them carefully.

It's customisable and reversible.


---
* Homepage: https://github.com/AltGr/opam-user-setup
* Source repo: git+https://github.com/AltGr/opam-user-setup.git
* Bug tracker: https://github.com/AltGr/opam-user-setup/issues

---

Pull-request generated by opam-publish v0.3.1