### PR TITLE
stog-rdf.0.16.1 - via opam-publish

### DIFF
--- a/packages/stog-rdf/stog-rdf.0.16.1/descr
+++ b/packages/stog-rdf/stog-rdf.0.16.1/descr
@@ -1,0 +1,5 @@
+Plugin for Stog. Define and query RDF graphs in rewrite rules.
+
+This plugin allows to use RDF graphs to generate parts of
+documents and to generate RDF graphs from elements in
+documents.

--- a/packages/stog-rdf/stog-rdf.0.16.1/opam
+++ b/packages/stog-rdf/stog-rdf.0.16.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: ["Maxence Guesdon"]
+homepage: "http://zoggy.github.io/stog/plugins/rdf.html"
+
+license: "GNU General Public License version 3"
+doc: ["http://zoggy.github.io/stog/plugins/rdf.html"]
+dev-repo: "https://github.com/zoggy/stog-rdf.git"
+bug-reports: "https://github.com/zoggy/stog-rdf/issues"
+
+tags: ["publication" "rdf" "sparql" "semantic web"]
+build: [
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "stog-rdf"]]
+depends: [
+  "stog" {= "0.16.0"}
+  "rdf" {>= "0.10.0"}
+]
+
+available: [ocaml-version >= "4.02.1"]

--- a/packages/stog-rdf/stog-rdf.0.16.1/url
+++ b/packages/stog-rdf/stog-rdf.0.16.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/stog-rdf/archive/0.16.1.tar.gz"
+checksum: "c5ceda5190eb8c0333e795cc7d1b7d31"


### PR DESCRIPTION
Plugin for Stog. Define and query RDF graphs in rewrite rules.

This plugin allows to use RDF graphs to generate parts of
documents and to generate RDF graphs from elements in
documents.

---
* Homepage: http://zoggy.github.io/stog/plugins/rdf.html
* Source repo: https://github.com/zoggy/stog-rdf.git
* Bug tracker: https://github.com/zoggy/stog-rdf/issues

---

Pull-request generated by opam-publish v0.3.1