### PR TITLE
async-zmq.0.3.0 - via opam-publish

### DIFF
--- a/packages/async-zmq/async-zmq.0.3.0/descr
+++ b/packages/async-zmq/async-zmq.0.3.0/descr
@@ -1,0 +1,3 @@
+Async wrapper for OCaml's zeromq bindings
+
+A faithful port of lwt-zmq

--- a/packages/async-zmq/async-zmq.0.3.0/opam
+++ b/packages/async-zmq/async-zmq.0.3.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+license: "MIT"
+authors: [ "Rudi Grinberg" ]
+
+homepage: "https://github.com/rgrinberg/async-zmq"
+bug-reports: "https://github.com/rgrinberg/async-zmq/issues"
+dev-repo: "https://github.com/rgrinberg/async-zmq.git"
+
+build: [ "omake" ]
+
+install: [ "omake" "install"]
+
+remove: [["ocamlfind" "remove" "async_zmq"]]
+
+depends: [
+  "ocamlfind" {build}
+  "omake" {build}
+  "core"
+  "async"
+  "ppx_sexp_conv" {build}
+  "ppx_deriving" {build}
+  "sexplib"
+  "zmq"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/async-zmq/async-zmq.0.3.0/url
+++ b/packages/async-zmq/async-zmq.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/async-zmq/archive/v0.3.0.tar.gz"
+checksum: "03988a5dd8e62479283ef6a367877393"


### PR DESCRIPTION
Async wrapper for OCaml's zeromq bindings

A faithful port of lwt-zmq


---
* Homepage: https://github.com/rgrinberg/async-zmq
* Source repo: https://github.com/rgrinberg/async-zmq.git
* Bug tracker: https://github.com/rgrinberg/async-zmq/issues

---

Pull-request generated by opam-publish v0.3.1