### PR TITLE
hmap.0.8.0 - via opam-publish

### DIFF
--- a/packages/hmap/hmap.0.8.0/descr
+++ b/packages/hmap/hmap.0.8.0/descr
@@ -1,0 +1,10 @@
+Heterogeneous value maps for OCaml
+v%%VERSION%%
+
+Hmap provides heterogeneous value maps for OCaml. These maps bind keys
+to values with arbitrary types. Keys witness the type of the value
+they are bound to which allows to add and lookup bindings in a type
+safe manner.
+
+Hmap has no dependency and is distributed under the ISC license.
+

--- a/packages/hmap/hmap.0.8.0/opam
+++ b/packages/hmap/hmap.0.8.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/hmap"
+doc: "http://erratique.ch/software/hmap/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/hmap.git"
+bug-reports: "http://github.com/dbuenzli/hmap/issues"
+tags: ["data-structure" "org:erratique"]
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+depopts: [  ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"
+ ]
+]

--- a/packages/hmap/hmap.0.8.0/url
+++ b/packages/hmap/hmap.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/hmap/releases/hmap-0.8.0.tbz"
+checksum: "4fff0508f0be8529dc8f8ac62cb3f951"


### PR DESCRIPTION
Heterogeneous value maps for OCaml
v%%VERSION%%

Hmap provides heterogeneous value maps for OCaml. These maps bind keys
to values with arbitrary types. Keys witness the type of the value
they are bound to which allows to add and lookup bindings in a type
safe manner.

Hmap has no dependency and is distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/hmap
* Source repo: http://erratique.ch/repos/hmap.git
* Bug tracker: http://github.com/dbuenzli/hmap/issues

---

Pull-request generated by opam-publish v0.3.1