### PR TITLE
secp256k1.0.1.2 - via opam-publish

### DIFF
--- a/packages/secp256k1/secp256k1.0.1.2/descr
+++ b/packages/secp256k1/secp256k1.0.1.2/descr
@@ -1,0 +1,3 @@
+Bitcoin elliptic curve library secp256k1 Ocaml wrapper
+
+Bitcoin	elliptic curve library secp256k1 Ocaml wrapper

--- a/packages/secp256k1/secp256k1.0.1.2/opam
+++ b/packages/secp256k1/secp256k1.0.1.2/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: "Davide Gessa <gessadavide@gmail.com>"
+homepage: "https://github.com/dakk/secp256k1-ml"
+bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
+license: "MIT"
+dev-repo: "https://github.com/dakk/secp256k1-ml"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["secp256k1"]

--- a/packages/secp256k1/secp256k1.0.1.2/url
+++ b/packages/secp256k1/secp256k1.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dakk/secp256k1-ml/archive/0.1.2.tar.gz"
+checksum: "1f1b3dcf5e8165735cdee620e52e462a"


### PR DESCRIPTION
Bitcoin elliptic curve library secp256k1 Ocaml wrapper

Bitcoin	elliptic curve library secp256k1 Ocaml wrapper


---
* Homepage: https://github.com/dakk/secp256k1-ml
* Source repo: https://github.com/dakk/secp256k1-ml
* Bug tracker: https://github.com/dakk/secp256k1-ml/issues

---

Pull-request generated by opam-publish v0.3.1