### PR TITLE
mirage-block-solo5.0.1.1 - via opam-publish

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/descr
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/descr
@@ -1,0 +1,3 @@
+Mirage BLOCK driver for Solo5
+
+Mirage BLOCK driver implementation for Solo5, based on mirage-block-{unix,xen}.

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+authors:      "Dan Williams <djwllia@us.ibm.com>"
+tags: [
+  "org:mirage"
+]
+build: [ [make] ]
+install: [ [make "install" "BINDIR=%{bin}%"] ]
+remove: [ [make "uninstall" "BINDIR=%{bin}%"] ]
+depends: [
+  "ocamlfind"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.1"}
+  "mirage-types" {>= "1.1.0"}
+  "mirage-solo5"
+  
+]

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/url
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-block-solo5/archive/v0.1.1.tar.gz"
+checksum: "5e1752ebe63ecf86464e6f239190cc9e"


### PR DESCRIPTION
Mirage BLOCK driver for Solo5

Mirage BLOCK driver implementation for Solo5, based on mirage-block-{unix,xen}.


---
* Homepage: https://github.com/mirage/mirage-block-solo5
* Source repo: https://github.com/mirage/mirage-block-solo5.git
* Bug tracker: https://github.com/mirage/mirage-block-solo5/issues

---

Pull-request generated by opam-publish v0.3.2