### PR TITLE
mlpost: add bound on OCaml version

### DIFF
--- a/packages/mlpost/mlpost.0.8.1/opam
+++ b/packages/mlpost/mlpost.0.8.1/opam
@@ -34,3 +34,4 @@ depends: [
   "conf-autoconf" {build}
 ]
 patches: ["opam.patch"]
+available: [ ocaml-version < "4.03.0" ]


### PR DESCRIPTION
`mlpost`'s configure script assumes that `ocamlbuild`'s version must be identical to OCaml's version.

upstream PR: https://github.com/backtracking/mlpost/pull/6

/cc @backtracking 
