### PR TITLE
rresult.0.4.0 - via opam-publish

### DIFF
--- a/packages/rresult/rresult.0.4.0/descr
+++ b/packages/rresult/rresult.0.4.0/descr
@@ -1,0 +1,9 @@
+Result value combinators for OCaml
+
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+Rresult depends on the compatibility `result` package and is
+distributed under the ISC license.

--- a/packages/rresult/rresult.0.4.0/opam
+++ b/packages/rresult/rresult.0.4.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build}
+   "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--installer" "true" ]]

--- a/packages/rresult/rresult.0.4.0/url
+++ b/packages/rresult/rresult.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/rresult/releases/rresult-0.4.0.tbz"
+checksum: "bee49d7098f94dca00eb2fdba1986885"


### PR DESCRIPTION
Result value combinators for OCaml

Rresult is an OCaml module for handling computation results and errors
in an explicit and declarative manner, without resorting to
exceptions. It defines combinators to operate on the `result` type
available from OCaml 4.03 in the standard library.

Rresult depends on the compatibility `result` package and is
distributed under the ISC license.


---
* Homepage: http://erratique.ch/software/rresult
* Source repo: http://erratique.ch/repos/rresult.git
* Bug tracker: https://github.com/dbuenzli/rresult/issues

---

Pull-request generated by opam-publish v0.3.1