### PR TITLE
Add a trunk compiler with lto enabled by default

### DIFF
--- a/compilers/4.04.0/4.04.0+forced_lto/4.04.0+forced_lto.comp
+++ b/compilers/4.04.0/4.04.0+forced_lto/4.04.0+forced_lto.comp
@@ -1,0 +1,12 @@
+opam-version: "1"
+version: "4.04.0"
+src: "https://github.com/chambart/ocaml-1/archive/lto.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["sh" "-exc" "echo \"* : lto = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.04.0/4.04.0+forced_lto/4.04.0+forced_lto.descr
+++ b/compilers/4.04.0/4.04.0+forced_lto/4.04.0+forced_lto.descr
@@ -1,0 +1,1 @@
+Whole program dead code elimination enabled by default (Warning: this breaks dynlink)


### PR DESCRIPTION
This is only for testing purpose, this will both compile and link with lto, breaking everything that use dynlink. A real version should only enable it for compilation.

This probably means that this should be enabled by a different link option.