### PR TITLE
usbmux.1.1.1 - via opam-publish

### DIFF
--- a/packages/usbmux/usbmux.1.1.1/descr
+++ b/packages/usbmux/usbmux.1.1.1/descr
@@ -1,0 +1,20 @@
+Control port remapping for iOS devices
+
+Talk to jailbroken iDevices over USB with the CLI, gandalf.
+
+Basically this lets you do:
+
+ssh -p <some_port> root@localhost
+
+for an iPhone/iPod/iDevice.
+
+Example usage:
+
+sudo `which gandalf` --mappings etc/mapping --daemonize --verbose
+
+See uptime, tunnels and other metadata with:
+
+gandalf --status
+
+Check out the man page or see the README at:
+https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.org

--- a/packages/usbmux/usbmux.1.1.1/files/_oasis_remove_.ml
+++ b/packages/usbmux/usbmux.1.1.1/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/usbmux/usbmux.1.1.1/files/usbmux.install
+++ b/packages/usbmux/usbmux.1.1.1/files/usbmux.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/usbmux/usbmux.1.1.1/opam
+++ b/packages/usbmux/usbmux.1.1.1/opam
@@ -1,0 +1,50 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/onlinemediagroup/ocaml-usbmux"
+bug-reports: "https://github.com/onlinemediagroup/ocaml-usbmux/issues"
+license: "BSD-3"
+dev-repo: "https://github.com/onlinemediagroup/ocaml-usbmux.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/usbmux/_oasis_remove_.ml" "%{etc}%/usbmux"]
+depends: [
+  "cmdliner" {build}
+  "cohttp"
+  "lwt" {>= "2.5.1"}
+  "ocamlfind" {build}
+  "oasis" {build & >= "0.4"}
+  "plist"
+  "stringext"
+  "yojson"
+]
+depexts: [
+  [["debian"] ["usbmuxd"]]
+  [["ubuntu"] ["usbmuxd"]]
+]
+available: [ocaml-version >= "4.02.0"]
+post-messages: [
+  "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."
+  "Simple invocation:"
+  "sudo `which gandalf` --mappings etc/mapping --daemonize --verbose"
+  "where etc/mapping is a file of the format <udid>:<localport>:<device_port>"
+  "See uptime, tunnels and other metadata with:"
+  "gandalf --status"
+  "Note that with over 13 devices usbmuxd will start to buck"
+  "because of threading issue with libplist."
+  "Use the custom one provided at https://github.com/onlinemediagroup/libplist"
+  ""
+  "The Linux kernel will also have trouble with many USB3.0 devices, ie over 15ish"
+  "Fix that issue by turning off USB3.0 support in your BIOS"
+  "For this and other issues, be sure to check the README"
+]

--- a/packages/usbmux/usbmux.1.1.1/url
+++ b/packages/usbmux/usbmux.1.1.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/onlinemediagroup/ocaml-usbmux/archive/v1.1.1.tar.gz"
+checksum: "64b835873d64891ddb0f22b6606aaba9"


### PR DESCRIPTION
Control port remapping for iOS devices

Talk to jailbroken iDevices over USB with the CLI, gandalf.

Basically this lets you do:

ssh -p <some_port> root@localhost

for an iPhone/iPod/iDevice.

Example usage:

sudo `which gandalf` --mappings etc/mapping --daemonize --verbose

See uptime, tunnels and other metadata with:

gandalf --status

Check out the man page or see the README at:
https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.org


---
* Homepage: https://github.com/onlinemediagroup/ocaml-usbmux
* Source repo: https://github.com/onlinemediagroup/ocaml-usbmux.git
* Bug tracker: https://github.com/onlinemediagroup/ocaml-usbmux/issues

---

Pull-request generated by opam-publish v0.3.1