### PR TITLE
Tyxml 4.0.0

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.2.6/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.6/opam
@@ -25,7 +25,7 @@ depopts: ["deriving" "tyxml" "reactiveData" ]
 
 conflicts: [
   "deriving" {< "0.6"}
-  "tyxml"    {< "3.2.1"}
+  "tyxml"    {< "3.2.1" & >= "4.0.0" }
   "tyxml"    {>= "3.6.0"}
   "reactiveData" {>= "0.2"}
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.7/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.7/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: ["deriving" "ppx_deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving"     {< "0.6"}
-  "tyxml"        {< "3.6.0"}
+  "tyxml"        {< "3.6.0" & >= "4.0.0" }
   "ppx_deriving" {< "3.0"}
   "reactiveData" {< "0.2"}
 ]

--- a/packages/ketrew/ketrew.2.0.0/opam
+++ b/packages/ketrew/ketrew.2.0.0/opam
@@ -26,5 +26,5 @@ depends: [
   "ppx_deriving" {>= "3.0"} "ppx_deriving_yojson" {>= "2.3"}
   "cohttp" {>= "0.17.0" } "lwt" {< "2.5.0" } "ssl"
   "conduit"
-  "js_of_ocaml" {>= "2.6" } "tyxml" "reactiveData"
+  "js_of_ocaml" {>= "2.6" } "tyxml" {< "4.0.0"} "reactiveData"
   ]

--- a/packages/ketrew/ketrew.2.0.0/opam
+++ b/packages/ketrew/ketrew.2.0.0/opam
@@ -26,5 +26,5 @@ depends: [
   "ppx_deriving" {>= "3.0"} "ppx_deriving_yojson" {>= "2.3"}
   "cohttp" {>= "0.17.0" } "lwt" {< "2.5.0" } "ssl"
   "conduit"
-  "js_of_ocaml" {>= "2.6" } "tyxml" {< "4.0.0"} "reactiveData"
+  "js_of_ocaml" {>= "2.6" } "tyxml" {<= "3.5.0"} "reactiveData"
   ]

--- a/packages/ocsigenserver/ocsigenserver.2.5/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.5/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlnet" {>= "3.6.0"}
   "pcre"
   "cryptokit"
-  "tyxml" {>= "3.3.0"}
+  "tyxml" {>= "3.3.0" & < "4.0.0"}
   ("dbm" | "sqlite3")
   "ipaddr" {>= "2.1"}
 ]

--- a/packages/ocsigenserver/ocsigenserver.2.6/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.6/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlnet" {>= "4.0.2"}
   "pcre"
   "cryptokit"
-  "tyxml" {>= "3.4.0"}
+  "tyxml" {>= "3.4.0" & < "4.0.0"}
   ("dbm" | "sqlite3")
   "ipaddr" {>= "2.1"}
   "camlp4"

--- a/packages/ocsigenserver/ocsigenserver.2.7/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.7/opam
@@ -50,7 +50,7 @@ depends: [
   "ocamlnet" {>= "4.0.2"}
   "pcre"
   "cryptokit"
-  "tyxml" {>= "3.4.0"}
+  "tyxml" {>= "3.4.0" & < "4.0.0"}
   ("dbm" | "sqlite3")
   "ipaddr" {>= "2.1"}
   "camlp4"

--- a/packages/podge/podge.0.2/opam
+++ b/packages/podge/podge.0.2/opam
@@ -25,7 +25,7 @@ depends: [
   "cohttp"
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
-  "tyxml"
+  "tyxml" {< "4.0.0"}
   "yojson"
   "ocamlbuild" {build}
 ]

--- a/packages/podge/podge.0.2/opam
+++ b/packages/podge/podge.0.2/opam
@@ -11,9 +11,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-remove: [
-  ["ocaml" "%{etc}%/podge/_oasis_remove_.ml" "%{etc}%/podge"]
-]
+remove: ["ocamlfind" "remove" "podge"]
 build-test: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]

--- a/packages/podge/podge.0.3/opam
+++ b/packages/podge/podge.0.3/opam
@@ -12,9 +12,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-remove: [
-  ["ocaml" "%{etc}%/podge/_oasis_remove_.ml" "%{etc}%/podge"]
-]
+remove: ["ocamlfind" "remove" "podge"]
 build-test: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]

--- a/packages/podge/podge.0.3/opam
+++ b/packages/podge/podge.0.3/opam
@@ -27,7 +27,7 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "re"
-  "tyxml"
+  "tyxml" {< "4.0.0"}
   "yojson"
   "ocamlbuild" {build}
 ]

--- a/packages/podge/podge.0.4/opam
+++ b/packages/podge/podge.0.4/opam
@@ -17,7 +17,7 @@ build-test: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-remove: ["ocaml" "%{etc}%/podge/_oasis_remove_.ml" "%{etc}%/podge"]
+remove: ["ocamlfind" "remove" "podge"]
 depends: [
   "ANSITerminal"
   "base-unix"

--- a/packages/podge/podge.0.4/opam
+++ b/packages/podge/podge.0.4/opam
@@ -26,7 +26,7 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "re"
-  "tyxml"
+  "tyxml" {< "4.0.0"}
   "yojson"
   "ocamlbuild" {build}
 ]

--- a/packages/podge/podge.0.5/opam
+++ b/packages/podge/podge.0.5/opam
@@ -17,7 +17,7 @@ build-test: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-remove: ["ocaml" "%{etc}%/podge/_oasis_remove_.ml" "%{etc}%/podge"]
+remove: ["ocamlfind" "remove" "podge"]
 depends: [
   "ANSITerminal"
   "base-unix"

--- a/packages/podge/podge.0.5/opam
+++ b/packages/podge/podge.0.5/opam
@@ -26,7 +26,7 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "re"
-  "tyxml"
+  "tyxml" {< "4.0.0"}
   "yojson"
   "stringext"
   "ocamlbuild" {build}

--- a/packages/podge/podge.0.7.0/opam
+++ b/packages/podge/podge.0.7.0/opam
@@ -17,7 +17,7 @@ build-test: [
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-remove: ["ocaml" "%{etc}%/podge/_oasis_remove_.ml" "%{etc}%/podge"]
+remove: ["ocamlfind" "remove" "podge"]
 depends: [
   "ANSITerminal"
   "base-unix"

--- a/packages/podge/podge.0.7.0/opam
+++ b/packages/podge/podge.0.7.0/opam
@@ -26,7 +26,7 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "re"
-  "tyxml"
+  "tyxml" {< "4.0.0"}
   "yojson"
   "stringext"
 ]

--- a/packages/tyxml-ppx/tyxml-ppx.4.0.0/descr
+++ b/packages/tyxml-ppx/tyxml-ppx.4.0.0/descr
@@ -1,0 +1,1 @@
+Virtual package for tyxml's ppx

--- a/packages/tyxml-ppx/tyxml-ppx.4.0.0/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.0.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "dev@ocsigen.org"
+author: "The ocsigen team"
+homepage: "https://ocsigen.org/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+build: ["ocamlfind" "query" "tyxml.ppx"]
+depends: [
+  "tyxml"
+  "markup" {>= "0.7.2"}
+  "ppx_tools"
+]
+available: ocaml-version >= "4.02"

--- a/packages/tyxml-ppx/tyxml-ppx.4.0.0/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.0.0/opam
@@ -11,4 +11,4 @@ depends: [
   "markup" {>= "0.7.2"}
   "ppx_tools"
 ]
-available: ocaml-version >= "4.02"
+available: [ocaml-version >= "4.02"]

--- a/packages/tyxml/tyxml.4.0.0/descr
+++ b/packages/tyxml/tyxml.4.0.0/descr
@@ -1,0 +1,6 @@
+TyXML is a library for building statically correct HTML5 and SVG documents
+
+TyXML allows you to build HTML5 and SVG trees whose validity is ensured by the typechecker.
+It provides a printer for said XML trees, along with a ppx syntax extension.
+Finally it also provides a functorial interface to choose your XML datastructure.
+It's part of the ocsigen project and is used in js_of_ocaml and eliom.

--- a/packages/tyxml/tyxml.4.0.0/opam
+++ b/packages/tyxml/tyxml.4.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+
+maintainer: "dev@ocsigen.org"
+author: "The ocsigen team"
+homepage: "https://ocsigen.org/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--%{markup+ppx_tools:enable}%-ppx"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--%{markup+ppx_tools:enable}%-ppx"
+      "--enable-tests"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tyxml"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "uutf"
+  "base-bytes"
+  "re"
+  "alcotest" {test}
+]
+depopts: [
+  "camlp4"
+  "markup"
+  "ppx_tools"
+]
+conflicts: [
+  "ppx_tools" { < "5.0" }
+]
+available: ocaml-version >= "4.02"
+messages: [
+  "For tyxml's ppx, please install tyxml-ppx."
+  {!markup:installed | !ppx_tools:installed}
+]

--- a/packages/tyxml/tyxml.4.0.0/opam
+++ b/packages/tyxml/tyxml.4.0.0/opam
@@ -41,7 +41,7 @@ depopts: [
 conflicts: [
   "ppx_tools" { < "5.0" }
 ]
-available: ocaml-version >= "4.02"
+available: [ocaml-version >= "4.02"]
 messages: [
   "For tyxml's ppx, please install tyxml-ppx."
   {!markup:installed | !ppx_tools:installed}

--- a/packages/tyxml/tyxml.4.0.0/url
+++ b/packages/tyxml/tyxml.4.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/tyxml/archive/4.0.0.tar.gz"
+checksum: "0245bc3e0011732eff14ff10ec933046"


### PR DESCRIPTION
Lot's of changes, breaking compat. The changelog is [here](https://github.com/ocsigen/tyxml/releases/tag/4.0.0).

The virtual package thing was advised by @rgrinberg and copied from mirage-conduit.

All @darioteixeira's packages already have a constraint, it seems. cc @fxfactorial @smondet 