### PR TITLE
Add new package dose3 version 4.3

### DIFF
--- a/packages/dose3/dose3.4.3/descr
+++ b/packages/dose3/dose3.4.3/descr
@@ -1,0 +1,1 @@
+Dose library (part of Mancoosi tools)

--- a/packages/dose3/dose3.4.3/opam
+++ b/packages/dose3/dose3.4.3/opam
@@ -16,7 +16,6 @@ license: "LGPL-v3+ with OCaml linking exception"
 dev-repo: "https://gforge.inria.fr/git/dose/dose.git"
 build: [
   ["./configure"]
-  [make printconf]
   [make]
 ]
 install: [make "installlib"]

--- a/packages/dose3/dose3.4.3/opam
+++ b/packages/dose3/dose3.4.3/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "pietro.abate@inria.fr"
+authors: [
+  "Pietro Abate"
+  "Jaap Boender"
+  "Roberto Di Cosmo"
+  "Johannes Schauer"
+  "Ralf Treinen"
+  "Stefano Zacchiroli"
+  "Jakub Zwolakowski"
+  "Olivier Rosello"
+]
+homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
+license: "LGPL-v3+ with OCaml linking exception"
+dev-repo: "https://gforge.inria.fr/git/dose/dose.git"
+build: [
+  ["./configure"]
+  [make printconf]
+  [make]
+]
+install: [make "installlib"]
+remove: [
+  ["./configure"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlgraph" {>= "1.8.6"}
+  "cudf" {>= "0.7"}
+  "conf-perl" {build}
+  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
+  "re" {>= "1.2.2"}
+  "ocamlbuild" {build}
+  "cppo" {build & >= "1.1.2"}
+]

--- a/packages/dose3/dose3.4.3/url
+++ b/packages/dose3/dose3.4.3/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/file/35797/dose3-4.3.tar.gz"
+checksum: "bb8b6be9a9d10b8b5e1906fac3861284"


### PR DESCRIPTION
Note that this commit adds a new package 'dose3' (as published upstream)
with version 4.3. This new package supersedes the package 'dose' already
present in the opam repository. This commit fix the name mismatch in the
opam repository.