### PR TITLE
lpi.0.0.2 - via opam-publish

### DIFF
--- a/packages/lpi/lpi.0.0.2/descr
+++ b/packages/lpi/lpi.0.0.2/descr
@@ -1,0 +1,4 @@
+A REPL and library for a small dependently-typed language.
+lpi is a small dependently-typed language supporting dependent
+lists and dependent function spaces, and intends to grow into
+a fully featured, statically-checked programming language.

--- a/packages/lpi/lpi.0.0.2/opam
+++ b/packages/lpi/lpi.0.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Sam Baxter <baxtersa14@gmail.com>"
+authors: "Sam Baxter <baxtersa14@gmail.com>"
+homepage: "http://github.com/baxtersa/lambda-pi"
+bug-reports: "http://github.com/baxtersa/lambda-pi/issues"
+license: "MIT"
+dev-repo: "https://github.com/baxtersa/lambda-pi.git"
+build: [
+  ["ocamllex" "src/lexer.mll"]
+  ["ocamlyacc" "src/parser.mly"]
+  [make "-C" "src/" "depend"]
+  [make "-C" "src/"]
+  [make "-C" "src/" "lpi"]
+]
+install: [make "-C" "src/" "install"]
+remove: ["ocamlfind" "remove" "lpi"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/lpi/lpi.0.0.2/url
+++ b/packages/lpi/lpi.0.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/baxtersa/lambda-pi/archive/v0.0.2.tar.gz"
+checksum: "7a6b764fb591a8f0c064af3015dc75f3"


### PR DESCRIPTION
A REPL and library for a small dependently-typed language.
lpi is a small dependently-typed language supporting dependent
lists and dependent function spaces, and intends to grow into
a fully featured, statically-checked programming language.

---
* Homepage: http://github.com/baxtersa/lambda-pi
* Source repo: https://github.com/baxtersa/lambda-pi.git
* Bug tracker: http://github.com/baxtersa/lambda-pi/issues

---

Pull-request generated by opam-publish v0.3.1