### PR TITLE
mirage-http.2.5.3 - via opam-publish

### DIFF
--- a/packages/mirage-http/mirage-http.2.5.3/descr
+++ b/packages/mirage-http/mirage-http.2.5.3/descr
@@ -1,0 +1,1 @@
+MirageOS-compatible implementation of the Cohttp interfaces

--- a/packages/mirage-http/mirage-http.2.5.3/opam
+++ b/packages/mirage-http/mirage-http.2.5.3/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/mirage-http"
+bug-reports:  "https://github.com/mirage/mirage-http/issues/"
+dev-repo:     "https://github.com/mirage/mirage-http.git"
+doc:          "https://mirage.github.io/mirage-http/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "mirage-types" {>= "2.0.0"}
+  "mirage-types-lwt"
+  "conduit"
+  "mirage-conduit" {>= "2.2.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp" {>= "0.18.0"}
+  "channel"
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/mirage-http/mirage-http.2.5.3/url
+++ b/packages/mirage-http/mirage-http.2.5.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-http/releases/download/2.5.3/mirage-http-2.5.3.tbz"
+checksum: "3e83cab7de7cca512bac4f54d485fc0a"


### PR DESCRIPTION
MirageOS-compatible implementation of the Cohttp interfaces


---
* Homepage: https://github.com/mirage/mirage-http
* Source repo: https://github.com/mirage/mirage-http.git
* Bug tracker: https://github.com/mirage/mirage-http/issues/

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1