### PR TITLE
hdf5: add bound on OCaml version

### DIFF
--- a/packages/hdf5/hdf5.0.1.1/opam
+++ b/packages/hdf5/hdf5.0.1.1/opam
@@ -21,4 +21,4 @@ depexts: [
   [["ubuntu"] ["libhdf5-serial-dev"]]
   [["osx" "homebrew"] ["homebrew/science/hdf5"]]
 ]
-available: [ocaml-version >= "4.02"]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.03.0"]

--- a/packages/hdf5/hdf5.0.1/opam
+++ b/packages/hdf5/hdf5.0.1/opam
@@ -19,4 +19,4 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02" ]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.03.0" ]


### PR DESCRIPTION
`hdf5` doesn't work because of AST changes in 4.03.0. It will have to be adapted to the new AST.

/cc @vbrankov (hi Vlad!)
