### PR TITLE
Add cppo version constraint to ppx_deriving

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.3.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.3/opam
@@ -22,7 +22,7 @@ build-doc: [
 depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build & >= "1.5.4"}
-  "cppo"       {build}
+  "cppo"       {build & >= "0.9.4"}
   "ppx_tools"  {>= "4.02.3"}
   "ounit"      {test}
 ]


### PR DESCRIPTION
For a completely obscur to me but reproducible (visible at https://travis-ci.org/Kappa-Dev/KaSim/jobs/148906835 ) reason,
opam chooses to install the oldest possible version of cppo when you ask to install yojson.
This version does not provide the ocamlbuild plugin ppx_deriving depends on and therefore its installation fails...