### PR TITLE
revert split-install (#6112) for ocamlbuild packages

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.9.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.0/opam
@@ -15,17 +15,15 @@ bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
-  make
-  "-f"
-  "configure.make"
-  "Makefile.config"
-  "OCAMLBUILD_PREFIX=%{prefix}%"
-  "OCAMLBUILD_BINDIR=%{bin}%"
-  "OCAMLBUILD_LIBDIR=%{lib}%"
-  "OCAML_NATIVE=%{ocaml-native}%"
-  "OCAML_NATIVE_TOOLS=%{ocaml-native}%"
+  [make "-f" "configure.make" "Makefile.config"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAML_NATIVE=%{ocaml-native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml-native}%"]
+  [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
 available: [ocaml-version >= "4.03"]
+depends: [ ]
 conflicts: [ "base-ocamlbuild" ]
-install: [make "check-if-preinstalled" "all" "opam-install"]

--- a/packages/ocamlbuild/ocamlbuild.0.9.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/opam
@@ -15,17 +15,15 @@ bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
-  make
-  "-f"
-  "configure.make"
-  "Makefile.config"
-  "OCAMLBUILD_PREFIX=%{prefix}%"
-  "OCAMLBUILD_BINDIR=%{bin}%"
-  "OCAMLBUILD_LIBDIR=%{lib}%"
-  "OCAML_NATIVE=%{ocaml-native}%"
-  "OCAML_NATIVE_TOOLS=%{ocaml-native}%"
+  [make "-f" "configure.make" "Makefile.config"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAML_NATIVE=%{ocaml-native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml-native}%"]
+  [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
 available: [ocaml-version >= "4.03"]
+depends: [ ]
 conflicts: [ "base-ocamlbuild" ]
-install: [make "check-if-preinstalled" "all" "opam-install"]

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/opam
@@ -15,20 +15,18 @@ bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
-  make
-  "-f"
-  "configure.make"
-  "Makefile.config"
-  "OCAMLBUILD_PREFIX=%{prefix}%"
-  "OCAMLBUILD_BINDIR=%{bin}%"
-  "OCAMLBUILD_LIBDIR=%{lib}%"
-  "OCAML_NATIVE=%{ocaml-native}%"
-  "OCAML_NATIVE_TOOLS=%{ocaml-native}%"
+  [make "-f" "configure.make" "Makefile.config"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAML_NATIVE=%{ocaml-native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml-native}%"]
+  [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
 available: [ocaml-version >= "4.03"]
+depends: [ ]
 conflicts: [
   "base-ocamlbuild"
   "ocamlfind" {< "1.5"}
 ]
-install: [make "check-if-preinstalled" "all" "opam-install"]


### PR DESCRIPTION
See discussion at the end of #6112 : the `opam-install` rule does not perform installation actions but creates an `ocamlbuild.install` file so it should remain in `build`