### PR TITLE
menhir: mark proper ocamlbuild dependency

### DIFF
--- a/packages/menhir/menhir.20130911/opam
+++ b/packages/menhir/menhir.20130911/opam
@@ -3,7 +3,7 @@ maintainer: "contact@ocamlpro.com"
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 install: [
   make

--- a/packages/menhir/menhir.20140422/opam
+++ b/packages/menhir/menhir.20140422/opam
@@ -17,7 +17,7 @@ build: [
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 install: [
   make
@@ -27,4 +27,3 @@ install: [
   "libdir=%{lib}%/menhir"
   "mandir=%{man}%/man1"
 ]
-available: [ocaml-version < "4.03.0"]

--- a/packages/menhir/menhir.20141215/opam
+++ b/packages/menhir/menhir.20141215/opam
@@ -10,7 +10,7 @@ build: [
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]
 patches: [

--- a/packages/menhir/menhir.20150914/opam
+++ b/packages/menhir/menhir.20150914/opam
@@ -10,7 +10,7 @@ build: [
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]
 patches: [

--- a/packages/menhir/menhir.20150921/opam
+++ b/packages/menhir/menhir.20150921/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20151005/opam
+++ b/packages/menhir/menhir.20151005/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20151012/opam
+++ b/packages/menhir/menhir.20151012/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20151023/opam
+++ b/packages/menhir/menhir.20151023/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20151026/opam
+++ b/packages/menhir/menhir.20151026/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20151030/opam
+++ b/packages/menhir/menhir.20151030/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20151103/opam
+++ b/packages/menhir/menhir.20151103/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20151112/opam
+++ b/packages/menhir/menhir.20151112/opam
@@ -18,6 +18,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & < "0.9.1"}
 ]
 available: [ ocaml-version >= "4.02" ]


### PR DESCRIPTION
Older versions of menhir have hygiene issue that were only revealed by
a feature change in ocamlbuild 0.9.1. It is unnecessary to require
(ocaml < 4.03), just to use ocamlbuild 0.9.0 -- available under 4.03
and above.