### PR TITLE
glsurf version 3.3.1

### DIFF
--- a/packages/glsurf/glsurf.3.3.1/descr
+++ b/packages/glsurf/glsurf.3.3.1/descr
@@ -1,0 +1,12 @@
+GlSurf, implicit curves and surfaces drawing and discretization
+
+GlSurf is a program (similar to Surf) to draw surfaces and curves from
+their implicit equations (that is drawing the set of points (x,y,z)
+such that f(x,y,z) = 0).
+
+It offers an intuitive and simple syntax to construct your functions,
+it can draw multiple surfaces simultaneously and it can use all the
+power of OpenGl to animate the surface, use transparency, etc ...
+
+Authors:
+	Christophe Raffalli

--- a/packages/glsurf/glsurf.3.3.1/opam
+++ b/packages/glsurf/glsurf.3.3.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "glsurf"
+version: "3.3.1"
+maintainer: "Christophe Raffalli <raffalli@univ-savoie.fr>"
+bug-reports:  "http://lama.univ-savoie.fr/mantis/search.php?project_id=2"
+authors:
+  [ "Christophe Raffalli <raffalli@univ-savoie.fr>" ]
+homepage: "http://lama.univ-savoie.fr/~raffalli/glsurf.html"
+license: "GPL-3.0"
+dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/glsurf/repos"
+build: [make]
+install: [make "install" "BINDIR=%{bin}%" "DOCDIR=%{doc}%"]
+remove: [
+  ["rm" "%{bin}%/glsurf"]
+  ["rm" "-rf" "%{doc}%/glsurf"]
+]
+depends: [
+  "camlimages"
+  "base-bytes"
+  "lablgl"
+  "camlp4" {build}
+  "ocamlfind" {build}
+]

--- a/packages/glsurf/glsurf.3.3.1/url
+++ b/packages/glsurf/glsurf.3.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://lama.univ-savoie.fr/~raffalli/glsurf/glsurf-3.3.1.tar.gz"
+checksum: "d4c7395ad2dc38dd4a42e6920cd6e1ed"

--- a/packages/glsurf/glsurf.3.3.1/url
+++ b/packages/glsurf/glsurf.3.3.1/url
@@ -1,2 +1,2 @@
 archive: "https://lama.univ-savoie.fr/~raffalli/glsurf/glsurf-3.3.1.tar.gz"
-checksum: "d4c7395ad2dc38dd4a42e6920cd6e1ed"
+checksum: "850fc2afa3c2dda6296fc2e125bfd91f"


### PR DESCRIPTION
This version mainly update the documentation and web page and polish some command while doing so.

- 0000014: [General] cleaning of main commands (raffalli) - resolved.
- 0000008: [General] sometime crash on parse error (raffalli) - resolved.
- 0000007: [General] check documentation against parser (raffalli) - resolved.
- 0000012: [General] give mantis address for bug report in opam (raffalli) - resolved.
- 0000004: [General] install as glsurf and not glsurf.opt - resolved.
- 0000010: [General] place parenthesis around & (or use &&) - resolved.
- 0000006: [General] check and update all examples if necessary - resolved.
- 0000005: [General] install the examples and doc in share/doc - resolved.
