### PR TITLE
mirage-bootvar-solo5.0.1.1 - via opam-publish

### DIFF
--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/descr
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/descr
@@ -1,0 +1,3 @@
+Mirage Bootvar implementation for Solo5
+
+Library for passing boot parameters from Solo5 to MirageOS.

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+homepage: "https://github.com/mirage/mirage-bootvar-solo5"
+bug-reports: "https://github.com/mirage/mirage-bootvar-solo5/issues/"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-bootvar-solo5.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-bootvar"]
+depends: ["mirage-solo5" "mirage-types" "astring"]

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/url
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-bootvar-solo5/archive/v0.1.1.tar.gz"
+checksum: "c527a623073ba8a60f7b2eae911f64c3"


### PR DESCRIPTION
Mirage Bootvar implementation for Solo5

Library for passing boot parameters from Solo5 to MirageOS.


---
* Homepage: https://github.com/mirage/mirage-bootvar-solo5
* Source repo: https://github.com/mirage/mirage-bootvar-solo5.git
* Bug tracker: https://github.com/mirage/mirage-bootvar-solo5/issues/

---

Pull-request generated by opam-publish v0.3.2