### PR TITLE
ocf does not compile with 4.03.0 (ppx incompatibility)

### DIFF
--- a/packages/ocf/ocf.0.1.0/opam
+++ b/packages/ocf/ocf.0.1.0/opam
@@ -1,18 +1,25 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "zoggy@bat8.org"
 authors: ["Maxence Guesdon"]
 homepage: "http://zoggy.github.io/ocf/"
 license: "GNU Lesser General Public License version 3"
 doc: ["http://zoggy.github.io/ocf/doc.html"]
+dev-repo: "https://github.com/zoggy/ocf.git"
+bug-reports: "https://github.com/zoggy/ocf/issues"
+tags: ["configuration" "options" "json"]
+
 build: [
   ["./configure" "--prefix" prefix]
   [make "all"]
+]
+install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "ocf"]]
 depends: [
+  "camlp4"
   "ocamlfind"
   "yojson" {>= "1.1.8"}
   "ppx_tools" {>= "0.99"}
 ]
-ocaml-version: [>= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.03.0"]

--- a/packages/ocf/ocf.0.2.0/opam
+++ b/packages/ocf/ocf.0.2.0/opam
@@ -17,8 +17,9 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "ocf"]]
 depends: [
+  "camlp4"
   "ocamlfind"
   "yojson" {>= "1.1.8"}
   "ppx_tools" {>= "0.99"}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.03.0"]

--- a/packages/ocf/ocf.0.3.0/opam
+++ b/packages/ocf/ocf.0.3.0/opam
@@ -17,8 +17,9 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "ocf"]]
 depends: [
+  "camlp4"
   "ocamlfind"
   "yojson" {>= "1.1.8"}
   "ppx_tools" {>= "0.99"}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.03.0"]

--- a/packages/ocf/ocf.0.4.0/opam
+++ b/packages/ocf/ocf.0.4.0/opam
@@ -21,4 +21,4 @@ depends: [
   "yojson" {>= "1.1.8"}
   "ppx_tools" {>= "0.99"}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.03.0"]


### PR DESCRIPTION
Also:
- older versions depend on `camlp4`.
- fixed version 0.1.0 to make opam-lint happy.
