### PR TITLE
gmp-freestanding.6.0.0 - via opam-publish

### DIFF
--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/descr
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/descr
@@ -1,0 +1,1 @@
+The GNU Multiple Precision Arithmetic Library

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/descr
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/descr
@@ -1,1 +1,3 @@
 The GNU Multiple Precision Arithmetic Library
+
+Freestanding build of GNU GMP.

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/gmp-freestanding.pc
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/gmp-freestanding.pc
@@ -1,0 +1,9 @@
+libdir=${pcfiledir}/../gmp-freestanding
+includedir=${libdir}/include
+
+Name: gmp-freestanding
+Version: 6.0.0
+URL: https://gmplib.org
+Description: The GNU Multiple Precision Arithmetic Library
+Cflags: -I${includedir}
+Libs: -L${libdir} -lgmp-freestanding

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/mirage-build.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/mirage-build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX="`opam config var prefix`/lib/gmp-freestanding"
+fi
+
+PKG_CONFIG_DEPS="ocaml-freestanding"
+check_deps () {
+  pkg-config --print-errors --exists ${PKG_CONFIG_DEPS}
+}
+
+if ! check_deps 2>/dev/null; then
+  # rely on `opam` if deps are unavailable
+  export PKG_CONFIG_PATH="`opam config var prefix`/lib/pkgconfig"
+fi
+check_deps || exit 1
+
+#
+# ocaml-freestanding does not provide a real cross compiler, so we fake it:
+# 
+# - set CC to stop configure trying to find a host compiler
+# - set CPPFLAGS to ocaml-freestanding CFLAGS, this prevents inclusion of
+#   system headers
+# - manually override tests for missing functions
+# - manually trim the components (SUBDIRS) of libgmp we build to the subset
+#   actually used by zarith-freestanding (our sole dependency)
+# - set -Werror=implicit-function-declaration at *build* time to catch any
+#   undefined symbols
+#
+ac_cv_func_obstack_vprintf=no \
+ac_cv_func_localeconv=no \
+./configure \
+    --host=x86_64-unknown-none --enable-fat --disable-shared \
+    CC=gcc "CPPFLAGS=$(pkg-config --cflags ${PKG_CONFIG_DEPS})"
+
+make SUBDIRS="mpn mpz mpq mpf" \
+    PRINTF_OBJECTS= SCANF_OBJECTS= \
+    CFLAGS+=-Werror=implicit-function-declaration

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/mirage-install.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/mirage-install.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX=`opam config var prefix`
+fi
+PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+LIBDIR=${PREFIX}/lib/gmp-freestanding
+
+mkdir -p ${PKG_CONFIG_PATH}
+cp gmp-freestanding.pc ${PKG_CONFIG_PATH}
+mkdir -p ${LIBDIR}
+cp .libs/libgmp.a ${LIBDIR}/libgmp-freestanding.a
+mkdir -p ${LIBDIR}/include
+cp gmp.h ${LIBDIR}/include

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer:   "Martin Lucina <martin@lucina.net>"
+homepage:     "https://gmplib.org/"
+license:      "GNU LGPL v3 and GNU GPL v2"
+authors:      "Torbjörn Granlund and contributors"
+
+build:   ["./mirage-build.sh"]
+install: ["./mirage-install.sh"]
+remove: [
+  "rm" "-rf"
+    "%{prefix}%/lib/pkgconfig/gmp-freestanding.pc"
+    "%{prefix}%/lib/gmp-freestanding"
+]
+depends: [
+  "ocaml-freestanding"
+]

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
@@ -3,6 +3,8 @@ maintainer:   "Martin Lucina <martin@lucina.net>"
 homepage:     "https://gmplib.org/"
 license:      "GNU LGPL v3 and GNU GPL v2"
 authors:      "Torbjörn Granlund and contributors"
+bug-reports:  "mirageos-devel@lists.xenproject.org"
+dev-repo:     "https://gmplib.org/devel/repo-usage.html"
 
 build:   ["./mirage-build.sh"]
 install: ["./mirage-install.sh"]

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
@@ -4,7 +4,6 @@ homepage:     "https://gmplib.org/"
 license:      "GNU LGPL v3 and GNU GPL v2"
 authors:      "Torbjörn Granlund and contributors"
 bug-reports:  "mirageos-devel@lists.xenproject.org"
-dev-repo:     "https://gmplib.org/devel/repo-usage.html"
 
 build:   ["./mirage-build.sh"]
 install: ["./mirage-install.sh"]

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/url
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://gmplib.org/download/gmp/gmp-6.0.0a.tar.xz"
+checksum: "1e6da4e434553d2811437aa42c7f7c76"


### PR DESCRIPTION
The GNU Multiple Precision Arithmetic Library


---
* Homepage: https://gmplib.org/
* Source repo: 
* Bug tracker: 

---
### opam-lint failures
- **WARNING** 37 Missing field 'dev-repo'
- **WARNING** 36 Missing field 'bug-reports'
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.2