### PR TITLE
osx-xattr.0.2.0 - via opam-publish

### DIFF
--- a/packages/osx-xattr/osx-xattr.0.2.0/descr
+++ b/packages/osx-xattr/osx-xattr.0.2.0/descr
@@ -1,0 +1,4 @@
+OS X extended attribute system call bindings
+
+`getxattr`, `fgetxattr`, `listxattr`, `flistxattr`, `removexattr`,
+`fremovexattr`, `setxattr`, and `fsetxattr` are bound.

--- a/packages/osx-xattr/osx-xattr.0.2.0/opam
+++ b/packages/osx-xattr/osx-xattr.0.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-osx-xattr"
+bug-reports: "https://github.com/dsheets/ocaml-osx-xattr/issues"
+license: "ISC"
+tags: ["osx" "xattr" "extended attributes" "file system"]
+dev-repo: "https://github.com/dsheets/ocaml-osx-xattr.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "ctypes" {>= "0.4.0"}
+  "unix-errno" {>= "0.4.0"}
+  "base-unix"
+  "unix-type-representations"
+]
+depopts: "lwt"
+available: [os = "darwin"]

--- a/packages/osx-xattr/osx-xattr.0.2.0/url
+++ b/packages/osx-xattr/osx-xattr.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-xattr/archive/0.2.0.tar.gz"
+checksum: "089fa8382c09d27140befa450d595575"


### PR DESCRIPTION
OS X extended attribute system call bindings

`getxattr`, `fgetxattr`, `listxattr`, `flistxattr`, `removexattr`,
`fremovexattr`, `setxattr`, and `fsetxattr` are bound.


---
* Homepage: https://github.com/dsheets/ocaml-osx-xattr
* Source repo: https://github.com/dsheets/ocaml-osx-xattr.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-xattr/issues

---

Pull-request generated by opam-publish v0.3.1