### PR TITLE
Constrain unix-fcntl to ctypes versions below 0.6.0

### DIFF
--- a/packages/unix-fcntl/unix-fcntl.0.2.0/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.2.0/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "unix-errno" {>= "0.2.0" & < "0.3.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/unix-fcntl/unix-fcntl.0.3.0/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.0/opam
@@ -11,7 +11,7 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "unix-errno" {>= "0.2.0" & < "0.4.0"}
   "alcotest" {test}
   "unix-type-representations"

--- a/packages/unix-fcntl/unix-fcntl.0.3.1/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.1/opam
@@ -16,7 +16,7 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "unix-errno" {>= "0.2.0" & < "0.4.0"}
   "alcotest" {test}
   "unix-type-representations"

--- a/packages/unix-fcntl/unix-fcntl.0.3.2/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.2/opam
@@ -12,7 +12,7 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "unix-errno" {>= "0.4.0"}
   "alcotest" {test}
   "unix-type-representations"


### PR DESCRIPTION
See https://github.com/dsheets/ocaml-unix-fcntl/pull/16 and https://github.com/ocamllabs/ocaml-ctypes/pull/389

/cc @dsheets 