### PR TITLE
Constrain ppx_deriving_yojson to OCaml < 4.03

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
@@ -21,3 +21,4 @@ depends: [
   "ppx_import" {test}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
@@ -29,3 +29,4 @@ depends: [
   "ppx_import" {test}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.03.0" ]


### PR DESCRIPTION
ppx_deriving_yojson [doesn't build with OCaml 4.03.0](https://travis-ci.org/ocaml/opam-repository/jobs/131017102#L801-L822):

```
# File "src/ppx_deriving_yojson.ml", line 261, characters 46-67:
# Error: The constructor Asttypes.Const_string belongs to the variant type
#          Asttypes.constant
#        but a constructor was expected belonging to the variant type
#          Parsetree.constant
```

/cc @whitequark 