### PR TITLE
Fix ocamlbuild configure bug

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.9.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.0/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
-  [make "-f" "configure.make" "Makefile.config"
+  [make "-f" "configure.make" "Makefile.config" "src/ocamlbuild_config.ml"
     "OCAMLBUILD_PREFIX=%{prefix}%"
     "OCAMLBUILD_BINDIR=%{bin}%"
     "OCAMLBUILD_LIBDIR=%{lib}%"

--- a/packages/ocamlbuild/ocamlbuild.0.9.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
-  [make "-f" "configure.make" "Makefile.config"
+  [make "-f" "configure.make" "Makefile.config" "src/ocamlbuild_config.ml"
     "OCAMLBUILD_PREFIX=%{prefix}%"
     "OCAMLBUILD_BINDIR=%{bin}%"
     "OCAMLBUILD_LIBDIR=%{lib}%"

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 
 build: [
-  [make "-f" "configure.make" "Makefile.config"
+  [make "-f" "configure.make" "Makefile.config" "src/ocamlbuild_config.ml"
     "OCAMLBUILD_PREFIX=%{prefix}%"
     "OCAMLBUILD_BINDIR=%{bin}%"
     "OCAMLBUILD_LIBDIR=%{lib}%"


### PR DESCRIPTION
This caused a very weird bug when ocamlbuild got installed before ocamlfind, and would pick up an ocamlfind from outside of the opam switch (e.g. from /usr/local/bin) ; everything would seem to go well but then `ocamlbuild -where` would report the location below `/usr/local/`, and compilation of some packages (e.g. re) would fail.

@gasche this should be ported to the upstream opam file