### PR TITLE
leveldb.1.1.2 - via opam-publish

### DIFF
--- a/packages/leveldb/leveldb.1.1.2/descr
+++ b/packages/leveldb/leveldb.1.1.2/descr
@@ -1,0 +1,13 @@
+OCaml bindings for Google's LevelDB library.
+
+These bindings expose nearly the full LevelDB C++ API, including:
+
+* iterators
+* snapshots
+* batch updates
+* support for custom comparators
+
+Blocking functions release the OCaml runtime system, allowing to:
+
+* run them in parallel with other OCaml code
+* perform multiple LevelDB operations in parallel

--- a/packages/leveldb/leveldb.1.1.2/opam
+++ b/packages/leveldb/leveldb.1.1.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "mfp@acm.org"
+authors: "mfp@acm.org"
+homepage: "https://github.com/mfp/ocaml-leveldb"
+bug-reports: "https://github.com/mfp/ocaml-leveldb/issues"
+license: "LGPL+static"
+doc: "https://github.com/mfp/ocaml-leveldb/blob/master/README.md"
+dev-repo: "git://github.com/mfp/ocaml-leveldb"
+build: ["omake" "-j9" "libs"]
+install: ["omake" "install" "prefix=%{prefix}%"]
+build-test: [
+  ["omake" "test"] {ounit:installed}
+]
+remove: ["ocamlfind" "remove" "leveldb"]
+depends: [
+  "ocamlfind" {build}
+  "omake" {build}
+  "ounit" {test}
+  "conf-leveldb"
+]
+depexts: [
+  [["debian"] ["libsnappy-dev"]]
+  [["ubuntu"] ["libsnappy-dev"]]
+]

--- a/packages/leveldb/leveldb.1.1.2/url
+++ b/packages/leveldb/leveldb.1.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mfp/ocaml-leveldb/archive/1.1.2.tar.gz"
+checksum: "690910f2bf70b4b1b2f6ca1a2075ac0a"


### PR DESCRIPTION
OCaml bindings for Google's LevelDB library.

These bindings expose nearly the full LevelDB C++ API, including:

* iterators
* snapshots
* batch updates
* support for custom comparators

Blocking functions release the OCaml runtime system, allowing to:

* run them in parallel with other OCaml code
* perform multiple LevelDB operations in parallel


---
* Homepage: https://github.com/mfp/ocaml-leveldb
* Source repo: git://github.com/mfp/ocaml-leveldb
* Bug tracker: https://github.com/mfp/ocaml-leveldb/issues

---

Pull-request generated by opam-publish v0.3.1