### PR TITLE
Update xapi-forkexecd constraints in preparation for xapi-stdext 2.0.0

### DIFF
--- a/packages/xapi-forkexecd/xapi-forkexecd.0.9.2/opam
+++ b/packages/xapi-forkexecd/xapi-forkexecd.0.9.2/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "xen-api@lists.xen.org"
+authors: ["David Scott"]
+homepage: "https://xapi-project.github.io/"
+bug-reports: "https://github.com/xapi-project/forkexecd/issues"
+dev-repo: "git://github.com/xapi-project/forkexecd"
+
 build: make
 remove: [make "uninstall" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "ETCDIR=%{prefix}%/etc"]
 depends: [
@@ -13,7 +18,6 @@ depends: [
   "xapi-idl"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xapi-project/forkexecd"
 install: [
   make "install" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "ETCDIR=%{prefix}%/etc"
 ]

--- a/packages/xapi-forkexecd/xapi-forkexecd.0.9.2/opam
+++ b/packages/xapi-forkexecd/xapi-forkexecd.0.9.2/opam
@@ -13,7 +13,7 @@ depends: [
   "rpc"
   "fd-send-recv"
   "uuidm"
-  "xapi-stdext"
+  "xapi-stdext" {< "2.0.0"}
   "re"
   "xapi-idl"
   "ocamlbuild" {build}


### PR DESCRIPTION
xapi-stdext 2.0.0 packs all its modules under the Stdext top level module, so packages which currently depend on it with no version constraints will fail to build.