### PR TITLE
deriving-ocsigen: add bound on OCaml version

### DIFF
--- a/packages/deriving-ocsigen/deriving-ocsigen.0.3c/opam
+++ b/packages/deriving-ocsigen/deriving-ocsigen.0.3c/opam
@@ -16,4 +16,4 @@ conflicts: [
   "type_conv" {>= "108.07.00"}
 ]
 install: [make "install"]
-available: [ocaml < "4.03.0"]
+available: [ocaml-version < "4.03.0"]

--- a/packages/deriving-ocsigen/deriving-ocsigen.0.5/opam
+++ b/packages/deriving-ocsigen/deriving-ocsigen.0.5/opam
@@ -20,4 +20,4 @@ conflicts: [
   "type_conv" {< "108.07.00"}
 ]
 install: [make "install"]
-available: [ocaml < "4.03.0"]
+available: [ocaml-version < "4.03.0"]


### PR DESCRIPTION
`deriving-ocsigen` does not work on OCaml >= 4.03.0, at least because of the addition of the optional `nonrec` keyword in type definitions.
