### PR TITLE
solo5-kernel-virtio.0.1.1 - via opam-publish

### DIFF
--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/descr
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/descr
@@ -1,0 +1,3 @@
+Solo5 unikernel base (virtio target)
+
+Solo5 as a unikernel base layer provides the lowest layer for Mirage/Solo5. This package includes Solo5 built for the "virtio" target, to run on KVM/QEMU or any other virtio-compliant hypervisor.

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
@@ -14,4 +14,4 @@ install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 depends: "conf-pkg-config"
 conflicts: "solo5-kernel-ukvm"
-available: [ocaml-version >= "4.02.3" & arch = "x86_64"]
+available: [ocaml-version >= "4.02.3" & arch = "x86_64" & os != "darwin"]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "https://github.com/solo5/solo5.git"
+build: [make "virtio"]
+install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
+remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
+depends: "conf-pkg-config"
+conflicts: "solo5-kernel-ukvm"
+available: [ocaml-version >= "4.02.3" & arch = "x86_64"]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/url
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Solo5/solo5/archive/v0.1.1.tar.gz"
+checksum: "72bf81d2dfcf25815169cef842c2e2dc"


### PR DESCRIPTION
Solo5 unikernel base (virtio target)

Solo5 as a unikernel base layer provides the lowest layer for Mirage/Solo5. This package includes Solo5 built for the "virtio" target, to run on KVM/QEMU or any other virtio-compliant hypervisor.


---
* Homepage: https://github.com/solo5/solo5
* Source repo: https://github.com/solo5/solo5.git
* Bug tracker: https://github.com/solo5/solo5/issues

---

Pull-request generated by opam-publish v0.3.2