### PR TITLE
opium.0.15.0 - via opam-publish

### DIFF
--- a/packages/opium/opium.0.15.0/descr
+++ b/packages/opium/opium.0.15.0/descr
@@ -1,0 +1,11 @@
+Sinatra like web toolkit based on Lwt + Cohttp
+
+Opium is a minimalistic library for quickly binding functions
+to http routes. Its features include (but not limited to):
+
+* Middleware system for app independent components
+* A simple router for matching urls and parsing parameters
+* Request/Response pretty printing for easier debugging
+
+Note: This library is still at an early stage so expect breakages
+until 1.0

--- a/packages/opium/opium.0.15.0/opam
+++ b/packages/opium/opium.0.15.0/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/opium"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+dev-repo: "https://github.com/rgrinberg/opium.git"
+
+build: [ [make "opam"] ]
+
+install: [make "install"]
+
+remove: [
+  ["ocamlfind" "remove" "opium"]
+  ["ocamlfind" "remove" "opium_kernel"]
+]
+
+build-test: [ [make "check"] ]
+
+depends: [
+  "ocamlfind" {build}
+  "omake" {build}
+  "hmap"
+  "cohttp" {>= "0.15.0"}
+  "ezjsonm" {>= "0.4.0"}
+  "base64" {>= "2.0.0"}
+  "lwt"
+  "cmdliner"
+  "fieldslib"
+  "sexplib"
+  "ppx_fields_conv"
+  "ppx_sexp_conv"
+  "re" {>= "1.3.0"}
+  "magic-mime"
+  "alcotest" {test}
+  "cow" {test & >= "0.10.0"}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opium/opium.0.15.0/url
+++ b/packages/opium/opium.0.15.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/opium/archive/v0.15.0.tar.gz"
+checksum: "24ce037546846438ce9bac10e21ec6d6"


### PR DESCRIPTION
Sinatra like web toolkit based on Lwt + Cohttp

Opium is a minimalistic library for quickly binding functions
to http routes. Its features include (but not limited to):

* Middleware system for app independent components
* A simple router for matching urls and parsing parameters
* Request/Response pretty printing for easier debugging

Note: This library is still at an early stage so expect breakages
until 1.0


---
* Homepage: https://github.com/rgrinberg/opium
* Source repo: https://github.com/rgrinberg/opium.git
* Bug tracker: https://github.com/rgrinberg/opium/issues

---

Pull-request generated by opam-publish v0.3.1