### PR TITLE
gen_js_api.1.0 - via opam-publish

### DIFF
--- a/packages/gen_js_api/gen_js_api.1.0/descr
+++ b/packages/gen_js_api/gen_js_api.1.0/descr
@@ -1,0 +1,8 @@
+Easy OCaml bindings for Javascript libraries
+
+gen_js_api aims at simplifying the creation of OCaml bindings for
+Javascript libraries.  Authors of bindings write OCaml signatures for
+Javascript libraries and the tool generates the actual binding code
+with a combination of implicit conventions and explicit annotations.
+
+gen_js_api is to be used with the js_of_ocaml compiler.

--- a/packages/gen_js_api/gen_js_api.1.0/opam
+++ b/packages/gen_js_api/gen_js_api.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Alain Frisch <alain.frisch@lexifi.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Sebastien Briais <sebastien.briais@lexifi.com"
+]
+homepage: "https://github.com/LexiFi/gen_js_api"
+bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
+license: "MIT"
+dev-repo: "https://github.com/LexiFi/gen_js_api.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "gen_js_api"]
+depends: [
+  "ocamlfind" {build}
+  "js_of_ocaml"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/gen_js_api/gen_js_api.1.0/url
+++ b/packages/gen_js_api/gen_js_api.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/LexiFi/gen_js_api/archive/v1.0.tar.gz"
+checksum: "da5b4cb35321bbd9ebb84b2c97bd4d80"


### PR DESCRIPTION
Easy OCaml bindings for Javascript libraries

gen_js_api aims at simplifying the creation of OCaml bindings for
Javascript libraries.  Authors of bindings write OCaml signatures for
Javascript libraries and the tool generates the actual binding code
with a combination of implicit conventions and explicit annotations.

gen_js_api is to be used with the js_of_ocaml compiler.


---
* Homepage: https://github.com/LexiFi/gen_js_api
* Source repo: https://github.com/LexiFi/gen_js_api.git
* Bug tracker: https://github.com/LexiFi/gen_js_api/issues

---

Pull-request generated by opam-publish v0.3.1