### PR TITLE
reactjs.0.0.2 - via opam-publish

### DIFF
--- a/packages/reactjs/reactjs.0.0.2/descr
+++ b/packages/reactjs/reactjs.0.0.2/descr
@@ -1,0 +1,16 @@
+OCaml bindings to ReactJS
+
+These are OCaml bindings to ReactJS. This means that you write OCaml
+and compile to JavaScript using the js_of_ocaml compiler.
+
+with just:
+
+$ ocamlfind ocamlc -package reactjs -linkpkg code.ml
+$ js_of_ocaml a.out -o from_ocaml.js
+
+See the github homepage for working code examples and check the
+wiki for common questions.
+
+Also check https://github.com/fxfactorial/ocaml-mailing-list for
+a self contained and working example of rendering ReactJS on node
+by also using OCaml bindings to nodejs.

--- a/packages/reactjs/reactjs.0.0.2/opam
+++ b/packages/reactjs/reactjs.0.0.2/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-reactjs"
+bug-reports: "https://github.com/fxfactorial/ocaml-reactjs/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-reactjs.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "reactjs"]
+depends: [
+  "js_of_ocaml" {>= "2.8.1"}
+  "lwt" {>= "2.5.2"}
+  "commonjs_of_ocaml" {>= "0.1.0"}
+  "ppx_deriving" {>= "4.0"}
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.0"]
+messages: "typesafe, mostly, ReactJS in OCaml!"
+post-messages: [
+  "Now you can write ReactJS in OCaml"
+  "and compile to JavaScript runnable on either"
+  "nodejs or the browser with just"
+  ""
+  "$ ocamlfind ocamlc -package reactjs -linkpkg code.ml"
+  "$ js_of_ocaml a.out -o from_ocaml.js"
+  ""
+  "Check github for several working examples and wiki for FAQs"
+  "Also check https://github.com/fxfactorial/ocaml-mailing-list for"
+  "a self contained and working example of rendering ReactJS"
+  "on node by also using OCaml bindings to nodejs"
+]

--- a/packages/reactjs/reactjs.0.0.2/url
+++ b/packages/reactjs/reactjs.0.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-reactjs/archive/v0.0.2.tar.gz"
+checksum: "9d47e662e8c74b6cca711ea3ef5918bf"


### PR DESCRIPTION
OCaml bindings to ReactJS

These are OCaml bindings to ReactJS. This means that you write OCaml
and compile to JavaScript using the js_of_ocaml compiler.

with just:

$ ocamlfind ocamlc -package reactjs -linkpkg code.ml
$ js_of_ocaml a.out -o from_ocaml.js

See the github homepage for working code examples and check the
wiki for common questions.

Also check https://github.com/fxfactorial/ocaml-mailing-list for
a self contained and working example of rendering ReactJS on node
by also using OCaml bindings to nodejs.


---
* Homepage: https://github.com/fxfactorial/ocaml-reactjs
* Source repo: https://github.com/fxfactorial/ocaml-reactjs.git
* Bug tracker: https://github.com/fxfactorial/ocaml-reactjs/issues

---

Pull-request generated by opam-publish v0.3.2