### PR TITLE
pds-reachability.0.2 - via opam-publish

### DIFF
--- a/packages/pds-reachability/pds-reachability.0.2/descr
+++ b/packages/pds-reachability/pds-reachability.0.2/descr
@@ -1,0 +1,4 @@
+A PDS reachability query library.
+This library performs efficient reachability queries on abstractly
+specified push-down systems.
+

--- a/packages/pds-reachability/pds-reachability.0.2/opam
+++ b/packages/pds-reachability/pds-reachability.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+homepage: "https://github.com/JHU-PL-Lab/pds-reachability"
+bug-reports: "https://github.com/JHU-PL-Lab/pds-reachability/issues"
+license: "Apache"
+dev-repo: "https://github.com/JHU-PL-Lab/pds-reachability.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: [
+  "ocaml"
+  "%{etc}%/pds-reachability/_oasis_remove_.ml"
+  "%{etc}%/pds-reachability"
+]
+depends: [
+  "base-threads"
+  "batteries"
+  "jhupllib"
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+  "ppx_deriving" {>= "3.2"}
+  "ppx_deriving_yojson"
+  "yojson"
+]

--- a/packages/pds-reachability/pds-reachability.0.2/url
+++ b/packages/pds-reachability/pds-reachability.0.2/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/JHU-PL-Lab/pds-reachability/archive/66ee9322ef9c4a474e607831cf9c6fea7c586811.zip"
+checksum: "66d2fb3dbbcd2fca866cc7ecaecc7a0b"


### PR DESCRIPTION
A PDS reachability query library.
This library performs efficient reachability queries on abstractly
specified push-down systems.



---
* Homepage: https://github.com/JHU-PL-Lab/pds-reachability
* Source repo: https://github.com/JHU-PL-Lab/pds-reachability.git
* Bug tracker: https://github.com/JHU-PL-Lab/pds-reachability/issues

---

Pull-request generated by opam-publish v0.3.1