### PR TITLE
ocamlbuild: subtly incompatible with ocamlfind < 1.6.2

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.9.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.0/opam
@@ -26,4 +26,7 @@ build: [
 
 available: [ocaml-version >= "4.03"]
 depends: [ ]
-conflicts: [ "base-ocamlbuild" ]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]

--- a/packages/ocamlbuild/ocamlbuild.0.9.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/opam
@@ -26,4 +26,7 @@ build: [
 
 available: [ocaml-version >= "4.03"]
 depends: [ ]
-conflicts: [ "base-ocamlbuild" ]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/opam
@@ -28,5 +28,5 @@ available: [ocaml-version >= "4.03"]
 depends: [ ]
 conflicts: [
   "base-ocamlbuild"
-  "ocamlfind" {< "1.5"}
+  "ocamlfind" {< "1.6.2"}
 ]


### PR DESCRIPTION
`ocamlbuild` is incompatible with `ocamlfind` versions prior to 1.6.2 because when `ocamlfind` is removed (for example because opam wants to upgrade to 1.6.2) it destroys `ocamlbuild`'s library directory.

`ocamlfind` 1.6.2 does not destroy `ocamlbuild` when it's removed.

When that happens `batteries` (for example) fails to compile.
