### PR TITLE
Fix missing deps and conflicts

### DIFF
--- a/packages/lwt/lwt.2.5.1/opam
+++ b/packages/lwt/lwt.2.5.1/opam
@@ -40,5 +40,6 @@ depopts: [
 conflicts: [
  "react" {<"1.0.0"}
  "ssl" {< "0.5.0"}
+ "camlp4" {= "4.02+7"} (* lacks "camlp4.quotations.o" *)
 ]
 available: [ocaml-version >= "4.01.0" & compiler != "4.02.1+BER"]

--- a/packages/typerex-lldb/typerex-lldb.1.0/opam
+++ b/packages/typerex-lldb/typerex-lldb.1.0/opam
@@ -23,5 +23,6 @@ remove: [
 depends: [
     "ocp-build" {>= "1.99.11-beta"}
     "conf-lldb" {= "3.5" }
+    "lwt"  (* we need lwt.unix *)
   ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03" ]


### PR DESCRIPTION
* typerex-lldb requires lwt.unix
* lwt.2.5.1 conflicts with camlp4.4.02+7 that lacks camlp4.quotations.o