### PR TITLE
hardcaml-llvmsim: fix deps

### DIFF
--- a/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.2/opam
+++ b/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.2/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/ujamjar/hardcaml-llvmsim"
+authors: "MicroJamJar Ltd"
 build: [make "all"]
 remove: [
   [make "uninstall"]

--- a/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.2/opam
+++ b/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.2/opam
@@ -7,8 +7,9 @@ remove: [
 ]
 depends: [
   "hardcaml" {>= "1.1.1"}
-  "llvm" {>= "3.4"}
+  "llvm" {>= "3.4" & < "3.6"}
   "ocamlbuild" {build}
+  "ctypes-foreign"
 ]
 depexts: [
   [["osx" "homebrew"] ["llvm"]]


### PR DESCRIPTION
Add a missing dep on `ctypes-foreign` and a bound on `llvm` version.
