### PR TITLE
ocaml-cordova.1.0 - via opam-publish

### DIFF
--- a/packages/ocaml-cordova/ocaml-cordova.1.0/descr
+++ b/packages/ocaml-cordova/ocaml-cordova.1.0/descr
@@ -1,5 +1,5 @@
 Binding OCaml to cordova Javascript object.
 
 Binding OCaml to cordova Javascript object. See
-https://github.com/dannywillems/ocaml-cordova-plugin-list for the completed list
+https://github.com/dannywillems/ocaml-cordova-plugin-list for the complete list
 of bindings to Cordova plugins.

--- a/packages/ocaml-cordova/ocaml-cordova.1.0/descr
+++ b/packages/ocaml-cordova/ocaml-cordova.1.0/descr
@@ -1,0 +1,5 @@
+Binding OCaml to cordova Javascript object.
+
+Binding OCaml to cordova Javascript object. See
+https://github.com/dannywillems/ocaml-cordova-plugin-list for the completed list
+of bindings to Cordova plugins.

--- a/packages/ocaml-cordova/ocaml-cordova.1.0/opam
+++ b/packages/ocaml-cordova/ocaml-cordova.1.0/opam
@@ -4,7 +4,7 @@ authors: "Danny Willems <contact@danny-willems.be>"
 homepage: "https://github.com/dannywillems/ocaml-cordova"
 bug-reports: "https://github.com/dannywillems/ocaml-cordova/issues"
 license: "LGPL-3.0 with OCaml linking exception"
-dev-repo: "https://github.com/dannywillems/ocaml-cordova"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova.git"
 build: [make "build"]
 install: [make "install"]
 remove: [make "remove"]

--- a/packages/ocaml-cordova/ocaml-cordova.1.0/opam
+++ b/packages/ocaml-cordova/ocaml-cordova.1.0/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova"
+bug-reports: "https://github.com/dannywillems/ocaml-cordova/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ocaml-cordova/ocaml-cordova.1.0/url
+++ b/packages/ocaml-cordova/ocaml-cordova.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dannywillems/ocaml-cordova/archive/v1.0.zip"
+checksum: "f4f1c70dd35cce5fd97e1716c7dadb7c"


### PR DESCRIPTION
Binding OCaml to cordova Javascript object.

Binding OCaml to cordova Javascript object. See
https://github.com/dannywillems/ocaml-cordova-plugin-list for the complete list
of bindings to Cordova plugins.


---
* Homepage: https://github.com/dannywillems/ocaml-cordova
* Source repo: https://github.com/dannywillems/ocaml-cordova
* Bug tracker: https://github.com/dannywillems/ocaml-cordova/issues

---

Pull-request generated by opam-publish v0.3.1