### PR TITLE
Update xapi-netdev constraints in preparation for xapi-stdext 2.0.0

### DIFF
--- a/packages/xapi-netdev/xapi-netdev.0.9.1/opam
+++ b/packages/xapi-netdev/xapi-netdev.0.9.1/opam
@@ -11,7 +11,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "xapi-stdext"
+  "xapi-stdext" {< "2.0.0"}
   "xapi-forkexecd"
   "ocamlbuild" {build}
 ]

--- a/packages/xapi-netdev/xapi-netdev.0.9.1/opam
+++ b/packages/xapi-netdev/xapi-netdev.0.9.1/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
-maintainer: "jonathan.ludlam@eu.citrix.com"
+maintainer: "xen-api@lists.xen.org"
+authors: ["Jonathan Ludlam <jonathan.ludlam@citrix.com>"]
+homepage: "https://xapi-project.github.io/"
+dev-repo: "git://github.com/xapi-project/netdev"
+bug-reports: "https://github.com/xapi-project/netdev/issues"
 build: make
 remove: [
   [make "uninstall" "BINDIR=%{bin}%"]
@@ -11,6 +15,5 @@ depends: [
   "xapi-forkexecd"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xapi-project/netdev"
 available: os = "linux"
 install: [make "install" "BINDIR=%{bin}%"]


### PR DESCRIPTION
xapi-stdext 2.0.0 packs all its modules under the Stdext top level module, so packages which currently depend on it with no version constraints will fail to build.