### PR TITLE
ocaml-protoc.0.1.2 - via opam-publish

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.0.1.2/descr
+++ b/packages/ocaml-protoc/ocaml-protoc.0.1.2/descr
@@ -1,0 +1,4 @@
+A Protobuf Compiler for OCaml
+
+'ocaml-protoc' is a compiler of Protobuf file (.proto) to OCaml code. 
+The compiler generate OCaml types with associated decoding/encoding functions following the Protobuf format.

--- a/packages/ocaml-protoc/ocaml-protoc.0.1.2/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.0.1.2/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors: [
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+license: "MIT"
+dev-repo: "https://github.com/mransan/ocaml-protoc.git"
+build: [
+  [make "lib.byte"]
+  [make "lib.native"] {ocaml-native}
+  [make "bin.byte"] {!ocaml-native}
+  [make "bin.native"] {ocaml-native}
+]
+install: [
+  [make "lib.install"]
+  [make "bin.install" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
+]
+remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_deriving_protobuf"
+]

--- a/packages/ocaml-protoc/ocaml-protoc.0.1.2/url
+++ b/packages/ocaml-protoc/ocaml-protoc.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mransan/ocaml-protoc/archive/0.1.2.1.tar.gz"
+checksum: "f944b45ebc78a663770e6ff765c5f07c"


### PR DESCRIPTION
A Protobuf Compiler for OCaml

'ocaml-protoc' is a compiler of Protobuf file (.proto) to OCaml code. 
The compiler generate OCaml types with associated decoding/encoding functions following the Protobuf format.


---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---

Pull-request generated by opam-publish v0.3.1