### PR TITLE
opam-create.0.1.0 - via opam-publish

### DIFF
--- a/packages/opam-create/opam-create.0.1.0/descr
+++ b/packages/opam-create/opam-create.0.1.0/descr
@@ -1,0 +1,6 @@
+A tool for creating new OCaml projects with OPAM, Oasis, and Merlin
+opam-create is a command-line program to help generate some of the boilerplate involved
+in creating OCaml projects, such as the opam, _oasis, and .merlin files. opam-create
+features a simple-to-use dialog that allows the user to input specific options for their
+repository, as well as a number of additional commands that allow the user to set options
+separately.

--- a/packages/opam-create/opam-create.0.1.0/opam
+++ b/packages/opam-create/opam-create.0.1.0/opam
@@ -22,3 +22,4 @@ depends: [
   "ppx_deriving" {>= "3.0" & < "4.0"}
   "ppx_deriving_yojson" {>= "2.4" & < "3.0"}
 ]
+tags: [ "flags:plugin" ]

--- a/packages/opam-create/opam-create.0.1.0/opam
+++ b/packages/opam-create/opam-create.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/opam-create"
+bug-reports: "https://github.com/nv-vn/opam-create/issues"
+license: "GPL"
+dev-repo: "https://github.com/nv-vn/opam-create.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: ["cp" "./main.native" "%{bin}%/opam-create"]
+remove: ["rm" "%{bin}%/opam-create"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "batteries" {>= "2.0.0" & < "3.0.0"}
+  "linenoise" {>= "0.9.0" & < "1.0.0"}
+  "ocaml-inifiles" {>= "1.2" & < "2.0"}
+  "yojson" {>= "1.3.0" & < "2.0.0"}
+  "ppx_blob" {>= "0.1" & < "0.2"}
+  "ppx_deriving" {>= "3.0" & < "4.0"}
+  "ppx_deriving_yojson" {>= "2.4" & < "3.0"}
+]

--- a/packages/opam-create/opam-create.0.1.0/url
+++ b/packages/opam-create/opam-create.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/opam-create/archive/v0.1.0.tar.gz"
+checksum: "e7d107d8e640f08270d181e131232c85"


### PR DESCRIPTION
A tool for creating new OCaml projects with OPAM, Oasis, and Merlin
opam-create is a command-line program to help generate some of the boilerplate involved
in creating OCaml projects, such as the opam, _oasis, and .merlin files. opam-create
features a simple-to-use dialog that allows the user to input specific options for their
repository, as well as a number of additional commands that allow the user to set options
separately.


---
* Homepage: https://github.com/nv-vn/opam-create
* Source repo: https://github.com/nv-vn/opam-create.git
* Bug tracker: https://github.com/nv-vn/opam-create/issues

---

Pull-request generated by opam-publish v0.3.1