### PR TITLE
fix conf-blas & conf-lapack for cygwin/mingw toolchain

### DIFF
--- a/packages/conf-blas/conf-blas.1/files/test-win.sh
+++ b/packages/conf-blas/conf-blas.1/files/test-win.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+cc=$(ocamlc -config | awk '/^bytecomp_c_compiler/ {$1="";sub(/^ /, ""); print}')
+$cc $CFLAGS test.c -lblas
+

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -6,8 +6,9 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2.0"
 build: [
-  ["sh" "-exc" "cc $CFLAGS test.c -lblas"] {os != "darwin"}
+  ["sh" "-exc" "cc $CFLAGS test.c -lblas"] {os != "darwin" & os != "win32"}
   ["sh" "-exc" "cc -framework Accelerate $CFLAGS test.c -lblas"] {os = "darwin"}
+  ["%{build}%/files/test-win.sh"] {os = "win32"}
 ]
 depexts: [
   [["debian"] ["libblas-dev"]]

--- a/packages/conf-lapack/conf-lapack.1/files/test-win.sh
+++ b/packages/conf-lapack/conf-lapack.1/files/test-win.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+cc=$(ocamlc -config | awk '/^bytecomp_c_compiler/ {$1="";sub(/^ /, ""); print}')
+$cc $CFLAGS test.c -llapack
+

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -6,8 +6,9 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2.0"
 build: [
-  ["sh" "-exc" "cc $CFLAGS test.c -llapack"] {os != "darwin"}
+  ["sh" "-exc" "cc $CFLAGS test.c -llapack"] {os != "darwin" & os != "win32"}
   ["sh" "-exc" "cc -framework Accelerate $CFLAGS test.c -llapack"] {os = "darwin"}
+  ["%{build}%/files/test-win.sh"] {os = "win32"}
 ]
 depexts: [
   [["debian"] ["liblapack-dev"]]


### PR DESCRIPTION
adds a shell script to select the correct c-compiler. For Windows builds, a cygwin environment is assumed and the correct (cross-) compiler is selected from `ocamlc -config` output.