### PR TITLE
Add ppx_defer 0.2.0

### DIFF
--- a/packages/ppx_defer/ppx_defer.0.2.0/descr
+++ b/packages/ppx_defer/ppx_defer.0.2.0/descr
@@ -1,0 +1,4 @@
+A syntax extension to provide a somewhat Go-like defer
+
+`[%defer e1]; e2` or `[%defer.lwt e1]; e2` will defer the evaluation of `e1`
+until after `e2` is evaluated.

--- a/packages/ppx_defer/ppx_defer.0.2.0/opam
+++ b/packages/ppx_defer/ppx_defer.0.2.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "ppx_defer"
+version: "0.2.0"
+maintainer: "Hezekiah M. Carty <hez@0ok.org>"
+authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
+license: "MIT"
+homepage: "https://github.com/hcarty/ppx_defer"
+bug-reports: "https://github.com/hcarty/ppx_defer/issues"
+dev-repo: "https://github.com/hcarty/ppx_defer.git"
+tags: [ "syntax" ]
+build:[
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ppx_tools" {>= "0.99.3"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_defer/ppx_defer.0.2.0/url
+++ b/packages/ppx_defer/ppx_defer.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hcarty/ppx_defer/archive/v0.2.0.tar.gz"
+checksum: "a9505957d567684a753f661c583c2b8a"


### PR DESCRIPTION
Adds `[%defer.lwt e1]; e2` syntax.