### PR TITLE
Lwt: hard dependency on conf-ncurses

### DIFF
--- a/packages/lwt/lwt.2.4.5/opam
+++ b/packages/lwt/lwt.2.4.5/opam
@@ -10,6 +10,7 @@ depends: [
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}
+  "conf-ncurses" {build}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.2.4.6/opam
+++ b/packages/lwt/lwt.2.4.6/opam
@@ -20,6 +20,7 @@ depends: [
   "camlp4"
   ("base-no-ppx" | "ppx_tools")
   "ocamlbuild" {build}
+  "conf-ncurses" {build}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.2.4.7/opam
+++ b/packages/lwt/lwt.2.4.7/opam
@@ -19,6 +19,7 @@ depends: [
   "ocamlfind" {>= "1.5.0"}
   ("base-no-ppx" | "ppx_tools")
   "ocamlbuild" {build}
+  "conf-ncurses" {build}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.2.4.8/opam
+++ b/packages/lwt/lwt.2.4.8/opam
@@ -19,6 +19,7 @@ depends: [
   "ocamlfind" {>= "1.5.0"}
   ("base-no-ppx" | "ppx_tools")
   "ocamlbuild" {build}
+  "conf-ncurses" {build}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.2.5.0/opam
+++ b/packages/lwt/lwt.2.5.0/opam
@@ -27,6 +27,7 @@ depends: [
   "ocamlfind" {build & >= "1.5.0"}
   ("base-no-ppx" | "ppx_tools")
   "ocamlbuild" {build}
+  "conf-ncurses" {build}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.2.5.1/opam
+++ b/packages/lwt/lwt.2.5.1/opam
@@ -27,6 +27,7 @@ depends: [
   "ocamlfind" {build & >= "1.5.0"}
   ("base-no-ppx" | "ppx_tools")
   "ocamlbuild" {build}
+  "conf-ncurses" {build}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.2.5.2/opam
+++ b/packages/lwt/lwt.2.5.2/opam
@@ -28,6 +28,7 @@ depends: [
   "base-bytes"
   ("base-no-ppx" | "ppx_tools")
   "ocamlbuild" {build}
+  "conf-ncurses" {build}
 ]
 depopts: [
   "base-threads"


### PR DESCRIPTION
Lwt requires ncurses to be installed in order to link a custom
toplevel in its configure script to detect pthreads.

ever since #6657 got merged this has been broken for distros
such as Alpine since ocamlfind no longer pulls in ncurses
as a transitive dependency