### PR TITLE
qtest.2.1.1 - via opam-publish

### DIFF
--- a/packages/qtest/qtest.2.1.1/descr
+++ b/packages/qtest/qtest.2.1.1/descr
@@ -1,0 +1,6 @@
+iTeML / qtest : Inline (Unit) Tests for OCaml.
+
+qtest extracts inline unit tests written using a special
+syntax in comments. Those tests are then run using the oUnit framework.
+The possibilities range from trivial tests -- extremely simple to use --
+to sophisticated random generation of test cases.

--- a/packages/qtest/qtest.2.1.1/files/qtest.install
+++ b/packages/qtest/qtest.2.1.1/files/qtest.install
@@ -1,0 +1,4 @@
+bin: [
+  "?qtest/_build/qtest.byte" {"qtest"}
+  "?qtest/_build/qtest.native" {"qtest"}
+]

--- a/packages/qtest/qtest.2.1.1/opam
+++ b/packages/qtest/qtest.2.1.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Vincent Hugot <vincent.hugot@gmail.com>"
+authors: "Vincent Hugot <vincent.hugot@gmail.com>"
+homepage: "https://github.com/vincent-hugot/iTeML"
+bug-reports: "https://github.com/vincent-hugot/iTeML/issues"
+doc:
+  "https://github.com/vincent-hugot/iTeML/blob/master/README.adoc#introduction"
+dev-repo: "git@github.com:vincent-hugot/iTeML.git"
+build: ["ocaml" "do.ml" "qtest" "build" prefix]
+install: ["ocaml" "do.ml" "qtest" "install" prefix]
+remove: ["ocaml" "do.ml" "qtest" "remove" prefix]
+depends: [
+  "ocamlfind"
+  "oasis" {>= "0.2.0"}
+  "ounit"
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/qtest/qtest.2.1.1/url
+++ b/packages/qtest/qtest.2.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vincent-hugot/iTeML/archive/v2.1.1.tar.gz"
+checksum: "4a65c746d0e2029b6d57c1db64f84d44"


### PR DESCRIPTION
iTeML / qtest : Inline (Unit) Tests for OCaml.

qtest extracts inline unit tests written using a special
syntax in comments. Those tests are then run using the oUnit framework.
The possibilities range from trivial tests -- extremely simple to use --
to sophisticated random generation of test cases.


---
* Homepage: https://github.com/vincent-hugot/iTeML
* Source repo: git@github.com:vincent-hugot/iTeML.git
* Bug tracker: https://github.com/vincent-hugot/iTeML/issues

---

Pull-request generated by opam-publish v0.3.1