### PR TITLE
Conf bmake.1.0

### DIFF
--- a/packages/broken/broken.0.3.0/opam
+++ b/packages/broken/broken.0.3.0/opam
@@ -12,10 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "broken"]

--- a/packages/broken/broken.0.3.0/opam
+++ b/packages/broken/broken.0.3.0/opam
@@ -12,12 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "broken"]
@@ -29,9 +27,5 @@ available: [
 depends: [
   "ocamlfind"
   "bsdowl" {>= "3.0.0"}
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
+  "conf-bmake"
 ]

--- a/packages/broken/broken.0.4.2/opam
+++ b/packages/broken/broken.0.4.2/opam
@@ -13,12 +13,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "broken"]
@@ -31,9 +29,5 @@ depends: [
   "ocamlfind"
   "base-unix"
   "bsdowl" {>= "3.0.0"}
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
+  "conf-bmake"
 ]

--- a/packages/broken/broken.0.4.2/opam
+++ b/packages/broken/broken.0.4.2/opam
@@ -13,10 +13,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "broken"]

--- a/packages/bsdowl/bsdowl.2.2/opam
+++ b/packages/bsdowl/bsdowl.2.2/opam
@@ -10,12 +10,15 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-r" "build"]
+  ["%{conf-bmake:path}%" "-r" "build"]
 ]
-depends: ["ocamlfind"]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
-  [["freebsd"] ["devel/bmake"]]
+install: [
+  ["%{conf-bmake:path}%" "install"]
+]
+remove: [
+  ["sh" "%{build}%/opam/files/remove.sh" prefix]
+]
+depends: [
+  "conf-bmake"
+  "ocamlfind"
 ]

--- a/packages/bsdowl/bsdowl.2.2/opam
+++ b/packages/bsdowl/bsdowl.2.2/opam
@@ -10,10 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-r" "build"]
+  [conf-bmake:path "-r" "build"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "install"]
+  [conf-bmake:path "install"]
 ]
 remove: [
   ["sh" "%{build}%/opam/files/remove.sh" prefix]

--- a/packages/bsdowl/bsdowl.2.2/opam
+++ b/packages/bsdowl/bsdowl.2.2/opam
@@ -1,8 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "michipili@gmail.com"
 authors: "Michael Grünewald"
 license: "CeCILL-B"
 homepage: "https://github.com/michipili/bsdowl"
+bug-reports: "https://github.com/michipili/bsdowl/issues"
+dev-repo: "https://github.com/michipili/bsdowl.git"
 tags: [
   "bsd"
   "bmake"

--- a/packages/bsdowl/bsdowl.3.0.0-20150401/opam
+++ b/packages/bsdowl/bsdowl.3.0.0-20150401/opam
@@ -12,19 +12,15 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-r" "build"] {os != "freebsd"}
-  ["make" "-r" "build"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-r" "build"]
 ]
 install: [
-  ["bmake" "install"] {os != "freebsd"}
-  ["make" "install"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "install"]
 ]
 remove: [
   ["sh" "%{build}%/opam/files/remove.sh" prefix]
 ]
-depends: ["ocamlfind"]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
+depends: [
+  "conf-bmake"
+  "ocamlfind"
 ]

--- a/packages/bsdowl/bsdowl.3.0.0-20150401/opam
+++ b/packages/bsdowl/bsdowl.3.0.0-20150401/opam
@@ -12,10 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-r" "build"]
+  [conf-bmake:path "-r" "build"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "install"]
+  [conf-bmake:path "install"]
 ]
 remove: [
   ["sh" "%{build}%/opam/files/remove.sh" prefix]

--- a/packages/bsdowl/bsdowl.3.0.0-20150830/opam
+++ b/packages/bsdowl/bsdowl.3.0.0-20150830/opam
@@ -12,19 +12,15 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-r" "build"] {os != "freebsd"}
-  ["make" "-r" "build"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-r" "build"]
 ]
 install: [
-  ["bmake" "install"] {os != "freebsd"}
-  ["make" "install"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "install"]
 ]
 remove: [
   ["sh" "%{build}%/opam/files/remove.sh" prefix]
 ]
-depends: ["ocamlfind"]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
+depends: [
+  "conf-bmake"
+  "ocamlfind"
 ]

--- a/packages/bsdowl/bsdowl.3.0.0-20150830/opam
+++ b/packages/bsdowl/bsdowl.3.0.0-20150830/opam
@@ -12,10 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-r" "build"]
+  [conf-bmake:path "-r" "build"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "install"]
+  [conf-bmake:path "install"]
 ]
 remove: [
   ["sh" "%{build}%/opam/files/remove.sh" prefix]

--- a/packages/conf-bmake/conf-bmake.1.0/descr
+++ b/packages/conf-bmake/conf-bmake.1.0/descr
@@ -1,0 +1,3 @@
+Virtual package relying on a BSD Make compatible program
+installation. This package can only install if a BSD Make compatible
+program is available on the system.

--- a/packages/conf-bmake/conf-bmake.1.0/descr
+++ b/packages/conf-bmake/conf-bmake.1.0/descr
@@ -1,3 +1,3 @@
 Virtual package relying on a BSD Make compatible program
-installation. This package can only install if a BSD Make compatible
-program is available on the system.
+This package can only install if a BSD Make compatible program is
+available on the system.

--- a/packages/conf-bmake/conf-bmake.1.0/files/detect_program.sh
+++ b/packages/conf-bmake/conf-bmake.1.0/files/detect_program.sh
@@ -1,0 +1,43 @@
+### detect_program.sh -- Detect program and save its path
+
+wlog()
+{
+    { printf "$@"; printf '\n'; } 1>&2
+}
+
+detect_which()
+{
+    ( IFS=':'
+      for path_elt in ${PATH}; do
+          wlog 'Debug: Looking for %s in %s' "$1" "${path_elt}"
+          if [ -x "${path_elt}/$1" ]; then
+              printf '%s' "${path_elt}/$1"
+              exit 0
+          fi
+      done
+
+      printf 'false'
+      exit 1 )
+}
+
+detect_config()
+{
+    local program_path
+
+    program_path=$(detect_which "$2")
+
+    if [ "${program_path}" = 'false' ]; then
+        wlog 'Debug: %s: Not found in PATH.' "$2"
+        exit 1
+    fi
+
+    cat > "$1" <<EOF
+path: "${program_path}"
+EOF
+}
+
+wlog 'Debug: program: %s' "$2"
+wlog 'Debug: output: %s' "$1"
+wlog 'Debug: pwd: %s' "$(pwd)"
+
+detect_config "$1" "$2"

--- a/packages/conf-bmake/conf-bmake.1.0/opam
+++ b/packages/conf-bmake/conf-bmake.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "michipili@gmail.com"
+homepage: "http://www.crufty.net/help/sjg/bmake.htm"
+authors: "sjg@crufty.net"
+bug-reports: "mailto:sjg@crufty.net"
+license: "BSD"
+build: [
+  ["sh" "./detect_program.sh" "./conf-bmake.config" "bmake"] {!(os = "freebsd" | os = "openbsd" | os = "netbsd")}
+  ["sh" "./detect_program.sh" "./conf-bmake.config" "make"] {(os = "freebsd" | os = "openbsd" | os = "netbsd")}
+]
+depexts: [
+  [["debian"] ["bmake"]]
+  [["ubuntu"] ["bmake"]]
+  [["centos"] ["bmake"]]
+  [["fedora"] ["bmake"]]
+  [["archlinux"] ["bmake"]]
+  [["gentoo"] ["sys-devel/bmake"]]
+  [["nixpkgs"] ["bmake"]]
+  [["osx" "homebrew"] ["bmake"]]
+  [["osx" "macports"] ["bmake"]]
+  [["alpine"] ["bmake"]]
+  [["oraclelinux"] ["bmake"]]
+  [["rhel"] ["bmake"]]
+]

--- a/packages/configuration/configuration.0.4.0/opam
+++ b/packages/configuration/configuration.0.4.0/opam
@@ -12,12 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "configuration"]
@@ -29,10 +27,6 @@ available: [
 depends: [
   "broken" {>= "0.4.1"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/configuration/configuration.0.4.0/opam
+++ b/packages/configuration/configuration.0.4.0/opam
@@ -12,10 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "configuration"]

--- a/packages/configuration/configuration.0.4.1/opam
+++ b/packages/configuration/configuration.0.4.1/opam
@@ -12,12 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "configuration"]
@@ -29,10 +27,6 @@ available: [
 depends: [
   "broken" {>= "0.4.1"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/configuration/configuration.0.4.1/opam
+++ b/packages/configuration/configuration.0.4.1/opam
@@ -12,10 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "configuration"]

--- a/packages/gasoline/gasoline.0.1/opam
+++ b/packages/gasoline/gasoline.0.1/opam
@@ -1,9 +1,11 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "michipili@gmail.com"
 authors: "Michael Grünewald"
 license: "CeCILL-B"
 homepage: "https://github.com/michipili/gasoline"
-ocaml-version: [< "4.02.0" & >= "4.01.0"]
+bug-reports: "https://github.com/michipili/gasoline/issues"
+dev-repo: "https://github.com/michipili/gasoline.git"
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.02.0" ]
 tags: [
   "application"
 ]

--- a/packages/gasoline/gasoline.0.1/opam
+++ b/packages/gasoline/gasoline.0.1/opam
@@ -11,8 +11,16 @@ depends: [
   "bsdowl"
   "ocamlfind"
   "camomile"
+  "conf-bmake"
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"]
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+]
+install: [
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "gasoline"]
+  ["rm" "-rf" "%{share}%/doc/gasoline"]
 ]

--- a/packages/gasoline/gasoline.0.1/opam
+++ b/packages/gasoline/gasoline.0.1/opam
@@ -15,10 +15,10 @@ depends: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "gasoline"]

--- a/packages/gasoline/gasoline.0.3.0/opam
+++ b/packages/gasoline/gasoline.0.3.0/opam
@@ -14,6 +14,7 @@ depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
   "camomile" {>= "0.8.5"}
+  "conf-bmake"
   "configuration" {>= "0.4.1"}
   "getopts" {>= "0.3.2"}
   "lemonade" {>= "0.2.1"}
@@ -21,12 +22,10 @@ depends: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make" "-I%{bsdowl:share}%" "all"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make" "-I%{bsdowl:share}%" "install"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "gasoline"]

--- a/packages/gasoline/gasoline.0.3.0/opam
+++ b/packages/gasoline/gasoline.0.3.0/opam
@@ -6,7 +6,7 @@ license: "CeCILL-B"
 homepage: "https://github.com/michipili/gasoline"
 bug-reports: "https://github.com/michipili/gasoline/issues"
 dev-repo: "https://github.com/michipili/gasoline.git"
-ocaml-version: [>= "4.02.0"]
+available: [ ocaml-version >= "4.02.0" ]
 tags: [
   "application"
 ]

--- a/packages/gasoline/gasoline.0.3.0/opam
+++ b/packages/gasoline/gasoline.0.3.0/opam
@@ -22,10 +22,10 @@ depends: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "gasoline"]

--- a/packages/gasoline/gasoline.0.4.0/opam
+++ b/packages/gasoline/gasoline.0.4.0/opam
@@ -22,10 +22,10 @@ depends: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "gasoline"]

--- a/packages/gasoline/gasoline.0.4.0/opam
+++ b/packages/gasoline/gasoline.0.4.0/opam
@@ -15,18 +15,17 @@ depends: [
   "bsdowl" {>= "3.0.0"}
   "camomile" {>= "0.8.5"}
   "configuration" {>= "0.4.1"}
+  "conf-bmake"
   "getopts" {>= "0.3.2"}
   "lemonade" {>= "0.3.0"}
   "ocamlfind"
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make" "-I%{bsdowl:share}%" "all"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make" "-I%{bsdowl:share}%" "install"]  {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "gasoline"]

--- a/packages/getopts/getopts.0.3.2/opam
+++ b/packages/getopts/getopts.0.3.2/opam
@@ -12,10 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "getopts"]

--- a/packages/getopts/getopts.0.3.2/opam
+++ b/packages/getopts/getopts.0.3.2/opam
@@ -12,12 +12,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "getopts"]
@@ -26,11 +24,7 @@ remove: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "lemonade" {>= "0.2.1" & < "0.4.0"}
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/lemonade-sqlite/lemonade-sqlite.0.1.0/opam
+++ b/packages/lemonade-sqlite/lemonade-sqlite.0.1.0/opam
@@ -13,12 +13,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade-sqlite"]
@@ -27,6 +25,7 @@ remove: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "lemonade" {>= "0.5.0"}
   "ocamlfind"
   "sqlite3" {>= "2.0.9"}

--- a/packages/lemonade-sqlite/lemonade-sqlite.0.1.0/opam
+++ b/packages/lemonade-sqlite/lemonade-sqlite.0.1.0/opam
@@ -13,10 +13,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade-sqlite"]

--- a/packages/lemonade/lemonade.0.2.0/opam
+++ b/packages/lemonade/lemonade.0.2.0/opam
@@ -11,10 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]

--- a/packages/lemonade/lemonade.0.2.0/opam
+++ b/packages/lemonade/lemonade.0.2.0/opam
@@ -11,12 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]
@@ -25,11 +23,7 @@ remove: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "mixture"{>= "0.2.0"}
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/lemonade/lemonade.0.3.0/opam
+++ b/packages/lemonade/lemonade.0.3.0/opam
@@ -11,10 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]

--- a/packages/lemonade/lemonade.0.3.0/opam
+++ b/packages/lemonade/lemonade.0.3.0/opam
@@ -11,12 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]
@@ -25,11 +23,7 @@ remove: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "mixture"{= "0.2.0"}
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/lemonade/lemonade.0.4.0/opam
+++ b/packages/lemonade/lemonade.0.4.0/opam
@@ -14,12 +14,10 @@ build: [
   ["./configure"
     "--prefix" prefix
     "--%{ppx_tools:enable}%-ppx-rewriter"]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]
@@ -31,11 +29,7 @@ available: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "mixture"{>= "1.0.0"}
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/lemonade/lemonade.0.4.0/opam
+++ b/packages/lemonade/lemonade.0.4.0/opam
@@ -14,10 +14,10 @@ build: [
   ["./configure"
     "--prefix" prefix
     "--%{ppx_tools:enable}%-ppx-rewriter"]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]

--- a/packages/lemonade/lemonade.0.5.0/opam
+++ b/packages/lemonade/lemonade.0.5.0/opam
@@ -14,12 +14,10 @@ build: [
   ["./configure"
     "--prefix" prefix
     "--%{ppx_tools:enable}%-ppx-rewriter"]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]
@@ -31,11 +29,7 @@ available: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "mixture"{>= "1.0.0"}
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/lemonade/lemonade.0.5.0/opam
+++ b/packages/lemonade/lemonade.0.5.0/opam
@@ -14,10 +14,10 @@ build: [
   ["./configure"
     "--prefix" prefix
     "--%{ppx_tools:enable}%-ppx-rewriter"]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "lemonade"]

--- a/packages/mixture/mixture.0.2.0/opam
+++ b/packages/mixture/mixture.0.2.0/opam
@@ -10,12 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "mixture"]
@@ -27,10 +25,6 @@ available: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/mixture/mixture.0.2.0/opam
+++ b/packages/mixture/mixture.0.2.0/opam
@@ -10,10 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "mixture"]

--- a/packages/mixture/mixture.0.2.1/opam
+++ b/packages/mixture/mixture.0.2.1/opam
@@ -10,12 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "mixture"]
@@ -27,10 +25,6 @@ available: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/mixture/mixture.0.2.1/opam
+++ b/packages/mixture/mixture.0.2.1/opam
@@ -10,10 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "mixture"]

--- a/packages/mixture/mixture.1.0.0/opam
+++ b/packages/mixture/mixture.1.0.0/opam
@@ -10,12 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "mixture"]
@@ -27,10 +25,6 @@ available: [
 depends: [
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "ocamlfind"
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/mixture/mixture.1.0.0/opam
+++ b/packages/mixture/mixture.1.0.0/opam
@@ -10,10 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "mixture"]

--- a/packages/rashell/rashell.0.1.0/opam
+++ b/packages/rashell/rashell.0.1.0/opam
@@ -11,12 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "rashell"]
@@ -28,11 +26,7 @@ available: [
 depends: [
   "ocamlfind"
   "broken" {>= "0.4.2"}
+  "conf-bmake"
   "bsdowl" {>= "3.0.0"}
   "lwt"    {>= "2.5.0"}
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/rashell/rashell.0.1.0/opam
+++ b/packages/rashell/rashell.0.1.0/opam
@@ -11,10 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "rashell"]

--- a/packages/rashell/rashell.0.2.0/opam
+++ b/packages/rashell/rashell.0.2.0/opam
@@ -11,12 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "rashell"]
@@ -27,10 +25,6 @@ depends: [
   "atdgen" {>= "1.7.1"}
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
+  "conf-bmake"
   "lwt"    {>= "2.5.0"}
-]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
 ]

--- a/packages/rashell/rashell.0.2.0/opam
+++ b/packages/rashell/rashell.0.2.0/opam
@@ -11,10 +11,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "rashell"]

--- a/packages/rashell/rashell.0.2.1/opam
+++ b/packages/rashell/rashell.0.2.1/opam
@@ -10,10 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "rashell"]

--- a/packages/rashell/rashell.0.2.1/opam
+++ b/packages/rashell/rashell.0.2.1/opam
@@ -10,12 +10,10 @@ tags: [
 ]
 build: [
   ["./configure" "--prefix" prefix]
-  ["bmake" "-I%{bsdowl:share}%" "all"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "all"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "all"]
 ]
 install: [
-  ["bmake" "-I%{bsdowl:share}%" "install"] {os != "freebsd"}
-  ["make"  "-I%{bsdowl:share}%" "install"] {os  = "freebsd"}
+  ["%{conf-bmake:path}%" "-I%{bsdowl:share}%" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "rashell"]
@@ -26,12 +24,7 @@ depends: [
   "atdgen"  {>= "1.7.1"}
   "broken"  {>= "0.4.2"}
   "bsdowl"  {>= "3.0.0"}
+  "conf-bmake"
   "lwt"     {>= "2.5.0"}
   "mixture" {>= "0.2.0"}
 ]
-depexts: [
-  [["debian"] ["bmake"]]
-  [["ubuntu"] ["bmake"]]
-  [["osx" "macports"] ["bmake"]]
-]
-available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
I finally took time to add a **conf-bmake** package to ease the integration of package building with a BSD Make compatible program instead of GNU Make.

This uses a `config-state-vars` declaration to store the path to the actual BSD Make compatible program used. This can be referred to as `%{conf-bmake:path}` in other packages.

I was not able to find any package using `config-state-vars` or the `config-input-vars` declarations, so I hope to have got this right. If everything looks good, I could update the other packages using a BSD Make compatible program so that everything get updated in one go. :)

@dsheets Since you suggested that change, I add you to the notification list for this PR.

References: https://github.com/ocaml/opam/issues/2247