### PR TITLE
ppx_type_conv 113.33.03 is compatible with ppx_deriving 4.0

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"      {build & >= "1.3.2"}
   "js-build-tools" {build & >= "113.33.04" & < "113.34.00"}
   "ppx_core"       {>= "113.33.03" & < "113.34.00"}
-  "ppx_deriving"   {>= "3.0" & < "4.0"}
+  "ppx_deriving"   {>= "3.0"}
   "ppx_driver"     {>= "113.33.03" & < "113.34.00"}
   "ppx_tools"      {>= "0.99.3"}
 ]


### PR DESCRIPTION
The compatibility issue was fixed in advance.