### PR TITLE
+bisect_ppx.1.1.0, older opam file constraints

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.0.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.1/opam
@@ -17,3 +17,4 @@ depends: [
   "ppx_tools" {build}
   "ocamlbuild" {build}
 ]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.0.2.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.2/opam
@@ -17,3 +17,4 @@ depends: [
   "ppx_tools" {build}
   "ocamlbuild" {build}
 ]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.0.2.3/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.3/opam
@@ -17,3 +17,4 @@ depends: [
   "ppx_tools" {build}
   "ocamlbuild" {build}
 ]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.0.2.4/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.4/opam
@@ -15,3 +15,4 @@ depends: [
   "ppx_tools" {build}
   "ocamlbuild" {build}
 ]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.0.2.5/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.5/opam
@@ -15,3 +15,4 @@ depends: [
   "ppx_tools" {build}
   "ocamlbuild" {build}
 ]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.0.2.6/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.6/opam
@@ -15,3 +15,4 @@ depends: [
   "ppx_tools" {build}
   "ocamlbuild" {build}
 ]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.0.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2/opam
@@ -17,3 +17,4 @@ depends: [
   "ppx_tools" {build}
   "ocamlbuild" {build}
 ]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.1.1.0/descr
+++ b/packages/bisect_ppx/bisect_ppx.1.1.0/descr
@@ -1,0 +1,19 @@
+Code coverage for OCaml
+
+Bisect_ppx helps you test thoroughly. It is a small preprocessor that inserts
+instrumentation at places in your code, such as if-then-else and match
+expressions. After you run tests, Bisect_ppx gives a nice HTML report showing
+which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, then run the
+report tool on the generated visitation files.
+
+This is an advanced fork of the original Bisect coverage tool. It has many
+improvements and updates.
+
+- Much more thorough code instrumentation, so you can find more gaps in your
+  testing.
+- Fast operation by default.
+- More legible and appealing HTML reports.
+- Various bugfixes.
+- No camlp4 dependency.

--- a/packages/bisect_ppx/bisect_ppx.1.1.0/files/bisect_ppx.install
+++ b/packages/bisect_ppx/bisect_ppx.1.1.0/files/bisect_ppx.install
@@ -1,0 +1,4 @@
+bin: [
+  "?_build/src/report/report.byte" {"bisect-ppx-report"}
+  "?_build/src/report/report.native" {"bisect-ppx-report"}
+]

--- a/packages/bisect_ppx/bisect_ppx.1.1.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.1.0/opam
@@ -1,0 +1,27 @@
+name: "bisect_ppx"
+version: "1.1.0"
+opam-version: "1.2"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "GPL3"
+homepage: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+dev-repo: "https://github.com/aantron/bisect_ppx.git"
+build: [make "build"]
+build-test: [make "dev" "tests"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "bisect_ppx"]
+depends: [
+  "ocamlfind" {build}
+  "ppx_tools" {build & >= "4.02.3"}
+  "ocamlbuild" {build}
+  "ounit" {test}
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/bisect_ppx/bisect_ppx.1.1.0/url
+++ b/packages/bisect_ppx/bisect_ppx.1.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.1.0.tar.gz"
+checksum: "963bb0ff4a1d9e5c0a0476adc326fa8e"


### PR DESCRIPTION
Changes:

- Port to 4.03.
- Allow exclusion of entire files, instead of only top-level values.
- Allow files to be excluded by regular expression, instead of only by exact string match.

`opam` files of older versions of package `bisect_ppx` have been updated to require OCaml >= 4.02, in part inspired by "broken deps" results in the OPAM Builder. Previously, we were relying on constraints of `ppx_tools` to prevent attempts to install `bisect_ppx` on OCaml < 4.02.