### PR TITLE
oml.0.0.6 - via opam-publish

### DIFF
--- a/packages/oml/oml.0.0.6/descr
+++ b/packages/oml/oml.0.0.6/descr
@@ -1,0 +1,7 @@
+An OCaml Math, Statistics, and ML Library
+
+Common algorithms and procedures to perform exploratory data analysis,
+machine learning and mathematical simulations.
+
+This package wraps libraries that have C and Fortran bindings to numerical
+code. For an OCaml only version. See oml-lite.

--- a/packages/oml/oml.0.0.6/opam
+++ b/packages/oml/oml.0.0.6/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+available: [ ocaml-version >= "4.03" ]
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/hammerlab/oml/"
+dev-repo: "https://github.com/hammerlab/oml.git"
+bug-reports: "https://github.com/hammerlab/oml/issues"
+license: "Apache2"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "oml"]
+depends: [
+  "ocamlfind" {build}
+  "cppo" { build & >= "1.4.0" }
+  "lacaml" { >= "8.0.6" }
+  "lbfgs" { >= "0.8.7" }
+  "ocephes" { >= "0.8" }
+]

--- a/packages/oml/oml.0.0.6/opam
+++ b/packages/oml/oml.0.0.6/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/hammerlab/oml/"
 dev-repo: "https://github.com/hammerlab/oml.git"
 bug-reports: "https://github.com/hammerlab/oml/issues"
 license: "Apache2"
-build: [make]
+build: [make "build"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [

--- a/packages/oml/oml.0.0.6/url
+++ b/packages/oml/oml.0.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/oml/archive/0.0.6.tar.gz"
+checksum: "6234bd8495da2693427cd1098ee45997"


### PR DESCRIPTION
An OCaml Math, Statistics, and ML Library

Common algorithms and procedures to perform exploratory data analysis,
machine learning and mathematical simulations.

This package wraps libraries that have C and Fortran bindings to numerical
code. For an OCaml only version. See oml-lite.


---
* Homepage: https://github.com/hammerlab/oml/
* Source repo: https://github.com/hammerlab/oml.git
* Bug tracker: https://github.com/hammerlab/oml/issues

---

Pull-request generated by opam-publish v0.3.2