### PR TITLE
frama-c-base: add bound on OCaml version

### DIFF
--- a/packages/frama-c-base/frama-c-base.20160501/opam
+++ b/packages/frama-c-base/frama-c-base.20160501/opam
@@ -110,4 +110,4 @@ conflicts: [
 ]
 
 available: [ ocaml-version >= "4.00.1" & ocaml-version != "4.02.0" &
-             ocaml-version != "4.02.2" ]
+             ocaml-version != "4.02.2" & ocaml-version < "4.04.0" ]


### PR DESCRIPTION
The latest `frama-c` doesn't work on OCaml 4.04.0 because `Set.map` was added to stdlib.

Also, there seems to be a missing depopt on `why3`?

/cc @bobot 
