### PR TITLE
ocp-indent.1.5.3 - via opam-publish

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.5.3/descr
+++ b/packages/ocp-indent/ocp-indent.1.5.3/descr
@@ -1,0 +1,13 @@
+A simple tool to indent OCaml programs
+
+Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
+machine ; this is much faster and more reliable than using regexps. Presets and
+configuration options available, with the possibility to set them project-wide.
+Supports most common syntax extensions, and extensible for others.
+
+Includes:
+
+* An indentor program, callable from the command-line or from within editors
+* Bindings for popular editors
+* A library that can be directly used by editor writers, or just for
+approximate parsing.

--- a/packages/ocp-indent/ocp-indent.1.5.3/opam
+++ b/packages/ocp-indent/ocp-indent.1.5.3/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "contact@ocamlpro.com"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "https://github.com/OCamlPro/ocp-indent.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocp-build" {>= "1.99.6-beta"}
+  "cmdliner"
+]
+post-messages: [
+  "This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")
+  (require 'ocp-indent)
+
+* for Vim, add this line to ~/.vimrc:
+  set rtp^=\"%{share}%/ocp-indent/vim\"
+"
+  {success & !user-setup:installed}
+]

--- a/packages/ocp-indent/ocp-indent.1.5.3/url
+++ b/packages/ocp-indent/ocp-indent.1.5.3/url
@@ -1,0 +1,2 @@
+src: "https://github.com/OCamlPro/ocp-indent/archive/1.5.3.tar.gz"
+checksum: "7515340b23df8884e4ae6f6a4315d5f7"


### PR DESCRIPTION
A simple tool to indent OCaml programs

Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
machine ; this is much faster and more reliable than using regexps. Presets and
configuration options available, with the possibility to set them project-wide.
Supports most common syntax extensions, and extensible for others.

Includes:

* An indentor program, callable from the command-line or from within editors
* Bindings for popular editors
* A library that can be directly used by editor writers, or just for
approximate parsing.


---
* Homepage: http://www.typerex.org/ocp-indent.html
* Source repo: git+https://github.com/OCamlPro/ocp-indent.git
* Bug tracker: https://github.com/OCamlPro/ocp-indent/issues

---

Pull-request generated by opam-publish v0.3.1