### PR TITLE
owee.0.2 - via opam-publish

### DIFF
--- a/packages/owee/owee.0.2/descr
+++ b/packages/owee/owee.0.2/descr
@@ -1,0 +1,6 @@
+OCaml library to work with DWARF format
+
+Owee is an experimental library to work with DWARF format.
+It can parse ELF binaries and interpret DWARF debugline programs.
+
+It can also be used to find locations of functions from the current process.

--- a/packages/owee/owee.0.2/opam
+++ b/packages/owee/owee.0.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: "Frédéric Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/owee"
+bug-reports: "https://github.com/let-def/owee"
+license: "MIT"
+dev-repo: "https://github.com/let-def/owee.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "owee"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/owee/owee.0.2/url
+++ b/packages/owee/owee.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/owee/archive/v0.2.tar.gz"
+checksum: "bff2cda731741045ed8a55107c49eb59"


### PR DESCRIPTION
OCaml library to work with DWARF format

Owee is an experimental library to work with DWARF format.
It can parse ELF binaries and interpret DWARF debugline programs.

It can also be used to find locations of functions from the current process.


---
* Homepage: https://github.com/let-def/owee
* Source repo: https://github.com/let-def/owee.git
* Bug tracker: https://github.com/let-def/owee

---

Pull-request generated by opam-publish v0.3.1