### PR TITLE
zipperposition.1.0 - via opam-publish

### DIFF
--- a/packages/zipperposition/zipperposition.1.0/descr
+++ b/packages/zipperposition/zipperposition.1.0/descr
@@ -1,0 +1,6 @@
+Zipperposition is a superposition prover for full first order logic with equality.
+
+
+The accent is on flexibility, modularity and simplicity rather than performance, to allow
+quick experimenting on automated theorem proving. It generates TSTP traces and features
+many simplification rules and redundancy criteria.

--- a/packages/zipperposition/zipperposition.1.0/opam
+++ b/packages/zipperposition/zipperposition.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://www.rocq.inria.fr/deducteam/Zipperposition/index.html"
+bug-reports: "https://github.com/c-cube/zipperposition/issues"
+tags: ["logic" "unification" "term" "superposition" "prover"]
+dev-repo: "https://github.com/c-cube/zipperposition.git"
+build: [
+  [
+    "./configure"
+    "--bindir"
+    "%{bin}%"
+    "--disable-tests"
+    "--disable-docs"
+    "--%{menhir:enable}%-parsers"
+    "--disable-solving"
+    "--disable-qcheck"
+    "--disable-tools"
+    "--enable-meta"
+  ]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "libzipperposition"]
+  ["rm" "%{bin}%/zipperposition"]
+]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "containers" {> "0.16"}
+  "sequence" {>= "0.4"}
+  "gen"
+  "oclock"
+  "oasis"
+  "msat" {>= "0.3" & < "0.4"}
+]
+depopts: [
+  "menhir" {build}
+  "qcheck" {test}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/zipperposition/zipperposition.1.0/url
+++ b/packages/zipperposition/zipperposition.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/zipperposition/archive/1.0.tar.gz"
+checksum: "48b8a8319663b6520622fe23f24fc073"


### PR DESCRIPTION
Zipperposition is a superposition prover for full first order logic with equality.


The accent is on flexibility, modularity and simplicity rather than performance, to allow
quick experimenting on automated theorem proving. It generates TSTP traces and features
many simplification rules and redundancy criteria.


---
* Homepage: https://www.rocq.inria.fr/deducteam/Zipperposition/index.html
* Source repo: https://github.com/c-cube/zipperposition.git
* Bug tracker: https://github.com/c-cube/zipperposition/issues

---

Pull-request generated by opam-publish v0.3.2