### PR TITLE
type_conv: add upper bound on OCaml version for older version of type_conv

### DIFF
--- a/packages/type_conv/type_conv.108.00.02/opam
+++ b/packages/type_conv/type_conv.108.00.02/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.108.00.02/opam
+++ b/packages/type_conv/type_conv.108.00.02/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.108.07.00/opam
+++ b/packages/type_conv/type_conv.108.07.00/opam
@@ -8,3 +8,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/type_conv/type_conv.108.07.00/opam
+++ b/packages/type_conv/type_conv.108.07.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.108.07.01/opam
+++ b/packages/type_conv/type_conv.108.07.01/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.108.07.01/opam
+++ b/packages/type_conv/type_conv.108.07.01/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.108.08.00/opam
+++ b/packages/type_conv/type_conv.108.08.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind" {>= "1.3.2"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "3.12.1" ]
+available: [ ocaml-version >= "3.12.1" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.108.08.00/opam
+++ b/packages/type_conv/type_conv.108.08.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.07.00/opam
+++ b/packages/type_conv/type_conv.109.07.00/opam
@@ -8,5 +8,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 patches: ["disable_warn_error.patch"]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.07.00/opam
+++ b/packages/type_conv/type_conv.109.07.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.08.00/opam
+++ b/packages/type_conv/type_conv.109.08.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.08.00/opam
+++ b/packages/type_conv/type_conv.109.08.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.09.00/opam
+++ b/packages/type_conv/type_conv.109.09.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.09.00/opam
+++ b/packages/type_conv/type_conv.109.09.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.10.00/opam
+++ b/packages/type_conv/type_conv.109.10.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.10.00/opam
+++ b/packages/type_conv/type_conv.109.10.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.11.00/opam
+++ b/packages/type_conv/type_conv.109.11.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.11.00/opam
+++ b/packages/type_conv/type_conv.109.11.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.12.00/opam
+++ b/packages/type_conv/type_conv.109.12.00/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.12.00/opam
+++ b/packages/type_conv/type_conv.109.12.00/opam
@@ -8,5 +8,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/janestreet/type_conv"
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.13.00/opam
+++ b/packages/type_conv/type_conv.109.13.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.13.00/opam
+++ b/packages/type_conv/type_conv.109.13.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.14.00/opam
+++ b/packages/type_conv/type_conv.109.14.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.14.00/opam
+++ b/packages/type_conv/type_conv.109.14.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.15.00/opam
+++ b/packages/type_conv/type_conv.109.15.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.15.00/opam
+++ b/packages/type_conv/type_conv.109.15.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [

--- a/packages/type_conv/type_conv.109.20.00/opam
+++ b/packages/type_conv/type_conv.109.20.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/type_conv/type_conv.109.20.00/opam
+++ b/packages/type_conv/type_conv.109.20.00/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/type_conv"
+bug-reports: "https://github.com/janestreet/type_conv/issues"
+dev-repo: "https://github.com/janestreet/type_conv.git"
 build: make
 remove: [["ocamlfind" "remove" "type_conv"]]
 depends: [


### PR DESCRIPTION
Because of the addition of the `nonrec` keyword in 4.03, older versions of `type_conv` compile and install without error but they fail to work, for example when trying to compiler `ocaml-data-notation.0.0.11`.
