### PR TITLE
Add camlzip.1.06

### DIFF
--- a/packages/camlzip/camlzip.1.06/descr
+++ b/packages/camlzip/camlzip.1.06/descr
@@ -1,0 +1,1 @@
+Provides easy access to compressed files in ZIP, GZIP and JAR format

--- a/packages/camlzip/camlzip.1.06/files/build_with_trunk.patch
+++ b/packages/camlzip/camlzip.1.06/files/build_with_trunk.patch
@@ -1,0 +1,33 @@
+From ef04e8b8b440a7012f5eb21b55eb89d138758097 Mon Sep 17 00:00:00 2001
+From: Etienne Millon <etienne@cryptosense.com>
+Date: Thu, 1 Sep 2016 11:14:25 +0200
+Subject: [PATCH 2/2] build_with_trunk
+
+---
+ zlibstubs.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/zlibstubs.c b/zlibstubs.c
+index 661729a..b4e6c61 100644
+--- a/zlibstubs.c
++++ b/zlibstubs.c
+@@ -17,6 +17,7 @@
+ 
+ #include <stdint.h>
+ #include <zlib.h>
++#include <stdint.h>
+ 
+ #include <caml/mlvalues.h>
+ #include <caml/alloc.h>
+@@ -169,7 +170,7 @@ value camlzip_inflateEnd(value vzs)
+ 
+ value camlzip_update_crc32(value crc, value buf, value pos, value len)
+ {
+-  return caml_copy_int32(crc32((uint32_t) Int32_val(crc), 
++  return caml_copy_int32(crc32((uint32_t) Int32_val(crc),
+                           &Byte_u(buf, Long_val(pos)),
+                           Long_val(len)));
+ }
+-- 
+2.9.3
+

--- a/packages/camlzip/camlzip.1.06/files/fix-install.patch
+++ b/packages/camlzip/camlzip.1.06/files/fix-install.patch
@@ -1,0 +1,76 @@
+From e13f6c12aa9f4a17111b21d0874a78d207e0244b Mon Sep 17 00:00:00 2001
+From: Etienne Millon <etienne@cryptosense.com>
+Date: Thu, 1 Sep 2016 11:13:41 +0200
+Subject: [PATCH 1/2] fix-install
+
+---
+ META     |  1 +
+ Makefile | 18 ++++++++++++++----
+ 2 files changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/META b/META
+index cc4c1b3..05c85fa 100644
+--- a/META
++++ b/META
+@@ -2,3 +2,4 @@ version="1.06"
+ requires="unix"
+ archive(byte)="zip.cma"
+ archive(native)="zip.cmxa"
++archive(native,plugin)="zip.cmxs"
+diff --git a/Makefile b/Makefile
+index 1e1503f..8f2fba9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -25,9 +25,15 @@ OCAMLMKLIB=ocamlmklib
+ OBJS=zlib.cmo zip.cmo gzip.cmo
+ C_OBJS=zlibstubs.o
+ 
++NATDYNLINK := $(shell if [ -f `ocamlc -where`/dynlink.cmxa ]; then echo YES; else echo NO; fi)
++
++ifeq "${NATDYNLINK}" "YES"
++CMXS = zip.cmxs
++endif
++
+ all: libcamlzip.a zip.cma
+ 
+-allopt: libcamlzip.a zip.cmxa
++allopt: libcamlzip.a zip.cmxa $(CMXS)
+ 
+ zip.cma: $(OBJS)
+ 	$(OCAMLMKLIB) -o zip -oc camlzip $(OBJS) \
+@@ -37,6 +43,9 @@ zip.cmxa: $(OBJS:.cmo=.cmx)
+ 	$(OCAMLMKLIB) -o zip -oc camlzip $(OBJS:.cmo=.cmx) \
+             -L$(ZLIB_LIBDIR) $(ZLIB_LIB)
+ 
++zip.cmxs: zip.cmxa
++	$(OCAMLOPT) -shared -linkall -I ./ -o $@ $^
++
+ libcamlzip.a: $(C_OBJS)
+ 	$(OCAMLMKLIB) -oc camlzip $(C_OBJS) \
+             -L$(ZLIB_LIBDIR) $(ZLIB_LIB)
+@@ -58,7 +67,7 @@ clean:
+ 
+ install:
+ 	mkdir -p $(INSTALLDIR)
+-	cp zip.cma zip.cmi gzip.cmi zip.mli gzip.mli libcamlzip.a $(INSTALLDIR)
++	cp zip.cma zip.cmi gzip.cmi zlib.cmi zip.mli gzip.mli zlib.mli libcamlzip.a $(INSTALLDIR)
+ 	if test -f dllcamlzip.so; then \
+ 	  cp dllcamlzip.so $(INSTALLDIR); \
+           ldconf=`$(OCAMLC) -where`/ld.conf; \
+@@ -68,10 +77,11 @@ install:
+         fi
+ 
+ installopt:
+-	cp zip.cmxa zip.a zip.cmx gzip.cmx $(INSTALLDIR)
++	cp zip.cmxa $(CMXS) zip.a zip.cmx gzip.cmx zlib.cmx $(INSTALLDIR)
+ 
+ install-findlib:
+-	ocamlfind install zip META *.mli *.a *.cmi *.cma $(wildcard *.cmxa) $(wildcard *.so)
++	ocamlfind install zip META *.mli *.a *.cmi *.cma $(wildcard *.cmx) $(wildcard *.cmxa) $(wildcard *.cmxs) $(wildcard *.so)
++	echo 'directory="../zip"' >> META && ocamlfind install camlzip META
+ 
+ depend:
+ 	gcc -MM -I$(ZLIB_INCLUDE) *.c > .depend
+-- 
+2.9.3
+

--- a/packages/camlzip/camlzip.1.06/findlib
+++ b/packages/camlzip/camlzip.1.06/findlib
@@ -1,0 +1,2 @@
+camlzip
+zip

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "seb@mondet.org"
 authors: ["Xavier Leroy"]
 homepage: "http://forge.ocamlcore.org/projects/camlzip/"

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "seb@mondet.org"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
 authors: ["Xavier Leroy"]
 homepage: "http://forge.ocamlcore.org/projects/camlzip/"
 license: "LGPL-2.1+ with OCaml linking exception"

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 maintainer: "Etienne Millon <etienne@cryptosense.com>"
 authors: ["Xavier Leroy"]
 homepage: "http://forge.ocamlcore.org/projects/camlzip/"
+bug-reports: "https://forge.ocamlcore.org/tracker/?atid=622&group_id=134"
 license: "LGPL-2.1+ with OCaml linking exception"
 build: [
   [make "all"]

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -1,0 +1,28 @@
+opam-version: "1"
+maintainer: "seb@mondet.org"
+authors: ["Xavier Leroy"]
+homepage: "http://forge.ocamlcore.org/projects/camlzip/"
+license: "LGPL-2.1+ with OCaml linking exception"
+build: [
+  [make "all"]
+  [make "allopt"]
+]
+remove: [
+  ["ocamlfind" "remove" "zip"]
+  ["ocamlfind" "remove" "camlzip"]
+]
+depends: ["ocamlfind"]
+depexts: [
+  [["debian"] ["zlib1g-dev"]]
+  [["ubuntu"] ["zlib1g-dev"]]
+  [["centos"] ["zlib-devel"]]
+  [["rhel"]   ["zlib-devel"]]
+  [["fedora"] ["zlib-devel"]]
+  [["alpine"] ["zlib-dev"]]
+]
+patches: [
+  "fix-install.patch"
+  "build_with_trunk.patch"
+]
+install: [make "install-findlib"]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/camlzip/camlzip.1.06/url
+++ b/packages/camlzip/camlzip.1.06/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1616/camlzip-1.06.tar.gz"
+checksum: "0874be16d02a7165dfc31edc06636e4c"


### PR DESCRIPTION
I added an entry for camlzip.1.06 from the ocaml forge and rebased the patches on top of it.
The main highlight of this release is safe-string support, so it requires ocaml >= 4.02.

(cc @smondet, listed as maintainer)