### PR TITLE
cstruct: add upper bound on OCaml version

### DIFF
--- a/packages/cstruct/cstruct.2.0.0/opam
+++ b/packages/cstruct/cstruct.2.0.0/opam
@@ -50,7 +50,7 @@ depopts: [
   "async"
   "lwt"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
 depexts: [
   [ ["debian"] ["time"] ]
   [ ["ubuntu"] ["time"] ]

--- a/packages/cstruct/cstruct.2.1.0/opam
+++ b/packages/cstruct/cstruct.2.1.0/opam
@@ -50,7 +50,7 @@ depopts: [
   "async"
   "lwt"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
 depexts: [
   [ ["debian"] ["time"] ]
   [ ["ubuntu"] ["time"] ]

--- a/packages/cstruct/cstruct.2.2.0/opam
+++ b/packages/cstruct/cstruct.2.2.0/opam
@@ -50,7 +50,7 @@ depopts: [
   "async"
   "lwt"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
 depexts: [
   [ ["debian"] ["time"] ]
   [ ["ubuntu"] ["time"] ]


### PR DESCRIPTION
When `ppx_tools` is available, `cstruct` provides a ppx tool, `ppx_cstruct`. On 4.04.0, it doesn't work. It builds, and it runs without error, but it fails to produce an output file. This breaks, for example, `arp.0.1.1`.

I guess `cstruct` has to be updated for 4.04.

/cc @avsm