### PR TITLE
osx-attr.0.1.0 - via opam-publish

### DIFF
--- a/packages/osx-attr/osx-attr.0.1.0/descr
+++ b/packages/osx-attr/osx-attr.0.1.0/descr
@@ -1,0 +1,4 @@
+OS X generic file system attribute system call bindings
+
+`getattrlist`, `fgetattrlist`, `getattrlistat`, `setattrlist`, and
+`fsetattrlist` are bound.

--- a/packages/osx-attr/osx-attr.0.1.0/opam
+++ b/packages/osx-attr/osx-attr.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-osx-attr"
+bug-reports: "https://github.com/dsheets/ocaml-osx-attr/issues"
+license: "ISC"
+tags: ["osx" "attr" "attributes" "getattrlist" "setattrlist" "file system"]
+dev-repo: "https://github.com/dsheets/ocaml-osx-attr.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "ctypes" {>= "0.4.0"}
+  "unix-errno" {>= "0.4.0"}
+  "base-unix"
+  "unix-type-representations"
+  "unix-time"
+]
+depopts: "lwt"
+available: [os = "darwin"]

--- a/packages/osx-attr/osx-attr.0.1.0/url
+++ b/packages/osx-attr/osx-attr.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-attr/archive/0.1.0.tar.gz"
+checksum: "30529b06ca3d2cfb9577ba62e24d1619"


### PR DESCRIPTION
OS X generic file system attribute system call bindings

`getattrlist`, `fgetattrlist`, `getattrlistat`, `setattrlist`, and
`fsetattrlist` are bound.


---
* Homepage: https://github.com/dsheets/ocaml-osx-attr
* Source repo: https://github.com/dsheets/ocaml-osx-attr.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-attr/issues

---

Pull-request generated by opam-publish v0.3.1