### PR TITLE
astring.0.8.2 - via opam-publish

### DIFF
--- a/packages/astring/astring.0.8.2/descr
+++ b/packages/astring/astring.0.8.2/descr
@@ -1,0 +1,16 @@
+Alternative String module for OCaml
+Release %%VERSION%%
+
+Astring exposes an alternative `String` module for OCaml. This module
+tries to balance minimality and expressiveness for basic, index-free,
+string processing and provides types and functions for substrings,
+string sets and string maps.
+
+Remaining compatible with the OCaml `String` module is a non-goal. The
+`String` module exposed by Astring has exception safe functions,
+removes deprecated and rarely used functions, alters some signatures
+and names, adds a few missing functions and fully exploits OCaml's
+newfound string immutability.
+
+Astring depends only on the OCaml standard library. It is distributed
+under the ISC license.

--- a/packages/astring/astring.0.8.2/opam
+++ b/packages/astring/astring.0.8.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/astring"
+doc: "http://erratique.ch/software/astring/doc"
+dev-repo: "http://erratique.ch/repos/astring.git"
+bug-reports: "https://github.com/dbuenzli/astring/issues"
+tags: [ "string" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/astring/astring.0.8.2/url
+++ b/packages/astring/astring.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/astring/releases/astring-0.8.2.tbz"
+checksum: "533f5b9a7c99b591043f69782123bd78"


### PR DESCRIPTION
Alternative String module for OCaml
Release %%VERSION%%

Astring exposes an alternative `String` module for OCaml. This module
tries to balance minimality and expressiveness for basic, index-free,
string processing and provides types and functions for substrings,
string sets and string maps.

Remaining compatible with the OCaml `String` module is a non-goal. The
`String` module exposed by Astring has exception safe functions,
removes deprecated and rarely used functions, alters some signatures
and names, adds a few missing functions and fully exploits OCaml's
newfound string immutability.

Astring depends only on the OCaml standard library. It is distributed
under the ISC license.


---
* Homepage: http://erratique.ch/software/astring
* Source repo: http://erratique.ch/repos/astring.git
* Bug tracker: https://github.com/dbuenzli/astring/issues

---


---
v0.8.2 2016-08-26 Zagreb
------------------------

- Fix String.Set.pp not using the `sep` argument.
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.2