### PR TITLE
camlidl.1.05: disable fatal warning for ocaml version >= 4.03

### DIFF
--- a/packages/camlidl/camlidl.1.05/files/disable-fatal-warn-31.diff
+++ b/packages/camlidl/camlidl.1.05/files/disable-fatal-warn-31.diff
@@ -1,0 +1,24 @@
+diff -Naur camlidl-1.05/config/Makefile.unix camlidl-1.05-patched/config/Makefile.unix
+--- camlidl-1.05/config/Makefile.unix	2002-04-22 12:50:46.000000000 +0100
++++ camlidl-1.05-patched/config/Makefile.unix	2016-05-04 13:10:23.370704022 +0100
+@@ -37,7 +37,7 @@
+ BINDIR=/usr/local/bin
+ 
+ # The Objective Caml compilers (the defaults below should be OK)
+-OCAMLC=ocamlc -g
++OCAMLC=ocamlc -g -warn-error -31
+ OCAMLOPT=ocamlopt
+ OCAMLYACC=ocamlyacc -v
+ OCAMLLEX=ocamllex
+diff -Naur camlidl-1.05/config/Makefile.win32 camlidl-1.05-patched/config/Makefile.win32
+--- camlidl-1.05/config/Makefile.win32	2004-07-08 13:21:58.000000000 +0100
++++ camlidl-1.05-patched/config/Makefile.win32	2016-05-04 13:10:23.370704022 +0100
+@@ -35,7 +35,7 @@
+ BINDIR=C:/ocaml/bin
+ 
+ # The Objective Caml compilers (the defaults below should be OK)
+-OCAMLC=ocamlc -g
++OCAMLC=ocamlc -g -warn-error -31
+ OCAMLOPT=ocamlopt
+ OCAMLDEP=ocamldep
+ OCAMLYACC=ocamlyacc -v

--- a/packages/camlidl/camlidl.1.05/opam
+++ b/packages/camlidl/camlidl.1.05/opam
@@ -6,9 +6,11 @@ license: "QPL-1.0 and LGPL-2 with exceptions"
 build: [
   ["mv" "config/Makefile.unix" "config/Makefile"] {(os = "darwin") | ((os = "linux") | ((os = "freebsd") | ((os = "bsd") | ((os = "unix") | (os = "cygwin")))))}
   ["mv" "config/Makefile.win32" "config/Makefile"] {os = "win32"}
-  ["sh" "-c" "echo 'OCAMLC=ocamlc -g -warn-error -31' >> config/Makefile" ] { ocaml-version >= "4.03" }
   ["mkdir" "-p" bin "%{lib}%/camlidl" "%{lib}%/camlidl/caml"]
   [make "all"]
   [make "install" "BINDIR=%{bin}%" "OCAMLLIB=%{lib}%/camlidl"]
 ]
-patches: ["cpp-location.diff"]
+patches: [
+  "cpp-location.diff"
+  "disable-fatal-warn-31.diff" { ocaml-version >= "4.03" }
+]

--- a/packages/camlidl/camlidl.1.05/opam
+++ b/packages/camlidl/camlidl.1.05/opam
@@ -1,7 +1,9 @@
 opam-version: "1.2"
-maintainer: "contact@ocamlpro.com"
+maintainer: "Nicolas Berthier <m@nberth.space>"
 authors: ["Xavier Leroy"]
 homepage: "http://caml.inria.fr/pub/old_caml_site/camlidl/"
+# dev-repo: "svn://scm.ocamlcore.org/svn/camlidl/trunk"
+bug-reports: "http://forge.ocamlcore.org/tracker/?group_id=132"
 license: "QPL-1.0 and LGPL-2 with exceptions"
 build: [
   ["mv" "config/Makefile.unix" "config/Makefile"] {(os = "darwin") | ((os = "linux") | ((os = "freebsd") | ((os = "bsd") | ((os = "unix") | (os = "cygwin")))))}

--- a/packages/camlidl/camlidl.1.05/opam
+++ b/packages/camlidl/camlidl.1.05/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
 authors: ["Xavier Leroy"]
 homepage: "http://caml.inria.fr/pub/old_caml_site/camlidl/"
@@ -6,6 +6,7 @@ license: "QPL-1.0 and LGPL-2 with exceptions"
 build: [
   ["mv" "config/Makefile.unix" "config/Makefile"] {(os = "darwin") | ((os = "linux") | ((os = "freebsd") | ((os = "bsd") | ((os = "unix") | (os = "cygwin")))))}
   ["mv" "config/Makefile.win32" "config/Makefile"] {os = "win32"}
+  ["sh" "-c" "echo 'OCAMLC=ocamlc -g -warn-error -31' >> config/Makefile" ] { ocaml-version >= "4.03" }
   ["mkdir" "-p" bin "%{lib}%/camlidl" "%{lib}%/camlidl/caml"]
   [make "all"]
   [make "install" "BINDIR=%{bin}%" "OCAMLLIB=%{lib}%/camlidl"]


### PR DESCRIPTION
Warnings about duplicate module names are fatal by default since 4.03
due to dangerous semantics for double-linking of modules involving
extensible variant types; yet I do not think this is much of a problem
here as long as the dupicate module in camlidl (Array) does not
involve this feature.