### PR TITLE
+http2https.1.0.0

### DIFF
--- a/packages/http2https/http2https.1.0.0/descr
+++ b/packages/http2https/http2https.1.0.0/descr
@@ -1,0 +1,5 @@
+HTTP to HTTPS redirector daemon
+
+This is a simple redirector that issues HTTP 302 responses to incoming HTTP
+requests.  It's useful to use as a listener on port 80 to redirect traffic to
+the corresponding HTTPS port on 443.

--- a/packages/http2https/http2https.1.0.0/opam
+++ b/packages/http2https/http2https.1.0.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/avsm/http2https"
+bug-reports: "https://github.com/avsm/http2https/issues"
+license: "ISC"
+dev-repo: "https://github.com/avsm/http2https.git"
+build: [ [make] ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cohttp" {>="0.19.3"}
+  "lwt"
+  "base-unix"
+]

--- a/packages/http2https/http2https.1.0.0/url
+++ b/packages/http2https/http2https.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/avsm/http2https/archive/v1.0.0.tar.gz"
+checksum: "01ba4654c8c4ac355bc09aecec6051a8"


### PR DESCRIPTION
This is a simple redirector that issues HTTP 302 responses to incoming HTTP
requests.  It's useful to use as a listener on port 80 to redirect traffic to
the corresponding HTTPS port on 443.