### PR TITLE
Update xapi-tapctl constraints in preparation for xapi-stdext 2.0.0

### DIFF
--- a/packages/xapi-tapctl/xapi-tapctl.0.9.2/opam
+++ b/packages/xapi-tapctl/xapi-tapctl.0.9.2/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
-maintainer: "jonathan.ludlam@eu.citrix.com"
+maintainer: "xen-api@lists.xen.org"
+authors: ["Jonathan Ludlam <jonathan.ludlam@eu.citrix.com>"]
+homepage: "https://xapi-project.github.io/"
+bug-reports: "https://github.com/xapi-project/tapctl/issues"
+dev-repo: "git://github.com/xapi-project/tapctl"
 build: make
 remove: [
   ["ocamlfind" "remove" "tapctl"]
@@ -11,5 +15,4 @@ depends: [
   "xapi-forkexecd"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xapi-project/tapctl"
 install: [make "install" "BINDIR=%{bin}%"]

--- a/packages/xapi-tapctl/xapi-tapctl.0.9.2/opam
+++ b/packages/xapi-tapctl/xapi-tapctl.0.9.2/opam
@@ -11,7 +11,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "xapi-stdext"
+  "xapi-stdext" {>= "0.13.0" & < "2.0.0"}
   "xapi-forkexecd"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
xapi-stdext 2.0.0 packs all its modules under the Stdext top level module, so packages which currently depend on it with no version constraints will fail to build.