### PR TITLE
osx-cf.0.1.0 - via opam-publish

### DIFF
--- a/packages/osx-cf/osx-cf.0.1.0/descr
+++ b/packages/osx-cf/osx-cf.0.1.0/descr
@@ -1,0 +1,5 @@
+OS X CoreFoundation bindings
+
+String, Array, Index, RunLoop (and Observer), and TimeInterval are
+bound. Additionally, an osx-cf.lwt subpackage provides lwt+RunLoop
+integration.

--- a/packages/osx-cf/osx-cf.0.1.0/opam
+++ b/packages/osx-cf/osx-cf.0.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Thomas Gazagnaire"]
+homepage: "https://github.com/dsheets/ocaml-osx-cf"
+bug-reports: "https://github.com/dsheets/ocaml-osx-cf/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/ocaml-osx-cf.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "alcotest" {test}
+  "base-bytes"
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+]
+depopts: ["lwt" "base-threads"]
+available: [os = "darwin"]

--- a/packages/osx-cf/osx-cf.0.1.0/url
+++ b/packages/osx-cf/osx-cf.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-cf/archive/0.1.0.tar.gz"
+checksum: "933897442a7cb63a95fd82b6faa4ee2a"


### PR DESCRIPTION
OS X CoreFoundation bindings

String, Array, Index, RunLoop (and Observer), and TimeInterval are
bound. Additionally, an osx-cf.lwt subpackage provides lwt+RunLoop
integration.


---
* Homepage: https://github.com/dsheets/ocaml-osx-cf
* Source repo: https://github.com/dsheets/ocaml-osx-cf.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-cf/issues

---

Pull-request generated by opam-publish v0.3.1