### PR TITLE
inotify.2.2 - via opam-publish

### DIFF
--- a/packages/inotify/inotify.2.2/descr
+++ b/packages/inotify/inotify.2.2/descr
@@ -1,0 +1,1 @@
+Inotify bindings for ocaml.

--- a/packages/inotify/inotify.2.2/opam
+++ b/packages/inotify/inotify.2.2/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "LGPL-2.1"
+homepage: "https://github.com/whitequark/ocaml-inotify"
+doc: "http://whitequark.github.io/ocaml-inotify"
+bug-reports: "https://github.com/whitequark/ocaml-inotify/issues"
+dev-repo: "git://github.com/whitequark/ocaml-inotify.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure"
+   "--%{lwt:enable}%-lwt" "--prefix" prefix "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "inotify"]
+]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlfind" {build}
+  "fileutils" {test}
+]
+depopts: ["lwt"]
+available: [os = "linux"]

--- a/packages/inotify/inotify.2.2/url
+++ b/packages/inotify/inotify.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ocaml-inotify/archive/v2.2.tar.gz"
+checksum: "a62de155ec4a1d102bc07fc75a060e08"


### PR DESCRIPTION
Inotify bindings for ocaml.


---
* Homepage: https://github.com/whitequark/ocaml-inotify
* Source repo: git://github.com/whitequark/ocaml-inotify.git
* Bug tracker: https://github.com/whitequark/ocaml-inotify/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1