### PR TITLE
edn.0.1.2-1-g09b142a - via opam-publish

### DIFF
--- a/packages/edn/edn.0.1.2-1-g09b142a/descr
+++ b/packages/edn/edn.0.1.2-1-g09b142a/descr
@@ -1,0 +1,2 @@
+Parsing OCaml library for EDN format
+

--- a/packages/edn/edn.0.1.2-1-g09b142a/opam
+++ b/packages/edn/edn.0.1.2-1-g09b142a/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+license: "MIT"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+dev-repo: "https://github.com/prepor/ocaml-edn.git"
+doc: "https://prepor.github.io/ocaml-edn/doc"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]
+build-test: [[
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+  "ocaml" "pkg/pkg.ml" "test" ]]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.2-1-g09b142a/url
+++ b/packages/edn/edn.0.1.2-1-g09b142a/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/prepor/ocaml-edn/releases/download/v0.1.2-1-g09b142a/edn-0.1.2-1-g09b142a.tbz"
+checksum: "5bda480f59bfd8ba7434f3f11e368fbf"


### PR DESCRIPTION
Parsing OCaml library for EDN format



---
* Homepage: http://github.com/prepor/ocaml-edn
* Source repo: https://github.com/prepor/ocaml-edn.git
* Bug tracker: http://github.com/prepor/ocaml-edn/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.1.2 2016-06-29 
--------------------------

- oasis changed to _tags + topkg
- prefix added to internal moduled
- few bugfixed in reader
- comments support added
Pull-request generated by opam-publish v0.3.2