### PR TITLE
travis.yml: Add 'sudo: required' to avoid running in a container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 install: bash -e .travis-ci-install.sh
 script: bash -e .travis-ci.sh
 cache: apt
+sudo: required
 matrix:
   include:
   - os: linux


### PR DESCRIPTION
Without this line, Travis will run the build in a Docker container in
which sudo is not allowed.   .travis-ci-install.sh and .travis-ci.sh
both use sudo extensively.

This problem might not affect the ocaml/opam-repository Travis job as
it was created before container-based infrastructure became the default
in Travis.

Signed-off-by: Euan Harris <euan.harris@citrix.com>