### PR TITLE
topkg.0.7.4 - via opam-publish

### DIFF
--- a/packages/topkg/topkg.0.7.4/descr
+++ b/packages/topkg/topkg.0.7.4/descr
@@ -1,0 +1,24 @@
+The transitory OCaml software packager
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml OPAM repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner] and
+`opam-lib`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner

--- a/packages/topkg/topkg.0.7.4/opam
+++ b/packages/topkg/topkg.0.7.4/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild" {build}
+  "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" "%{name}%"
+          "--pinned" "%{pinned}%"
+]]

--- a/packages/topkg/topkg.0.7.4/url
+++ b/packages/topkg/topkg.0.7.4/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/topkg/releases/topkg-0.7.4.tbz"
+checksum: "f12bcf50f081d2ea42f6ed013fca848b"


### PR DESCRIPTION
The transitory OCaml software packager

Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml OPAM repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner] and
`opam-lib`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner


---
* Homepage: http://erratique.ch/software/topkg
* Source repo: http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---


---
v0.7.4 2016-06-17 Cambridge (UK)
--------------------------------

- Add test description and run support. New `topkg test` command.
- Add distribution publication description support. Allows to define the
  set of default publication artefacts in the package description. The cli
  syntax of `topkg publish` for alternative artefacts changes from
  `alt KIND` to `alt-KIND`.
- Distributed (and thus installed) OPAM files are now properly
  versioned via the `version:` field.
- Improve tarball reproducibility across systems by not relying on the
  VCS checkout state for determining the read and write rights (#43).
- OPAM package submission: use the `opam-publish` submit message
  to append the release notes to the submission.
- Toy GitHub delegate: improve user authentication by trying to steal
  an existing opam-publish token.
- Toy GitHub delegate: improve package documentation publication. Thanks
  to Thomas Gazagnaire for the patches.
- Error message and IPC logging level propagation improvements. Thanks to
  Thomas Gazagnaire for the help.
Pull-request generated by opam-publish v0.3.2