### PR TITLE
Add typerex-clibs.1.0

### DIFF
--- a/packages/typerex-clibs/typerex-clibs.1.0/descr
+++ b/packages/typerex-clibs/typerex-clibs.1.0/descr
@@ -1,0 +1,5 @@
+A set of bindings to common C libraries
+
+These libraries are probably not very useful as there exists other
+equivalent bindings, but they are useful for some OCamlPro's tools
+that have been using them for a long time.

--- a/packages/typerex-clibs/typerex-clibs.1.0/findlib
+++ b/packages/typerex-clibs/typerex-clibs.1.0/findlib
@@ -1,0 +1,3 @@
+ocplib-zlib
+ocplib-digest
+

--- a/packages/typerex-clibs/typerex-clibs.1.0/opam
+++ b/packages/typerex-clibs/typerex-clibs.1.0/opam
@@ -1,0 +1,35 @@
+(**************************************************************)
+(*                                                            *)
+(*      This file is managed by ocp-autoconf                  *)
+(*  Remove it from `manage_files` in 'ocp-autoconf.config'    *)
+(*  if you want to modify it manually (or use 'opam.trailer') *)
+(*                                                            *)
+(**************************************************************)
+
+opam-version: "1.2"
+build: [
+  [     "./configure"
+    "--prefix"
+    "%{prefix}%"
+    "--with-ocamldir=%{prefix}%/lib"
+    "--with-metadir=%{prefix}%/lib"
+  ]
+  [ make ]
+]
+install: [
+  [ make "install" ]
+]
+remove: [
+]
+depends: [
+     "ocamlfind"
+     "ocp-build" {>= "1.99.17-beta" }
+]
+available: [ocaml-version >= "3.12.1"]
+maintainer: "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+authors: [
+  "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+]
+dev-repo: "https://github.com/OCamlPro/typerex-clibs.git"
+bug-reports: "https://github.com/OCamlPro/typerex-clibs/issues"
+homepage: "http://github.com/OCamlPro/typerex-clibs"

--- a/packages/typerex-clibs/typerex-clibs.1.0/url
+++ b/packages/typerex-clibs/typerex-clibs.1.0/url
@@ -1,0 +1,2 @@
+archive: "http://github.com/OCamlPro/typerex-clibs/archive/1.0.tar.gz"
+checksum: "fe09f4e6c66f396438822103d2c2bad6"


### PR DESCRIPTION
A set of bindings to common C libraries

These libraries are probably not very useful as there exists other
equivalent bindings, but they are useful for some OCamlPro's tools
that have been using them for a long time.
