### PR TITLE
Constrain opasswd to ctypes versions below 0.6.0

### DIFF
--- a/packages/opasswd/opasswd.0.9.3/opam
+++ b/packages/opasswd/opasswd.0.9.3/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ctypes" {>= "0.2.2"}
+  "ctypes" {>= "0.2.2" & < "0.6.0"}
   "ctypes-foreign"
   "ocamlbuild" {build}
 ]

--- a/packages/opasswd/opasswd.0.9.3/opam
+++ b/packages/opasswd/opasswd.0.9.3/opam
@@ -20,3 +20,4 @@ depends: [
 ]
 tags: [ "org:xapi-project" ]
 dev-repo: "git://github.com/mcclurmc/ocaml-opasswd"
+available: [ ocaml-version < "4.03.0" ]


### PR DESCRIPTION
See https://github.com/xapi-project/ocaml-opasswd/pull/5

/cc @simonjbeaumont.  A new release of opasswd would be appreciated!