### PR TITLE
ppx_json_types.0.3 - via opam-publish

### DIFF
--- a/packages/ppx_json_types/ppx_json_types.0.3/descr
+++ b/packages/ppx_json_types/ppx_json_types.0.3/descr
@@ -1,0 +1,4 @@
+JSON type providers
+A solution for dynamically creating JSON-based types from Web-hosted
+type information, providing the tools necessary to work with values
+of the type at compile-time.

--- a/packages/ppx_json_types/ppx_json_types.0.3/opam
+++ b/packages/ppx_json_types/ppx_json_types.0.3/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/otp"
+bug-reports: "https://github.com/nv-vn/otp/issues"
+license: "GPL"
+dev-repo: "https://github.com/nv-vn/otp.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ppx_json_types"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "lwt" {>= "2.5.0"}
+  "cohttp" {>= "0.19.0"}
+  "yojson" {>= "1.3.0"}
+  "ppx_tools" {>= "0.99.2"}
+  "ppx_deriving" {>= "3.0"}
+  "ppx_deriving_yojson" {>= "2.4"}
+]

--- a/packages/ppx_json_types/ppx_json_types.0.3/url
+++ b/packages/ppx_json_types/ppx_json_types.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/otp/archive/0.3.tar.gz"
+checksum: "4e5b7d75e1af7a19f404b2989754eff7"


### PR DESCRIPTION
JSON type providers
A solution for dynamically creating JSON-based types from Web-hosted
type information, providing the tools necessary to work with values
of the type at compile-time.


---
* Homepage: https://github.com/nv-vn/otp
* Source repo: https://github.com/nv-vn/otp.git
* Bug tracker: https://github.com/nv-vn/otp/issues

---

Pull-request generated by opam-publish v0.3.1