### PR TITLE
Fix dependence between irmin & ocaml-git

### DIFF
--- a/packages/irmin/irmin.0.10.1/opam
+++ b/packages/irmin/irmin.0.10.1/opam
@@ -37,9 +37,10 @@ depends: [
   "cmdliner"
   "crunch"
   "base-unix" {test}
-  "git"       {test & = "1.7.2"}
-  "cohttp"    {test}
-  "alcotest"  {test & >="0.4.1"}
+  "git" {test & = "1.7.2"}
+  "cohttp" {test}
+  "alcotest" {test & >="0.4.1"}
+  "ocamlbuild" {build}
 ]
 depopts: [
   "base-unix"

--- a/packages/irmin/irmin.0.10.1/opam
+++ b/packages/irmin/irmin.0.10.1/opam
@@ -37,10 +37,9 @@ depends: [
   "cmdliner"
   "crunch"
   "base-unix" {test}
-  "git" {test}
-  "cohttp" {test}
-  "alcotest" {test & >= "0.4.1"}
-  "ocamlbuild" {build}
+  "git"       {test & = "1.7.2"}
+  "cohttp"    {test}
+  "alcotest"  {test & >="0.4.1"}
 ]
 depopts: [
   "base-unix"
@@ -51,7 +50,7 @@ depopts: [
 ]
 conflicts: [
   "cohttp" {< "0.18.3"}
-  "git"    {< "1.7.1" & >= "1.8.0"}
+  "git"    {< "1.7.1" & > "1.7.2"}
   "conduit" {< "0.9.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
We constraint irmin to use ocaml-git.1.7.2 because the upstream change
the interface (specifically, rename Git.SHA to Git.Hash).

cc @samoht !