### PR TITLE
Cautiously disable atdgen on 4.03, it seems to be segfaulting

### DIFF
--- a/packages/atdgen/atdgen.1.4.0/opam
+++ b/packages/atdgen/atdgen.1.4.0/opam
@@ -14,3 +14,8 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson"
 ]
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.4.1/opam
+++ b/packages/atdgen/atdgen.1.4.1/opam
@@ -14,3 +14,8 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson"
 ]
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.5.0/opam
+++ b/packages/atdgen/atdgen.1.5.0/opam
@@ -15,3 +15,8 @@ depends: [
   "yojson" {>= "1.2.0" }
 ]
 dev-repo: "git://github.com/mjambon/atdgen"
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.6.0/opam
+++ b/packages/atdgen/atdgen.1.6.0/opam
@@ -15,3 +15,8 @@ depends: [
   "yojson" {>= "1.2.0" }
 ]
 dev-repo: "git://github.com/mjambon/atdgen"
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.6.1/opam
+++ b/packages/atdgen/atdgen.1.6.1/opam
@@ -15,3 +15,8 @@ depends: [
   "yojson" {>= "1.2.1" }
 ]
 dev-repo: "git://github.com/mjambon/atdgen"
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.7.1/opam
+++ b/packages/atdgen/atdgen.1.7.1/opam
@@ -24,3 +24,8 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1" }
 ]
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.7.2/opam
+++ b/packages/atdgen/atdgen.1.7.2/opam
@@ -24,3 +24,8 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1" }
 ]
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.8.0/opam
+++ b/packages/atdgen/atdgen.1.8.0/opam
@@ -24,3 +24,8 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1" }
 ]
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]

--- a/packages/atdgen/atdgen.1.9.0/opam
+++ b/packages/atdgen/atdgen.1.9.0/opam
@@ -24,3 +24,8 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1" }
 ]
+
+# Cautiously disable atdgen on 4.03, it seems to be segfaulting
+# https://github.com/mjambon/atdgen/issues/45
+# https://github.com/OCamlPro/opam-publish/issues/40
+available: [ocaml-version < "4.03"]


### PR DESCRIPTION
Atdgen seems to be causing segfault issues on OCaml 4.03, see
  https://github.com/mjambon/atdgen/issues/45
  https://github.com/OCamlPro/opam-publish/issues/40
  and a report of user 'lwzukw' on #ocaml on May 5th

It is not clear yet whether the issue are flambda-only or not: we've
had reports of segfaults that may be related even under non-flambda
4.03.0.

I think it's better to prevent Atdgen user from migrating to 4.03
while the issue is not understood and resolved: they would lose more
time debugging their segfaults (and it looks bad on the OCaml stability
for probably-unrelated reasons) than pleasure from the new version.