### PR TITLE
minor release of Jane Street packages (113.33.03)

### DIFF
--- a/packages/async/async.113.33.03/descr
+++ b/packages/async/async.113.33.03/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async/async.113.33.03/opam
+++ b/packages/async/async.113.33.03/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async"
+bug-reports: "https://github.com/janestreet/async/issues"
+dev-repo: "https://github.com/janestreet/async.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async_extra"     {>= "113.33.00" & < "113.34.00"}
+  "async_kernel"    {>= "113.33.00" & < "113.34.00"}
+  "async_unix"      {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async/async.113.33.03/url
+++ b/packages/async/async.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async-113.33.03.tar.gz"
+checksum: "88c14299b3a5aede906a46c89e7f0aec"

--- a/packages/async_extended/async_extended.113.33.03/descr
+++ b/packages/async_extended/async_extended.113.33.03/descr
@@ -1,0 +1,4 @@
+Additional utilities for async
+Async_extended is a collection of utilities for async. They don't
+get the same level of review compared to other packages of the core
+suite but they might still be useful.

--- a/packages/async_extended/async_extended.113.33.03/opam
+++ b/packages/async_extended/async_extended.113.33.03/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_extended"
+bug-reports: "https://github.com/janestreet/async_extended/issues"
+dev-repo: "https://github.com/janestreet/async_extended.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_find"      {>= "113.33.00" & < "113.34.00"}
+  "async_inotify"   {>= "113.33.00" & < "113.34.00"}
+  "async_shell"     {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "camlzip"
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_extended/async_extended.113.33.03/url
+++ b/packages/async_extended/async_extended.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_extended-113.33.03.tar.gz"
+checksum: "0e48fc15880cdc69d5e735dbaa6f71c9"

--- a/packages/async_extra/async_extra.113.33.03/descr
+++ b/packages/async_extra/async_extra.113.33.03/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_extra/async_extra.113.33.03/opam
+++ b/packages/async_extra/async_extra.113.33.03/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_extra"
+bug-reports: "https://github.com/janestreet/async_extra/issues"
+dev-repo: "https://github.com/janestreet/async_extra.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"       {build}
+  "ocamlfind"        {build & >= "1.3.2"}
+  "async_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "async_rpc_kernel" {>= "113.33.00" & < "113.34.00"}
+  "async_unix"       {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"         {>= "113.33.00" & < "113.34.00"}
+  "core"             {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"        {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"   {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"         {>= "113.33.00" & < "113.34.00"}
+  "sexplib"          {>= "113.33.00" & < "113.34.00"}
+  "typerep"          {>= "113.33.00" & < "113.34.00"}
+  "variantslib"      {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_extra/async_extra.113.33.03/url
+++ b/packages/async_extra/async_extra.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_extra-113.33.03.tar.gz"
+checksum: "5ae5688e3f7e27c9c4728ea4fb9ad996"

--- a/packages/async_find/async_find.113.33.03/descr
+++ b/packages/async_find/async_find.113.33.03/descr
@@ -1,0 +1,1 @@
+Directory traversal with Async

--- a/packages/async_find/async_find.113.33.03/opam
+++ b/packages/async_find/async_find.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_find"
+bug-reports: "https://github.com/janestreet/async_find/issues"
+dev-repo: "https://github.com/janestreet/async_find.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_find/async_find.113.33.03/url
+++ b/packages/async_find/async_find.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_find-113.33.03.tar.gz"
+checksum: "50f870f4631c0309904d620d1193c826"

--- a/packages/async_inotify/async_inotify.113.33.03/descr
+++ b/packages/async_inotify/async_inotify.113.33.03/descr
@@ -1,0 +1,1 @@
+Async wrapper for inotify

--- a/packages/async_inotify/async_inotify.113.33.03/opam
+++ b/packages/async_inotify/async_inotify.113.33.03/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_inotify"
+bug-reports: "https://github.com/janestreet/async_inotify/issues"
+dev-repo: "https://github.com/janestreet/async_inotify.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_find"      {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "inotify"
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_inotify/async_inotify.113.33.03/url
+++ b/packages/async_inotify/async_inotify.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_inotify-113.33.03.tar.gz"
+checksum: "ec25f0e00aa725260460fd53e94bc5e6"

--- a/packages/async_kernel/async_kernel.113.33.03/descr
+++ b/packages/async_kernel/async_kernel.113.33.03/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_kernel/async_kernel.113.33.03/opam
+++ b/packages/async_kernel/async_kernel.113.33.03/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_kernel"
+bug-reports: "https://github.com/janestreet/async_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_kernel/async_kernel.113.33.03/url
+++ b/packages/async_kernel/async_kernel.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_kernel-113.33.03.tar.gz"
+checksum: "b33b2d9a6de58c1258c03418303e569b"

--- a/packages/async_parallel/async_parallel.113.33.03/descr
+++ b/packages/async_parallel/async_parallel.113.33.03/descr
@@ -1,0 +1,3 @@
+Distributed computing library
+Parallel is a library for running tasks in other processes on a
+cluster of machines.

--- a/packages/async_parallel/async_parallel.113.33.03/opam
+++ b/packages/async_parallel/async_parallel.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_parallel"
+bug-reports: "https://github.com/janestreet/async_parallel/issues"
+dev-repo: "https://github.com/janestreet/async_parallel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_parallel/async_parallel.113.33.03/url
+++ b/packages/async_parallel/async_parallel.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_parallel-113.33.03.tar.gz"
+checksum: "7269b3e4f989bbb4e126983d2ecd3891"

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/descr
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/descr
@@ -1,0 +1,5 @@
+Platform-independent core of Async RPC library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_rpc_kernel"
+bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
+dev-repo: "https://github.com/janestreet/async_rpc_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async_kernel"    {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/url
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_rpc_kernel-113.33.03.tar.gz"
+checksum: "1ba4d3d39647883a24f061b643be998c"

--- a/packages/async_shell/async_shell.113.33.03/descr
+++ b/packages/async_shell/async_shell.113.33.03/descr
@@ -1,0 +1,1 @@
+Shell helpers for Async

--- a/packages/async_shell/async_shell.113.33.03/opam
+++ b/packages/async_shell/async_shell.113.33.03/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_shell"
+bug-reports: "https://github.com/janestreet/async_shell/issues"
+dev-repo: "https://github.com/janestreet/async_shell.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_shell/async_shell.113.33.03/url
+++ b/packages/async_shell/async_shell.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_shell-113.33.03.tar.gz"
+checksum: "ae8c79533a5e632504d61d1fac8f8814"

--- a/packages/async_smtp/async_smtp.113.33.03/descr
+++ b/packages/async_smtp/async_smtp.113.33.03/descr
@@ -1,0 +1,1 @@
+SMTP client and server

--- a/packages/async_smtp/async_smtp.113.33.03/opam
+++ b/packages/async_smtp/async_smtp.113.33.03/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_smtp"
+bug-reports: "https://github.com/janestreet/async_smtp/issues"
+dev-repo: "https://github.com/janestreet/async_smtp.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_extended"  {>= "113.33.00" & < "113.34.00"}
+  "async_shell"     {>= "113.33.00" & < "113.34.00"}
+  "async_ssl"       {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "cryptokit"
+  "email_message"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_smtp/async_smtp.113.33.03/url
+++ b/packages/async_smtp/async_smtp.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_smtp-113.33.03.tar.gz"
+checksum: "11b64d369ebc31359838a5a7fab014fb"

--- a/packages/async_ssl/async_ssl.113.33.03/descr
+++ b/packages/async_ssl/async_ssl.113.33.03/descr
@@ -1,0 +1,4 @@
+An Async-pipe-based interface with OpenSSL.
+
+This library allows you to create an SSL client and server, with
+encrypted communication between both.

--- a/packages/async_ssl/async_ssl.113.33.03/opam
+++ b/packages/async_ssl/async_ssl.113.33.03/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_ssl"
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "https://github.com/janestreet/async_ssl.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "conf-openssl"
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "ctypes"
+  "ctypes-foreign"
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_ssl/async_ssl.113.33.03/url
+++ b/packages/async_ssl/async_ssl.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_ssl-113.33.03.tar.gz"
+checksum: "50e4f25b4c939695bd9b9b7e0957ebcc"

--- a/packages/async_unix/async_unix.113.33.03/descr
+++ b/packages/async_unix/async_unix.113.33.03/descr
@@ -1,0 +1,5 @@
+Monadic concurrency library
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/async_unix/async_unix.113.33.03/opam
+++ b/packages/async_unix/async_unix.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_unix"
+bug-reports: "https://github.com/janestreet/async_unix/issues"
+dev-repo: "https://github.com/janestreet/async_unix.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async_kernel"    {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/async_unix/async_unix.113.33.03/url
+++ b/packages/async_unix/async_unix.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/async_unix-113.33.03.tar.gz"
+checksum: "784f9b955b04cc5117f9b07909498b3e"

--- a/packages/bignum/bignum.113.33.03/descr
+++ b/packages/bignum/bignum.113.33.03/descr
@@ -1,0 +1,1 @@
+Core-flavoured wrapper around zarith's arbitrary-precision rationals.

--- a/packages/bignum/bignum.113.33.03/opam
+++ b/packages/bignum/bignum.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/bignum"
+bug-reports: "https://github.com/janestreet/bignum/issues"
+dev-repo: "https://github.com/janestreet/bignum.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+  "zarith"          {>= "1.4"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/bignum/bignum.113.33.03/url
+++ b/packages/bignum/bignum.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/bignum-113.33.03.tar.gz"
+checksum: "084d6da6de36aaea85320f9517bda59f"

--- a/packages/bin_prot/bin_prot.113.33.03/descr
+++ b/packages/bin_prot/bin_prot.113.33.03/descr
@@ -1,0 +1,5 @@
+A binary protocol generator
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/bin_prot/bin_prot.113.33.03/opam
+++ b/packages/bin_prot/bin_prot.113.33.03/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/bin_prot"
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix "--%{mirage-xen:enable}%-xen"]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]
+depopts: [
+  "mirage-xen-ocaml"
+]

--- a/packages/bin_prot/bin_prot.113.33.03/url
+++ b/packages/bin_prot/bin_prot.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/bin_prot-113.33.03.tar.gz"
+checksum: "d90c8977da36e4aafd3e0421744fd818"

--- a/packages/core/core.113.33.03/descr
+++ b/packages/core/core.113.33.03/descr
@@ -1,0 +1,4 @@
+Industrial strength alternative to OCaml's standard library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/core/core.113.33.03/opam
+++ b/packages/core/core.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "base-threads"
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/core/core.113.33.03/url
+++ b/packages/core/core.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core-113.33.03.tar.gz"
+checksum: "3a8c63205917a85de8ed597c11c1fc76"

--- a/packages/core_bench/core_bench.113.33.03/descr
+++ b/packages/core_bench/core_bench.113.33.03/descr
@@ -1,0 +1,1 @@
+Benchmarking library

--- a/packages/core_bench/core_bench.113.33.03/opam
+++ b/packages/core_bench/core_bench.113.33.03/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_bench"
+bug-reports: "https://github.com/janestreet/core_bench/issues"
+dev-repo: "https://github.com/janestreet/core_bench.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/core_bench/core_bench.113.33.03/url
+++ b/packages/core_bench/core_bench.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_bench-113.33.03.tar.gz"
+checksum: "ac6b4fa58d1d4baa236d398f5a4d41b3"

--- a/packages/core_extended/core_extended.113.33.03/descr
+++ b/packages/core_extended/core_extended.113.33.03/descr
@@ -1,0 +1,4 @@
+Extra components that are not as closely vetted or as stable as Core
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/core_extended/core_extended.113.33.03/opam
+++ b/packages/core_extended/core_extended.113.33.03/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_extended"
+bug-reports: "https://github.com/janestreet/core_extended/issues"
+dev-repo: "https://github.com/janestreet/core_extended.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/core_extended/core_extended.113.33.03/url
+++ b/packages/core_extended/core_extended.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_extended-113.33.03.tar.gz"
+checksum: "fb7241bc4ec78b6cca1e4fc5edfe6e96"

--- a/packages/core_kernel/core_kernel.113.33.03/descr
+++ b/packages/core_kernel/core_kernel.113.33.03/descr
@@ -1,0 +1,6 @@
+Industrial strength alternative to OCaml's standard library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+Core_kernel is the system-independent part of Core.

--- a/packages/core_kernel/core_kernel.113.33.03/opam
+++ b/packages/core_kernel/core_kernel.113.33.03/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_kernel"
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "https://github.com/janestreet/core_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "result"
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/core_kernel/core_kernel.113.33.03/url
+++ b/packages/core_kernel/core_kernel.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_kernel-113.33.03.tar.gz"
+checksum: "e56da86bcb955e6d65a2da04a973b11f"

--- a/packages/core_profiler/core_profiler.113.33.03/descr
+++ b/packages/core_profiler/core_profiler.113.33.03/descr
@@ -1,0 +1,3 @@
+Profiling library
+Core_profiler is a library that helps you profile programs and
+estimate various costs.

--- a/packages/core_profiler/core_profiler.113.33.03/opam
+++ b/packages/core_profiler/core_profiler.113.33.03/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_profiler"
+bug-reports: "https://github.com/janestreet/core_profiler/issues"
+dev-repo: "https://github.com/janestreet/core_profiler.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "textutils"       {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/core_profiler/core_profiler.113.33.03/url
+++ b/packages/core_profiler/core_profiler.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/core_profiler-113.33.03.tar.gz"
+checksum: "ee6773c060e0a8fe02b0728ebbcc3934"

--- a/packages/email_message/email_message.113.33.03/descr
+++ b/packages/email_message/email_message.113.33.03/descr
@@ -1,0 +1,1 @@
+E-mail message parser

--- a/packages/email_message/email_message.113.33.03/opam
+++ b/packages/email_message/email_message.113.33.03/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/email_message"
+bug-reports: "https://github.com/janestreet/email_message/issues"
+dev-repo: "https://github.com/janestreet/email_message.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "magic-mime"
+  "ounit"
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/email_message/email_message.113.33.03/url
+++ b/packages/email_message/email_message.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/email_message-113.33.03.tar.gz"
+checksum: "c70421d757efcf9c7dc6cc1ceb6cbb38"

--- a/packages/fieldslib/fieldslib.113.33.03/descr
+++ b/packages/fieldslib/fieldslib.113.33.03/descr
@@ -1,0 +1,5 @@
+Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/fieldslib/fieldslib.113.33.03/opam
+++ b/packages/fieldslib/fieldslib.113.33.03/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/fieldslib"
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "https://github.com/janestreet/fieldslib.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/fieldslib/fieldslib.113.33.03/url
+++ b/packages/fieldslib/fieldslib.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/fieldslib-113.33.03.tar.gz"
+checksum: "20566b9efc8dfc6b7d769ffc060afafc"

--- a/packages/incremental/incremental.113.33.03/descr
+++ b/packages/incremental/incremental.113.33.03/descr
@@ -1,0 +1,5 @@
+Library for incremental computations
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/incremental/incremental.113.33.03/opam
+++ b/packages/incremental/incremental.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/incremental"
+bug-reports: "https://github.com/janestreet/incremental/issues"
+dev-repo: "https://github.com/janestreet/incremental.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"         {build}
+  "ocamlfind"          {build & >= "1.3.2"}
+  "bin_prot"           {>= "113.33.00" & < "113.34.00"}
+  "core"               {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"          {>= "113.33.00" & < "113.34.00"}
+  "incremental_kernel" {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"     {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"           {>= "113.33.00" & < "113.34.00"}
+  "sexplib"            {>= "113.33.00" & < "113.34.00"}
+  "typerep"            {>= "113.33.00" & < "113.34.00"}
+  "variantslib"        {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/incremental/incremental.113.33.03/url
+++ b/packages/incremental/incremental.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/incremental-113.33.03.tar.gz"
+checksum: "22c47bb459bea77c0f6228ae4d9b04c6"

--- a/packages/incremental_kernel/incremental_kernel.113.33.03/descr
+++ b/packages/incremental_kernel/incremental_kernel.113.33.03/descr
@@ -1,0 +1,5 @@
+Library for incremental computations depending only on Core_kernel
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/incremental_kernel/incremental_kernel.113.33.03/opam
+++ b/packages/incremental_kernel/incremental_kernel.113.33.03/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/incremental_kernel"
+bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
+dev-repo: "https://github.com/janestreet/incremental_kernel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/incremental_kernel/incremental_kernel.113.33.03/url
+++ b/packages/incremental_kernel/incremental_kernel.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/incremental_kernel-113.33.03.tar.gz"
+checksum: "89de7454800d09285e5549874ac2e0f9"

--- a/packages/jane-street-tests/jane-street-tests.113.33.03/descr
+++ b/packages/jane-street-tests/jane-street-tests.113.33.03/descr
@@ -1,0 +1,5 @@
+Tests for Jane Street packages
+This packages only tests that the various Jane Street components such
+as inline tests work as expected in the opensource world.
+
+It installs nothing.

--- a/packages/jane-street-tests/jane-street-tests.113.33.03/opam
+++ b/packages/jane-street-tests/jane-street-tests.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/jane-street-tests"
+bug-reports: "https://github.com/janestreet/jane-street-tests/issues"
+dev-repo: "https://github.com/janestreet/jane-street-tests.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"           {build}
+  "ocamlfind"            {build & >= "1.3.2"}
+  "bin_prot"             {>= "113.33.00" & < "113.34.00"}
+  "core"                 {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"            {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"       {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"           {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"            {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"           {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"           {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"              {>= "113.33.00" & < "113.34.00"}
+  "toplevel_expect_test" {>= "113.33.00" & < "113.34.00"}
+  "typerep"              {>= "113.33.00" & < "113.34.00"}
+  "variantslib"          {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/jane-street-tests/jane-street-tests.113.33.03/url
+++ b/packages/jane-street-tests/jane-street-tests.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/jane-street-tests-113.33.03.tar.gz"
+checksum: "abf026fa1ac5eabbf1c790974c8c3c3a"

--- a/packages/jenga/jenga.113.33.03/descr
+++ b/packages/jenga/jenga.113.33.03/descr
@@ -1,0 +1,1 @@
+Build system

--- a/packages/jenga/jenga.113.33.03/opam
+++ b/packages/jenga/jenga.113.33.03/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/jenga"
+bug-reports: "https://github.com/janestreet/jenga/issues"
+dev-repo: "https://github.com/janestreet/jenga.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "async_inotify"   {>= "113.33.00" & < "113.34.00"}
+  "async_parallel"  {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ocaml_plugin"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "re2"             {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/jenga/jenga.113.33.03/url
+++ b/packages/jenga/jenga.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/jenga-113.33.03.tar.gz"
+checksum: "2726eaf0c5b7d18bd687a875f67f1b1c"

--- a/packages/js-build-tools/js-build-tools.113.33.03/descr
+++ b/packages/js-build-tools/js-build-tools.113.33.03/descr
@@ -1,0 +1,7 @@
+Collection of tools to help building Jane Street Packages
+This packages contains tools to help building Jane Street
+Packages. However most of it is general purpose.
+It contains::
+- an oasis2opam-install tool to produce a .install file from the oasis
+  build log
+- an js_build_tools ocamlbuild plugin with various goodies

--- a/packages/js-build-tools/js-build-tools.113.33.03/opam
+++ b/packages/js-build-tools/js-build-tools.113.33.03/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/js-build-tools"
+bug-reports: "https://github.com/janestreet/js-build-tools/issues"
+dev-repo: "https://github.com/janestreet/js-build-tools.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ocamlbuild"
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/js-build-tools/js-build-tools.113.33.03/url
+++ b/packages/js-build-tools/js-build-tools.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/js-build-tools-113.33.03.tar.gz"
+checksum: "18234d96c4ddba4201dc44ad7e7d26be"

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.03/descr
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.03/descr
@@ -1,0 +1,1 @@
+Automatically build and dynlink OCaml source files

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.03/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.03/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ocaml_plugin"
+bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
+dev-repo: "https://github.com/janestreet/ocaml_plugin.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ocamlbuild"
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.03/url
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ocaml_plugin-113.33.03.tar.gz"
+checksum: "b32fb3fe3af80e2992be4d0d179a45fe"

--- a/packages/patdiff/patdiff.113.33.03/descr
+++ b/packages/patdiff/patdiff.113.33.03/descr
@@ -1,0 +1,1 @@
+File Diff using the Patience Diff algorithm

--- a/packages/patdiff/patdiff.113.33.03/opam
+++ b/packages/patdiff/patdiff.113.33.03/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/patdiff"
+bug-reports: "https://github.com/janestreet/patdiff/issues"
+dev-repo: "https://github.com/janestreet/patdiff.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "core_extended"   {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "patience_diff"   {>= "113.33.00" & < "113.34.00"}
+  "pcre"
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/patdiff/patdiff.113.33.03/url
+++ b/packages/patdiff/patdiff.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/patdiff-113.33.03.tar.gz"
+checksum: "dcadb69df38615020e72241b39253e44"

--- a/packages/patience_diff/patience_diff.113.33.03/descr
+++ b/packages/patience_diff/patience_diff.113.33.03/descr
@@ -1,0 +1,1 @@
+Diff library using Bram Cohen's patience diff algorithm.

--- a/packages/patience_diff/patience_diff.113.33.03/opam
+++ b/packages/patience_diff/patience_diff.113.33.03/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/patience_diff"
+bug-reports: "https://github.com/janestreet/patience_diff/issues"
+dev-repo: "https://github.com/janestreet/patience_diff.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/patience_diff/patience_diff.113.33.03/url
+++ b/packages/patience_diff/patience_diff.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/patience_diff-113.33.03.tar.gz"
+checksum: "ccf0a0bd7ad76ccf9338b6bcc86db3c3"

--- a/packages/ppx_assert/ppx_assert.113.33.03/descr
+++ b/packages/ppx_assert/ppx_assert.113.33.03/descr
@@ -1,0 +1,2 @@
+Assert-like extension nodes that raise useful errors on failure
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_assert/ppx_assert.113.33.03/opam
+++ b/packages/ppx_assert/ppx_assert.113.33.03/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_assert"
+bug-reports: "https://github.com/janestreet/ppx_assert/issues"
+dev-repo: "https://github.com/janestreet/ppx_assert.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_compare"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+  "sexplib"        {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_assert/ppx_assert.113.33.03/url
+++ b/packages/ppx_assert/ppx_assert.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_assert-113.33.03.tar.gz"
+checksum: "4da98302d2827397b6330451d44cd3e2"

--- a/packages/ppx_bench/ppx_bench.113.33.03/descr
+++ b/packages/ppx_bench/ppx_bench.113.33.03/descr
@@ -1,0 +1,2 @@
+Syntax extension for writing in-line benchmarks in ocaml code
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_bench/ppx_bench.113.33.03/opam
+++ b/packages/ppx_bench/ppx_bench.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_bench"
+bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+dev-repo: "https://github.com/janestreet/ppx_bench.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"       {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_bench/ppx_bench.113.33.03/url
+++ b/packages/ppx_bench/ppx_bench.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_bench-113.33.03.tar.gz"
+checksum: "e6cf0f4fe55b2444bb14cbff1e9a69be"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/descr
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/descr
@@ -1,0 +1,2 @@
+Generation of bin_prot readers and writers from types
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_bin_prot"
+bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
+dev-repo: "https://github.com/janestreet/ppx_bin_prot.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "bin_prot"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/url
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_bin_prot-113.33.03.tar.gz"
+checksum: "b3ef749c641056781dd2b861e72c7692"

--- a/packages/ppx_compare/ppx_compare.113.33.03/descr
+++ b/packages/ppx_compare/ppx_compare.113.33.03/descr
@@ -1,0 +1,2 @@
+Generation of comparison functions from types
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_compare/ppx_compare.113.33.03/opam
+++ b/packages/ppx_compare/ppx_compare.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_compare"
+bug-reports: "https://github.com/janestreet/ppx_compare/issues"
+dev-repo: "https://github.com/janestreet/ppx_compare.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_compare/ppx_compare.113.33.03/url
+++ b/packages/ppx_compare/ppx_compare.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_compare-113.33.03.tar.gz"
+checksum: "7b47b40c0c771f4eb2c72f0892c2083f"

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.03/descr
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.03/descr
@@ -1,0 +1,2 @@
+Deprecated
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.03/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.03/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_conv_func"
+bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
+dev-repo: "https://github.com/janestreet/ppx_conv_func.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.03/url
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_conv_func-113.33.03.tar.gz"
+checksum: "3362d819409651f61d49b7d9807fad17"

--- a/packages/ppx_core/ppx_core.113.33.03/descr
+++ b/packages/ppx_core/ppx_core.113.33.03/descr
@@ -1,0 +1,2 @@
+Standard library for ppx rewriters
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_core/ppx_core.113.33.03/opam
+++ b/packages/ppx_core/ppx_core.113.33.03/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_core"
+bug-reports: "https://github.com/janestreet/ppx_core/issues"
+dev-repo: "https://github.com/janestreet/ppx_core.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_core/ppx_core.113.33.03/url
+++ b/packages/ppx_core/ppx_core.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_core-113.33.03.tar.gz"
+checksum: "043a6c5582b7aff0f8906b11792c6080"

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/descr
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/descr
@@ -1,0 +1,2 @@
+Generate functions to read/write records in csv format
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_csv_conv"
+bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_csv_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_conv_func"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/url
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_csv_conv-113.33.03.tar.gz"
+checksum: "17cc03de9a83a1c17660bc180b6a9904"

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/descr
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/descr
@@ -1,0 +1,2 @@
+Printf-style format-strings for user-defined string conversion
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_custom_printf"
+bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
+dev-repo: "https://github.com/janestreet/ppx_custom_printf.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/url
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_custom_printf-113.33.03.tar.gz"
+checksum: "303cd723860c591491e813a43e846699"

--- a/packages/ppx_driver/ppx_driver.113.33.03/descr
+++ b/packages/ppx_driver/ppx_driver.113.33.03/descr
@@ -1,0 +1,2 @@
+Feature-full driver for OCaml AST transformers
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_driver/ppx_driver.113.33.03/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.03/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_driver"
+bug-reports: "https://github.com/janestreet/ppx_driver/issues"
+dev-repo: "https://github.com/janestreet/ppx_driver.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ocamlbuild"
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_optcomp"    {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_driver/ppx_driver.113.33.03/url
+++ b/packages/ppx_driver/ppx_driver.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_driver-113.33.03.tar.gz"
+checksum: "9e87c2d1ea772718637afc335e88dc45"

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.03/descr
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.03/descr
@@ -1,0 +1,2 @@
+Generate a list containing all values of a finite type
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.03/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.03/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_enumerate"
+bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
+dev-repo: "https://github.com/janestreet/ppx_enumerate.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.03/url
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_enumerate-113.33.03.tar.gz"
+checksum: "b38bcd9acb621609bcca45cd1c9825bf"

--- a/packages/ppx_expect/ppx_expect.113.33.03/descr
+++ b/packages/ppx_expect/ppx_expect.113.33.03/descr
@@ -1,0 +1,2 @@
+Cram like framework for OCaml
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_expect/ppx_expect.113.33.03/opam
+++ b/packages/ppx_expect/ppx_expect.113.33.03/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "https://github.com/janestreet/ppx_expect.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"        {build}
+  "ocamlfind"         {build & >= "1.3.2"}
+  "fieldslib"         {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"    {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_compare"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_custom_printf" {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_fields_conv"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"         {>= "0.99.3"}
+  "ppx_variants_conv" {>= "113.33.00" & < "113.34.00"}
+  "re"
+  "sexplib"           {>= "113.33.00" & < "113.34.00"}
+  "variantslib"       {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_expect/ppx_expect.113.33.03/url
+++ b/packages/ppx_expect/ppx_expect.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_expect-113.33.03.tar.gz"
+checksum: "ceca13eb18037e611717029d16ca48d7"

--- a/packages/ppx_fail/ppx_fail.113.33.03/descr
+++ b/packages/ppx_fail/ppx_fail.113.33.03/descr
@@ -1,0 +1,2 @@
+Add location to calls to failwiths
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_fail/ppx_fail.113.33.03/opam
+++ b/packages/ppx_fail/ppx_fail.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_fail"
+bug-reports: "https://github.com/janestreet/ppx_fail/issues"
+dev-repo: "https://github.com/janestreet/ppx_fail.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_fail/ppx_fail.113.33.03/url
+++ b/packages/ppx_fail/ppx_fail.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_fail-113.33.03.tar.gz"
+checksum: "e7deb90ac7e23000bf9287a57ccce174"

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/descr
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/descr
@@ -1,0 +1,2 @@
+Generation of accessor and iteration functions for ocaml records
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_fields_conv"
+bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_fields_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "fieldslib"      {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/url
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_fields_conv-113.33.03.tar.gz"
+checksum: "5e86c8e11ff261dc85301fcf7236c8bf"

--- a/packages/ppx_here/ppx_here.113.33.03/descr
+++ b/packages/ppx_here/ppx_here.113.33.03/descr
@@ -1,0 +1,2 @@
+Expands [%here] into its location
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_here/ppx_here.113.33.03/opam
+++ b/packages/ppx_here/ppx_here.113.33.03/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_here"
+bug-reports: "https://github.com/janestreet/ppx_here/issues"
+dev-repo: "https://github.com/janestreet/ppx_here.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_here/ppx_here.113.33.03/url
+++ b/packages/ppx_here/ppx_here.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_here-113.33.03.tar.gz"
+checksum: "4bdb1122a2952a31674d403477ed66c2"

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.03/descr
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.03/descr
@@ -1,0 +1,2 @@
+Syntax extension for writing in-line tests in ocaml code
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.03/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.03/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "https://github.com/janestreet/ppx_inline_test.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.03/url
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_inline_test-113.33.03.tar.gz"
+checksum: "6abbbcbe8aefbb9d30721e252cd5c7f4"

--- a/packages/ppx_jane/ppx_jane.113.33.03/descr
+++ b/packages/ppx_jane/ppx_jane.113.33.03/descr
@@ -1,0 +1,3 @@
+Standard Jane Street ppx rewriters
+This package installs a ppx-jane executable, which is a ppx driver
+including all standard Jane Street ppx rewriters.

--- a/packages/ppx_jane/ppx_jane.113.33.03/opam
+++ b/packages/ppx_jane/ppx_jane.113.33.03/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_jane"
+bug-reports: "https://github.com/janestreet/ppx_jane/issues"
+dev-repo: "https://github.com/janestreet/ppx_jane.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"        {build}
+  "ocamlfind"         {build & >= "1.3.2"}
+  "js-build-tools"    {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"         {>= "113.33.00" & < "113.34.00"}
+  "ppx_bin_prot"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_compare"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_custom_printf" {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_enumerate"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_fail"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_fields_conv"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"          {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test"   {>= "113.33.00" & < "113.34.00"}
+  "ppx_let"           {>= "113.33.00" & < "113.34.00"}
+  "ppx_pipebang"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_message"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_value"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_typerep_conv"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_variants_conv" {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_jane/ppx_jane.113.33.03/url
+++ b/packages/ppx_jane/ppx_jane.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_jane-113.33.03.tar.gz"
+checksum: "14e4dea12340e225e7b413b6c3b62a37"

--- a/packages/ppx_let/ppx_let.113.33.03/descr
+++ b/packages/ppx_let/ppx_let.113.33.03/descr
@@ -1,0 +1,2 @@
+Monadic let-bindings
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_let/ppx_let.113.33.03/opam
+++ b/packages/ppx_let/ppx_let.113.33.03/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_let"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+dev-repo: "https://github.com/janestreet/ppx_let.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_let/ppx_let.113.33.03/url
+++ b/packages/ppx_let/ppx_let.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_let-113.33.03.tar.gz"
+checksum: "6906bf23335538f03936eca782436f21"

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.03/descr
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.03/descr
@@ -1,0 +1,2 @@
+Optional compilation for OCaml
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.03/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.03/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_optcomp"
+bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
+dev-repo: "https://github.com/janestreet/ppx_optcomp.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.03/url
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_optcomp-113.33.03.tar.gz"
+checksum: "d7281106c873157e3d10f62be3db0367"

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.03/descr
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.03/descr
@@ -1,0 +1,2 @@
+A ppx rewriter that inlines reverse application operators `|>` and `|!`
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.03/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.03/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_pipebang"
+bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
+dev-repo: "https://github.com/janestreet/ppx_pipebang.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.03/url
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_pipebang-113.33.03.tar.gz"
+checksum: "c48be58c00c4d55cedce702ecef35584"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/descr
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/descr
@@ -1,0 +1,2 @@
+Generation of S-expression conversion functions from type definitions
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_sexp_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+  "sexplib"        {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/url
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_sexp_conv-113.33.03.tar.gz"
+checksum: "065b0f514aee32a2dbcd9e19d98af85c"

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/descr
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/descr
@@ -1,0 +1,2 @@
+A ppx rewriter for easy construction of s-expressions
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_message"
+bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
+dev-repo: "https://github.com/janestreet/ppx_sexp_message.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/url
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_sexp_message-113.33.03.tar.gz"
+checksum: "91b7c60217aa86d73b1cd33ec6909a2d"

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/descr
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/descr
@@ -1,0 +1,2 @@
+A ppx rewriter that simplifies building s-expressions from ocaml values
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_value"
+bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
+dev-repo: "https://github.com/janestreet/ppx_sexp_value.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/url
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_sexp_value-113.33.03.tar.gz"
+checksum: "0582ea3bc8edddc6bb8731514059da84"

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.03/descr
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.03/descr
@@ -1,0 +1,2 @@
+Support Library for type-driven code generators
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_type_conv"
+bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_type_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_deriving"   {>= "3.0"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.03/url
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_type_conv-113.33.03.tar.gz"
+checksum: "180b8573949073c52ed706db75937875"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/descr
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/descr
@@ -1,0 +1,2 @@
+Generation of runtime types from type declarations
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_typerep_conv"
+bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_typerep_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+  "typerep"        {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/url
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_typerep_conv-113.33.03.tar.gz"
+checksum: "5dfa2918b204dee5ee5f09ee0863be63"

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/descr
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/descr
@@ -1,0 +1,2 @@
+Generation of accessor and iteration functions for ocaml variant types
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_variants_conv"
+bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_variants_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+  "variantslib"    {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/url
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_variants_conv-113.33.03.tar.gz"
+checksum: "4062a75f20445c4c30d40999b0addd8b"

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/descr
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/descr
@@ -1,0 +1,2 @@
+Generate XML conversion functions from records
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_xml_conv"
+bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_xml_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_conv_func"  {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_tools"      {>= "0.99.3"}
+  "ppx_type_conv"  {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/url
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_xml_conv-113.33.03.tar.gz"
+checksum: "5e19fbaf48b500aed0f68fdc61ed7da7"

--- a/packages/re2/re2.113.33.03/descr
+++ b/packages/re2/re2.113.33.03/descr
@@ -1,0 +1,1 @@
+OCaml bindings for RE2, Google's regular expression library

--- a/packages/re2/re2.113.33.03/opam
+++ b/packages/re2/re2.113.33.03/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/re2"
+bug-reports: "https://github.com/janestreet/re2/issues"
+dev-repo: "https://github.com/janestreet/re2.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]
+depexts: [
+ [ ["fedora"] ["gcc-c++"] ]
+ [ ["oraclelinux"] ["gcc-c++"] ]
+]

--- a/packages/re2/re2.113.33.03/url
+++ b/packages/re2/re2.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/re2-113.33.03.tar.gz"
+checksum: "6d23b0dcb9e72f197fe22eef65204f44"

--- a/packages/rpc_parallel/rpc_parallel.113.33.03/descr
+++ b/packages/rpc_parallel/rpc_parallel.113.33.03/descr
@@ -1,0 +1,5 @@
+Type-safe parallel library built on top of Async_rpc
+Rpc_parallel offers an API to define various workers and protocols,
+spawn workers as separate processes, and communicate with them using
+Async Rpc.
+

--- a/packages/rpc_parallel/rpc_parallel.113.33.03/opam
+++ b/packages/rpc_parallel/rpc_parallel.113.33.03/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/rpc_parallel"
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "https://github.com/janestreet/rpc_parallel.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "async"           {>= "113.33.00" & < "113.34.00"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/rpc_parallel/rpc_parallel.113.33.03/url
+++ b/packages/rpc_parallel/rpc_parallel.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/rpc_parallel-113.33.03.tar.gz"
+checksum: "cfb5ea1cd8fad6fae47adaebd35b12d1"

--- a/packages/sexplib/sexplib.113.33.03/descr
+++ b/packages/sexplib/sexplib.113.33.03/descr
@@ -1,0 +1,5 @@
+Library for serializing OCaml values to and from S-expressions
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib/sexplib.113.33.03/opam
+++ b/packages/sexplib/sexplib.113.33.03/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/sexplib"
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "https://github.com/janestreet/sexplib.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/sexplib/sexplib.113.33.03/url
+++ b/packages/sexplib/sexplib.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/sexplib-113.33.03.tar.gz"
+checksum: "739af487f05e0ffd8626e9acb653b33d"

--- a/packages/textutils/textutils.113.33.03/descr
+++ b/packages/textutils/textutils.113.33.03/descr
@@ -1,0 +1,1 @@
+Text output utilities

--- a/packages/textutils/textutils.113.33.03/opam
+++ b/packages/textutils/textutils.113.33.03/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/textutils"
+bug-reports: "https://github.com/janestreet/textutils/issues"
+dev-repo: "https://github.com/janestreet/textutils.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core"            {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/textutils/textutils.113.33.03/url
+++ b/packages/textutils/textutils.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/textutils-113.33.03.tar.gz"
+checksum: "7b4a62f49660363aafd866b146522c44"

--- a/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/descr
+++ b/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/descr
@@ -1,0 +1,5 @@
+Expectation tests for the OCaml toplevel
+Allows one to write both toplevel phrases and the expected output from
+the toplevel in the same file. This provides an easy way to test
+compilations errors as well as provide a nice alternative to using
+the toplevel in a terminal.

--- a/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/toplevel_expect_test"
+bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
+dev-repo: "https://github.com/janestreet/toplevel_expect_test.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"      {build}
+  "ocamlfind"       {build & >= "1.3.2"}
+  "bin_prot"        {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"     {>= "113.33.00" & < "113.34.00"}
+  "fieldslib"       {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"  {build & >= "113.33.00" & < "113.34.00"}
+  "ocamlfind"       {>= "1.3.2"}
+  "ppx_assert"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_bench"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_core"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_expect"      {>= "113.33.00" & < "113.34.00"}
+  "ppx_here"        {>= "113.33.00" & < "113.34.00"}
+  "ppx_inline_test" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane"        {>= "113.33.00" & < "113.34.00"}
+  "sexplib"         {>= "113.33.00" & < "113.34.00"}
+  "typerep"         {>= "113.33.00" & < "113.34.00"}
+  "variantslib"     {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/url
+++ b/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/toplevel_expect_test-113.33.03.tar.gz"
+checksum: "9eb6aa7f6eecf22a088303c3db48ddcc"

--- a/packages/typerep/typerep.113.33.03/descr
+++ b/packages/typerep/typerep.113.33.03/descr
@@ -1,0 +1,1 @@
+typerep is a library for runtime types.

--- a/packages/typerep/typerep.113.33.03/opam
+++ b/packages/typerep/typerep.113.33.03/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/typerep"
+bug-reports: "https://github.com/janestreet/typerep/issues"
+dev-repo: "https://github.com/janestreet/typerep.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/typerep/typerep.113.33.03/url
+++ b/packages/typerep/typerep.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/typerep-113.33.03.tar.gz"
+checksum: "8a1ace5ff29e625d6f1f513a4de24dec"

--- a/packages/typerep_extended/typerep_extended.113.33.03/descr
+++ b/packages/typerep_extended/typerep_extended.113.33.03/descr
@@ -1,0 +1,4 @@
+Runtime types for OCaml
+typerep_extended is a set of additional modules for typerep. They are
+not part of the base typerep library to avoid a circular dependency
+between core_kernel and typerep.

--- a/packages/typerep_extended/typerep_extended.113.33.03/opam
+++ b/packages/typerep_extended/typerep_extended.113.33.03/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/typerep_extended"
+bug-reports: "https://github.com/janestreet/typerep_extended/issues"
+dev-repo: "https://github.com/janestreet/typerep_extended.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"       {build}
+  "ocamlfind"        {build & >= "1.3.2"}
+  "bin_prot"         {>= "113.33.00" & < "113.34.00"}
+  "core_kernel"      {>= "113.33.00" & < "113.34.00"}
+  "js-build-tools"   {build & >= "113.33.00" & < "113.34.00"}
+  "ppx_bin_prot"     {>= "113.33.00" & < "113.34.00"}
+  "ppx_driver"       {>= "113.33.00" & < "113.34.00"}
+  "ppx_sexp_conv"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_type_conv"    {>= "113.33.00" & < "113.34.00"}
+  "ppx_typerep_conv" {>= "113.33.00" & < "113.34.00"}
+  "sexplib"          {>= "113.33.00" & < "113.34.00"}
+  "typerep"          {>= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/typerep_extended/typerep_extended.113.33.03/url
+++ b/packages/typerep_extended/typerep_extended.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/typerep_extended-113.33.03.tar.gz"
+checksum: "926a2b4b589c1806fae435dfa05d49d8"

--- a/packages/variantslib/variantslib.113.33.03/descr
+++ b/packages/variantslib/variantslib.113.33.03/descr
@@ -1,0 +1,4 @@
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/variantslib/variantslib.113.33.03/opam
+++ b/packages/variantslib/variantslib.113.33.03/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/variantslib"
+bug-reports: "https://github.com/janestreet/variantslib/issues"
+dev-repo: "https://github.com/janestreet/variantslib.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build & >= "1.3.2"}
+  "js-build-tools" {build & >= "113.33.00" & < "113.34.00"}
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/variantslib/variantslib.113.33.03/url
+++ b/packages/variantslib/variantslib.113.33.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/variantslib-113.33.03.tar.gz"
+checksum: "f8e9d6362f6dd0ba92ee706e584d4790"


### PR DESCRIPTION
This minor release bump the version of all Jane Street packages but only the build system was touched for most of the packages.

The reason is that we had a script to generate a `.install` file from oasis and it was broken on Windows. I factored it out into a package [js-build-tools](https://github.com/janestreet/js-build-tools) along with some ocamlbuild stuff, that will make future changes easier.