### PR TITLE
posix-types.0.1.0 - via opam-publish

### DIFF
--- a/packages/posix-types/posix-types.0.1.0/descr
+++ b/packages/posix-types/posix-types.0.1.0/descr
@@ -1,0 +1,5 @@
+ctypes-compatible type representations for the types exposed in <sys/types.h>.
+
+The implementation details, such as sizes and alignments, of the types vary
+from platform to platform, but the interface of each type is consistent across
+platforms.

--- a/packages/posix-types/posix-types.0.1.0/opam
+++ b/packages/posix-types/posix-types.0.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+authors: "yallop@gmail.com"
+homepage: "https://github.com/yallop/ocaml-posix-types"
+bug-reports: "http://github.com/yallop/ocaml-posix-types/issues"
+license: "MIT"
+dev-repo: "http://github.com/yallop/ocaml-posix-types.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "posix-types"]
+depends: [
+  "ctypes" {>= "0.5.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/posix-types/posix-types.0.1.0/url
+++ b/packages/posix-types/posix-types.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/yallop/ocaml-posix-types/archive/0.1.0.tar.gz"
+checksum: "88dd4f46dea1bcdd4151aa61676030b5"


### PR DESCRIPTION
ctypes-compatible type representations for the types exposed in `<sys/types.h>`.

The implementation details, such as sizes and alignments, of the types vary
from platform to platform, but the interface of each type is consistent across
platforms.


---
* Homepage: https://github.com/yallop/ocaml-posix-types
* Source repo: http://github.com/yallop/ocaml-posix-types.git
* Bug tracker: http://github.com/yallop/ocaml-posix-types/issues

---

Pull-request generated by opam-publish v0.3.1