### PR TITLE
Constrain ocephes to ctypes versions below 0.6.0

### DIFF
--- a/packages/ocephes/ocephes.0.1.1/opam
+++ b/packages/ocephes/ocephes.0.1.1/opam
@@ -11,6 +11,6 @@ remove: ["ocamlfind" "remove" "ocephes"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0" }
   "ocamlbuild" {build}
 ]

--- a/packages/ocephes/ocephes.0.1.2/opam
+++ b/packages/ocephes/ocephes.0.1.2/opam
@@ -11,6 +11,6 @@ remove: ["ocamlfind" "remove" "ocephes"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}
-  "ctypes"
+  "ctypes" { < "0.6.0" }
   "ocamlbuild" {build}
 ]

--- a/packages/ocephes/ocephes.0.1/opam
+++ b/packages/ocephes/ocephes.0.1/opam
@@ -11,6 +11,6 @@ remove: ["ocamlfind" "remove" "ocephes"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0" }
   "ocamlbuild" {build}
 ]

--- a/packages/ocephes/ocephes.0.8.1/opam
+++ b/packages/ocephes/ocephes.0.8.1/opam
@@ -11,6 +11,6 @@ remove: ["ocamlfind" "remove" "ocephes"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes"
+  "ctypes" { < "0.6.0" }
   "ctypes-foreign"
 ]

--- a/packages/ocephes/ocephes.0.8/opam
+++ b/packages/ocephes/ocephes.0.8/opam
@@ -11,5 +11,5 @@ remove: ["ocamlfind" "remove" "ocephes"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build}
-  "ctypes"
+  "ctypes" { < "0.6.0" }
 ]


### PR DESCRIPTION
See https://github.com/rleonid/ocephes/pull/12

/cc @rleonid.  A new release of ocephes would be appreciated!
