### PR TITLE
irmin-watcher.0.1.3 - via opam-publish

### DIFF
--- a/packages/irmin-watcher/irmin-watcher.0.1.3/descr
+++ b/packages/irmin-watcher/irmin-watcher.0.1.3/descr
@@ -1,0 +1,9 @@
+Portable Irmin watch backends using FSevents or Inotify
+
+
+irmin-watcher implements [Irmin's watch hooks][watch] for various OS,
+using FSevents in OSX and Inotify on Linux.
+
+irmin-watcher is distributed under the ISC license.
+
+[watch]: http://mirage.github.io/irmin/Irmin.Private.Watch.html

--- a/packages/irmin-watcher/irmin-watcher.0.1.3/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.1.3/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage: "https://github.com/samoht/irmin-watcher"
+doc: "https://samoht.github.io/irmin-watcher/"
+license: "ISC"
+dev-repo: "https://github.com/samoht/irmin-watcher.git"
+bug-reports: "https://github.com/samoht/irmin-watcher/issues"
+available: [ ocaml-version >= "4.02.0" & opam-version >= "1.2.2" ]
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "cppo"       {build}
+  "alcotest"   {test}
+  "lwt" "logs" "fmt" "astring"
+]
+depopts: ["inotify" "osx-fsevents"]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--tests" "false"
+    "--pinned" pinned
+    "--with-fsevents" osx-fsevents:installed
+    "--with-inotify" inotify:installed
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
+     "--pinned" pinned
+     "--with-fsevents" osx-fsevents:installed
+     "--with-inotify" inotify:installed]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]

--- a/packages/irmin-watcher/irmin-watcher.0.1.3/url
+++ b/packages/irmin-watcher/irmin-watcher.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/irmin-watcher/releases/download/0.1.3/irmin-watcher-0.1.3.tbz"
+checksum: "ecd8c4e531c27b79d39d41163f3305a7"


### PR DESCRIPTION
Portable Irmin watch backends using FSevents or Inotify


irmin-watcher implements [Irmin's watch hooks][watch] for various OS,
using FSevents in OSX and Inotify on Linux.

irmin-watcher is distributed under the ISC license.

[watch]: http://mirage.github.io/irmin/Irmin.Private.Watch.html

---
* Homepage: https://github.com/samoht/irmin-watcher
* Source repo: https://github.com/samoht/irmin-watcher.git
* Bug tracker: https://github.com/samoht/irmin-watcher/issues

---


---
### 0.1.3

- Fix `uname` runtime checks on Windows
Pull-request generated by opam-publish v0.3.2