### PR TITLE
bulletml.0.2.0 - via opam-publish

### DIFF
--- a/packages/bulletml/bulletml.0.2.0/descr
+++ b/packages/bulletml/bulletml.0.2.0/descr
@@ -1,0 +1,4 @@
+Library to manipulate shmup patterns
+
+This provides a set of tools to manipulate BulletML, a XML-based description
+language for patterns of bullets present in shoot-them-up (shmup) games.

--- a/packages/bulletml/bulletml.0.2.0/opam
+++ b/packages/bulletml/bulletml.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <me@emillon.org>"
+authors: "Etienne Millon <me@emillon.org>"
+homepage: "https://github.com/emillon/bulletml"
+bug-reports: "https://github.com/emillon/bulletml/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/emillon/bulletml.git"
+build: [make]
+install: [make "install"]
+build-test: [make "check"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ounit" {test}
+  "base64" {>= "2.0.0"}
+  "re"
+  "mparser"
+  "alcotest"
+  "xml-light"
+  "ocamlsdl"
+  "js_of_ocaml" {>= "2.6"}
+  "ounit"
+  "ppx_deriving"
+]
+available: [ocaml-version >= "4.02.2"]

--- a/packages/bulletml/bulletml.0.2.0/url
+++ b/packages/bulletml/bulletml.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/emillon/bulletml/archive/v0.2.0.tar.gz"
+checksum: "366d117b591b95afec028774f6e0ff6e"


### PR DESCRIPTION
Library to manipulate shmup patterns

This provides a set of tools to manipulate BulletML, a XML-based description
language for patterns of bullets present in shoot-them-up (shmup) games.


---
* Homepage: https://github.com/emillon/bulletml
* Source repo: https://github.com/emillon/bulletml.git
* Bug tracker: https://github.com/emillon/bulletml/issues

---

Pull-request generated by opam-publish v0.3.1