### PR TITLE
unix-sys-resource.0.1.0 - via opam-publish

### DIFF
--- a/packages/unix-sys-resource/unix-sys-resource.0.1.0/descr
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.0/descr
@@ -1,0 +1,14 @@
+Unix sys/resource.h types and bindings (getrlimit, setrlimit, and friends)
+
+unix-sys-resource provides access to the features exposed in
+sys/resource.h in a way that is not tied to the implementation on the
+host system.
+
+The Sys_resource module provides types and functions for describing and
+working with rlimit resources and limits.
+
+The Sys_resource_unix module provides bindings to functions that use the
+types in Sys_resource.
+
+Currently, getrlimit and setrlimit and their corresponding flags are
+bound.

--- a/packages/unix-sys-resource/unix-sys-resource.0.1.0/opam
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets"]
+homepage: "https://github.com/dsheets/ocaml-unix-sys-resource"
+bug-reports: "https://github.com/dsheets/ocaml-unix-sys-resource/issues"
+dev-repo: "https://github.com/dsheets/ocaml-unix-sys-resource.git"
+tags: [ "unix" "posix" "sys/resource.h" "getrlimit" "setrlimit" "rlimit" ]
+license: "ISC"
+build: [
+  [make "build"]
+]
+build-test: [
+  [make "test"]
+]
+install: [
+  [make "install"]
+]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "unix-errno" {>= "0.3.0"}
+  "ctypes"
+]
+depopts: [
+  "base-unix"
+]
+conflicts: [
+  "ctypes" {< "0.4.0"}
+]

--- a/packages/unix-sys-resource/unix-sys-resource.0.1.0/url
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dsheets/ocaml-unix-sys-resource/archive/0.1.0.tar.gz"
+checksum: "7555aa595876f249cadabcb71c12ef60"


### PR DESCRIPTION
Unix sys/resource.h types and bindings (getrlimit, setrlimit, and friends)

unix-sys-resource provides access to the features exposed in
sys/resource.h in a way that is not tied to the implementation on the
host system.

The Sys_resource module provides types and functions for describing and
working with rlimit resources and limits.

The Sys_resource_unix module provides bindings to functions that use the
types in Sys_resource.

Currently, getrlimit and setrlimit and their corresponding flags are
bound.


---
* Homepage: https://github.com/dsheets/ocaml-unix-sys-resource
* Source repo: https://github.com/dsheets/ocaml-unix-sys-resource.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-sys-resource/issues

---

Pull-request generated by opam-publish v0.3.1