### PR TITLE
shared-secret.0.1 - via opam-publish

### DIFF
--- a/packages/shared-secret/shared-secret.0.1/descr
+++ b/packages/shared-secret/shared-secret.0.1/descr
@@ -1,1 +1,2 @@
+Exceptions are shared secrets.
 Abstract (encapsulated) messages or hidden (semi-deterministic) exceptions using OCaml's module system.

--- a/packages/shared-secret/shared-secret.0.1/descr
+++ b/packages/shared-secret/shared-secret.0.1/descr
@@ -1,0 +1,1 @@
+Abstract (encapsulated) messages or hidden (semi-deterministic) exceptions using OCaml's module system.

--- a/packages/shared-secret/shared-secret.0.1/opam
+++ b/packages/shared-secret/shared-secret.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Marco Aurélio <marcoonroad@gmail.com>"
+authors: "Marco Aurélio <marcoonroad@gmail.com>"
+homepage: "http://github.com/marcoonroad/shared-secret"
+bug-reports: "http://github.com/marcoonroad/shared-secret/issues"
+license: "MIT License"
+dev-repo: "http://github.com/marcoonroad/shared-secret.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--%{ounit:enable}%-tests"]
+  [make]
+]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "shared-secret"]
+depends: [
+  "ounit" {test}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/shared-secret/shared-secret.0.1/opam
+++ b/packages/shared-secret/shared-secret.0.1/opam
@@ -6,6 +6,7 @@ bug-reports: "http://github.com/marcoonroad/shared-secret/issues"
 license: "MIT License"
 dev-repo: "http://github.com/marcoonroad/shared-secret.git"
 build: [
+  ["oasis" "setup"]
   ["./configure" "--prefix=%{prefix}%" "--%{ounit:enable}%-tests"]
   [make]
 ]
@@ -14,6 +15,7 @@ build-test: [make "test"]
 remove: ["ocamlfind" "remove" "shared-secret"]
 depends: [
   "ounit" {test}
+  "oasis" {build}
   "ocamlfind" {build}
 ]
 available: [ocaml-version >= "4.02"]

--- a/packages/shared-secret/shared-secret.0.1/opam
+++ b/packages/shared-secret/shared-secret.0.1/opam
@@ -3,7 +3,7 @@ maintainer: "Marco Aurélio <marcoonroad@gmail.com>"
 authors: "Marco Aurélio <marcoonroad@gmail.com>"
 homepage: "http://github.com/marcoonroad/shared-secret"
 bug-reports: "http://github.com/marcoonroad/shared-secret/issues"
-license: "MIT License"
+license: "MIT"
 dev-repo: "http://github.com/marcoonroad/shared-secret.git"
 build: [
   ["oasis" "setup"]

--- a/packages/shared-secret/shared-secret.0.1/url
+++ b/packages/shared-secret/shared-secret.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/marcoonroad/shared-secret/archive/v0.1.zip"
+checksum: "469fe27234d2f131bb67f3328dea674b"

--- a/packages/shared-secret/shared-secret.0.1/url
+++ b/packages/shared-secret/shared-secret.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/marcoonroad/shared-secret/archive/v0.1.zip"
-checksum: "469fe27234d2f131bb67f3328dea674b"
+checksum: "3ac49e697da692e74f8f20a4bea50dbe"


### PR DESCRIPTION
Abstract (encapsulated) messages or hidden (semi-deterministic) exceptions using OCaml's module system.


---
* Homepage: http://github.com/marcoonroad/shared-secret
* Source repo: http://github.com/marcoonroad/shared-secret.git
* Bug tracker: http://github.com/marcoonroad/shared-secret/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1