### PR TITLE
charrua-core: add upper bounds on cstruct

### DIFF
--- a/packages/charrua-core/charrua-core.0.1/opam
+++ b/packages/charrua-core/charrua-core.0.1/opam
@@ -14,7 +14,8 @@ build: [
 depends: [
   "ocamlfind" {build}
   "lwt"
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "sexplib" {< "113.01.00"}
   "menhir"
   "ipaddr"

--- a/packages/charrua-core/charrua-core.0.2/opam
+++ b/packages/charrua-core/charrua-core.0.2/opam
@@ -13,7 +13,8 @@ build: [
 ]
 depends: [
   "ocamlfind" {build}
-  "cstruct"
+  "cstruct" {<= "1.9.0"}
+  "type_conv" {build}
   "sexplib" {< "113.01.00"}
   "menhir"
   "ipaddr" {>= "2.4.0"}


### PR DESCRIPTION
This is part of the great cstruct.syntax purge, see
[mirage/ocaml-cstruct#95]

Signed-off-by: David Scott <dave@recoil.org>