### PR TITLE
vmnet: add upper-bounds on cstruct (for cstruct.syntax)

### DIFF
--- a/packages/vmnet/vmnet.1.0.0/opam
+++ b/packages/vmnet/vmnet.1.0.0/opam
@@ -15,10 +15,11 @@ remove: ["ocamlfind" "remove" "vmnet"]
 depends: [
   "ocamlfind" {build}
   "camlp4" {build}
+  "type_conv" {build}
   "sexplib" {< "113.24.00"}
   "ipaddr" {>= "2.5.0"}
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.4.0"}
+  "cstruct" {>= "1.4.0" & <= "1.9.0"}
   "ocamlbuild" {build}
 ]
 available: [ os = "darwin" ]

--- a/packages/vmnet/vmnet.1.0.1/opam
+++ b/packages/vmnet/vmnet.1.0.1/opam
@@ -15,10 +15,11 @@ remove: ["ocamlfind" "remove" "vmnet"]
 depends: [
   "ocamlfind" {build}
   "camlp4" {build}
+  "type_conv" {build}
   "sexplib" {< "113.24.00"}
   "ipaddr" {>= "2.5.0"}
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.4.0"}
+  "cstruct" {>= "1.4.0" & <= "1.9.0"}
   "ocamlbuild" {build}
 ]
 available: [ os = "darwin" ]

--- a/packages/vmnet/vmnet.1.0.2/opam
+++ b/packages/vmnet/vmnet.1.0.2/opam
@@ -15,10 +15,11 @@ remove: ["ocamlfind" "remove" "vmnet"]
 depends: [
   "ocamlfind" {build}
   "camlp4" {build}
+  "type_conv" {build}
   "sexplib" {< "113.24.00"}
   "ipaddr" {>= "2.5.0"}
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.4.0"}
+  "cstruct" {>= "1.4.0" & <= "1.9.0"}
   "ocamlbuild" {build}
 ]
 available: [ os = "darwin" ]


### PR DESCRIPTION
This is part of the great cstruct.syntax purge, see
[mirage/ocaml-cstruct#95]

Signed-off-by: David Scott <dave@recoil.org>