### PR TITLE
ppx-debugger: add upper bound on OCaml version

### DIFF
--- a/packages/ppx_debugger/ppx_debugger.1.0/opam
+++ b/packages/ppx_debugger/ppx_debugger.1.0/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03.0" ]


### PR DESCRIPTION
`ppx_debugger` does not compile with OCaml 4.03 and later because the AST types have changed.

Note: upstream is aware of the incompatibility (https://github.com/xvw/ppx_debugger/issues/1).

/cc @xvw 