### PR TITLE
Fix installation of frama-c-base with doc

### DIFF
--- a/packages/frama-c-base/frama-c-base.20160501/opam
+++ b/packages/frama-c-base/frama-c-base.20160501/opam
@@ -73,12 +73,12 @@ remove: [
                                    !conf-gnomecanvas:installed }
 ]
   [make "uninstall"]
-  ["rm" "-rf" frama-c:doc]
+  ["rm" "-rf" frama-c-base:doc]
 ]
 
 build-doc: [
    [make "-C" "doc" "download"]
-   [make "-C" "doc" "FRAMAC_DOCDIR=%{frama-c:doc}%" "install"]
+   [make "-C" "doc" "FRAMAC_DOCDIR=%{frama-c-base:doc}%" "install"]
 ]
 
 build-test: [


### PR DESCRIPTION
Was using the wrong pkg name in the parameter.
opam config list frama-c-base confirm that frama-c-base:doc is indeed defined.
Closes #7317
