### PR TITLE
protocol-9p.0.6.0: remove an unnecessary dependency on ctypes

### DIFF
--- a/packages/protocol-9p/protocol-9p.0.6.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.6.0/opam
@@ -25,7 +25,6 @@ depends: [
   "result"
   "mirage-types-lwt"
   "lwt" {>= "2.4.7"}
-  "ctypes"
   "base-unix"
   "cmdliner"
   "stringext"


### PR DESCRIPTION
Signed-off-by: David Scott <dave@recoil.org>