### PR TITLE
ppx_deriving_yojson.3.0 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/descr
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/descr
@@ -1,0 +1,4 @@
+JSON codec generator for OCaml >=4.02
+
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator.

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: "whitequark <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_deriving_yojson"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+license: "MIT"
+doc: "http://whitequark.github.io/ppx_deriving_yojson"
+tags: ["syntax" "json"]
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_ppx_yojson.byte"
+  "--"
+]
+depends: [
+  "yojson"
+  "result"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ocamlfind" {build}
+  "cppo" {build}
+  "ounit" {test}
+  "ppx_import" {test & >= "1.1"}
+]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/url
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving_yojson/archive/v3.0.tar.gz"
+checksum: "8ec1badbd729420e5531f8fe51cbf3b7"


### PR DESCRIPTION
JSON codec generator for OCaml >=4.02

ppx_deriving_yojson is a ppx_deriving plugin that provides
a JSON codec generator.


---
* Homepage: https://github.com/whitequark/ppx_deriving_yojson
* Source repo: git://github.com/whitequark/ppx_deriving_yojson.git
* Bug tracker: https://github.com/whitequark/ppx_deriving_yojson/issues

---

Pull-request generated by opam-publish v0.3.2