### PR TITLE
Fix ocaml-version < 4.01.0

### DIFF
--- a/packages/core/core.109.31.00/opam
+++ b/packages/core/core.109.31.00/opam
@@ -23,7 +23,7 @@ depends: [
   "variantslib" {= "109.15.00"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.01.0" ]
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "https://github.com/janestreet/core.git"
 install: [[make "install"]]


### PR DESCRIPTION
Both earlier and later versions have a constraint ocaml-version < 4.01.0, but not this one. As a result, it tries to install and fails on 4.01.0, because of the new O_CLOEXEC field in Unix.