### PR TITLE
ocaml-top: add bounds on ocp-build versions

### DIFF
--- a/packages/ocaml-top/ocaml-top.1.0.0/opam
+++ b/packages/ocaml-top/ocaml-top.1.0.0/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "http://www.typerex.org/ocaml-top.html"
 license: "GPL 3"
 build: [
@@ -21,7 +22,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.6-beta"}
+  "ocp-build" {>= "1.99.6-beta" & < "1.99.8-beta"}
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
   "ocp-indent" {>= "1.3.0" & < "1.4.0"}

--- a/packages/ocaml-top/ocaml-top.1.0.1/opam
+++ b/packages/ocaml-top/ocaml-top.1.0.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "http://www.typerex.org/ocaml-top.html"
 license: "GPL 3"
 build: [
@@ -21,7 +22,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.6-beta"}
+  "ocp-build" {>= "1.99.6-beta" & < "1.99.8-beta"}
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
   "ocp-indent" {>= "1.3.1" & < "1.4.0"}

--- a/packages/ocaml-top/ocaml-top.1.1.0/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.0/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "http://www.typerex.org/ocaml-top.html"
 license: "GPL 3"
 build: [
@@ -21,7 +22,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.6-beta"}
+  "ocp-build" {>= "1.99.6-beta" & < "1.99.8-beta"}
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
   "ocp-indent" {>= "1.3.1" & < "1.4.0"}

--- a/packages/ocaml-top/ocaml-top.1.1.1/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "contact@ocamlpro.com"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "http://www.typerex.org/ocaml-top.html"
 license: "GPL 3"
 build: [
@@ -21,7 +22,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.6-beta"}
+  "ocp-build" {>= "1.99.6-beta" & < "1.99.17-beta"}
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
   "ocp-indent" {>= "1.4.0"}

--- a/packages/ocaml-top/ocaml-top.1.1.2/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.2/opam
@@ -12,7 +12,7 @@ build: [
   ["ocp-build" "ocaml-top"]
 ]
 depends: [
-  "ocp-build" {>= "1.99.6-beta"}
+  "ocp-build" {>= "1.99.6-beta" & < "1.99.17-beta"}
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}
   "ocp-indent" {>= "1.4.1"}


### PR DESCRIPTION
Notes:

- older versions of `ocaml-top` call `ocp-build` with the `-install-bin` option, which is not understood by any of the available versions of `ocp-build`.
- I have no idea why `opam lint` accepts `contact@ocamlpro.com` as maintainer for 1.1.2 but not for the other versions.

/cc @AltGr 
