### PR TITLE
osx-mount.0.1.0 - via opam-publish

### DIFF
--- a/packages/osx-mount/osx-mount.0.1.0/descr
+++ b/packages/osx-mount/osx-mount.0.1.0/descr
@@ -1,0 +1,4 @@
+Bindings to OS X mount system calls
+
+`getmntinfo` and `statfs` are bound as well as the statfs struct as a
+record type. 

--- a/packages/osx-mount/osx-mount.0.1.0/opam
+++ b/packages/osx-mount/osx-mount.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-osx-mount"
+bug-reports: "https://github.com/dsheets/ocaml-osx-mount/issues"
+license: "ISC"
+tags: ["osx" "mount" "mountpoint" "mtab" "mount table" "file system"]
+dev-repo: "https://github.com/dsheets/ocaml-osx-mount.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "ctypes" {>= "0.4.0"}
+  "unix-errno" {>= "0.4.0"}
+  "base-unix"
+]
+depopts: "lwt"
+available: [os = "darwin"]

--- a/packages/osx-mount/osx-mount.0.1.0/url
+++ b/packages/osx-mount/osx-mount.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-mount/archive/0.1.0.tar.gz"
+checksum: "5e03ce2886b33fecf9ea25cc2f4ee9f3"


### PR DESCRIPTION
Bindings to OS X mount system calls

`getmntinfo` and `statfs` are bound as well as the statfs struct as a
record type. 


---
* Homepage: https://github.com/dsheets/ocaml-osx-mount
* Source repo: https://github.com/dsheets/ocaml-osx-mount.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-mount/issues

---

Pull-request generated by opam-publish v0.3.1