### PR TITLE
slack-backup.0.1 - via opam-publish

### DIFF
--- a/packages/slack-backup/slack-backup.0.1/descr
+++ b/packages/slack-backup/slack-backup.0.1/descr
@@ -1,0 +1,3 @@
+Small tool to backup IM and channels from slack.
+
+Binary and library to backup IM and channels from slack.

--- a/packages/slack-backup/slack-backup.0.1/files/_oasis_remove_.ml
+++ b/packages/slack-backup/slack-backup.0.1/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/slack-backup/slack-backup.0.1/files/slack-backup.install
+++ b/packages/slack-backup/slack-backup.0.1/files/slack-backup.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/slack-backup/slack-backup.0.1/opam
+++ b/packages/slack-backup/slack-backup.0.1/opam
@@ -24,3 +24,4 @@ depends: [
   "result"
   "slacko"
 ]
+available: [ ocaml-version >= "4.02.1" ]

--- a/packages/slack-backup/slack-backup.0.1/opam
+++ b/packages/slack-backup/slack-backup.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/slack-backup"
+bug-reports: "https://github.com/Khady/slack-backup/issues"
+dev-repo: "git+https://github.com/Khady/slack-backup.git"
+license: "MIT"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: [
+  "ocaml" "%{etc}%/slack-backup/_oasis_remove_.ml" "%{etc}%/slack-backup"
+]
+depends: [
+  "cmdliner" {build}
+  "ocamlfind" {build}
+  "result"
+  "slacko"
+]

--- a/packages/slack-backup/slack-backup.0.1/url
+++ b/packages/slack-backup/slack-backup.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Khady/slack-backup/archive/0.1.zip"
+checksum: "021171eb1436d2c24a007c46f8ba2f0d"


### PR DESCRIPTION
Small tool to backup IM and channels from slack.

Binary and library to backup IM and channels from slack.


---
* Homepage: https://github.com/Khady/slack-backup
* Source repo: git+https://github.com/Khady/slack-backup.git
* Bug tracker: https://github.com/Khady/slack-backup/issues

---

Pull-request generated by opam-publish v0.3.1