### PR TITLE
conf-ncurses: exclude freebsd from ncurses check

### DIFF
--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
-  ["pkg-config" "ncurses"] { os != "darwin"}
+  ["pkg-config" "ncurses"] { os != "darwin" & os != "freebsd" }
 ]
 depends: [
   "conf-pkg-config"


### PR DESCRIPTION
Just like for OS X, it'll be there