### PR TITLE
Add upper bounds on cstruct to older xenstore packages

### DIFF
--- a/packages/xenstore/xenstore.1.0.0/opam
+++ b/packages/xenstore/xenstore.1.0.0/opam
@@ -1,13 +1,23 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/mirage/ocaml-xenstore"
+bug-reports:  "https://github.com/mirage/ocaml-xenstore/issues"
+dev-repo:     "https://github.com/mirage/ocaml-xenstore.git"
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
   "cstruct" {< "0.6.0"}

--- a/packages/xenstore/xenstore.1.0.0/opam
+++ b/packages/xenstore/xenstore.1.0.0/opam
@@ -20,7 +20,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "cstruct" {< "0.6.0"}
+  "cstruct" {< "0.5.2"}
   "lwt"
   "ounit"
   "ocamlfind"

--- a/packages/xenstore/xenstore.1.1.0/opam
+++ b/packages/xenstore/xenstore.1.1.0/opam
@@ -1,13 +1,23 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/mirage/ocaml-xenstore"
+bug-reports:  "https://github.com/mirage/ocaml-xenstore/issues"
+dev-repo:     "https://github.com/mirage/ocaml-xenstore.git"
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
   "cstruct" {< "0.6.0"}
@@ -16,4 +26,3 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-xenstore"

--- a/packages/xenstore/xenstore.1.1.0/opam
+++ b/packages/xenstore/xenstore.1.1.0/opam
@@ -20,7 +20,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "cstruct" {< "0.6.0"}
+  "cstruct" {< "0.5.2"}
   "lwt"
   "ounit"
   "ocamlfind"

--- a/packages/xenstore/xenstore.1.2.0/opam
+++ b/packages/xenstore/xenstore.1.2.0/opam
@@ -1,20 +1,30 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/mirage/ocaml-xenstore"
+bug-reports:  "https://github.com/mirage/ocaml-xenstore/issues"
+dev-repo:     "https://github.com/mirage/ocaml-xenstore.git"
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ounit"
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-xenstore"

--- a/packages/xenstore/xenstore.1.2.1/opam
+++ b/packages/xenstore/xenstore.1.2.1/opam
@@ -1,20 +1,30 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/mirage/ocaml-xenstore"
+bug-reports:  "https://github.com/mirage/ocaml-xenstore/issues"
+dev-repo:     "https://github.com/mirage/ocaml-xenstore.git"
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ounit"
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-xenstore"

--- a/packages/xenstore/xenstore.1.2.2/opam
+++ b/packages/xenstore/xenstore.1.2.2/opam
@@ -1,20 +1,30 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/mirage/ocaml-xenstore"
+bug-reports:  "https://github.com/mirage/ocaml-xenstore/issues"
+dev-repo:     "https://github.com/mirage/ocaml-xenstore.git"
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ounit"
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-xenstore"

--- a/packages/xenstore/xenstore.1.2.3/opam
+++ b/packages/xenstore/xenstore.1.2.3/opam
@@ -1,20 +1,31 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/mirage/ocaml-xenstore"
+bug-reports:  "https://github.com/mirage/ocaml-xenstore/issues"
+dev-repo:     "https://github.com/mirage/ocaml-xenstore.git"
+
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
-remove: [["ocamlfind" "remove" "xenstore"]]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "xenstore"]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ounit"
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-xenstore"

--- a/packages/xenstore/xenstore.1.2.5/opam
+++ b/packages/xenstore/xenstore.1.2.5/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer:   "dave.scott@eu.citrix.com"
+maintainer:   "dave@recoil.org"
 authors:      [
   "Vincent Hanquez"
   "Thomas Gazagnaire"
@@ -17,7 +17,8 @@ remove:  ["ocamlfind" "remove" "xenstore"]
 
 depends: [
   "ocamlfind" {build}
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "camlp4"
   "ocamlbuild" {build}


### PR DESCRIPTION
- only cstruct <= 1.9.0 will create cstruct.syntax, and only if
  type_conv is installed. See [mirage/ocaml-cstruct#95]
- correct maintainer email address (was @eu.citrix.com, now @recoil.org)
- opam lint old metadata

Signed-off-by: David Scott <dave@recoil.org>