### PR TITLE
ppx_blob.0.2: Required for compatibility with 4.03, but also works with 4.02

### DIFF
--- a/packages/ppx_blob/ppx_blob.0.2/descr
+++ b/packages/ppx_blob/ppx_blob.0.2/descr
@@ -1,0 +1,1 @@
+Include a file as a string at compile time

--- a/packages/ppx_blob/ppx_blob.0.2/opam
+++ b/packages/ppx_blob/ppx_blob.0.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+build: [
+  [make "native-code"] {ocaml-native}
+  [make "byte-code"] {!ocaml-native}
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "ppx_blob"]]
+depends: ["ocamlfind" {>= "1.5.2"}]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_blob/ppx_blob.0.2/opam
+++ b/packages/ppx_blob/ppx_blob.0.2/opam
@@ -1,4 +1,6 @@
 opam-version: "1.2"
+name: "ppx_blob"
+version: "0.2"
 authors: "John Whitington"
 maintainer: "contact@coherentgraphics.co.uk"
 homepage: "https://github.com/johnwhitington/ppx_blob"
@@ -12,5 +14,8 @@ install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "ppx_blob"]]
-depends: ["ocamlfind" {>= "1.5.2"}]
+depends: [
+  "ocamlfind" {build & >= "1.5.2"}
+  "ppx_tools" {build}
+]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_blob/ppx_blob.0.2/url
+++ b/packages/ppx_blob/ppx_blob.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/johnwhitington/ppx_blob/archive/v0.2.tar.gz"
+checksum: "46a9d06b8037ca217fdcc3f2888b04b5"

--- a/packages/ppx_blob/ppx_blob.0.2/url
+++ b/packages/ppx_blob/ppx_blob.0.2/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/johnwhitington/ppx_blob/archive/v0.2.tar.gz"
-checksum: "46a9d06b8037ca217fdcc3f2888b04b5"
+checksum: "c25401923d7e6efe6af400f1100c7923"


### PR DESCRIPTION
This is a new version of ppx_blob which works with the upcoming 4.03. But is also works for 4.02 (the changes in the parse tree have been abstracted by relying on ppx_tools). This is the work of Anton Bachin.

Forgive me for presenting this as a manual pull request yet again, but I still can't get the pin-based testing workflow (and thus opam-publish) to work. It seems to try to install the old (v0.1) version...

```
feast:ppx_blob.0.2 john$ opam pin add ppx_blob .
[NOTE] Package ppx_blob is already path-pinned to
       /Users/john/repos/opam-repository/packages/ppx_blob/ppx_blob.0.2.
       This will erase any previous custom definition.
Proceed ? [Y/n] Y

[ppx_blob] /Users/john/repos/opam-repository/packages/ppx_blob/ppx_blob.0.2/ synchronized
[ppx_blob] Installing new package description from
/Users/john/repos/opam-repository/packages/ppx_blob/ppx_blob.0.2

ppx_blob needs to be installed.
The following actions will be performed:
  ∗  install ppx_blob 0.1*
Do you want to continue ? [Y/n] n
[NOTE] Pinning command successful, but your installed packages may be out of sync.
```