### PR TITLE
pcap-format updates

### DIFF
--- a/packages/pcap-format/pcap-format.0.3.1/opam
+++ b/packages/pcap-format/pcap-format.0.3.1/opam
@@ -1,11 +1,21 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-pcap"
+dev-repo:     "https://github.com/mirage/ocaml-pcap.git"
+bug-reports:  "https://github.com/mirage/ocaml-pcap/issues"
+authors: [
+  "Anil Madhavapeddy"
+  "Dave Scott"
+  "Richard Mortier"
+]
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make]
+]
+install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pcap"]]

--- a/packages/pcap-format/pcap-format.0.3.2/opam
+++ b/packages/pcap-format/pcap-format.0.3.2/opam
@@ -1,11 +1,21 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-pcap"
+dev-repo:     "https://github.com/mirage/ocaml-pcap.git"
+bug-reports:  "https://github.com/mirage/ocaml-pcap/issues"
+authors: [
+  "Anil Madhavapeddy"
+  "Dave Scott"
+  "Richard Mortier"
+]
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make]
+]
+install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pcap"]]

--- a/packages/pcap-format/pcap-format.0.3.3/opam
+++ b/packages/pcap-format/pcap-format.0.3.3/opam
@@ -1,11 +1,21 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-pcap"
+dev-repo:     "https://github.com/mirage/ocaml-pcap.git"
+bug-reports:  "https://github.com/mirage/ocaml-pcap/issues"
+authors: [
+  "Anil Madhavapeddy"
+  "Dave Scott"
+  "Richard Mortier"
+]
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
   [make]
+]
+install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pcap-format"]]
@@ -20,4 +30,3 @@ conflicts: [
   "mirage-net-socket"
   "mirage" {< "0.9.2"}
 ]
-dev-repo: "git://github.com/mirage/ocaml-pcap"

--- a/packages/pcap-format/pcap-format.0.3.3/opam
+++ b/packages/pcap-format/pcap-format.0.3.3/opam
@@ -21,7 +21,8 @@ install: [
 remove: [["ocamlfind" "remove" "pcap-format"]]
 depends: [
   "ocamlfind"
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.6.0" & <= "1.9.0"}
+  "type_conv" {build}
   "lwt" {>= "2.4.0"}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
- `opam lint` clean
- add upper bound on cstruct (see [mirage/ocaml-cstruct#95]