### PR TITLE
nocrypto.0.5.3 - via opam-publish

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.3/descr
+++ b/packages/nocrypto/nocrypto.0.5.3/descr
@@ -1,0 +1,6 @@
+Small functional-style crypto library.
+
+Ciphers: AES, 3DES, RC4.
+Hashes: MD5, SHA1, SHA2.
+Pubkey: RSA, DH, DSA.
+Rng: Fortuna.

--- a/packages/nocrypto/nocrypto.0.5.3/opam
+++ b/packages/nocrypto/nocrypto.0.5.3/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+homepage:     "https://github.com/mirleft/ocaml-nocrypto"
+dev-repo:     "https://github.com/mirleft/ocaml-nocrypto.git"
+bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"
+author:       "David Kaloper <david@numm.org>"
+maintainer:   "David Kaloper <david@numm.org>"
+license:      "BSD2"
+
+build: [
+  [ "./configure" "--prefix" prefix
+     "--%{lwt:enable}%-lwt"
+     "--%{mirage-xen+mirage-entropy-xen:enable}%-xen" ]
+  [ make ]
+]
+install: [ make "install" ]
+remove:  [ "ocamlfind" "remove" "nocrypto" ]
+
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "ocamlbuild" {build}
+  "cstruct" {>= "1.6.0"}
+  "zarith"
+  "sexplib"
+  "ppx_sexp_conv"
+  ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy-xen" & "zarith-xen"))
+  "ounit" {test}
+]
+
+depopts: [
+  "lwt"
+]
+
+conflicts: [
+  "mirage-xen" {<"2.2.0"}
+  "mirage-entropy-xen" {<"0.3.0"}
+]
+
+build-test: [
+  [ "./configure" "--%{ounit:enable}%-tests" ]
+  [ make "test" ]
+]
+
+tags: [ "org:mirage" ]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/nocrypto/nocrypto.0.5.3/url
+++ b/packages/nocrypto/nocrypto.0.5.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirleft/ocaml-nocrypto/archive/v0.5.3.tar.gz"
+checksum: "1b771555139c23da4fdf02244fc7b4a9"


### PR DESCRIPTION
Small functional-style crypto library.

Ciphers: AES, 3DES, RC4.
Hashes: MD5, SHA1, SHA2.
Pubkey: RSA, DH, DSA.
Rng: Fortuna.


---
* Homepage: https://github.com/mirleft/ocaml-nocrypto
* Source repo: https://github.com/mirleft/ocaml-nocrypto.git
* Bug tracker: https://github.com/mirleft/ocaml-nocrypto/issues

---

Pull-request generated by opam-publish v0.3.1