### PR TITLE
ocaml-monadic.0.3.2 - via opam-publish

### DIFF
--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/descr
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/descr
@@ -1,0 +1,3 @@
+Lightweight monadic syntax extension.
+This project contains a lightweight PPX extension for OCaml to support natural monadic syntax.
+

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+homepage: "https://github.com/zepalmer/ocaml-monadic"
+bug-reports: "https://github.com/zepalmer/ocaml-monadic/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/zepalmer/ocaml-monadic.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.0" & opam-version >= "1.2"]

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/url
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/zepalmer/ocaml-monadic/archive/d2d7b672c4fac6ff927fdfe83b4c8e56ef1ba97b.tar.gz"
+checksum: "ef81c066ccb26fb486cba1f97c33da55"


### PR DESCRIPTION
Lightweight monadic syntax extension.
This project contains a lightweight PPX extension for OCaml to support natural monadic syntax.



---
* Homepage: https://github.com/zepalmer/ocaml-monadic
* Source repo: https://github.com/zepalmer/ocaml-monadic.git
* Bug tracker: https://github.com/zepalmer/ocaml-monadic/issues

---

Pull-request generated by opam-publish v0.3.1