### PR TITLE
ocp-build: add bound on OCaml version

### DIFF
--- a/packages/ocp-build/ocp-build.1.99.14-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.14-beta/opam
@@ -34,4 +34,4 @@ depends: [
                   repository, we need it... *)
   ]
 conflicts: [ "typerex"  {< "1.99.7"} ]
-available: [ocaml-version >= "3.12.0"]
+available: [ocaml-version >= "3.12.0" & ocaml-version < "4.04.0"]

--- a/packages/ocp-build/ocp-build.1.99.16-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.16-beta/opam
@@ -33,4 +33,4 @@ depends: [
                   repository, we need it... *)
   ]
 conflicts: [ "typerex"  {< "1.99.7"} ]
-available: [ocaml-version >= "3.12.0"]
+available: [ocaml-version >= "3.12.0" & ocaml-version < "4.04.0"]


### PR DESCRIPTION
Note: version 1.99.17 of ocp-build already works with OCaml 4.04.0