### PR TITLE
aws.1.0.1 - via opam-publish

### DIFF
--- a/packages/aws/aws.1.0.1/descr
+++ b/packages/aws/aws.1.0.1/descr
@@ -1,0 +1,6 @@
+Amazon Web Services SDK
+ocaml-aws is an Amazon Web Services SDK for OCaml. Its source
+distribution includes a core runtime API and a code generation tool
+that generates individual libraries from [botocore][] service
+descriptions.
+

--- a/packages/aws/aws.1.0.1/opam
+++ b/packages/aws/aws.1.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "1.2"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+           "Daniel Patterson <dbp@dbpmail.net>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/ocaml-aws"
+dev-repo: "https://github.com/inhabitedtype/ocaml-aws.git"
+bug-reports: "https://github.com/inhabitedtype/ocaml-aws/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix
+    "--%{lwt+cohttp+ssl:enable}%-lwt"
+    "--%{async+cohttp+async_ssl:enable}%-async"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "aws"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"
+    "--%{lwt+cohttp+ssl:enable}%-lwt"
+    "--%{async+cohttp+async_ssl:enable}%-async"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "calendar"
+  "ezxmlm"
+  "nocrypto"
+  "ocamlfind" {build}
+  "uri"
+]
+depopts: [
+  "async"
+  "async_ssl"
+  "base-threads"
+  "base-unix"
+  "cohttp"
+  "lwt"
+  "ssl"
+]
+conflicts: [
+  "cohttp" {< "0.17.0"}
+]
+available: [ ocaml-version >= "4.01" ]

--- a/packages/aws/aws.1.0.1/url
+++ b/packages/aws/aws.1.0.1/url
@@ -1,0 +1,2 @@
+archive:"https://github.com/inhabitedtype/ocaml-aws/releases/download/aws-1.0.1/aws-1.0.1.tar.gz"
+checksum:"077ac52195a96a3491da0abe71f81b25"


### PR DESCRIPTION
Amazon Web Services SDK
ocaml-aws is an Amazon Web Services SDK for OCaml. Its source
distribution includes a core runtime API and a code generation tool
that generates individual libraries from [botocore][] service
descriptions.



---
* Homepage: https://github.com/inhabitedtype/ocaml-aws
* Source repo: https://github.com/inhabitedtype/ocaml-aws.git
* Bug tracker: https://github.com/inhabitedtype/ocaml-aws/issues

---

Pull-request generated by opam-publish v0.3.1