### PR TITLE
cohttp.0.20.2 - via opam-publish

### DIFF
--- a/packages/cohttp/cohttp.0.20.2/descr
+++ b/packages/cohttp/cohttp.0.20.2/descr
@@ -1,0 +1,9 @@
+HTTP(S) library for Lwt, Async and Mirage
+
+There are several optional dependencies which activate functionality:
+
+* Lwt: `opam install lwt cohttp`
+* Lwt and SSL: `opam install lwt ssl cohttp`
+* Async: `opam install async cohttp`
+* Async and SSL: `opam install async_ssl cohttp`
+

--- a/packages/cohttp/cohttp.0.20.2/opam
+++ b/packages/cohttp/cohttp.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
+build: [make "PREFIX=%{prefix}%"]
+install: [make "PREFIX=%{prefix}%" "install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "cohttp"]
+depends: [
+  "base-bytes"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cmdliner" {build & >= "0.9.4"}
+  "re"
+  "uri" {>= "1.9.0"}
+  "fieldslib"
+  "sexplib"
+  "conduit" {>= "0.11.0"}
+  "ppx_fields_conv"
+  "ppx_sexp_conv"
+  "stringext"
+  "base64" {>= "2.0.0"}
+  "magic-mime"
+  "ounit" {test}
+  "alcotest" {test}
+]
+depopts: ["async" "lwt" "js_of_ocaml"]
+conflicts: [
+  "async" {< "113.24.00"}
+  "lwt" {< "2.5.0"}
+  "js_of_ocaml" {< "2.6"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/cohttp/cohttp.0.20.2/url
+++ b/packages/cohttp/cohttp.0.20.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cohttp/archive/v0.20.2.tar.gz"
+checksum: "30f504f6be979a5a799a6a2f3ee4e443"


### PR DESCRIPTION
HTTP(S) library for Lwt, Async and Mirage

There are several optional dependencies which activate functionality:

* Lwt: `opam install lwt cohttp`
* Lwt and SSL: `opam install lwt ssl cohttp`
* Async: `opam install async cohttp`
* Async and SSL: `opam install async_ssl cohttp`



---
* Homepage: https://github.com/mirage/ocaml-cohttp
* Source repo: https://github.com/mirage/ocaml-cohttp.git
* Bug tracker: https://github.com/mirage/ocaml-cohttp/issues

---

Pull-request generated by opam-publish v0.3.1