### PR TITLE
usbmux.1.2.0 - via opam-publish

### DIFF
--- a/packages/usbmux/usbmux.1.2.0/descr
+++ b/packages/usbmux/usbmux.1.2.0/descr
@@ -1,0 +1,27 @@
+Control port remapping for iOS devices
+
+Now you can ssh into your jailbroken iDevice using the CLI, gandalf.
+Simple invocation:
+sudo `which gandalf` --mappings etc/mapping --daemonize --verbose
+
+where etc/mapping is a file such that # start comments and consists of 
+an array of json objects with these fields, note that name can be null 
+and is just a nickname for this tunnel, other fields are required.
+
+# This is a comment
+[{"udid":"9cdfac9f74c5e18a6eff3611c0927df5cf4f2eca",
+  "name":"i11",
+  "forwarding": [{"local_port":2000, "device_port":22},
+                 {"local_port":3000, "device_port":1122}]}]
+
+See uptime, tunnels and other metadata with:
+gandalf --status
+Note that with over 13 devices usbmuxd will start to buck 
+because of threading issue with libplist.
+Use the custom one provided at https://github.com/onlinemediagroup/libplist
+
+The Linux kernel will also have trouble with many USB3.0 devices, ie over 15ish
+Fix that issue by turning off USB3.0 support in your BIOS
+
+Check out the man page or see the README at:
+https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.md

--- a/packages/usbmux/usbmux.1.2.0/files/_oasis_remove_.ml
+++ b/packages/usbmux/usbmux.1.2.0/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/usbmux/usbmux.1.2.0/files/usbmux.install
+++ b/packages/usbmux/usbmux.1.2.0/files/usbmux.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/usbmux/usbmux.1.2.0/opam
+++ b/packages/usbmux/usbmux.1.2.0/opam
@@ -1,0 +1,61 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/onlinemediagroup/ocaml-usbmux"
+bug-reports: "https://github.com/onlinemediagroup/ocaml-usbmux/issues"
+license: "BSD-3"
+dev-repo: "https://github.com/onlinemediagroup/ocaml-usbmux.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/usbmux/_oasis_remove_.ml" "%{etc}%/usbmux"]
+depends: [
+  "cmdliner" {build}
+  "cohttp"
+  "lwt" {>= "2.5.1"}
+  "ocamlfind" {build}
+  "oasis" {build & >= "0.4"}
+  "ppx_deriving_yojson" {>= "2.4"}
+  "plist"
+  "yojson"
+]
+depexts: [
+  [["debian"] ["usbmuxd"]]
+  [["ubuntu"] ["usbmuxd"]]
+]
+available: [ocaml-version >= "4.02.0"]
+post-messages: [
+  "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."
+  "Simple invocation:"
+  "sudo `which gandalf` --mappings etc/mapping --daemonize --verbose"
+  "
+where etc/mapping is a file such that # start comments and consists of 
+an array of json objects with these fields, note that name can be null 
+and is just a nickname for this tunnel, other fields are required.
+
+# This is a comment
+[{\"udid\":\"9cdfac9f74c5e18a6eff3611c0927df5cf4f2eca\",
+  \"name\":\"i11\",
+  \"forwarding\": [{\"local_port\":2000, \"device_port\":22},
+                 {\"local_port\":3000, \"device_port\":1122}]}]
+  "
+  "See uptime, tunnels and other metadata with:"
+  "gandalf --status"
+  "Note that with over 13 devices usbmuxd will start to buck"
+  "because of threading issue with libplist."
+  "Use the custom one provided at https://github.com/onlinemediagroup/libplist"
+  ""
+  "The Linux kernel will also have trouble with many USB3.0 devices, ie over 15ish"
+  "Fix that issue by turning off USB3.0 support in your BIOS"
+  "Check out the man page or see the README at:"
+  "https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.md"
+]

--- a/packages/usbmux/usbmux.1.2.0/url
+++ b/packages/usbmux/usbmux.1.2.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/onlinemediagroup/ocaml-usbmux/archive/v1.2.0.tar.gz"
+checksum: "cbbd176aabc34442ba20e45e775bbd2a"


### PR DESCRIPTION
Control port remapping for iOS devices

Now you can ssh into your jailbroken iDevice using the CLI, gandalf.
Simple invocation:

```
sudo `which gandalf` --mappings etc/mapping --daemonize --verbose
```

where etc/mapping is a file such that # start comments and consists of 
an array of json objects with these fields, note that name can be null 
and is just a nickname for this tunnel, other fields are required.

```shell
# This is a comment
[{"udid":"9cdfac9f74c5e18a6eff3611c0927df5cf4f2eca",
  "name":"i11",
  "forwarding": [{"local_port":2000, "device_port":22},
                 {"local_port":3000, "device_port":1122}]}]
```

See uptime, tunnels and other metadata with:
gandalf --status
Note that with over 13 devices usbmuxd will start to buck 
because of threading issue with libplist.
Use the custom one provided at https://github.com/onlinemediagroup/libplist

The Linux kernel will also have trouble with many USB3.0 devices, ie over 15ish
Fix that issue by turning off USB3.0 support in your BIOS

Check out the man page or see the README at:
https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.md


---
* Homepage: https://github.com/onlinemediagroup/ocaml-usbmux
* Source repo: https://github.com/onlinemediagroup/ocaml-usbmux.git
* Bug tracker: https://github.com/onlinemediagroup/ocaml-usbmux/issues

---

Pull-request generated by opam-publish v0.3.1