### PR TITLE
js_of_ocaml 2.4.1 miss some ocaml version constraint

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
@@ -18,3 +18,4 @@ conflicts: [
   "tyxml"    {< "3.2.1"}
   "tyxml"    {>= "3.6.0"}
 ]
+available: [ ocaml-version <= "4.01.0" ]


### PR DESCRIPTION
It compiles ok but is not really usable on OCaml 4.02 and 4.03
This was noticed looking at http://opam.ocamlpro.com/builder/html/report-full.html