### PR TITLE
ocamlbuild: add bound on OCaml version

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.9.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.0/opam
@@ -24,7 +24,7 @@ build: [
   [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
-available: [ocaml-version >= "4.03"]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.04"]
 depends: [ ]
 conflicts: [
   "base-ocamlbuild"


### PR DESCRIPTION
When your project has C files, `ocamlbuild` 0.9.0 will compile them by passing both `-c` and `-o` to the OCaml compiler, which 4.04.0 rejects.

This breaks `cryptokit` and `pcre` and probably many others.

Later versions of `ocamlbuild` have fixed the problem.

/cc @gasche 