### PR TITLE
ppx_optcomp does not compile on 4.04

### DIFF
--- a/packages/ppx_optcomp/ppx_optcomp.113.33.00+4.03/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.00+4.03/opam
@@ -15,4 +15,4 @@ depends: [
   "ppx_core"   {>= "113.33.00+4.03" & < "113.34.00+4.03"}
   "ppx_tools"  {>= "0.99.3"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.04.0" ]


### PR DESCRIPTION
because of the SHARP -> HASH rewrite