### PR TITLE
ptime.0.8.2 - via opam-publish

### DIFF
--- a/packages/ptime/ptime.0.8.2/descr
+++ b/packages/ptime/ptime.0.8.2/descr
@@ -1,0 +1,20 @@
+POSIX time for OCaml
+
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
+human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime depends on the `result` compatibility package. Ptime_clock
+depends on your system library. Ptime_clock's optional JavaScript
+support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
+distributed under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+[jsoo]: http://ocsigen.org/js_of_ocaml/

--- a/packages/ptime/ptime.0.8.2/opam
+++ b/packages/ptime/ptime.0.8.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/ptime"
+doc: "http://erratique.ch/software/ptime/doc"
+dev-repo: "http://erratique.ch/repos/ptime.git"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+tags: [ "time" "posix" "system" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "result"
+]
+depopts: [ "js_of_ocaml" ]
+build:[[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]

--- a/packages/ptime/ptime.0.8.2/url
+++ b/packages/ptime/ptime.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/ptime/releases/ptime-0.8.2.tbz"
+checksum: "4ec5780673bbb2f7553ef45f1e55839d"


### PR DESCRIPTION
POSIX time for OCaml

Ptime has platform independent POSIX time support in pure OCaml. It
provides a type to represent a well-defined range of POSIX timestamps
with picosecond precision, conversion with date-time values,
conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
human-readable, locale-independent representation.

The additional Ptime_clock library provides access to a system POSIX
clock and to the system's current time zone offset.

Ptime is not a calendar library.

Ptime depends on the `result` compatibility package. Ptime_clock
depends on your system library. Ptime_clock's optional JavaScript
support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
distributed under the ISC license.

[rfc3339]: http://tools.ietf.org/html/rfc3339
[jsoo]: http://ocsigen.org/js_of_ocaml/


---
* Homepage: http://erratique.ch/software/ptime
* Source repo: http://erratique.ch/repos/ptime.git
* Bug tracker: https://github.com/dbuenzli/ptime/issues

---


---
v0.8.2 2016-07-22 Zagreb
------------------------

* Add `?tz_offset_s` optional argument to `Ptime.weekday`. Thanks
  to Maxence Guesdon for suggesting.
Pull-request generated by opam-publish v0.3.2