### PR TITLE
topkg.0.7.6 - via opam-publish

### DIFF
--- a/packages/topkg/topkg.0.7.6/descr
+++ b/packages/topkg/topkg.0.7.6/descr
@@ -1,0 +1,24 @@
+The transitory OCaml software packager
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml OPAM repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner] and
+`opam-lib`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner

--- a/packages/topkg/topkg.0.7.6/opam
+++ b/packages/topkg/topkg.0.7.6/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild" {build}
+  "result" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--pinned" pinned ]

--- a/packages/topkg/topkg.0.7.6/url
+++ b/packages/topkg/topkg.0.7.6/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/topkg/releases/topkg-0.7.6.tbz"
+checksum: "d410d2e8d22e92fd587dde25cc12a96b"


### PR DESCRIPTION
The transitory OCaml software packager

Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml OPAM repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner] and
`opam-lib`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner


---
* Homepage: http://erratique.ch/software/topkg
* Source repo: http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---


---
v0.7.6 2016-07-01 Cambridge (UK)
--------------------------------

- Add `pkg/pkg.ml clean` command. Removes the OPAM install file
  and performs an effect that can be specified via `clean` in the
 `Pkg.build` description. The `topkg clean` command now simply forwards
  to this command.
- Change the signature of the build command `cmd` in the `Pkg.build`
  specification. This is an API breaking change but does not affect any
  published package. See #53 for details.
- Add `Conf.OCaml.word_size`. Reports the bit word size for
  the programs that are produced by a given compiler.
- Build configuration key parsing. Fail hard on any error instead
  of warn and continue (#56). Thanks to Thomas Gazagnaire for suggesting
  the previous idea was a terrible one.
- Add a `--debug` configuration key. Defaults to `true` or the value
  of the `TOPKG_CONF_DEBUG` environment variable. The default build
  system invocation is changed to enable save of debugging information
  in build artefacts if they key is `true`. The key is generally not
  meant to be specified by packagers so that the policy can changed in
  bulk over topkg packages (#54).
- `Pkg.files_to_watermark` default function. Make sure only files are
  returned (#58). Fixes problems with symlinks to directories in git
  checkout. Thanks to Thomas Gazagnaire for reporting.
- Improve error message of some `Topkg.OS` functions (#57).
- Remove deprecated `--installer` configuration key.
- `topkg lint` fix regression in error OPAM lint report.
Pull-request generated by opam-publish v0.3.2