### PR TITLE
ocp-manager: add bounds on OCaml and ocp-build versions

### DIFF
--- a/packages/ocp-manager/ocp-manager.0.1.2/opam
+++ b/packages/ocp-manager/ocp-manager.0.1.2/opam
@@ -1,5 +1,7 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+authors: "OcamlPro"
+homepage: "http://www.typerex.org/ocp-manager.html"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocp-manager/ocp-manager.0.1.2/opam
+++ b/packages/ocp-manager/ocp-manager.0.1.2/opam
@@ -8,5 +8,6 @@ remove: [
   [ "rm" "-f" "%{prefix}%/ocp-manager" ]
   [ "rm" "-f" "%{prefix}%/man/man1/ocp-manager.1" ]
 ]
-depends: [ "ocp-build" {>= "1.99.6" } ]
+depends: [ "ocp-build" {>= "1.99.6" & < "1.99.17"} ]
 install: [make "install.opam"]
+available: [ocaml-version < "4.03.0"]

--- a/packages/ocp-manager/ocp-manager.0.1.3/opam
+++ b/packages/ocp-manager/ocp-manager.0.1.3/opam
@@ -1,5 +1,7 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+authors: "OcamlPro"
+homepage: "http://www.typerex.org/ocp-manager.html"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocp-manager/ocp-manager.0.1.3/opam
+++ b/packages/ocp-manager/ocp-manager.0.1.3/opam
@@ -8,5 +8,6 @@ remove: [
   [ "rm" "-f" "%{prefix}%/ocp-manager" ]
   [ "rm" "-f" "%{prefix}%/man/man1/ocp-manager.1" ]
 ]
-depends: [ "ocp-build" {>= "1.99.6" } ]
+depends: [ "ocp-build" {>= "1.99.6" & < "1.99.17" } ]
 install: [make "install.opam"]
+available: [ocaml-version < "4.03.0"]


### PR DESCRIPTION
`ocp-manager` does not build with the newest `ocp-build` because it doesn't export the `FileLines` module.

`ocp-manager` also doesn't work on OCaml >= 4.03 because it triggers warning 31 which, by some kind of magic, the build system turns into an error.

/cc @lefessan 
