### PR TITLE
ocaml-monadic.0.3.2 - via opam-publish

### DIFF
--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/descr
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/descr
@@ -1,0 +1,3 @@
+Lightweight monadic syntax extension.
+This project contains a lightweight PPX extension for OCaml to support natural monadic syntax.
+

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+available: [ocaml-version >= "4.02.0" & opam-version >= "1.2"]
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "BSD-3-clause"
+homepage: "https://github.com/zepalmer/ocaml-monadic"
+dev-repo: "https://github.com/zepalmer/ocaml-monadic.git"
+bug-reports: "https://github.com/zepalmer/ocaml-monadic/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ppx_tools" {build}
+]

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/url
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/zepalmer/ocaml-monadic/archive/16a58948594661ce5d3e4e64229f97d830b12db2.tar.gz"
+checksum: "92a1e18faeba70e9c7e48546f58afd63"


### PR DESCRIPTION
Lightweight monadic syntax extension.
This project contains a lightweight PPX extension for OCaml to support natural monadic syntax.



---
* Homepage: https://github.com/zepalmer/ocaml-monadic
* Source repo: https://github.com/zepalmer/ocaml-monadic.git
* Bug tracker: https://github.com/zepalmer/ocaml-monadic/issues

---

Pull-request generated by opam-publish v0.3.1