### PR TITLE
Fix broken stublibs in dbm.1.0

### DIFF
--- a/packages/dbm/dbm.1.0/files/mkdir-stublibs.patch
+++ b/packages/dbm/dbm.1.0/files/mkdir-stublibs.patch
@@ -1,0 +1,17 @@
+diff -C 2 -r -w camldbm-1.0.orig/Makefile camldbm-1.0/Makefile
+*** camldbm-1.0.orig/Makefile	2011-11-22 16:56:49.000000000 +0100
+--- camldbm-1.0/Makefile	2016-03-18 15:26:56.032475666 +0100
+***************
+*** 58,62 ****
+  
+  install::
+! 	if test -f dllcamldbm.$(SO); then cp dllcamldbm.$(SO) $(STUBLIBDIR)/; fi 
+  	cp libcamldbm.$(A) $(LIBDIR)/
+  	cd $(LIBDIR) && ranlib libcamldbm.$(A)
+--- 58,62 ----
+  
+  install::
+! 	if test -f dllcamldbm.$(SO); then mkdir $(STUBLIBDIR) || echo Ok; cp dllcamldbm.$(SO) $(STUBLIBDIR)/; fi 
+  	cp libcamldbm.$(A) $(LIBDIR)/
+  	cd $(LIBDIR) && ranlib libcamldbm.$(A)
+Only in camldbm-1.0: Makefile~

--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -19,4 +19,5 @@ depexts: [
 patches: [
   "hasgotfix.patch"
   "include_fix.patch"
+  "mkdir-stublibs.patch"
 ]


### PR DESCRIPTION
lib/stublibs may be missing, so a patch is added to create the directory if needed.
