### PR TITLE
Fixed opam list output, authors

### DIFF
--- a/packages/pareto/pareto.0.3/descr
+++ b/packages/pareto/pareto.0.3/descr
@@ -1,4 +1,5 @@
-GSL powered OCaml statistics library, which provides:
+GSL powered OCaml statistics library.
+It provides:
 
 * Common statistical tests for significant differences between samples.
 * Uniform interface for common discrete and continuous probability distributions.

--- a/packages/pareto/pareto.0.3/opam
+++ b/packages/pareto/pareto.0.3/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 
-author: "Sergei Lebedev <superbobry@gmail.com>"
 maintainer: "Sergei Lebedev <superbobry@gmail.com>"
+authors: ["Sergei Lebedev <superbobry@gmail.com>"]
 
 build: [
   ["./configure" "--prefix" "%{prefix}%"]
@@ -17,4 +17,3 @@ homepage: "https://github.com/superbobry/pareto"
 dev-repo: "https://github.com/superbobry/pareto.git"
 bug-reports: "https://github.com/superbobry/pareto/issues"
 license: "MIT"
-authors: ["Sergei Lebedev"]


### PR DESCRIPTION
Improved one-liner in `opam list -a`.

Fixed author name duplication (see https://opam.ocaml.org/packages/pareto/pareto.0.3/).

/cc @superbobry 