### PR TITLE
ppx_include: add upper bound on OCaml version

### DIFF
--- a/packages/ppx_include/ppx_include.1.0/opam
+++ b/packages/ppx_include/ppx_include.1.0/opam
@@ -13,4 +13,4 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"]


### PR DESCRIPTION
`ppx_include` is incompatible with 4.03 and later because of the AST changes.

/cc @whitequark 