### PR TITLE
conf-blas & conf-lapack: fix script path for win32

### DIFF
--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -8,7 +8,7 @@ license: "GPL-2.0"
 build: [
   ["sh" "-exc" "cc $CFLAGS test.c -lblas"] {os != "darwin" & os != "win32"}
   ["sh" "-exc" "cc -framework Accelerate $CFLAGS test.c -lblas"] {os = "darwin"}
-  ["%{build}%/files/test-win.sh"] {os = "win32"}
+  ["%{build}%/test-win.sh"] {os = "win32"}
 ]
 depexts: [
   [["debian"] ["libblas-dev"]]

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -8,7 +8,7 @@ license: "GPL-2.0"
 build: [
   ["sh" "-exc" "cc $CFLAGS test.c -llapack"] {os != "darwin" & os != "win32"}
   ["sh" "-exc" "cc -framework Accelerate $CFLAGS test.c -llapack"] {os = "darwin"}
-  ["%{build}%/files/test-win.sh"] {os = "win32"}
+  ["%{build}%/test-win.sh"] {os = "win32"}
 ]
 depexts: [
   [["debian"] ["liblapack-dev"]]


### PR DESCRIPTION
Fix path to shell script for conf-blas & conf-lapack for build on win32.

Sorry, I am an opam newbie and still learning how it works...
