### PR TITLE
Let's use `conf-{expat,gtk2,udunits}`

### DIFF
--- a/packages/conf-expat/conf-expat.1/opam
+++ b/packages/conf-expat/conf-expat.1/opam
@@ -1,10 +1,12 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "blue-prawn"
 homepage: "http://www.libexpat.org/"
 license: "MIT"
 build: [["pkg-config" "expat"]]
+depends: [ "conf-pkg-config" {build} ]
 depexts: [
   [["debian"] ["libexpat1-dev"]]
   [["mageia"] ["libexpat1-devel"]]
   [["ubuntu"] ["libexpat1-dev"]]
+  [["homebrew" "osx"]  ["expat"]]
 ]

--- a/packages/conf-gtk2/conf-gtk2.1/descr
+++ b/packages/conf-gtk2/conf-gtk2.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on a gtk+-2.0 system installation.
+This package can only install if the gtk+-2.0 lib is installed on the system.

--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Gregoire.Henry@ocamlpro.com"
+homepage: "http://www.gtk.org/"
+license: "LGPL-2"
+build: [["pkg-config" "gtk+-2.0"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  [["debian"] ["libgtk2.0-dev"]]
+  [["ubuntu"] ["libgtk2.0-dev"]]
+  [["homebrew" "osx"] ["gtk"]]
+]
+post-messages: [
+  "This package requires gtk+ 2.0 development packages installed on your system" {failure}
+  "To solve pkg-config issues, you may need to do
+'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' (macports)
+or 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig' (homebrew)
+and retry" {failure & (os = "darwin")}
+]

--- a/packages/conf-udunits/conf-udunits.1/descr
+++ b/packages/conf-udunits/conf-udunits.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on an udunits system installation.
+This package can only install if the udunits lib is installed on the system.

--- a/packages/conf-udunits/conf-udunits.1/opam
+++ b/packages/conf-udunits/conf-udunits.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Gregoire.Henry@ocamlpro.com"
+homepage: "http://www.unidata.ucar.edu/software/udunits/"
+license: "BSD-4"
+build: [["pkg-config" "udunits"]]
+depends: [ "conf-pkg-config" {build} ]
+depexts: [
+  [["debian"] ["libudunits2-dev"]]
+  [["ubuntu"] ["libudunits2-dev"]]
+  [["osx" "homebrew"] ["udunits"]]
+]

--- a/packages/lablgtk/lablgtk.2.14.2-oasis8/opam
+++ b/packages/lablgtk/lablgtk.2.14.2-oasis8/opam
@@ -3,13 +3,15 @@ maintainer: "contact@ocamlpro.com"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
+]
+install: [
   ["ocaml" "setup.ml" "-install"]
 ]
 available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" "camlp4"]
-depexts: [
-  [["debian"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["ubuntu"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["homebrew" "osx"] ["gtk" "expat"]]
+depends: [
+  "ocamlfind" {build}
+  "conf-expat" {build}
+  "conf-gtk2" {build}
+  "camlp4"
 ]

--- a/packages/lablgtk/lablgtk.2.16.0/opam
+++ b/packages/lablgtk/lablgtk.2.16.0/opam
@@ -4,27 +4,22 @@ homepage: "http://lablgtk.forge.ocamlcore.org/"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]
+]
+install: [
   [make "install"]
 ]
 available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
+depends: [
+  "ocamlfind" {>= "1.2.1" & build}
+  "conf-expat" {build}
+  "conf-gtk2" {build}
+  "camlp4"
+]
 depopts: [
   "conf-gtksourceview"
   "conf-gnomecanvas"
   "conf-glade"
   "lablgl"
 ]
-depexts: [
-  [["debian"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["ubuntu"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["homebrew" "osx"] ["gtk" "expat"]]
-]
 patches: ["lablgldir.patch"]
-post-messages: [
-  "This package requires gtk+ 2.0 development packages installed on your system" {failure}
-  "To solve pkg-config issues, you may need to do
-'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' (macports)
-or 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig' (homebrew)
-and retry" {failure & (os = "darwin")}
-]

--- a/packages/lablgtk/lablgtk.2.18.2/opam
+++ b/packages/lablgtk/lablgtk.2.18.2/opam
@@ -4,27 +4,22 @@ homepage: "http://lablgtk.forge.ocamlcore.org/"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]
+]
+install: [
   [make "install"]
 ]
 available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
+depends: [
+  "ocamlfind" {>= "1.2.1" & build}
+  "conf-expat" {build}
+  "conf-gtk2" {build}
+  "camlp4"
+]
 depopts: [
   "conf-gtksourceview"
   "conf-gnomecanvas"
   "conf-glade"
   "lablgl"
 ]
-depexts: [
-  [["debian"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["ubuntu"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["homebrew" "osx"] ["gtk" "expat"]]
-]
 patches: ["lablgldir.patch"]
-post-messages: [
-  "This package requires gtk+ 2.0 development packages installed on your system" {failure}
-  "To solve pkg-config issues, you may need to do
-'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' (macports)
-or 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig' (homebrew)
-and retry" {failure & (os = "darwin")}
-]

--- a/packages/lablgtk/lablgtk.2.18.3/opam
+++ b/packages/lablgtk/lablgtk.2.18.3/opam
@@ -4,27 +4,22 @@ homepage: "http://lablgtk.forge.ocamlcore.org/"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]
+]
+install: [
   [make "install"]
 ]
 available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
+depends: [
+  "ocamlfind" {>= "1.2.1" & build}
+  "conf-expat" {build}
+  "conf-gtk2" {build}
+  "camlp4"
+]
 depopts: [
   "conf-gtksourceview"
   "conf-gnomecanvas"
   "conf-glade"
   "lablgl"
 ]
-depexts: [
-  [["debian"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["ubuntu"] ["libgtk2.0-dev" "libexpat1-dev"]]
-  [["homebrew" "osx"] ["gtk" "expat"]]
-]
 patches: ["lablgldir.patch"]
-post-messages: [
-  "This package requires gtk+ 2.0 development packages installed on your system" {failure}
-  "To solve pkg-config issues, you may need to do
-'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' (macports)
-or 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig' (homebrew)
-and retry" {failure & (os = "darwin")}
-]

--- a/packages/ocaml-expat/ocaml-expat.0.9.1/opam
+++ b/packages/ocaml-expat/ocaml-expat.0.9.1/opam
@@ -5,13 +5,13 @@ homepage: "http://mmzeeman.home.xs4all.nl/ocaml/"
 build: [
   [make "all"]
   [make "allopt"]
+]
+install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "expat"]]
-depends: ["ocamlfind" {build}]
-depexts: [
- [["debian"] ["libexpat1-dev"]]
- [["ubuntu"] ["libexpat1-dev"]]
- [["osx" "homebrew"] ["expat"]]
+depends: [
+  "ocamlfind" {build}
+  "conf-expat" {build}
 ]
 patches: [ "Makefile.patch" ]

--- a/packages/udunits/udunits.0.1.1/opam
+++ b/packages/udunits/udunits.0.1.1/opam
@@ -7,18 +7,17 @@ tags: [ "clib:udunits2" "clib:m" "clib:expat"  ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
+]
+install: [
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [
   ["ocamlfind" "remove" "udunits"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-]
-depexts: [
-  [["debian"] ["libudunits2-dev" "libexpat1-dev"]]
-  [["ubuntu"] ["libudunits2-dev" "libexpat1-dev"]]
-  [["osx" "homebrew"] ["udunits" "expat"]]
+  "conf-expat" {build}
+  "conf-udunits" {build}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-udunits"

--- a/packages/udunits/udunits.0.2.0/opam
+++ b/packages/udunits/udunits.0.2.0/opam
@@ -7,18 +7,17 @@ tags: [ "clib:udunits2" "clib:m" "clib:expat"  ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
+]
+install: [
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [
   ["ocamlfind" "remove" "udunits"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-]
-depexts: [
-  [["debian"] ["libudunits2-dev" "libexpat1-dev"]]
-  [["ubuntu"] ["libudunits2-dev" "libexpat1-dev"]]
-  [["osx" "homebrew"] ["udunits" "expat"]]
+  "conf-expat" {build}
+  "conf-udunits" {build}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-udunits"


### PR DESCRIPTION
In a ongoing effort to regroup `depext` into "virtual" packages named `conf-*`, this PR updates the `opam` file for:

- lablgtk (\cc @garrigue )
- udunits (\cc @hcarty )
