### PR TITLE
+markup.0.7.2

### DIFF
--- a/packages/markup/markup.0.7.2/descr
+++ b/packages/markup/markup.0.7.2/descr
@@ -1,0 +1,20 @@
+Error-recovering functional HTML5 and XML parsers and writers
+
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8.

--- a/packages/markup/markup.0.7.2/opam
+++ b/packages/markup/markup.0.7.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "markup"
+version: "0.7.2"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "https://github.com/aantron/markup.ml.git"
+license: "BSD"
+depends: [
+  "uutf"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ounit" {test}
+]
+depopts: ["lwt"]
+build: [
+  [make "build"]
+]
+build-test: [
+  [make "test"]
+]
+build-doc: [
+  [make "docs"]
+]
+install: [make "ocamlfind-install"]
+remove: ["ocamlfind" "remove" "markup"]

--- a/packages/markup/markup.0.7.2/url
+++ b/packages/markup/markup.0.7.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/aantron/markup.ml/archive/0.7.2.tar.gz"
+checksum: "317d5223978342edcf7083153b2106f6"


### PR DESCRIPTION
[Changelog](https://github.com/aantron/markup.ml/releases/tag/0.7.2). Preparing for TyXML 4.0.