### PR TITLE
depgraph.0.1.0 - via opam-publish

### DIFF
--- a/packages/depgraph/depgraph.0.1.0/descr
+++ b/packages/depgraph/depgraph.0.1.0/descr
@@ -1,0 +1,10 @@
+dot graphs out of ocamldep output
+
+depgraph will read source ml and mli source files from STDIN and use ocamldep
+to construct a dependency graph. It will then output the dependency graph in
+the .dot format.
+
+NOTE: This tool doesn't work well in the presence of packs
+
+Example:
+$ git ls-files | depgraph -i "test_" > g.dot

--- a/packages/depgraph/depgraph.0.1.0/opam
+++ b/packages/depgraph/depgraph.0.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "rgrinberg <rudi.grinberg@gmail.com>"
+authors: "rgrinberg <rudi.grinberg@gmail.com>"
+homepage: "https://github.com/rgrinberg/ocaml-depgraph"
+bug-reports: "https://github.com/rgrinberg/ocaml-depgraph/issues"
+license: "MIT"
+dev-repo: "git://github.com/rgrinberg/ocaml-depgraph"
+build: ["omake"]
+depends: [
+  "ocamlfind" {build}
+  "omake" {build}
+  "cmdliner"
+  "ocamlgraph"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/depgraph/depgraph.0.1.0/url
+++ b/packages/depgraph/depgraph.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ocaml-depgraph/archive/v0.1.0.tar.gz"
+checksum: "fe2edddf8ecfcf6b40fcc22ebe6992f7"


### PR DESCRIPTION
dot graphs out of ocamldep output

depgraph will read source ml and mli source files from STDIN and use ocamldep
to construct a dependency graph. It will then output the dependency graph in
the .dot format.

NOTE: This tool doesn't work well in the presence of packs

Example:
$ git ls-files | depgraph -i "test_" > g.dot


---
* Homepage: https://github.com/rgrinberg/ocaml-depgraph
* Source repo: git://github.com/rgrinberg/ocaml-depgraph
* Bug tracker: https://github.com/rgrinberg/ocaml-depgraph/issues

---

Pull-request generated by opam-publish v0.3.1