### PR TITLE
Constrain unix-sys-stat to ctypes versions below 0.6.0

### DIFF
--- a/packages/unix-sys-stat/unix-sys-stat.0.3.0/opam
+++ b/packages/unix-sys-stat/unix-sys-stat.0.3.0/opam
@@ -20,4 +20,5 @@ depends: [
 depopts: "base-unix"
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
 ]

--- a/packages/unix-sys-stat/unix-sys-stat.0.3.1/opam
+++ b/packages/unix-sys-stat/unix-sys-stat.0.3.1/opam
@@ -21,4 +21,5 @@ depends: [
 depopts: "base-unix"
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
 ]


### PR DESCRIPTION
See https://github.com/dsheets/ocaml-unix-sys-stat/pull/19 and https://github.com/ocamllabs/ocaml-ctypes/pull/389.

/cc @dsheets 
