### PR TITLE
edn.0.1.2 - via opam-publish

### DIFF
--- a/packages/edn/edn.0.1.2/descr
+++ b/packages/edn/edn.0.1.2/descr
@@ -1,0 +1,1 @@
+Parsing library for the EDN format (https://github.com/edn-format/edn)

--- a/packages/edn/edn.0.1.2/opam
+++ b/packages/edn/edn.0.1.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+license: "MIT"
+dev-repo: "https://github.com/prepor/ocaml-edn.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/edn/edn.0.1.2/url
+++ b/packages/edn/edn.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/prepor/ocaml-edn/archive/v0.1.2.tar.gz"
+checksum: "bc90510f08e65227160c9e72553cc82d"


### PR DESCRIPTION
Parsing library for the EDN format (https://github.com/edn-format/edn)


---
* Homepage: http://github.com/prepor/ocaml-edn
* Source repo: https://github.com/prepor/ocaml-edn.git
* Bug tracker: http://github.com/prepor/ocaml-edn/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.2