### PR TITLE
ppx_deriving.1.2 - via opam-publish

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.1.2/descr
+++ b/packages/ppx_deriving/ppx_deriving.1.2/descr
@@ -1,0 +1,3 @@
+A sample syntax extension that uses OCaml's new extension points API.
+
+A sample syntax extension that uses OCaml's new extension points API.

--- a/packages/ppx_deriving/ppx_deriving.1.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "Public domain"
+homepage: "https://github.com/whitequark/ppx_getenv"
+bug-reports: "https://github.com/whitequark/ppx_getenv/issues"
+dev-repo: "git://github.com/whitequark/ppx_getenv.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_getenv.byte" "--"
+]
+depends: [
+  "cppo"         {build}
+  "ppx_tools"    {>= "0.99.1"}
+  "ounit"        {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_deriving/ppx_deriving.1.2/url
+++ b/packages/ppx_deriving/ppx_deriving.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_getenv/archive/v1.2.tar.gz"
+checksum: "a34bb7949c7b703e4d1ee49b016cb541"


### PR DESCRIPTION
A sample syntax extension that uses OCaml's new extension points API.

A sample syntax extension that uses OCaml's new extension points API.


---
* Homepage: https://github.com/whitequark/ppx_getenv
* Source repo: git://github.com/whitequark/ppx_getenv.git
* Bug tracker: https://github.com/whitequark/ppx_getenv/issues

---

Pull-request generated by opam-publish v0.3.2