### PR TITLE
telegraml.2.1.1 - via opam-publish

### DIFF
--- a/packages/telegraml/telegraml.2.1.1/descr
+++ b/packages/telegraml/telegraml.2.1.1/descr
@@ -1,0 +1,5 @@
+Telegram Bot API for OCaml
+An implementation of the Telegram Bot API in 100% OCaml,
+using Lwt for asynchronous operations and Cohttp for networking.
+Implements most basic functionality present in the API, plus
+convenience modules for error handling and defining commands.

--- a/packages/telegraml/telegraml.2.1.1/opam
+++ b/packages/telegraml/telegraml.2.1.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/telegraml"
+bug-reports: "https://github.com/nv-vn/telegraml/issues"
+license: "MIT"
+dev-repo: "https://github.com/nv-vn/telegraml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "telegraml"]
+available: [ocaml-version >= "4.02"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "lwt" {>= "2.5.0"}
+  "cohttp" {>= "0.19.0"}
+  "yojson" {>= "1.3.0"}
+  "batteries" {>= "2.4.0"}
+]

--- a/packages/telegraml/telegraml.2.1.1/url
+++ b/packages/telegraml/telegraml.2.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/TelegraML/archive/v2.1.1.tar.gz"
+checksum: "f03521247bb70508b4311f28bbe45b26"


### PR DESCRIPTION
Telegram Bot API for OCaml
An implementation of the Telegram Bot API in 100% OCaml,
using Lwt for asynchronous operations and Cohttp for networking.
Implements most basic functionality present in the API, plus
convenience modules for error handling and defining commands.


---
* Homepage: https://github.com/nv-vn/telegraml
* Source repo: https://github.com/nv-vn/telegraml.git
* Bug tracker: https://github.com/nv-vn/telegraml/issues

---

Pull-request generated by opam-publish v0.3.1