### PR TITLE
Add tcpip.2.7.0

### DIFF
--- a/packages/tcpip/tcpip.2.7.0/descr
+++ b/packages/tcpip/tcpip.2.7.0/descr
@@ -1,0 +1,5 @@
+Userlevel TCP/IP stack
+
+The library provides a networking stack for the MirageOS
+library operating system that supports IPv4, IPv6, ARPv4,
+DHCPv4 and TCP/IP.

--- a/packages/tcpip/tcpip.2.7.0/opam
+++ b/packages/tcpip/tcpip.2.7.0/opam
@@ -1,0 +1,68 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+authors: [
+  "Anil Madhavapeddy"
+  "Balraj Singh"
+  "Richard Mortier"
+  "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire"
+  "Vincent Bernardoff"
+  "Magnus Skjegstad"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "David Scott"
+  "Gabor Pali"
+  "Hannes Mehnert"
+  "Haris Rotsos"
+  "Kia"
+  "Luke Dunstan"
+  "Pablo Polvorin"
+  "Tim Cuthbertson"
+  "lnmx"
+  "pqwy"
+]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["./configure" "--prefix" prefix
+    "--%{mirage-xen:enable}%-xen"
+    "--%{mirage-net-unix:enable}%-unix"
+  ]
+  [make]
+]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test" "TESTFLAGS=-v"]
+]
+
+install: [make "install"]
+remove: ["ocamlfind" "remove" "tcpip"]
+depends: [
+  "ocamlfind" {build}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "channel"
+  "mirage-types" {>= "2.6.0"}
+  "mirage-unix" {>= "1.1.0"}
+  "mirage-console"
+  "mirage-clock-unix" {>= "1.0.0"}
+  "ipaddr" {>= "2.2.0"}
+  "mirage-profile" {>= "0.5"}
+  "mirage-flow" {test}
+  "mirage-vnetif" {test}
+  "alcotest" {test}
+  "pcap-format" {test}
+  "lwt" {>= "2.4.7"}
+]
+depopts: [
+  "mirage-xen"
+  "mirage-net-unix"
+]
+conflicts: [
+  "mirage-net-unix" { < "1.1.0" }
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/tcpip/tcpip.2.7.0/url
+++ b/packages/tcpip/tcpip.2.7.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-tcpip/archive/v2.7.0.tar.gz"
+checksum: "2cafb834f1440088ca9689577a7dc3e6"


### PR DESCRIPTION
This is part of the great cstruct.syntax purge, see
[mirage/ocaml-cstruct#95]

Signed-off-by: David Scott <dave@recoil.org>