### PR TITLE
msat.0.3 - via opam-publish

### DIFF
--- a/packages/msat/msat.0.3/descr
+++ b/packages/msat/msat.0.3/descr
@@ -1,0 +1,8 @@
+Modular sat/smt solver
+
+This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
+- proof output
+- push/pop operations
+- CNF transformation tools
+
+This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.

--- a/packages/msat/msat.0.3/opam
+++ b/packages/msat/msat.0.3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes@inria.fr"]
+authors: [
+  "Sylvain Conchon"
+  "Alain Mebsout"
+  "Stephane Lecuyer"
+  "Simon Cruanes"
+  "Guillaume Bury"
+]
+homepage: "https://github.com/Gbury/mSAT"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+license: "Apache"
+tags: ["sat" "smt"]
+dev-repo: "https://github.com/Gbury/mSAT.git"
+build: [
+  [make "disable_log"]
+  [make "lib"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "msat"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/msat/msat.0.3/opam
+++ b/packages/msat/msat.0.3/opam
@@ -22,4 +22,4 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/msat/msat.0.3/url
+++ b/packages/msat/msat.0.3/url
@@ -1,2 +1,2 @@
 http: "https://github.com/Gbury/mSAT/archive/v0.3.tar.gz"
-checksum: "1430254ddee79349b1eae297924f411e"
+checksum: "b9e15b20e3ca3a762ba2ccba1e83dbdf"

--- a/packages/msat/msat.0.3/url
+++ b/packages/msat/msat.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Gbury/mSAT/archive/v0.3.tar.gz"
+checksum: "1430254ddee79349b1eae297924f411e"


### PR DESCRIPTION
Modular sat/smt solver

This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
- proof output
- push/pop operations
- CNF transformation tools

This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.


---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---

Pull-request generated by opam-publish v0.3.1