### PR TITLE
memcpy.0.1.0 - via opam-publish

### DIFF
--- a/packages/memcpy/memcpy.0.1.0/descr
+++ b/packages/memcpy/memcpy.0.1.0/descr
@@ -1,0 +1,10 @@
+Safe and efficient copying between blocks of memory.
+
+There are several ways of storing and accessing blocks of memory in an OCaml program, including
+
+* bytes and string values for mutable and immutable strings that reside in the OCaml heap
+* bigarray values for reference-counted blocks that reside in the OCaml heaps
+* Ctypes ptr values that can be used to address arbitrary addresses using typed descriptions of the memory layout.
+* Ctypes array values that provide bounds-checked access to ptr-addressed memory.
+
+The Memcpy module provides functions for safely and efficiently copying blocks of memory between these different representations.

--- a/packages/memcpy/memcpy.0.1.0/opam
+++ b/packages/memcpy/memcpy.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+author: "yallop@gmail.com"
+homepage: "https://github.com/yallop/ocaml-memcpy"
+dev-repo: "http://github.com/yallop/ocaml-memcpy.git"
+bug-reports: "http://github.com/yallop/ocaml-memcpy/issues"
+license: "MIT"
+build: [[make]]
+install: [[make "install"]]
+build-test: [[make "test"]]
+remove: [["ocamlfind" "remove" "memcpy"]]
+depends: [
+   "ctypes" {>= "0.4.0"}
+   "ounit" {test}
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/memcpy/memcpy.0.1.0/url
+++ b/packages/memcpy/memcpy.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/yallop/ocaml-memcpy/archive/0.1.0.tar.gz"
+checksum: "4ba882a985d936633ec8bf0e382aa632"


### PR DESCRIPTION
Safe and efficient copying between blocks of memory.

There are several ways of storing and accessing blocks of memory in an OCaml program, including

* bytes and string values for mutable and immutable strings that reside in the OCaml heap
* bigarray values for reference-counted blocks that reside in the OCaml heaps
* Ctypes ptr values that can be used to address arbitrary addresses using typed descriptions of the memory layout.
* Ctypes array values that provide bounds-checked access to ptr-addressed memory.

The `Memcpy` module provides functions for safely and efficiently copying blocks of memory between these different representations.


---
* Homepage: https://github.com/yallop/ocaml-memcpy
* Source repo: http://github.com/yallop/ocaml-memcpy.git
* Bug tracker: http://github.com/yallop/ocaml-memcpy/issues

---

Pull-request generated by opam-publish v0.3.1