### PR TITLE
Core suite 113.33.00

### DIFF
--- a/packages/async/async.113.33.00/descr
+++ b/packages/async/async.113.33.00/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async/async.113.33.00/opam
+++ b/packages/async/async.113.33.00/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async"
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async_extra"     {>= "113.33.00" & < "113.34.00"}
+  "async_kernel"    {>= "113.33.00" & < "113.34.00"}
+  "async_unix"      {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async/async.113.33.00/url
+++ b/packages/async/async.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async-113.33.00.tar.gz"
+checksum: "c97951e1d544206d0f79c564c4ec2107"

--- a/packages/async_extended/async_extended.113.33.00/descr
+++ b/packages/async_extended/async_extended.113.33.00/descr
@@ -1,0 +1,4 @@
+Additional utilities for async
+Async_extended is a collection of utilities for async. They don't
+get the same level of review compared to other packages of the core
+suite but they might still be useful.

--- a/packages/async_extended/async_extended.113.33.00/opam
+++ b/packages/async_extended/async_extended.113.33.00/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_extended"
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_find"      {>= "113.33.00" & < "113.34.00"}
+  "async_inotify"   {>= "113.33.00" & < "113.34.00"}
+  "async_shell"     {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "camlzip"
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_extended/async_extended.113.33.00/url
+++ b/packages/async_extended/async_extended.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_extended-113.33.00.tar.gz"
+checksum: "6c55d7a8c1f75b2c5e7be02c6dc885af"

--- a/packages/async_extra/async_extra.113.33.00/descr
+++ b/packages/async_extra/async_extra.113.33.00/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_extra/async_extra.113.33.00/opam
+++ b/packages/async_extra/async_extra.113.33.00/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_extra"
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"       {build}
+  "ocamlfind"        {build & >= "1.3.2"}
+  "async_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "async_rpc_kernel" {>= "113.33.00" & < "113.34.00"}
+  "async_unix"       {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"         {>= "113.33.00" & < "113.34.00"}
+  "core"             {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"        {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"         {>= "113.33.00" & < "113.34.00"}
+  "sexplib"          {>= "113.33.00" & < "113.34.00"}
+  "typerep"          {>= "113.24.00" & < "113.25.00"}
+  "variantslib"      {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_extra/async_extra.113.33.00/url
+++ b/packages/async_extra/async_extra.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_extra-113.33.00.tar.gz"
+checksum: "fee685e2459a9689ed38fe7a97e9678c"

--- a/packages/async_find/async_find.113.33.00/descr
+++ b/packages/async_find/async_find.113.33.00/descr
@@ -1,0 +1,1 @@
+Directory traversal with Async

--- a/packages/async_find/async_find.113.33.00/opam
+++ b/packages/async_find/async_find.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_find"
+bug-reports: "https://github.com/janestreet/async_find/issues"
+dev-repo: "https://github.com/janestreet/async_find.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_find/async_find.113.33.00/url
+++ b/packages/async_find/async_find.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_find-113.33.00.tar.gz"
+checksum: "48578665687a89f7e8c10f96fec3267f"

--- a/packages/async_inotify/async_inotify.113.33.00/descr
+++ b/packages/async_inotify/async_inotify.113.33.00/descr
@@ -1,0 +1,1 @@
+Async wrapper for inotify

--- a/packages/async_inotify/async_inotify.113.33.00/opam
+++ b/packages/async_inotify/async_inotify.113.33.00/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_inotify"
+bug-reports: "https://github.com/janestreet/async_inotify/issues"
+dev-repo: "https://github.com/janestreet/async_inotify.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_find"      {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "inotify"
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_inotify/async_inotify.113.33.00/url
+++ b/packages/async_inotify/async_inotify.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_inotify-113.33.00.tar.gz"
+checksum: "a19e01be8ee5975e2c6a01e7814b91aa"

--- a/packages/async_kernel/async_kernel.113.33.00/descr
+++ b/packages/async_kernel/async_kernel.113.33.00/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_kernel/async_kernel.113.33.00/opam
+++ b/packages/async_kernel/async_kernel.113.33.00/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_kernel"
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_kernel/async_kernel.113.33.00/url
+++ b/packages/async_kernel/async_kernel.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_kernel-113.33.00.tar.gz"
+checksum: "52abf5f549ede14a385bb1b625ebf3ce"

--- a/packages/async_parallel/async_parallel.113.33.00/descr
+++ b/packages/async_parallel/async_parallel.113.33.00/descr
@@ -1,0 +1,3 @@
+Distributed computing library
+Parallel is a library for running tasks in other processes on a
+cluster of machines.

--- a/packages/async_parallel/async_parallel.113.33.00/opam
+++ b/packages/async_parallel/async_parallel.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_parallel"
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_parallel/async_parallel.113.33.00/url
+++ b/packages/async_parallel/async_parallel.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_parallel-113.33.00.tar.gz"
+checksum: "21ce56815b82946859aff7bd33cb7176"

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/descr
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/descr
@@ -1,0 +1,5 @@
+Platform-independent core of Async RPC library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_rpc_kernel"
+bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_rpc_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async_kernel"    {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/url
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_rpc_kernel-113.33.00.tar.gz"
+checksum: "2bbf1501f4e4f60d99993db86376235f"

--- a/packages/async_shell/async_shell.113.33.00/descr
+++ b/packages/async_shell/async_shell.113.33.00/descr
@@ -1,0 +1,1 @@
+Shell helpers for Async

--- a/packages/async_shell/async_shell.113.33.00/opam
+++ b/packages/async_shell/async_shell.113.33.00/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_shell"
+bug-reports: "https://github.com/janestreet/async_shell/issues"
+dev-repo: "https://github.com/janestreet/async_shell.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_shell/async_shell.113.33.00/url
+++ b/packages/async_shell/async_shell.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_shell-113.33.00.tar.gz"
+checksum: "3de7060b779fac47c8876ac671cc7ae2"

--- a/packages/async_smtp/async_smtp.113.33.00/descr
+++ b/packages/async_smtp/async_smtp.113.33.00/descr
@@ -1,0 +1,1 @@
+SMTP client and server

--- a/packages/async_smtp/async_smtp.113.33.00/opam
+++ b/packages/async_smtp/async_smtp.113.33.00/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_smtp"
+bug-reports: "https://github.com/janestreet/async_smtp/issues"
+dev-repo: "https://github.com/janestreet/async_smtp.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_extended"  {>= "113.33.00" & < "113.34.00"}
+  "async_shell"     {>= "113.33.00" & < "113.34.00"}
+  "async_ssl"       {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "cryptokit"
+  "email_message"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_smtp/async_smtp.113.33.00/url
+++ b/packages/async_smtp/async_smtp.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_smtp-113.33.00.tar.gz"
+checksum: "db4da11a3e497b77697758e305b56347"

--- a/packages/async_ssl/async_ssl.113.33.00/descr
+++ b/packages/async_ssl/async_ssl.113.33.00/descr
@@ -1,0 +1,4 @@
+An Async-pipe-based interface with OpenSSL.
+
+This library allows you to create an SSL client and server, with
+encrypted communication between both.

--- a/packages/async_ssl/async_ssl.113.33.00/opam
+++ b/packages/async_ssl/async_ssl.113.33.00/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_ssl"
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "https://github.com/janestreet/async_ssl.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "ctypes"
+  "ctypes-foreign"
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]
+depexts: [
+  [["debian"] ["libssl-dev"]]
+  [["ubuntu"] ["libssl-dev"]]
+  [["centos"] ["openssl-devel"]]
+]

--- a/packages/async_ssl/async_ssl.113.33.00/url
+++ b/packages/async_ssl/async_ssl.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_ssl-113.33.00.tar.gz"
+checksum: "8a6e138bc2602311a8d1fc6cd67d4e81"

--- a/packages/async_unix/async_unix.113.33.00/descr
+++ b/packages/async_unix/async_unix.113.33.00/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_unix/async_unix.113.33.00/opam
+++ b/packages/async_unix/async_unix.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_unix"
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async_kernel"    {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/async_unix/async_unix.113.33.00/url
+++ b/packages/async_unix/async_unix.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_unix-113.33.00.tar.gz"
+checksum: "e06377d77e0878d955856c6902b338e6"

--- a/packages/bignum/bignum.113.33.00/descr
+++ b/packages/bignum/bignum.113.33.00/descr
@@ -1,0 +1,1 @@
+Core-flavoured wrapper around zarith's arbitrary-precision rationals.

--- a/packages/bignum/bignum.113.33.00/opam
+++ b/packages/bignum/bignum.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/bignum"
+bug-reports: "https://github.com/janestreet/bignum/issues"
+dev-repo: "https://github.com/janestreet/bignum.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+  "zarith"
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/bignum/bignum.113.33.00/url
+++ b/packages/bignum/bignum.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/bignum-113.33.00.tar.gz"
+checksum: "af139fab4ea1313a393b2dfcce2892fc"

--- a/packages/bin_prot/bin_prot.113.33.00/descr
+++ b/packages/bin_prot/bin_prot.113.33.00/descr
@@ -1,0 +1,5 @@
+A binary protocol generator
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/bin_prot/bin_prot.113.33.00/opam
+++ b/packages/bin_prot/bin_prot.113.33.00/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/bin_prot"
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/bin_prot/bin_prot.113.33.00/url
+++ b/packages/bin_prot/bin_prot.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/bin_prot-113.33.00.tar.gz"
+checksum: "c7a3b40330d5c81d9867a29124ef4c1e"

--- a/packages/core/core.113.33.00/descr
+++ b/packages/core/core.113.33.00/descr
@@ -1,0 +1,4 @@
+Industrial strength alternative to OCaml's standard library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/core/core.113.33.00/opam
+++ b/packages/core/core.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "base-threads"
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/core/core.113.33.00/url
+++ b/packages/core/core.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core-113.33.00.tar.gz"
+checksum: "e4058e861148c05926424d79ea65d687"

--- a/packages/core_bench/core_bench.113.33.00/descr
+++ b/packages/core_bench/core_bench.113.33.00/descr
@@ -1,0 +1,1 @@
+Benchmarking library

--- a/packages/core_bench/core_bench.113.33.00/opam
+++ b/packages/core_bench/core_bench.113.33.00/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_bench"
+bug-reports: "https://github.com/janestreet/core_bench/issues"
+dev-repo: "https://github.com/janestreet/core_bench.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/core_bench/core_bench.113.33.00/url
+++ b/packages/core_bench/core_bench.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_bench-113.33.00.tar.gz"
+checksum: "f135b5cdc9f8952f5e803dab858f6c79"

--- a/packages/core_extended/core_extended.113.33.00/descr
+++ b/packages/core_extended/core_extended.113.33.00/descr
@@ -1,0 +1,4 @@
+Extra components that are not as closely vetted or as stable as Core
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/core_extended/core_extended.113.33.00/opam
+++ b/packages/core_extended/core_extended.113.33.00/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_extended"
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/core_extended/core_extended.113.33.00/url
+++ b/packages/core_extended/core_extended.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_extended-113.33.00.tar.gz"
+checksum: "613f7a4603308008a93becddf473349e"

--- a/packages/core_kernel/core_kernel.113.33.00/descr
+++ b/packages/core_kernel/core_kernel.113.33.00/descr
@@ -1,0 +1,6 @@
+Industrial strength alternative to OCaml's standard library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+Core_kernel is the system-independent part of Core.

--- a/packages/core_kernel/core_kernel.113.33.00/opam
+++ b/packages/core_kernel/core_kernel.113.33.00/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_kernel"
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "result"
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/core_kernel/core_kernel.113.33.00/url
+++ b/packages/core_kernel/core_kernel.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_kernel-113.33.00.tar.gz"
+checksum: "6f3410200a3e5e224396fed144fdd74c"

--- a/packages/core_profiler/core_profiler.113.33.00/descr
+++ b/packages/core_profiler/core_profiler.113.33.00/descr
@@ -1,0 +1,3 @@
+Profiling library
+Core_profiler is a library that helps you profile programs and
+estimate various costs.

--- a/packages/core_profiler/core_profiler.113.33.00/opam
+++ b/packages/core_profiler/core_profiler.113.33.00/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_profiler"
+bug-reports: "https://github.com/janestreet/core_profiler/issues"
+dev-repo: "https://github.com/janestreet/core_profiler.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/core_profiler/core_profiler.113.33.00/url
+++ b/packages/core_profiler/core_profiler.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_profiler-113.33.00.tar.gz"
+checksum: "ba13b09185f53a41899e388ba0b30732"

--- a/packages/email_message/email_message.113.33.00/descr
+++ b/packages/email_message/email_message.113.33.00/descr
@@ -1,0 +1,1 @@
+E-mail message parser

--- a/packages/email_message/email_message.113.33.00/opam
+++ b/packages/email_message/email_message.113.33.00/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/email_message"
+bug-reports: "https://github.com/janestreet/email_message/issues"
+dev-repo: "https://github.com/janestreet/email_message.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "magic-mime"
+  "ounit"
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/email_message/email_message.113.33.00/url
+++ b/packages/email_message/email_message.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/email_message-113.33.00.tar.gz"
+checksum: "effa2ebdd84f23b05e5186fcba4bd3dc"

--- a/packages/incremental/incremental.113.33.00/descr
+++ b/packages/incremental/incremental.113.33.00/descr
@@ -1,0 +1,5 @@
+Library for incremental computations
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/incremental/incremental.113.33.00/opam
+++ b/packages/incremental/incremental.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/incremental"
+bug-reports: "https://github.com/janestreet/incremental/issues"
+dev-repo: "https://github.com/janestreet/incremental.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"         {build}
+  "ocamlfind"          {build & >= "1.3.2"}
+  "bin_prot"           {>= "113.33.00" & < "113.34.00"}
+  "core"               {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"          {>= "113.24.00" & < "113.25.00"}
+  "incremental_kernel" {>= "113.33.00" & < "113.34.00"}
+  "ppx_assert"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"           {>= "113.33.00" & < "113.34.00"}
+  "sexplib"            {>= "113.33.00" & < "113.34.00"}
+  "typerep"            {>= "113.24.00" & < "113.25.00"}
+  "variantslib"        {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/incremental/incremental.113.33.00/url
+++ b/packages/incremental/incremental.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/incremental-113.33.00.tar.gz"
+checksum: "3c88c08b6939aec8adb2ecc0da3d8113"

--- a/packages/incremental_kernel/incremental_kernel.113.33.00/descr
+++ b/packages/incremental_kernel/incremental_kernel.113.33.00/descr
@@ -1,0 +1,5 @@
+Library for incremental computations depending only on Core_kernel
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/incremental_kernel/incremental_kernel.113.33.00/opam
+++ b/packages/incremental_kernel/incremental_kernel.113.33.00/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/incremental_kernel"
+bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
+dev-repo: "https://github.com/janestreet/incremental_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/incremental_kernel/incremental_kernel.113.33.00/url
+++ b/packages/incremental_kernel/incremental_kernel.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/incremental_kernel-113.33.00.tar.gz"
+checksum: "07ec43ef8cdbbc078654b3d3a7d6e0c2"

--- a/packages/jenga/jenga.113.33.00/descr
+++ b/packages/jenga/jenga.113.33.00/descr
@@ -1,0 +1,1 @@
+Build system

--- a/packages/jenga/jenga.113.33.00/opam
+++ b/packages/jenga/jenga.113.33.00/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/jenga"
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_inotify"   {>= "113.33.00" & < "113.34.00"}
+  "async_parallel"  {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ocaml_plugin"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/jenga/jenga.113.33.00/url
+++ b/packages/jenga/jenga.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/jenga-113.33.00.tar.gz"
+checksum: "44adb50a88112cd97785c21441d77df9"

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.00/descr
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.00/descr
@@ -1,0 +1,1 @@
+Automatically build and dynlink OCaml source files

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.00/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ocaml_plugin"
+bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
+dev-repo: "https://github.com/janestreet/ocaml_plugin.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ocamlbuild"
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.00/url
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ocaml_plugin-113.33.00.tar.gz"
+checksum: "6194b32757a20eb226696f9f07ececa0"

--- a/packages/patdiff/patdiff.113.33.00/descr
+++ b/packages/patdiff/patdiff.113.33.00/descr
@@ -1,0 +1,1 @@
+File Diff using the Patience Diff algorithm

--- a/packages/patdiff/patdiff.113.33.00/opam
+++ b/packages/patdiff/patdiff.113.33.00/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/patdiff"
+bug-reports: "https://github.com/janestreet/patdiff/issues"
+dev-repo: "https://github.com/janestreet/patdiff.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "patience_diff"   {>= "113.33.00" & < "113.34.00"}
+  "pcre"
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/patdiff/patdiff.113.33.00/url
+++ b/packages/patdiff/patdiff.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/patdiff-113.33.00.tar.gz"
+checksum: "5d3f2d460c7c5f270825e8dd7b3ade97"

--- a/packages/patience_diff/patience_diff.113.33.00/descr
+++ b/packages/patience_diff/patience_diff.113.33.00/descr
@@ -1,0 +1,1 @@
+Diff library using Bram Cohen's patience diff algorithm.

--- a/packages/patience_diff/patience_diff.113.33.00/opam
+++ b/packages/patience_diff/patience_diff.113.33.00/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/patience_diff"
+bug-reports: "https://github.com/janestreet/patience_diff/issues"
+dev-repo: "https://github.com/janestreet/patience_diff.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/patience_diff/patience_diff.113.33.00/url
+++ b/packages/patience_diff/patience_diff.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/patience_diff-113.33.00.tar.gz"
+checksum: "1640185808755fa3b6d9a8cd52ca825a"

--- a/packages/ppx_assert/ppx_assert.113.33.00/descr
+++ b/packages/ppx_assert/ppx_assert.113.33.00/descr
@@ -1,0 +1,2 @@
+Assert-like extension nodes that raise useful errors on failure
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_assert/ppx_assert.113.33.00/opam
+++ b/packages/ppx_assert/ppx_assert.113.33.00/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_assert"
+bug-reports: "https://github.com/janestreet/ppx_assert/issues"
+dev-repo: "https://github.com/janestreet/ppx_assert.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_compare"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+  "sexplib"       {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_assert/ppx_assert.113.33.00/url
+++ b/packages/ppx_assert/ppx_assert.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_assert-113.33.00.tar.gz"
+checksum: "6c445be7fb9cc61e215ecd8fb151e276"

--- a/packages/ppx_bench/ppx_bench.113.33.00/descr
+++ b/packages/ppx_bench/ppx_bench.113.33.00/descr
@@ -1,0 +1,2 @@
+Syntax extension for writing in-line benchmarks in ocaml code
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_bench/ppx_bench.113.33.00/opam
+++ b/packages/ppx_bench/ppx_bench.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_bench"
+bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+dev-repo: "https://github.com/janestreet/ppx_bench.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "ppx_core"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"       {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_bench/ppx_bench.113.33.00/url
+++ b/packages/ppx_bench/ppx_bench.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_bench-113.33.00.tar.gz"
+checksum: "94acdc65dd61fd7581cb63cea29cff56"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/descr
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/descr
@@ -1,0 +1,2 @@
+Generation of bin_prot readers and writers from types
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_bin_prot"
+bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
+dev-repo: "https://github.com/janestreet/ppx_bin_prot.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "bin_prot"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/url
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_bin_prot-113.33.00.tar.gz"
+checksum: "97e9c964207d992acc275b795d038ff7"

--- a/packages/ppx_compare/ppx_compare.113.33.00/descr
+++ b/packages/ppx_compare/ppx_compare.113.33.00/descr
@@ -1,0 +1,2 @@
+Generation of comparison functions from types
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_compare/ppx_compare.113.33.00/opam
+++ b/packages/ppx_compare/ppx_compare.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_compare"
+bug-reports: "https://github.com/janestreet/ppx_compare/issues"
+dev-repo: "https://github.com/janestreet/ppx_compare.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_compare/ppx_compare.113.33.00/url
+++ b/packages/ppx_compare/ppx_compare.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_compare-113.33.00.tar.gz"
+checksum: "6d3877b589b4acf89e370a35c9a81b46"

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.00/descr
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.00/descr
@@ -1,0 +1,2 @@
+Deprecated
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.00/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.00/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_conv_func"
+bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
+dev-repo: "https://github.com/janestreet/ppx_conv_func.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.00/url
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_conv_func-113.33.00.tar.gz"
+checksum: "f797a1ffb79d47d8944ef11069dc9700"

--- a/packages/ppx_core/ppx_core.113.33.00/descr
+++ b/packages/ppx_core/ppx_core.113.33.00/descr
@@ -1,0 +1,2 @@
+Standard library for ppx rewriters
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_core/ppx_core.113.33.00/opam
+++ b/packages/ppx_core/ppx_core.113.33.00/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_core"
+bug-reports: "https://github.com/janestreet/ppx_core/issues"
+dev-repo: "https://github.com/janestreet/ppx_core.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_tools"  {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_core/ppx_core.113.33.00/url
+++ b/packages/ppx_core/ppx_core.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_core-113.33.00.tar.gz"
+checksum: "97bae1ab35171189153009318a2f8474"

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/descr
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/descr
@@ -1,0 +1,2 @@
+Generate functions to read/write records in csv format
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_csv_conv"
+bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_csv_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_conv_func" {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/url
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_csv_conv-113.33.00.tar.gz"
+checksum: "de398fbeb93792426b01fe30bc645103"

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/descr
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/descr
@@ -1,0 +1,2 @@
+Printf-style format-strings for user-defined string conversion
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_custom_printf"
+bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
+dev-repo: "https://github.com/janestreet/ppx_custom_printf.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/url
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_custom_printf-113.33.00.tar.gz"
+checksum: "6393e260776b7d89b3027031d6eee61b"

--- a/packages/ppx_driver/ppx_driver.113.33.00/descr
+++ b/packages/ppx_driver/ppx_driver.113.33.00/descr
@@ -1,0 +1,2 @@
+Feature-full driver for OCaml AST transformers
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_driver/ppx_driver.113.33.00/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.00/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_driver"
+bug-reports: "https://github.com/janestreet/ppx_driver/issues"
+dev-repo: "https://github.com/janestreet/ppx_driver.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"  {build}
+  "ocamlfind"   {build & >= "1.3.2"}
+  "ocamlbuild"
+  "ppx_core"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_optcomp" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_driver/ppx_driver.113.33.00/url
+++ b/packages/ppx_driver/ppx_driver.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_driver-113.33.00.tar.gz"
+checksum: "4ddefe64b09991947771900afaedbae6"

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.00/descr
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.00/descr
@@ -1,0 +1,2 @@
+Generate a list containing all values of a finite type
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.00/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.00/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_enumerate"
+bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
+dev-repo: "https://github.com/janestreet/ppx_enumerate.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.00/url
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_enumerate-113.33.00.tar.gz"
+checksum: "c783e4886c53e7caac7d22c8a5174429"

--- a/packages/ppx_expect/ppx_expect.113.33.00/descr
+++ b/packages/ppx_expect/ppx_expect.113.33.00/descr
@@ -1,0 +1,2 @@
+Cram like framework for OCaml
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_expect/ppx_expect.113.33.00/opam
+++ b/packages/ppx_expect/ppx_expect.113.33.00/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "https://github.com/janestreet/ppx_expect.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"        {build}
+  "ocamlfind"         {build & >= "1.3.2"}
+  "fieldslib"         {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_compare"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_custom_printf" {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_fields_conv"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"         {>= "0.99.3"}
+  "ppx_variants_conv" {>= "113.33.00" & < "113.34.00"}
+  "re"
+  "sexplib"           {>= "113.33.00" & < "113.34.00"}
+  "variantslib"       {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_expect/ppx_expect.113.33.00/url
+++ b/packages/ppx_expect/ppx_expect.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_expect-113.33.00.tar.gz"
+checksum: "6af5d958118157727efa63beb65f8809"

--- a/packages/ppx_fail/ppx_fail.113.33.00/descr
+++ b/packages/ppx_fail/ppx_fail.113.33.00/descr
@@ -1,0 +1,2 @@
+Add location to calls to failwiths
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_fail/ppx_fail.113.33.00/opam
+++ b/packages/ppx_fail/ppx_fail.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_fail"
+bug-reports: "https://github.com/janestreet/ppx_fail/issues"
+dev-repo: "https://github.com/janestreet/ppx_fail.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_core"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver" {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"  {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_fail/ppx_fail.113.33.00/url
+++ b/packages/ppx_fail/ppx_fail.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_fail-113.33.00.tar.gz"
+checksum: "093746ad5e0f58cd83e9829d9502917e"

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/descr
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/descr
@@ -1,0 +1,2 @@
+Generation of accessor and iteration functions for ocaml records
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_fields_conv"
+bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_fields_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "fieldslib"     {>= "113.24.00" & < "113.25.00"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/url
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_fields_conv-113.33.00.tar.gz"
+checksum: "b7b1aed6d373bdf99d56812189ab7eaf"

--- a/packages/ppx_here/ppx_here.113.33.00/descr
+++ b/packages/ppx_here/ppx_here.113.33.00/descr
@@ -1,0 +1,2 @@
+Expands [%here] into its location
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_here/ppx_here.113.33.00/opam
+++ b/packages/ppx_here/ppx_here.113.33.00/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_here"
+bug-reports: "https://github.com/janestreet/ppx_here/issues"
+dev-repo: "https://github.com/janestreet/ppx_here.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_core"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_here/ppx_here.113.33.00/url
+++ b/packages/ppx_here/ppx_here.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_here-113.33.00.tar.gz"
+checksum: "6db0986b2758954c7c1995e7cbc363c8"

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.00/descr
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.00/descr
@@ -1,0 +1,2 @@
+Syntax extension for writing in-line tests in ocaml code
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.00/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.00/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "https://github.com/janestreet/ppx_inline_test.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_core"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"  {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.00/url
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_inline_test-113.33.00.tar.gz"
+checksum: "cf2712068628c410e7bfd60dc07b663c"

--- a/packages/ppx_jane/ppx_jane.113.33.00/descr
+++ b/packages/ppx_jane/ppx_jane.113.33.00/descr
@@ -1,0 +1,3 @@
+Standard Jane Street ppx rewriters
+This package installs a ppx-jane executable, which is a ppx driver
+including all standard Jane Street ppx rewriters.

--- a/packages/ppx_jane/ppx_jane.113.33.00/opam
+++ b/packages/ppx_jane/ppx_jane.113.33.00/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_jane"
+bug-reports: "https://github.com/janestreet/ppx_jane/issues"
+dev-repo: "https://github.com/janestreet/ppx_jane.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"        {build}
+  "ocamlfind"         {build & >= "1.3.2"}
+  "ppx_assert"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_bin_prot"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_compare"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_custom_printf" {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_enumerate"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_fail"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_fields_conv"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_let"           {>= "113.33.00" & < "113.34.00"}
+  "ppx_pipebang"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_message"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_value"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_typerep_conv"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_variants_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_jane/ppx_jane.113.33.00/url
+++ b/packages/ppx_jane/ppx_jane.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_jane-113.33.00.tar.gz"
+checksum: "3480f4d57791b160b98e04ea106e1995"

--- a/packages/ppx_let/ppx_let.113.33.00/descr
+++ b/packages/ppx_let/ppx_let.113.33.00/descr
@@ -1,0 +1,2 @@
+Monadic let-bindings
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_let/ppx_let.113.33.00/opam
+++ b/packages/ppx_let/ppx_let.113.33.00/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_let"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+dev-repo: "https://github.com/janestreet/ppx_let.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_core"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_let/ppx_let.113.33.00/url
+++ b/packages/ppx_let/ppx_let.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_let-113.33.00.tar.gz"
+checksum: "b5a89b5ffef23a0b0aac4dff3ae8fc1d"

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.00/descr
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.00/descr
@@ -1,0 +1,2 @@
+Optional compilation for OCaml
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.00/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.00/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_optcomp"
+bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
+dev-repo: "https://github.com/janestreet/ppx_optcomp.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_core"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"  {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.00/url
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_optcomp-113.33.00.tar.gz"
+checksum: "55c340c0f5173fdda648a64fe0287f71"

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.00/descr
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.00/descr
@@ -1,0 +1,2 @@
+A ppx rewriter that inlines reverse application operators `|>` and `|!`
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.00/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.00/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_pipebang"
+bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
+dev-repo: "https://github.com/janestreet/ppx_pipebang.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_core"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"  {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.00/url
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_pipebang-113.33.00.tar.gz"
+checksum: "7e8ca893518b320997094320e6785c57"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/descr
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/descr
@@ -1,0 +1,2 @@
+Generation of S-expression conversion functions from type definitions
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_sexp_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+  "sexplib"       {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/url
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_sexp_conv-113.33.00.tar.gz"
+checksum: "bcb2578d49a4d2119caf6f57c4ada5f3"

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/descr
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/descr
@@ -1,0 +1,2 @@
+A ppx rewriter for easy construction of s-expressions
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_message"
+bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
+dev-repo: "https://github.com/janestreet/ppx_sexp_message.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/url
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_sexp_message-113.33.00.tar.gz"
+checksum: "23999084dbdc32452217a716d1b39341"

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/descr
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/descr
@@ -1,0 +1,2 @@
+A ppx rewriter that simplifies building s-expressions from ocaml values
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_value"
+bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
+dev-repo: "https://github.com/janestreet/ppx_sexp_value.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/url
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_sexp_value-113.33.00.tar.gz"
+checksum: "ab306f4e09065740f8b05a54a2d3714d"

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.00/descr
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.00/descr
@@ -1,0 +1,2 @@
+Support Library for type-driven code generators
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_type_conv"
+bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_type_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"   {build}
+  "ocamlfind"    {build & >= "1.3.2"}
+  "ppx_core"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_deriving" {>= "3.0"}
+  "ppx_driver"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"    {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.00/url
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_type_conv-113.33.00.tar.gz"
+checksum: "470f20531bfd497ea8ee48e4f4a717b4"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/descr
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/descr
@@ -1,0 +1,2 @@
+Generation of runtime types from type declarations
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_typerep_conv"
+bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_typerep_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+  "typerep"       {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/url
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_typerep_conv-113.33.00.tar.gz"
+checksum: "b36942d856f8b6127f0722c927d6af2f"

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/descr
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/descr
@@ -1,0 +1,2 @@
+Generation of accessor and iteration functions for ocaml variant types
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_variants_conv"
+bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_variants_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+  "variantslib"   {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/url
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_variants_conv-113.33.00.tar.gz"
+checksum: "7bcb2dd95f84f8b77066afad2d73a0a7"

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/descr
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/descr
@@ -1,0 +1,2 @@
+Generate XML conversion functions from records
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_xml_conv"
+bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_xml_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_conv_func" {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/url
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_xml_conv-113.33.00.tar.gz"
+checksum: "595d79ea019ca2181ccb7bd5da47f536"

--- a/packages/re2/re2.113.33.00/descr
+++ b/packages/re2/re2.113.33.00/descr
@@ -1,0 +1,1 @@
+OCaml bindings for RE2, Google's regular expression library

--- a/packages/re2/re2.113.33.00/opam
+++ b/packages/re2/re2.113.33.00/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/re2"
+bug-reports: "https://github.com/janestreet/re2/issues"
+dev-repo: "https://github.com/janestreet/re2.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/re2/re2.113.33.00/url
+++ b/packages/re2/re2.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/re2-113.33.00.tar.gz"
+checksum: "89b6465f84f88a9b4d43243ae26be1a2"

--- a/packages/rpc_parallel/rpc_parallel.113.33.00/descr
+++ b/packages/rpc_parallel/rpc_parallel.113.33.00/descr
@@ -1,0 +1,5 @@
+Type-safe parallel library built on top of Async_rpc
+Rpc_parallel offers an API to define various workers and protocols,
+spawn workers as separate processes, and communicate with them using
+Async Rpc.
+

--- a/packages/rpc_parallel/rpc_parallel.113.33.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.113.33.00/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/rpc_parallel"
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "https://github.com/janestreet/rpc_parallel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/rpc_parallel/rpc_parallel.113.33.00/url
+++ b/packages/rpc_parallel/rpc_parallel.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/rpc_parallel-113.33.00.tar.gz"
+checksum: "c8692f8273cf1b2fdbf0040c2b19e725"

--- a/packages/sexplib/sexplib.113.33.00/descr
+++ b/packages/sexplib/sexplib.113.33.00/descr
@@ -1,0 +1,5 @@
+Library for serializing OCaml values to and from S-expressions
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib/sexplib.113.33.00/opam
+++ b/packages/sexplib/sexplib.113.33.00/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/sexplib"
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "https://github.com/janestreet/sexplib.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/sexplib/sexplib.113.33.00/url
+++ b/packages/sexplib/sexplib.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/sexplib-113.33.00.tar.gz"
+checksum: "f2a8f3f178656afbc76fdbd2884eaa2f"

--- a/packages/textutils/textutils.113.33.00/descr
+++ b/packages/textutils/textutils.113.33.00/descr
@@ -1,0 +1,1 @@
+Text output utilities

--- a/packages/textutils/textutils.113.33.00/opam
+++ b/packages/textutils/textutils.113.33.00/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/textutils"
+bug-reports: "https://github.com/janestreet/textutils/issues"
+dev-repo: "https://github.com/janestreet/textutils.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.24.00" & < "113.25.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.24.00" & < "113.25.00"}
+  "variantslib"     {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/textutils/textutils.113.33.00/url
+++ b/packages/textutils/textutils.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/textutils-113.33.00.tar.gz"
+checksum: "304d0ea440f5a2c7fe5c02e8725f4f0d"

--- a/packages/typerep_extended/typerep_extended.113.33.00/descr
+++ b/packages/typerep_extended/typerep_extended.113.33.00/descr
@@ -1,0 +1,4 @@
+Runtime types for OCaml
+typerep_extended is a set of additional modules for typerep. They are
+not part of the base typerep library to avoid a circular dependency
+between core_kernel and typerep.

--- a/packages/typerep_extended/typerep_extended.113.33.00/opam
+++ b/packages/typerep_extended/typerep_extended.113.33.00/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/typerep_extended"
+bug-reports: "https://github.com/janestreet/typerep_extended/issues"
+dev-repo: "https://github.com/janestreet/typerep_extended.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"       {build}
+  "ocamlfind"        {build & >= "1.3.2"}
+  "bin_prot"         {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bin_prot"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_type_conv"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_typerep_conv" {>= "113.33.00" & < "113.34.00"}
+  "sexplib"          {>= "113.33.00" & < "113.34.00"}
+  "typerep"          {>= "113.24.00" & < "113.25.00"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/typerep_extended/typerep_extended.113.33.00/url
+++ b/packages/typerep_extended/typerep_extended.113.33.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/typerep_extended-113.33.00.tar.gz"
+checksum: "fada8a2f434fd7c1cada205de8692b6c"


### PR DESCRIPTION
Tested on 32 & 64 bits.
As well as on OS X.

## 113.33.00

### async

Keep up to date with interface changes in `Async_kernel`, `Async_extra` and
`Async_unix`.

### async_extended

- Create library to fork and do calculations in child process.

- `Command_rpc.with_close` returns an `Or_error.t Deferred.t`, and indeed if it
  fails to execute the binary, it will return an `Error _` rather than raising.
  However, if it successfully executes the binary but then the handshake fails,
  it raises an exception. Successfully executing the binary but then having the
  handshake fail is I think a reasonable thing to want to catch, as it's what
  you'll get if you are starting the command rpc slave via ssh and there's some
  problem on the remote side.

  I haven't thought very hard about what happens if the subprocess dies after
  successful handshake and/or the implications of the Writer's monitor being the
  monitor in effect when `with_close` is called. I think heartbeats will kill the
  connection before this becomes an issue.

- Remove `Async_extended.Deprecated_async_bench`

  It's causing problems for the open-source release on platforms that don't have
  `Posix_clock.gettime`:

      https://github.com/janestreet/async_extended/issues/1

  Seems that a module with Deprecated in the name and no uses should just be binned.

- add a simple tcp proxy that is useful in testing for simulating network issues

### async_extra

- Rename `Async.Std.Schedule.every_{enter,tag_change}` to
  `Async.Std.Schedule.every_{enter,tag_change}_without_pushback` and introduce
  `Async.Std.Schedule.every_{enter,tag_change}` with pushback behavior.

  The resulting functions are analogous to `Pipe.iter_without_pushback` and
  `Pipe.iter`.

- Replaced `Persistent_rpc_client` with a successor `Persistent_connection`
  for maintaining persistent connections to all manner of services, not
  just rpc servers.

- Make `Bus.pipe1_exn` take a `Source_position.t` to be more consistent with
  `first_exn` and `iter_exn`.  This also shows better debug sexps on `Bus` when
  multiple pipes are subscribed to the bus.

### async_kernel

- In `Pipe`, deprecated `read_at_most` and `read_now_at_most`, and
  replaced them with `read'` and `read_now'`, respectively.

- Reverted a recent feature that changed `Pipe`'s default
  `max_queue_length` from `Int.max_value` to `100`.  It looks like 100
  is to small to keep `Pipe` overhead to a minimum -- we saw a
  noticeable slowdown in Async.Log.  We're going to do some more
  benchmarking and try to reduce the overhead and choose a better
  number.

- Added `Async.Std.Let_syntax = Deferred.Let_syntax`, which makes it
  possible to use `%bind` and `%map` after `open Async.Std`.

  This required fixing a few places where the new `Let_syntax` in scope
  shadowed `Command.Param.Let_syntax`.

- Improve stacktrace for unhandle async exception in js\_of\_ocaml.

  Wrapping the unhandle exception with `Error.create` will serialize this exception
  and prevent us to have good error reporting in Js\_of\_ocaml.

- Reworked `Async_kernel`'s clock handling to make it possible to use a
  notion of time distinct from the wall-clock time used by `Clock_ns`
  and maintained by the Async scheduler.  There is now a self-contained
  `Time_source` module, a data structure that holds a timing-wheel.  All
  of the code that was in `Clock_ns` and implicitly used the Async
  scheduler and its timing wheel is now in `Time_source`, and is
  suitably parameterized to work on an arbitrary time source with an
  arbitrary timing wheel.  `Clock_ns` is now a wrapper around
  `Time_source` that implicitly uses the Async scheduler's time source.

  `Time_source` still uses the Async scheduler for running jobs that
  fire -- the new power comes from the user being able to advance time
  distinctly from the wall clock.

- Changed `Time_source.sexp_of_t` to display "<wall_clock>" for the
  wall-clock time source.  We don't want to display the events because
  that can be ridiculously large.

  And, for non-wall-clock time sources, don't show the `Job.t`s in
  events, because they are uninformative pool pointers.

- Added `Time_source.advance_by`.

- Added `Time_source.alarm_precision`.

- Added to `Async.Scheduler` `Time_ns` analogs of `cycle_start` and
  `cycle_times`:

      val cycle_start_ns : unit -> Time_ns.t
      val cycle_times_ns : unit -> Time_ns.Span.t Stream.t

- Add `Deferred.map_choice` for transforming the output of `Deferred.choice`.

- Remove an avoidable call to `is_determined` in `Deferred.value_exn`.  The patch is
  meant to preserve current error messages without adding any allocation overhead
  compared to the existing.

  Context: implementation of Eager_deferred in the works that essentially wants to
  redefine map, bind, etc, in the following way:

      let map t ~f =
        if Deferred.is_determined t
        then return (f (Deferred.value_exn t))
        else Deferred.map t ~f
      ;;

- Add `Pipe.read_choice` to encode the appropriate way of combining `values_available`
  and `read_now` to conditionally read from a pipe.

### async_parallel

- Add an option `~close_stdout_and_stderr` to `Async_parallel_deprecated.Std.Parallel.init`
  to close the `stdout` & `stderr` fds.

  This is needed when using `Async_parallel_deprecated` in a daemonized processes, such as
  the in-development jenga server.

  Without this option, Calling ` Process.run ~prog:"jenga" ~args:`"server";"start"` ` from
  build-manager is problematic because the resulting deferred never becomes determined.

### async_rpc_kernel

- Cleans up the implementation-side interface for aborting `Pipe_rpc`s.

  Summary

  The `aborted` `Deferred.t` that got passed to `Pipe_rpc` implementations is
  gone. The situations where it would have been determined now close the reading
  end of the user-supplied pipe instead.

  Details

  Previously, when an RPC dispatcher decided to abort a query, the RPC
  implementation would get its `aborted` `Deferred.t` filled in, but would remain
  free to write some final elements to the pipe.

  This is a little bit more flexible than the new interface, but it's also
  problematic in that the implementer could easily just not pay attention to
  `aborted`. (They're not obligated to pay attention to when the pipe is closed,
  either, but at least they can't keep writing to it.) We don't think the extra
  flexibility was used at all.

  In the future, we may also simplify the client side to remove the `abort`
  function on the dispatch side (at least when not using `dispatch_iter`). For the
  time being it remains, but closing the received pipe is the preferred way of
  aborting the query.

  There are a couple of known ways this might have changed behavior from before.
  Both of these appear not to cause problems in the jane repo.

  - In the past, an implementation could write to a pipe as long as the client
    didn't disconnect, even if it closed its pipe. Now writes will raise after
    a client closes its pipe (or calls `abort`), since the implementor's pipe will
    also be closed in this case. Doing this was already unsafe, though, since the
    pipe *was* closed if the RPC connection was closed.

  - `aborted` was only determined if a client aborted the query or the connection
    was closed. The new alternative, `Pipe.closed` called on the returned pipe,
    will also be determined if the implementation closes the pipe itself. This is
    unlikely to cause serious issues but could potentially cause some confusing
    logging.

- Blocking RPC implementations (i.e., ones made with `Rpc.implement'`) now capture
  the backtrace when they raise. This is consistent with what happens in the
  deferred implementation case, since in that case the implementation is run
  inside a `Monitor.try_with`, which captures backtraces as well.

  Here's an example of what a new error looks like:

    ((rpc_error
      (Uncaught_exn
       ((location "server-side blocking rpc computation")
        (exn
         (Invalid_argument
          "Float.iround_up_exn: argument (100000000000000000000.000000) is too large"))
        (backtrace
          "Raised at file \"pervasives.ml\", line 31, characters 25-45\
         \nCalled from file \"result.ml\", line 43, characters 17-22\
         \nCalled from file \"monad.ml\", line 17, characters 20-28\
         \n"))))
     (connection_description ("Client connected via TCP" (localhost 3333)))
     (rpc_tag foo) (rpc_version 1))

- Actually deprecated `deprecated_dispatch_multi` functions in
  `Versioned_rpc`.

### async_smtp

- Allow an smtp\_client to connect to a local unix socket

- Better logging

### async_ssl

- Make sure to close the `Pipe.Writer.t` that goes back to the application, otherwise the
  application will never get an `Eof if the connection is closed.

### async_unix

- expose a function to get the number of jobs that async has run since Scheduler.go

- In `Log` change `sexp` to be immediate rather than lazy.

  This changes the behavior the `sexp` function.  I've gone through the entire
  tree rewriting `sexp` to `create_s`, attempting to follow these guidelines:

  - If the logging is clearly intended to always happen (error logging,
  transaction log logging, etc.) I translated the call unguarded.

  - If the logging was already guarded with an if statetment I translated
  the call unguarded.

  - Otherwise, I added a call to `Log.would_log` as a guarding if.  This duplicates
  the behavior of `sexp`, which would avoid the sexp conversion if the log
  message was never going to be logged.


- `Writer.with_file_atomic` checks if destination file exists and then
  stats it to get existing permissions. File can go away before the call
  to stat, which would make the `with_file_atomic` to error out, which
  seems harsh. I think it is better to continue on in this case.
  Besides, `Async.file_exists` is essentially just another stat, so we might as
  well just do the stat without checking whether file exists or not.

- Moved various `let%test`'s in `Async_unix` library into their own
  module.  I'd like the `let%test`'s to be in files that depend on
  `Std`, so that they can pick up a top-level side effect that `Std`
  does, specifically the assignment of `Monitor.try_with_log_exn`.  The
  child feature of this feature makes the change to do that assignment.

- Changed the `Async_unix` library's assignment of
  `Monitor.try_with_log_exn` to be a top-level side effect that happens
  if `Async_unix.Std` is used.  This fixes a bug in which
  `Thread_safe.block_on_async` (and other bits of `Async_unix`) failed to
  to do the assignment.  The assignment was part of `Scheduler.go`,
  which isn't called by `Thread_safe.block_on_async`.  This in turn
  cause programs that use `Thread_safe.block_on_async` and do not use
  `Scheduler.go`, like inline tests, to raise if they needed to report
  an exception raised to `Monitor.try_with` that already returned.

- Deprecate the (blocking) `Sexp.save_*` functions in `Async_unix.Std`.

  Please do not switch from `Sexp.save*` to `Writer.save_sexp*` in this
  feature -- this feature is just for the deprecation.  You can do the
  switch in a subfeature or later feature.

  A note aboute `Core_extended.Sexp`
  ----------------------------------

  This feature causes surprising behavior in `Core_extended.Sexp`, where
  opening `Async.Std` undoes any previous open of `Core_extended.Std`:

       open Core.Std
       open Core_extended.Std

       type t = int Sexp.Comprehension.t `@@deriving sexp`

       open Async.Std

       type u = int Sexp.Comprehension.t `@@deriving sexp`

  The type `t` is fine but `u` fails to compile because at that point
  the module Sexp has no submodule Comprehension.

  But we already have the same problem with module `Unix` if you open
  `Async.Std` after `Core_extended.Std`, so I left the `Sexp` module as is.

- Added `Async.Unix.Stats.compare`.

- Changed Async's logging of exceptions raised to a `Monitor.try_with`
  that already returned to use `Log.Global.sexp` rather than
  `Log.global.error`.  For logs that use single-line sexps, that makes
  them much nicer.

- Added to `Async.Scheduler` `Time_ns` analogs of `cycle_start` and
  `cycle_times`:

      val cycle_start_ns : unit -> Time_ns.t
      val cycle_times_ns : unit -> Time_ns.Span.t Stream.t

- I'm tired of having to write `>>| ok_exn` after most calls to Process, let's just make
  Process provide these functions directly.
  Also you can't write `>>| ok_exn` nicely anyway when using the let%bind and friends.

- Added a test demonstrating that `Async.Process.create` returns `Ok`
  when `exec` fails.  And updated the `create`'s documentation.

### bignum

- This release improves the slow path of bignum of string. The previous
  version used a split on `'_'` followed by a concat, which allocated a
  bunch of intermediate strings.

### core

- Updated to follow core\_kernel's evolution.

- Add variance annotations to a few types in `Command`.

- `Command.Param.choice` represents a sum type.

- Added `Command.Spec.of_param` for conversion from new-style to old
  style command line specifications.  This is expected to be useful for
  gradually converting Spec-based commands into Param-based ones.

- `flag_names` and `anon_names` gives the flags and anons used by a
  Command.Param.t, while `mnemonic` combines them to give a string
  that's good for referring to that param in error messages.

  This feature improves the interface of `Command.Param.one_of` by
  saving the caller from passing the flag names separately.

- Remove the closure allocation from `Date0.create_exn`

- Many apps take schedules as command line parameters (to determine when
  they'll be up, or when they should raise issues, etc.).  Let's add a
  Schedule.Stable.V4.flag function to generate the command line param to
  make writing this common pattern easier.

- Add Ofday.Option to `time_ns.ml`.

  Exports `Time_ns.Span.Option.unchecked_value` and
  `.Ofday.Option.unchecked_value`!

- Finally fix `Time_ns.Of_day.of_local_time` w.r.t. DST transitions after
  regression test failures at the DST transition.

  As a result, clarified slightly the role of `Time_ns.Ofday`, like
  `Time.Ofday`, as 24h wall-clock times, not linear time offsets, which
  latter would have to be up to 25h for DST.

- Adds `Command.Spec.Arg_type.percent`.

- Add `Stable.V1` to `Time_ns.Ofday.Option.t`, add it to `Core.Stable`, and
  standardize the interface to `Option` modules in `Time_ns`.

- Add `Time_ns.to_ofday`.

### core_extended

- Update to follow `core[_kernel]` evolution.

### core_kernel

- Rename Tuple.T2.map1 and Tuple.T2.map2 to `map_fst` and `map_snd`,
  following the convention of the accessors.  Usually, numeric suffixes
  mean higher arities, not different fields.

- After discussion, rather than checking for overflow in `Time_ns`
  arithmetic, clarify that it's silently ignored.  (Subsequent
  conversions may or may not notice.)

  We did identify the set of functions to document:

      Time_ns.Span.((+), (-), scale_int, scale_int63, create, of_parts)
      Time_ns.(add, sub, diff, abs_diff, next_multiple)

  Added `Core_int63.(add_with_overflow_exn, abs_with_overflow_exn, neg_with_overflow_exn)`
  in the course of abandoned work on overflow detection in `Time_ns`.  These may
  be useful.  `mul_with_overflow_exn` was abandoned because
    1. it's a lot of work to review
    2. there's a better approach: Go to the C level and check the high word of
       the product from the IMUL instruction, which is both simpler and faster.

- Changes related to Float.sign

  Float.sign currently maps -1e-8 and nan to Zero.  Some users don't
  expect this.  This feature addresses that via the following changes:

  - `Float.sign` renamed to `Float.robust_sign`.  (`Float.sign` is
    still present, but deprecated.)

  - `Float.sign_exn` introduced which does not use robust comparison,
    and which raises on `nan`.

  - `Sign` pulled out of `Float` and made its own module, and
    `sign : t -> Sign.t` added to `Comparable.With_zero`.  In particular,
    `Int.sign : int -> Sign.t` now exists.  (In looking at existing uses
    of `Float.sign`, there was at least one case where the user was
    converting an int to a float to get its sign.  That ended up being
    deleted, but it still seems desirable to have `Int.sign`.
    There were also record types with a field `sign : Float.Sign.t` where
    logically the type has no real connection to `Float`.)

  - Uses of `Float.robust_sign` revisited to make sure that's the behavior
    we want.

- Added Quickcheck tests for `Hashtbl` functions, using `Map` as a point of comparison.
  A lot of `Hashtbl` functions did not have tests, so I used an interface trick to
  require every function to show up in the test module.  The easiest way to write a readable
  test for every function was to compare it to a similar datatype, so I went with `Map`.

- Allow clients of `Hashtbl.incr` and `Hashtbl.decr` to specify entries should be removed if the value is 0

- The type of `symmetric_diff` has a typo in it.

- Switched `Timing_wheel_ns` to use `%message` and `%sexp`.

- Improved the error message raised by `Timing_wheel.add` and
  `reschedule` if the supplied time is before the start of the current
  interval.

  Previously, the error message was something like:

    ("Timing_wheel.Priority_queue got invalid key"
     (key ...) (timing_wheel ...))

  Now, it will be like:

    ("Timing_wheel cannot schedule alarm before start of current interval"
     (at ...) (now_interval_num_start ...))

  The old message was confusing because `key` is less understandable
  than `at`, and because it didn't make clear that this is a usage
  error, as opposed to a Timing_wheel bug.

  Implementing this efficiently required adding a field to timing wheel:

    mutable now_interval_num_start : Time_ns.t

  so that the check done by `add` is fast.

- Add `Comparable.Make_using_comparator`.

  Since `Map` and `Set` already have `Make_using_comparator` functors,
  there's no particular reason for `Comparable` not to have one.

  More concretely, this will be useful when (if) we add stable
  containers to core: we can add a stable version of `Comparable.Make`,
  then pass the resulting comparator into the unstable functor to get
  equal types.

- Add a `Total_map.Make_using_comparator` functor to allow the creation
  of total maps which are type equivalent to regular maps.

- Change default major heap increments to be % of the heap size instead of a constant increment

  Also changed type of overhead parameters to Percent.t

- Remove modules `Core.Std.Sexp.Sexp_{option,list,array,opaque}`, which
  used to allow binability for types `sexp_option`, `sexp_list`, etc.,
  but now serve no purpose.

- Change the signature of the output of
  `Comparable.Make{,_binable}_using_comparator` to not include `comparator_witness`.

  This is so that code like this will compile:

    include T
    include Comparable.Make_using_comparator (T)

- Changed `Timing_wheel_ns` so that it only supports times at or after
  the epoch, i.e. only non-negative `Time_ns.t` values.  Times before
  the epoch aren't needed, and supporting negative times unnecessarily
  complicates the implementation.

  Removed fields from `Timing_wheel_ns.t` that are now constants:

    ; min_time         : Time_ns.t
    ; max_time         : Time_ns.t
    ; min_interval_num : Interval_num.t

- In `Timing_wheel.t`, cache `alarm_upper_bound`, which allows us to
  give an improved error message when `Timing_wheel.add` is called with
  a time beyond `alarm_upper_bound`.

- Add `Sequence.merge_with_duplicates`

    (** `merge_with_duplicates_element t1 t2 ~cmp` interleaves the elements of `t1` and `t2`.
        Where the two next available elements of `t1` and `t2` are unequal according to `cmp`,
        the smaller is produced first. *)
    val merge_with_duplicates
      :  'a t
      -> 'a t
      -> cmp:('a -> 'a -> int)

    module Merge_with_duplicates_element : sig
      type 'a t =
        | Left of 'a
        | Right of 'a
        | Both of 'a * 'a
      `@@deriving bin_io, compare, sexp`
    end

- Add `Set.merge_to_sequence`

    (** Produces the elements of the two sets between `greater_or_equal_to` and
        `less_or_equal_to` in `order`, noting whether each element appears in the left set,
        the right set, or both.  In the both case, both elements are returned, in case the
        caller can distinguish between elements that are equal to the sets' comparator.  Runs
        in O(length t + length t'). *)

    val merge_to_sequence
      :  ?order               : ` `Increasing (** default *) | `Decreasing `
      -> ?greater_or_equal_to : 'a
      -> ?less_or_equal_to    : 'a
      -> ('a, 'cmp) t
      -> ('a, 'cmp) t
      -> 'a Merge_to_sequence_element.t Sequence.t

    module Merge_to_sequence_element : sig
      type 'a t = 'a Sequence.Merge_with_duplicates_element.t =
        | Left of 'a
        | Right of 'a
        | Both of 'a * 'a
      `@@deriving bin_io, compare, sexp`
    end

- Make `Hashtbl.merge_into` take explicit variant type

    type 'a merge_into_action = Remove | Set_to of 'a

    val merge_into
    :  f:(key:'k key -> 'a1 -> 'a2 option -> 'a2 merge_into_action)
    -> src:('k, 'a1) t
    -> dst:('k, 'a2) t
    -> unit

  The `f` used to return 'a2 option, and it was unclear whether None
  meant do nothing or remove.  (It meant do nothing.)

- Some red-black tree code showed a 15-20% speedup by inlining the
  comparison, rather than relying on the `caml_int_compare` external
  call. I've tried to cleanly apply it to `Core_int` (though it can't
  really be done without an Obj.magic), though this may be a better fit
  for a compiler patch to treat int comparisons as an intrinsic.

  Testing
  -------
  Added an inline test for boundary cases. Presently it returns the
  identical values to `caml_int_compare`, though probably it should only
  be held to same sign results.

- Rename `Hashtbl.[filter_]replace_all[i]` to `Hashtbl.[filter_]map[i]_inplace`.

- Import `debug.ml` from incremental.

- `Float_intf` used 'float' sometimes where it means 't'.

- Added `Identifiable.Make_with_comparator`, for situations where you want
  to preserve the already known comparator, for example to define stable
  sets and maps that are type equivalent to unstable types and sets.

### incremental

- Made it possible to use Incremental without invalidation -- i.e. a
  change in a the left-hand side of bind does *not* invalidate nodes
  created on the right-hand side.

  This is configurable via the argument to
  `Incremental.Make_with_config`, which now takes:

      val bind_lhs_change_should_invalidate_rhs : bool

  So, one can now build an Incremental without invalidation using:

      Incremental.Make_with_config (struct
        include Incremental.Config.Default ()
        let bind_lhs_change_should_invalidate_rhs = false
      end) ()

  Implementation
  --------------
  The implementation is simple:
    When a bind rhs changes, instead of `invalidate_nodes_created_on_rhs`,
    we `rescope_nodes_created_on_rhs`, which moves the nodes up to
    the bind's parent.

  Testing
  -------
  Turned the unit tests into a functor parameterized on
  `bind_lhs_change_should_invalidate_rhs`, and run them with both `true`
  and `false`.  Modified tests where necessary to skip tests of
  invalidity when `bind_lhs_change_should_invalidate_rhs = false`.

  Added a unit test of `bind_lhs_change_should_invalidate_rhs = true`
  that makes sure a node created on a bind rhs whose lhs subsequently
  changes continues to stabilize correctly.

- Splitted incremental into a part that can run in javascript, incremental_kernel, and the
  other one.

### jenga

- Jenga's `Api` is extended with `printf` and `printf_verbose`, and `verbose` is removed.
  These changes are in preparation for jenga/server.


  In jenga/server, builds will run on a daemonized server; the build trace is displayed on
  any clients which are `watch`ing. `Api.printf` and `Api.printf_verbose` allow messages
  from the `jenga/root.ml`.

  The command line flag `-verbose` will be a client flag, not a server flag, allowing the
  choice of verbosity to be selected per-client. It therefore won't make sense to allow
  `jenga/root.ml` to ask if `verbose` is true, so we remove `verbose` from the jenga `Api`.

  Instead `jenga/root/ml` can use `printf_verbose` for messages which are to be displayed
  only by a client that is watching with `-verbose`.


- Make benchmark analysis script compute heap stats in addition to time.

- Give more information about why we build `Dep.action` and `Dep.action_stdout`, because right
  now, the output of jenga sometimes doesn't contain the information (the summary line
  contains it, but it's not always printed, at least when using `-stop-on-error`). For
  instance:

  Old jenga:

      *** jenga: ERROR: (summary) a/.DEFAULT: External command failed
            - build a stdout
            + bash -e -u -o pipefail -c false
            - exit a stdout, 3ms, exited with code 1
      *** jenga: ERROR: (summary) a/foo.ml.d: External command failed
            - build a stdout
            + .../ocamldep.opt -modules -impl foo.ml
            foo.ml:
            File "foo.ml", line 2, characters 0-0:
            Error: Syntax error
            - exit a stdout, 4ms, exited with code 2


  New jenga:

      *** jenga: ERROR: (summary) a/.DEFAULT: External command failed
            - build a .DEFAULT
            + bash -e -u -o pipefail -c false
            - exit a .DEFAULT, 5ms, exited with code 1
      *** jenga: ERROR: (summary) a/foo.ml.d: External command failed
            - build a rule of foo.ml.d
            + .../ocamldep.opt -modules -impl foo.ml
            foo.ml:
            File "foo.ml", line 2, characters 0-0:
            Error: Syntax error
            - exit a rule of foo.ml.d, 6ms, exited with code 2

- When

  - a command run by jenga forks
  - and that fork inherits the stdout/stderr pipes to jenga
  - and the fork doesn't terminate
  - but the initial process does terminate

  we are in a situation where, jenga before this feature would consider the command is still
  running. This makes for some annoying debug, because which command started the stray
  process is hard to tell, the stdout and stderr of the initial process are not visible
  anywhere (they are in jenga's memory), etc.
  Also jenga appears stuck.

  So instead, we expect the stdout/stderr to close shortly after the initial process dies,
  and if not, we close stdout/stderr ourselves and consider that the command failed.


  To test, I put this in a jbuild:
      (alias
       ((name DEFAULT)
        (deps ())
        (action "(echo false >&2; sleep 4) & ")))

  and `JENGA_OPTIONS='((fd_close_timeout 2s))' jenga -P` complained:

      *** jenga: ERROR: (summary) lib/sexplib/src/.DEFAULT: External command failed
            - build lib/sexplib/src stdout
            + bash -e -u -o pipefail -c '(echo false >&2; sleep 4) & '
            false
            - exit lib/sexplib/src stdout, 2.004s, stdout or stderr wasn't closed 2s after process exited (due to a stray process perhaps?)

  Also I had hydra do a full tree build (both in jane-continuous-release and jane-release)
  and they both succeeded.

- Remove jenga command line flag which was `-delay N`

  This controlled `Config.delay_for_dev` which inserted a delay of N seconds before running
  any job in `Job.run`. I have heard this described as the most pointless command line flag
  of all time!

  Reason to fix now: Another feature `jane/jenga/api.printf` removes `Api.verbose` which
  exposes `Config.verbose` to jenga/root.ml. Following both features, we can remove the
  `Run.For_user` hackery.

- Avoid `nan` from divide-by-0 in jenga monitor's `finish_time_estimator`.

  Without this fix, we may get `nan` as the value of a `Time.t` which breaks an invariant of
  the `Time` module. This may result in a crash in `Time.to_ofday`.

      ("unhandled exception"
       ((monitor.ml.Error_
         ((exn "Option.value_exn None")
          (backtrace
           ("Raised by primitive operation at file \"option.ml\", line 59, characters 4-21"
            "Called from file \"zone.ml\", line 751, characters 8-104"
            "Called from file \"zone.ml\", line 761, characters 10-48"
            "Called from file \"time0.ml\", line 275, characters 31-54"
            "Called from file \"finish_time_estimator.ml\", line 38, characters 14-54"
            "Called from file \"message.ml\", line 384, characters 30-66"
            "Called from file \"list.ml\", line 73, characters 12-15"
            "Called from file \"list.ml\", line 73, characters 12-15"
            "Called from file \"message.ml\", line 158, characters 2-42"
            "Called from file \"deferred0.ml\", line 65, characters 64-69"
            "Called from file \"job_queue.ml\", line 160, characters 6-47" ""))
          (monitor
           (((name try_with) (here ()) (id 4) (has_seen_error true)
             (is_detached true))))))
        ((pid 17688) (thread_id 4

- Code refactoring to avoid circular module dependencies in `jenga/server` feature.

  There changes have no semantic effects; it's just code movement.

  1. Extract `Message.Job_summary` as a top level module.
  2. Extract `Build.Run_reason` as a top level module.
  3. Create all `Effort.Counter` instances in `Progress`.

- The current cycle detection in build.ml is very hard to use correctly.
  Implement a robust cycle detection in Tenacious.

  Additionally, this feature lets the user see what jenga is currently working on by doing `jenga diagnostics dump-tenacious-graph`.

  Along the way, fixed `jenga monitor` to exit non-zero when it can't discover jengaroot.

- Change `jenga -time` to prefix lines with absolute times. More standard & helpful.

- Extend jenga Api with support for registering environment variables.
  These can be accessed and manipulated via RPC to the running jenga.

  This feature is necessary to support env-var discovery in build-manager via RPC, rather
  than the current hack of parsing the output from jenga.

  Environment variable manipulation is exposed on the command line with:

      jenga env get NAME
      jenga env set NAME VALUE
      jenga env unset NAME
      jenga env print

  The Api supports access to either the current value of a variable, or to a dependency
  which responds dynamically to changes made by `setenv`.

      Var.peek   : 'a Var.t -> 'a
      Dep.getenv : 'a Var.t -> 'a Dep.t

- Removed `update-stream` RPC. Was never used by anything.
  It wouldn't have worked anyway because it contained interned paths.

  Removed `app/jenga/lib/rpc_intf.mli` - just unhelpful code duplication of the
  descriptions in `rpc_intf.ml`.

- Error message when running on nfs was super-confusing.

- Avoid double-reporting build errors originating from the action of a multi-target rule.
  (And in future avoid double-reporting the error to the `error-pipe' of jenga/server.)

  1. Attribute an error to the head target ONLY.

  2. Additional targets are treated as dependants of the `head_target`, and so (if
  demanded) are regarded as having `failure' not `error' status.

  3. Always use `head-target` in the "-build" line message, instead of whatever target
  happens (non deterministically) to get `demanded` first.

  4. Allow user control over the which target is regarded as the `head_target`, by taking
  the first target listed as the `head_target`.


- Couple of extra messages bracketing when GC is performed & finished.

- Stop taking nfs locks, just rely on local locks, so we're finally
  free from the bug of Nfs_lock where it can't remove a half created
  lock.
  Also clean things up while I'm here, no change intended in
  special_paths.ml.

- Refactor code to remove distinction between types `Progess.Need.t` and `Goal.t`; removing
  the `Progess.Need.t` type by supporting the one additional case of `Need.jengaroot` as a
  `Goal.t`.

  Allow the user to demand a `build' of (just) the jengaroot.

- Add support for unsetting environment variables prior to running actions

### ocaml_plugin

- Improve the check plugin command that comes with ocaml-plugin:

  1) Improve documentation, add `readme` to include more info about what is being
  checked exactly.

  2) Avoid the switch `-code-style _` for application that have made a choice of
  code style statically.  Having the swtich available at runtime is just
  confusing, since only 1 style is going to work anyway.

### ppx_bench

- Add an attribute `@name_suffix` to `let%bench_module`. This is an arbitrary
  expression that gets concatenated to the name of the bench module. It's
  useful to have this when using `ppx_bench` inside a functor, to distinguish
  each functor application in the output.

### ppx_expect

- Don't remove trailing semicolons when producing a correction.

- Corrected `%expect`s with double quoted strings don't have the single space padding.

- In the ppx\_expect runtime, flush stdout before redirecting it
  This is to avoid capturing leftover of the stdout buffer.

- Make sure the expect-test runtime doesn't generate
  `%collector_never_triggered`, which is not accepted by ppx\_expect.
  Instead generate:

    `%expect {| DID NOT REACH THIS PROGRAM POINT |}`

- Make expect tests pass the user description to the inline test runtime

- Fix a race condition in the ppx\_expect runtime


- Change ppx\_expect be more permissive when matching whitespace in actual output.
  See `ppx/ppx_expect/README.org` for details.

  Changes to the implementation of ppx\_expect (including some refactoring):
  - factorized the common bits between the runtime and ppx rewriter
    into one library expect_test_common
  - factorized different structures representing the same thing using polymorphism
  - communicate data structures between the ppx rewriter and runtime
    using a generated lifter instead of hand-written lifters
  - splitted the matching and correction writing code: the .corrected is
    now only created when needed instead of all the time
  - added a concrete syntax tree to represent both the actual output and
    expectation in non-exact mode.
    This allow to keep the user formatting as much as possible
  - made various bits more re-usable

- Change the default style of multi-line expectation to:

    `%expect {|
      abc
      def |}`

  More generally, try to preserve the formatting a bit more when
  correcting from empty or single to multi-line.

- Arrange things so that when `open Async.Std` is opened, `%expect ...`
  expressions are of type `unit Deferred.t` and flush stdout before
  capturing the output.

### ppx_fields_conv

- Fix errors in `ppx_fields_conv` documentation

- Add unit tests for `ppx_fields_conv` functions

- Fix some idiosyncracies where the implementations in `ppx_fields_conv.ml` differed
  (ex: a variable would be called one thing when implementing one function but
  would be called something different when implementing every other function).

### ppx_inline_test

- Allow to configure hooks for inline tests by redefining a module
  Inline\_test\_config.

### ppx_optcomp

- Install standalone ppx-optcomp program that can be run through `-pp`

### ppx_sexp_conv

- Clean up the documentation for sexplib, modernizing it to include
  `ppx_sexp_conv`, and breaking up the documentation between sexplib and
  `ppx_sexp_conv`.  Also changed the formatting to use org-mode, so it
  will render properly on github.  Markdown doesn't render well by
  default, unless you use quite different conventions about linebeaks.

### rpc_parallel

- Adding the mandatory arguments `redirect_stderr` and `redirect_stdout` to `Map_reduce` so it is easier to debug your workers.
  Also removed `spawn_exn` in favor of only exposing `spawn_config_exn`. If you want to spawn a single worker, make a config of one worker.

- Cleans up the implementation-side interface for aborting `Pipe_rpc`s.

  Summary

  The `aborted` `Deferred.t` that got passed to `Pipe_rpc` implementations is
  gone. The situations where it would have been determined now close the reading
  end of the user-supplied pipe instead.

  Details

  Previously, when an RPC dispatcher decided to abort a query, the RPC
  implementation would get its `aborted` `Deferred.t` filled in, but would remain
  free to write some final elements to the pipe.

  This is a little bit more flexible than the new interface, but it's also
  problematic in that the implementer could easily just not pay attention to
  `aborted`. (They're not obligated to pay attention to when the pipe is closed,
  either, but at least they can't keep writing to it.) We don't think the extra
  flexibility was used at all.

  In the future, we may also simplify the client side to remove the `abort`
  function on the dispatch side (at least when not using `dispatch_iter`). For the
  time being it remains, but closing the received pipe is the preferred way of
  aborting the query.

  There are a couple of known ways this might have changed behavior from before.
  Both of these appear not to cause problems in the jane repo.

  - In the past, an implementation could write to a pipe as long as the client
    didn't disconnect, even if it closed its pipe. Now writes will raise after
    a client closes its pipe (or calls `abort`), since the implementor's pipe will
    also be closed in this case. Doing this was already unsafe, though, since the
    pipe *was* closed if the RPC connection was closed.

  - `aborted` was only determined if a client aborted the query or the connection
    was closed. The new alternative, `Pipe.closed` called on the returned pipe,
    will also be determined if the implementation closes the pipe itself. This is
    unlikely to cause serious issues but could potentially cause some confusing
    logging.

- Deal with an fd leak in Managed worker connections

- This feature completely restructured `rpc_parallel` to make it more
  transparent in what it does and doesn't do. I offloaded all the
  connection management and cleanup responsibilities to the user.

  What `Rpc_parallel` used to do for you:
  ------------------------------------
   - Internally there was a special (behind the scenes) Rpc connection
     maintained between the worker and its master upon spawn. Upon this
     connection closing, the worker would shut itself down and the
     master would be notified of a connection lost.
   - We would keep a connection table for you. `run` was called on the
     worker type (i.e. a host and port) because it's implementation
     would get a connection (using an existing one or doing a
     `Rpc.Connection.client`).

  What it now does:
  -----------------
   - No special Rpc connection is maintained, so all cleanup is the job
     of the user
   - No internal connection table. `run` is called on a connection type,
     so you have to manage connections yourself
   - Exposes connection states (unique to each connection) along with
     worker states (shared between connections)
   - There is an explicit `Managed` module that does connection
     management for you
   - There is an explicit `Heartbeater` type that can be used in spawned
     workers to connect to their master and handle cleanup

- There was a race condition where `spawn` would return a `Worker.t` even though the worker had not daemonized yet.
  This manifested itself in a spurious test case failure.

  This also allowed for running the worker initialization code before we daemonize.

- Reuse the master rpc settings when the worker connects using the `Heartbeater` module

- Make all global state and rpc servers lazy.

  Namely:
  1) Toplevel hashtables are initialized with size 1 to reduce overhead due to linking with `Rpc_parallel`
  2) The master rpc server is only started upon the first call to spawn


- Fixed a `Rpc_parallel` bug that caused a Master to Worker call to never return.

- Add new functions `spawn_and_connect` and `spawn_and_connection_exn` which return back the worker and a connection to the worker.

  Also, move all the example code off of the managed module

- Some refactoring:

  1) Take `serve` out of the `Connection` module. It shouldn't be in there because it does nothing with the `Connection.t` type
  2) Remove some unnecessary functions defined on `Connection.t`'s. E.g. no longer expose `close_reason` because all the exception handling will be done with the registered exn handlers.
  3) Move `Rpc_settings` module
  4) Separate `global_state` into `as_worker` and `as_master`
  5) Some cleanup with how we are managing worker ids
  6) create a record type for `Init_connection_state_rpc.query`

### sexplib

- Changes `Sexp.to_string` to escape all non-ASCII characters.

  Previously chars >= 127 are escaped or not depending on:
  1. other character in the string
  2. the system
  3. environment variable settings

  (2) and (3) are because `String.escaped` from the stdlib uses the C
  function `isprint` which is locale and OS dependent.

  This can cause invalid UTF-8 sequence to be printed by sexplib, which
  is annoying:

    https://github.com/janestreet/sexplib/issues/18

  Starting with this release, sexplib:
  1. copies the `String.escaped` function of OCaml 4.03 which escapes
     all non-ascii characters
  2. make sure we escape the string when it contains characters >= 127

- Clean up the documentation for sexplib, modernizing it to include
  `ppx_sexp_conv`, and breaking up the documentation between sexplib and
  `ppx_sexp_conv`.  Also changed the formatting to use org-mode, so it
  will render properly on github.  Markdown doesn't render well by
  default, unless you use quite different conventions about linebeaks.

- In sexp macro library, avoid returning success when there is any error
  reading a sexp. In particular, this prevents

    sexp resolve <(echo '(:use x)')

  from silently succeeding.

  Also, now we no longer read an included file multiple times.
  This lets even crazy stuff like this to work:

    $ echo 'hi ' | sexp resolve <(echo '((:include /dev/stdin) (:include /dev/stdin))')
