### PR TITLE
Fix stublibs destination for dbm.1.0

### DIFF
--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -8,7 +8,7 @@ build: [
   ["./configure"]
   [make "all"]
   [make "test"]
-  [make "install" "STUBLIBDIR=%{lib}%/stublibs" "LIBDIR=%{lib}%/dbm"]
+  [make "install" "STUBLIBDIR=%{lib}%/ocaml/stublibs" "LIBDIR=%{lib}%/dbm"]
   ["cp" "META" "%{lib}%/dbm"]
 ]
 depends: ["ocamlfind"]


### PR DESCRIPTION
Install may fail if lib/stublibs does not exist. lib/ocaml/stublibs always exist, so it is a safer destination.