### PR TITLE
Fix for bug #3864.

### DIFF
--- a/packages/cairo/cairo.1.2.0/files/configure_lablgtkdir.patch
+++ b/packages/cairo/cairo.1.2.0/files/configure_lablgtkdir.patch
@@ -1,0 +1,13 @@
+diff --git a/config.make.in b/config.make.in
+index 0b4af37..d7b93b2 100644
+--- a/config.make.in
++++ b/config.make.in
+@@ -11,7 +11,7 @@ OCAMLDEP   = @OCAMLDEP@
+ INSTALLDIR = $(OCAMLLIB)/cairo
+ 
+ LABLGTKDIR = @LABLGTKDIR@
+-C_LABLGTKDIR = $(subst +,$(OCAMLLIB)/,$(LABLGTKDIR))
++C_LABLGTKDIR = $(LABLGTKDIR)
+ 
+ # stop ocamlmklib moaning
+ FILT = -Wl,--export-dynamic

--- a/packages/cairo/cairo.1.2.0/opam
+++ b/packages/cairo/cairo.1.2.0/opam
@@ -23,6 +23,7 @@ depends: [
 patches: [
   "opam.patch"
   "configure_fontconfig.patch"
+  "configure_lablgtkdir.patch"
 ]
 authors: [
   "Olivier Andrieu"


### PR DESCRIPTION
This patch fixes issue #3864, by simply not trying to substitute the "+" symbol in the library path. Indeed, this is useless for opam as all paths given to the configure are absolute.