### PR TITLE
dog.0.2.1 - via opam-publish

### DIFF
--- a/packages/dog/dog.0.2.1/descr
+++ b/packages/dog/dog.0.2.1/descr
@@ -1,0 +1,5 @@
+A loyal and faithful synchronisation tool that you can rely on.
+
+This simple tool allows to watch distributed directories and gather
+the changes in a central Git repository, where every watched directories
+appear as sub-directories.

--- a/packages/dog/dog.0.2.1/opam
+++ b/packages/dog/dog.0.2.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/samoht/dog"
+bug-reports:  "https://github.com/samoht/dog/issues"
+dev-repo:     "https://github.com/samoht/dog.git"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned]
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "lwt" {>= "2.4.5"}
+  "irmin" {>= "0.10.0"}
+  "irmin-unix"
+  "git" {>= "1.4.10"}
+  "logs" "fmt"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/dog/dog.0.2.1/url
+++ b/packages/dog/dog.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/dog/releases/download/0.2.1/dog-0.2.1.tbz"
+checksum: "feef8463ad7fc380a3a433807c87fcac"


### PR DESCRIPTION
A loyal and faithful synchronisation tool that you can rely on.

This simple tool allows to watch distributed directories and gather
the changes in a central Git repository, where every watched directories
appear as sub-directories.

---
* Homepage: https://github.com/samoht/dog
* Source repo: https://github.com/samoht/dog.git
* Bug tracker: https://github.com/samoht/dog/issues

---

Pull-request generated by opam-publish v0.3.1