### PR TITLE
minisat2.0.4 - via opam-publish

### DIFF
--- a/packages/minisat2/minisat2.0.4/descr
+++ b/packages/minisat2/minisat2.0.4/descr
@@ -1,0 +1,4 @@
+Bindings for minisat 2 SAT solver
+
+These are bindings for ocaml for the minisat http://minisat.se/MiniSat.html
+SAT solver.

--- a/packages/minisat2/minisat2.0.4/opam
+++ b/packages/minisat2/minisat2.0.4/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "pietro abate <pietro.abate@inria.fr>"
+authors: "Pietro Abate and Flavio Lerda"
+homepage: "https://github.com/abate/minisat-ocaml"
+license: "GPL3 WITH linking exception"
+dev-repo: "https://github.com/abate/minisat-ocaml.git"
+build: [
+  ["%{make}%"]
+  ["%{make}%" "opt"]
+]
+install: ["%{make}%" "install"]
+depexts: [
+  [["debian"] ["minisat"]]
+  [["ubuntu"] ["minisat"]]
+]
+
+remove: ["%{make}%" "uninstall"]

--- a/packages/minisat2/minisat2.0.4/url
+++ b/packages/minisat2/minisat2.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fgaray/minisat-ocaml/archive/0.4.tar.gz"
+checksum: "3099a7249c313448d2bbfaa908d3625d"


### PR DESCRIPTION
Bindings for minisat 2 SAT solver

These are bindings for ocaml for the minisat http://minisat.se/MiniSat.html
SAT solver.

---
- Homepage: https://github.com/abate/minisat-ocaml
- Source repo: https://github.com/abate/minisat-ocaml.git
- Bug tracker: 

---
### opam-lint failures
- **WARNING** 36 Missing field 'bug-reports'

---

Pull-request generated by opam-publish v0.3.1
