### PR TITLE
dose3.5.0-rc1 New upstream release

### DIFF
--- a/packages/dose3/dose3.5.0-rc1/descr
+++ b/packages/dose3/dose3.5.0-rc1/descr
@@ -1,0 +1,1 @@
+Dose library (part of Mancoosi tools)

--- a/packages/dose3/dose3.5.0-rc1/opam
+++ b/packages/dose3/dose3.5.0-rc1/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "pietro.abate@inria.fr"
+authors: [
+  "Pietro Abate"
+  "Jaap Boender"
+  "Roberto Di Cosmo"
+  "Johannes Schauer"
+  "Ralf Treinen"
+  "Stefano Zacchiroli"
+  "Jakub Zwolakowski"
+  "Olivier Rosello"
+]
+homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
+license: "LGPL-v3+ with OCaml linking exception"
+dev-repo: "https://gforge.inria.fr/git/dose/dose.git"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [make "installlib"]
+remove: [
+  ["./configure"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlgraph" {>= "1.8.6"}
+  "cudf" {>= "0.7"}
+  "conf-perl" {build}
+  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
+  "re" {>= "1.2.2"}
+  "ocamlbuild" {build}
+  "cppo" {build & >= "1.1.2"}
+]

--- a/packages/dose3/dose3.5.0-rc1/url
+++ b/packages/dose3/dose3.5.0-rc1/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/file/35925/dose3-5.0~rc1.tar.gz"
+checksum: "987941da447c35515f3deb8598e48d0a"


### PR DESCRIPTION
New upstream release . Fix the problem about global_constraints mentioned in https://github.com/ocaml/opam/pull/2541

 * finally implement keep_package/version/feature properly. The globalid
   index that was used to optionally encode the global constraints is
   now disappeared. This simplify the interface of the solver.
 * massive refactoring. Change of API . All functions in Depsolver*
   accept a new paramenter "global_constraints" that is a vpkgformula
   enconding all packages that must be co-installed by by default with
   each request. This is used to properly encode debian essential packages
   without abusing 'Keep_package as before.
 * Depsolver_int.{solve,init_solver_unit,init_solver_cache} have a new optional
   argument 'explain'. When false, reduce the memory footprint.
 * Depsolver.{check_request,check_request_using} accept a new parameter dummy
   that can be used to pass arbitrary contraints as a cudf.package that is going
   to be coinstalled as part of the request and filtered out in the result.
 * improvements to the documentation and test units
 * add --compare to ceve when used with pef://
 * improvements to distcheck --lowmem
 * StdOptions.lastest now returns an integer to consider only the last n versions
   of each package
 * API change : CudfAdd.latest
 * API change : CudfAdd.inttovar -> CudfAdd.inttopkg
 * API change : add parameter to check_request and check_request_using
 * apt-cudf : package up or downgrades are expressed in a single
   "Install" request and that these do not show up as a "Remove" request anymore.
 * StdOptions.DistribOptions.add_options are now different for each input ( ex.
   StdOptions.DistribOptions.add_debian_options )uu
 * Debian.Printer.pp_* functions are now methods of the Debian.package class
