### PR TITLE
qtest.2.2 - via opam-publish

### DIFF
--- a/packages/qtest/qtest.2.2/descr
+++ b/packages/qtest/qtest.2.2/descr
@@ -1,0 +1,6 @@
+iTeML / qtest : Inline (Unit) Tests for OCaml.
+
+qtest extracts inline unit tests written using a special
+syntax in comments. Those tests are then run using the oUnit framework.
+The possibilities range from trivial tests -- extremely simple to use --
+to sophisticated random generation of test cases.

--- a/packages/qtest/qtest.2.2/files/qtest.install
+++ b/packages/qtest/qtest.2.2/files/qtest.install
@@ -1,0 +1,4 @@
+bin: [
+  "?qtest/_build/qtest.byte" {"qtest"}
+  "?qtest/_build/qtest.native" {"qtest"}
+]

--- a/packages/qtest/qtest.2.2/opam
+++ b/packages/qtest/qtest.2.2/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Vincent Hugot <vincent.hugot@gmail.com>"
+authors: [
+  "Vincent Hugot <vincent.hugot@gmail.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+homepage: "https://github.com/vincent-hugot/iTeML"
+bug-reports: "https://github.com/vincent-hugot/iTeML/issues"
+doc:
+  "https://github.com/vincent-hugot/iTeML/blob/master/README.adoc#introduction"
+tags: ["test" "property" "quickcheck"]
+dev-repo: "git@github.com:vincent-hugot/iTeML.git"
+build: [make "build"]
+install: [make "BIN=%{bin}%" "install"]
+remove: [
+  ["ocamlfind" "remove" "qcheck"]
+  ["rm" "%{bin}%/qtest"]
+]
+depends: [
+  "ocamlfind"
+  "ounit" {>= "2.0.0"}
+  "ocamlbuild" {build}
+  "base-bytes"
+]
+conflicts: "qcheck"
+available: [ocaml-version >= "4.00.0"]

--- a/packages/qtest/qtest.2.2/url
+++ b/packages/qtest/qtest.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vincent-hugot/iTeML/archive/v2.2.tar.gz"
+checksum: "68f9f31932876f5810c3ca37976b8381"


### PR DESCRIPTION
iTeML / qtest : Inline (Unit) Tests for OCaml.

qtest extracts inline unit tests written using a special
syntax in comments. Those tests are then run using the oUnit framework.
The possibilities range from trivial tests -- extremely simple to use --
to sophisticated random generation of test cases.


---
* Homepage: https://github.com/vincent-hugot/iTeML
* Source repo: git@github.com:vincent-hugot/iTeML.git
* Bug tracker: https://github.com/vincent-hugot/iTeML/issues

---

Pull-request generated by opam-publish v0.3.1