### PR TITLE
ppx_include.1.1 - via opam-publish

### DIFF
--- a/packages/ppx_include/ppx_include.1.1/descr
+++ b/packages/ppx_include/ppx_include.1.1/descr
@@ -1,0 +1,4 @@
+Include OCaml source files in each other
+
+ppx_include is a syntax extension that allows to include
+an OCaml source file inside another one.

--- a/packages/ppx_include/ppx_include.1.1/opam
+++ b/packages/ppx_include/ppx_include.1.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: "whitequark <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_include"
+bug-reports: "https://github.com/whitequark/ppx_include/issues"
+license: "MIT"
+tags: "syntax"
+dev-repo: "git://github.com/whitequark/ppx_include.git"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_ppx_include.byte"
+  "--"
+]
+depends: [
+  "ocamlfind" {build}
+  "cppo" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_include/ppx_include.1.1/url
+++ b/packages/ppx_include/ppx_include.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_include/archive/v1.1.tar.gz"
+checksum: "83f647db794cad43fad29bc95a23233b"


### PR DESCRIPTION
Include OCaml source files in each other

ppx_include is a syntax extension that allows to include
an OCaml source file inside another one.


---
* Homepage: https://github.com/whitequark/ppx_include
* Source repo: git://github.com/whitequark/ppx_include.git
* Bug tracker: https://github.com/whitequark/ppx_include/issues

---

Pull-request generated by opam-publish v0.3.2