### PR TITLE
+cstruct 2.2.0

### DIFF
--- a/packages/cstruct/cstruct.2.2.0/descr
+++ b/packages/cstruct/cstruct.2.2.0/descr
@@ -1,0 +1,22 @@
+access C structures via a camlp4 extension
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the Bigarray module.
+
+An example pcap description using PPX extension points is:
+
+```
+[%%cstruct
+type pcap_header = {
+  magic_number: uint32_t;   (* magic number *)
+  version_major: uint16_t;  (* major version number *)
+  version_minor: uint16_t;  (* minor version number *)
+  thiszone: uint32_t;       (* GMT to local correction *)
+  sigfigs: uint32_t;        (* accuracy of timestamps *)
+  snaplen: uint32_t;        (* max length of captured packets, in octets *)
+  network: uint32_t;        (* data link type *)
+} [@@little_endian]]
+```
+
+For Camlp4 support, please use a version of Cstruct that is `<=1.9.0`

--- a/packages/cstruct/cstruct.2.2.0/opam
+++ b/packages/cstruct/cstruct.2.2.0/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["./configure"
+      "--prefix" prefix
+      "--%{lwt:enable}%-lwt"
+      "--%{ppx_tools:enable}%-ppx"
+      "--%{async:enable}%-async"
+      "--%{base-unix:enable}%-unix"]
+  [make]
+]
+build-test: [
+  ["./configure"
+      "--prefix" prefix
+      "--%{lwt:enable}%-lwt"
+      "--%{ppx_tools:enable}%-ppx"
+      "--%{async:enable}%-async"
+      "--%{base-unix:enable}%-unix"
+      "--enable-tests"]
+  [make]
+  [make "test"]
+]
+install: [
+  [make "install"]
+  [make "js-install"]
+]
+remove:  [
+  [make "js-uninstall"]
+  ["ocamlfind" "remove" "cstruct"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ounit"     {test}
+  "ocplib-endian"
+  "sexplib"
+  "base-bytes"
+]
+depopts: [
+  "ppx_tools"
+  "async"
+  "lwt"
+]
+available: [ocaml-version >= "4.02.3"]
+depexts: [
+  [ ["debian"] ["time"] ]
+  [ ["ubuntu"] ["time"] ]
+]

--- a/packages/cstruct/cstruct.2.2.0/url
+++ b/packages/cstruct/cstruct.2.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cstruct/archive/v2.2.0.tar.gz"
+checksum: "49f2fa14c95ecf3e55f76831e2548ab8"


### PR DESCRIPTION
Make `create` zero out the new buffer. The new `create_unsafe`
function can be used if you want to trade safety for speed.