### PR TITLE
asl.0.8 - via opam-publish

### DIFF
--- a/packages/asl/asl.0.8/descr
+++ b/packages/asl/asl.0.8/descr
@@ -1,0 +1,4 @@
+Bindings for the Apple System Log API
+
+The Apple System Log allows applications to send log messages, which can
+be recorded, filterd and searched.

--- a/packages/asl/asl.0.8/opam
+++ b/packages/asl/asl.0.8/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+homepage: "https://github.com/mirage/ocaml-asl"
+bug-reports: "https://github.com/mirage/ocaml-asl/issues"
+license: "ISC"
+dev-repo: "https://github.com/mirage/ocaml-asl.git"
+build: [make "PREFIX=%{prefix}%"]
+install: [make "PREFIX=%{prefix}%" "install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "asl"]
+depends: [
+  "result"
+  "logs"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [os = "darwin"]

--- a/packages/asl/asl.0.8/url
+++ b/packages/asl/asl.0.8/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-asl/archive/v0.8.tar.gz"
+checksum: "9a15d71b31bf71476dc853a242ca0903"


### PR DESCRIPTION
Bindings for the Apple System Log API

The Apple System Log allows applications to send log messages, which can
be recorded, filterd and searched.


---
* Homepage: https://github.com/mirage/ocaml-asl
* Source repo: https://github.com/mirage/ocaml-asl.git
* Bug tracker: https://github.com/mirage/ocaml-asl/issues

---

Pull-request generated by opam-publish v0.3.1