### PR TITLE
conf-ncurses: do not enforce the use of pkg-config

### DIFF
--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -5,7 +5,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
-  ["pkg-config" "ncurses"]
 ]
 depends: [
   "conf-pkg-config"
@@ -19,6 +18,7 @@ depexts: [
   [["oraclelinux"] ["ncurses-devel"]]
   [["centos"] ["ncurses-devel"]]
   [["rhel"] ["ncurses-devel"]]
+  [["opensuse"] ["ncurses-devel"]] # note: doesnt use pkg-config
 ]
 ## For BSD-like where 'ncurses' is preinstalled but `pkg-config` is not,
 ## see 'conf-ncurses.1+bsd'


### PR DESCRIPTION
Some systems, such as OpenSUSE, do not install pkg-config descriptions
reliably, and so this package unnecessarily fails despite ncurses
being installed fine.

This PR disables the enforced `pkg-config ncurses` invocation but
retains the depext hints, and adds an OpenSUSE depext.  With this,
installation works fine on OpenSUSE 42.1 and this user should be
happier: http://lambda.jstolarek.com/2016/05/installing-ocaml-under-opensuse-11-4-or-the-compilation-of-conf-ncurses-failed/