### PR TITLE
cmark.0.2.0 - via opam-publish

### DIFF
--- a/packages/cmark/cmark.0.2.0/descr
+++ b/packages/cmark/cmark.0.2.0/descr
@@ -1,0 +1,1 @@
+OCaml bindings for the CMark Common Markdown parsing and rendering library.

--- a/packages/cmark/cmark.0.2.0/opam
+++ b/packages/cmark/cmark.0.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Jonathan Chan <jyc@fastmail.fm>"
+authors: "Jonathan Chan <jyc@fastmail.fm>"
+homepage: "https://github.com/jonathanyc/ocaml-cmark"
+bug-reports: "https://github.com/jonathanyc/ocaml-cmark/issues"
+license: "BSD 2-Clause"
+dev-repo: "git@github.com:jonathanyc/ocaml-cmark.git"
+install: ["./car" "lib"]
+remove: ["./car" "unlib"]
+depends: [
+  "ocamlfind" {build}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+depexts: [
+  ["homebrew" "osx"]
+  ["cmark"]
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/cmark/cmark.0.2.0/url
+++ b/packages/cmark/cmark.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jonathanyc/ocaml-cmark/archive/0.2.0.tar.gz"
+checksum: "a1d0979deee4c059852f7b3d5b06cf10"


### PR DESCRIPTION
OCaml bindings for the CMark Common Markdown parsing and rendering library.


---
* Homepage: https://github.com/jonathanyc/ocaml-cmark
* Source repo: git@github.com:jonathanyc/ocaml-cmark.git
* Bug tracker: https://github.com/jonathanyc/ocaml-cmark/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1