### PR TITLE
Update xapi-inventory constraints in preparation for xapi-stdext 2.0.0

### DIFF
--- a/packages/xapi-inventory/xapi-inventory.0.9.1/opam
+++ b/packages/xapi-inventory/xapi-inventory.0.9.1/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
-maintainer: "john.else@citrix.com"
+maintainer: "xen-api@lists.xen.org"
+authors: ["John Else"]
+homepage: "https://xapi-project.github.io/"
+dev-repo: "git://github.com/xapi-project/xcp-inventory"
+bug-reports: "https://github.com/xapi-project/xcp-inventory/issues"
 build: [
   ["./configure" "--default_inventory=%{prefix}%/etc"]
   [make]
@@ -13,5 +17,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xapi-project/xcp-inventory"
 install: [make "install"]

--- a/packages/xapi-inventory/xapi-inventory.0.9.1/opam
+++ b/packages/xapi-inventory/xapi-inventory.0.9.1/opam
@@ -13,7 +13,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "xapi-stdext"
+  "xapi-stdext" {>= "0.13.0" & < "2.0.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
xapi-stdext 2.0.0 packs all its modules under the Stdext top level module, so packages which currently depend on it with no version constraints will fail to build.