### PR TITLE
Add missing ocamlbuild dependency for msat.0.2

### DIFF
--- a/packages/msat/msat.0.2/opam
+++ b/packages/msat/msat.0.2/opam
@@ -17,6 +17,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.1"]


### PR DESCRIPTION
I forgot the ocamlbuild dependency when submitting the last version of msat. This rectifies it.