### PR TITLE
functoria.1.1.0 - via opam-publish

### DIFF
--- a/packages/functoria/functoria.1.1.0/descr
+++ b/packages/functoria/functoria.1.1.0/descr
@@ -1,0 +1,9 @@
+A DSL to organize functor applications.
+
+Functoria is a DSL to describe a set of modules and functors, their
+types and how to apply them in order to produce a complete
+application.
+
+The main use case is mirage. See the mirage repository for details:
+
+    https://github.com/mirage/mirage

--- a/packages/functoria/functoria.1.1.0/opam
+++ b/packages/functoria/functoria.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Dave Scott"
+  "Thomas Leonard"
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/mirage/functoria"
+bug-reports: "https://github.com/mirage/functoria/issues"
+license: "ISC"
+dev-repo: "https://github.com/mirage/functoria.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--%{ounit:enable}%-tests"]
+  [make]
+]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "functoria"]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+  "cmdliner" {>= "0.9.8"}
+  "rresult"
+  "fmt"
+  "ocamlgraph"
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/functoria/functoria.1.1.0/url
+++ b/packages/functoria/functoria.1.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/functoria/archive/1.1.0.tar.gz"
+checksum: "a46aa627a472db9b9dd1bdfd8c45eaf6"


### PR DESCRIPTION
A DSL to organize functor applications.

Functoria is a DSL to describe a set of modules and functors, their
types and how to apply them in order to produce a complete
application.

The main use case is mirage. See the mirage repository for details:

    https://github.com/mirage/mirage


---
* Homepage: https://github.com/mirage/functoria
* Source repo: https://github.com/mirage/functoria.git
* Bug tracker: https://github.com/mirage/functoria/issues

---

Pull-request generated by opam-publish v0.3.1