### PR TITLE
Added pxp-1.2.8

### DIFF
--- a/packages/pxp/pxp.1.2.8/descr
+++ b/packages/pxp/pxp.1.2.8/descr
@@ -1,0 +1,7 @@
+Polymorphic XML Parser
+PXP is an XML parser for OCaml. It represents the parsed document
+either as tree or as stream of events. In tree mode, it is possible to
+validate the XML document against a DTD.
+
+The acronym PXP means Polymorphic XML Parser. This name reflects the
+ability to create XML trees with polymorphic type parameters.

--- a/packages/pxp/pxp.1.2.8/findlib
+++ b/packages/pxp/pxp.1.2.8/findlib
@@ -1,0 +1,6 @@
+pxp
+pxp-engine
+pxp-lex-iso88591
+pxp-lex-utf8
+pxp-pp
+pxp-ulex-utf8

--- a/packages/pxp/pxp.1.2.8/opam
+++ b/packages/pxp/pxp.1.2.8/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+name: "pxp"
+version: "1.2.8"
+maintainer: "codinuum@me.com"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/pxp.html"
+dev-repo: "https://gitlab.camlcity.org/gerd/lib-pxp.git"
+bug-reports: "ocaml-pxp-users@orcaware.com"
+build: [
+  [
+    "./configure"
+    "-without-wlex"
+    "-without-wlex-compat"
+    "-lexlist"
+    "utf8,iso88591"
+  ]
+  [make "all"]
+  [make "opt"]
+]
+install: [make "install" "MANDIR=%{man}%"]
+remove: [
+  ["ocamlfind" "remove" "pxp-engine"]
+  ["ocamlfind" "remove" "pxp-lex-iso88591"]
+  ["ocamlfind" "remove" "pxp-lex-utf8"]
+  ["ocamlfind" "remove" "pxp-pp"]
+  ["ocamlfind" "remove" "pxp-ulex-utf8"]
+  ["ocamlfind" "remove" "pxp"]
+]
+depends: [
+  "ocamlfind"
+  "ocamlnet" {>= "4.1.0"}
+  "ulex"
+]

--- a/packages/pxp/pxp.1.2.8/opam
+++ b/packages/pxp/pxp.1.2.8/opam
@@ -32,6 +32,6 @@ depends: [
   "ulex"
 ]
 available: [
-  ocaml-version >= "4.01"
+  ocaml-version >= "4.01" &
   ocaml-version <= "4.02.3"
 ]

--- a/packages/pxp/pxp.1.2.8/opam
+++ b/packages/pxp/pxp.1.2.8/opam
@@ -31,3 +31,7 @@ depends: [
   "ocamlnet" {>= "4.1.0"}
   "ulex"
 ]
+available: [
+  ocaml-version >= "4.01"
+  ocaml-version <= "4.02.3"
+]

--- a/packages/pxp/pxp.1.2.8/url
+++ b/packages/pxp/pxp.1.2.8/url
@@ -1,0 +1,3 @@
+archive: "http://download.camlcity.org/download/pxp-1.2.8.tar.gz"
+checksum: "e9155cf1705287a52f90ec3737924d8a"
+


### PR DESCRIPTION
Pxp-1.2.7 is incompatible with ocamlnet-4.1.x.