### PR TITLE
omonad: add bound on OCaml version

### DIFF
--- a/packages/omonad/omonad.0.3.0/opam
+++ b/packages/omonad/omonad.0.3.0/opam
@@ -4,6 +4,7 @@ authors: [
   "Jeremy Yallop"
 ]
 maintainer: "yallop@gmail.com"
+homepage: "https://github.com/yallop/omonad"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--enable-tests" "--prefix" prefix]

--- a/packages/omonad/omonad.0.3.0/opam
+++ b/packages/omonad/omonad.0.3.0/opam
@@ -17,5 +17,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/yallop/omonad"
-available: ocaml-version >= "4.02.0"
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"]
 install: ["ocaml" "setup.ml" "-install"]


### PR DESCRIPTION
`omonad` will need several changes to adapt to AST changes in 4.03.0.

/cc @yallop 
You might also want to give a better value for the `homepage` field.
