### PR TITLE
aws-elasticloadbalancing.0.1.0 - via opam-publish

### DIFF
--- a/packages/aws-elasticloadbalancing/aws-elasticloadbalancing.0.1.0/descr
+++ b/packages/aws-elasticloadbalancing/aws-elasticloadbalancing.0.1.0/descr
@@ -1,0 +1,1 @@
+Elastic Load Balancing

--- a/packages/aws-elasticloadbalancing/aws-elasticloadbalancing.0.1.0/opam
+++ b/packages/aws-elasticloadbalancing/aws-elasticloadbalancing.0.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" "Daniel Patterson <dbp@dbpmail.net>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/ocaml-aws"
+dev-repo: "https://github.com/inhabitedtype/ocaml-aws.git"
+bug-reports: "https://github.com/inhabitedtype/ocaml-aws/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "aws-autoscaling"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "aws" {>= "0.1.0"}
+  "ocamlfind" {build}
+]

--- a/packages/aws-elasticloadbalancing/aws-elasticloadbalancing.0.1.0/url
+++ b/packages/aws-elasticloadbalancing/aws-elasticloadbalancing.0.1.0/url
@@ -1,0 +1,2 @@
+archive:"https://github.com/inhabitedtype/ocaml-aws/releases/download/aws-1.0.2/aws-elasticloadbalancing-0.1.0.tar.gz"
+checksum:"0549b85b53590aad6c7ae71b111101ee"


### PR DESCRIPTION
Elastic Load Balancing


---
* Homepage: https://github.com/inhabitedtype/ocaml-aws
* Source repo: https://github.com/inhabitedtype/ocaml-aws.git
* Bug tracker: https://github.com/inhabitedtype/ocaml-aws/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1