### PR TITLE
opium won't currently install

### DIFF
--- a/packages/opium/opium.0.14.0/opam
+++ b/packages/opium/opium.0.14.0/opam
@@ -33,7 +33,7 @@ depends: [
   "magic-mime"
   "cppo" {build}
   "ounit" {test}
-  "cow" {test & >= "0.10.0"}
+  "cow" {test & >= "0.10.0" & < "2.0.0"}
 ]
 
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
There seems to be one or more missing dependency constraints on 0.14.0 (and likely prior versions)