### PR TITLE
tophide 1.0.4, for ocaml 4.03

### DIFF
--- a/packages/tophide/tophide.1.0.4/descr
+++ b/packages/tophide/tophide.1.0.4/descr
@@ -1,0 +1,3 @@
+Hides toplevel values whose name starts with an underscore
+OCaml toplevel printer for syntax extensions that define identifiers
+that should remain hidden.

--- a/packages/tophide/tophide.1.0.4/findlib
+++ b/packages/tophide/tophide.1.0.4/findlib
@@ -1,0 +1,1 @@
+tophide

--- a/packages/tophide/tophide.1.0.4/opam
+++ b/packages/tophide/tophide.1.0.4/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "Martin Jambon"
+homepage: "https://github.com/mjambon/tophide"
+bug-reports: "https://github.com/mjambon/tophide/issues"
+build: make
+remove: [["ocamlfind" "remove" "tophide"]]
+depends: ["ocamlfind"]
+dev-repo: "git://github.com/mjambon/tophide"
+available: ocaml-version >= "4.03"
+install: [make "install"]

--- a/packages/tophide/tophide.1.0.4/url
+++ b/packages/tophide/tophide.1.0.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mjambon/tophide/archive/v1.0.4.tar.gz"
+checksum: "7e1cbeed68d4df62475435f7d15939f0"


### PR DESCRIPTION
@damiendoligez : I added the missing line `bug-reports` that opam lint was complaining about in your pull request https://github.com/ocaml/opam-repository/pull/7221:

```
bug-reports: "https://github.com/mjambon/tophide/issues"
```