### PR TITLE
milter: add bound on OCaml version

### DIFF
--- a/packages/milter/milter.1.0.1/opam
+++ b/packages/milter/milter.1.0.1/opam
@@ -17,3 +17,4 @@ depexts: [
   [["ubuntu"] ["libmilter-dev"]]
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.04.0"]

--- a/packages/milter/milter.1.0.1/opam
+++ b/packages/milter/milter.1.0.1/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "andrenth@gmail.com"
 authors: ["Andre Nathan"]
+homepage: "https://github.com/andrenth/ocaml-milter"
 license: "BSD3"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]


### PR DESCRIPTION
`milter` does not compile on 4.04 because of a wrong use of `CAMLlocal`.

upstream PR: https://github.com/andrenth/ocaml-milter/pull/1

/cc @andrenth 