### PR TITLE
flowcaml: remove bound on OCaml version

### DIFF
--- a/packages/flowcaml/flowcaml.1.07/opam
+++ b/packages/flowcaml/flowcaml.1.07/opam
@@ -15,5 +15,3 @@ remove: [
   ["sh" "-c" "cd src-flowcaml && %{make}% uninstall"]
 ]
 install: ["sh" "-c" "cd src-flowcaml && %{make}% install"]
-
-available: [ ocaml-version < "4.04.0" ]


### PR DESCRIPTION
The compatibility is restored by 4.04.0+dev (see https://github.com/ocaml/ocaml/pull/772).

/cc @vtst @pmundkur

see also #7186 