### PR TITLE
Improved the opam file of slap 3.0.1

### DIFF
--- a/packages/slap/slap.3.0.1/opam
+++ b/packages/slap/slap.3.0.1/opam
@@ -22,11 +22,11 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bigarray"
   "base-bytes"
-  "ocamlfind" {>= "1.5.0"}
+  "ocamlfind" {build & >= "1.5.0"}
   "lacaml" {>= "8.0.0"}
-  "cppo"
+  "cppo" {build}
 ]
 depopts: [
-  "ounit"
+  "ounit" {test}
 ]
 available: [ ocaml-version >= "3.12" ]

--- a/packages/slap/slap.3.0.1/opam
+++ b/packages/slap/slap.3.0.1/opam
@@ -13,10 +13,8 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 remove: [
-  ["ocaml" "setup.ml" "-configure"
-   "--prefix" prefix
-   "--disable-ppx"  {ocaml-version < "4.02"}]
-  ["ocaml" "setup.ml" "-uninstall"]
+  ["ocamlfind" "remove" "slap"]
+  ["rm" "-f" "%{bin}%/ppx_slap"]
 ]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [

--- a/packages/slap/slap.3.0.1/opam
+++ b/packages/slap/slap.3.0.1/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 remove: [
-  ["ocamlfind" "remove" "slap"]
+  ["ocaml" "setup.ml" "-configure"
+   "--prefix" prefix
+   "--disable-ppx"  {ocaml-version < "4.02"}]
+  ["ocaml" "setup.ml" "-uninstall"]
 ]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [


### PR DESCRIPTION
I reflected the advices in PR #6629:

- Added `{build}` annotations to `ocamlfind` and `cppo`
- Added `{test}` annotation to `ounit`
- Improved instructions for uninstalling `ppx_slap`