### PR TITLE
cordova-plugin-push-notifications --> v1.1

### DIFF
--- a/packages/cordova-plugin-push-notifications/cordova-plugin-push-notifications.1.1/descr
+++ b/packages/cordova-plugin-push-notifications/cordova-plugin-push-notifications.1.1/descr
@@ -1,0 +1,4 @@
+Binding OCaml to phonegap-plugin-push using gen_js_api.
+
+Binding OCaml to phonegap-plugin-push using gen_js_api.
+See https://github.com/dannywillems/ocaml-cordova-plugin-list for the complete list of bindings to Cordova plugins.

--- a/packages/cordova-plugin-push-notifications/cordova-plugin-push-notifications.1.1/opam
+++ b/packages/cordova-plugin-push-notifications/cordova-plugin-push-notifications.1.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-push"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-push/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-push.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-push-notifications/cordova-plugin-push-notifications.1.1/url
+++ b/packages/cordova-plugin-push-notifications/cordova-plugin-push-notifications.1.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-push/archive/v1.1.zip"
+checksum: "0356c51b4962b7e6bc0ec8302570ac79"


### PR DESCRIPTION
- Some fixed has been done.
- Change the global structure for types (use a module with a type t instead of a type in the top-level).
- Add some functions.

And this version has been tested with Eliom.