### PR TITLE
flowcaml: add bound on OCaml version

### DIFF
--- a/packages/flowcaml/flowcaml.1.07/opam
+++ b/packages/flowcaml/flowcaml.1.07/opam
@@ -1,5 +1,7 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "prashanth.mundkur@gmail.com"
+authors: "Vincent.Simonet@vtst.net"
+homepage: "http://www.normalesup.org/~simonet/soft/flowcaml/"
 build: [
   [
     "sh"

--- a/packages/flowcaml/flowcaml.1.07/opam
+++ b/packages/flowcaml/flowcaml.1.07/opam
@@ -13,3 +13,5 @@ remove: [
   ["sh" "-c" "cd src-flowcaml && %{make}% uninstall"]
 ]
 install: ["sh" "-c" "cd src-flowcaml && %{make}% install"]
+
+available: [ ocaml-version < "4.04.0" ]


### PR DESCRIPTION
flowcaml doesn't work with OCaml 4.04 because it does dirty things with external declarations and stdlib modules.

/cc @vtst @pmundkur 
