### PR TITLE
uuidm.0.9.6 - via opam-publish

### DIFF
--- a/packages/uuidm/uuidm.0.9.6/descr
+++ b/packages/uuidm/uuidm.0.9.6/descr
@@ -1,0 +1,9 @@
+Universally unique identifiers (UUIDs) for OCaml
+
+Uuidm is an OCaml module implementing 128 bits universally unique
+identifiers version 3, 5 (named based with MD5, SHA-1 hashing) and 4
+(random based) according to [RFC 4122][rfc4122].
+
+Uuidm has no dependency and is distributed under the ISC license.
+
+[rfc4122]: http://tools.ietf.org/html/rfc4122

--- a/packages/uuidm/uuidm.0.9.6/opam
+++ b/packages/uuidm/uuidm.0.9.6/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uuidm"
+doc: "http://erratique.ch/software/uuidm/doc/Uuidm"
+dev-repo: "http://erratique.ch/repos/uuidm.git"
+bug-reports: "https://github.com/dbuenzli/uuidm/issues"
+tags: [ "uuid" "codec" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bytes" ]
+depopts: [
+  "cmdliner"
+]
+build:
+[  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+           "--with-cmdliner" "%{cmdliner:installed}%" ]

--- a/packages/uuidm/uuidm.0.9.6/url
+++ b/packages/uuidm/uuidm.0.9.6/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uuidm/releases/uuidm-0.9.6.tbz"
+checksum: "98ef30cd99ad4e4f7b4c33affa19465b"


### PR DESCRIPTION
Universally unique identifiers (UUIDs) for OCaml

Uuidm is an OCaml module implementing 128 bits universally unique
identifiers version 3, 5 (named based with MD5, SHA-1 hashing) and 4
(random based) according to [RFC 4122][rfc4122].

Uuidm has no dependency and is distributed under the ISC license.

[rfc4122]: http://tools.ietf.org/html/rfc4122


---
* Homepage: http://erratique.ch/software/uuidm
* Source repo: http://erratique.ch/repos/uuidm.git
* Bug tracker: https://github.com/dbuenzli/uuidm/issues

---


---
v0.9.6 2016-08-12 Zagreb
------------------------

- Safe-string support. Thanks to Josh Allmann for the help.
- Deprecate `Uuidm.create` in favor of `Uuidm.v`.
- Deprecate `Uuidm.print` in favor of `Uuidm.pp_string`
- Add `Uuidm.pp`.
- Relicensed from BSD3 to ISC.
- Build depend on topkg.
- `uuidtrip` uses `Cmdliner` which becomes an optional dependency of
  the package. The command line interface is unchanged except for long
  options which have to be written with a double dash. Binary output
  no longer adds an ending newline.
Pull-request generated by opam-publish v0.3.2