### PR TITLE
ocamlfind does not depend on ncurses

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -9,5 +9,4 @@ build: [
 available: [(ocaml-version >= "3.08") & (ocaml-version < "3.12.2")]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -9,5 +9,4 @@ build: [
 ocaml-version: [> "3.12.2"]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -10,5 +10,4 @@ build: [
 available: [(ocaml-version >= "3.08") & (ocaml-version <= "4.01.0")] # ocamlfind uses Arg.align of 3.08
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -8,6 +8,5 @@ build: [
 ]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -8,6 +8,5 @@ build: [
 ]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -13,7 +13,6 @@ remove: [
 ]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -13,7 +13,6 @@ remove: [
 ]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -13,7 +13,6 @@ remove: [
 ]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -14,6 +14,5 @@ remove: [
 ]
 depends: [
   "conf-m4"
-  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -18,6 +18,5 @@ remove: [
 ]
 depends: [
   "conf-m4" {build}
-  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -19,5 +19,4 @@ remove: [
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
 depends: [
   "conf-m4" {build}
-  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.6.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.1/opam
@@ -19,5 +19,4 @@ remove: [
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
 depends: [
   "conf-m4" {build}
-  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.6.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.2/opam
@@ -23,5 +23,4 @@ remove: [
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
 depends: [
   "conf-m4" {build}
-  "conf-ncurses" {build}
 ]


### PR DESCRIPTION
There have been several installation issues with ocamlfind recently due
to the fact that conf-ncurses uses pkg-config to check installability,
which is only valid under recent ncurses versions. But in fact ocamlfind
does not depend on ncurses at all (I just checked with Gerd Stolpmann),
so there is no reason for the dependency in the first place.

fixes #5880