### PR TITLE
batteries 2.5.0

### DIFF
--- a/packages/batteries/batteries.2.5.0/descr
+++ b/packages/batteries/batteries.2.5.0/descr
@@ -1,0 +1,3 @@
+Community-maintained foundation library
+
+Batteries extends and enriches OCaml's standard library. It provides a unified IO system, numerous data structures, powerful iterators, unicode strings and ropes, parsers, command-line options, and many other features.

--- a/packages/batteries/batteries.2.5.0/findlib
+++ b/packages/batteries/batteries.2.5.0/findlib
@@ -1,0 +1,1 @@
+batteries

--- a/packages/batteries/batteries.2.5.0/opam
+++ b/packages/batteries/batteries.2.5.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "batteries"
+maintainer: "thelema314@gmail.com"
+authors: "OCaml batteries-included team"
+homepage: "http://batteries.forge.ocamlcore.org/"
+bug-reports: "https://github.com/ocaml-batteries-team/batteries-included/issues"
+dev-repo: "https://github.com/ocaml-batteries-team/batteries-included.git"
+license: "LGPL-2.1+ with OCaml linking exception"
+doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "batteries"]]
+
+depends: [
+  "ocamlfind" {>= "1.5.3"}
+  "ocamlbuild" {build}
+  "qtest" {test & >= "2.0.0"}
+]
+available: [
+  ocaml-version >= "3.12.1"
+& ocaml-version < "4.04.0"
+]

--- a/packages/batteries/batteries.2.5.0/url
+++ b/packages/batteries/batteries.2.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-batteries-team/batteries-included/archive/v2.5.0.tar.gz"
+checksum: "b9484a9d41cb8329c8a341e6c5122729"


### PR DESCRIPTION
The main new change of this new release is that it is compatible with
OCaml 4.03.