### PR TITLE
Disable tests for inotify 2.3

### DIFF
--- a/packages/inotify/inotify.2.3/opam
+++ b/packages/inotify/inotify.2.3/opam
@@ -10,12 +10,6 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-build-test: [
-  ["ocaml" "setup.ml" "-configure"
-   "--%{lwt:enable}%-lwt" "--prefix" prefix "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 install: [
   ["ocaml" "setup.ml" "-install"]
 ]


### PR DESCRIPTION
These are broken on 4.02: https://travis-ci.org/docker/datakit/jobs/151249936#L1259

Fixed upstream by https://github.com/whitequark/ocaml-inotify/commit/716c8002cc1652f58eb0c400ae92e04003cba8c9

/cc @whitequark 