### PR TITLE
mirage.2.7.1 - via opam-publish

### DIFF
--- a/packages/mirage/mirage.2.7.1/descr
+++ b/packages/mirage/mirage.2.7.1/descr
@@ -1,0 +1,12 @@
+The MirageOS library operating system
+
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.

--- a/packages/mirage/mirage.2.7.1/opam
+++ b/packages/mirage/mirage.2.7.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
+]
+homepage: "http://http://www.openmirage.org/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/mirage.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--bindir" bin]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["rm" "-f" "%{bin}%/mirage"]
+  ["ocamlfind" "remove" "mirage"]
+]
+depends: [
+  "mirage-types-lwt"
+  "mirage-types" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0"}
+  "functoria"
+  "astring"
+]
+conflicts: [
+  "nocrypto" {< "0.4.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage/mirage.2.7.1/url
+++ b/packages/mirage/mirage.2.7.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage/archive/v2.7.1.tar.gz"
+checksum: "46968154d8c61114c03bf0522231f82c"


### PR DESCRIPTION
The MirageOS library operating system

MirageOS is a library operating system that constructs unikernels for
secure, high-performance network applications across a variety of
cloud computing and mobile platforms. Code can be developed on a
normal OS such as Linux or MacOS X, and then compiled into a
fully-standalone, specialised unikernel that runs under the Xen
hypervisor.

Since Xen powers most public cloud computing infrastructure such as
Amazon EC2 or Rackspace, this lets your servers run more cheaply,
securely and with finer control than with a full software stack.


---
* Homepage: http://http://www.openmirage.org/
* Source repo: https://github.com/mirage/mirage.git
* Bug tracker: https://github.com/mirage/mirage/issues/

---

Pull-request generated by opam-publish v0.3.1