### PR TITLE
base-no-ppx: mark as unavailable on 4.03.0

### DIFF
--- a/packages/base-no-ppx/base-no-ppx.base/opam
+++ b/packages/base-no-ppx/base-no-ppx.base/opam
@@ -1,2 +1,2 @@
 opam-version: "1.2"
-available: [ ocaml-version < "4.02.0" | ocaml-version >= "4.03.0" ]
+available: [ ocaml-version < "4.02.0" ]


### PR DESCRIPTION
This reverts 7bb763f0b452, which marked base-no-ppx as available on 4.03.0 since ppx_tools were not available.