### PR TITLE
usbmux.1.3.1 - via opam-publish

### DIFF
--- a/packages/usbmux/usbmux.1.3.1/opam
+++ b/packages/usbmux/usbmux.1.3.1/opam
@@ -25,6 +25,7 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build & >= "0.4"}
   "ppx_deriving_yojson" {>= "2.4"}
+  "base-threads"
   "plist"
   "yojson"
 ]


### PR DESCRIPTION
Control port remapping for iOS devices

Now you can ssh into your jailbroken iDevice using the CLI, gandalf.
Simple invocation:
sudo `which gandalf` --mappings etc/mapping --daemonize --verbose

where etc/mapping is a file such that # start comments and consists of 
an array of json objects with these fields, note that name can be null 
and is just a nickname for this tunnel, other fields are required.

```
# This is a comment
[{"udid":"9cdfac9f74c5e18a6eff3611c0927df5cf4f2eca",
  "name":"i11",
  "forwarding": [{"local_port":2000, "device_port":22},
                 {"local_port":3000, "device_port":1122}]}]
```

See uptime, tunnels and other metadata with:
gandalf --status
Note that with over 13 devices usbmuxd will start to buck 
because of threading issue with libplist.
Use the custom one provided at https://github.com/onlinemediagroup/libplist

The Linux kernel will also have trouble with many USB3.0 devices, ie over 15ish
Fix that issue by turning off USB3.0 support in your BIOS

Check out the man page or see the README at:
https://github.com/onlinemediagroup/ocaml-usbmux/blob/master/README.md


---
* Homepage: https://github.com/onlinemediagroup/ocaml-usbmux
* Source repo: https://github.com/onlinemediagroup/ocaml-usbmux.git
* Bug tracker: https://github.com/onlinemediagroup/ocaml-usbmux/issues

---

Pull-request generated by opam-publish v0.3.1