### PR TITLE
alcotest.0.5.0 - via opam-publish

### DIFF
--- a/packages/alcotest/alcotest.0.5.0/descr
+++ b/packages/alcotest/alcotest.0.5.0/descr
@@ -1,0 +1,11 @@
+Alcotest is a lightweight and colourful test framework.
+
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple `TESTABLE` module type, a `check` function to assert test
+predicates and a `run` function to perform a list of `unit -> unit`
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.

--- a/packages/alcotest/alcotest.0.5.0/opam
+++ b/packages/alcotest/alcotest.0.5.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "fmt"
+  "astring"
+  "result"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/alcotest/alcotest.0.5.0/url
+++ b/packages/alcotest/alcotest.0.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/alcotest/releases/download/0.5.0/alcotest-0.5.0.tbz"
+checksum: "9f9783b00a6302e2a9110b66886b4bc2"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework.

Alcotest exposes simple interface to perform unit tests. It exposes
a simple `TESTABLE` module type, a `check` function to assert test
predicates and a `run` function to perform a list of `unit -> unit`
test callbacks.

Alcotest provides a quiet and colorful output where only faulty runs
are fully displayed at the end of the run (with the full logs ready to
inspect), with a simple (yet expressive) query language to select the
tests to run.


---
* Homepage: https://github.com/mirage/alcotest/
* Source repo: https://github.com/mirage/alcotest.git
* Bug tracker: https://github.com/mirage/alcotest/issues/

---


---
### 0.5.0 (2016-06-27)

* Use `topkg` (#68, @samoht)
* Add `Alcotest.reject` to always fail tests (#64, @talex5)
* Fix pretty-printing of `Alcotest.list` (#53, #65, @talex5)
* Add an `argv` optional argument to `run` to use custom command-line arguments
  (#63, @dinosaure saure)
* Fix typo in JSON output (#67, @fxfactorial)
* Use `Astring` for the unit tests (#62, @hannesm)
Pull-request generated by opam-publish v0.3.2