### PR TITLE
ocamllint.0.3.0 - via opam-publish

### DIFF
--- a/packages/ocamllint/ocamllint.0.3.0/descr
+++ b/packages/ocamllint/ocamllint.0.3.0/descr
@@ -1,0 +1,7 @@
+Detect common errors in OCaml code
+
+OCamllint is a ppx plugin that checks for patterns in a OCaml code base:
+
+  - common programming errors: using the wrong kind of comparison, computing
+    unused values, going several times through a data structure, etc.
+  - enforce style: use snake_case for identifiers, module types in caps, etc.

--- a/packages/ocamllint/ocamllint.0.3.0/opam
+++ b/packages/ocamllint/ocamllint.0.3.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/ocamllint"
+bug-reports: "https://github.com/cryptosense/ocamllint/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/ocamllint.git"
+build: [
+    [make "all"]
+]
+install: [
+    [make "install"]
+]
+build-test: [make "check"]
+remove: [["ocamlfind" "remove" "ocamllint"]]
+depends: [
+    "ocamlfind" {>= "1.5.0"}
+    "ounit" {test}
+    "ppx_tools" {>= "5.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocamllint/ocamllint.0.3.0/url
+++ b/packages/ocamllint/ocamllint.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/cryptosense/ocamllint/archive/v0.3.0.tar.gz"
+checksum: "225f5182cdfc40ee6c71ad0367c971ce"


### PR DESCRIPTION
Detect common errors in OCaml code

OCamllint is a ppx plugin that checks for patterns in a OCaml code base:

  - common programming errors: using the wrong kind of comparison, computing
    unused values, going several times through a data structure, etc.
  - enforce style: use snake_case for identifiers, module types in caps, etc.


---
* Homepage: https://github.com/cryptosense/ocamllint
* Source repo: https://github.com/cryptosense/ocamllint.git
* Bug tracker: https://github.com/cryptosense/ocamllint/issues

---

Pull-request generated by opam-publish v0.3.2