### PR TITLE
ocaml-freestanding.0.1.1 - via opam-publish

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/descr
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/descr
@@ -1,0 +1,3 @@
+Freestanding OCaml runtime
+
+This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer.

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+dev-repo: "https://github.com/mirage/ocaml-freestanding.git"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind"
+  "ocaml-src"
+  ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
+]
+available: [ocaml-version >= "4.02.3" & arch = "x86_64"]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/url
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-freestanding/archive/v0.1.1.tar.gz"
+checksum: "88736a6d0db81ebf1e7ea257cacfcf1e"


### PR DESCRIPTION
Freestanding OCaml runtime

This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer.


---
* Homepage: https://github.com/mirage/ocaml-freestanding
* Source repo: https://github.com/mirage/ocaml-freestanding.git
* Bug tracker: https://github.com/mirage/ocaml-freestanding/issues/

---

Pull-request generated by opam-publish v0.3.2