### PR TITLE
now that we're on trusty, no need anymore for this hack!

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -104,20 +104,6 @@ function build_one {
       fi
   else
     echo "... package available."
-    case $TRAVIS_OS_NAME in
-        linux)
-            # we need fresh gcc and binutils, maybe...
-            # this can soon be removed, once travis upgraded their infrastructure
-            if [ `opam install --dry-run $pkg | grep -c mirage-entropy-xen` -gt 0 ] ; then
-                echo "installing a recent gcc and binutils (mainly to get mirage-entropy-xen working\!)"
-                sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-                sudo apt-get -qq update
-                sudo apt-get install -y gcc-4.8
-                sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-                wget http://mirrors.kernel.org/ubuntu/pool/main/b/binutils/binutils_2.24-5ubuntu3.1_amd64.deb
-                sudo dpkg -i binutils_2.24-5ubuntu3.1_amd64.deb
-            fi
-    esac
     echo
     echo "====== External dependency handling ======"
     opam install depext


### PR DESCRIPTION
once upon a time... more than a year ago I introduced this awful hack in 50c3f615335f85c7ca009cd4ceaa136b22aeb4d0

now that opam-repository switched over to `trusty`, where gcc4.8 is the default, I'm happy to remember to cleanup after myself...