### PR TITLE
topkg.0.7.0 - via opam-publish

### DIFF
--- a/packages/topkg/topkg.0.7.0/descr
+++ b/packages/topkg/topkg.0.7.0/descr
@@ -1,0 +1,24 @@
+The transitory OCaml software packager
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml OPAM repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner] and
+`opam-lib`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner

--- a/packages/topkg/topkg.0.7.0/opam
+++ b/packages/topkg/topkg.0.7.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild" {build}
+  "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" "%{name}%"
+          "--installer" "true"
+]]

--- a/packages/topkg/topkg.0.7.0/url
+++ b/packages/topkg/topkg.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/topkg/releases/topkg-0.7.0.tbz"
+checksum: "a891dd1c46d3fc157b911605c7608be6"


### PR DESCRIPTION
The transitory OCaml software packager

Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml OPAM repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner] and
`opam-lib`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner


---
* Homepage: http://erratique.ch/software/topkg
* Source repo: http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---

Pull-request generated by opam-publish v0.3.1