### PR TITLE
oml does not compile with newer versions of lacaml

### DIFF
--- a/packages/oml/oml.0.0.1/opam
+++ b/packages/oml/oml.0.0.1/opam
@@ -11,8 +11,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [
   "ocamlfind" {build}
-  "lacaml"
+  "lacaml" {< "8.0.0"}
   "lbfgs"
-  "ocephes"
+  "ocephes" {< "0.8"}
   "ocamlbuild" {build}
 ]

--- a/packages/oml/oml.0.0.2/opam
+++ b/packages/oml/oml.0.0.2/opam
@@ -11,8 +11,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [
   "ocamlfind" {build}
-  "lacaml"
+  "lacaml" {< "8.0.0"}
   "lbfgs"
-  "ocephes"
+  "ocephes" {< "0.8"}
   "ocamlbuild" {build}
 ]

--- a/packages/oml/oml.0.0.3/opam
+++ b/packages/oml/oml.0.0.3/opam
@@ -10,9 +10,9 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [
   "ocamlfind" {build}
-  "lacaml"
+  "lacaml" {< "8.0.0"}
   "lbfgs"
-  "ocephes"
+  "ocephes" {< "0.8"}
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01"]

--- a/packages/oml/oml.0.0.5/opam
+++ b/packages/oml/oml.0.0.5/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [
   "ocamlfind" {build}
-  "lacaml"
+  "lacaml" {< "8.0.0"}
   "lbfgs"
   "ocephes"
 ]


### PR DESCRIPTION
Also, older versions of `oml` won't compile with the latest `ocephes`.

cc @rleonid 