### PR TITLE
milter.1.0.2 - via opam-publish

### DIFF
--- a/packages/milter/milter.1.0.2/descr
+++ b/packages/milter/milter.1.0.2/descr
@@ -1,0 +1,4 @@
+OCaml libmilter bindings
+
+This package provides OCaml bindings for sendmail's libmilter, allowing
+integration of OCaml programs with compatible MTAs.

--- a/packages/milter/milter.1.0.2/opam
+++ b/packages/milter/milter.1.0.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/ocaml-milter"
+bug-reports: "https://github.com/andrenth/ocaml-milter/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-milter.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "milter"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
+depexts: [
+  [["debian"] ["libmilter-dev"]]
+  [["ubuntu"] ["libmilter-dev"]]
+]

--- a/packages/milter/milter.1.0.2/url
+++ b/packages/milter/milter.1.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-milter/archive/1.0.2.tar.gz"
+checksum: "ab907129dbd1dd8b9d27e355d285cda0"


### PR DESCRIPTION
OCaml libmilter bindings

This package provides OCaml bindings for sendmail's libmilter, allowing
integration of OCaml programs with compatible MTAs.


---
* Homepage: https://github.com/andrenth/ocaml-milter
* Source repo: https://github.com/andrenth/ocaml-milter.git
* Bug tracker: https://github.com/andrenth/ocaml-milter/issues

---

Pull-request generated by opam-publish v0.3.2