### PR TITLE
+depext.1.0.0

### DIFF
--- a/packages/depext/depext.1.0.0/descr
+++ b/packages/depext/depext.1.0.0/descr
@@ -1,0 +1,7 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can perform OS and
+distribution detection, query OPAM for the right external dependencies on a set
+of packages, and call the OS's package manager in the appropriate way to install
+them.

--- a/packages/depext/depext.1.0.0/opam
+++ b/packages/depext/depext.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+tags: "flags:plugin"
+dev-repo: "https://github.com/ocaml/opam-depext.git"
+build: [
+  [
+    "ocamlopt"
+    "-I"
+    cmdliner:lib
+    "unix.cmxa"
+    "cmdliner.cmxa"
+    "-o"
+    "opam-depext"
+    "depext.ml"
+  ]
+    {ocaml-native}
+  [
+    "ocamlc"
+    "-I"
+    cmdliner:lib
+    "unix.cma"
+    "cmdliner.cma"
+    "-o"
+    "opam-depext"
+    "depext.ml"
+  ]
+    {!ocaml-native}
+]
+depends: [
+  "cmdliner" {build}
+]
+available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.1.0.0/url
+++ b/packages/depext/depext.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam-depext/archive/v1.0.0.tar.gz"
+checksum: "7e15840d2100dad80c1d4e224d0af829"


### PR DESCRIPTION
* Add support for `-y`, `-j <jobs>` and `-v` flags when used in
  conjunction with `opam depext -i`.  These are passed through to
  the `opam install` command and allow non-interactive, parallel and
  verbose output to be activated in the OPAM source builds.  This
  conveniently allows the most common flags to `opam install` to be
  used by an equivalent `opam depext -i` call.
* Fix the debug printing when using `opam depext -d` to flush output
  more often and add newlines.
* Add support for Oracle Linux via the `oraclelinux` tag.
* Add support for Raspbian Linux via the `raspbian` tag (#41).
* Add support for OpenSUSE via the `opensuse` tag.
* Fix FreeBSD support