### PR TITLE
+dockerfile.1.7.0

### DIFF
--- a/packages/dockerfile/dockerfile.1.7.0/descr
+++ b/packages/dockerfile/dockerfile.1.7.0/descr
@@ -1,0 +1,18 @@
+Typed interface for constructing Docker container descriptions
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+- **HTML Documentation**: https://avsm.github.io/ocaml-dockerfile
+- **Source:**: https://github.com/avsm/ocaml-dockerfile
+- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
+- **Email**: <mirageos-devel@lists.xenproject.org>
+

--- a/packages/dockerfile/dockerfile.1.7.0/opam
+++ b/packages/dockerfile/dockerfile.1.7.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+license: "ISC"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "dockerfile"]
+depends: [
+  "ocamlfind" {build} 
+  "cmdliner"
+  "ppx_sexp_conv"
+  "base-bytes"
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/dockerfile/dockerfile.1.7.0/url
+++ b/packages/dockerfile/dockerfile.1.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/archive/v1.7.0.tar.gz"
+checksum: "215e1f7aa4791d29958608953bf2a96d"


### PR DESCRIPTION
* *Multiarch:* Add Alpine 3.4 and Alpine/ARMHF 3.4 and
  deprecate Raspbian 7.
* Add OpenSUSE/Zypper support and add OpenSUSE 42.1 to the
  default distro build list.
* Add Ubuntu 16.10 to the distro list, and remove Ubuntu 15.10
  from default build list now that 16.10 LTS is available.
* Add Fedora 24 and make it the alias for Fedora stable. Also
  install `redhat-rpm-config` which is needed for pthreads.
* Add an `extra` arg the Dockerfile_distro matrix targets to
  add more distros to the mix, such as Raspbian.
* Support multiple OPAM versions in the matrix generation, 
  to make testing OPAM master easier.
* Always do an `rpm --rebuilddb` before a Yum invocation to
  deal with possible OverlayFS brokenness.
* Support `opam_version` to distro calls to build and install
  the latest version of OPAM2-dev.
* Add `xz` into Alpine containers so that untar of those works.
* Expose the development versions of OCaml compilers.
