### PR TITLE
unix-sys-resource.0.1.2 - via opam-publish

### DIFF
--- a/packages/unix-sys-resource/unix-sys-resource.0.1.2/descr
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.2/descr
@@ -1,0 +1,14 @@
+Unix sys/resource.h types and bindings (getrlimit, setrlimit, and friends)
+
+unix-sys-resource provides access to the features exposed in
+sys/resource.h in a way that is not tied to the implementation on the
+host system.
+
+The Sys_resource module provides types and functions for describing and
+working with rlimit resources and limits.
+
+The Sys_resource_unix module provides bindings to functions that use the
+types in Sys_resource.
+
+Currently, getrlimit and setrlimit and their corresponding flags are
+bound.

--- a/packages/unix-sys-resource/unix-sys-resource.0.1.2/opam
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-unix-sys-resource"
+bug-reports: "https://github.com/dsheets/ocaml-unix-sys-resource/issues"
+license: "ISC"
+tags: ["unix" "posix" "sys/resource.h" "getrlimit" "setrlimit" "rlimit"]
+dev-repo: "https://github.com/dsheets/ocaml-unix-sys-resource.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "unix-errno" {>= "0.4.0"}
+  "ctypes"
+]
+depopts: "base-unix"
+conflicts: [
+  "ctypes" {< "0.4.0"}
+]

--- a/packages/unix-sys-resource/unix-sys-resource.0.1.2/url
+++ b/packages/unix-sys-resource/unix-sys-resource.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-sys-resource/archive/0.1.2.tar.gz"
+checksum: "e9a89a897418be0e9956e67d5e7e501b"


### PR DESCRIPTION
Unix sys/resource.h types and bindings (getrlimit, setrlimit, and friends)

unix-sys-resource provides access to the features exposed in
sys/resource.h in a way that is not tied to the implementation on the
host system.

The Sys_resource module provides types and functions for describing and
working with rlimit resources and limits.

The Sys_resource_unix module provides bindings to functions that use the
types in Sys_resource.

Currently, getrlimit and setrlimit and their corresponding flags are
bound.


---
* Homepage: https://github.com/dsheets/ocaml-unix-sys-resource
* Source repo: https://github.com/dsheets/ocaml-unix-sys-resource.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-sys-resource/issues

---

Pull-request generated by opam-publish v0.3.1