### PR TITLE
p3: add bound on OCaml version

### DIFF
--- a/packages/p3/p3.0.0.6/opam
+++ b/packages/p3/p3.0.0.6/opam
@@ -1,6 +1,8 @@
 opam-version: "1.2"
 maintainer: "opam@tom-ridge.com"
-build: [make "all"]
+authors: "Tom Ridge"
+homepage: "https://github.com/tomjridge/p3/wiki/P3"
+build: [make "-C" "build"]
 remove: [["ocamlfind" "remove" "p3"]]
 depends: ["ocamlfind"]
 dev-repo: "git://github.com/tomjridge/p3"


### PR DESCRIPTION
The examples of `p3.0.0.6` do not compile on OCaml 4.03 and later because of lexer changes.

They seem to have been dropped from the latest dev version of p3.

/cc @tomjridge 