### PR TITLE
lablgtk-2.18.4

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.4/descr
+++ b/packages/lablgtk/lablgtk.2.18.4/descr
@@ -1,0 +1,7 @@
+OCaml interface to GTK+
+
+If you have problems compiling this on MacOS X, try this using Homebrew:
+
+$ brew install gtk+
+$ export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig
+$ opam install lablgtk

--- a/packages/lablgtk/lablgtk.2.18.4/files/lablgldir.patch
+++ b/packages/lablgtk/lablgtk.2.18.4/files/lablgldir.patch
@@ -1,0 +1,12 @@
+diff -Naur lablgtk-2.16.0.orig/configure lablgtk-2.16.0/configure
+--- lablgtk-2.16.0.orig/configure	2012-08-23 12:37:48.000000000 +0200
++++ lablgtk-2.16.0/configure	2013-08-21 11:16:50.707187151 +0200
+@@ -4066,7 +4066,7 @@
+       cat > conftest.ml << EOF
+       open Raw
+ EOF
+-      if $CAMLC -c -I "${LABLGLDIR:=+lablGL}" conftest.ml > /dev/null 2>&1 ; then
++      if $CAMLC -c -I "$LABLGLDIR" conftest.ml > /dev/null 2>&1 ; then
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LABLGLDIR" >&5
+ $as_echo "$LABLGLDIR" >&6; }
+       else

--- a/packages/lablgtk/lablgtk.2.18.4/files/lablgtk.install
+++ b/packages/lablgtk/lablgtk.2.18.4/files/lablgtk.install
@@ -1,0 +1,5 @@
+bin: [
+  "src/lablgtk2"
+  "src/gdk_pixbuf_mlsource"
+  "?src/lablgladecc2"
+]

--- a/packages/lablgtk/lablgtk.2.18.4/findlib
+++ b/packages/lablgtk/lablgtk.2.18.4/findlib
@@ -1,0 +1,1 @@
+lablgtk2

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -1,6 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "http://lablgtk.forge.ocamlcore.org/"
+bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=220"
+dev-repo: "https://github.com:garrigue/lablgtk.git"
+license: "LGPL with linking exception"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -1,0 +1,34 @@
+opam-version: "1"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+homepage: "http://lablgtk.forge.ocamlcore.org/"
+build: [
+  ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
+  [make "world"]
+  [make "install"]
+]
+available: [ocaml-version >= "3.11.0"] # as indicated in README file
+remove: [["ocamlfind" "remove" "lablgtk2"]]
+depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
+depopts: [
+  "conf-gtksourceview"
+  "conf-gnomecanvas"
+  "conf-glade"
+  "lablgl"
+]
+depexts: [
+  [["debian"] ["libgtk2.0-dev" "libexpat1-dev"]]
+  [["ubuntu"] ["libgtk2.0-dev" "libexpat1-dev"]]
+  [["homebrew" "osx"] ["gtk" "expat"]]
+  [["centos"] ["gtk2-devel"]]
+  [["fedora"] ["gtk2-devel"]]
+  [["oraclelinux"] ["gtk2-devel"]]
+  [["alpine"] ["gtk+2.0-dev"]]
+]
+patches: ["lablgldir.patch"]
+post-messages: [
+  "This package requires gtk+ 2.0 development packages installed on your system" {failure}
+  "To solve pkg-config issues, you may need to do
+'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' (macports)
+or 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig' (homebrew)
+and retry" {failure & (os = "darwin")}
+]

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -3,7 +3,7 @@ maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "http://lablgtk.forge.ocamlcore.org/"
 bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=220"
-dev-repo: "https://github.com:garrigue/lablgtk.git"
+dev-repo: "https://github.com/garrigue/lablgtk.git"
 license: "LGPL with linking exception"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -8,11 +8,13 @@ license: "LGPL with linking exception"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]
+]
+install: [
   [make "install"]
 ]
 available: [ocaml-version >= "3.11.0"] # as indicated in README file
 remove: [["ocamlfind" "remove" "lablgtk2"]]
-depends: ["ocamlfind" {>= "1.2.1"} "camlp4"]
+depends: ["ocamlfind" {>= "1.2.1"}]
 depopts: [
   "conf-gtksourceview"
   "conf-gnomecanvas"

--- a/packages/lablgtk/lablgtk.2.18.4/url
+++ b/packages/lablgtk/lablgtk.2.18.4/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1602/lablgtk-2.18.4.tar.gz"
+checksum: "cb95497a3a34facd70d475892a806d02"


### PR DESCRIPTION
LablGTK release 2.18.4, required for compatibility with ocaml 4.03.
Also fixes a number of bugs, and allows tuning the GC.