### PR TITLE
conduit does not compile when mirage-dns is present and tcpip absent

### DIFF
--- a/packages/conduit/conduit.0.10.0/opam
+++ b/packages/conduit/conduit.0.10.0/opam
@@ -20,6 +20,7 @@ depends: [
   "uri"
   "cstruct" {>="1.0.1"}
   "ipaddr" {>="2.5.0"}
+  "tcpip"
 ]
 depopts: [
   "async"


### PR DESCRIPTION
As `mirage-dns` is an optional dependency, I don't know how to express this constraint precisely, the best I can do is to require `tcpip` all the time.
