### PR TITLE
unix-dirent.0.3.4 - via opam-publish

### DIFF
--- a/packages/unix-dirent/unix-dirent.0.3.4/descr
+++ b/packages/unix-dirent/unix-dirent.0.3.4/descr
@@ -1,0 +1,13 @@
+ocaml-unix-dirent provides access to the features exposed in dirent.h
+in a way that is not tied to the implementation on the host system.
+
+The Dirent module provides functions for translating between the file kinds
+accessible through dirent.h and their values on particular systems.
+
+The Dirent_unix provides bindings to functions that use the types in Dirent
+along with a representation of the host system.  The bindings support a more
+comprehensive range of file kinds than the corresponding functions in the
+standard OCaml Unix module.  The Dirent_unix_lwt module exports non-blocking
+versions of the functions in Dirent_unix based on the Lwt cooperative
+threading library.
+

--- a/packages/unix-dirent/unix-dirent.0.3.4/opam
+++ b/packages/unix-dirent/unix-dirent.0.3.4/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Jeremy Yallop"]
+homepage: "https://github.com/dsheets/ocaml-unix-dirent"
+bug-reports: "https://github.com/dsheets/ocaml-unix-dirent/issues"
+license: "ISC"
+tags: ["unix" "posix" "dirent" "syscall" "readdir"]
+dev-repo: "https://github.com/dsheets/ocaml-unix-dirent.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "base-bytes"
+]
+depopts: [
+  "base-unix" "unix-type-representations" "ctypes" "unix-errno" "lwt"
+]
+conflicts: [
+  "ctypes" {< "0.6.0"}
+  "unix-errno" {< "0.5.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/unix-dirent/unix-dirent.0.3.4/url
+++ b/packages/unix-dirent/unix-dirent.0.3.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-dirent/archive/0.3.4.tar.gz"
+checksum: "3d5b1a2b996acdcd8bae82365dee025b"


### PR DESCRIPTION
ocaml-unix-dirent provides access to the features exposed in dirent.h
in a way that is not tied to the implementation on the host system.

The Dirent module provides functions for translating between the file kinds
accessible through dirent.h and their values on particular systems.

The Dirent_unix provides bindings to functions that use the types in Dirent
along with a representation of the host system.  The bindings support a more
comprehensive range of file kinds than the corresponding functions in the
standard OCaml Unix module.  The Dirent_unix_lwt module exports non-blocking
versions of the functions in Dirent_unix based on the Lwt cooperative
threading library.



---
* Homepage: https://github.com/dsheets/ocaml-unix-dirent
* Source repo: https://github.com/dsheets/ocaml-unix-dirent.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-dirent/issues

---

Pull-request generated by opam-publish v0.3.1