### PR TITLE
Sync OCaml compiler PRs

### DIFF
--- a/compilers/4.04.0/4.04.0+pr555/4.04.0+pr555.descr
+++ b/compilers/4.04.0/4.04.0+pr555/4.04.0+pr555.descr
@@ -1,1 +1,0 @@
-Ensure that register typing constraints are respected at join points

--- a/compilers/4.04.0/4.04.0+pr557/4.04.0+pr557.comp
+++ b/compilers/4.04.0/4.04.0+pr557/4.04.0+pr557.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/mshinwell/ocaml/archive/join_reg_typing.tar.gz"
+src: "https://github.com/lpw25/ocaml/archive/fix-infinite-unrolling.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]

--- a/compilers/4.04.0/4.04.0+pr557/4.04.0+pr557.descr
+++ b/compilers/4.04.0/4.04.0+pr557/4.04.0+pr557.descr
@@ -1,0 +1,1 @@
+Fix infinite unrolling bug


### PR DESCRIPTION
The latest compiler pull requests for OCaml 4.04.0 as of
Sat 23 Apr 2016 00:00:01 BST