### PR TITLE
linenoise.0.9.0 - via opam-publish

### DIFF
--- a/packages/linenoise/linenoise.0.9.0/descr
+++ b/packages/linenoise/linenoise.0.9.0/descr
@@ -1,0 +1,19 @@
+Simple readline like functionality
+
+These are self contained OCaml bindings to linenoise,
+no system libraries needed at all.
+
+Here's the simplest program:
+
+let rec user_input prompt cb =
+  match LNoise.linenoise prompt with
+  | None -> ()
+  | Some v -> cb v;
+    user_input prompt cb
+
+let () =
+  (fun from_user -> Printf.sprintf "Got: %s" from_user |> print_endline)
+  |> user_input "test_program> "
+
+and compile with:
+$ ocamlfind ocamlopt ex.ml -package linenoise -linkpkg -o T

--- a/packages/linenoise/linenoise.0.9.0/opam
+++ b/packages/linenoise/linenoise.0.9.0/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-linenoise"
+bug-reports: "https://github.com/fxfactorial/ocaml-linenoise/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-linenoise.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "linenoise"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+post-messages: [
+  "Here is the simplest program:"
+  "
+let rec user_input prompt cb =
+  match LNoise.linenoise prompt with
+  | None -> ()
+  | Some v -> cb v;
+    user_input prompt cb
+
+let () =
+  (fun from_user -> Printf.sprintf \"Got: %s\" from_user |> print_endline)
+  |> user_input \"test_program> \"
+  "
+  "
+and compile with:
+$ ocamlfind ocamlopt ex.ml -package linenoise -linkpkg -o T
+  "
+]

--- a/packages/linenoise/linenoise.0.9.0/url
+++ b/packages/linenoise/linenoise.0.9.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-linenoise/archive/v0.9.0.tar.gz"
+checksum: "90fd86ede3d31cee3f6380f5b35c9199"


### PR DESCRIPTION
Simple readline like functionality

These are self contained OCaml bindings to linenoise,
no system libraries needed at all.

Here's the simplest program:
```ocaml
let rec user_input prompt cb =
  match LNoise.linenoise prompt with
  | None -> ()
  | Some v -> cb v;
    user_input prompt cb

let () =
  (fun from_user -> Printf.sprintf "Got: %s" from_user |> print_endline)
  |> user_input "test_program> "
```
and compile with:
`$ ocamlfind ocamlopt ex.ml -package linenoise -linkpkg -o T`

---
* Homepage: https://github.com/fxfactorial/ocaml-linenoise
* Source repo: https://github.com/fxfactorial/ocaml-linenoise/.git
* Bug tracker: https://github.com/fxfactorial/ocaml-linenoise/issues

---

Pull-request generated by opam-publish v0.3.1