### PR TITLE
ocamlbuild 0.9.2

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.9.2/descr
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/descr
@@ -1,0 +1,1 @@
+OCamlbuild is a build system with builtin rules to easily build most OCaml projects.

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/findlib
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/findlib
@@ -1,0 +1,1 @@
+ocamlbuild

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+name: "ocamlbuild"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+version: "0.9.2"
+
+authors: [
+  "Nicolas Pouillard"
+  "Berke Durak"
+]
+
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml/ocamlbuild.git"
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+
+build: [
+  [make "-f" "configure.make" "Makefile.config"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAML_NATIVE=%{ocaml-native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml-native}%"]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+
+doc: [
+  "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
+  "https://github.com/gasche/manual-ocamlbuild/blob/master/manual.md"
+]
+
+available: [ocaml-version >= "4.03"]
+depends: [ ]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.5"}
+]

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/url
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/ocamlbuild/archive/0.9.2.tar.gz"
+checksum: "b8c90bac4e54e3b5b8243c4845122dd2"


### PR DESCRIPTION
OCamlbuild 0.9.2 is a release to support OCaml 4.03. Martin Neuhäußer
contributed new flags for flambda-specific optimization options. We
also extend the scope of the flags -opaque and -for-pack, to align
with 4.03 best practices. Note that OCamlbuild should still work
correctly under older OCaml releases.