### PR TITLE
Constrain unix-dirent to ctypes versions below 0.6.0

### DIFF
--- a/packages/unix-dirent/unix-dirent.0.3.0/opam
+++ b/packages/unix-dirent/unix-dirent.0.3.0/opam
@@ -19,6 +19,7 @@ depopts: [
 ]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
   "unix-errno" {>= "0.4.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/unix-dirent/unix-dirent.0.3.1/opam
+++ b/packages/unix-dirent/unix-dirent.0.3.1/opam
@@ -20,6 +20,7 @@ depopts: [
 ]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.6.0"}
   "unix-errno" {< "0.4.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]


### PR DESCRIPTION
See https://github.com/dsheets/ocaml-unix-dirent/pull/12 and https://github.com/ocamllabs/ocaml-ctypes/pull/389

/cc @dsheets 