### PR TITLE
ogen.0.1.2 - via opam-publish

### DIFF
--- a/packages/ogen/ogen.0.1.2/descr
+++ b/packages/ogen/ogen.0.1.2/descr
@@ -1,0 +1,6 @@
+A tool for creating new OCaml projects with OPAM, Oasis, and Merlin
+ogen is a command-line program to help generate some of the boilerplate involved
+in creating OCaml projects, such as the opam, _oasis, and .merlin files. ogen
+features a simple-to-use dialog that allows the user to input specific options for their
+repository, as well as a number of additional commands that allow the user to set options
+separately.

--- a/packages/ogen/ogen.0.1.2/opam
+++ b/packages/ogen/ogen.0.1.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/ogen"
+bug-reports: "https://github.com/nv-vn/ogen/issues"
+license: "GPL"
+dev-repo: "https://github.com/nv-vn/ogen.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: ["cp" "./main.native" "%{bin}%/ogen"]
+remove: ["rm" "%{bin}%/ogen"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "batteries" {>= "2.0.0" & < "3.0.0"}
+  "linenoise" {>= "0.9.0" & < "1.0.0"}
+  "ocaml-inifiles" {>= "1.2" & < "2.0"}
+  "yojson" {>= "1.3.0" & < "2.0.0"}
+  "ppx_blob" {>= "0.1" & < "0.2"}
+  "ppx_deriving" {>= "3.0" & < "4.0"}
+  "ppx_deriving_yojson" {>= "2.4" & < "3.0"}
+]

--- a/packages/ogen/ogen.0.1.2/opam
+++ b/packages/ogen/ogen.0.1.2/opam
@@ -11,14 +11,15 @@ build: [
 ]
 install: ["cp" "./main.native" "%{bin}%/ogen"]
 remove: ["rm" "%{bin}%/ogen"]
+available: [ocaml-version >= "4.02" & < "4.03"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}
-  "batteries" {>= "2.0.0" & < "3.0.0"}
-  "linenoise" {>= "0.9.0" & < "1.0.0"}
-  "ocaml-inifiles" {>= "1.2" & < "2.0"}
-  "yojson" {>= "1.3.0" & < "2.0.0"}
-  "ppx_blob" {>= "0.1" & < "0.2"}
-  "ppx_deriving" {>= "3.0" & < "4.0"}
-  "ppx_deriving_yojson" {>= "2.4" & < "3.0"}
+  "batteries" {>= "2.0.0"}
+  "linenoise" {>= "0.9.0"}
+  "ocaml-inifiles" {>= "1.2"}
+  "yojson" {>= "1.3.0"}
+  "ppx_blob" {>= "0.1"}
+  "ppx_deriving" {>= "3.0"}
+  "ppx_deriving_yojson" {>= "2.4"}
 ]

--- a/packages/ogen/ogen.0.1.2/opam
+++ b/packages/ogen/ogen.0.1.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["cp" "./main.native" "%{bin}%/ogen"]
 remove: ["rm" "%{bin}%/ogen"]
-available: [ocaml-version >= "4.02" & < "4.03"]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.03"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}

--- a/packages/ogen/ogen.0.1.2/url
+++ b/packages/ogen/ogen.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/ogen/archive/v0.1.2.tar.gz"
+checksum: "20d5fd51ca89ff9c927995b206ce1b5b"


### PR DESCRIPTION
A tool for creating new OCaml projects with OPAM, Oasis, and Merlin
ogen is a command-line program to help generate some of the boilerplate involved
in creating OCaml projects, such as the opam, _oasis, and .merlin files. ogen
features a simple-to-use dialog that allows the user to input specific options for their
repository, as well as a number of additional commands that allow the user to set options
separately.


---
* Homepage: https://github.com/nv-vn/ogen
* Source repo: https://github.com/nv-vn/ogen.git
* Bug tracker: https://github.com/nv-vn/ogen/issues

---

Pull-request generated by opam-publish v0.3.1