### PR TITLE
fix version fields of newer beta compilers

### DIFF
--- a/compilers/4.03.0/4.03.0+beta1+flambda/4.03.0+beta1+flambda.comp
+++ b/compilers/4.03.0/4.03.0+beta1+flambda/4.03.0+beta1+flambda.comp
@@ -1,5 +1,5 @@
 opam-version: "1"
-version: "4.03.0+beta1+flambda"
+version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]

--- a/compilers/4.03.0/4.03.0+beta1-no-debug/4.03.0+beta1-no-debug.comp
+++ b/compilers/4.03.0/4.03.0+beta1-no-debug/4.03.0+beta1-no-debug.comp
@@ -1,5 +1,5 @@
 opam-version: "1"
-version: "4.03.0+beta1-no-debug"
+version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]

--- a/compilers/4.03.0/4.03.0+beta1/4.03.0+beta1.comp
+++ b/compilers/4.03.0/4.03.0+beta1/4.03.0+beta1.comp
@@ -1,5 +1,5 @@
 opam-version: "1"
-version: "4.03.0+beta1"
+version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]

--- a/compilers/4.03.0/4.03.0+beta2-no-debug/4.03.0+beta2-no-debug.comp
+++ b/compilers/4.03.0/4.03.0+beta2-no-debug/4.03.0+beta2-no-debug.comp
@@ -1,5 +1,5 @@
 opam-version: "1"
-version: "4.03.0+beta2-no-debug"
+version: "4.03.0"
 src: "https://codeload.github.com/ocaml/ocaml/legacy.tar.gz/4.03.0+beta2"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]

--- a/compilers/4.03.0/4.03.0+beta2/4.03.0+beta2.comp
+++ b/compilers/4.03.0/4.03.0+beta2/4.03.0+beta2.comp
@@ -1,5 +1,5 @@
 opam-version: "1"
-version: "4.03.0+beta2"
+version: "4.03.0"
 src: "https://codeload.github.com/ocaml/ocaml/legacy.tar.gz/4.03.0+beta2"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]

--- a/compilers/4.03.0/4.03.0+flambda/4.03.0+trunk+flambda.comp
+++ b/compilers/4.03.0/4.03.0+flambda/4.03.0+trunk+flambda.comp
@@ -1,5 +1,5 @@
 opam-version: "1"
-version: "4.03.0+trunk+flambda"
+version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]


### PR DESCRIPTION
The historical semantics of compiler names is a bit weird, and was one
of the motivations for unifying package and compiler definitions.

The .comp file is expected to be named "version+variant", with
"version" the base version of OCaml (e.g. 4.02.3), and "variant" the
specific OCaml variant (for official versions, "+variant" is omitted).

Then the compiler _name_ is the full string "version+variant",
including, therefore, the version.

Follows that the version can't contain the character "+", and newer
compilers don't respect these rules, with e.g. a file name
"4.03.0+beta" and a 'version:' field which is also "4.03.0+beta". Note
that they _do_ include the "+beta" part in their version number
though.

Also, opam 1.2.2 doesn't handle the error well, see for example
https://github.com/ocaml/opam/issues/2516.

It's not an ideal solution, but this PR declares the truncated version
in the 'version:' field to avoid the error.