### PR TITLE
Small fix for dev repo ppx_tools

### DIFF
--- a/packages/ppx_tools/ppx_tools.4.02.3/opam
+++ b/packages/ppx_tools/ppx_tools.4.02.3/opam
@@ -4,7 +4,7 @@ authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
 license: "MIT"
 homepage: "https://github.com/alainfrisch/ppx_tools"
 bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
-dev-repo: "git://github.com/alainfrisch/ppx_tools.git"
+dev-repo: "git://github.com/alainfrisch/ppx_tools.git#4.02"
 tags: [ "syntax" ]
 build: [[make "all"]]
 install: [[make "install"]]


### PR DESCRIPTION
Since dev of the 4.02 version of ppx_tools is on another branch, this should be more convenient. 

@AltGr How is chosen the `dev-repo` ? Will something like that work ? 

cc @alainfrisch 