### PR TITLE
socket-daemon.0.3.0 - via opam-publish

### DIFF
--- a/packages/socket-daemon/socket-daemon.0.3.0/descr
+++ b/packages/socket-daemon/socket-daemon.0.3.0/descr
@@ -1,0 +1,6 @@
+Create daemons listening to a socket for stop, restart, ..., orders
+
+Lwt-oriented library to make your server run as a daemon and
+listen to a socket file. Provides a module to create the command-line
+client which send commands (stop, restart, ...) to the server through
+the socket.

--- a/packages/socket-daemon/socket-daemon.0.3.0/opam
+++ b/packages/socket-daemon/socket-daemon.0.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: ["Maxence Guesdon"]
+homepage: "http://github.com/zoggy/ocaml-socket-daemon"
+
+license: "GNU General Public License version 3"
+
+doc: ["http://github.com/zoggy/ocaml-socket-daemon"]
+dev-repo: "https://github.com/zoggy/ocaml-socket-daemon.git"
+bug-reports: "https://github.com/zoggy/ocaml-socket-daemon/issues"
+
+tags: ["socket" "daemon" "unix"]
+
+build: [
+  [make "all"]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [["ocamlfind" "remove" "socket-daemon"]]
+depends: [
+  "lwt" { >= "2.5" }
+  "ppx_deriving_yojson" { >= "3.0" }
+]
+
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/socket-daemon/socket-daemon.0.3.0/url
+++ b/packages/socket-daemon/socket-daemon.0.3.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/zoggy/ocaml-socket-daemon/archive/release-0.3.0.tar.gz"
+checksum: "b8b982c83dd18f4f2ac89bce00caab89"


### PR DESCRIPTION
Create daemons listening to a socket for stop, restart, ..., orders

Lwt-oriented library to make your server run as a daemon and
listen to a socket file. Provides a module to create the command-line
client which send commands (stop, restart, ...) to the server through
the socket.


---
* Homepage: http://github.com/zoggy/ocaml-socket-daemon
* Source repo: https://github.com/zoggy/ocaml-socket-daemon.git
* Bug tracker: https://github.com/zoggy/ocaml-socket-daemon/issues

---

Pull-request generated by opam-publish v0.3.2