### PR TITLE
pbkdf.0.1.0 - via opam-publish

### DIFF
--- a/packages/pbkdf/pbkdf.0.1.0/descr
+++ b/packages/pbkdf/pbkdf.0.1.0/descr
@@ -1,0 +1,3 @@
+Password based key derivation functions from PKCS#5, RFC 2898
+
+An implementation of PBKDF 1 and 2 as defined by PKCS#5 (RFC 2898) in OCaml, using nocrypto.

--- a/packages/pbkdf/pbkdf.0.1.0/opam
+++ b/packages/pbkdf/pbkdf.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+authors: [
+  "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+  "Sonia Meruelo <smeruelo.gmail.com>"
+]
+homepage: "https://github.com/abeaumont/ocaml-pbkdf"
+bug-reports: "https://github.com/abeaumont/ocaml-pbkdf/issues"
+license: "BSD2"
+dev-repo: "https://github.com/abeaumont/ocaml-pbkdf.git"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+  "alcotest=false"
+]
+build-test: [
+  [
+    "ocaml"
+    "pkg/build.ml"
+    "native=%{ocaml-native}%"
+    "native-dynlink=%{ocaml-native-dynlink}%"
+    "alcotest=true"
+  ]
+  [
+    "sh"
+    "-exc"
+    "if test -f ./pbkdf_tests.native; then ./pbkdf_tests.native -v; else ./pbkdf_tests.byte -v; fi"
+  ]
+]
+depends: [
+  "ocamlfind" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.0"}
+  "alcotest" {test}
+  "ocamlbuild" {build}
+]

--- a/packages/pbkdf/pbkdf.0.1.0/url
+++ b/packages/pbkdf/pbkdf.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/abeaumont/ocaml-pbkdf/archive/0.1.0.tar.gz"
+checksum: "a59b1ec460f25209ea5259ded6a18fbe"


### PR DESCRIPTION
Password based key derivation functions from PKCS#5, RFC 2898

An implementation of PBKDF 1 and 2 as defined by PKCS#5 (RFC 2898) in OCaml, using nocrypto.


---
* Homepage: https://github.com/abeaumont/ocaml-pbkdf
* Source repo: https://github.com/abeaumont/ocaml-pbkdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-pbkdf/issues

---

Pull-request generated by opam-publish v0.3.1