### PR TITLE
Eliom 4.2.0 only works correctly with Ocsigenserver 2.6

### DIFF
--- a/packages/eliom/eliom.4.2.0/opam
+++ b/packages/eliom/eliom.4.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "js_of_ocaml" {>= "2.5"}
   "tyxml" {>= "3.3.0" & < "3.6.0"}
   "calendar"
-  "ocsigenserver" {>= "2.6"}
+  "ocsigenserver" {= "2.6"}
   "ipaddr" {>= "2.1"}
   "reactiveData"
   "ocamlbuild"


### PR DESCRIPTION
**NOTE:** Please do **not** merge before feedback from someone on the Ocsigen team!

Currently, Eliom 4.2.0 has `ocsigenserver >= 2.6` on its `depends` fields.  However, Eliom 4.2.0 [does not work correctly with Ocsigenserver 2.7](https://github.com/ocsigen/ocsigenserver/issues/97).  This PR fixes the constraint. (Note that other versions of Eliom are probably also affected.)

@balat, @Drup, @vasilisp: what do you think?