### PR TITLE
http_router.0.1.2 - via opam-publish

### DIFF
--- a/packages/http_router/http_router.0.1.2/descr
+++ b/packages/http_router/http_router.0.1.2/descr
@@ -1,0 +1,3 @@
+Simple http router for cohttp and async.
+
+This is a simple http router for cohttp and async.  It allows you to route http requests to handlers.  Routes can be specified with a DSL that allows you to route constants and regex parts.

--- a/packages/http_router/http_router.0.1.2/opam
+++ b/packages/http_router/http_router.0.1.2/opam
@@ -14,7 +14,7 @@ remove: ["ocamlfind" "remove" "http-router"]
 depends: [
   "ocamlfind" {build}
   "async"
-  "cohttp"
+  "cohttp" {>= "0.15.0"}
   "re"
-  "oUnit" {test}
+  "ounit" {test}
 ]

--- a/packages/http_router/http_router.0.1.2/opam
+++ b/packages/http_router/http_router.0.1.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Brecht Hoflack <brecht.hoflack@gmail.com>"
+authors: "Brecht Hoflack <brecht.hoflack@gmail.com>"
+homepage: "http://github.com/bhoflack/http_router"
+bug-reports: "http://github.com/bhoflack/http_router/issues"
+license: "MIT"
+dev-repo: "http://github.com/bhoflack/http_router.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "http-router"]
+depends: [
+  "ocamlfind" {build}
+  "async"
+  "cohttp"
+  "re"
+  "oUnit" {test}
+]

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "55fb28e7134a304c7847bda3db343143"
+checksum: "ce0090f9cdeb0f42e4a914109c68fbf7"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "5ff7a3cff4f0e1f58fb751749d56714f"
+checksum: "560c0c289ece42c7502e520c56cb21d8"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "560c0c289ece42c7502e520c56cb21d8"
+checksum: "02e83f46236bb09b40741dd53b47eb9d"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "1ef8ed7c06f34cd1c64643b13c724058"
+checksum: "0c8a8b140af075abbda702d9b50bf2d7"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "02e83f46236bb09b40741dd53b47eb9d"
+checksum: "b01b408de11af7612f09b61a7127e8f6"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "ce0090f9cdeb0f42e4a914109c68fbf7"
+checksum: "b12fbcb44441a35a219cd749596285fb"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
+checksum: "5ff7a3cff4f0e1f58fb751749d56714f"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "b01b408de11af7612f09b61a7127e8f6"
+checksum: "1ef8ed7c06f34cd1c64643b13c724058"

--- a/packages/http_router/http_router.0.1.2/url
+++ b/packages/http_router/http_router.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bhoflack/http_router/archive/v0.1.2.zip"
-checksum: "0c8a8b140af075abbda702d9b50bf2d7"
+checksum: "55fb28e7134a304c7847bda3db343143"


### PR DESCRIPTION
Simple http router for cohttp and async.

This is a simple http router for cohttp and async.  It allows you to route http requests to handlers.  Routes can be specified with a DSL that allows you to route constants and regex parts.

---
* Homepage: http://github.com/bhoflack/http_router
* Source repo: http://github.com/bhoflack/http_router.git
* Bug tracker: http://github.com/bhoflack/http_router/issues

---
Pull-request generated by opam-publish v0.2.1