### PR TITLE
lru-cache.0.1.0 - via opam-publish

### DIFF
--- a/packages/lru-cache/lru-cache.0.1.0/descr
+++ b/packages/lru-cache/lru-cache.0.1.0/descr
@@ -1,0 +1,5 @@
+A simple implementation of a LRU cache.
+
+ocaml-lru-cache is a simple OCaml implementation of a cache using
+the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)
+strategy.

--- a/packages/lru-cache/lru-cache.0.1.0/opam
+++ b/packages/lru-cache/lru-cache.0.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: ["Maxence Guesdon"]
+homepage: "https://github.com/zoggy/ocaml-lru-cache"
+license: "GNU Lesser General Public License version 3"
+doc: ["https://github.com/zoggy/ocaml-lru-cache"]
+dev-repo: "https://github.com/zoggy/ocaml-lru-cache.git"
+bug-reports: "https://github.com/zoggy/ocaml-lru-cache/issues"
+tags: ["cache"]
+
+build: [
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "lru-cache"]]
+depends: [
+  "ocamlfind"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/lru-cache/lru-cache.0.1.0/url
+++ b/packages/lru-cache/lru-cache.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/ocaml-lru-cache/archive/0.1.0.tar.gz"
+checksum: "0d5398118c2c7d1e5d5a86f1ed23b893"


### PR DESCRIPTION
A simple implementation of a LRU cache.

ocaml-lru-cache is a simple OCaml implementation of a cache using
the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)
strategy.

---
* Homepage: https://github.com/zoggy/ocaml-lru-cache
* Source repo: https://github.com/zoggy/ocaml-lru-cache.git
* Bug tracker: https://github.com/zoggy/ocaml-lru-cache/issues

---

Pull-request generated by opam-publish v0.3.1