### PR TITLE
+mirage-no-solo5

### DIFF
--- a/packages/mirage-no-solo5/mirage-no-solo5.1/descr
+++ b/packages/mirage-no-solo5/mirage-no-solo5.1/descr
@@ -1,0 +1,1 @@
+Virtual package conflicting with mirage-solo5

--- a/packages/mirage-no-solo5/mirage-no-solo5.1/opam
+++ b/packages/mirage-no-solo5/mirage-no-solo5.1/opam
@@ -1,0 +1,5 @@
+opam-version: "1"
+maintainer: "anonymous"
+homepage: "http://openmirage.org"
+license: "BSD2"
+conflicts: [ "mirage-solo5" ]

--- a/packages/mirage-no-solo5/mirage-no-solo5.1/opam
+++ b/packages/mirage-no-solo5/mirage-no-solo5.1/opam
@@ -1,5 +1,6 @@
-opam-version: "1"
-maintainer: "anonymous"
-homepage: "http://openmirage.org"
+opam-version: "1.2"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: ["mirageos-devel@lists.xenproject.org"]
+homepage: "http://mirage.io"
 license: "BSD2"
 conflicts: [ "mirage-solo5" ]

--- a/packages/mirage-no-solo5/mirage-no-solo5.1/opam
+++ b/packages/mirage-no-solo5/mirage-no-solo5.1/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer: "mirageos-devel@lists.xenproject.org"
 authors: ["mirageos-devel@lists.xenproject.org"]
-homepage: "http://mirage.io"
+homepage: "https://mirage.io"
 license: "BSD2"
 conflicts: [ "mirage-solo5" ]

--- a/packages/mirage-no-xen/mirage-no-xen.1/opam
+++ b/packages/mirage-no-xen/mirage-no-xen.1/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer: "mirageos-devel@lists.xenproject.org"
 authors: ["mirageos-devel@lists.xenproject.org"]
-homepage: "http://mirage.io"
+homepage: "https://mirage.io"
 license: "BSD2"
 conflicts: [ "mirage-xen" ]

--- a/packages/mirage-no-xen/mirage-no-xen.1/opam
+++ b/packages/mirage-no-xen/mirage-no-xen.1/opam
@@ -1,5 +1,6 @@
-opam-version: "1"
-maintainer: "anonymous"
-homepage: "http://openmirage.org"
+opam-version: "1.2"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: ["mirageos-devel@lists.xenproject.org"]
+homepage: "http://mirage.io"
 license: "BSD2"
 conflicts: [ "mirage-xen" ]


### PR DESCRIPTION
similar to mirage-no-xen a fake package to describe dependencies in nocrypto properly (either we want solo5 support and then we require some other packages (gmp/zarith with solo5 support), or no solo5 support)