### PR TITLE
Add conf-graphics to check for the Graphics library

### DIFF
--- a/packages/archimedes/archimedes.0.4.13/opam
+++ b/packages/archimedes/archimedes.0.4.13/opam
@@ -17,6 +17,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "archimedes"]]
 depends: [
+  "graphics"
   "ocamlfind"
   "cairo2"
   "ocamlbuild" {build}

--- a/packages/archimedes/archimedes.0.4.15/opam
+++ b/packages/archimedes/archimedes.0.4.15/opam
@@ -18,6 +18,7 @@ build: [
 build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "archimedes"]]
 depends: [
+  "graphics"
   "cairo2"
   "ocamlfind"
   "camlp4"

--- a/packages/archimedes/archimedes.0.4.17/opam
+++ b/packages/archimedes/archimedes.0.4.17/opam
@@ -12,8 +12,9 @@ dev-repo: "http://forge.ocamlcore.org/anonscm/git/archimedes/archimedes.git"
 bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=105"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix
-    "--%{ocamlfind:enable}%-graphics"
-    "--enable-cairo2" { "%{cairo2:installed}%" }]
+    "--%{graphics:enable}%-graphics"
+    "--enable-cairo2" { "%{cairo2:installed}%" }
+  ]
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
@@ -22,7 +23,7 @@ remove: [
 ]
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"
-    "--%{ocamlfind:enable}%-graphics"
+    "--%{graphics:enable}%-graphics"
     "--enable-cairo2" { "%{cairo2:installed}%" }]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
@@ -30,11 +31,11 @@ build-test: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "graphics"
   "ocamlfind" {build}
   "camlp4" {build}
   "ocamlbuild" {build}
 ]
 depopts: [
   "cairo2"
+  "graphics"
 ]

--- a/packages/archimedes/archimedes.0.4.17/opam
+++ b/packages/archimedes/archimedes.0.4.17/opam
@@ -30,6 +30,7 @@ build-test: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
+  "graphics"
   "ocamlfind" {build}
   "camlp4" {build}
   "ocamlbuild" {build}

--- a/packages/graphics/graphics.1.0/descr
+++ b/packages/graphics/graphics.1.0/descr
@@ -1,0 +1,2 @@
+Virtual package to check the availability of the Graphics library
+

--- a/packages/graphics/graphics.1.0/opam
+++ b/packages/graphics/graphics.1.0/opam
@@ -1,0 +1,8 @@
+opam-version: "1"
+maintainer: "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+homepage: "http://www.ocaml.org/"
+license: "LGPL+EXN-BIN"
+build: [["ocamlc" "-custom" "graphics.cma" "-o" "test"]]
+post-messages: [
+  "This package checks whether the Graphics library was compiled." {failure}
+]


### PR DESCRIPTION
archimedes fails to install when Graphics is not available, which is the case of ocaml-3.12.1 compiled with opam on Debian, see:

 http://opam.ocamlpro.com/builder/html/report-last.html#archimedes

I think it is better if the failure is detected earlier using a conf-graphics package.