### PR TITLE
mirage-xen-ocaml: add bound on OCaml version

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
@@ -14,4 +14,4 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.01.0" & os = "linux"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.04.0" & os = "linux"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
@@ -14,4 +14,4 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.01.0" & os = "linux"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.04.0" & os = "linux"]


### PR DESCRIPTION
`mirage-xen-ocaml` does not work on 4.04 because of a change in `ocaml-src`: compiling `misc.c` now requires building `version.h` first.

/cc @avsm 