### PR TITLE
Remove OCaml 4.03 version constraint from ctypes 0.4.* packages.

### DIFF
--- a/packages/ctypes/ctypes.0.4.0/opam
+++ b/packages/ctypes/ctypes.0.4.0/opam
@@ -27,4 +27,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ (ocaml-version >= "4.00.0") & (ocaml-version < "4.03.0") ]
+available: [ ocaml-version >= "4.00.0" ]

--- a/packages/ctypes/ctypes.0.4.1/opam
+++ b/packages/ctypes/ctypes.0.4.1/opam
@@ -27,4 +27,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ (ocaml-version >= "4.00.0") & (ocaml-version < "4.03.0") ]
+available: [ ocaml-version >= "4.00.0" ]

--- a/packages/ctypes/ctypes.0.4.2/opam
+++ b/packages/ctypes/ctypes.0.4.2/opam
@@ -28,4 +28,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ (ocaml-version >= "4.00.0") & (ocaml-version < "4.03.0") ]
+available: [ ocaml-version >= "4.00.0" ]


### PR DESCRIPTION
Fixes ocamllabs/ocaml-ctypes#357.