### PR TITLE
asetmap.0.8.0 - via opam-publish

### DIFF
--- a/packages/asetmap/asetmap.0.8.0/descr
+++ b/packages/asetmap/asetmap.0.8.0/descr
@@ -1,0 +1,8 @@
+Alternative, compatible, OCaml standard library Sets and Maps
+
+asetmap provides slightly tweaked OCaml standard library Set and Map
+functors. asetmap tries to maximize compatibility with the standard
+library. It essentially gets rid of `Not_found` exceptions and provide
+pretty-printers for the data types.
+
+asetmap has no dependency is distributed under the ISC license.

--- a/packages/asetmap/asetmap.0.8.0/opam
+++ b/packages/asetmap/asetmap.0.8.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/asetmap"
+doc: "http://erratique.ch/software/asetmap/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/asetmap.git"
+bug-reports: "https://github.com/dbuenzli/asetmap/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]

--- a/packages/asetmap/asetmap.0.8.0/url
+++ b/packages/asetmap/asetmap.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/asetmap/releases/asetmap-0.8.0.tbz"
+checksum: "5bebd8ab267d3b9d10f83ae8739a09c2"


### PR DESCRIPTION
Alternative, compatible, OCaml standard library Sets and Maps

asetmap provides slightly tweaked OCaml standard library Set and Map
functors. asetmap tries to maximize compatibility with the standard
library. It essentially gets rid of `Not_found` exceptions and provide
pretty-printers for the data types.

asetmap has no dependency is distributed under the ISC license.


---
* Homepage: http://erratique.ch/software/asetmap
* Source repo: http://erratique.ch/repos/asetmap.git
* Bug tracker: https://github.com/dbuenzli/asetmap/issues

---


---
v0.8.0 2016-08-26 Zagreb
------------------------

First release. 
Pull-request generated by opam-publish v0.3.2