### PR TITLE
key-parsers.0.4.0 - via opam-publish

### DIFF
--- a/packages/key-parsers/key-parsers.0.4.0/descr
+++ b/packages/key-parsers/key-parsers.0.4.0/descr
@@ -1,0 +1,4 @@
+Parsers for multiple key formats
+
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman
+or Elliptic curve public and private keys.

--- a/packages/key-parsers/key-parsers.0.4.0/opam
+++ b/packages/key-parsers/key-parsers.0.4.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+author: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/key-parsers.git"
+build: [make]
+build-test: [make "check"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "key-parsers"]
+depends: [
+  "ocamlfind" {build}
+  "ppx_deriving" {= "4.0"}
+  "ppx_deriving_yojson" {= "3.0"}
+  "ounit" {test & = "2.0.0"}
+  "ppx_blob" {test & = "0.2"}
+  "hex" {test & = "1.0.0"}
+  "asn1-combinators" {= "0.1.2"}
+  "zarith" {= "1.4.1"}
+  "result" {= "1.2"}
+]

--- a/packages/key-parsers/key-parsers.0.4.0/url
+++ b/packages/key-parsers/key-parsers.0.4.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/cryptosense/key-parsers/archive/v0.4.0.zip"
+checksum: "0e9d2166d81279f47ccc942b4b3640fd"


### PR DESCRIPTION
Parsers for multiple key formats

This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman
or Elliptic curve public and private keys.


---
* Homepage: https://github.com/cryptosense/key-parsers
* Source repo: https://github.com/cryptosense/key-parsers.git
* Bug tracker: https://github.com/cryptosense/key-parsers/issues

---

Pull-request generated by opam-publish v0.3.1