### PR TITLE
protocol-9p.0.5.1 - via opam-publish

### DIFF
--- a/packages/protocol-9p/protocol-9p.0.5.1/descr
+++ b/packages/protocol-9p/protocol-9p.0.5.1/descr
@@ -1,0 +1,6 @@
+Client and server implementation of 9P, in a Mirage-friendly style
+
+Protocol-9p is an implementation of the plan9 9P fileserver protocol,
+building on top of the Mirage libraries. Client and server implementations
+are provided. The library supports 9P2000 and 9P2000.u protocol variants.
+The server code is compatible with the Linux kernel client.

--- a/packages/protocol-9p/protocol-9p.0.5.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.5.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard"]
+homepage: "https://github.com/mirage/ocaml-9p"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+license: "ISC"
+dev-repo: "https://github.com/mirage/ocaml-9p.git"
+build: [make]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "protocol-9p"]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "cstruct" {>= "1.6.0" & < "2.0.0"}
+  "sexplib" {<= "113.00.00"}
+  "result"
+  "mirage-types-lwt"
+  "lwt" {>= "2.4.7"}
+  "cmdliner"
+  "stringext"
+  "fmt"
+  "logs" {>= "0.5.0"}
+  "type_conv" {build}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test & >= "0.4.0"}
+]
+depopts: "lambda-term"
+available: [ocaml-version >= "4.02.0"]

--- a/packages/protocol-9p/protocol-9p.0.5.1/url
+++ b/packages/protocol-9p/protocol-9p.0.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-9p/archive/v0.5.1.tar.gz"
+checksum: "14bb94e9aa8ac205d6b8b5e3a5062542"


### PR DESCRIPTION
Client and server implementation of 9P, in a Mirage-friendly style

Protocol-9p is an implementation of the plan9 9P fileserver protocol,
building on top of the Mirage libraries. Client and server implementations
are provided. The library supports 9P2000 and 9P2000.u protocol variants.
The server code is compatible with the Linux kernel client.


---
* Homepage: https://github.com/mirage/ocaml-9p
* Source repo: https://github.com/mirage/ocaml-9p.git
* Bug tracker: https://github.com/mirage/ocaml-9p/issues

---

Pull-request generated by opam-publish v0.3.1