### PR TITLE
tensorflow.0.0.2 - via opam-publish

### DIFF
--- a/packages/tensorflow/tensorflow.0.0.2/descr
+++ b/packages/tensorflow/tensorflow.0.0.2/descr
@@ -1,0 +1,4 @@
+TensorFlow bindings for OCaml
+
+The tensorflow-ocaml project provides some OCaml bindings for TensorFlow, a machine learning framework.
+These bindings are in an early stage of their development. Some operators are not supported and the API is likely to change in the future. You may also encounter some segfaults. That being said they already contain the necessary to train a convolution network using various optimizers.

--- a/packages/tensorflow/tensorflow.0.0.2/opam
+++ b/packages/tensorflow/tensorflow.0.0.2/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Laurent Mazare <lmazare@gmail.com>"
+homepage: "https://github.com/LaurentMazare/tensorflow-ocaml"
+bug-reports: "https://github.com/LaurentMazare/tensorflow-ocaml/issues"
+dev-repo: "git+https://github.com/LaurentMazare/tensorflow-ocaml.git"
+build: [make "tensorflow.lib"]
+authors: [ "Laurent Mazare" "Nicolas Oury" ]
+
+
+depends: [
+  "core_kernel"
+  "ctypes" {>= "0.5"}
+  "ctypes-foreign"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+depopts: "gnuplot"
+available: [ocaml-version >= "4.02.1"]

--- a/packages/tensorflow/tensorflow.0.0.2/url
+++ b/packages/tensorflow/tensorflow.0.0.2/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/LaurentMazare/tensorflow-ocaml/archive/0.0.2.tar.gz"
+checksum: "7066f82cd64cd2e7c08185b0aa739f01"


### PR DESCRIPTION
TensorFlow bindings for OCaml

The tensorflow-ocaml project provides some OCaml bindings for TensorFlow, a machine learning framework.
These bindings are in an early stage of their development. Some operators are not supported and the API is likely to change in the future. You may also encounter some segfaults. That being said they already contain the necessary to train a convolution network using various optimizers.


---
* Homepage: https://github.com/LaurentMazare/tensorflow-ocaml
* Source repo: git+https://github.com/LaurentMazare/tensorflow-ocaml.git
* Bug tracker: https://github.com/LaurentMazare/tensorflow-ocaml/issues

---

Pull-request generated by opam-publish v0.3.1