### PR TITLE
aperf.0.1 - via opam-publish

### DIFF
--- a/packages/aperf/aperf.0.1/descr
+++ b/packages/aperf/aperf.0.1/descr
@@ -1,0 +1,1 @@
+OCaml tools for loop perforation

--- a/packages/aperf/aperf.0.1/opam
+++ b/packages/aperf/aperf.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Philip Dexter <philip.dexter@gmail.com>"
+authors: "Philip Dexter <philip.dexter@gmail.com>"
+homepage: "http://github.com/philipdexter/aperf"
+bug-reports: "http://github.com/philipdexter/aperf/issues"
+dev-repo: "http://git.phfilip.com/aperf"
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "compiler-libs"
+  "cmdliner"
+]

--- a/packages/aperf/aperf.0.1/url
+++ b/packages/aperf/aperf.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/philipdexter/aperf/archive/v0.1.tar.gz"
+checksum: "87d8b88278ab17d876f0e385987c3d57"

--- a/packages/aperf/aperf.0.1/url
+++ b/packages/aperf/aperf.0.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/philipdexter/aperf/archive/v0.1.tar.gz"
+archive: "http://github.com/philipdexter/aperf/archive/v0.1.tar.gz"
 checksum: "87d8b88278ab17d876f0e385987c3d57"


### PR DESCRIPTION
OCaml tools for loop perforation


---
* Homepage: http://github.com/philipdexter/aperf
* Source repo: http://git.phfilip.com/aperf
* Bug tracker: http://github.com/philipdexter/aperf/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.1 2016-07-26
---------------

Initial release.
Pull-request generated by opam-publish v0.3.2