### PR TITLE
Eliom depends on Camlp4 <= 4.02+6

### DIFF
--- a/packages/eliom/eliom.4.0.0/opam
+++ b/packages/eliom/eliom.4.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "calendar"
   "tyxml" {< "3.2"}
   "ocsigenserver" {>= "2.4.0" & < "2.6"}
-  "camlp4"
+  "camlp4" {<= "4.02+6"}
   "ipaddr" {>= "2.1"}
   "ocamlbuild"
 ]

--- a/packages/eliom/eliom.4.1.0/opam
+++ b/packages/eliom/eliom.4.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "js_of_ocaml" {>= "2.5"}
   "tyxml" {>= "3.3.0" & < "3.6.0"}
   "calendar"
-  "camlp4"
+  "camlp4" {<= "4.02+6"}
   "ocsigenserver" {= "2.5"}
   "ipaddr" {>= "2.1"}
   "reactiveData"

--- a/packages/eliom/eliom.4.2.0/opam
+++ b/packages/eliom/eliom.4.2.0/opam
@@ -8,6 +8,7 @@ license: "LGPL-2.1 with OCaml linking exception"
 build: [make]
 depends: [
   "ocamlfind"
+  "camlp4" {<= "4.02+6"}
   "deriving" {>= "0.6"}
   "js_of_ocaml" {>= "2.5"}
   "tyxml" {>= "3.3.0" & < "3.6.0"}

--- a/packages/eliom/eliom.5.0.0/opam
+++ b/packages/eliom/eliom.5.0.0/opam
@@ -11,6 +11,7 @@ build: [
 ]
 depends: [
   "ocamlfind"
+  "camlp4" {<= "4.02+6"}
   "deriving" {>= "0.6"}
   ("base-no-ppx" | "ppx_tools" {>= "0.99.3"})
   "js_of_ocaml" {> "2.6"}


### PR DESCRIPTION
The recently-released Camlp4 4.02+7 breaks Eliom. See ocsigen/eliom#277. This PR adds the constraint `"camlp4" {<= "4.02+6"}` for the recent Eliom releases. 