### PR TITLE
unix-errno.0.4.1 - via opam-publish

### DIFF
--- a/packages/unix-errno/unix-errno.0.4.1/descr
+++ b/packages/unix-errno/unix-errno.0.4.1/descr
@@ -1,0 +1,10 @@
+Unix errno types, maps, and support
+
+unix-errno can be used with or without ctypes and OCaml's Unix
+module. Without ctypes and Unix, the basic types and functions are
+provided as well as Errno_host containing errno maps for popular
+operating systems. The errno-srcgen tool for generating OCaml source
+representing Errno.Host.t values will also be built. With ctypes and
+Unix, you'll also receive the errno-map tool for outputting the current
+host's errno map and the Errno_unix module containing an errno global
+variable checking function and Unix.error type converters.

--- a/packages/unix-errno/unix-errno.0.4.1/opam
+++ b/packages/unix-errno/unix-errno.0.4.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-unix-errno"
+bug-reports: "https://github.com/dsheets/ocaml-unix-errno/issues"
+license: "ISC"
+tags: ["errno" "errno.h" "errors" "unix" "syscall"]
+dev-repo: "https://github.com/dsheets/ocaml-unix-errno.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "base-bytes"
+  "result"
+]
+depopts: ["base-unix" "ctypes"]
+conflicts: [
+  "ctypes" {< "0.4.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/unix-errno/unix-errno.0.4.1/url
+++ b/packages/unix-errno/unix-errno.0.4.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-errno/archive/0.4.1.tar.gz"
+checksum: "f56a66ce5c58fe39cd04067f2acba1ac"


### PR DESCRIPTION
Unix errno types, maps, and support

unix-errno can be used with or without ctypes and OCaml's Unix
module. Without ctypes and Unix, the basic types and functions are
provided as well as Errno_host containing errno maps for popular
operating systems. The errno-srcgen tool for generating OCaml source
representing Errno.Host.t values will also be built. With ctypes and
Unix, you'll also receive the errno-map tool for outputting the current
host's errno map and the Errno_unix module containing an errno global
variable checking function and Unix.error type converters.


---
* Homepage: https://github.com/dsheets/ocaml-unix-errno
* Source repo: https://github.com/dsheets/ocaml-unix-errno.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-errno/issues

---

Pull-request generated by opam-publish v0.3.1