### PR TITLE
Add upper bounds for unix-errno on dirent, fcntl, sys-stat, and sys-resource

### DIFF
--- a/packages/unix-dirent/unix-dirent.0.3.0/opam
+++ b/packages/unix-dirent/unix-dirent.0.3.0/opam
@@ -19,5 +19,6 @@ depopts: [
 ]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "unix-errno" {>= "0.4.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/unix-fcntl/unix-fcntl.0.3.0/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.4.0"}
-  "unix-errno" {>= "0.2.0"}
+  "unix-errno" {>= "0.2.0" & < "0.4.0"}
   "alcotest" {test}
   "unix-type-representations"
 ]

--- a/packages/unix-fcntl/unix-fcntl.0.3.1/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.4.0"}
-  "unix-errno" {>= "0.2.0"}
+  "unix-errno" {>= "0.2.0" & < "0.4.0"}
   "alcotest" {test}
   "unix-type-representations"
 ]

--- a/packages/unix-sys-resource/unix-sys-resource.0.1.0/opam
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "alcotest" {test}
-  "unix-errno" {>= "0.3.0"}
+  "unix-errno" {>= "0.3.0" & < "0.4.0"}
   "ctypes"
 ]
 depopts: [

--- a/packages/unix-sys-stat/unix-sys-stat.0.3.0/opam
+++ b/packages/unix-sys-stat/unix-sys-stat.0.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlbuild" {build}
   "alcotest" {test}
   "base-bytes"
-  "unix-errno" {>= "0.3.0"}
+  "unix-errno" {>= "0.3.0" & < "0.4.0"}
   "ctypes"
 ]
 depopts: "base-unix"


### PR DESCRIPTION
`unix-errno.0.4.0` is coming and it breaks compat with 0.3.0.