### PR TITLE
Batteries.2.5.1

### DIFF
--- a/packages/batteries/batteries.2.5.0/opam
+++ b/packages/batteries/batteries.2.5.0/opam
@@ -22,7 +22,4 @@ depends: [
   "ocamlbuild" {build}
   "qtest" {test & >= "2.0.0"}
 ]
-available: [
-  ocaml-version >= "3.12.1"
-& ocaml-version < "4.04.0"
-]
+available: [ false ] # use 2.5.1 instead

--- a/packages/batteries/batteries.2.5.2/descr
+++ b/packages/batteries/batteries.2.5.2/descr
@@ -1,0 +1,1 @@
+a community-maintained standard library extension

--- a/packages/batteries/batteries.2.5.2/findlib
+++ b/packages/batteries/batteries.2.5.2/findlib
@@ -1,0 +1,1 @@
+batteries

--- a/packages/batteries/batteries.2.5.2/opam
+++ b/packages/batteries/batteries.2.5.2/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "batteries"
+maintainer: "thelema314@gmail.com"
+authors: "OCaml batteries-included team"
+homepage: "http://batteries.forge.ocamlcore.org/"
+bug-reports: "https://github.com/ocaml-batteries-team/batteries-included/issues"
+dev-repo: "https://github.com/ocaml-batteries-team/batteries-included.git"
+license: "LGPL-2.1+ with OCaml linking exception"
+doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "batteries"]]
+
+depends: [
+  "ocamlfind" {>= "1.5.3"}
+  "ocamlbuild" {build}
+  "qtest" {test & >= "2.0.0"}
+]
+available: [
+  ocaml-version >= "3.12.1"
+& ocaml-version < "4.04.0"
+]

--- a/packages/batteries/batteries.2.5.2/url
+++ b/packages/batteries/batteries.2.5.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-batteries-team/batteries-included/archive/v2.5.2.tar.gz"
+checksum: "540ebfd52c57cc63dfaf7d5b4eea8045"


### PR DESCRIPTION
There is a silly linking issue in 2.5.0 that actually makes it unusable. This patch-point release fixes it. Sorry for the churn...