### PR TITLE
iocaml <0.4.9 is incompatible with cohttp < 0.21.0

### DIFF
--- a/packages/iocaml/iocaml.0.4.2/opam
+++ b/packages/iocaml/iocaml.0.4.2/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4"}
   "lwt-zmq"
   "websocket" {>= "0.8"}
-  "cohttp" {>= "0.10.0"}
+  "cohttp" {>= "0.10.0" & <"0.21.0"}
   "crunch"
   "iocaml-kernel" {= "0.4.0"}
   "iocamljs-kernel" {= "0.4.0"}

--- a/packages/iocaml/iocaml.0.4.3/opam
+++ b/packages/iocaml/iocaml.0.4.3/opam
@@ -12,7 +12,7 @@ depends: [
   "cow" {< "2.0.0"}
   "lwt" {>= "2.4"}
   "websocket" {>= "0.8"}
-  "cohttp" {>= "0.10.0"}
+  "cohttp" {>= "0.10.0" & <"0.21.0"}
   "crunch"
   "ctypes" {>= "0.2.3"}
   "ctypes-foreign"

--- a/packages/iocaml/iocaml.0.4.4/opam
+++ b/packages/iocaml/iocaml.0.4.4/opam
@@ -12,7 +12,7 @@ depends: [
   "cow" {< "2.0.0"}
   "lwt" {>= "2.4"}
   "websocket" {>= "0.8"}
-  "cohttp" {>= "0.10.0"}
+  "cohttp" {>= "0.10.0" & <"0.21.0"}
   "crunch"
   "ctypes" {>= "0.4"}
   "ctypes-foreign"

--- a/packages/iocaml/iocaml.0.4.5/opam
+++ b/packages/iocaml/iocaml.0.4.5/opam
@@ -12,7 +12,7 @@ depends: [
   "cow" {< "2.0.0"}
   "lwt" {>= "2.4"}
   "websocket" {>= "0.8"}
-  "cohttp" {>= "0.10.0"}
+  "cohttp" {>= "0.10.0" & <"0.21.0"}
   "crunch"
   "ctypes" {>= "0.3"}
   "ctypes-foreign"

--- a/packages/iocaml/iocaml.0.4.6/opam
+++ b/packages/iocaml/iocaml.0.4.6/opam
@@ -13,7 +13,7 @@ depends: [
   "cow" {< "2.0.0"}
   "lwt" {>= "2.4"}
   "websocket" {= "0.8.1"}
-  "cohttp" {>= "0.10.0"}
+  "cohttp" {>= "0.10.0" & <"0.21.0"}
   "crunch"
   "ctypes" {>= "0.3"}
   "ctypes-foreign"

--- a/packages/iocaml/iocaml.0.4.7/opam
+++ b/packages/iocaml/iocaml.0.4.7/opam
@@ -16,7 +16,7 @@ depends: [
   "cow" {< "2.0.0"}
   "lwt" {>= "2.4"}
   "websocket" {>= "0.9" & < "1.0"}
-  "cohttp" {>= "0.15.0"}
+  "cohttp" {>= "0.15.0" & <"0.21.0"}
   "crunch"
   "ctypes" {>= "0.3"}
   "ctypes-foreign"

--- a/packages/iocaml/iocaml.0.4.8/opam
+++ b/packages/iocaml/iocaml.0.4.8/opam
@@ -15,7 +15,7 @@ depends: [
   "cow" {< "2.0.0"}
   "lwt" {>= "2.4"}
   "websocket" {>= "2.0"}
-  "cohttp" {>= "0.15.0"}
+  "cohttp" {>= "0.15.0" & <"0.21.0"}
   "crunch"
   "ctypes" {>= "0.3"}
   "ctypes-foreign"


### PR DESCRIPTION
fixed upstream in andrewray/iocamlserver@c3e1673c35809894fc8306f3bcc0f07133a5c1c5
/cc @andrewray