### PR TITLE
Build the compilers only once

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -69,10 +69,9 @@ function opam_version_compat {
 }
 opam_version_compat
 
-function build_one {
-  pkg=$1
-  echo "build one: $pkg ($OPAM_SWITCH)"
+function build_switch {
   rm -rf ~/.opam
+  echo "build switch: $OPAM_SWITCH"
   if [ -n "${opam_version_11}" ]; then
       # Hide OCaml build log
       if opam init . --comp=$OPAM_SWITCH > build.log 2>&1 ; then
@@ -86,6 +85,11 @@ function build_one {
       opam init . --comp=$OPAM_SWITCH
   fi
   eval `opam config env`
+}
+
+function build_one {
+  pkg=$1
+  echo "build one: $pkg"
   # test for installability
   echo "Checking for availability..."
   if ! opam install $pkg --dry-run; then
@@ -137,6 +141,8 @@ function build_one {
     fi
   fi
 }
+
+build_switch
 
 for i in `cat tobuild.txt`; do
   build_one $i

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -123,7 +123,6 @@ function build_one {
     opam install depext
     depext=$(opam depext -ls $pkg --no-sources)
     opam depext $pkg
-    opam remove depext -a
     echo
     echo "====== Installing package ======"
     opam install $pkg


### PR DESCRIPTION
This was useful to start from scratch at the beginning, but now the packages behave much more nicely so it's better to be fast.