### PR TITLE
scrypt-kdf.0.1.0 - via opam-publish

### DIFF
--- a/packages/scrypt-kdf/scrypt-kdf.0.1.0/descr
+++ b/packages/scrypt-kdf/scrypt-kdf.0.1.0/descr
@@ -1,0 +1,3 @@
+The scrypt Password-Based Key Derivation Function in pure OCaml
+
+A pure OCaml implementation of scrypt password based key derivation function, as defined in The scrypt Password-Based Key Derivation Function internet draft, including test cases from the RFC. It also includes a pure OCaml implementation of Salsa20 Core functions, both Salsa20/20 Core and the reduced Salsa20/8 Core (required by scrypt) and Salsa20/12 Core functions, including test cases from the spec.

--- a/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+authors: [
+  "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+  "Sonia Meruelo <smeruelo@gmail.com>"
+]
+homepage: "https://github.com/abeaumont/ocaml-scrypt-kdf"
+bug-reports: "https://github.com/abeaumont/ocaml-scrypt-kdf/issues"
+license: "BSD2"
+dev-repo: "https://github.com/abeaumont/ocaml-scrypt-kdf.git"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+  "alcotest=false"
+]
+build-test: [
+  [
+    "ocaml"
+    "pkg/build.ml"
+    "native=%{ocaml-native}%"
+    "native-dynlink=%{ocaml-native-dynlink}%"
+    "alcotest=true"
+  ]
+  ["sh" "-exc" "./run_tests.sh"]
+]
+depends: [
+  "ocamlfind" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.0"}
+  "pbkdf" {>= "0.1.0"}
+  "alcotest" {test}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/scrypt-kdf/scrypt-kdf.0.1.0/url
+++ b/packages/scrypt-kdf/scrypt-kdf.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/abeaumont/ocaml-scrypt-kdf/archive/0.1.0.tar.gz"
+checksum: "dfb4a5028fa8bd5735a65a994ccad911"


### PR DESCRIPTION
The scrypt Password-Based Key Derivation Function in pure OCaml

A pure OCaml implementation of scrypt password based key derivation function, as defined in The scrypt Password-Based Key Derivation Function internet draft, including test cases from the RFC. It also includes a pure OCaml implementation of Salsa20 Core functions, both Salsa20/20 Core and the reduced Salsa20/8 Core (required by scrypt) and Salsa20/12 Core functions, including test cases from the spec.

---
* Homepage: https://github.com/abeaumont/ocaml-scrypt-kdf
* Source repo: https://github.com/abeaumont/ocaml-scrypt-kdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-scrypt-kdf/issues

---

Pull-request generated by opam-publish v0.3.1