### PR TITLE
Patch js_of_ocaml to disable ppx_deriving with OCaml 4.03.0.

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.2.7/files/ppx_deriving_4.03.patch
+++ b/packages/js_of_ocaml/js_of_ocaml.2.7/files/ppx_deriving_4.03.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.conf b/Makefile.conf
+index 2be0c43..650cf23 100644
+--- a/Makefile.conf
++++ b/Makefile.conf
+@@ -49,8 +49,6 @@ NATDYNLINK ?= $(shell if [ -f `ocamlc -where`/dynlink.cmxa ]; then echo YES; els
+ 
+ WITH_PPX_TOOLS ?= $(shell if [ -f `ocamlfind query ppx_tools 2> /dev/null`/ppx_tools.cma ]; then echo YES; else echo NO; fi)
+ 
+-WITH_PPX_DERIVING ?= $(shell if [ -f `ocamlfind query ppx_deriving 2> /dev/null`/ppx_deriving.cma ]; then echo YES; else echo NO; fi)
+-
+ ##disabled for ocaml < 4.02.2+trunk
+ ifeq "${WITH_PPX_TOOLS}" "YES"
+ ifneq ($(shell ocamlc -version | grep -q -E "4.02.[01]"; echo $$?),0)

--- a/packages/js_of_ocaml/js_of_ocaml.2.7/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.7/opam
@@ -29,3 +29,6 @@ conflicts: [
   "reactiveData" {< "0.2"}
 ]
 available: [ ocaml-version >= "4.00.0" ]
+patches: [
+  "ppx_deriving_4.03.patch" { ocaml-version >= "4.03.0" }
+]


### PR DESCRIPTION
Both ppx_deriving and js_of_ocaml are installable on OCaml 4.03.0, but the combination is not.  This patch disables ppx_deriving support in js_of_ocaml on OCaml 4.03, following a suggestion by @Drup.

/cc @hhugo

