### PR TITLE
Fix regression on fmt introduced by 5e78e69b02e06ad09d.

### DIFF
--- a/packages/fmt/fmt.0.8.0/opam
+++ b/packages/fmt/fmt.0.8.0/opam
@@ -10,8 +10,8 @@ license: "ISC"
 available: [ ocaml-version >= "4.01.0"]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild" {build & >= "0.7.5"}
-  "topkg" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.7.5"}
   "result"
 ]
 depopts: [ "base-unix" "cmdliner" ]


### PR DESCRIPTION
Odd that CI didn't catch this.