### PR TITLE
junit.0.1 - via opam-publish

### DIFF
--- a/packages/junit/junit.0.1/descr
+++ b/packages/junit/junit.0.1/descr
@@ -1,0 +1,3 @@
+Library to produce XML JUnit reports.
+Library to produce XML JUnit reports.
+

--- a/packages/junit/junit.0.1/opam
+++ b/packages/junit/junit.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocaml-junit"
+bug-reports: "https://github.com/Khady/ocaml-junit/issues"
+license: "MIT"
+dev-repo: "git://github.com/Khady/ocaml-junit.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "junit"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ptime"
+  "tyxml" {>= "4.0.0"}
+]
+available: [ocaml-version >= "4.02.1"]

--- a/packages/junit/junit.0.1/opam
+++ b/packages/junit/junit.0.1/opam
@@ -6,13 +6,11 @@ bug-reports: "https://github.com/Khady/ocaml-junit/issues"
 license: "MIT"
 dev-repo: "git://github.com/Khady/ocaml-junit.git"
 build: [
-  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
 build-test: [
-  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
@@ -20,7 +18,6 @@ build-test: [
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "junit"]
 depends: [
-  "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ptime"

--- a/packages/junit/junit.0.1/url
+++ b/packages/junit/junit.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Khady/ocaml-junit/archive/0.1.zip"
+checksum: "b25790f915ed08bd87796b3d722e0fd0"


### PR DESCRIPTION
Library to produce XML JUnit reports.
Library to produce XML JUnit reports.



---
* Homepage: https://github.com/Khady/ocaml-junit
* Source repo: git://github.com/Khady/ocaml-junit.git
* Bug tracker: https://github.com/Khady/ocaml-junit/issues

---

Pull-request generated by opam-publish v0.3.1