### PR TITLE
mirage-unix: add bound on cstruct version

### DIFF
--- a/packages/mirage-unix/mirage-unix.0.9.4/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.4/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [

--- a/packages/mirage-unix/mirage-unix.0.9.4/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.4/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
   "shared-memory-ring" {>= "0.4.1"}

--- a/packages/mirage-unix/mirage-unix.0.9.5/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.5/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [

--- a/packages/mirage-unix/mirage-unix.0.9.5/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.5/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
   "shared-memory-ring" {>= "0.4.1"}

--- a/packages/mirage-unix/mirage-unix.0.9.6/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.6/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [

--- a/packages/mirage-unix/mirage-unix.0.9.6/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.6/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
   "shared-memory-ring" {>= "0.4.1"}

--- a/packages/mirage-unix/mirage-unix.0.9.7/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.7/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "cstruct" {>= "0.7.1"}
+  "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
   "shared-memory-ring" {>= "0.4.3"}

--- a/packages/mirage-unix/mirage-unix.0.9.7/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.7/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [

--- a/packages/mirage-unix/mirage-unix.0.9.8/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.8/opam
@@ -1,9 +1,9 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
 build: [make "unix-build"]
-remove: [[make "unix-uninstall" "PREFIX=%{prefix}%"]]
+remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "cstruct" {>= "0.8.1"}
+  "cstruct" {>= "0.8.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "shared-memory-ring" {>= "0.4.3"}

--- a/packages/mirage-unix/mirage-unix.0.9.8/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.8/opam
@@ -1,6 +1,9 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
 build: [make "unix-build"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
   "cstruct" {>= "0.8.1" & < "2.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.9/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.9/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [[make "unix-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page-unix" {>= "0.9.9"}

--- a/packages/mirage-unix/mirage-unix.0.9.9/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.9/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [[make "unix-uninstall" "PREFIX=%{prefix}%"]]
 depends: [

--- a/packages/mirage-unix/mirage-unix.1.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.0.0/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [[make "unix-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page-unix" {>= "0.9.9"}

--- a/packages/mirage-unix/mirage-unix.1.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.0.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [[make "unix-uninstall" "PREFIX=%{prefix}%"]]
 depends: [

--- a/packages/mirage-unix/mirage-unix.1.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.1.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.1.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.1.0/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.0/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.1/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.0/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.1.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.1/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.2/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.1.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.2/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.3/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.1.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.3/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.2.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.0/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.2.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.1/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.2/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/packages/mirage-unix/mirage-unix.2.2.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.2/opam
@@ -5,7 +5,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}


### PR DESCRIPTION
also, fix uninstall instructions for mirage-unix.0.9.8.

Note: this is for older versions of mirage-unix, which don't work with ppx-based versions of cstruct.