### PR TITLE
osx-cf.0.1.1 - via opam-publish

### DIFF
--- a/packages/osx-cf/osx-cf.0.1.1/descr
+++ b/packages/osx-cf/osx-cf.0.1.1/descr
@@ -1,0 +1,5 @@
+OS X CoreFoundation bindings
+
+String, Array, Index, RunLoop (and Observer), and TimeInterval are
+bound. Additionally, an osx-cf.lwt subpackage provides lwt+RunLoop
+integration.

--- a/packages/osx-cf/osx-cf.0.1.1/opam
+++ b/packages/osx-cf/osx-cf.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Thomas Gazagnaire"]
+homepage: "https://github.com/dsheets/ocaml-osx-cf"
+bug-reports: "https://github.com/dsheets/ocaml-osx-cf/issues"
+license: "ISC"
+doc: "https://dsheets.github.io/ocaml-osx-cf/"
+dev-repo: "https://github.com/dsheets/ocaml-osx-cf.git"
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--tests"
+  "false"
+  "--pinned"
+  pinned
+  "--with-lwt"
+  lwt:installed
+]
+build-test: [
+  [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--tests"
+    "true"
+    "--pinned"
+    pinned
+    "--with-lwt"
+    lwt:installed
+  ]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "topkg" {build & >= "0.7.2"}
+  "alcotest" {test}
+  "base-bytes"
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+]
+depopts: ["lwt" "base-threads"]
+available: [os = "darwin"]

--- a/packages/osx-cf/osx-cf.0.1.1/url
+++ b/packages/osx-cf/osx-cf.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-cf/archive/0.1.1.tar.gz"
+checksum: "7232aa423d252281f102a30f77cf66f4"


### PR DESCRIPTION
OS X CoreFoundation bindings

String, Array, Index, RunLoop (and Observer), and TimeInterval are
bound. Additionally, an osx-cf.lwt subpackage provides lwt+RunLoop
integration.


---
* Homepage: https://github.com/dsheets/ocaml-osx-cf
* Source repo: https://github.com/dsheets/ocaml-osx-cf.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-cf/issues

---

Pull-request generated by opam-publish v0.3.1