### PR TITLE
Require < ocaml 4.03 for amqp-client 0.9

### DIFF
--- a/packages/amqp-client/amqp-client.0.9.0/opam
+++ b/packages/amqp-client/amqp-client.0.9.0/opam
@@ -20,4 +20,4 @@ depends: [
 conflicts: [
   "lwt" {< "2.4.6"}
 ]
-available: [ ocaml-version >= "4.02.0" & ocaml-version < 4.03.0 ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03.0" ]

--- a/packages/amqp-client/amqp-client.0.9.0/opam
+++ b/packages/amqp-client/amqp-client.0.9.0/opam
@@ -20,4 +20,4 @@ depends: [
 conflicts: [
   "lwt" {< "2.4.6"}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < 4.03.0 ]


### PR DESCRIPTION
amqp-client 0.9 requires ocaml < 4.03.0, as it does not compile.