### PR TITLE
cowabloga.0.1.0 - via opam-publish

### DIFF
--- a/packages/cowabloga/cowabloga.0.1.0/descr
+++ b/packages/cowabloga/cowabloga.0.1.0/descr
@@ -1,0 +1,3 @@
+Simple static blogging support.
+
+ALPHA. It will likely be in flux for a little while.

--- a/packages/cowabloga/cowabloga.0.1.0/opam
+++ b/packages/cowabloga/cowabloga.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "mort@cantab.net"
+authors:      ["Anil Madhavapeddy" "Richard Mortier"]
+license:      "ISC"
+tags:         "org:mirage"
+dev-repo:     "https://github.com/mirage/cowabloga.git"
+homepage:     "https://github.com/mirage/cowabloga"
+bug-reports:  "https://github.com/mirage/cowabloga/issues"
+
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "cowabloga"]
+depends: [
+  "cow" {>= "0.9.1"}
+  "omd" {>= "0.8.2"}
+  "lwt" {>= "2.4.3"}
+  "cohttp" {>= "0.15.0"}
+  "cstruct" {>= "1.0.1"}
+  "magic-mime"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/cowabloga/cowabloga.0.1.0/url
+++ b/packages/cowabloga/cowabloga.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/cowabloga/archive/v0.1.0.tar.gz"
+checksum: "ef7ad62166edd9b091b7354bd488b620"


### PR DESCRIPTION
Simple static blogging support.

ALPHA. It will likely be in flux for a little while.


---
* Homepage: https://github.com/mirage/cowabloga
* Source repo: https://github.com/mirage/cowabloga.git
* Bug tracker: https://github.com/mirage/cowabloga/issues

---

Pull-request generated by opam-publish v0.3.1