### PR TITLE
deriving 0.7.1

### DIFF
--- a/packages/deriving/deriving.0.7.1/descr
+++ b/packages/deriving/deriving.0.7.1/descr
@@ -1,0 +1,1 @@
+Extension to OCaml for deriving functions from type declarations

--- a/packages/deriving/deriving.0.7.1/findlib
+++ b/packages/deriving/deriving.0.7.1/findlib
@@ -1,0 +1,1 @@
+deriving

--- a/packages/deriving/deriving.0.7.1/opam
+++ b/packages/deriving/deriving.0.7.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name: "deriving"
+version: "0.7.1"
+maintainer: "dev@ocsigen.org"
+author: "Jeremy Yallop <yallop@gmail.com>"
+homepage: "http://github.com/ocsigen/deriving/"
+bug-reports: "https://github.com/ocsigen/deriving/issues/"
+dev-repo: "https://github.com/ocsigen/deriving.git"
+license: "MIT"
+build: [
+  ["./configure" "--prefix" prefix "--%{type_conv:enable}%-tc"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "deriving"]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "optcomp" {>= "1.6"}
+  "camlp4"
+  "oasis" {build & >= "0.4.4"}
+]
+depopts: ["type_conv"]
+conflicts: ["type_conv" {< "108.07.00"}]

--- a/packages/deriving/deriving.0.7.1/url
+++ b/packages/deriving/deriving.0.7.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/deriving/archive/0.7.1.tar.gz"
+checksum: "1260cf1427560542ae5725a6871775f0"

--- a/packages/deriving/deriving.0.7/opam
+++ b/packages/deriving/deriving.0.7/opam
@@ -1,11 +1,18 @@
 opam-version: "1.2"
+name: "deriving"
+version: "0.7"
 maintainer: "dev@ocsigen.org"
+author: "Jeremy Yallop <yallop@gmail.com>"
+homepage: "http://github.com/ocsigen/deriving/"
+bug-reports: "https://github.com/ocsigen/deriving/issues/"
+dev-repo: "https://github.com/ocsigen/deriving.git"
+license: "MIT"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{type_conv:enable}%-tc"]
   [make]
-  [make "install"]
 ]
-remove: [["ocamlfind" "remove" "deriving"]]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "deriving"]
 depends: [
   "ocamlfind"
   "base-bytes"
@@ -15,3 +22,4 @@ depends: [
 ]
 depopts: ["type_conv"]
 conflicts: ["type_conv" {< "108.07.00"}]
+available: [ocaml-version <= "4.02.3"]


### PR DESCRIPTION
0.7.1 is a minor release to restore compatibility with OCaml 4.03.

The constraints for 0.7 have been updated to require OCaml `<= 4.02.3`.

Fixes #6613 .