### PR TITLE
ocf.0.5.0 - via opam-publish

### DIFF
--- a/packages/ocf/ocf.0.5.0/descr
+++ b/packages/ocf/ocf.0.5.0/descr
@@ -1,0 +1,3 @@
+Library to load and store configuration options in JSON syntax.
+
+The library provides convenient ways to define and combines configuration options.

--- a/packages/ocf/ocf.0.5.0/opam
+++ b/packages/ocf/ocf.0.5.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: ["Maxence Guesdon"]
+homepage: "http://zoggy.github.io/ocf/"
+license: "GNU Lesser General Public License version 3"
+doc: ["http://zoggy.github.io/ocf/doc.html"]
+dev-repo: "https://github.com/zoggy/ocf.git"
+bug-reports: "https://github.com/zoggy/ocf/issues"
+tags: ["configuration" "options" "json"]
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "ocf"]]
+depends: [
+  "ocamlfind"
+  "yojson" {>= "1.3.2"}
+  "ppx_tools" {>= "4.03.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ocf/ocf.0.5.0/url
+++ b/packages/ocf/ocf.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/ocf/archive/release-0.5.0.tar.gz"
+checksum: "e4e73bea9472b2e77f62604033b098d8"


### PR DESCRIPTION
Library to load and store configuration options in JSON syntax.

The library provides convenient ways to define and combines configuration options.


---
* Homepage: http://zoggy.github.io/ocf/
* Source repo: https://github.com/zoggy/ocf.git
* Bug tracker: https://github.com/zoggy/ocf/issues

---

Pull-request generated by opam-publish v0.3.1