### PR TITLE
higher.0.3.1 - via opam-publish

### DIFF
--- a/packages/higher/higher.0.3.1/descr
+++ b/packages/higher/higher.0.3.1/descr
@@ -1,0 +1,1 @@
+Library for higher-kinded programming.

--- a/packages/higher/higher.0.3.1/opam
+++ b/packages/higher/higher.0.3.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop" "Leo White"]
+homepage: "https://github.com/ocamllabs/higher"
+bug-reports: "https://github.com/ocamllabs/higher/issues"
+dev-repo: "https://github.com/ocamllabs/higher.git"
+license: "MIT"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"]]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+]
+tags: ["org:ocamllabs"]

--- a/packages/higher/higher.0.3.1/url
+++ b/packages/higher/higher.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocamllabs/higher/archive/0.3.1.tar.gz"
+checksum: "e9e2d2e6db151367be596cd0bcef6ce7"


### PR DESCRIPTION
Library for higher-kinded programming.


---
* Homepage: https://github.com/ocamllabs/higher
* Source repo: https://github.com/ocamllabs/higher.git
* Bug tracker: https://github.com/ocamllabs/higher/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1