### PR TITLE
Constrain unix-errno to ctypes versions below 0.6.0

### DIFF
--- a/packages/unix-errno/unix-errno.0.2.0/opam
+++ b/packages/unix-errno/unix-errno.0.2.0/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "rresult"
   "ocamlbuild" {build}
 ]

--- a/packages/unix-errno/unix-errno.0.3.0/opam
+++ b/packages/unix-errno/unix-errno.0.3.0/opam
@@ -18,5 +18,6 @@ depends: [
 depopts: ["base-unix" "ctypes"]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/unix-errno/unix-errno.0.4.0/opam
+++ b/packages/unix-errno/unix-errno.0.4.0/opam
@@ -18,5 +18,6 @@ depends: [
 depopts: ["base-unix" "ctypes"]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/unix-errno/unix-errno.0.4.1/opam
+++ b/packages/unix-errno/unix-errno.0.4.1/opam
@@ -20,5 +20,6 @@ depends: [
 depopts: ["base-unix" "ctypes"]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
See https://github.com/dsheets/ocaml-unix-errno/pull/9 and https://github.com/ocamllabs/ocaml-ctypes/pull/389

/cc @dsheets 