### PR TITLE
rdf: several fixes

### DIFF
--- a/packages/rdf/rdf.0.10.0/opam
+++ b/packages/rdf/rdf.0.10.0/opam
@@ -34,5 +34,5 @@ conflicts: [
   "lwt" {< "2.4.5"}
   "mysql" {< "1.1.1"}
 ]
-available: [ocaml-version >= "4.02.2"]
+available: [ocaml-version >= "4.02.2" & ocaml-version < "4.03.0" ]
 

--- a/packages/rdf/rdf.0.2/opam
+++ b/packages/rdf/rdf.0.2/opam
@@ -10,6 +10,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "camlp4"
   "xmlm" {>= "1.1.1"}
   "ocamlnet"
 ]

--- a/packages/rdf/rdf.0.3/opam
+++ b/packages/rdf/rdf.0.3/opam
@@ -10,6 +10,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "camlp4"
   "xmlm" {>= "1.1.1"}
   "ocamlnet"
 ]

--- a/packages/rdf/rdf.0.4/opam
+++ b/packages/rdf/rdf.0.4/opam
@@ -10,6 +10,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "camlp4"
   "xmlm" {>= "1.1.1"}
   "ocamlnet" {>= "3.6"}
 ]

--- a/packages/rdf/rdf.0.5/opam
+++ b/packages/rdf/rdf.0.5/opam
@@ -24,7 +24,7 @@ depends: [
   "xmlm" {>= "1.1.1"}
   "ocamlnet" {>= "3.6"}
   "ulex" {>= "1.1"}
-  "menhir" {>= "20120123"}
+  "menhir" {>= "20120123" & < "20141215"}
 ]
 depopts: ["mysql" "postgresql"]
 conflicts: [

--- a/packages/rdf/rdf.0.7.0/opam
+++ b/packages/rdf/rdf.0.7.0/opam
@@ -32,5 +32,5 @@ depopts: ["mysql" "postgresql"]
 conflicts: [
   "mysql" {< "1.1.1"}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/rdf/rdf.0.7.1/opam
+++ b/packages/rdf/rdf.0.7.1/opam
@@ -32,5 +32,5 @@ depopts: ["mysql" "postgresql"]
 conflicts: [
   "mysql" {< "1.1.1"}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/rdf/rdf.0.8.0/opam
+++ b/packages/rdf/rdf.0.8.0/opam
@@ -32,5 +32,5 @@ depopts: ["mysql" "postgresql"]
 conflicts: [
   "mysql" {< "1.1.1"}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]

--- a/packages/rdf/rdf.0.9.0/opam
+++ b/packages/rdf/rdf.0.9.0/opam
@@ -35,5 +35,5 @@ conflicts: [
   "lwt" {< "2.4.5"}
   "mysql" {< "1.1.1"}
 ]
-available: ocaml-version >= "4.02.0"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03.0" ]
 install: [make "install"]


### PR DESCRIPTION
- missing deps on `camlp4`
- missing bound on `menhir`
- bounds on OCaml version

@zoggy :

The latest versions of `rdf` do not compile under 4.03.0 and later because of the change in the lexing of number literals: you'll have to add spaces between hex numbers and the `..` operator.

Finally, there was a small change to the AST, which you'll have to take into account.
