### PR TITLE
BetterErrors.0.0.1 - via opam-publish

### DIFF
--- a/packages/BetterErrors/BetterErrors.0.0.1/descr
+++ b/packages/BetterErrors/BetterErrors.0.0.1/descr
@@ -1,0 +1,4 @@
+Better compiler error output.
+
+Pipe in the text of OCaml compiler errors; it'll output them prettified.
+https://github.com/chenglou/BetterErrors

--- a/packages/BetterErrors/BetterErrors.0.0.1/opam
+++ b/packages/BetterErrors/BetterErrors.0.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Cheng Lou <chenglou92@gmail.com>"
+authors: "Cheng Lou <chenglou92@gmail.com>"
+homepage: "https://github.com/chenglou/BetterErrors"
+bug-reports: "https://github.com/chenglou/BetterErrors"
+license: "MIT"
+dev-repo: "https://github.com/chenglou/BetterErrors.git"
+available: [ocaml-version >= "4.02.1"]
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ANSITerminal" {>= "0.6.5"}
+  "re" {>= "1.5.0"}
+]

--- a/packages/BetterErrors/BetterErrors.0.0.1/url
+++ b/packages/BetterErrors/BetterErrors.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/chenglou/BetterErrors/archive/v0.0.1.tar.gz"
+checksum: "aaac92a8c9a6078f4264454c0053e98f"


### PR DESCRIPTION
Better compiler error output.

Pipe in the text of OCaml compiler errors; it'll output them prettified.
https://github.com/chenglou/BetterErrors

---
* Homepage: https://github.com/chenglou/BetterErrors
* Source repo: https://github.com/chenglou/BetterErrors.git
* Bug tracker: https://github.com/chenglou/BetterErrors

---

Pull-request generated by opam-publish v0.3.1