### PR TITLE
lwt: fix configure command

### DIFF
--- a/packages/lwt/lwt.2.4.3/opam
+++ b/packages/lwt/lwt.2.4.3/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "jeremie@dimino.org"
 build: [
   ["patch" "-p1" "-i" "4.01cloexec.diff"] {ocaml-version >= "4.01.0"}
-  ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix:enable}%-extra" "--%{base-threads:enable}%-preemptive" "--%{lablgtk:enable}%-glib" "--%{text:enable}%-text" {"%{react:installed}%"}]
+  ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix+base-threads:enable}%-extra" "--%{base-threads:enable}%-preemptive" "--%{lablgtk:enable}%-glib" "--%{text:enable}%-text" {"%{react:installed}%"}]
   [make "build"]
   [make "install"]
 ]

--- a/packages/lwt/lwt.2.4.4/opam
+++ b/packages/lwt/lwt.2.4.4/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "jeremie@dimino.org"
 build: [
-  ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix:enable}%-extra" "--%{base-threads:enable}%-preemptive" "--%{lablgtk:enable}%-glib" "--%{text:enable}%-text" {"%{react:installed}%"}]
+  ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix+base-threads:enable}%-extra" "--%{base-threads:enable}%-preemptive" "--%{lablgtk:enable}%-glib" "--%{text:enable}%-text" {"%{react:installed}%"}]
   [make "build"]
   [make "install"]
 ]

--- a/packages/lwt/lwt.2.4.5/opam
+++ b/packages/lwt/lwt.2.4.5/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "jeremie@dimino.org"
 build: [
-  ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix:enable}%-extra" "--%{base-threads:enable}%-preemptive" "--%{lablgtk:enable}%-glib" "--%{text:enable}%-text" {"%{react:installed}%"}]
+  ["./configure" "--%{conf-libev:enable}%-libev" "--%{react:enable}%-react" "--%{ssl:enable}%-ssl" "--%{base-unix:enable}%-unix" "--%{base-unix+base-threads:enable}%-extra" "--%{base-threads:enable}%-preemptive" "--%{lablgtk:enable}%-glib" "--%{text:enable}%-text" {"%{react:installed}%"}]
   [make "build"]
   [make "install"]
 ]

--- a/packages/lwt/lwt.2.4.6/opam
+++ b/packages/lwt/lwt.2.4.6/opam
@@ -7,7 +7,7 @@ build: [
     "--%{react:enable}%-react"
     "--%{ssl:enable}%-ssl"
     "--%{base-unix:enable}%-unix"
-    "--%{base-unix:enable}%-extra"
+    "--%{base-unix+base-threads:enable}%-extra"
     "--%{base-threads:enable}%-preemptive"
     "--%{lablgtk:enable}%-glib"
     "--%{ppx_tools:enable}%-ppx"]


### PR DESCRIPTION
The configure command line is wrong when base-unix is present and base-threads absent.
