### PR TITLE
Tidy up shared-memory-ring packages

### DIFF
--- a/packages/shared-memory-ring/shared-memory-ring.0.2.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.2.0/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.0.2.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.2.0/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.6.0"}

--- a/packages/shared-memory-ring/shared-memory-ring.0.2.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.2.0/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.0.3.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.3.0/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.0.3.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.3.0/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.6.0"}

--- a/packages/shared-memory-ring/shared-memory-ring.0.3.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.3.0/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.0.3.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.3.1/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.0.3.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.3.1/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.6.0"}

--- a/packages/shared-memory-ring/shared-memory-ring.0.3.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.3.1/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.0/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.0/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.6.0"}

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.0/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.1/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.1/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.6.0"}

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.1/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.2/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.2/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.2/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.2/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.6.0"}

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.2/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.2/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.3/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.3/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.3/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.3/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.7.1"}

--- a/packages/shared-memory-ring/shared-memory-ring.0.4.3/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.0.4.3/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {>= "0.7.1" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.1.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.0.0/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -17,4 +22,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.1.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.0.0/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.7.1"}

--- a/packages/shared-memory-ring/shared-memory-ring.1.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.0.0/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {>= "0.7.1" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.1.1.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.1.0/opam
@@ -8,8 +8,8 @@ license:      "ISC"
 tags:         [ "org:mirage" "org:xapi-project"]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.7.1"}

--- a/packages/shared-memory-ring/shared-memory-ring.1.1.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.1.0/opam
@@ -1,9 +1,11 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+maintainer:   "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
+tags:         [ "org:mirage" "org:xapi-project"]
 build: [
   [make "all"]
   [make "install"]
@@ -17,4 +19,3 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/shared-memory-ring"

--- a/packages/shared-memory-ring/shared-memory-ring.1.1.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.1.0/opam
@@ -12,7 +12,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {>= "0.7.1" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring/shared-memory-ring.1.1.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.1.1/opam
@@ -11,8 +11,8 @@ tags: [
 ]
 build: [
   [make "all"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
   "cstruct" {>= "0.7.1"}

--- a/packages/shared-memory-ring/shared-memory-ring.1.1.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.1.1/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
+authors:      ["Anil Madhavapeddy" "David Scott"]
+homepage:     "https://github.com/mirage/shared-memory-ring"
+bug-reports:  "https://github.com/mirage/shared-memory-ring/issues"
+dev-repo:     "https://github.com/mirage/shared-memory-ring.git"
+license:      "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/shared-memory-ring/shared-memory-ring.1.1.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.1.1/opam
@@ -15,7 +15,8 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "shared-memory-ring"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "lwt"
   "ocamlfind"
   "ounit"


### PR DESCRIPTION
- all old versions are `opam lint` clean
- maintainer email address corrected
- add upper-bound on `cstruct` which is about to drop support for camlp4