### PR TITLE
Constrain unix-sys-resource to ctypes versions below 0.6.0

### DIFF
--- a/packages/unix-sys-resource/unix-sys-resource.0.1.0/opam
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.0/opam
@@ -28,4 +28,5 @@ depopts: [
 ]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
 ]

--- a/packages/unix-sys-resource/unix-sys-resource.0.1.1/opam
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.1/opam
@@ -20,4 +20,5 @@ depends: [
 depopts: "base-unix"
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
 ]


### PR DESCRIPTION
See https://github.com/dsheets/ocaml-unix-sys-resource/pull/2 and https://github.com/ocamllabs/ocaml-ctypes/pull/389

/cc @dsheets