### PR TITLE
mirage-console-solo5.0.1.1 - via opam-publish

### DIFF
--- a/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/descr
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/descr
@@ -1,0 +1,3 @@
+Mirage CONSOLE implementation for Solo5
+
+Mirage CONSOLE implementation for Solo5

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-console-solo5"
+bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo:      "https://github.com/mirage/mirage-console-solo5.git"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [make
+         "PREFIX=%{prefix}%" ]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: ["ocamlfind" "remove" "mirage-console-solo5"]
+depends: [
+  "ocamlfind" {build}
+  "mirage-console"
+  "mirage-types-lwt"
+  "mirage-solo5"
+]
+depopts: [
+]
+conflicts: [
+]

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/url
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-console-solo5/archive/v0.1.1.tar.gz"
+checksum: "e6749a92ac0ed788d8be54094565a039"


### PR DESCRIPTION
Mirage CONSOLE implementation for Solo5

Mirage CONSOLE implementation for Solo5


---
* Homepage: https://github.com/mirage/mirage-console-solo5
* Source repo: https://github.com/mirage/mirage-console-solo5.git
* Bug tracker: https://github.com/mirage/mirage-console-solo5/issues

---

Pull-request generated by opam-publish v0.3.2