### PR TITLE
mirage-solo5.0.1.1 - via opam-publish

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.1.1/descr
+++ b/packages/mirage-solo5/mirage-solo5.0.1.1/descr
@@ -1,0 +1,3 @@
+Platform bindings for Mirage on Solo5
+
+This package provides the platform bindings for Mirage/Solo5.

--- a/packages/mirage-solo5/mirage-solo5.0.1.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.1.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "https://github.com/mirage/mirage-solo5.git"
+authors:       [ "Anil Madhavapeddy <anil@recoil.org>" "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" ]
+license:      "ISC"
+
+build:   [make "solo5-build"]
+install: [make "solo5-install"   "PREFIX=%{prefix}%"]
+remove:  [make "solo5-uninstall" "PREFIX=%{prefix}%"]
+
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-profile" {>= "0.3"}
+  "ocaml-freestanding"
+]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-solo5/mirage-solo5.0.1.1/url
+++ b/packages/mirage-solo5/mirage-solo5.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-solo5/archive/v0.1.1.tar.gz"
+checksum: "f27fb6ebf3840a5b45fef14e527b59a5"


### PR DESCRIPTION
Platform bindings for Mirage on Solo5

This package provides the platform bindings for Mirage/Solo5.


---
* Homepage: https://github.com/mirage/mirage-solo5
* Source repo: https://github.com/mirage/mirage-solo5.git
* Bug tracker: https://github.com/mirage/mirage-solo5/issues/

---

Pull-request generated by opam-publish v0.3.2