### PR TITLE
xenctrl.0.9.30: clarify license

### DIFF
--- a/packages/xenctrl/xenctrl.0.9.30/opam
+++ b/packages/xenctrl/xenctrl.0.9.30/opam
@@ -15,7 +15,7 @@ authors: [
 ]
 homepage: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs"
 bug-reports: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/issues"
-license: "LGPL"
+license: "LGPL-2.1+ with OCaml linking exception"
 dev-repo: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs.git"
 tags: [
   "org:mirage"


### PR DESCRIPTION
It's not simply "LGPL": it's a particular version with the OCaml
linking exception.

Signed-off-by: David Scott <dave@recoil.org>