### PR TITLE
reins: add bound on OCaml version

### DIFF
--- a/packages/reins/reins.0.1a/opam
+++ b/packages/reins/reins.0.1a/opam
@@ -1,5 +1,6 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
+authors: "Mike Furr"
 homepage: "http://ocaml-reins.sourceforge.net/"
 doc: "http://ocaml-reins.sourceforge.net/api/index.html"
 

--- a/packages/reins/reins.0.1a/opam
+++ b/packages/reins/reins.0.1a/opam
@@ -11,3 +11,5 @@ remove: ["ocamlfind" "remove" "reins"]
 patches: ["fix_build.patch" ]
 depends: ["ocamlfind" "omake"]
 install: ["omake" "install"]
+
+available: [ocaml-version < "4.03.0"]


### PR DESCRIPTION
Playing dirty tricks with `external` and stdlib modules: not compatible with 4.03 and later.

patch sent upstream but development doesn't seem active: https://sourceforge.net/p/ocaml-reins/bugs/2/

/cc @ygrek 