### PR TITLE
updated urls to bitstring

### DIFF
--- a/packages/bitstring/bitstring.2.0.3/url
+++ b/packages/bitstring/bitstring.2.0.3/url
@@ -1,2 +1,2 @@
-archive: "http://bitstring.googlecode.com/files/ocaml-bitstring-2.0.3.tar.gz"
+archive: "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/bitstring/ocaml-bitstring-2.0.3.tar.gz"
 checksum: "88ad0ee29af8b077e63896da23ec9054"

--- a/packages/bitstring/bitstring.2.0.4/url
+++ b/packages/bitstring/bitstring.2.0.4/url
@@ -1,2 +1,2 @@
-archive: "http://bitstring.googlecode.com/files/ocaml-bitstring-2.0.4.tar.gz"
+archive: "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/bitstring/ocaml-bitstring-2.0.4.tar.gz"
 checksum: "5f92601000aea467c989afe141cb1632"


### PR DESCRIPTION
It looks like, that google code has changed their backing storage
and broke all urls. I've updated them, but it would be better to
mirror the archives on the github.