### PR TITLE
Add ounit dependency to mirage-flow tests

### DIFF
--- a/packages/mirage-flow/mirage-flow.1.1.0/opam
+++ b/packages/mirage-flow/mirage-flow.1.1.0/opam
@@ -19,4 +19,5 @@ depends: [
   "cstruct"
   "lwt" {>= "2.5.0"}
   "alcotest" {test}
+  "ounit"    {test}
 ]


### PR DESCRIPTION
This is already fixed in upstream's opam file, but seems that an old one has
been used for the release instead.

This fixes https://github.com/mirage/mirage-flow/issues/14