### PR TITLE
add ocamlbuild build dependencies to recent packages from mmottl

### DIFF
--- a/packages/aifad/aifad.2.0.7/opam
+++ b/packages/aifad/aifad.2.0.7/opam
@@ -22,6 +22,7 @@ depends: [
   "base-threads" {build}
   "cfg" {build}
   "ocamlfind" {build & >= "1.3.1"}
+  "ocamlbuild" {build}
   "pcre" {build}
   "res" {build}
 ]

--- a/packages/aifad/aifad.2.0.8/opam
+++ b/packages/aifad/aifad.2.0.8/opam
@@ -22,6 +22,7 @@ depends: [
   "base-threads" {build}
   "cfg" {build}
   "ocamlfind" {build & >= "1.3.1"}
+  "ocamlbuild" {build}
   "pcre" {build}
   "res" {build}
 ]

--- a/packages/lacaml/lacaml.8.0.4/opam
+++ b/packages/lacaml/lacaml.8.0.4/opam
@@ -32,6 +32,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "3.12" ]
 depexts: [

--- a/packages/lacaml/lacaml.8.0.5/opam
+++ b/packages/lacaml/lacaml.8.0.5/opam
@@ -32,6 +32,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "3.12" ]
 depexts: [

--- a/packages/lacaml/lacaml.8.0.6/opam
+++ b/packages/lacaml/lacaml.8.0.6/opam
@@ -32,6 +32,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "3.12" ]
 depexts: [

--- a/packages/lacaml/lacaml.8.0.7/opam
+++ b/packages/lacaml/lacaml.8.0.7/opam
@@ -32,6 +32,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "3.12" ]
 depexts: [

--- a/packages/pcre/pcre.7.1.6/opam
+++ b/packages/pcre/pcre.7.1.6/opam
@@ -22,6 +22,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
   "conf-libpcre"
   "ocamlbuild" {build}
 ]

--- a/packages/pcre/pcre.7.2.2/opam
+++ b/packages/pcre/pcre.7.2.2/opam
@@ -22,6 +22,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
   # Included from _opam file
   "conf-libpcre"
 ]

--- a/packages/pcre/pcre.7.2.3/opam
+++ b/packages/pcre/pcre.7.2.3/opam
@@ -22,6 +22,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
   # Included from _opam file
   "conf-libpcre"
 ]

--- a/packages/postgresql/postgresql.4.0.0/opam
+++ b/packages/postgresql/postgresql.4.0.0/opam
@@ -29,6 +29,7 @@ depends: [
   "base-bytes"
   "base-threads"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
 ]
 depopts: [
   "lablgtk" {build}

--- a/packages/postgresql/postgresql.4.0.1/opam
+++ b/packages/postgresql/postgresql.4.0.1/opam
@@ -29,6 +29,7 @@ depends: [
   "base-bytes"
   "base-threads"
   "ocamlfind" {build & >= "1.5"}
+  "ocamlbuild" {build}
 ]
 depopts: [
   "lablgtk" {build}

--- a/packages/sqlite3/sqlite3.4.0.3/opam
+++ b/packages/sqlite3/sqlite3.4.0.3/opam
@@ -23,6 +23,7 @@ build-test: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "ocamlfind" {build & >= "1.3.1"}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "3.12" ]
 depexts: [


### PR DESCRIPTION
@mmottl , please update your way to generate the opam files. 
It will be necessary for ocaml 4.03.0.