### PR TITLE
fix ordma

### DIFF
--- a/packages/ordma/ordma.0.0.2/opam
+++ b/packages/ordma/ordma.0.0.2/opam
@@ -6,7 +6,7 @@ authors: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
 homepage: "https://github.com/toolslive/ordma"
 bug-reports: "https://github.com/toolslive/ordma/issues"
 license: "TBD"
-dev-repo: "https://github.com/toolslive/ordma"
+dev-repo: "https://github.com/toolslive/ordma.git"
 
 build: [
   [make lib]


### PR DESCRIPTION
[ERROR] At ~/.opam/repo/default/packages/ordma/ordma.0.0.2/opam:9:45:
  Not a recognised version-control URL