### PR TITLE
smtp: add conflict with recent lwt

### DIFF
--- a/packages/smtp/smtp.0.2/opam
+++ b/packages/smtp/smtp.0.2/opam
@@ -1,16 +1,18 @@
 opam-version: "1.2"
 maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
 authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+homepage: "https://github.com/vbmithr/ocaml-smtp"
+bug-reports: "https://github.com/vbmithr/ocaml-smtp/issues"
 license: "ISC"
 tags: [ "smtp" ]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-depopts: ["lwt"]
+depopts: ["lwt" "base-unix"]
 conflicts: ["lwt" {>= "2.5.0"}]
 dev-repo: "git://github.com/vbmithr/ocaml-smtp"
-install: [
+build: [
   "ocaml"
   "pkg/build.ml"
   "native=true"

--- a/packages/smtp/smtp.0.2/opam
+++ b/packages/smtp/smtp.0.2/opam
@@ -8,6 +8,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["lwt"]
+conflicts: ["lwt" {>= "2.5.0"}]
 dev-repo: "git://github.com/vbmithr/ocaml-smtp"
 install: [
   "ocaml"


### PR DESCRIPTION
`smtp` does not work with the latest versions of `lwt`.

/cc @vbmithr