### PR TITLE
angstrom: add missing dependency on ocplib-endian and bound on lwt

### DIFF
--- a/packages/angstrom/angstrom.0.1.0/opam
+++ b/packages/angstrom/angstrom.0.1.0/opam
@@ -26,10 +26,12 @@ depends: [
   "cstruct" {>= "0.6.0"}
   "ocamlfind" {build}
   "result"
+  "ocplib-endian" {>= "0.6"}
 ]
 depopts: [
   "async"
   "base-unix"
   "lwt"
 ]
+conflicts: [ "lwt" {< "2.4.7"} ]
 available: [ ocaml-version >= "4.00.0" ]

--- a/packages/angstrom/angstrom.0.1.1/opam
+++ b/packages/angstrom/angstrom.0.1.1/opam
@@ -26,10 +26,12 @@ depends: [
   "cstruct" {>= "0.6.0"}
   "ocamlfind" {build}
   "result"
+  "ocplib-endian" {>= "0.6"}
 ]
 depopts: [
   "async"
   "base-unix"
   "lwt"
 ]
+conflicts: [ "lwt" {< "2.4.7"} ]
 available: [ ocaml-version >= "4.00.0" ]


### PR DESCRIPTION
Does not compile with older `ocplib-endian` and `lwt`.
