### PR TITLE
sqlite3: fix OS X support

### DIFF
--- a/packages/sqlite3/sqlite3.4.0.5/opam
+++ b/packages/sqlite3/sqlite3.4.0.5/opam
@@ -9,7 +9,9 @@ bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
 tags: [ "clib:sqlite3" "clib:pthread"  ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
-  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-build"] { os != "darwin" }
+  ["env" "SQLITE3_OCAML_BREWCHECK=1"
+   "ocaml" "setup.ml" "-build"] { os = "darwin" }
 ]
 install: ["ocaml" "setup.ml" "-install"]
 remove: [
@@ -35,4 +37,5 @@ depexts: [
   [["rhel"] ["sqlite-devel"]]
   [["fedora"] ["sqlite-devel"]]
   [["alpine"] ["sqlite-dev"]]
+  [["osx" "homebrew"] ["sqlite3"]]
 ]


### PR DESCRIPTION
As discovered in #7298 and #7308, sqlite3 was not working on OS X. This fixes that.

/cc @mmottl 