### PR TITLE
ppx_deriving_morphism.0.3 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/descr
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/descr
@@ -1,0 +1,5 @@
+Morphism generator for OCaml >=4.02
+
+ppx_deriving_morphism is a ppx_deriving plugin that provides
+a generator for records implementing openly recursive map and fold routines
+for arbitrary data structures.

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Christoph Höger <christoph.hoeger@tu-berlin.de>"
+authors: "Christoph Höger <christoph.hoeger@tu-berlin.de>"
+homepage: "https://github.com/choeger/ppx_deriving_morphism"
+bug-reports: "https://github.com/choeger/ppx_deriving_morphism/issues"
+license: "BSD"
+tags: "syntax"
+dev-repo: "git://github.com/choeger/ppx_deriving_morphism.git"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_ppx_morphism.byte"
+  "--"
+]
+depends: [
+  "ppx_deriving" {>= "3.0" & < "4.0"}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "ppx_import" {test}
+]

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/url
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/choeger/ppx_deriving_morphism/archive/v0.3.tar.gz"
+checksum: "91edff76f7a88440991a7006cf58be50"


### PR DESCRIPTION
Morphism generator for OCaml >=4.02

ppx_deriving_morphism is a ppx_deriving plugin that provides
a generator for records implementing openly recursive map and fold routines
for arbitrary data structures.


---
* Homepage: https://github.com/choeger/ppx_deriving_morphism
* Source repo: git://github.com/choeger/ppx_deriving_morphism.git
* Bug tracker: https://github.com/choeger/ppx_deriving_morphism/issues

---

Pull-request generated by opam-publish v0.3.1