### PR TITLE
containers.0.18 - via opam-publish

### DIFF
--- a/packages/containers/containers.0.18/opam
+++ b/packages/containers/containers.0.18/opam
@@ -27,7 +27,6 @@ build-doc: [make "doc"]
 remove: ["ocamlfind" "remove" "containers"]
 depends: [
   "ocamlfind" {build}
-  "oasis" {build}
   "base-bytes"
   "result"
   "cppo" {build}


### PR DESCRIPTION
A modular extension of the OCaml standard library with a focus on data structures.

Containers is an extension of OCaml's standard library (under BSD license)
focused on data structures, combinators and iterators, without dependencies on
unix, str or num. Every module is independent and is prefixed with 'CC' in the
global namespace. Some modules extend the stdlib (e.g. CCList provides safe
map/fold_right/append, and additional functions on lists).

It also features sub-libraries for dealing with strings, helpers for unix,
threads, and S-expressions.


---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---

Pull-request generated by opam-publish v0.3.2