### PR TITLE
opamfu 0.1.3 depends on opam-lib (>= 1.2.1), not (>= 1.2.0)

### DIFF
--- a/packages/opamfu/opamfu.0.1.3/opam
+++ b/packages/opamfu/opamfu.0.1.3/opam
@@ -19,7 +19,7 @@ install: [
 remove: [[make "uninstall"]]
 depends: [
   "ocamlfind"
-  "opam-lib" { >= "1.2.0" }
+  "opam-lib" { >= "1.2.1" }
   "uri" { >= "1.3.11" }
 ]
 depopts: ["cmdliner"]


### PR DESCRIPTION
Below is the build failure when using opam-lib 1.2.0:

```
+ ocamlfind ocamlc -c -w @f@p@u@40 -g -package cmdliner -package uri -package opam-lib.client -I lib -I ui -o lib/opamfUniverse.cmo lib/opamfUniverse.ml
File "lib/opamfUniverse.ml", line 173, characters 34-64:
Error: Unbound value OpamState.static_base_packages
Command exited with code 2.
Makefile:32: recipe for target 'build' failed
```

I tested that opamfu 0.1.2 builds with opam-lib 1.2.0, and that opamfu
0.1.3 builds with opam-lib 1.2.1.