### PR TITLE
ppx_measure.1.0 - via opam-publish

### DIFF
--- a/packages/ppx_measure/ppx_measure.1.0/descr
+++ b/packages/ppx_measure/ppx_measure.1.0/descr
@@ -1,0 +1,3 @@
+Provide a Type-safe way to manage unit of measure
+
+ppx_measure is an extension to manage unit of measure as phantom-type. see https://github.com/xvw/ppx_measure to see some examples.

--- a/packages/ppx_measure/ppx_measure.1.0/opam
+++ b/packages/ppx_measure/ppx_measure.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "xvw <xavier.vdw@gmail.com>"
+authors: "xvw <xavier.vdw@gmail.com>"
+homepage: "https://github.com/xvw/ppx_measure"
+bug-reports: "https://github.com/xvw/ppx_measure/issues"
+license: "MIT"
+dev-repo: "https://github.com/xvw/ppx_measure.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ppx_measure"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/ppx_measure/ppx_measure.1.0/url
+++ b/packages/ppx_measure/ppx_measure.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/xvw/ppx_measure/releases/download/v1.0/ppx_measure.tar.gz"
+checksum: "a020fcedfb77070b054f04262a06dd9d"


### PR DESCRIPTION
Provide a Type-safe way to manage unit of measure

ppx_measure is an extension to manage unit of measure as phantom-type. see https://github.com/xvw/ppx_measure to see some examples.


---
* Homepage: https://github.com/xvw/ppx_measure
* Source repo: https://github.com/xvw/ppx_measure.git
* Bug tracker: https://github.com/xvw/ppx_measure/issues

---

Pull-request generated by opam-publish v0.3.1