### PR TITLE
+flow_parser.0.32.0

### DIFF
--- a/packages/flow_parser/flow_parser.0.32.0/descr
+++ b/packages/flow_parser/flow_parser.0.32.0/descr
@@ -1,0 +1,6 @@
+The Flow parser is a JavaScript parser written in OCaml. It produces an AST
+that conforms to SpiderMonkey's Parser API and that mostly matches what esprima
+produces. The Flow Parser can be compiled to native code or can be compiled to
+JavaScript using js_of_ocaml.
+
+To find out more about Flow, check out <http://flowtype.org>.

--- a/packages/flow_parser/flow_parser.0.32.0/opam
+++ b/packages/flow_parser/flow_parser.0.32.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "flow_parser"
+version: "0.32.0"
+maintainer: "gabe@fb.com"
+authors: [
+  "Avik Chaudhuri"
+  "Basil Hosmer"
+  "Gabe Levi"
+  "Jeff Morrison"
+  "Marshall Roch"
+  "Sam Goldman"
+]
+homepage: "https://github.com/facebook/flow/tree/master/src/parser"
+bug-reports: "https://github.com/facebook/flow/issues"
+license: "BSD3"
+
+# This is pretty hacky, but v0.32.0 has already been release. We'll
+# add a real META file and a Makefile rule for v0.33.0
+build: [
+  ["sh" "-c" "cd src/parser && ocamlbuild parser_flow.cma parser_flow.cmxa"]
+  ["sh" "-c" "echo 'name=\"parser_flow\"' > src/parser/META"]
+  ["sh" "-c" "echo 'version=\"0.32.0\"' >> src/parser/META"]
+  ["sh" "-c" "echo 'description=\"flow parser ocamlfind package\"' >> src/parser/META"]
+  ["sh" "-c" "echo 'archive(byte)=\"parser_flow.cma\"' >> src/parser/META"]
+  ["sh" "-c" "echo 'archive(native)=\"parser_flow.cmxa\"' >> src/parser/META"]
+]
+
+install: [
+  ["sh" "-c" "cd src/parser/ && ocamlfind install flow_parser META _build/parser_flow.cma _build/parser_flow.cmxa _build/*.cmi"]
+]
+remove: ["ocamlfind" "remove" "flow_parser"]
+depends: "ocamlfind" {build}
+available: [ocaml-version >= "4.01.0"]
+dev-repo: "https://github.com/facebook/flow.git"

--- a/packages/flow_parser/flow_parser.0.32.0/url
+++ b/packages/flow_parser/flow_parser.0.32.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/facebook/flow/archive/v0.32.0.tar.gz"
+checksum: "c26a1bf00f9e8b71c614db8bb9860be5"


### PR DESCRIPTION
There are some people who are interested in using the Flow parser. It doesn't have any dependencies and works as a standalone parser. This PR attempts to make it available as an opam package. `opam install flow_parser` should install a `flow_parser` library via ocamlfind.

The build and install are a little hacky, since Flow v0.32.0 has already been installed, so I can't add a `META` file or add rules to the `Makefile`. We'll clean this up for v0.33.0, though.

To test I cloned https://github.com/facebook/flow and added this `opam` file to it. Then I ran

```Bash
$ opam pin add flow_parser .
Package flow_parser does not exist, create as a NEW package ? [Y/n] y
flow_parser is now path-pinned to /Users/glevi/projects/flow-facebook
[NOTE] You are pinning to /Users/glevi/projects/flow-facebook as a raw path while it seems to be a git repository.
[NOTE] Consider pinning with '-k git' to have OPAM synchronise with your commits and ignore build artefacts.

[flow_parser.~unknown] Synchronizing with /Users/glevi/projects/flow-facebook
Installing new package description for flow_parser from /Users/glevi/projects/flow-facebook/opam

flow_parser needs to be installed.
The following actions will be performed:
 - install   flow_parser.0.32.0*
=== + 1 ===
Do you want to continue ? [Y/n] y

=-=- Synchronizing package archives -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  � 
[flow_parser.0.32.0] Synchronizing with /Users/glevi/projects/flow-facebook

=-=- Installing packages =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  � 
Building flow_parser.0.32.0:
  sh -c cd src/parser && ocamlbuild parser_flow.cma parser_flow.cmxa
  sh -c echo 'name="parser_flow"' > src/parser/META
  sh -c echo 'version="0.32.0"' >> src/parser/META
  sh -c echo 'description="flow parser ocamlfind package"' >> src/parser/META
  sh -c echo 'archive(byte)="parser_flow.cma"' >> src/parser/META
  sh -c echo 'archive(native)="parser_flow.cmxa"' >> src/parser/META
  sh -c cd src/parser/ && ocamlfind install flow_parser META _build/parser_flow.cma _build/parser_flow.cmxa _build/*.cmi
Installing flow_parser.0.32.0.
```

And then to test it out I ran


```Bash
$ ocaml
        OCaml version 4.02.1

# #use "topfind";;
- : unit = ()
Findlib has been successfully loaded. Additional directives:
  #require "package";;      to load a package
  #list;;                   to list the available packages
  #camlp4o;;                to load camlp4 (standard syntax)
  #camlp4r;;                to load camlp4 (revised syntax)
  #predicates "p,q,...";;   to set these predicates
  Topfind.reset();;         to force that packages will be reloaded
  #thread;;                 to enable threads

- : unit = ()
# #require "flow_parser";;
/Users/glevi/.opam/4.02.1/lib/flow_parser: added to search path
/Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.cma: loaded
# Parser_flow.program "1+1";;
- : Parser_flow.Ast.program * (Loc.t * Parser_flow.Error.t) list =
(({Loc.source = None; start = {Loc.line = 1; column = 0; offset = 0};
   _end = {Loc.line = 1; column = 3; offset = 3}},
  [({Loc.source = None; start = {Loc.line = 1; column = 0; offset = 0};
     _end = {Loc.line = 1; column = 3; offset = 3}},
    Parser_flow.Ast.Statement.Expression
     {Parser_flow.Ast.Statement.Expression.expression =
       ({Loc.source = None; start = {Loc.line = 1; column = 0; offset = 0};
         _end = {Loc.line = 1; column = 3; offset = 3}},
        Parser_flow.Ast.Expression.Binary
         {Parser_flow.Ast.Expression.Binary.operator =
           Parser_flow.Ast.Expression.Binary.Plus;
          left =
           ({Loc.source = None;
             start = {Loc.line = 1; column = 0; offset = 0};
             _end = {Loc.line = 1; column = 1; offset = 1}},
            Parser_flow.Ast.Expression.Literal
             {Parser_flow.Ast.Literal.value =
               Parser_flow.Ast.Literal.Number 1.;
              raw = "1"});
          right =
           ({Loc.source = None;
             start = {Loc.line = 1; column = 2; offset = 2};
             _end = {Loc.line = 1; column = 3; offset = 3}},
            Parser_flow.Ast.Expression.Literal
             {Parser_flow.Ast.Literal.value =
               Parser_flow.Ast.Literal.Number 1.;
              raw = "1"})})})],
  []),
 [])
```