### PR TITLE
mirage-logs.0.2 - via opam-publish

### DIFF
--- a/packages/mirage-logs/mirage-logs.0.2/descr
+++ b/packages/mirage-logs/mirage-logs.0.2/descr
@@ -1,0 +1,5 @@
+A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps.
+
+It can also log only important messages to the console, while writing all received messages to a ring buffer which is displayed if an exception occurs.
+
+If tracing is enabled (via mirage-profile), it also writes each log message to the trace buffer.

--- a/packages/mirage-logs/mirage-logs.0.2/opam
+++ b/packages/mirage-logs/mirage-logs.0.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "talex5@gmail.com"
+authors: "Thomas Leonard"
+homepage: "https://github.com/mirage/mirage-logs"
+bug-reports: "https://github.com/mirage/mirage-logs/issues"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-logs.git"
+build: [make "PREFIX=%{prefix}%"]
+install: [make "PREFIX=%{prefix}%" "install"]
+remove: ["ocamlfind" "remove" "mirage-logs"]
+depends: [
+  "logs" {>= "0.5.0"}
+  "ocamlfind" {build}
+  "oasis" {build}
+  "mirage-types"
+  "mirage-profile"
+  "lwt"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-logs/mirage-logs.0.2/url
+++ b/packages/mirage-logs/mirage-logs.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-logs/archive/v0.2.tar.gz"
+checksum: "8a2d211deb69970b95b8890e68194357"


### PR DESCRIPTION
A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps.

It can also log only important messages to the console, while writing all received messages to a ring buffer which is displayed if an exception occurs.

If tracing is enabled (via mirage-profile), it also writes each log message to the trace buffer.


---
* Homepage: https://github.com/mirage/mirage-logs
* Source repo: https://github.com/mirage/mirage-logs.git
* Bug tracker: https://github.com/mirage/mirage-logs/issues

---

Pull-request generated by opam-publish v0.3.1