### PR TITLE
sodium: fix ctypes version bound

### DIFF
--- a/packages/sodium/sodium.0.4.1/opam
+++ b/packages/sodium/sodium.0.4.1/opam
@@ -16,7 +16,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind"
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "ocamlbuild" {build}
 ]
 depexts: [

--- a/packages/sodium/sodium.0.5.0/opam
+++ b/packages/sodium/sodium.0.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind"
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.6.0"}
   "ocamlbuild" {build}
 ]
 depexts: [


### PR DESCRIPTION
opam-builder report:
  <http://opam.ocamlpro.com/builder/html/sodium/sodium.0.5.0/57f96b30bff10fbb79b7d53086df011e>

upstream discussion:
  https://github.com/dsheets/ocaml-sodium/issues/33