### PR TITLE
apply the fix to use conf-openssl in async_ssl to complete depexts

### DIFF
--- a/packages/async_ssl/async_ssl.113.33.01/opam
+++ b/packages/async_ssl/async_ssl.113.33.01/opam
@@ -17,6 +17,7 @@ depends: [
   "core"            {>= "113.33.00" & < "113.34.00"}
   "ctypes"
   "ctypes-foreign"
+  "conf-openssl"
   "fieldslib"       {>= "113.24.00" & < "113.25.00"}
   "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
   "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
@@ -29,8 +30,3 @@ depends: [
   "variantslib"     {>= "113.24.00" & < "113.25.00"}
 ]
 available: [ ocaml-version >= "4.02.3" ]
-depexts: [
-  [["debian"] ["libssl-dev"]]
-  [["ubuntu"] ["libssl-dev"]]
-  [["centos"] ["openssl-devel"]]
-]

--- a/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
@@ -10,6 +10,7 @@ depexts: [
   [ ["ubuntu"] [ "libffi-dev" ] ]
   [ ["osx" "homebrew"] ["libffi"] ]
   [ ["centos"] ["libffi-devel"] ]
+  [ ["oraclelinux"] ["libffi-devel"] ]
   [ ["fedora"] ["libffi-devel"] ]
   [ ["alpine"] ["libffi-dev"] ]
  ]


### PR DESCRIPTION
This fixes fedora/rhel/oracle linux
See related fix in 0573218863e8069049c13ecd1e83ced0d393098e