### PR TITLE
ocamlbuild: change the URL of the manual

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.9.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.0/opam
@@ -12,6 +12,7 @@ license: "LGPL-2 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml/ocamlbuild.git"
 homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
   make
@@ -23,10 +24,6 @@ build: [
   "OCAMLBUILD_LIBDIR=%{lib}%"
   "OCAML_NATIVE=%{ocaml-native}%"
   "OCAML_NATIVE_TOOLS=%{ocaml-native}%"
-]
-doc: [
-  "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
-  "https://github.com/gasche/manual-ocamlbuild/blob/master/manual.md"
 ]
 
 available: [ocaml-version >= "4.03"]

--- a/packages/ocamlbuild/ocamlbuild.0.9.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/opam
@@ -12,6 +12,7 @@ license: "LGPL-2 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml/ocamlbuild.git"
 homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
   make
@@ -23,10 +24,6 @@ build: [
   "OCAMLBUILD_LIBDIR=%{lib}%"
   "OCAML_NATIVE=%{ocaml-native}%"
   "OCAML_NATIVE_TOOLS=%{ocaml-native}%"
-]
-doc: [
-  "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
-  "https://github.com/gasche/manual-ocamlbuild/blob/master/manual.md"
 ]
 
 available: [ocaml-version >= "4.03"]

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/opam
@@ -12,6 +12,7 @@ license: "LGPL-2 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml/ocamlbuild.git"
 homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
   make
@@ -23,10 +24,6 @@ build: [
   "OCAMLBUILD_LIBDIR=%{lib}%"
   "OCAML_NATIVE=%{ocaml-native}%"
   "OCAML_NATIVE_TOOLS=%{ocaml-native}%"
-]
-doc: [
-  "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
-  "https://github.com/gasche/manual-ocamlbuild/blob/master/manual.md"
 ]
 
 available: [ocaml-version >= "4.03"]


### PR DESCRIPTION
The manual has now moved to the ocaml/ocamlbuild repository itself.
Fixes ocaml/ocamlbuild#97.