### PR TITLE
opal.0.1.0 - via opam-publish

### DIFF
--- a/packages/opal/opal.0.1.0/descr
+++ b/packages/opal/opal.0.1.0/descr
@@ -1,0 +1,3 @@
+Self-contained monadic parser combinators for OCaml
+
+Opal is a minimum collection of useful parsers and combinators (~150 loc of OCaml) that makes writing parsers easier. It is designed to be small, self-contained, pure-functional, and only includes most essential parsers, so that one could include single file in the project or just embed it in other OCaml source code files.

--- a/packages/opal/opal.0.1.0/opam
+++ b/packages/opal/opal.0.1.0/opam
@@ -5,9 +5,7 @@ homepage: "https://github.com/pyrocat101/opal"
 bug-reports: "https://github.com/pyrocat101/opal/issues"
 license: "MIT"
 dev-repo: "https://github.com/pyrocat101/opal.git"
-available: [
-  [ocaml-version >= "4.01.0"]
-]
+available: [ ocaml-version >= "4.01.0" ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/opal/opal.0.1.0/opam
+++ b/packages/opal/opal.0.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Linjie Ding <i@pyroc.at>"
+authors: "Linjie Ding <i@pyroc.at>"
+homepage: "https://github.com/pyrocat101/opal"
+bug-reports: "https://github.com/pyrocat101/opal/issues"
+license: "MIT"
+dev-repo: "https://github.com/pyrocat101/opal.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "opal"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/opal/opal.0.1.0/opam
+++ b/packages/opal/opal.0.1.0/opam
@@ -5,11 +5,14 @@ homepage: "https://github.com/pyrocat101/opal"
 bug-reports: "https://github.com/pyrocat101/opal/issues"
 license: "MIT"
 dev-repo: "https://github.com/pyrocat101/opal.git"
-build: [
-  ["./configure" "--prefix=%{prefix}%"]
-  [make]
+available: [
+  [ocaml-version >= "4.01.0"]
 ]
-install: [make "install"]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "opal"]
 depends: [
   "ocamlfind" {build}

--- a/packages/opal/opal.0.1.0/url
+++ b/packages/opal/opal.0.1.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/pyrocat101/opal/archive/v0.1.0.tar.gz"
-checksum: "e9c202cd84d4aedf3c9be7bf603cab9f"
+checksum: "e9296ec6cd04e2365c49e9fcc0c69b60"

--- a/packages/opal/opal.0.1.0/url
+++ b/packages/opal/opal.0.1.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/pyrocat101/opal/archive/v0.1.0.tar.gz"
-checksum: "141aaef25e531601ab8d0b4573c7bb0b"
+checksum: "e14e5d187eab5375873a4976102d68d5"

--- a/packages/opal/opal.0.1.0/url
+++ b/packages/opal/opal.0.1.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/pyrocat101/opal/archive/v0.1.0.tar.gz"
-checksum: "e14e5d187eab5375873a4976102d68d5"
+checksum: "e9c202cd84d4aedf3c9be7bf603cab9f"

--- a/packages/opal/opal.0.1.0/url
+++ b/packages/opal/opal.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/pyrocat101/opal/archive/v0.1.0.tar.gz"
+checksum: "141aaef25e531601ab8d0b4573c7bb0b"


### PR DESCRIPTION
Self-contained monadic parser combinators for OCaml

Opal is a minimum collection of useful parsers and combinators (~150 loc of OCaml) that makes writing parsers easier. It is designed to be small, self-contained, pure-functional, and only includes most essential parsers, so that one could include single file in the project or just embed it in other OCaml source code files.


---
* Homepage: https://github.com/pyrocat101/opal
* Source repo: https://github.com/pyrocat101/opal.git
* Bug tracker: https://github.com/pyrocat101/opal/issues

---

Pull-request generated by opam-publish v0.3.1