### PR TITLE
gasoline.0.5.0: Restrict dependencies to newest versions of getopts

### DIFF
--- a/packages/gasoline/gasoline.0.5.0/opam
+++ b/packages/gasoline/gasoline.0.5.0/opam
@@ -16,7 +16,7 @@ depends: [
   "camomile" {>= "0.8.5"}
   "configuration" {>= "0.4.1"}
   "conf-bmake"
-  "getopts" {>= "0.3.2"}
+  "getopts" {>= "0.4.0"}
   "lemonade" {>= "0.6.0"}
   "ocamlfind"
 ]


### PR DESCRIPTION
Problems have been reported when trying to build against older versions of getopts.