### PR TITLE
mirage-dns: add dependency on tcpip

### DIFF
--- a/packages/mirage-dns/mirage-dns.2.5.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.5.0/opam
@@ -21,5 +21,6 @@ depends: [
   "mirage-types-lwt" {>= "2.3.0"}
   "lwt"              {>= "2.4.3"}
   "cstruct"          {>= "1.0.0"}
+  "tcpip"
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
Without this dependency, `conduit` fails to build with this error:
```
ocamlfind: Package `tcpip' not found - required by `dns.mirage'
```
