### PR TITLE
Constrain lz4 to ctypes versions below 0.6.0

### DIFF
--- a/packages/lz4/lz4.1.0.1/opam
+++ b/packages/lz4/lz4.1.0.1/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "lz4"]]
 depends: [
   "base-bytes"
   "ocamlfind"
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "ocamlbuild" {build}
 ]
 depexts: [

--- a/packages/lz4/lz4.1.1.0/opam
+++ b/packages/lz4/lz4.1.1.0/opam
@@ -22,7 +22,7 @@ remove: ["ocamlfind" "remove" "lz4"]
 depends: [
   "base-bytes"
   "ocamlfind"
-  "ctypes" {>= "0.4.1"}
+  "ctypes" {>= "0.4.1" & < "0.6.0"}
   "ounit"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
See https://github.com/whitequark/ocaml-lz4/pull/10

/cc @whitequark.  A new release of lz4 would be appreciated!
