### PR TITLE
unix-sys-stat.0.5.0 - via opam-publish

### DIFF
--- a/packages/unix-sys-stat/unix-sys-stat.0.5.0/descr
+++ b/packages/unix-sys-stat/unix-sys-stat.0.5.0/descr
@@ -1,0 +1,5 @@
+ocaml-unix-sys-stat provides access to the features exposed in sys/stat.h in a way that is not tied to the implementation on the host system.
+
+The Sys_stat module provides functions for translating between the file types and mode bits accessible through sys/stat.h and their values on particular systems. The Sys_stat_host module exports representations of various hosts.
+
+The Sys_stat_unix provides bindings to functions that use the types in Sys_stat along with a representation of the host system. The bindings support a more comprehensive range of flags than the corresponding functions in the standard OCaml Unix module.

--- a/packages/unix-sys-stat/unix-sys-stat.0.5.0/opam
+++ b/packages/unix-sys-stat/unix-sys-stat.0.5.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Jeremy Yallop"]
+homepage: "https://github.com/dsheets/ocaml-unix-sys-stat"
+bug-reports: "https://github.com/dsheets/ocaml-unix-sys-stat/issues"
+license: "ISC"
+tags: ["unix" "posix" "sys/stat.h" "syscall" "stat"]
+dev-repo: "https://github.com/dsheets/ocaml-unix-sys-stat.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "base-bytes"
+  "unix-errno" {>= "0.4.0"}
+  "ctypes" {>= "0.6.0"}
+  "posix-types"
+  "unix-type-representations"
+]
+depopts: ["base-unix" "lwt"]

--- a/packages/unix-sys-stat/unix-sys-stat.0.5.0/url
+++ b/packages/unix-sys-stat/unix-sys-stat.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-sys-stat/archive/0.5.0.tar.gz"
+checksum: "23220a65aa78c3c51451d21379d899ea"


### PR DESCRIPTION
ocaml-unix-sys-stat provides access to the features exposed in sys/stat.h in a way that is not tied to the implementation on the host system.

The Sys_stat module provides functions for translating between the file types and mode bits accessible through sys/stat.h and their values on particular systems. The Sys_stat_host module exports representations of various hosts.

The Sys_stat_unix provides bindings to functions that use the types in Sys_stat along with a representation of the host system. The bindings support a more comprehensive range of flags than the corresponding functions in the standard OCaml Unix module.


---
* Homepage: https://github.com/dsheets/ocaml-unix-sys-stat
* Source repo: https://github.com/dsheets/ocaml-unix-sys-stat.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-sys-stat/issues

---

Pull-request generated by opam-publish v0.3.1