### PR TITLE
git.1.8.0 - via opam-publish

### DIFF
--- a/packages/git/git.1.8.0/descr
+++ b/packages/git/git.1.8.0/descr
@@ -1,0 +1,17 @@
+Git format and protocol in pure OCaml
+
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also the
+pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects. For instance, it is
+possible to make a pack file position independant (as the Zlib
+compression might change the relative offsets between the packed
+objects), to generate pack indexes from pack files, or to expand
+the filesystem of a given commit.
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git/git.1.8.0/opam
+++ b/packages/git/git.1.8.0/opam
@@ -1,0 +1,67 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+
+build: [
+  ["./configure"
+     "--prefix" prefix
+     "--%{mirage-http+mirage-flow+mirage-types-lwt+channel:enable}%-mirage"
+     "--%{conduit+cohttp+camlzip+nocrypto+base-unix:enable}%-unix"
+  ]
+  [make]
+]
+build-test: [
+  ["./configure" "--enable-tests" "--enable-mirage" "--enable-unix"]
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "git"]
+depends: [
+  "cmdliner"
+  "mstruct"    {>= "1.3.1"}
+  "ocamlgraph"
+  "uri"        {>= "1.3.12"}
+  "lwt"        {>= "2.4.7"}
+  "mtime"
+  "logs"
+  "fmt"
+  "hex"
+  "astring"
+  "crc"
+  "alcotest"         {test}
+  "mirage-types-lwt" {test}
+  "mirage-http"      {test}
+  "mirage-flow"      {test}
+  "channel"          {test}
+  "mirage-fs-unix"   {test & >="1.1.4"}
+  "cohttp"           {test}
+  "conduit"          {test}
+  "base-unix"        {test}
+  "camlzip"          {test}
+  "nocrypto"         {test}
+]
+depopts: [
+  # --enable-mirage
+  "mirage-types-lwt"
+  "mirage-http"
+  "mirage-flow"
+  "channel"
+  # --enable-unix
+  "cohttp"
+  "conduit"
+  "base-unix"
+  "camlzip"
+  "nocrypto"
+]
+conflicts: [
+ "cohttp"   {< "0.19.1"}
+ "conduit"  {< "0.8.4"}
+ "alcotest" {< "0.4.0"}
+ "camlzip"  {< "1.05"}
+ "nocrypto" {< "0.2.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.8.0/url
+++ b/packages/git/git.1.8.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-git/archive/1.8.0.tar.gz"
+checksum: "15565eb2875b3c1d37875f3b2a1da753"


### PR DESCRIPTION
Git format and protocol in pure OCaml

Support for on-disk and in-memory Git stores. Can read and write all
the Git objects: the usual blobs, trees, commits and tags but also the
pack files, pack indexes and the index file (where the staging area
lives).

All the objects share a consistent API, and convenience functions are
provided to manipulate the different objects. For instance, it is
possible to make a pack file position independant (as the Zlib
compression might change the relative offsets between the packed
objects), to generate pack indexes from pack files, or to expand
the filesystem of a given commit.

The library comes with a command-line tool called `ogit` which shares
a similar interface with `git`, but where all operations are mapped to
the API exposed `ocaml-git` (and hence using only OCaml code).


---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---

Pull-request generated by opam-publish v0.3.1