### PR TITLE
secp256k1-ml.0.1 - via opam-publish

### DIFF
--- a/packages/secp256k1-ml/secp256k1-ml.0.1/descr
+++ b/packages/secp256k1-ml/secp256k1-ml.0.1/descr
@@ -1,0 +1,4 @@
+Bitcoin secp256k1 library wrapper for Ocaml
+
+This library wrap the Bitcoin secp256k1 C library in an
+Ocaml module.

--- a/packages/secp256k1-ml/secp256k1-ml.0.1/opam
+++ b/packages/secp256k1-ml/secp256k1-ml.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: "Davide Gessa <gessadavide@gmail.com>"
+homepage: "https://github.com/dakk/secp256k1-ml"
+bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
+license: "MIT"
+dev-repo: "https://github.com/dakk/secp256k1-ml"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make]
+remove: ["secp256k1"]

--- a/packages/secp256k1-ml/secp256k1-ml.0.1/url
+++ b/packages/secp256k1-ml/secp256k1-ml.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dakk/secp256k1-ml/archive/0.1.zip"
+checksum: "11e5f088b3771017afc73c2a61d16729"


### PR DESCRIPTION
Bitcoin secp256k1 library wrapper for Ocaml

This library wrap the Bitcoin secp256k1 C library in an
Ocaml module.


---
* Homepage: https://github.com/dakk/secp256k1-ml
* Source repo: https://github.com/dakk/secp256k1-ml
* Bug tracker: https://github.com/dakk/secp256k1-ml/issues

---

Pull-request generated by opam-publish v0.3.1