### PR TITLE
Revert "Merge pull request #6657 from gasche/ocamlfind-no-ncurses"

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -9,4 +9,5 @@ build: [
 available: [(ocaml-version >= "3.08") & (ocaml-version < "3.12.2")]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -9,4 +9,5 @@ build: [
 ocaml-version: [> "3.12.2"]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -10,4 +10,5 @@ build: [
 available: [(ocaml-version >= "3.08") & (ocaml-version <= "4.01.0")] # ocamlfind uses Arg.align of 3.08
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -8,5 +8,6 @@ build: [
 ]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -8,5 +8,6 @@ build: [
 ]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -13,6 +13,7 @@ remove: [
 ]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -13,6 +13,7 @@ remove: [
 ]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -13,6 +13,7 @@ remove: [
 ]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -14,5 +14,6 @@ remove: [
 ]
 depends: [
   "conf-m4"
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -18,5 +18,6 @@ remove: [
 ]
 depends: [
   "conf-m4" {build}
+  "conf-ncurses"
 ]
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -19,4 +19,5 @@ remove: [
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
 depends: [
   "conf-m4" {build}
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.6.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.1/opam
@@ -19,4 +19,5 @@ remove: [
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
 depends: [
   "conf-m4" {build}
+  "conf-ncurses"
 ]

--- a/packages/ocamlfind/ocamlfind.1.6.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.2/opam
@@ -23,4 +23,5 @@ remove: [
 available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
 depends: [
   "conf-m4" {build}
+  "conf-ncurses" {build}
 ]


### PR DESCRIPTION
This reverts commit f45249c61b7f5eece77ccda6fd37acf4bab39af5, reversing
changes made to e7a191dd0d0c493002e2d80ed6a3cb6a029e295f.

I proposed to remove the ncurses dependency after:
- noticing that it caused failure for some users (eg. OpenSUSE)
  http://lambda.jstolarek.com/2016/05/installing-ocaml-under-opensuse-11-4-or-the-compilation-of-conf-ncurses-failed/
- checking with Gerd Stolpmann that ocamlfind did not depend on ncurses

It turns out that the dependency comes from a hard dependency of the
OCaml compiler runtime for ncurses, that infects any software compiled
with -custom or embedding the runtime (eg. custom toplevels). It is
wrong to have the dependency at the ocamlfind level, but removing it
revealed a similar issue for plenty of downstream packages and it
breaks lots of stuff.

Let's revert that change for now and think about the issue more
carefully. I think a better long-term solution would be to do away
with the ncurses dependency in the compiler distribution.

For more discussion, see:
- https://github.com/ocaml/opam-repository/pull/6657
- https://github.com/ocaml/opam-repository/pull/6773