### PR TITLE
solvuu_build: add bound on OCaml version and fix checksum

### DIFF
--- a/packages/solvuu_build/solvuu_build.0.0.1/opam
+++ b/packages/solvuu_build/solvuu_build.0.0.1/opam
@@ -25,5 +25,5 @@ depends: [
 ]
 
 available: [
-  ocaml-version >= "4.02.0"
+  ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"
 ]

--- a/packages/solvuu_build/solvuu_build.0.0.1/url
+++ b/packages/solvuu_build/solvuu_build.0.0.1/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/solvuu/solvuu_build/archive/v0.0.1.tar.gz"
-checksum: "f5388b83c6d7277305bb9a28a790bfb2"
+checksum: "c00af9b70675fb3ea553c798a2a73d69"

--- a/packages/solvuu_build/solvuu_build.0.0.2/opam
+++ b/packages/solvuu_build/solvuu_build.0.0.2/opam
@@ -13,4 +13,4 @@ build: [
 install: [make "_build/META"]
 remove: []
 depends: ["ocamlfind" "ocamlbuild" "ocamlgraph"]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"]

--- a/packages/solvuu_build/solvuu_build.0.0.2/url
+++ b/packages/solvuu_build/solvuu_build.0.0.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/solvuu/solvuu_build/archive/v0.0.2.tar.gz"
-checksum: "16c2a467cf307e707e99abe4b0d5628f"
+checksum: "0bd8283f14825c4a078e76c0e595535f"


### PR DESCRIPTION
Note: the problem that prevents `solvuu_build` from compiling with 4.03 and 4.04 is already fixed upstream.
