### PR TITLE
unix-time.0.1.0 - via opam-publish

### DIFF
--- a/packages/unix-time/unix-time.0.1.0/descr
+++ b/packages/unix-time/unix-time.0.1.0/descr
@@ -1,0 +1,9 @@
+Unix time.h types, maps, and support
+
+unix-time provides access to the features exposed in time.h in a way
+that is not tied to the implementation on the host system.
+
+The Time module provides types which are analogous to those defined in
+time.h such as timespec.
+
+The Time_unix module provides a ctypes view for timespec.

--- a/packages/unix-time/unix-time.0.1.0/opam
+++ b/packages/unix-time/unix-time.0.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-unix-time"
+bug-reports: "https://github.com/dsheets/ocaml-unix-time/issues"
+license: "ISC"
+tags: ["unix" "posix" "time.h" "tm" "timespec"]
+dev-repo: "https://github.com/dsheets/ocaml-unix-time.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "unix-errno" {>= "0.4.0"}
+  "ctypes"
+]
+depopts: "base-unix"
+conflicts: [
+  "ctypes" {< "0.4.0"}
+]

--- a/packages/unix-time/unix-time.0.1.0/url
+++ b/packages/unix-time/unix-time.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-time/archive/0.1.0.tar.gz"
+checksum: "e53ba3b7ffee0605dc7975b7269f9efe"


### PR DESCRIPTION
Unix time.h types, maps, and support

unix-time provides access to the features exposed in time.h in a way
that is not tied to the implementation on the host system.

The Time module provides types which are analogous to those defined in
time.h such as timespec.

The Time_unix module provides a ctypes view for timespec.


---
* Homepage: https://github.com/dsheets/ocaml-unix-time
* Source repo: https://github.com/dsheets/ocaml-unix-time.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-time/issues

---

Pull-request generated by opam-publish v0.3.1