### PR TITLE
riakc_ppx does not compile with recent versions of core

### DIFF
--- a/packages/riakc_ppx/riakc_ppx.3.1.3/opam
+++ b/packages/riakc_ppx/riakc_ppx.3.1.3/opam
@@ -9,7 +9,7 @@ install: ["omake" "install"]
 remove: ["ocamlfind" "remove" "riakc_ppx"]
 depends: [
   "ocamlfind"
-  "core" {>= "109.12.00"}
+  "core" {>= "109.12.00" & < "112.35.00"}
   "async"
   "ppx_deriving_protobuf" {>= "2.0"}
   "bitstring" {>= "2.0.4"}


### PR DESCRIPTION
AFAICT this problem is already fixed upstream by
https://github.com/struktured/riakc_ppx/commit/b74df510c32d7e7a77dbae36045c8f83b10e7347
