### PR TITLE
Travis: drop opam 1.1.2 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
   - os: linux
     env: OCAML_VERSION=4.02 OPAM_VERSION=1.2.0
   - os: linux
-    env: OCAML_VERSION=4.02 OPAM_VERSION=1.1.2
-  - os: linux
     env: OCAML_VERSION=4.01 OPAM_VERSION=1.2.2
   - os: linux
     env: OCAML_VERSION=4.00 OPAM_VERSION=1.2.2


### PR DESCRIPTION
The infrastructure is somehow recently broken resulting in

> [ERROR] global-config does not define the variable available.

If you know how to fix this issue or believe that we shouldn't drop opam 1.1.2 testing, please submit another PR. In the meantime, this will stop CI tests from failing with nonsensical errors due to indeterminism in our infrastructure.