### PR TITLE
Fix ocaml-version constraint for ocp-index 1.0.0

### DIFF
--- a/packages/ocp-index/ocp-index.1.0.0/opam
+++ b/packages/ocp-index/ocp-index.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner"
 ]
 depopts: ["curses"]
-available: [ ocaml-version >= "4.00.0" & available < "4.02" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.02" ]
 post-messages: [
   "OCP-INDEX installed.
 


### PR DESCRIPTION
In 1.2.0 this was saying:

```
RROR] available is not a valid variable.
[WARNING] Invalid variable available in filter
```

And the constraint was discarded for opam 1.2.2