### PR TITLE
conf-libuv: update list of external dependencies

### DIFF
--- a/packages/conf-libuv/conf-libuv.1/opam
+++ b/packages/conf-libuv/conf-libuv.1/opam
@@ -4,17 +4,20 @@ homepage: "https://github.com/libuv/libuv"
 license: "MIT"
 bug-reports: "https://github.com/libuv/libuv/issues"
 authors: [ "Ryan Dahl" "Bert Belder" "et al." ]
+depends: ["conf-pkg-config"]
 build: [
-  ["pkg-config" "libuv" "--atleast-version=1"] { os != "freebsd" }
-  ["pkgconf" "libuv" "--atleast-version=1"] { os = "freebsd" }
+  ["pkg-config" "libuv" "--atleast-version=1"]
 ]
 depexts: [
-#  not available in any mainstream distro at the momement
-#  [["debian"] ["pkg-config" "libuv-dev"]]
-#  [["ubuntu"] ["pkg-config" "libuv-dev"]]
-  [["osx" "homebrew"] ["libuv" "pkg-config"]]
-  [["freebsd"] ["pkgconf" "libuv"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/fdopen/cbfb14114f4ec423a1a4/raw/1d4144f16aa2c65d39a1be5aae39911dc5e53ef6/install-libuv.sh"]]
+  [["debian"] ["libuv1-dev"]]
+  [["ubuntu"] ["libuv1-dev"]]
+  [["osx" "homebrew"] ["libuv"]]
+  [["freebsd"] ["libuv"]]
+  [["alpine"] ["libuv-dev"]]
+  [["centos"] ["libuv-devel"]]
+  [["rhel"]   ["libuv-devel"]]
+  [["fedora"] ["libuv-devel"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/fdopen/cbfb14114f4ec423a1a4/raw/6ba4cef74e94a7307391bddb7ff20db5d8065bfe/install-libuv.sh"]]
 ]
 post-messages: [
   "This package requires libuv 1.x development packages installed on your system" {failure}


### PR DESCRIPTION
I had to remove the updates to conf-libuv from the previous pull request (https://github.com/ocaml/opam-repository/pull/6881 ), because the distros used by travis are too old (no libuv1-dev packages) and the builds failed at an early stage.

( `conf-libuv` is only a depot. Otherwise an internal static version will be used)
