### PR TITLE
Constrain zstd to ctypes versions below 0.6.0

### DIFF
--- a/packages/zstd/zstd.0.1/opam
+++ b/packages/zstd/zstd.0.1/opam
@@ -28,7 +28,7 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ocamlbuild" {build}
-  "ctypes"
+  "ctypes"  { < "0.6.0" }
   ("extlib" {test} |"extlib-compat" {test})
   "base-unix" {test}
 ]


### PR DESCRIPTION
See https://github.com/ygrek/ocaml-zstd/pull/3

/cc @ygrek.  A new release of zstd would be appreciated!