### PR TITLE
Fix records.0.1.0 with ocaml 4.01.0

### DIFF
--- a/packages/records/records.0.1.0/opam
+++ b/packages/records/records.0.1.0/opam
@@ -10,10 +10,12 @@ install: [make "install"]
 build-test: [make "check"]
 remove: ["ocamlfind" "remove" "records"]
 depends: [
-  "bisect_ppx" {test}
   "ocamlfind" {build}
   "ounit" {test}
   "yojson"
   "ocamlbuild" {build}
+]
+depopts: [
+  "bisect_ppx" {test}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
According to [OWS](http://ows.irill.org/2016-06-06/c0fd5455d452bf3508bd01e8d7d88c833e3314d7/4.01.0/records.0.1.0.svg), this combination was not working. This is a backport of [this commit](https://github.com/cryptosense/records/commit/608ea3a9ae8ceaef20707ed1f7fae076847b518d) which makes the bisect_ppx dependency optional and fixes the test suite.

:sparkles: Thanks! :sparkles: 