### PR TITLE
fpath.0.7.0 - via opam-publish

### DIFF
--- a/packages/fpath/fpath.0.7.0/descr
+++ b/packages/fpath/fpath.0.7.0/descr
@@ -1,0 +1,10 @@
+File system paths for OCaml
+
+Fpath is an OCaml module for handling file system paths with POSIX or
+Windows conventions. Fpath processes paths without accessing the file
+system and is independent from any system library.
+
+Fpath depends on [Astring][astring] and is distributed under the ISC
+license.
+
+[astring]: http://erratique.ch/software/astring

--- a/packages/fpath/fpath.0.7.0/opam
+++ b/packages/fpath/fpath.0.7.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/fpath"
+doc: "http://erratique.ch/software/fpath"
+dev-repo: "http://erratique.ch/repos/fpath.git"
+bug-reports: "https://github.com/dbuenzli/fpath/issues"
+tags: [ "file" "system" "path" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build}
+   "result"
+   "astring"
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--installer" "true" ]]

--- a/packages/fpath/fpath.0.7.0/url
+++ b/packages/fpath/fpath.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/fpath/releases/fpath-0.7.0.tbz"
+checksum: "865c9e7057626894f0e5a54f07bf8295"


### PR DESCRIPTION
File system paths for OCaml

Fpath is an OCaml module for handling file system paths with POSIX or
Windows conventions. Fpath processes paths without accessing the file
system and is independent from any system library.

Fpath depends on [Astring][astring] and is distributed under the ISC
license.

[astring]: http://erratique.ch/software/astring


---
* Homepage: http://erratique.ch/software/fpath
* Source repo: http://erratique.ch/repos/fpath.git
* Bug tracker: https://github.com/dbuenzli/fpath/issues

---

Pull-request generated by opam-publish v0.3.1