### PR TITLE
Add cstruct upper bounds to older mirage-profile packages

### DIFF
--- a/packages/mirage-profile/mirage-profile.0.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.1/opam
@@ -18,7 +18,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "ocplib-endian"
   "io-page"
   "lwt"

--- a/packages/mirage-profile/mirage-profile.0.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.1/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 name: "mirage-profile"
 version: "0.1"
-available: [ ocaml-version >= "4.01" ]
+available: [ ocaml-version >= "4.01" & os != "darwin" ]
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://github.com/mirage/mirage-profile"

--- a/packages/mirage-profile/mirage-profile.0.3/opam
+++ b/packages/mirage-profile/mirage-profile.0.3/opam
@@ -18,7 +18,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "ocplib-endian"
   "io-page"
   "lwt"

--- a/packages/mirage-profile/mirage-profile.0.3/opam
+++ b/packages/mirage-profile/mirage-profile.0.3/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 name: "mirage-profile"
 version: "0.3"
-available: [ ocaml-version >= "4.00" ]
+available: [ ocaml-version >= "4.00" & os != "darwin" ]
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://github.com/mirage/mirage-profile"

--- a/packages/mirage-profile/mirage-profile.0.4/opam
+++ b/packages/mirage-profile/mirage-profile.0.4/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 name: "mirage-profile"
 version: "0.4"
-available: [ ocaml-version >= "4.00" ]
+available: [ ocaml-version >= "4.00" & os != "darwin" ]
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://github.com/mirage/mirage-profile"

--- a/packages/mirage-profile/mirage-profile.0.4/opam
+++ b/packages/mirage-profile/mirage-profile.0.4/opam
@@ -18,7 +18,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "ocplib-endian"
   "io-page"
   "lwt"

--- a/packages/mirage-profile/mirage-profile.0.5/opam
+++ b/packages/mirage-profile/mirage-profile.0.5/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-available: [ ocaml-version >= "4.00" ]
+available: [ ocaml-version >= "4.00" & os != "darwin" ]
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://github.com/mirage/mirage-profile"

--- a/packages/mirage-profile/mirage-profile.0.5/opam
+++ b/packages/mirage-profile/mirage-profile.0.5/opam
@@ -15,7 +15,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "ocplib-endian"
   "io-page"
   "lwt"

--- a/packages/mirage-profile/mirage-profile.0.6.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.6.1/opam
@@ -17,7 +17,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "ocplib-endian"
   "io-page"
   "lwt"

--- a/packages/mirage-profile/mirage-profile.0.6/opam
+++ b/packages/mirage-profile/mirage-profile.0.6/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-available: [ ocaml-version >= "4.00" ]
+available: [ ocaml-version >= "4.00" & os != "darwin" ]
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://github.com/mirage/mirage-profile"

--- a/packages/mirage-profile/mirage-profile.0.6/opam
+++ b/packages/mirage-profile/mirage-profile.0.6/opam
@@ -17,7 +17,8 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "ocplib-endian"
   "io-page"
   "lwt"


### PR DESCRIPTION
See [mirage/ocaml-cstruct#95]: the next version of cstruct will
drop support for camlp4.

/cc @talex5