### PR TITLE
hardcaml-waveterm: two problems

### DIFF
--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
@@ -6,7 +6,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "hardcaml"
+  "hardcaml" {>= "1.1.0"}
   "lambda-term"
   "ocamlbuild" {build}
 ]

--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
@@ -11,6 +11,6 @@ depends: [
   "lambda-term"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.04.0" ]
 dev-repo: "git://github.com/ujamjar/hardcaml-waveterm"
 install: [make "install"]

--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "andy.ray@ujamjar.com"
 homepage: "https://github.com/ujamjar/hardcaml-waveterm"
+authors: "MicroJamJar Ltd."
 build: [make "all"]
 remove: [
   [make "uninstall"]


### PR DESCRIPTION
`hardcaml-waveterm` doesn't work with `hardcaml` 1.0.0.

It also fails to compile under 4.04.0+beta2, with a rather mysterious type error. I don't know if this is a bug in OCaml or a new restriction, and I don't know how to work around it. It seems related to the double-view problem. Any idea @garrigue @lpw25 ?

/cc @andrewray 
