### PR TITLE
dose: add pod2html depext for fedora

### DIFF
--- a/packages/dose/dose.3.2.2+opam/opam
+++ b/packages/dose/dose.3.2.2+opam/opam
@@ -38,3 +38,7 @@ patches: [
   "0002-ocamlgraph-1.8.6.diff" {ocamlgraph:version >= "1.8.6"}
 ]
 install: [make "install"]
+depexts: [
+ [["fedora"] ["perl-Pod-Html"]]
+]
+

--- a/packages/dose/dose.3.2.2/opam
+++ b/packages/dose/dose.3.2.2/opam
@@ -34,3 +34,6 @@ patches: [
   "0002-ocamlgraph-1.8.6.diff" {ocamlgraph:version >= "1.8.6"}
 ]
 install: [make "install"]
+depexts: [
+ [["fedora"] ["perl-Pod-Html"]]
+]

--- a/packages/dose/dose.3.3/opam
+++ b/packages/dose/dose.3.3/opam
@@ -42,3 +42,6 @@ patches: [
   "0001-Removed-hard-failure-cases-in-favor-of-finer-diagnos.patch"
   "0002-ocamlgraph-1.8.6.diff" {ocamlgraph:version >= "1.8.6"}
 ]
+depexts: [
+ [["fedora"] ["perl-Pod-Html"]]
+]

--- a/packages/dose/dose.3.4.1/opam
+++ b/packages/dose/dose.3.4.1/opam
@@ -33,3 +33,6 @@ depends: [
   "ocamlbuild" {build}
   "cppo" {build}
 ]
+depexts: [
+ [["fedora"] ["perl-Pod-Html"]]
+]

--- a/packages/dose/dose.3.4.2/opam
+++ b/packages/dose/dose.3.4.2/opam
@@ -33,3 +33,6 @@ depends: [
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}
 ]
+depexts: [
+ [["fedora"] ["perl-Pod-Html"]]
+]


### PR DESCRIPTION
otherwise build fails with a missing pod2html during
the installation phase, blocking installation of `opam-publish`
on fedora