### PR TITLE
Don't restrict js-build-tools to 4.02.3

### DIFF
--- a/packages/js-build-tools/js-build-tools.113.33.04/opam
+++ b/packages/js-build-tools/js-build-tools.113.33.04/opam
@@ -14,4 +14,4 @@ depends: [
   "ocamlfind"  {build & >= "1.3.2"}
   "ocamlbuild"
 ]
-available: [ ocaml-version = "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" ]


### PR DESCRIPTION
I see no reason to restrict this package to 4.02.3. It does not seem to depend on compiler libs or anything that could break on version change.

@diml did I miss something ?