### PR TITLE
runa.0.1.0 - via opam-publish

### DIFF
--- a/packages/runa/runa.0.1.0/descr
+++ b/packages/runa/runa.0.1.0/descr
@@ -1,0 +1,10 @@
+General helper library for js_of_ocaml
+
+Runa is a collection of helper functions for `js_of_ocaml`
+programming. It does not assume anything other than what is provided
+by `js_of_ocaml`, aka no assumption of `nodejs`.  Use this library for
+yourself as well and make your `OCaml` to `JavaScript` coding that
+much easier; even better contribute some snippets as well!
+
+To use in your programs, simply add `runa` to your ocamlfind
+`-package` declaration(s), and be sure to do `-linkpkg` as well.

--- a/packages/runa/runa.0.1.0/opam
+++ b/packages/runa/runa.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/runa"
+bug-reports: "https://github.com/fxfactorial/runa/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/runa.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "react_js"]
+depends: [
+  "js_of_ocaml" {>= "2.7"}
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/runa/runa.0.1.0/url
+++ b/packages/runa/runa.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/runa/archive/v0.1.0.tar.gz"
+checksum: "05858352c35f2e77887894a8da31dbee"


### PR DESCRIPTION
General helper library for js_of_ocaml

Runa is a collection of helper functions for `js_of_ocaml`
programming. It does not assume anything other than what is provided
by `js_of_ocaml`, aka no assumption of `nodejs`.  Use this library for
yourself as well and make your `OCaml` to `JavaScript` coding that
much easier; even better contribute some snippets as well!

To use in your programs, simply add `runa` to your ocamlfind
`-package` declaration(s), and be sure to do `-linkpkg` as well.


---
* Homepage: https://github.com/fxfactorial/runa
* Source repo: https://github.com/fxfactorial/runa.git
* Bug tracker: https://github.com/fxfactorial/runa/issues

---

Pull-request generated by opam-publish v0.3.1