### PR TITLE
Remove base-no-ppx for ocaml 4.03.

### DIFF
--- a/packages/base-no-ppx/base-no-ppx.base/opam
+++ b/packages/base-no-ppx/base-no-ppx.base/opam
@@ -1,2 +1,2 @@
 opam-version: "1.2"
-available: [ ocaml-version < "4.02.0" | ocaml-version >= "4.03.0" ]
+available: [ ocaml-version < "4.02.0" ]


### PR DESCRIPTION
cc @chambart 

I guess the objective was to be able to compile packages that optionally depends on ppx, but we should remove it now. It breaks lwt's configuration.
For the next version, I think using `opam pin -e` locally would be a better idea...