### PR TITLE
uucd.4.0.0 - via opam-publish

### DIFF
--- a/packages/uucd/uucd.4.0.0/descr
+++ b/packages/uucd/uucd.4.0.0/descr
@@ -1,0 +1,14 @@
+Unicode character database decoder for OCaml
+Release %%VERSION%% — Unicode version %%UNICODE_VERSION%%
+
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][3] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[3]: http://erratique.ch/software/xmlm 

--- a/packages/uucd/uucd.4.0.0/opam
+++ b/packages/uucd/uucd.4.0.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uucd"
+dev-repo: "http://erratique.ch/repos/uucd.git"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+doc: "http://erratique.ch/software/uucd/doc/Uucd"
+tags: [ "unicode" "database" "decoder" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "xmlm" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/uucd/uucd.4.0.0/url
+++ b/packages/uucd/uucd.4.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uucd/releases/uucd-4.0.0.tbz"
+checksum: "69ae8029a928a8be574e67e7c2095e7a"


### PR DESCRIPTION
Unicode character database decoder for OCaml
Release %%VERSION%% — Unicode version %%UNICODE_VERSION%%

Uucd is an OCaml module to decode the data of the [Unicode character 
database][1] from its XML [representation][2]. It provides high-level 
(but not necessarily efficient) access to the data so that efficient 
representations can be extracted.

Uucd is made of a single module, depends on [Xmlm][3] and is distributed
under the ISC license.

[1]: http://www.unicode.org/reports/tr44/
[2]: http://www.unicode.org/reports/tr42/
[3]: http://erratique.ch/software/xmlm 


---
* Homepage: http://erratique.ch/software/uucd
* Source repo: http://erratique.ch/repos/uucd.git
* Bug tracker: https://github.com/dbuenzli/uucd/issues

---


---
v4.0.0 2016-06-26 Cambridge (UK)
--------------------------------

- Updated for Unicode 9.0.0
- Build depend on topkg.
- Relicensed from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.2