### PR TITLE
ordma.0.0.1 - via opam-publish

### DIFF
--- a/packages/ordma/ordma.0.0.1/descr
+++ b/packages/ordma/ordma.0.0.1/descr
@@ -1,0 +1,1 @@
+ordma provides ocaml bindings to librdmacm (rsocket)

--- a/packages/ordma/ordma.0.0.1/opam
+++ b/packages/ordma/ordma.0.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
+authors: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
+homepage: "https://github.com/toolslive/ordma"
+bug-reports: "https://github.com/toolslive/ordma/issues"
+license: "TBD"
+dev-repo: "https://github.com/toolslive/ordma"
+build: [make "lib"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "lwt" {>= "2.5.1"}
+]
+depexts: [
+  [["ubuntu"] ["librdmacm-dev"]]
+]
+available: [os = "linux" & ocaml-version >= "4.02.0"]

--- a/packages/ordma/ordma.0.0.1/url
+++ b/packages/ordma/ordma.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/toolslive/ordma/archive/0.0.1.tar.gz"
+checksum: "245fda663419cfd44d3d67c59a820f33"


### PR DESCRIPTION
ordma provides ocaml bindings to librdmacm (rsocket)


---
* Homepage: https://github.com/toolslive/ordma
* Source repo: https://github.com/toolslive/ordma
* Bug tracker: https://github.com/toolslive/ordma/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1