### PR TITLE
fix piqi and piqilib version constraint on camlp4

### DIFF
--- a/packages/piqi/piqi.0.6.0/opam
+++ b/packages/piqi/piqi.0.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "easy-format"
   "ulex"
   "xmlm"
-  "camlp4" {< "4.02.0"}
+  "camlp4" {< "4.02"}
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/alavrik/piqi"

--- a/packages/piqi/piqi.0.6.5/opam
+++ b/packages/piqi/piqi.0.6.5/opam
@@ -16,7 +16,7 @@ depends: [
   "easy-format"
   "ulex"
   "xmlm"
-  "camlp4" {< "4.02.0"}
+  "camlp4" {< "4.02"}
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/alavrik/piqi"

--- a/packages/piqilib/piqilib.0.6.6/opam
+++ b/packages/piqilib/piqilib.0.6.6/opam
@@ -16,7 +16,7 @@ depends: [
   "easy-format"
   "ulex"
   "xmlm"
-  "camlp4" {< "4.02.0"}
+  "camlp4" {< "4.02"}
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/alavrik/piqi"


### PR DESCRIPTION
I'm compiling OPAM packages on OCaml 4.02.3 installed as the system compiler. OPAM reports camlp4's version as `4.02+system`. When comparing that to `4.02.0`, it decides that `4.02+system` < `4.02.0` and tries to install an incompatible version of `piqi` or `piqilib`.

TL;DR: `4.02.0` is not the smallest possible version number for camlp4 on OCaml `4.02.x`.
