### PR TITLE
pcap-format.0.4.0: can actually use cstruct 2.0+

### DIFF
--- a/packages/pcap-format/pcap-format.0.4.0/opam
+++ b/packages/pcap-format/pcap-format.0.4.0/opam
@@ -20,7 +20,7 @@ install: [
 remove: [["ocamlfind" "remove" "pcap-format"]]
 depends: [
   "ocamlfind"
-  "cstruct" {>= "1.9.0" & < "2.0.0"}
+  "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "lwt" {test & >= "2.4.0"}
   "ipaddr"


### PR DESCRIPTION
Effectively reverts #6405. Thanks @hannesm for additional testing and pointing this out!

I can't reproduce the issue I saw earlier.