### PR TITLE
Package dbm: Add depexts for CentOS et al

### DIFF
--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -14,6 +14,9 @@ depexts: [
   [["debian"] ["libgdbm-dev"]]
   [["ubuntu"] ["libgdbm-dev"]]
   [["nixpkgs"] ["gdbm"]]
+  [["centos"] ["gdbm-devel"]]
+  [["rhel"] ["gdbm-devel"]]
+  [["fedora"] ["gdbm-devel"]]
 ]
 patches: [
   "hasgotfix.patch"


### PR DESCRIPTION
A user of the dbm package reports the below on CentOS.  This PR is a plausible fix, but it is completely untested.

> When you install dbm on CentOS 7 using opam, depext should report the package gdbm-devel as a dependency, but instead it fails to install.
> Steps to reproduce:
> 1. Create a fresh install of CentOS 7
> 2. Install listed dependencies with opam depext
> 3. Attempt to install dbm.1.0, it will fail
> 4. Install gdbm-devel
> 5. Attempt to install dbm.1.0, it will succeed