### PR TITLE
ppx_bigarray: add upper bounds on OCaml version

### DIFF
--- a/packages/ppx_bigarray/ppx_bigarray.0.0.1/opam
+++ b/packages/ppx_bigarray/ppx_bigarray.0.0.1/opam
@@ -23,4 +23,4 @@ depopts: [
   "base-bigarray"
   "ounit"
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03.0" ]

--- a/packages/ppx_bigarray/ppx_bigarray.0.1.0/opam
+++ b/packages/ppx_bigarray/ppx_bigarray.0.1.0/opam
@@ -23,4 +23,4 @@ depopts: [
   "base-bigarray"
   "ounit"
 ]
-available: [ ocaml-version >= "4.02.1" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03.0" ]


### PR DESCRIPTION
`ppx_bigarray` will have to be adapted to the AST changes in 4.03.0.

/cc @akabe 