### PR TITLE
ppx_deriving 3.2 does not compile on 4.03

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.0.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.0.1/opam
@@ -9,5 +9,5 @@ depends: [
   "ppx_tools" {>= "0.99"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.0"]
+ocaml-version: [>= "4.02.0" & < "4.03"]
 dev-repo: "git://github.com/whitequark/ppx_deriving"

--- a/packages/ppx_deriving/ppx_deriving.0.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.0.2/opam
@@ -9,5 +9,5 @@ depends: [
   "ppx_tools" {>= "0.99"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.02.0"]
+ocaml-version: [>= "4.02.0" & < "4.03"]
 dev-repo: "git://github.com/whitequark/ppx_deriving"

--- a/packages/ppx_deriving/ppx_deriving.0.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.0.3/opam
@@ -24,5 +24,5 @@ depends: [
 # "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03"]
 dev-repo: "git://github.com/whitequark/ppx_deriving"

--- a/packages/ppx_deriving/ppx_deriving.1.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.0/opam
@@ -25,4 +25,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version = "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version = "4.02.1" & ocaml-version < "4.03" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.1.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.1/opam
@@ -17,4 +17,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version = "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version = "4.02.1" & ocaml-version < "4.03" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.0/opam
@@ -17,4 +17,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version = "4.02.2" & opam-version >= "1.2"]
+available: [ocaml-version = "4.02.2" & ocaml-version < "4.03" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.1/opam
@@ -17,4 +17,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.2" & opam-version >= "1.2"]
+available: [ocaml-version >= "4.02.2" & ocaml-version < "4.03" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.2.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.2/opam
@@ -17,4 +17,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.2" & opam-version >= "1.2"]
+available: [ocaml-version >= "4.02.2" & ocaml-version < "4.03" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.3.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.0/opam
@@ -28,4 +28,4 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.2" & opam-version >= "1.2"]
+available: [ocaml-version >= "4.02.2" & ocaml-version < "4.03" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.3.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.1/opam
@@ -28,4 +28,4 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit" {test}
 ]
-available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.03" & opam-version >= "1.2"]

--- a/packages/ppx_deriving/ppx_deriving.3.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.2/opam
@@ -25,4 +25,4 @@ depends: [
   "ppx_tools"  {>= "0.99.2"}
   "ounit"      {test}
 ]
-available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" & opam-version >= "1.2" ]


### PR DESCRIPTION
It seems that ppx_deriving 3.2 does not build on 4.03 due to changes in the AST. This patch updates it's `available` field to stop it being selected. Completely untested, I just edited the file on GitHub.