### PR TITLE
mark mirage-fs-unix-1.0.0 and 1.1.0 self-conflicting (contain directory traversals)

### DIFF
--- a/packages/mirage-fs-unix/mirage-fs-unix.1.0.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.0.0/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-fs-unix"
 build: [
   [make]
   [make "install"]
@@ -12,5 +13,5 @@ depends: [
   "mirage-types" {>= "0.5.0"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version = "0" ] (* insecure, not installable! *)
 dev-repo: "git://github.com/mirage/mirage-fs-unix"

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.1.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.1.0/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-fs-unix"
 build: [
   [make]
   [make "install"]
@@ -12,5 +13,5 @@ depends: [
   "mirage-types" {>= "1.1.0"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version = "0" ] (* insecure, not installable! *)
 dev-repo: "git://github.com/mirage/mirage-fs-unix"


### PR DESCRIPTION
see https://github.com/mirage/mirage-fs-unix/blob/master/CHANGES (avoid accidental installation of insecure packages)