### PR TITLE
oasis 0.4.7: remove all the test dependencies from the package

### DIFF
--- a/packages/oasis/oasis.0.4.7/opam
+++ b/packages/oasis/oasis.0.4.7/opam
@@ -16,15 +16,10 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-unix"
-  "expect" {test & >= "0.0.4"}
-  "omake" {test}
-  "fileutils" {test}
-  "camlp4" {test}
   "ocamlbuild"
   "ocamlfind" {>= "1.3.1"}
   "ocamlify" {build}
   "ocamlmod" {build}
-  "ounit" {test & >= "2.0.0"}
 ]
 depopts: [
   "benchmark"


### PR DESCRIPTION
This could lead to unecessary confusion, like:

- install oasis.0.4.7 -> install qtest.2.1.1 -> install batteries.2.5.2 -> install expect.0.0.4 -> install oasis.0.4.7

On https://travis-ci.org/mirage/ocaml-github/jobs/155560032