### PR TITLE
Constrain the old ANSITerminal 0.6 to oasis < 0.4.7

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.6/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.6/opam
@@ -1,5 +1,11 @@
 opam-version: "1.2"
-maintainer: "contact@ocamlpro.com"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ANSITerminal"
+dev-repo: "https://github.com/Chris00/ANSITerminal.git"
+bug-reports: "https://github.com/Chris00/ANSITerminal/issues"
+tags: [ "terminal"  ]
 build: [
   ["rm" "setup.ml"] {ocaml-version >= "4.00.0"}
   ["oasis" "setup"] {ocaml-version >= "4.00.0"}
@@ -9,7 +15,7 @@ build: [
 remove: [["ocamlfind" "remove" "ANSITerminal"]]
 depends: [
   "ocamlfind"
-  "oasis" {>= "0.3.0"}
+  "oasis" {build & >= "0.3.0" & < "0.4.7"}
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]


### PR DESCRIPTION
Fix https://github.com/ocaml/opam-repository/pull/7281#issuecomment-242320767