### PR TITLE
ppx_deriving_protobuf.2.5 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/descr
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/descr
@@ -1,0 +1,2 @@
+A Protocol Buffers codec generator for OCaml >=4.02
+A Protocol Buffers codec generator for OCaml >=4.02

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/opam
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving_protobuf"
+doc: "https://whitequark.github.io/ppx_deriving_protobuf"
+bug-reports: "https://github.com/whitequark/ppx_deriving_protobuf/issues"
+dev-repo: "https://github.com/whitequark/ppx_deriving_protobuf.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_protobuf.byte" "--"
+]
+build-doc: [
+  make "doc"
+]
+depends: [
+  "ocamlbuild"   {build}
+  "ocamlfind"    {build}
+  "cppo"         {build}
+  "ppx_deriving" {>= "3.2" & < "5.0"}
+  "ounit"        {test}
+  "uint"         {test}
+]

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/url
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/whitequark/ppx_deriving_protobuf/archive/v2.5.tar.gz"
+checksum: "2e3ba97f2354ba51cb470f899e3ccc25"


### PR DESCRIPTION
A Protocol Buffers codec generator for OCaml >=4.02
A Protocol Buffers codec generator for OCaml >=4.02


---
* Homepage: https://github.com/whitequark/ppx_deriving_protobuf
* Source repo: https://github.com/whitequark/ppx_deriving_protobuf.git
* Bug tracker: https://github.com/whitequark/ppx_deriving_protobuf/issues

---

Pull-request generated by opam-publish v0.3.2