### PR TITLE
osx-fsevents.0.1.2 - via opam-publish

### DIFF
--- a/packages/osx-fsevents/osx-fsevents.0.1.2/descr
+++ b/packages/osx-fsevents/osx-fsevents.0.1.2/descr
@@ -1,0 +1,3 @@
+OS X FSevents bindings
+
+osx-fsevents includes event stream resumption and an optional lwt sublibrary.

--- a/packages/osx-fsevents/osx-fsevents.0.1.2/opam
+++ b/packages/osx-fsevents/osx-fsevents.0.1.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Thomas Gazagnaire"]
+homepage: "https://github.com/dsheets/ocaml-osx-fsevents"
+bug-reports: "https://github.com/dsheets/ocaml-osx-fsevents/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/ocaml-osx-fsevents.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "alcotest" {test}
+  "ctypes" {>= "0.4.0"}
+  "osx-cf"
+  "cmdliner"
+]
+depopts: "lwt"
+available: [os = "darwin"]

--- a/packages/osx-fsevents/osx-fsevents.0.1.2/url
+++ b/packages/osx-fsevents/osx-fsevents.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-fsevents/archive/0.1.2.tar.gz"
+checksum: "6d30870cede56577448baf643b1974ca"


### PR DESCRIPTION
OS X FSevents bindings

osx-fsevents includes event stream resumption and an optional lwt sublibrary.


---
* Homepage: https://github.com/dsheets/ocaml-osx-fsevents
* Source repo: https://github.com/dsheets/ocaml-osx-fsevents.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-fsevents/issues

---

Pull-request generated by opam-publish v0.3.1