### PR TITLE
unix-fcntl.0.3.2 - via opam-publish

### DIFF
--- a/packages/unix-fcntl/unix-fcntl.0.3.2/descr
+++ b/packages/unix-fcntl/unix-fcntl.0.3.2/descr
@@ -1,0 +1,16 @@
+Unix fcntl.h types, maps, and support
+
+unix-fcntl provides access to the features exposed in fcntl.h in a way
+that is not tied to the implementation on the host system.
+
+The Fcntl module provides functions for translating between the names
+of the flags exposed in fcntl.h and their values on particular
+systems. The Fcntl_host module exports representations of various
+hosts.
+
+The Fcntl_unix provides bindings to functions that use the flags in
+Fcntl along with a representation of the host system. The bindings
+support a more comprehensive range of flags than the corresponding
+functions in the standard OCaml Unix module. The Fcntl_unix_lwt module
+exports non-blocking versions of the functions in Fcntl_unix based on
+the Lwt cooperative threading library.

--- a/packages/unix-fcntl/unix-fcntl.0.3.2/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Jeremy Yallop"]
+homepage: "https://github.com/dsheets/ocaml-unix-fcntl"
+bug-reports: "https://github.com/dsheets/ocaml-unix-fcntl/issues"
+license: "ISC"
+tags: ["unix" "posix" "fcntl" "syscall" "open"]
+dev-repo: "https://github.com/dsheets/ocaml-unix-fcntl.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.4.0"}
+  "unix-errno" {>= "0.4.0"}
+  "alcotest" {test}
+  "unix-type-representations"
+]
+depopts: ["lwt" "base-threads"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/unix-fcntl/unix-fcntl.0.3.2/url
+++ b/packages/unix-fcntl/unix-fcntl.0.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-fcntl/archive/0.3.2.tar.gz"
+checksum: "0bfd104d54153e930b588236be89db02"


### PR DESCRIPTION
Unix fcntl.h types, maps, and support

unix-fcntl provides access to the features exposed in fcntl.h in a way
that is not tied to the implementation on the host system.

The Fcntl module provides functions for translating between the names
of the flags exposed in fcntl.h and their values on particular
systems. The Fcntl_host module exports representations of various
hosts.

The Fcntl_unix provides bindings to functions that use the flags in
Fcntl along with a representation of the host system. The bindings
support a more comprehensive range of flags than the corresponding
functions in the standard OCaml Unix module. The Fcntl_unix_lwt module
exports non-blocking versions of the functions in Fcntl_unix based on
the Lwt cooperative threading library.


---
* Homepage: https://github.com/dsheets/ocaml-unix-fcntl
* Source repo: https://github.com/dsheets/ocaml-unix-fcntl.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-fcntl/issues

---

Pull-request generated by opam-publish v0.3.1