### PR TITLE
camomile.0.8.5: remove camlp4 dep

### DIFF
--- a/packages/camomile/camomile.0.8.5/opam
+++ b/packages/camomile/camomile.0.8.5/opam
@@ -13,4 +13,4 @@ build: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "camomile"]]
-depends: ["ocamlfind" "camlp4"]
+depends: ["ocamlfind"]


### PR DESCRIPTION
I specifically added a patch to remove this dep long ago, because it is very annoying to have utop depend on camlp4. However, https://github.com/ocaml/opam-repository/commit/0f1b5d69ab7bb1598fa39c9df4beaec97aaad5a3 (https://github.com/ocaml/opam-repository/pull/5783) restored it for some reason. I believe this is a mistake.

cc @timbertson 