### PR TITLE
Fix available ocaml versions

### DIFF
--- a/packages/slap/slap.0.0.0/opam
+++ b/packages/slap/slap.0.0.0/opam
@@ -6,7 +6,8 @@ homepage: "https://github.com/akabe/slap"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.0.0/opam
+++ b/packages/slap/slap.0.0.0/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.0.0.0/opam
+++ b/packages/slap/slap.0.0.0/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.1.0/opam
+++ b/packages/slap/slap.0.1.0/opam
@@ -6,7 +6,8 @@ homepage: "https://github.com/akabe/slap"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.1.0/opam
+++ b/packages/slap/slap.0.1.0/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.0.1.0/opam
+++ b/packages/slap/slap.0.1.0/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.0/opam
+++ b/packages/slap/slap.0.2.0/opam
@@ -6,7 +6,8 @@ homepage: "https://github.com/akabe/slap"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.0/opam
+++ b/packages/slap/slap.0.2.0/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.0.2.0/opam
+++ b/packages/slap/slap.0.2.0/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.1/opam
+++ b/packages/slap/slap.0.2.1/opam
@@ -6,7 +6,8 @@ homepage: "https://github.com/akabe/slap"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.1/opam
+++ b/packages/slap/slap.0.2.1/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.0.2.1/opam
+++ b/packages/slap/slap.0.2.1/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.2/opam
+++ b/packages/slap/slap.0.2.2/opam
@@ -6,7 +6,8 @@ homepage: "http://akabe.github.io/slap/"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.2/opam
+++ b/packages/slap/slap.0.2.2/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.0.2.2/opam
+++ b/packages/slap/slap.0.2.2/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.3/opam
+++ b/packages/slap/slap.0.2.3/opam
@@ -6,7 +6,8 @@ homepage: "http://akabe.github.io/slap/"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.0.2.3/opam
+++ b/packages/slap/slap.0.2.3/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.0.2.3/opam
+++ b/packages/slap/slap.0.2.3/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12.1" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.1.0.0/opam
+++ b/packages/slap/slap.1.0.0/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "4.02" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "4.02" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.1.0.0/opam
+++ b/packages/slap/slap.1.0.0/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.1.0.0/opam
+++ b/packages/slap/slap.1.0.0/opam
@@ -6,7 +6,8 @@ homepage: "http://akabe.github.io/slap/"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "4.02" ]
+available: [ ocaml-version >= "4.02" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.1.0.1/opam
+++ b/packages/slap/slap.1.0.1/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "4.02" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "4.02" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.1.0.1/opam
+++ b/packages/slap/slap.1.0.1/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {< "7.2.2"}
+  "lacaml" {>= "7.0.12" & < "7.2.2"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.1.0.1/opam
+++ b/packages/slap/slap.1.0.1/opam
@@ -6,7 +6,8 @@ homepage: "http://akabe.github.io/slap/"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "4.02" ]
+available: [ ocaml-version >= "4.02" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.2.0.0/opam
+++ b/packages/slap/slap.2.0.0/opam
@@ -23,6 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "4.02" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "4.02" ]
 dev-repo: "git://github.com/akabe/slap"
 bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.2.0.0/opam
+++ b/packages/slap/slap.2.0.0/opam
@@ -15,7 +15,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
-  "lacaml" {>= "7.2.3"}
+  "lacaml" {>= "7.2.3" & < "8.0.0"}
   "ocamlfind"
   "cppo"
   "ocamlbuild" {build}

--- a/packages/slap/slap.2.0.0/opam
+++ b/packages/slap/slap.2.0.0/opam
@@ -6,7 +6,8 @@ homepage: "http://akabe.github.io/slap/"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-install"]
+]
+install: ["ocaml" "setup.ml" "-install"
 ]
 remove: [
   ["ocamlfind" "remove" "slap"]
@@ -22,5 +23,6 @@ depends: [
 depopts: [
   "ounit"
 ]
-ocaml-version: [ >= "4.02" ]
+available: [ ocaml-version >= "4.02" ]
 dev-repo: "git://github.com/akabe/slap"
+bug-reports: "https://github.com/akabe/slap/issues"

--- a/packages/slap/slap.2.0.1/opam
+++ b/packages/slap/slap.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {>= "1.5.0"}
-  "lacaml" {>= "7.2.3"}
+  "lacaml" {>= "7.2.3" & < "8.0.0"}
   "cppo"
   "ocamlbuild" {build}
 ]

--- a/packages/slap/slap.2.0.1/opam
+++ b/packages/slap/slap.2.0.1/opam
@@ -27,4 +27,4 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12" ]

--- a/packages/slap/slap.2.0.2/opam
+++ b/packages/slap/slap.2.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {>= "1.5.0"}
-  "lacaml" {>= "7.2.3"}
+  "lacaml" {>= "7.2.3" & < "8.0.0"}
   "cppo"
 ]
 depopts: [

--- a/packages/slap/slap.2.0.2/opam
+++ b/packages/slap/slap.2.0.2/opam
@@ -26,4 +26,4 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12" ]

--- a/packages/slap/slap.3.0.0/opam
+++ b/packages/slap/slap.3.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {>= "1.5.0"}
-  "lacaml" {>= "7.2.3"}
+  "lacaml" {>= "7.2.3" & < "8.0.0"}
   "cppo"
 ]
 depopts: [

--- a/packages/slap/slap.3.0.0/opam
+++ b/packages/slap/slap.3.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {>= "1.5.0"}
-  "lacaml" {>= "7.2.3" & < "8.0.0"}
+  "lacaml" {>= "8.0.0"}
   "cppo"
 ]
 depopts: [

--- a/packages/slap/slap.3.0.0/opam
+++ b/packages/slap/slap.3.0.0/opam
@@ -26,4 +26,4 @@ depends: [
 depopts: [
   "ounit"
 ]
-available: [ ocaml-version >= "3.12" ]
+available: [ ocaml-version <= "4.02.3" & ocaml-version >= "3.12" ]


### PR DESCRIPTION
I added the upper bound of OCaml versions because Slap 3.0.0 or below cannot be compiled in OCaml 4.03. In addition, I fixed older opam files according to `opam lint`.