### PR TITLE
edn.0.1.4 - via opam-publish

### DIFF
--- a/packages/edn/edn.0.1.4/descr
+++ b/packages/edn/edn.0.1.4/descr
@@ -1,0 +1,2 @@
+Parsing OCaml library for EDN format
+

--- a/packages/edn/edn.0.1.4/opam
+++ b/packages/edn/edn.0.1.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+license: "MIT"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+dev-repo: "https://github.com/prepor/ocaml-edn.git"
+doc: "https://prepor.github.io/ocaml-edn/doc"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]
+build-test: [[
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+  "ocaml" "pkg/pkg.ml" "test" ]]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+  "topkg" {build}
+  "oUnit" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.4/url
+++ b/packages/edn/edn.0.1.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/prepor/ocaml-edn/releases/download/v0.1.4/edn-0.1.4.tbz"
+checksum: "d135b0ffb41d08b0a6e8ff2666482edf"


### PR DESCRIPTION
Parsing OCaml library for EDN format



---
* Homepage: http://github.com/prepor/ocaml-edn
* Source repo: https://github.com/prepor/ocaml-edn.git
* Bug tracker: http://github.com/prepor/ocaml-edn/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.1.4 2016-08-26
--------------------------

thanks to @mpenet

- emit correct nil
- fix EDN List writer
- fix _tags for case sensitive file systems
- add some roundtrip tests
Pull-request generated by opam-publish v0.3.2