### PR TITLE
Add a compiler with `safe-string` globally enabled

### DIFF
--- a/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.comp
+++ b/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.comp
@@ -1,0 +1,11 @@
+opam-version: "1"
+version: "4.04.0"
+src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.descr
+++ b/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.descr
@@ -1,0 +1,1 @@
+OCaml 4.04.0 with -safe-string enabled.


### PR DESCRIPTION
Add a compiler built from OCaml `trunk` with `-safe-string` passed at configuration time.

See https://github.com/ocaml/ocaml/pull/687.