### PR TITLE
pomap: fix bounds on OCaml versions

### DIFF
--- a/packages/pomap/pomap.3.0.1/opam
+++ b/packages/pomap/pomap.3.0.1/opam
@@ -10,5 +10,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mmottl/pomap"
-available: ocaml-version <= "4.01.0"
+available: ocaml-version < "4.01.0"
 install: [make "install"]

--- a/packages/pomap/pomap.3.0.1/opam
+++ b/packages/pomap/pomap.3.0.1/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: "Markus Mottl"
+homepage: "http://mmottl.github.io/pomap/"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/pomap/pomap.3.0.2/opam
+++ b/packages/pomap/pomap.3.0.2/opam
@@ -11,3 +11,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mmottl/pomap"
 install: [make "install"]
+available: ocaml-version < "4.02.0"

--- a/packages/pomap/pomap.3.0.2/opam
+++ b/packages/pomap/pomap.3.0.2/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: "Markus Mottl"
+homepage: "http://mmottl.github.io/pomap/"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/pomap/pomap.3.0.3/opam
+++ b/packages/pomap/pomap.3.0.3/opam
@@ -11,3 +11,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mmottl/pomap"
 install: [make "install"]
+available: ocaml-version < "4.02.0"

--- a/packages/pomap/pomap.3.0.3/opam
+++ b/packages/pomap/pomap.3.0.3/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: "Markus Mottl"
+homepage: "http://mmottl.github.io/pomap/"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/pomap/pomap.3.0.4/opam
+++ b/packages/pomap/pomap.3.0.4/opam
@@ -10,3 +10,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: ocaml-version < "4.02.0"

--- a/packages/pomap/pomap.3.0.4/opam
+++ b/packages/pomap/pomap.3.0.4/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: "Markus Mottl"
+homepage: "http://mmottl.github.io/pomap/"
+dev-repo: "git://github.com/mmottl/pomap"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/pomap/pomap.3.0.5/opam
+++ b/packages/pomap/pomap.3.0.5/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: "Markus Mottl"
+homepage: "http://mmottl.github.io/pomap/"
+dev-repo: "git://github.com/mmottl/pomap"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/pomap/pomap.3.0.5/opam
+++ b/packages/pomap/pomap.3.0.5/opam
@@ -10,3 +10,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.04.0"]


### PR DESCRIPTION
Note: the latest release of `pomap` does not work on OCaml 4.04 because `Set.map` was added to stdlib.

/cc @mmottl 