### PR TITLE
bitstring: fix -c -o compilation command line

### DIFF
--- a/packages/bitstring/bitstring.2.0.4/files/fix_404.patch
+++ b/packages/bitstring/bitstring.2.0.4/files/fix_404.patch
@@ -1,0 +1,10 @@
+--- ocaml-bitstring-2.0.4.orig/Makefile.in	2016-08-12 14:47:34.000000000 +0200
++++ ocaml-bitstring-2.0.4/Makefile.in	2016-08-12 14:50:51.000000000 +0200
+@@ -110,7 +110,7 @@
+ 	  -I +camlp4 -pp camlp4of -c $<
+ 
+ pa_bitstring.cmo: pa_bitstring.ml bitstring.cma bitstring_persistent.cma
+-	$(OCAMLFIND) ocamlc bitstring.cma -I +camlp4 dynlink.cma camlp4lib.cma \
++	$(OCAMLFIND) ocamlc -I +camlp4 \
+ 	  -pp camlp4of -c $< -o $@
+ 

--- a/packages/bitstring/bitstring.2.0.4/opam
+++ b/packages/bitstring/bitstring.2.0.4/opam
@@ -10,7 +10,10 @@ build: [
   [make "srcdir=./"]
 ]
 build-test: [[make "check"]]
-patches: ["fix_402.patch" {ocaml-version >= "4.02"}]
+patches: [
+  "fix_402.patch" {ocaml-version >= "4.02"}
+  "fix_404.patch"
+]
 remove: [["ocamlfind" "remove" "bitstring"]]
 depends: ["ocamlfind" {build} "camlp4" {build}]
 depexts: [


### PR DESCRIPTION
I'm making a patch for this one because upstream development appears to be stopped.
