### PR TITLE
plplot: add missing depext on ubuntu (and debian?)

### DIFF
--- a/packages/plplot/plplot.5.11.0/opam
+++ b/packages/plplot/plplot.5.11.0/opam
@@ -25,8 +25,8 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  [["debian"] ["libplplot-dev"]]
-  [["ubuntu"] ["libplplot-dev"]]
+  [["debian"] ["libplplot-dev" "libshp-dev"]]
+  [["ubuntu"] ["libplplot-dev" "libshp-dev"]]
   [[ "osx" "homebrew" ] [ "plplot" ]]
 ]
 

--- a/packages/plplot/plplot.5.11.0/opam
+++ b/packages/plplot/plplot.5.11.0/opam
@@ -30,3 +30,4 @@ depexts: [
   [[ "osx" "homebrew" ] [ "plplot" ]]
 ]
 
+available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
Note: not tested on Debian. The OSX depext appear to be correct.
