### PR TITLE
cconv: adjust conflicts field

### DIFF
--- a/packages/cconv/cconv.0.3.1/opam
+++ b/packages/cconv/cconv.0.3.1/opam
@@ -38,6 +38,7 @@ available: [
 ]
 conflicts: [
   "ppx_deriving" { < "2.0" }
+  "ppx_deriving" { >= "3.3" }
 ]
 dev-repo: "https://github.com/c-cube/cconv.git"
 bug-reports: "https://github.com/c-cube/cconv/issues/"

--- a/packages/cconv/cconv.0.3/opam
+++ b/packages/cconv/cconv.0.3/opam
@@ -38,6 +38,7 @@ available: [
 ]
 conflicts: [
   "ppx_deriving" { < "2.0" }
+  "ppx_deriving" { >= "3.3" }
 ]
 dev-repo: "https://github.com/c-cube/cconv.git"
 bug-reports: "https://github.com/c-cube/cconv/issues/"


### PR DESCRIPTION
When `ppx_deriving` is present, `cconv` depends on AST data structures that have changed in 4.03.0, so `cconv` 0.3 and 0.3.1 are not compatible with the newer `ppx_deriving` (and OCaml) versions.
