### PR TITLE
getopts v0.4.0

### DIFF
--- a/packages/getopts/getopts.0.4.0/descr
+++ b/packages/getopts/getopts.0.4.0/descr
@@ -1,0 +1,3 @@
+Analyse command line arguments
+
+WWW: https://github.com/michipili/getopts

--- a/packages/getopts/getopts.0.4.0/opam
+++ b/packages/getopts/getopts.0.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+version: "0.4.0"
+maintainer: "michipili@gmail.com"
+authors: "Michael Grünewald"
+license: "CeCILL-B"
+homepage: "https://github.com/michipili/getopts"
+bug-reports: "https://github.com/michipili/getopts/issues"
+dev-repo: "https://github.com/michipili/getopts.git"
+tags: [
+  "cli"
+  "system"
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [conf-bmake:path "-I%{bsdowl:share}%" "all"]
+]
+install: [
+  [conf-bmake:path "-I%{bsdowl:share}%" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "getopts"]
+  ["rm" "-rf" "%{share}%/doc/getopts"]
+]
+available: [
+  ocaml-version >= "4.02.3"
+]
+depends: [
+  "conf-bmake"
+  "broken" {>= "0.4.2"}
+  "bsdowl" {>= "3.0.0"}
+  "lemonade" {>= "0.4.0"}
+  "ocamlfind"
+]

--- a/packages/getopts/getopts.0.4.0/url
+++ b/packages/getopts/getopts.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/michipili/getopts/releases/download/v0.4.0/getopts-0.4.0.tar.xz"
+checksum: "7153239eebb6114763aba3f3ab81c8a3"


### PR DESCRIPTION
A release of getopts compatible with modern Lemonade.

Needed for https://github.com/ocaml/opam-repository/pull/6855.