### PR TITLE
iri.0.3.0 - via opam-publish

### DIFF
--- a/packages/iri/iri.0.3.0/descr
+++ b/packages/iri/iri.0.3.0/descr
@@ -1,0 +1,5 @@
+IRI (RFC3987) native OCaml implementation.
+
+OCaml implementation of Internationalized Resource Identifiers (IRIs).
+This implementation does not depend on regular expression library. Is is implemented using
+Sedlex, thus it will be usable in Javascript (with Js_of_ocaml).

--- a/packages/iri/iri.0.3.0/files/ocaml-before.4.03.0.patch
+++ b/packages/iri/iri.0.3.0/files/ocaml-before.4.03.0.patch
@@ -1,0 +1,30 @@
+diff --git a/iri_types.ml b/iri_types.ml
+index 491720f..1ca8694 100644
+--- a/iri_types.ml
++++ b/iri_types.ml
+@@ -492,13 +492,13 @@ let normalize_host s =
+   let len = String.length s in
+   if len > 0 then
+     match String.get s 0 with
+-      '[' -> String.uppercase_ascii s (* uppercase hexa *)
+-    | _ -> String.lowercase_ascii s (* lowercase regname *)
++      '[' -> String.uppercase s (* uppercase hexa *)
++    | _ -> String.lowercase s (* lowercase regname *)
+   else
+     s
+ 
+ let normalize_port t =
+-  match String.lowercase_ascii t.scheme, t.port with
++  match String.lowercase t.scheme, t.port with
+     "http", Some 80 -> { t with port = None }
+   | "https", Some 443 -> { t with port = None }
+   | "ftp", Some 21 -> { t with port = None }
+@@ -509,7 +509,7 @@ let normalize_port t =
+ 
+ let normalize_case t =
+   { t with
+-    scheme = String.lowercase_ascii t.scheme ;
++    scheme = String.lowercase t.scheme ;
+     host = map_opt normalize_host t.host ;
+   }
+ 

--- a/packages/iri/iri.0.3.0/opam
+++ b/packages/iri/iri.0.3.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/ocaml-iri/"
+bug-reports: "https://github.com/zoggy/ocaml-iri/issues"
+license: "GNU Lesser General Public License version 3"
+doc: "http://zoggy.github.io/ocaml-iri/doc.html"
+tags: ["web" "iri" "rfc3987"]
+dev-repo: "https://github.com/zoggy/ocaml-iri.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "iri"]
+depends: [
+  "ocamlfind"
+  "sedlex" {>= "1.99.2"}
+  "uutf" {>= "0.9.4"}
+  "uunf" {>= "1.0"}
+]
+available: [ocaml-version >= "4.02.2"]
+
+patches: [ "ocaml-before.4.03.0.patch" { ocaml-version < "4.03.0" } ]
+

--- a/packages/iri/iri.0.3.0/url
+++ b/packages/iri/iri.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/ocaml-iri/archive/release-0.3.0.tar.gz"
+checksum: "c7473781ec408f1b37d65ded5e932319"


### PR DESCRIPTION
IRI (RFC3987) native OCaml implementation.

OCaml implementation of Internationalized Resource Identifiers (IRIs).
This implementation does not depend on regular expression library. Is is implemented using
Sedlex, thus it will be usable in Javascript (with Js_of_ocaml).

---
* Homepage: http://zoggy.github.io/ocaml-iri/
* Source repo: https://github.com/zoggy/ocaml-iri.git
* Bug tracker: https://github.com/zoggy/ocaml-iri/issues

---

Pull-request generated by opam-publish v0.3.1