### PR TITLE
ocp-index.1.1.5 - via opam-publish

### DIFF
--- a/packages/ocp-index/ocp-index.1.1.5/descr
+++ b/packages/ocp-index/ocp-index.1.1.5/descr
@@ -1,0 +1,9 @@
+Lightweight completion and documentation browsing for OCaml libraries
+
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-browser`, an interface browser for installed and in-project modules. This requires lambda-term installed
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`.

--- a/packages/ocp-index/ocp-index.1.1.5/opam
+++ b/packages/ocp-index/ocp-index.1.1.5/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: ["Louis Gesbert" "Gabriel Radanne"]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "LGPL"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "https://github.com/OCamlPro/ocp-index.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocp-build" {>= "1.99.13-beta"}
+  "ocp-indent" {>= "1.4.2"}
+  "re"
+  "cmdliner"
+]
+depopts: "lambda-term"
+conflicts: [
+  "lambda-term" {< "1.7"}
+]
+available: [ocaml-version >= "4.01.0"]
+messages: [
+  "For ocp-browser, please also install package lambda-term"
+    {!lambda-term:installed}
+]
+post-messages: [
+  "
+This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{prefix}%/share/emacs/site-lisp\")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim
+  "
+    {success & !user-setup:installed}
+]

--- a/packages/ocp-index/ocp-index.1.1.5/url
+++ b/packages/ocp-index/ocp-index.1.1.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocp-index/archive/1.1.5.tar.gz"
+checksum: "3d2d70aa17ea046d7b621a75a965da96"


### PR DESCRIPTION
Lightweight completion and documentation browsing for OCaml libraries

This package includes
* The `ocp-index` library and command-line tool
* `ocp-browser`, an interface browser for installed and in-project modules. This requires lambda-term installed
* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))

To automatically configure your editors, install this with package `user-setup`.


---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them

---

Pull-request generated by opam-publish v0.3.2