### PR TITLE
+github.1.1.0

### DIFF
--- a/packages/github/github.1.1.0/descr
+++ b/packages/github/github.1.1.0/descr
@@ -1,0 +1,5 @@
+GitHub APIv3 client bindings
+
+This library provides access to many of the most used GitHub API
+endpoints while making authorization, two-factor authentication, rate
+limit monitoring, event delivery, and polling easy to use.

--- a/packages/github/github.1.1.0/opam
+++ b/packages/github/github.1.1.0/opam
@@ -46,3 +46,4 @@ depopts: [
 conflicts: [
   "js_of_ocaml" {< "2.4.0"}
 ]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/github/github.1.1.0/opam
+++ b/packages/github/github.1.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+]
+homepage: "https://github.com/mirage/ocaml-github"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+dev-repo: "https://github.com/mirage/ocaml-github.git"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+  "git"
+]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--%{base-unix:enable}%-unix" "--%{js_of_ocaml:enable}%-js" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "github"]
+]
+depends: [
+  "ocamlfind"
+  "ssl"
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.17.0"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "1.5.0"}
+  "yojson" {>= "1.2.0"}
+  "stringext"
+  "lambda-term"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+depopts: [
+  "js_of_ocaml"
+]
+conflicts: [
+  "js_of_ocaml" {< "2.4.0"}
+]

--- a/packages/github/github.1.1.0/url
+++ b/packages/github/github.1.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-github/archive/v1.1.0.tar.gz"
+checksum: "b24a324299ce6569aa663a28bb5b79c9"


### PR DESCRIPTION
* Add new_status_context and status_context fields (#88)
* Add setting the jar cookie by the `GH_COOKIE` env var (#100 by @rgrinberg)
* Remove camlp4 as a build time dependency (#99, #104, #106 by @rgrinberg)
* Add Windows tests via Appveyor (#98)
* Add jar 'local' subcommand for printing local cookies (#111 by @rgrinberg)
* Add Repo.contributor_stats for contributor statistics (#114 by @sevenEng)
* Add stats_contributor type (#114 by @sevenEng)
* Add stats_contributors type (#114 by @sevenEng)
* Add contribution_week type
* Fix Repo.get_tags_and_times exception when repository has no tags (#113)
* Change Github_core.Make to accept an Env module making the library
  Mirage compatible by moving a Unix.getenv invocation into a parameter (#93)
* Add contributor and contributors types (#112)
* Add Repo.contributors to list contributors to a repository (#112)
* Register automatically a Message exception printer (#116)
* Fix `git jar` help strings to match the command reality.
* Improve `git jar create --help` manual page.
* Add `git-gist create [--public] --descr <descr> <file1> <fileN>` to
  upload new gists.