### PR TITLE
amqp-client does not compile with lwt 2.4.5

### DIFF
--- a/packages/amqp-client/amqp-client.0.9.0/opam
+++ b/packages/amqp-client/amqp-client.0.9.0/opam
@@ -17,4 +17,7 @@ depends: [
   "ocplib-endian"
   "async_unix" | "lwt"
 ]
+conflicts: [
+  "lwt" {< "2.4.6"}
+]
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
Note: as soon as `lwt` is present, `amqp-client`'s config will pick it up, even if it's the wrong version.
