### PR TITLE
ctypes v0.4.x: depend on conf-pkg-config

### DIFF
--- a/packages/ctypes/ctypes.0.4.0/opam
+++ b/packages/ctypes/ctypes.0.4.0/opam
@@ -21,6 +21,7 @@ remove: [
 depends: [
    "base-bytes"
    "ocamlfind" {build}
+   "conf-pkg-config" {build}
 ]
 depopts: [
    "ctypes-foreign"

--- a/packages/ctypes/ctypes.0.4.1/opam
+++ b/packages/ctypes/ctypes.0.4.1/opam
@@ -21,6 +21,7 @@ remove: [
 depends: [
    "base-bytes"
    "ocamlfind" {build}
+   "conf-pkg-config" {build}
 ]
 depopts: [
    "ctypes-foreign"

--- a/packages/ctypes/ctypes.0.4.2/opam
+++ b/packages/ctypes/ctypes.0.4.2/opam
@@ -22,6 +22,7 @@ remove: [
 depends: [
    "base-bytes"
    "ocamlfind" {build}
+   "conf-pkg-config" {build}
 ]
 depopts: [
    "ctypes-foreign"


### PR DESCRIPTION
This is needed to discover the include path for libffi on OSX when
installed by homebrew.

Related to [ocamllabs/ocaml-ctypes#335]

Signed-off-by: David Scott <dave.scott@docker.com>