### PR TITLE
rdf.0.10.0 - via opam-publish

### DIFF
--- a/packages/rdf/rdf.0.10.0/descr
+++ b/packages/rdf/rdf.0.10.0/descr
@@ -1,0 +1,13 @@
+Native OCaml implementation of RDF Graphs and Sparql 1.1 Query.
+
+Implemented features
+
+- Three storages available: in memory, in a MySQL or in a Postgresql database,
+- Ability to define your own storages,
+- Transactions,
+- Importing from and exporting to RDF/XML and Turtle formats,
+- Executing Sparql 1.1 queries,
+- HTTP binding of the Sparql protocol, using Lwt.
+
+
+

--- a/packages/rdf/rdf.0.10.0/opam
+++ b/packages/rdf/rdf.0.10.0/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/ocaml-rdf/"
+license: "GNU Lesser General Public License version 3"
+doc: "http://zoggy.github.io/ocaml-rdf/doc.html"
+dev-repo: "https://github.com/zoggy/ocaml-rdf.git"
+bug-reports: "https://github.com/zoggy/ocaml-rdf/issues"
+tags: ["rdf" "semantic web" "xml" "turtle" "graph" "sparql" "utf8"]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "rdf"]
+depends: [
+  "ocamlfind"
+  "xmlm" {>= "1.1.1"}
+  "sedlex" {>= "1.99.2"}
+  "menhir" {>= "20151112"}
+  "uuidm" {>= "0.9.5"}
+  "cryptokit" {>= "1.7"}
+  "pcre" {>= "7.0.2"}
+  "yojson" {>= "1.1.8"}
+  "iri" {>= "0.2.0"}
+  "uri" {>= "1.9.1"}
+  "calendar" {>= "2.03.2"}
+]
+depopts: ["mysql" "postgresql" "cohttp" "lwt"]
+conflicts: [
+  "cohttp" {< "0.11.2"}
+  "lwt" {< "2.4.5"}
+  "mysql" {< "1.1.1"}
+]
+available: [ocaml-version >= "4.02.2"]
+

--- a/packages/rdf/rdf.0.10.0/url
+++ b/packages/rdf/rdf.0.10.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/ocaml-rdf/archive/0.10.0.tar.gz"
+checksum: "9fad8205b792f3643382454d5637acb5"


### PR DESCRIPTION
Native OCaml implementation of RDF Graphs and Sparql 1.1 Query.

Implemented features

- Three storages available: in memory, in a MySQL or in a Postgresql database,
- Ability to define your own storages,
- Transactions,
- Importing from and exporting to RDF/XML and Turtle formats,
- Executing Sparql 1.1 queries,
- HTTP binding of the Sparql protocol, using Lwt.





---
* Homepage: http://zoggy.github.io/ocaml-rdf/
* Source repo: https://github.com/zoggy/ocaml-rdf.git
* Bug tracker: https://github.com/zoggy/ocaml-rdf/issues

---

Pull-request generated by opam-publish v0.3.1