### PR TITLE
crdt-ml.0.10.0 - via opam-publish

### DIFF
--- a/packages/crdt-ml/crdt-ml.0.10.0/descr
+++ b/packages/crdt-ml/crdt-ml.0.10.0/descr
@@ -1,0 +1,6 @@
+CRDTs - Conflict-Free Replicated Data Types for OCaml
+
+A set of useful state-based CRDTs for OCaml. Includes 6 different datatypes in both mutable and immutable versions.
+
+Please note that these implementations are for educational purposes only. They are not suited for production work.
+

--- a/packages/crdt-ml/crdt-ml.0.10.0/opam
+++ b/packages/crdt-ml/crdt-ml.0.10.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "Borja o'Cook <borjaocook@gmail.com>"
+authors: "Borja o'Cook <borjaocook@gmail.com>"
+homepage: "https://github.com/ergl/crdt-ml/"
+bug-reports: "https://github.com/ergl/crdt-ml/issues"
+license: "GPL-3"
+dev-repo: "https://github.com/ergl/crdt-ml.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: [
+  ["ocamlfind" "remove" "crdt"]
+  ["ocamlfind" "remove" "crdt_immutable"]
+  ["ocamlfind" "remove" "crdt_mutable"]
+  ["ocamlfind" "remove" "crdt_util"]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "qtest" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/crdt-ml/crdt-ml.0.10.0/url
+++ b/packages/crdt-ml/crdt-ml.0.10.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ergl/crdt-ml/archive/v0.10.0.tar.gz"
+checksum: "b8337dcb24a3220a3c35bd5bae5c8f12"


### PR DESCRIPTION
CRDTs - Conflict-Free Replicated Data Types for OCaml

A set of useful state-based CRDTs for OCaml. Includes 6 different datatypes in both mutable and immutable versions.

Please note that these implementations are for educational purposes only. They are not suited for production work.



---
* Homepage: https://github.com/ergl/crdt-ml/
* Source repo: https://github.com/ergl/crdt-ml.git
* Bug tracker: https://github.com/ergl/crdt-ml/issues

---

Pull-request generated by opam-publish v0.3.2