### PR TITLE
oml-lite.0.0.6 - via opam-publish

### DIFF
--- a/packages/oml-lite/oml-lite.0.0.6/descr
+++ b/packages/oml-lite/oml-lite.0.0.6/descr
@@ -1,0 +1,7 @@
+An OCaml (only) Math, Statistics, and ML Library
+
+Common algorithms and procedures to perform exploratory data analysis,
+machine learning and mathematical simulations.
+
+This package exports a subset of oml that does not depend on any
+C or Frotran bindings.

--- a/packages/oml-lite/oml-lite.0.0.6/descr
+++ b/packages/oml-lite/oml-lite.0.0.6/descr
@@ -4,4 +4,4 @@ Common algorithms and procedures to perform exploratory data analysis,
 machine learning and mathematical simulations.
 
 This package exports a subset of oml that does not depend on any
-C or Frotran bindings.
+C or Fortran bindings.

--- a/packages/oml-lite/oml-lite.0.0.6/opam
+++ b/packages/oml-lite/oml-lite.0.0.6/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+available: [ ocaml-version >= "4.03" ]
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/hammerlab/oml/"
+dev-repo: "https://github.com/hammerlab/oml.git"
+bug-reports: "https://github.com/hammerlab/oml/issues"
+license: "Apache2"
+build: [make "lite" ]
+install: [make "install-lite"]
+remove: ["ocamlfind" "remove" "oml-lite"]
+depends: [
+  "ocamlfind" {build}
+  "cppo" { build & >= "1.4.0" }
+]

--- a/packages/oml-lite/oml-lite.0.0.6/url
+++ b/packages/oml-lite/oml-lite.0.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/oml/archive/0.0.6.tar.gz"
+checksum: "6234bd8495da2693427cd1098ee45997"


### PR DESCRIPTION
An OCaml (only) Math, Statistics, and ML Library

Common algorithms and procedures to perform exploratory data analysis,
machine learning and mathematical simulations.

This package exports a subset of oml that does not depend on any
C or Frotran bindings.


---
* Homepage: https://github.com/hammerlab/oml/
* Source repo: https://github.com/hammerlab/oml.git
* Bug tracker: https://github.com/hammerlab/oml/issues

---

Pull-request generated by opam-publish v0.3.2