### PR TITLE
jhupllib.0.1 - via opam-publish

### DIFF
--- a/packages/jhupllib/jhupllib.0.1/descr
+++ b/packages/jhupllib/jhupllib.0.1/descr
@@ -1,0 +1,3 @@
+A library of tools and utilities for JHU PL lab projects.
+A library of tools and utilities for JHU PL lab projects.
+

--- a/packages/jhupllib/jhupllib.0.1/opam
+++ b/packages/jhupllib/jhupllib.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+homepage: "http://www.big-bang-lang.org/"
+bug-reports: "https://github.com/JHU-PL-Lab/jhu-pl-lib/issues"
+license: "Apache"
+dev-repo: "https://github.com/JHU-PL-Lab/jhu-pl-lib.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocaml" "%{etc}%/jhupllib/_oasis_remove_.ml" "%{etc}%/jhupllib"]
+depends: [
+  "base-threads"
+  "batteries"
+  "monadlib"
+  "oasis" {build & >= "0.4"}
+  "ocaml-monadic"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+  "ppx_deriving"
+  "yojson"
+]

--- a/packages/jhupllib/jhupllib.0.1/url
+++ b/packages/jhupllib/jhupllib.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/JHU-PL-Lab/jhu-pl-lib/archive/da46a9e849d8d8f627e59025726d90e64268c9f1.zip"
+checksum: "e8284912f1eaadd88c5327103893370d"


### PR DESCRIPTION
A library of tools and utilities for JHU PL lab projects.
A library of tools and utilities for JHU PL lab projects.



---
* Homepage: http://www.big-bang-lang.org/
* Source repo: https://github.com/JHU-PL-Lab/jhu-pl-lib.git
* Bug tracker: https://github.com/JHU-PL-Lab/jhu-pl-lib/issues

---

Pull-request generated by opam-publish v0.3.1