### PR TITLE
ppx_debugger.1.0 - via opam-publish

### DIFF
--- a/packages/ppx_debugger/ppx_debugger.1.0/descr
+++ b/packages/ppx_debugger/ppx_debugger.1.0/descr
@@ -1,0 +1,5 @@
+ppx_debugger is a small semi-interactive for debugging OCaml execution
+
+This syntactic extension provide some primitive for interactive debugging
+in OCaml. log, breakpoint and catch. See more information on
+https://github.com/xvw/ppx_debugger/README.md

--- a/packages/ppx_debugger/ppx_debugger.1.0/opam
+++ b/packages/ppx_debugger/ppx_debugger.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "xvw <xavier.vdw@gmail.com>"
+authors: "xvw <xavier.vdw@gmail.com>"
+homepage: "https://github.com/xvw/ppx_debugger"
+bug-reports: "https://github.com/xvw/ppx_debugger/issues"
+license: "GPL3"
+dev-repo: "https://github.com/xvw/ppx_debugger.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ppx_debugger"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/ppx_debugger/ppx_debugger.1.0/url
+++ b/packages/ppx_debugger/ppx_debugger.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/xvw/ppx_debugger/releases/download/v1.0/ppx_debugger.tar.gz"
+checksum: "1b6537b17f45c84ec2b8ebab18b3b256"


### PR DESCRIPTION
ppx_debugger is a small semi-interactive for debugging OCaml execution

This syntactic extension provide some primitive for interactive debugging
in OCaml. log, breakpoint and catch. See more information on
https://github.com/xvw/ppx_debugger/README.md


---
* Homepage: https://github.com/xvw/ppx_debugger
* Source repo: https://github.com/xvw/ppx_debugger.git
* Bug tracker: https://github.com/xvw/ppx_debugger/issues

---

Pull-request generated by opam-publish v0.3.1