### PR TITLE
base58.0.1.0 - via opam-publish

### DIFF
--- a/packages/base58/base58.0.1.0/descr
+++ b/packages/base58/base58.0.1.0/descr
@@ -1,0 +1,4 @@
+Base58 encoding and decoding
+
+This library enables you to encode and decode into base58 representation using the alphabet of your choice.
+

--- a/packages/base58/base58.0.1.0/opam
+++ b/packages/base58/base58.0.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors: "Maxime Ransan <maxime.ransan@gmail.com>"
+homepage: "https://github.com/mransan/base58"
+bug-reports: "https://github.com/mransan/base58/issues"
+license: "MIT"
+tags: ["base58" "encoding"]
+dev-repo: "https://github.com/mransan/base58.git"
+build: [
+  [make "lib.byte"]
+  [make "lib.native"] {ocaml-native}
+]
+install: [make "lib.install"]
+remove: [make "lib.uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]

--- a/packages/base58/base58.0.1.0/url
+++ b/packages/base58/base58.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mransan/base58/archive/0.1.0.tar.gz"
+checksum: "e1f6fd4ad91b96b4c2bd678648a319bb"


### PR DESCRIPTION
Base58 encoding and decoding

This library enables you to encode and decode into base58 representation using the alphabet of your choice.



---
* Homepage: https://github.com/mransan/base58
* Source repo: https://github.com/mransan/base58.git
* Bug tracker: https://github.com/mransan/base58/issues

---

Pull-request generated by opam-publish v0.3.1