### PR TITLE
Fix topkg.0.7.6 for OPAM 1.2.0 users

### DIFF
--- a/packages/topkg/topkg.0.7.6/opam
+++ b/packages/topkg/topkg.0.7.6/opam
@@ -15,4 +15,4 @@ depends: [
 build: [
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name
-          "--pinned" pinned ]
+          "--pinned" "%{pinned}%" ]


### PR DESCRIPTION
Apparently 1.2.0 is still relevant.