### PR TITLE
tsdl-image.0.1.2 - via opam-publish

### DIFF
--- a/packages/tsdl-image/tsdl-image.0.1.2/descr
+++ b/packages/tsdl-image/tsdl-image.0.1.2/descr
@@ -1,0 +1,4 @@
+SDL2_Image bindings to go with Tsdl
+
+Tsdl_image provides bindings to SDL2_Image intended to be used with
+Tsdl.

--- a/packages/tsdl-image/tsdl-image.0.1.2/opam
+++ b/packages/tsdl-image/tsdl-image.0.1.2/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Julian Squires <julian@cipht.net>"
+authors: "Julian Squires <julian@cipht.net>"
+homepage: "http://github.com/tokenrove/tsdl-image"
+bug-reports: "http://github.com/tokenrove/tsdl-image/issues"
+license: "BSD3"
+tags: ["bindings" "graphics"]
+dev-repo: "https://github.com/tokenrove/tsdl-image.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tsdl_image"]
+depends: [
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "tsdl" {>= "0.9.0"}
+  "result"
+  "oasis" {build}
+]
+depexts: [
+  [["debian"] ["libsdl2-image-dev"]]
+  [["homebrew" "osx"] ["sdl2_image"]]
+  [["ubuntu"] ["libsdl2-image-dev"]]
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/tsdl-image/tsdl-image.0.1.2/url
+++ b/packages/tsdl-image/tsdl-image.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/tokenrove/tsdl-image/archive/0.1.2.tar.gz"
+checksum: "c7c93ac65ad78875be065648ea9f4164"


### PR DESCRIPTION
SDL2_Image bindings to go with Tsdl

Tsdl_image provides bindings to SDL2_Image intended to be used with
Tsdl.


---
* Homepage: http://github.com/tokenrove/tsdl-image
* Source repo: https://github.com/tokenrove/tsdl-image.git
* Bug tracker: http://github.com/tokenrove/tsdl-image/issues

---

Pull-request generated by opam-publish v0.3.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocaml/opam-repository/7015)
<!-- Reviewable:end -->
