### PR TITLE
aws-autoscaling.0.1.0 - via opam-publish

### DIFF
--- a/packages/aws-autoscaling/aws-autoscaling.0.1.0/descr
+++ b/packages/aws-autoscaling/aws-autoscaling.0.1.0/descr
@@ -1,0 +1,1 @@
+Auto Scaling

--- a/packages/aws-autoscaling/aws-autoscaling.0.1.0/opam
+++ b/packages/aws-autoscaling/aws-autoscaling.0.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" "Daniel Patterson <dbp@dbpmail.net>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/ocaml-aws"
+dev-repo: "https://github.com/inhabitedtype/ocaml-aws.git"
+bug-reports: "https://github.com/inhabitedtype/ocaml-aws/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "aws-autoscaling"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "aws" {>= "0.1.0"}
+  "ocamlfind" {build}
+]

--- a/packages/aws-autoscaling/aws-autoscaling.0.1.0/url
+++ b/packages/aws-autoscaling/aws-autoscaling.0.1.0/url
@@ -1,0 +1,2 @@
+archive:"https://github.com/inhabitedtype/ocaml-aws/releases/download/aws-1.0.2/aws-autoscaling-0.1.0.tar.gz"
+checksum:"2490e4b74da35ce2444c0f3dc228e695"


### PR DESCRIPTION
Auto Scaling


---
* Homepage: https://github.com/inhabitedtype/ocaml-aws
* Source repo: https://github.com/inhabitedtype/ocaml-aws.git
* Bug tracker: https://github.com/inhabitedtype/ocaml-aws/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1