### PR TITLE
ssl: add conf-which

### DIFF
--- a/packages/ssl/ssl.0.5.2/opam
+++ b/packages/ssl/ssl.0.5.2/opam
@@ -16,5 +16,6 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" name]]
 depends: [
   "ocamlfind" {build}
+  "conf-which" {build}
   "conf-openssl"
 ]


### PR DESCRIPTION
`which` is needed at build time, otherwise:

```
configuring ocaml-ssl 0.5.2
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking for pthread_create in -lpthread... yes
checking for ocamlc... ./configure: line 2987: which: command not found
no
configure: error: Cannot find ocamlc.
```