### PR TITLE
opam-repository broken on BSD

### DIFF
--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -4,7 +4,7 @@ homepage: "http://www.gnu.org/software/m4/m4.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-3"
-build: [["m4" "--version"]]
+build: [["sh" "-c" "echo | m4"]]
 depexts: [
   [["debian"] ["m4"]]
   [["ubuntu"] ["m4"]]

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -4,7 +4,7 @@ homepage: "http://www.gnu.org/software/m4/m4.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-3"
-build: [["sh" "-c" "echo | m4"]]
+build: [["sh" "-exc" "echo | m4"]]
 depexts: [
   [["debian"] ["m4"]]
   [["ubuntu"] ["m4"]]


### PR DESCRIPTION
Dear highly valued opam repository maintainers (and @timbertson),

it is great that you try to improve the external dependencies every now and then.  But could you please slightly more careful whenever you introduce new system-wide preconditions, which sensible UNIX systems have installed by default?

To be more precise, PR #5649 introduced the `conf-m4` package, which build instrucitons are `m4 --version`.  While [posix standardised m4](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/m4.html), you might notice that `--version` is a GNU extension.  Thus, a recent `opam update && opam upgrade` blew up all installed packages (to a point of no return since the suggested `opam switch import xx.state` bailed again on `conf-m4` (maybe a bug for @AltGr - though not clear to me how such a rollback might work (since it would need to downgrade the local package repository before)).

This PR patches the build instructions to use no options of `m4`, which should work for all `m4` binaries out there.