### PR TITLE
Update xapi-idl constraints in preparation for xapi-stdext 2.0.0

### DIFF
--- a/packages/xapi-idl/xapi-idl.0.11.0/opam
+++ b/packages/xapi-idl/xapi-idl.0.11.0/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "xen-api@lists.xen.org"
+authors: ["David Scott"]
+homepage: "https://xapi-project.github.io/"
+bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
+dev-repo: "git://github.com/xapi-project/xcp-idl"
 build: [make "all"]
 remove: [
   ["ocamlfind" "remove" "xcp"]
@@ -19,5 +23,4 @@ depends: [
   "xapi-backtrace"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xapi-project/xcp-idl"
 install: [make "install"]

--- a/packages/xapi-idl/xapi-idl.0.11.0/opam
+++ b/packages/xapi-idl/xapi-idl.0.11.0/opam
@@ -16,8 +16,8 @@ depends: [
   "xmlm"
   "rpc" {> "1.4.0"}
   "ocamlfind"
-  "message-switch"
-  "xapi-stdext" {>= "0.13.0"}
+  "message-switch" {< "0.11.0"}
+  "xapi-stdext" {>= "0.13.0" & < "2.0.0"}
   "xapi-rrd" {>= "0.10.1"}
   "xapi-inventory"
   "xapi-backtrace"


### PR DESCRIPTION
xapi-stdext 2.0.0 packs all its modules under the Stdext top level module, so packages which currently depend on it with no version constraints will fail to build.