### PR TITLE
sibylfs-lem: fix dash-ism for regular bourne shell users

### DIFF
--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/files/generate_install_manifest.sh
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/files/generate_install_manifest.sh
@@ -2,7 +2,7 @@
 
 echo "bin: ["                                  > sibylfs-lem.install
 echo "  \"src/main.native\" {\"lem\"}"        >> sibylfs-lem.install
-echo "]\nlib: ["                              >> sibylfs-lem.install
+printf "]\nlib: [\n"                          >> sibylfs-lem.install
 
 ls -1 library/*.* hol-lib/*.* isabelle-lib/*.* coq-lib/*.* ocaml-lib/*.* \
 | sed -e "s/\\(.*\\)/  \"\1\" \{ \"\1\" \}/"  >> sibylfs-lem.install


### PR DESCRIPTION
`bash` will not interpret `\n` in `echo`'s arguments.
`sh` will not interpret `\n` in `echo`'s arguments...
but `bash` emulating `sh` will...
*interpret `\n` in `echo`'s arguments!!!*

Hooray!

Edit: I was wrong. It's a `bash`/`sh` vs `dash`-ism. The answer is actually `printf`. Whatever.