### PR TITLE
opal.0.1.1 - via opam-publish

### DIFF
--- a/packages/opal/opal.0.1.1/descr
+++ b/packages/opal/opal.0.1.1/descr
@@ -1,0 +1,3 @@
+Self-contained monadic parser combinators for OCaml
+
+Opal is a minimum collection of useful parsers and combinators (~150 loc of OCaml) that makes writing parsers easier. It is designed to be small, self-contained, pure-functional, and only includes most essential parsers, so that one could include single file in the project or just embed it in other OCaml source code files.

--- a/packages/opal/opal.0.1.1/opam
+++ b/packages/opal/opal.0.1.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Linjie Ding <i@pyroc.at>"
+authors: "Linjie Ding <i@pyroc.at>"
+homepage: "https://github.com/pyrocat101/opal"
+bug-reports: "https://github.com/pyrocat101/opal/issues"
+license: "MIT"
+dev-repo: "https://github.com/pyrocat101/opal.git"
+build: [make "ncl" "bcl"]
+install: [make "libinstall"]
+remove: ["ocamlfind" "remove" "opal"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opal/opal.0.1.1/url
+++ b/packages/opal/opal.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/pyrocat101/opal/archive/v0.1.1.tar.gz"
+checksum: "d294e29242d9ac2204dc95bb8d73e61b"


### PR DESCRIPTION
Self-contained monadic parser combinators for OCaml

Opal is a minimum collection of useful parsers and combinators (~150 loc of OCaml) that makes writing parsers easier. It is designed to be small, self-contained, pure-functional, and only includes most essential parsers, so that one could include single file in the project or just embed it in other OCaml source code files.


---
* Homepage: https://github.com/pyrocat101/opal
* Source repo: https://github.com/pyrocat101/opal.git
* Bug tracker: https://github.com/pyrocat101/opal/issues

---

Pull-request generated by opam-publish v0.3.2