### PR TITLE
nanomsg: needs recent containers, ipaddr; older ppx_deriving

### DIFF
--- a/packages/nanomsg/nanomsg.1.0/opam
+++ b/packages/nanomsg/nanomsg.1.0/opam
@@ -24,9 +24,9 @@ depends: [
   "ocamlfind" {build}
   "ctypes" {>= "0.2"}
   "ctypes-foreign"
-  "containers"
-  "ipaddr"
-  "ppx_deriving" {>= "1.0.0"}
+  "containers" {>= "0.7"}
+  "ipaddr" {>= "2.2.0"}
+  "ppx_deriving" {>= "1.0" & < "3.0"}
   "ocamlbuild" {build}
   "lwt" {test}
 ]


### PR DESCRIPTION
Fixes #5946.