### PR TITLE
mirage-net-solo5.0.1.1 - via opam-publish

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/descr
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/descr
@@ -1,0 +1,3 @@
+Mirage NETWORK implementation for Solo5
+
+Mirage NETWORK implementation for Solo5

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "https://github.com/mirage/mirage-net-solo5.git"
+authors:       [ "Anil Madhavapeddy <anil@recoil.org>" "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" ]
+license:       "ISC"
+build: [ [make] ]
+install: [ [make "install"] ]
+remove: ["ocamlfind" "remove" "mirage-net-solo5"]
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-types" {>= "1.1.0"}
+  "io-page" {>= "1.0.0"}
+  "ipaddr" {>= "1.0.0"}
+  "mirage-profile" {>="0.3"}
+  "mirage-solo5"
+]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/url
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-net-solo5/archive/v0.1.1.tar.gz"
+checksum: "3df27174b2e40febec43492cdfbdc50f"


### PR DESCRIPTION
Mirage NETWORK implementation for Solo5

Mirage NETWORK implementation for Solo5


---
* Homepage: https://github.com/mirage/mirage-net-solo5
* Source repo: https://github.com/mirage/mirage-net-solo5.git
* Bug tracker: https://github.com/mirage/mirage-net-solo5/issues

---

Pull-request generated by opam-publish v0.3.2