### PR TITLE
commonjs_of_ocaml.0.1.0 - via opam-publish

### DIFF
--- a/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/descr
+++ b/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/descr
@@ -1,0 +1,4 @@
+Import and export CommonJS modules in js_of_ocaml
+Helper PPX and functions for ease of interfacing with other CommonJS
+modules when building a project through js_of_ocaml
+

--- a/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/files/_oasis_remove_.ml
+++ b/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/files/commonjs_of_ocaml.install
+++ b/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/files/commonjs_of_ocaml.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/opam
+++ b/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Tony Aldridge <tony@angry-lawyer.com>"
+authors: "Tony Aldridge <tony@angry-lawyer.com>"
+homepage: "https://github.com/angrylawyer/commonjs_of_ocaml"
+bug-reports: "https://github.com/angrylawyer/commonjs_of_ocaml/issues"
+dev-repo: "https://github.com/angrylawyer/commonjs_of_ocaml.git"
+license: "MIT"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: [
+  "ocaml"
+  "%{etc}%/commonjs_of_ocaml/_oasis_remove_.ml"
+  "%{etc}%/commonjs_of_ocaml"
+]
+depends: [
+  "js_of_ocaml" {>= "2.7"}
+  "ocamlfind" {build}
+  "cppo" {build}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/url
+++ b/packages/commonjs_of_ocaml/commonjs_of_ocaml.0.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/AngryLawyer/commonjs_of_ocaml/archive/v0.1.0.tar.gz"
+checksum: "3e5dccd67a02ac7c01df182426c542f6"


### PR DESCRIPTION
Import and export CommonJS modules in js_of_ocaml
Helper PPX and functions for ease of interfacing with other CommonJS
modules when building a project through js_of_ocaml



---
* Homepage: https://github.com/angrylawyer/commonjs_of_ocaml
* Source repo: https://github.com/angrylawyer/commonjs_of_ocaml.git
* Bug tracker: https://github.com/angrylawyer/commonjs_of_ocaml/issues

---

Pull-request generated by opam-publish v0.3.1