### PR TITLE
unix-errno 0.4.2 and ctypes 0.7.0 are incompatible

### DIFF
--- a/packages/unix-errno/unix-errno.0.4.2/opam
+++ b/packages/unix-errno/unix-errno.0.4.2/opam
@@ -20,5 +20,6 @@ depends: [
 depopts: ["base-unix" "ctypes"]
 conflicts: [
   "ctypes" {< "0.4.0"}
+  "ctypes" {>= "0.7.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
[Evidence](https://travis-ci.org/ocaml/opam-repository/jobs/149770069).