### PR TITLE
+flowtype.0.25.0

### DIFF
--- a/packages/flowtype/flowtype.0.25.0/descr
+++ b/packages/flowtype/flowtype.0.25.0/descr
@@ -1,0 +1,15 @@
+Flow is a static typechecker for JavaScript.
+
+To find out more about Flow, check out <http://flowtype.org>.
+
+Flow adds static typing to JavaScript to improve developer productivity and
+code quality. In particular, static typing offers benefits like early error
+checking, which helps you avoid certain kinds of runtime failures, and code
+intelligence, which aids code maintenance, navigation, transformation, and
+optimization.
+
+We have designed Flow so developers can reap its benefits without losing the
+"feel" of coding in JavaScript. Flow adds minimal compile-time overhead, as it
+does all its work proactively in the background. And Flow does not force you to
+change how you code — it performs sophisticated program analysis to work with
+the idioms you already know and love.

--- a/packages/flowtype/flowtype.0.25.0/files/flowtype.install
+++ b/packages/flowtype/flowtype.0.25.0/files/flowtype.install
@@ -1,0 +1,1 @@
+bin: ["bin/flow" {"flow"}]

--- a/packages/flowtype/flowtype.0.25.0/opam
+++ b/packages/flowtype/flowtype.0.25.0/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+name: "flowtype"
+version: "0.25.0"
+maintainer: "gabe@fb.com"
+authors: [
+  "Avik Chaudhuri"
+  "Basil Hosmer"
+  "Gabe Levi"
+  "Jeff Morrison"
+  "Marshall Roch"
+  "Sam Goldman"
+]
+homepage: "http://flowtype.org"
+bug-reports: "https://github.com/facebook/flow/issues"
+license: "BSD3"
+doc: "http://flowtype.org/docs/getting-started.html"
+dev-repo: "https://github.com/facebook/flow.git"
+build: [
+  ["git" "init"]
+  ["git" "config" "user.email" "ignoreme@example.com"]
+  ["git" "config" "user.name" "Ignore Me"]
+  ["git" "commit" "--allow-empty" "-m" "First commit"]
+  [make]
+]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
+depexts: [
+  [["centos"] ["elfutils-libelf-devel"]]
+  [["debian"] ["libelf-dev"]]
+  [["ubuntu"] ["libelf-dev"]]
+]
+post-messages: [
+  "This package requires libelf to be installed on your system" {failure}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/flowtype/flowtype.0.25.0/url
+++ b/packages/flowtype/flowtype.0.25.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/facebook/flow/archive/v0.25.0.tar.gz"
+checksum: "8ac32ca61889a4937dbf15b414cfc86d"


### PR DESCRIPTION
To test, I did something like this

```Bash
opam switch 4.03.0
git clone git@github.com:facebook/flow.git
cd flow
git checkout v0.25.0
cp -r ~/projects/opam-repository/packages/flowtype/flowtype.0.25.0/* .
opam pin add . -n
opam install --verbose flowtype
opam pin remove flowtype
```

Is there a better way to test? I looked at https://opam.ocaml.org/doc/Packaging.html but it seemed to assume that you have a local copy of the code available. It would be nice if there was a way to pin and install from the source in `packages/flowtype/flowtype.0.25.0/url`