### PR TITLE
More ppx_type_conv/ppx_deriving constraint fixes

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
@@ -12,7 +12,7 @@ build-doc: [[make "doc"]]
 depends: [
   "ocamlfind" {>= "1.3.2"}
   "ppx_core" {>= "113.09.00" & < "113.10.00"}
-  "ppx_deriving" {>= "3.0"}
+  "ppx_deriving" {>= "3.0" & < "4.0"}
   "ppx_tools"
   "ppx_driver" {>= "113.09.00" & < "113.10.00"}
   "ocamlbuild" {build}

--- a/packages/ppx_type_conv/ppx_type_conv.113.24.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.24.00/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild"   {build}
   "ocamlfind"    {build & >= "1.3.2"}
   "ppx_core"     {>= "113.24.00" & < "113.25.00"}
-  "ppx_deriving" {>= "3.0"}
+  "ppx_deriving" {>= "3.0" & < "4.0"}
   "ppx_driver"   {>= "113.24.00" & < "113.25.00"}
   "ppx_tools"
 ]

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.00+4.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.00+4.03/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild"   {build}
   "ocamlfind"    {build & >= "1.3.2"}
   "ppx_core"     {>= "113.33.00+4.03" & < "113.34.00+4.03"}
-  "ppx_deriving" {>= "3.0"}
+  "ppx_deriving" {>= "3.0" & < "4.0"}
   "ppx_driver"   {>= "113.33.00+4.03" & < "113.34.00+4.03"}
   "ppx_tools"    {>= "0.99.3"}
 ]

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"      {build & >= "1.3.2"}
   "js-build-tools" {build & >= "113.33.04" & < "113.34.00"}
   "ppx_core"       {>= "113.33.03" & < "113.34.00"}
-  "ppx_deriving"   {>= "3.0"}
+  "ppx_deriving"   {>= "3.0" & < "4.0"}
   "ppx_driver"     {>= "113.33.03" & < "113.34.00"}
   "ppx_tools"      {>= "0.99.3"}
 ]


### PR DESCRIPTION
ppx_type_conv requires ppx_deriving < 4.0

cc @samoht @lpw25