### PR TITLE
ctypes-build.0.0.1 - via opam-publish

### DIFF
--- a/packages/ctypes-build/ctypes-build.0.0.1/descr
+++ b/packages/ctypes-build/ctypes-build.0.0.1/descr
@@ -1,0 +1,1 @@
+Support for building Ctypes bindings.

--- a/packages/ctypes-build/ctypes-build.0.0.1/opam
+++ b/packages/ctypes-build/ctypes-build.0.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop" "David Sheets"]
+homepage: "https://github.com/yallop/ocaml-ctypes-build"
+bug-reports: "https://github.com/yallop/ocaml-ctypes-build/issues"
+license: "MIT"
+dev-repo: "https://github.com/yallop/ocaml-ctypes-build.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild"
+  "ctypes" {>= "0.6.0"}
+]

--- a/packages/ctypes-build/ctypes-build.0.0.1/url
+++ b/packages/ctypes-build/ctypes-build.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/yallop/ocaml-ctypes-build/archive/0.0.1.tar.gz"
+checksum: "51101b3b74cf6ee622ec36581a43e680"


### PR DESCRIPTION
Support for building Ctypes bindings.


---
* Homepage: https://github.com/yallop/ocaml-ctypes-build
* Source repo: https://github.com/yallop/ocaml-ctypes-build.git
* Bug tracker: https://github.com/yallop/ocaml-ctypes-build/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.2