### PR TITLE
utp.0.9.0 - via opam-publish

### DIFF
--- a/packages/utp/utp.0.9.0/descr
+++ b/packages/utp/utp.0.9.0/descr
@@ -1,0 +1,4 @@
+OCaml bindings for [libutp](https://github.com/bittorrent/libutp).
+
+A high-level interface to Lwt is in the module Utp_lwt.  See the docs at
+https://nojb.github.io/ocaml-utp.

--- a/packages/utp/utp.0.9.0/opam
+++ b/packages/utp/utp.0.9.0/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+authors: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+homepage: "https://www.github.com/nojb/ocaml-utp"
+bug-reports: "https://www.github.com/nojb/ocaml-utp/issues"
+license: "MIT"
+dev-repo: "https://www.github.com/nojb/ocaml-utp.git"
+build: [make "all"]
+build-doc: [make "doc"]
+depends: ["base-bytes" "ocamlfind" {build} "lwt"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/utp/utp.0.9.0/url
+++ b/packages/utp/utp.0.9.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nojb/ocaml-utp/archive/0.9.0.tar.gz"
+checksum: "8e8ae498e55557bfc91e38b8efad5bd6"


### PR DESCRIPTION
OCaml bindings for [libutp](https://github.com/bittorrent/libutp).

A high-level interface to Lwt is in the module Utp_lwt.  See the docs at
https://nojb.github.io/ocaml-utp.


---
* Homepage: https://www.github.com/nojb/ocaml-utp
* Source repo: https://www.github.com/nojb/ocaml-utp.git
* Bug tracker: https://www.github.com/nojb/ocaml-utp/issues

---

Pull-request generated by opam-publish v0.3.1