### PR TITLE
Unify configure invocation

### DIFF
--- a/packages/conf-autoconf/conf-autoconf.0.1/files/detect_autoconf_settings.sh
+++ b/packages/conf-autoconf/conf-autoconf.0.1/files/detect_autoconf_settings.sh
@@ -1,0 +1,79 @@
+### detect_autoconf_settings.sh -- Detect autoconf settings
+
+wlog()
+{
+    { printf "$@"; printf '\n'; } 1>&2
+}
+
+detect_plan()
+{
+    awk -v envpath="${PATH}" '
+function is_valid(prefix) {
+  return (prefix != "") && (match(prefix, " ") == 0);
+}
+
+BEGIN {
+  split(envpath, path, ":");
+  for(i in path) {
+    prefix = path[i];
+    gsub("/s?bin", "", prefix);
+    if(is_valid(prefix) && !(prefix in seen)) {
+      printf("%s\n", prefix);
+    }
+    seen[prefix];
+  }
+}
+'
+}
+
+detect_execute()
+{
+    local prefix has_include has_lib
+
+    while read prefix; do
+        if test -d "${prefix}/include"; then
+            has_include='yes';
+        else
+            has_include='no';
+        fi
+        if test -d "${prefix}/lib"; then
+            has_lib='yes';
+        else
+            has_lib='no';
+        fi
+        printf '%s|%s|%s\n' "${prefix}" "${has_include}" "${has_lib}"
+    done
+}
+
+detect_opamconf()
+{
+    awk -F '|' '
+function sprint_conf(flag, dir, array, _sep, _prefix, _ax) {
+  _sep=""
+  for(_prefix in include) {
+    _ax= _ax sprintf("%s%s%s/%s", _sep, flag, _prefix, dir);
+    _sep=" "
+  }
+  return _ax
+}
+
+
+$2 == "yes" { include[$1]; include_flag = 1; }
+$3 == "yes" { lib[$1]; lib_flag = 1; }
+
+END {
+  if(include_flag) {
+    printf("cflags: \"CFLAGS=%s\"\n", sprint_conf("-I", "include", include));
+    printf("cppflags: \"CPPFLAGS=%s\"\n", sprint_conf("-I", "include", include));
+  }
+  if(lib_flag) {
+    printf("ldflags: \"LDFLAGS=%s\"\n", sprint_conf("-L", "lib", lib));
+  }
+  if(include_flag || lib_flag) {
+    printf("ocamlflags: \"OCAMLFLAGS=%s%s%s\"\n", sprint_conf("-ccopt -I", "include", include), (include_flag ? " " : ""), sprint_conf("-cclib -L", "lib", lib))
+  }
+}
+'
+}
+
+(detect_plan | detect_execute | detect_opamconf) > "$1"

--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -7,6 +7,7 @@ dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-3.0"
 build: [
   ["which" "autoconf"]
+  ["sh" "./detect_autoconf_settings.sh" "./conf-autoconf.config"]
 ]
 depends: [
   "conf-which" {build}

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -6,7 +6,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
+  ["env" conf-autoconf:cflags "sh" "-exc" "cc ${CFLAGS} -c test.c"]
+]
+depends: [
+  "conf-autoconf"
 ]
 depexts: [
   [["debian"] ["libgmp-dev"]]

--- a/packages/faad/faad.0.3.3/opam
+++ b/packages/faad/faad.0.3.3/opam
@@ -3,15 +3,17 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-faad"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "faad"]
-depends: ["ocamlfind"]
+depends: [
+  "conf-autoconf"
+  "ocamlfind"
+]
 depexts: [
   [["debian"] ["libfaad-dev"]]
   [["ubuntu"] ["libfaad-dev"]]

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -6,13 +6,13 @@ bug-reports: "https://github.com/savonet/ocaml-fdkaac/issues"
 license: "GPL-2.0"
 dev-repo: "https://github.com/savonet/ocaml-fdkaac.git"
 build: [
-  ["./configure" "--prefix=%{prefix}%"] { os != "darwin" }
-  ["./configure" "OCAMLFLAGS=-cclib -L/usr/local/lib" "--prefix=%{prefix}%"] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "fdkaac"]
 depends: [
+  "conf-autoconf"
   "ocamlfind" {build}
 ]
 depexts: [

--- a/packages/flac/flac.0.1.2/opam
+++ b/packages/flac/flac.0.1.2/opam
@@ -3,15 +3,18 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-flac"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "flac"]
-depends: ["ocamlfind" "ogg"]
+depends: [
+  "conf-autoconf"
+  "ocamlfind"
+  "ogg"
+]
 depexts: [
   [["debian"] ["libflac-dev"]]
   [["ubuntu"] ["libflac-dev"]]

--- a/packages/ladspa/ladspa.0.1.5/opam
+++ b/packages/ladspa/ladspa.0.1.5/opam
@@ -3,15 +3,17 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-ladspa"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "ladspa"]
-depends: ["ocamlfind"]
+depends: [
+  "conf-autoconf"
+  "ocamlfind"
+]
 depexts: [
   [["debian"] ["ladspa-sdk"]]
   [["ubuntu"] ["ladspa-sdk"]]

--- a/packages/lame/lame.0.3.3/opam
+++ b/packages/lame/lame.0.3.3/opam
@@ -3,15 +3,17 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-lame"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "lame"]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "conf-autoconf"
+]
 depexts: [
   [ ["debian"] [ "libmp3lame-dev" ] ]
   [ ["ubuntu"] [ "libmp3lame-dev" ] ]

--- a/packages/lo/lo.0.1.1/opam
+++ b/packages/lo/lo.0.1.1/opam
@@ -3,15 +3,17 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-lo"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "lo"]
-depends: ["ocamlfind"]
+depends: [
+  "conf-autoconf"
+  "ocamlfind"
+]
 depexts: [
  [["ubuntu"]["liblo-dev"]]
  [["debian"]["liblo-dev"]]

--- a/packages/mysql/mysql.1.1.3/opam
+++ b/packages/mysql/mysql.1.1.3/opam
@@ -3,8 +3,7 @@ maintainer: "ygrek@autistici.org"
 homepage: "http://ocaml-mysql.forge.ocamlcore.org"
 doc: "http://ocaml-mysql.forge.ocamlcore.org/doc/index.html"
 build: [
-  ["./configure" "--prefix" "%{prefix}%"] { os != "freebsd" }
-  ["env" "CPPFLAGS=-I/usr/local/include/mysql" "LDFLAGS=-L/usr/local/lib/mysql" "./configure" "--prefix" "%{prefix}%"] { os = "freebsd" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags]
   [make]
   [make "install"]
 ]
@@ -14,7 +13,11 @@ build-doc: [
 remove: [
   ["ocamlfind" "remove" "mysql"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "conf-autoconf"
+  "ocamlfind"
+  "camlp4"
+]
 depexts: [
   [ [ "debian" ] [ "libmysqlclient-dev" ] ]
   [ [ "ubuntu" ] [ "libmysqlclient-dev" ] ]

--- a/packages/mysql/mysql.1.2.0/opam
+++ b/packages/mysql/mysql.1.2.0/opam
@@ -3,7 +3,7 @@ maintainer: "ygrek@autistici.org"
 homepage: "http://ocaml-mysql.forge.ocamlcore.org"
 doc: "http://ocaml-mysql.forge.ocamlcore.org/doc/index.html"
 build: [
-  ["./configure" "--prefix" "%{prefix}%"]
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags]
   [make]
   [make "install"]
 ]

--- a/packages/opus/opus.0.1.1/opam
+++ b/packages/opus/opus.0.1.1/opam
@@ -3,8 +3,7 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-opus"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
@@ -12,6 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "opus"]
 depends: [
+  "conf-autoconf"
   "ocamlfind"
   "ogg"
 ]

--- a/packages/schroedinger/schroedinger.0.1.1/opam
+++ b/packages/schroedinger/schroedinger.0.1.1/opam
@@ -3,8 +3,7 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-schroedinger"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
@@ -12,6 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "schroedinger"]
 depends: [
+  "conf-autoconf"
   "ocamlfind"
   "ogg"
 ]

--- a/packages/speex/speex.0.2.1/opam
+++ b/packages/speex/speex.0.2.1/opam
@@ -3,8 +3,7 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-speex"
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["./configure" "CFLAGS=-I/usr/local/include" "LDFLAGS=-L/usr/local/lib" "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib" "--prefix" prefix] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cflags conf-autoconf:ldflags conf-autoconf:ocamlflags]
   [make]
 ]
 install: [
@@ -12,6 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "speex"]
 depends: [
+  "conf-autoconf"
   "ocamlfind"
   "ogg"
 ]

--- a/packages/ssl/ssl.0.5.2/opam
+++ b/packages/ssl/ssl.0.5.2/opam
@@ -6,10 +6,7 @@ dev-repo: "https://github.com/savonet/ocaml-ssl.git"
 bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
 
 build: [
-  ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["sh" "-exc"
-   "./configure --prefix %{prefix}% CPPFLAGS=\"$CPPFLAGS -I/opt/local/include -I/usr/local/opt/openssl/include\""
-  ] { os = "darwin" }
+  ["./configure" "--prefix" prefix conf-autoconf:cppflags]
   [make]
 ]
 install: [[make "install"]]

--- a/packages/zarith/zarith.1.3/opam
+++ b/packages/zarith/zarith.1.3/opam
@@ -3,14 +3,14 @@ maintainer: "contact@ocamlpro.com"
 authors: "Xavier Leroy"
 homepage: "https://forge.ocamlcore.org/projects/zarith"
 build: [
-  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
-  ["env" "LDFLAGS=-L/usr/local/lib" "CC=cc" "CFLAGS=-I/usr/local/include -O3 -Wall -Wextra" "./configure"] { os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ["env" autoconf:cflags autoconf:ldflags "./configure"]
   [make]
   [make "install"]
 ]
 remove:  ["ocamlfind" "remove" "zarith"]
 depends: [
   "ocamlfind"
+  "conf-autoconf"
   "conf-gmp"
   "conf-perl" {build}
 ]

--- a/packages/zarith/zarith.1.4.1/opam
+++ b/packages/zarith/zarith.1.4.1/opam
@@ -3,8 +3,7 @@ maintainer: "thomas.braibant@gmail.com"
 authors: "Xavier Leroy"
 homepage: "https://forge.ocamlcore.org/projects/zarith"
 build: [
-  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
-  ["env" "LDFLAGS=-L/usr/local/lib" "CFLAGS=-I/usr/local/include" "./configure"] { os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ["env" autoconf:cflags autoconf:ldflags "./configure"]
   [make]
 ]
 install: [
@@ -13,6 +12,7 @@ install: [
 remove:  ["ocamlfind" "remove" "zarith"]
 depends: [
   "ocamlfind"
+  "conf-autoconf"
   "conf-gmp"
   "conf-perl" {build}
 ]

--- a/packages/zarith/zarith.1.4/opam
+++ b/packages/zarith/zarith.1.4/opam
@@ -3,8 +3,7 @@ maintainer: "thomas.braibant@gmail.com"
 authors: "Xavier Leroy"
 homepage: "https://forge.ocamlcore.org/projects/zarith"
 build: [
-  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
-  ["env" "LDFLAGS=-L/usr/local/lib" "CFLAGS=-I/usr/local/include" "./configure"] { os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ["env" autoconf:cflags autoconf:ldflags "./configure"]
   [make]
 ]
 install: [
@@ -13,6 +12,7 @@ install: [
 remove:  ["ocamlfind" "remove" "zarith"]
 depends: [
   "ocamlfind"
+  "conf-autoconf"
   "conf-gmp"
   "conf-perl" {build}
 ]


### PR DESCRIPTION
This is to solve #6271.

It might not be the best solution to handle everything in conf-autoconf, maybe we need an extra conf-* package just to store the configuration values. As usual, feedback is welcome! :)

Also, it should  be useful to adapt the linter to incite package author to use these variables, but I do not know where to start.