### PR TITLE
Add Ocamlnet 4.1.2

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.2/descr
+++ b/packages/ocamlnet/ocamlnet.4.1.2/descr
@@ -1,0 +1,10 @@
+Internet protocols (HTTP, CGI, e-mail etc.) and helper data structures
+(mail messages, character sets, etc.)
+
+Ocamlnet is an enhanced system platform library for Ocaml. As the name
+suggests, large parts of it have to do with network programming, but
+it is actually not restricted to this. Other parts deal with the
+management of multiple worker processes, and the interaction with
+other programs running on the same machine. You can also view Ocamlnet
+as an extension of the system interface as provided by the Unix module
+of the standard library.

--- a/packages/ocamlnet/ocamlnet.4.1.2/files/ocamlnet.install
+++ b/packages/ocamlnet/ocamlnet.4.1.2/files/ocamlnet.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/rpc-generator/ocamlrpcgen"
+  "src/netplex/netplex-admin"
+]

--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -1,0 +1,61 @@
+opam-version: "1.2"
+maintainer: "vb@luminar.eu.org"
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.2/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-%{conf-gssapi:enable}%-gssapi"
+    "-%{conf-gnutls:enable}%-gnutls"
+    "-%{pcre:enable}%-pcre"
+    "-%{lablgtk:enable}%-gtk2"
+    "-%{camlzip:enable}%-zip"
+    "-with-nethttpd"
+  ]
+  [make "all"]
+  [make "opt"]
+]
+authors: ["Gerd Stolpmann"]
+remove: [
+  ["ocamlfind" "remove" "equeue"]
+  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
+  ["ocamlfind" "remove" "netcamlbox"]
+  ["ocamlfind" "remove" "netcgi2"]
+  ["ocamlfind" "remove" "netcgi2-plex"]
+  ["ocamlfind" "remove" "netclient"]
+  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
+  ["ocamlfind" "remove" "nethttpd"]
+  ["ocamlfind" "remove" "netmulticore"]
+  ["ocamlfind" "remove" "netplex"]
+  ["ocamlfind" "remove" "netshm"]
+  ["ocamlfind" "remove" "netstring"]
+  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
+  ["ocamlfind" "remove" "netsys"]
+  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
+  ["ocamlfind" "remove" "netunidata"]
+  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
+  ["ocamlfind" "remove" "pop"]
+  ["ocamlfind" "remove" "rpc"]
+  ["ocamlfind" "remove" "rpc-auth-local"]
+  ["ocamlfind" "remove" "rpc-generator"]
+  ["ocamlfind" "remove" "shell"]
+  ["ocamlfind" "remove" "smtp"]
+
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild"
+]
+depopts: [
+  "conf-gnutls"
+  "conf-gssapi"
+  "lablgtk"
+  "pcre"
+  "camlzip"
+]
+available: [ ocaml-version >= "4.00.0"]
+install: [make "install"]

--- a/packages/ocamlnet/ocamlnet.4.1.2/url
+++ b/packages/ocamlnet/ocamlnet.4.1.2/url
@@ -1,0 +1,2 @@
+archive: "http://download.camlcity.org/download/ocamlnet-4.1.2.tar.gz"
+checksum: "cc8b3434119e51b0e855b33a687e9c4b"


### PR DESCRIPTION
This is the latest version of Ocamlnet ([changelog](http://projects.camlcity.org/projects/dl/ocamlnet-4.1.2/ChangeLog)). It is compatible with OCaml 4.03.

For what it's worth, I am not involved with Ocamlnet. I just updated the OPAM files.