### PR TITLE
ocamlbuild-protoc.0.1 - via opam-publish

### DIFF
--- a/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/descr
+++ b/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/descr
@@ -1,0 +1,3 @@
+ocaml-protoc plugin for Ocamlbuild
+
+Automatically generates `_pb.ml*` files from a `.proto`.

--- a/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/opam
+++ b/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocamlbuild-protoc"
+bug-reports: "https://github.com/Khady/ocamlbuild-protoc/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Khady/ocamlbuild-protoc.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ocamlbuild_protoc"]
+depends: [
+  "ocamlfind" {build}
+  "ocaml-protoc"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/url
+++ b/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Khady/ocamlbuild-protoc/archive/v0.1.zip"
+checksum: "ed20fb2bb19189ff4f89296b48b89670"


### PR DESCRIPTION
ocaml-protoc plugin for Ocamlbuild

Automatically generates `_pb.ml*` files from a `.proto`.

---
* Homepage: https://github.com/Khady/ocamlbuild-protoc
* Source repo: git+https://github.com/Khady/ocamlbuild-protoc.git
* Bug tracker: https://github.com/Khady/ocamlbuild-protoc/issues

---

Pull-request generated by opam-publish v0.3.1