### PR TITLE
webbrowser.0.6.0 - via opam-publish

### DIFF
--- a/packages/webbrowser/webbrowser.0.6.0/descr
+++ b/packages/webbrowser/webbrowser.0.6.0/descr
@@ -1,0 +1,12 @@
+Open and reload URIs in browsers from OCaml
+
+Webbrowser is a library to open and reload URIs in web browsers from
+OCaml.
+
+Webbrowser depends on [bos][bos]. The optional command line support
+provided by the Webbrowser_cli library depends on [cmdliner][cmdliner].
+
+Webbrowser is distributed under the ISC license. 
+
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner

--- a/packages/webbrowser/webbrowser.0.6.0/opam
+++ b/packages/webbrowser/webbrowser.0.6.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/webbrowser"
+doc: "http://erratique.ch/software/webbrowser/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/webbrowser.git"
+bug-reports: "https://github.com/dbuenzli/webbrowser/issues"
+tags: [ "web" "http" "uri" "browser" "cli" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "rresult"
+  "astring"
+  "bos"
+ ]
+depopts: [
+   "cmdliner"
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+ ]

--- a/packages/webbrowser/webbrowser.0.6.0/url
+++ b/packages/webbrowser/webbrowser.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/webbrowser/releases/webbrowser-0.6.0.tbz"
+checksum: "13b1ac970d60ff99464752411a67df78"


### PR DESCRIPTION
Open and reload URIs in browsers from OCaml

Webbrowser is a library to open and reload URIs in web browsers from
OCaml.

Webbrowser depends on [bos][bos]. The optional command line support
provided by the Webbrowser_cli library depends on [cmdliner][cmdliner].

Webbrowser is distributed under the ISC license. 

[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner


---
* Homepage: http://erratique.ch/software/webbrowser
* Source repo: http://erratique.ch/repos/webbrowser.git
* Bug tracker: https://github.com/dbuenzli/webbrowser/issues

---


---
v0.6.0 2016-08-08 Zagreb
-------------------------

First release. 
Pull-request generated by opam-publish v0.3.2