### PR TITLE
merlin-extend.0.3 - via opam-publish

### DIFF
--- a/packages/merlin-extend/merlin-extend.0.3/descr
+++ b/packages/merlin-extend/merlin-extend.0.3/descr
@@ -1,0 +1,4 @@
+A protocol to provide custom frontend to Merlin
+
+This protocol allows to replace the OCaml frontend of Merlin.
+It extends what used to be done with the `-pp' flag to handle a few more cases.

--- a/packages/merlin-extend/merlin-extend.0.3/opam
+++ b/packages/merlin-extend/merlin-extend.0.3/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/merlin-extend"
+bug-reports: "https://github.com/let-def/merlin-extend"
+license: "MIT"
+dev-repo: "https://github.com/let-def/merlin-extend.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "merlin_extend"]
+depends: [
+  "ocamlfind" {build}
+  "cppo" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/merlin-extend/merlin-extend.0.3/url
+++ b/packages/merlin-extend/merlin-extend.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/merlin-extend/archive/v0.3.tar.gz"
+checksum: "9c6dfd4f53328f02f12fcc265f4e2dda"


### PR DESCRIPTION
A protocol to provide custom frontend to Merlin

This protocol allows to replace the OCaml frontend of Merlin.
It extends what used to be done with the `-pp' flag to handle a few more cases.


---
* Homepage: https://github.com/let-def/merlin-extend
* Source repo: https://github.com/let-def/merlin-extend.git
* Bug tracker: https://github.com/let-def/merlin-extend

---

Pull-request generated by opam-publish v0.3.2