### PR TITLE
aperf.0.1.2 - via opam-publish

### DIFF
--- a/packages/aperf/aperf.0.1.2/descr
+++ b/packages/aperf/aperf.0.1.2/descr
@@ -1,0 +1,1 @@
+OCaml tools for loop perforation

--- a/packages/aperf/aperf.0.1.2/opam
+++ b/packages/aperf/aperf.0.1.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Philip Dexter <philip.dexter@gmail.com>"
+authors: "Philip Dexter <philip.dexter@gmail.com>"
+homepage: "http://github.com/philipdexter/aperf"
+bug-reports: "http://github.com/philipdexter/aperf/issues"
+dev-repo: "http://github.com/philipdexter/aperf.git"
+available: [ ocaml-version >= "4.03" ]
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cmdliner"
+  "ppx_tools"
+]

--- a/packages/aperf/aperf.0.1.2/url
+++ b/packages/aperf/aperf.0.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/philipdexter/aperf/archive/v0.1.2.tar.gz"
+checksum: "68f60133dd5d805efd43f1518c03a601"


### PR DESCRIPTION
OCaml tools for loop perforation


---
* Homepage: http://github.com/philipdexter/aperf
* Source repo: http://github.com/philipdexter/aperf.git
* Bug tracker: http://github.com/philipdexter/aperf/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.1.2 ____-
-------------------

- Expose aperf as a library
- Offer handles into approximation for array and list iter
- Run the program 10 times and take the average to get the running time
Pull-request generated by opam-publish v0.3.2