### PR TITLE
syslog-message.0.0.1 - via opam-publish

### DIFF
--- a/packages/syslog-message/syslog-message.0.0.1/descr
+++ b/packages/syslog-message/syslog-message.0.0.1/descr
@@ -1,0 +1,3 @@
+Syslog Message Parser
+
+This is a library for parsing and generating RFC 3164 compatible Syslog messages.

--- a/packages/syslog-message/syslog-message.0.0.1/opam
+++ b/packages/syslog-message/syslog-message.0.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Jochen Bartl <jochenbartl@mailbox.org>"
+authors: "Jochen Bartl <jochenbartl@mailbox.org>"
+homepage: "https://github.com/verbosemode/syslog-message"
+bug-reports: "https://github.com/verbosemode/syslog-message/issues"
+license: "FreeBSD"
+dev-repo: "https://github.com/verbosemode/syslog-message.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "syslog-message"]
+depends: [
+  "astring"
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+  "ptime"
+  "qcheck" {test}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/syslog-message/syslog-message.0.0.1/url
+++ b/packages/syslog-message/syslog-message.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/verbosemode/syslog-message/archive/0.0.1.tar.gz"
+checksum: "23646fb9778c9f46eef1a0d00799d8f5"


### PR DESCRIPTION
Syslog Message Parser

This is a library for parsing and generating RFC 3164 compatible Syslog messages.


---
* Homepage: https://github.com/verbosemode/syslog-message
* Source repo: https://github.com/verbosemode/syslog-message.git
* Bug tracker: https://github.com/verbosemode/syslog-message/issues

---

Pull-request generated by opam-publish v0.3.1