### PR TITLE
ppx_measure: add upper bound on OCaml version

### DIFF
--- a/packages/ppx_measure/ppx_measure.1.0/opam
+++ b/packages/ppx_measure/ppx_measure.1.0/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.03.0"]

--- a/packages/ppx_measure/ppx_measure.1.1/opam
+++ b/packages/ppx_measure/ppx_measure.1.1/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.03.0"]


### PR DESCRIPTION
incompatibility due to AST changes in 4.03

/cc @xvw 