### PR TITLE
Turn default 4.03.0 compilers as debug by default

### DIFF
--- a/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
+++ b/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
@@ -3,6 +3,7 @@ version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
+++ b/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
@@ -3,6 +3,7 @@ version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
+++ b/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
@@ -3,6 +3,7 @@ version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0/4.03.0.comp
+++ b/compilers/4.03.0/4.03.0/4.03.0.comp
@@ -3,6 +3,7 @@ version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]


### PR DESCRIPTION
The beta versions where changed like that too, but it was apparently
forgot when 4.03.0 was officialy released.

This should probably be done on 4.04 compilers too.