### PR TITLE
Update ppx_jsobject_conv : 0.1.0

### DIFF
--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/descr
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/descr
@@ -1,0 +1,6 @@
+Ppx plugin for Typeconv to derive conversion from ocaml types to js objects to use with js_of_ocaml.
+
+For types annotated with [@@deriving jsobject], plugin will generate pair of functions: *_of_jsobject/jsobject_of_*
+to convert from/to JavaScript objects. This allows one to use clean OCaml types to describe their logic, while having ability
+to easy go down to js types. Easy conversion from js objects to OCaml types means also, one can use fast native JSON.parse to
+convert JSON to OCaml types.

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Roma Sokolov <sokolov.r.v@gmail.com>"
+authors: [ "Roma Sokolov <sokolov.r.v@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/little-arhat/ppx_jsobject_conv"
+bug-reports: "https://github.com/little-arhat/ppx_jsobject_conv/issues"
+dev-repo: "git://github.com/little-arhat/ppx_jsobject_conv.git"
+tags: [ "syntax" "jsoo" "javascript"]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "js_of_ocaml"
+  "result"
+  "ppx_type_conv" {>= "113.24.00"}
+  "ppx_driver"
+  "ppx_core"
+  "ocamlfind"    {build}
+  "ocamlbuild"   {build}
+]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/url
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/little-arhat/ppx_jsobject_conv/archive/v0.0.6.tar.gz"
+checksum: "625f4e8c428750b916185825b5a5ad58"

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/url
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/url
@@ -1,3 +1,3 @@
 http:
-  "https://github.com/little-arhat/ppx_jsobject_conv/archive/v0.0.6.tar.gz"
+  "https://github.com/little-arhat/ppx_jsobject_conv/archive/v0.1.0.tar.gz"
 checksum: "625f4e8c428750b916185825b5a5ad58"


### PR DESCRIPTION
Breaking change to make conversion functions more symmetrical:
Js.Unsafe.any replaced to 'm Js.t.