### PR TITLE
Fix text.0.8.0 installation on *BSD

### DIFF
--- a/packages/text/text.0.8.0/opam
+++ b/packages/text/text.0.8.0/opam
@@ -1,7 +1,11 @@
 opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
+authors: "Jeremie Dimino"
+homepage: "https://github.com/vbmithr/ocaml-text"
+bug-reports: "https://github.com/vbmithr/ocaml-text/issues"
 build: [
-  ["./configure" "--%{pcre:enable}%-pcre"]
+  [make "setup.exe"]
+  ["./setup.exe" "-configure" "--%{pcre:enable}%-pcre"]
   [make]
 ]
 remove: [["ocamlfind" "remove" "text"]]


### PR DESCRIPTION
This PR fixes an installation issue on FreeBSD (and the other BSDs, I would guess).

The OASIS-generated `configure` script calls `make` to produce the `setup.exe` file, but `make` normally stands for BSD `make`, while the Makefile contains GNU-isms. The solution is to use OPAM's `make` built-in, which calls GNU `make`.

#6807 did the same for `deriving`.