### PR TITLE
ocamlbuild 0.9.1

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.9.1/descr
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/descr
@@ -1,0 +1,1 @@
+OCamlbuild is a build system with builtin rules to easily build most OCaml projects.

--- a/packages/ocamlbuild/ocamlbuild.0.9.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "ocamlbuild"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+version: "0.9.1"
+
+authors: [
+  "Nicolas Pouillard"
+  "Berke Durak"
+]
+
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml/ocamlbuild.git"
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+
+build: [
+  [make "-f" "configure.make" "Makefile.config"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAML_NATIVE=%{ocaml-native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml-native}%"]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+
+doc: [
+  "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
+  "https://github.com/gasche/manual-ocamlbuild/blob/master/manual.md"
+]
+
+available: [ocaml-version >= "4.03"]
+depends: [ ]
+conflicts: [ "base-ocamlbuild" ]
+

--- a/packages/ocamlbuild/ocamlbuild.0.9.1/url
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/ocamlbuild/archive/0.9.1.tar.gz"
+checksum: "939031b23fb862a49f986d14a2e298cd"


### PR DESCRIPTION
This is a minor release meant to synchronize with ocaml 4.03 release branch behavior ( ocaml/ocaml#464 , ocaml/ocamlbuild#51 ). The last 0.9.0 is not compatible with it ( see bug report ocaml/ocamlbuild#58 ).