### PR TITLE
ssl: add bound on OCaml version

### DIFF
--- a/packages/ssl/ssl.0.4.6/opam
+++ b/packages/ssl/ssl.0.4.6/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: "Christopher Zimmermann <christopher@gmerlin.de>"
+author: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+
 build: [
   ["./pkgconfigure" "--prefix" prefix] {os = "openbsd"}
   ["./configure" "--prefix" prefix] {os != "openbsd"}

--- a/packages/ssl/ssl.0.4.6/opam
+++ b/packages/ssl/ssl.0.4.6/opam
@@ -12,3 +12,4 @@ depexts: [
   [["ubuntu"] ["libssl-dev"]]
 ]
 install: [make "install"]
+available: [ocaml-version < "4.04.0"]

--- a/packages/ssl/ssl.0.4.6a/opam
+++ b/packages/ssl/ssl.0.4.6a/opam
@@ -13,3 +13,4 @@ depexts: [
   [["ubuntu"] ["libssl-dev"]]
 ]
 install: [make "install"]
+available: [ocaml-version < "4.04.0"]

--- a/packages/ssl/ssl.0.4.6a/opam
+++ b/packages/ssl/ssl.0.4.6a/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: "Christopher Zimmermann <christopher@gmerlin.de>"
+author: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+
 patches: ["fix-accept.diff"]
 build: [
   ["./pkgconfigure" "--prefix" prefix] {os = "openbsd"}

--- a/packages/ssl/ssl.0.4.7/opam
+++ b/packages/ssl/ssl.0.4.7/opam
@@ -14,3 +14,4 @@ depexts: [
   [["fedora"] ["openssl-devel"]]
 ]
 install: [make "install"]
+available: [ocaml-version < "4.04.0"]

--- a/packages/ssl/ssl.0.4.7/opam
+++ b/packages/ssl/ssl.0.4.7/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: "Christopher Zimmermann <christopher@gmerlin.de>"
+author: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+
 build: [
   ["./pkgconfigure" "--prefix" prefix] {os = "openbsd"}
   ["./configure" "--prefix" prefix] {os != "openbsd"}

--- a/packages/ssl/ssl.0.5.0/opam
+++ b/packages/ssl/ssl.0.5.0/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
-maintainer: "contact@ocamlpro.com"
+maintainer: "Christopher Zimmermann <christopher@gmerlin.de>"
+author: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+
 build: [
   ["./pkgconfigure" "--prefix" prefix] {os = "openbsd"}
   ["./configure" "--prefix" prefix] {os != "openbsd"}
@@ -14,6 +19,5 @@ depexts: [
   [["centos"] ["openssl-devel"]]
   [["fedora"] ["openssl-devel"]]
 ]
-dev-repo: "git://github.com/savonet/ocaml-ssl"
 install: [make "install"]
 available: [ocaml-version < "4.04.0"]

--- a/packages/ssl/ssl.0.5.0/opam
+++ b/packages/ssl/ssl.0.5.0/opam
@@ -16,3 +16,4 @@ depexts: [
 ]
 dev-repo: "git://github.com/savonet/ocaml-ssl"
 install: [make "install"]
+available: [ocaml-version < "4.04.0"]

--- a/packages/ssl/ssl.0.5.2/opam
+++ b/packages/ssl/ssl.0.5.2/opam
@@ -19,3 +19,4 @@ depends: [
   "conf-which" {build}
   "conf-openssl"
 ]
+available: [ocaml-version < "4.04.0"]


### PR DESCRIPTION
Note: the fix is already done upstream, but not released: https://github.com/savonet/ocaml-ssl/commit/ceec769a0d56a7d5d78440168d4bd78e5af51d9d

/cc @smimram 
