### PR TITLE
Add camlp4 dependencies to 0install

### DIFF
--- a/packages/0install/0install.2.6.2/opam
+++ b/packages/0install/0install.2.6.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ssl"
   "ocurl"
   "ocamlbuild" {build}
+  "camlp4" {build}
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [

--- a/packages/0install/0install.2.8/opam
+++ b/packages/0install/0install.2.8/opam
@@ -15,6 +15,7 @@ depends: [
   "ocurl"
   "sha"
   "ocamlbuild" {build}
+  "camlp4" {build}
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [

--- a/packages/0install/0install.2.8/opam
+++ b/packages/0install/0install.2.8/opam
@@ -22,4 +22,4 @@ depexts: [
   [["ubuntu"] ["unzip"]]
   [["debian"] ["unzip"]]
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.02" ]

--- a/packages/0install/0install.2.9.1/opam
+++ b/packages/0install/0install.2.9.1/opam
@@ -17,6 +17,7 @@ depends: [
   "ocurl"
   "sha"
   "ocamlbuild" {build}
+  "camlp4" {build}
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [


### PR DESCRIPTION
From http://opam.ocamlpro.com/builder/html/0install/0install.2.9.1/54c0565def1a887ad67b0c73e2dd83c0,
 0install seems to lack a direct dependency to camlp4.
