### PR TITLE
edn.0.1.1 - via opam-publish

### DIFF
--- a/packages/edn/edn.0.1.1/descr
+++ b/packages/edn/edn.0.1.1/descr
@@ -1,0 +1,1 @@
+Parsing library for the EDN format (https://github.com/edn-format/edn)

--- a/packages/edn/edn.0.1.1/opam
+++ b/packages/edn/edn.0.1.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+license: "MIT"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+dev-repo: "https://github.com/prepor/ocaml-edn.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "edn"]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.1/url
+++ b/packages/edn/edn.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/prepor/ocaml-edn/archive/v0.1.1.tar.gz"
+checksum: "95e8ccf8202a33dcc3135e9240f11b5d"


### PR DESCRIPTION
Parsing library for the EDN format (https://github.com/edn-format/edn)


---
* Homepage: http://github.com/prepor/ocaml-edn
* Source repo: https://github.com/prepor/ocaml-edn.git
* Bug tracker: http://github.com/prepor/ocaml-edn/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1