### PR TITLE
mirage-types.2.8.0: add ocamlbuild build dependency

### DIFF
--- a/packages/mirage-types/mirage-types.2.8.0/opam
+++ b/packages/mirage-types/mirage-types.2.8.0/opam
@@ -10,7 +10,10 @@ build:   [make "build-types"]
 install: [make "install-types"]
 remove:  ["ocamlfind" "remove" "mirage-types"]
 
-depends:   ["ocamlfind"]
+depends:   [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 depopts:   ["lwt" "cstruct" "io-page" "ipaddr"]
 conflicts: ["ipaddr" {< "2.0.0"}]
 


### PR DESCRIPTION
/cc @avsm 

Possibly older versions also need this treatment but I was too lazy to check them.