### PR TITLE
ocamllint.0.2.0 - via opam-publish

### DIFF
--- a/packages/ocamllint/ocamllint.0.2.0/descr
+++ b/packages/ocamllint/ocamllint.0.2.0/descr
@@ -1,0 +1,7 @@
+Detect common errors in OCaml code
+
+OCamllint is a ppx plugin that checks for patterns in a OCaml code base:
+
+  - common programming errors: using the wrong kind of comparison, computing
+    unused values, going several times through a data structure, etc.
+  - enforce style: use snake_case for identifiers, module types in caps, etc.

--- a/packages/ocamllint/ocamllint.0.2.0/opam
+++ b/packages/ocamllint/ocamllint.0.2.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/ocamllint"
+bug-reports: "https://github.com/cryptosense/ocamllint/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/ocamllint.git"
+build: [
+    [make "all"]
+]
+install: [
+    [make "install"]
+]
+build-test: [make "check"]
+remove: [["ocamlfind" "remove" "ocamllint"]]
+depends: [
+    "ocamlfind" {>= "1.5.0"}
+    "ounit" {test}
+    "ppx_tools"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocamllint/ocamllint.0.2.0/url
+++ b/packages/ocamllint/ocamllint.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/cryptosense/ocamllint/archive/v0.2.0.tar.gz"
+checksum: "f09848b2dd24fb574a1d50545cac08ea"


### PR DESCRIPTION
Detect common errors in OCaml code

OCamllint is a ppx plugin that checks for patterns in a OCaml code base:

  - common programming errors: using the wrong kind of comparison, computing
    unused values, going several times through a data structure, etc.
  - enforce style: use snake_case for identifiers, module types in caps, etc.


---
* Homepage: https://github.com/cryptosense/ocamllint
* Source repo: https://github.com/cryptosense/ocamllint.git
* Bug tracker: https://github.com/cryptosense/ocamllint/issues

---

Pull-request generated by opam-publish v0.3.1