### PR TITLE
ocephes.0.8.1 - via opam-publish

### DIFF
--- a/packages/ocephes/ocephes.0.1.1/url
+++ b/packages/ocephes/ocephes.0.1.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/rleonid/Ocephes/archive/0.1.1.tar.gz"
-checksum: "8188c6eb2e8313519ea6524b57f9bd50"
+checksum: "a9c3f7897e5f9bff56853c6f3b8d79e8"

--- a/packages/ocephes/ocephes.0.1.2/url
+++ b/packages/ocephes/ocephes.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/rleonid/ocephes/archive/0.1.2.tar.gz"
-checksum: "7a12ff6d39f8226a8e4bb0e8664d6bb2"
+checksum: "2cb1102e3e551b946dd2e61bf867448e"

--- a/packages/ocephes/ocephes.0.1/url
+++ b/packages/ocephes/ocephes.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/rleonid/Ocephes/archive/0.1.tar.gz"
-checksum: "4702d3d5c338a4312d845ff2b06cf3ab"
+checksum: "9f5d7582be599f664eb85710685c15c5"

--- a/packages/ocephes/ocephes.0.8.1/descr
+++ b/packages/ocephes/ocephes.0.8.1/descr
@@ -1,0 +1,4 @@
+Bindings to special math functions from the Cephes library
+
+Ctypes bindings to some of the functions in this common C
+mathematical functions library.

--- a/packages/ocephes/ocephes.0.8.1/opam
+++ b/packages/ocephes/ocephes.0.8.1/opam
@@ -12,4 +12,5 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes"
+  "ctypes-foreign"
 ]

--- a/packages/ocephes/ocephes.0.8.1/opam
+++ b/packages/ocephes/ocephes.0.8.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/rleonid/ocephes"
+bug-reports: "https://github.com/rleonid/ocephes/issues"
+license: "BSD 3"
+dev-repo: "https://github.com/rleonid/ocephes.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ocephes"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes"
+]

--- a/packages/ocephes/ocephes.0.8.1/url
+++ b/packages/ocephes/ocephes.0.8.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rleonid/ocephes/archive/0.8.1.tar.gz"
+checksum: "e6193b00956c26d9805802fd7921f712"

--- a/packages/ocephes/ocephes.0.8.1/url
+++ b/packages/ocephes/ocephes.0.8.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/rleonid/ocephes/archive/0.8.1.tar.gz"
-checksum: "3ff430aaa7573157c09c2e9cc1753685"
+checksum: "b3e972bc41b49702b50972cfa8d31229"

--- a/packages/ocephes/ocephes.0.8.1/url
+++ b/packages/ocephes/ocephes.0.8.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/rleonid/ocephes/archive/0.8.1.tar.gz"
-checksum: "e6193b00956c26d9805802fd7921f712"
+checksum: "3ff430aaa7573157c09c2e9cc1753685"

--- a/packages/ocephes/ocephes.0.8/url
+++ b/packages/ocephes/ocephes.0.8/url
@@ -1,2 +1,2 @@
 http: "https://github.com/rleonid/Ocephes/archive/0.8.tar.gz"
-checksum: "f95529322ca97aa08dd3c11d95816b92"
+checksum: "dd0a046fa89746cb62b1005cc0a6d28e"


### PR DESCRIPTION
Bindings to special math functions from the Cephes library

Ctypes bindings to some of the functions in this common C
mathematical functions library.


---
* Homepage: https://github.com/rleonid/ocephes
* Source repo: https://github.com/rleonid/ocephes.git
* Bug tracker: https://github.com/rleonid/ocephes/issues

---

Pull-request generated by opam-publish v0.3.1