### PR TITLE
Mark mixture.1.0.0 unavailable for OCaml 4.02.1

### DIFF
--- a/packages/mixture/mixture.1.0.0/opam
+++ b/packages/mixture/mixture.1.0.0/opam
@@ -20,7 +20,7 @@ remove: [
   ["rm" "-rf" "%{share}%/doc/mixture"]
 ]
 available: [
-  ocaml-version >= "4.00.1"
+  (ocaml-version >= "4.00.1") & (ocaml-version != "4.02.1")
 ]
 depends: [
   "broken" {>= "0.4.2"}


### PR DESCRIPTION
The package mixture.1.0.0 does not build with OCaml
4.02.1 because of a bug fixed in 4.02.3. When trying
to build that version of mixture with OCaml 4.02.1,
the process fails with the message:

  analyse_module: parsetree and typedtree don't match.

See http://opam.ocamlpro.com/builder/html/mixture/mixture.1.0.0/a6a7ab7ed8da92b9b8ed37de79b5231b

----

Side question: what is the recommended way to gently phase out obsolete package definitions? (like v0.2.0 and v0.2.1)