### PR TITLE
bos.0.1.3 - via opam-publish

### DIFF
--- a/packages/bos/bos.0.1.3/descr
+++ b/packages/bos/bos.0.1.3/descr
@@ -1,0 +1,18 @@
+Basic OS interaction for OCaml
+
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs

--- a/packages/bos/bos.0.1.3/opam
+++ b/packages/bos/bos.0.1.3/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/bos"
+doc: "http://erratique.ch/software/bos/doc"
+dev-repo: "http://erratique.ch/repos/bos.git"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.7.4"}
+  "conf-which"
+  "base-unix"
+  "rresult"
+  "astring"
+  "fpath"
+  "fmt"
+  "logs"
+  "mtime" {test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/bos/bos.0.1.3/url
+++ b/packages/bos/bos.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/bos/releases/bos-0.1.3.tbz"
+checksum: "81e5a0f9bee75bc9406ed73f96108f73"


### PR DESCRIPTION
Basic OS interaction for OCaml

Bos provides support for basic and robust interaction with the
operating system in OCaml. It has functions to access the process
environment, parse command line arguments, interact with the file
system and run command line programs.

Bos works equally well on POSIX and Windows operating systems.

Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
distributed under the ISC license.

[rresult]: http://erratique.ch/software/rresult
[astring]: http://erratique.ch/software/astring
[fmt]: http://erratique.ch/software/fmt
[fpath]: http://erratique.ch/software/fpath
[logs]: http://erratique.ch/software/logs


---
* Homepage: http://erratique.ch/software/bos
* Source repo: http://erratique.ch/repos/bos.git
* Bug tracker: https://github.com/dbuenzli/bos/issues

---


---
v0.1.3 2016-07-12 Cambridge (UK)
--------------------------------

- `Cmd.dump`, make representation cut and paste friendly. This
  affects logging made by the library.
- Add `Cmd.of_values`, converts arbitrary list of values to
  a corresponding argument list.
- Fix `OS.Path.exists`. Existing file path traversals returned
  and error rather than `false`.
  
Pull-request generated by opam-publish v0.3.2