### PR TITLE
alsa: add bound on ocaml version

### DIFF
--- a/packages/alsa/alsa.0.2.1/opam
+++ b/packages/alsa/alsa.0.2.1/opam
@@ -12,3 +12,4 @@ depexts: [
   [["ubuntu"] ["libasound2-dev"]]
 ]
 install: [make "install"]
+available: [ ocaml-version < "4.04.0" ]

--- a/packages/alsa/alsa.0.2.2/opam
+++ b/packages/alsa/alsa.0.2.2/opam
@@ -17,3 +17,4 @@ depexts: [
 ]
 bug-reports: "https://github.com/savonet/ocaml-alsa/issues"
 dev-repo: "https://github.com/savonet/ocaml-alsa.git"
+available: [ ocaml-version < "4.04.0" ]


### PR DESCRIPTION
Alsa doesn't compile on 4.04 because of the added check for wrong usage of `CAMLparam*`. I've sent a PR upstream (https://github.com/savonet/ocaml-alsa/pull/1).
