### PR TITLE
rdbg: add bounds on ounit and OCaml

### DIFF
--- a/packages/rdbg/rdbg.1.65/opam
+++ b/packages/rdbg/rdbg.1.65/opam
@@ -27,6 +27,6 @@ depends: [
   "lutils"
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
-  "ounit" {build}
+  "ounit" {build & >= "2.0.0"}
 ]
-available: [ ocaml-version >= "4.01" ]
+available: [ ocaml-version >= "4.01" & ocaml-version < "4.04.0" ]


### PR DESCRIPTION
* needs Ounit >= 2.0.0
* uses both `-c` and `-o` with multiple files (incompatible with 4.04.0)

This package uses `oasis` with a config file that makes it generate a command line with both `.cma` arguments and `-c` and `-o`, which doesn't really make sense, and is rejected by OCaml 4.04.0. Unfortunately I don't know enough about oasis to suggest a fix.

/cc @jahierwan @gildor478 
