### PR TITLE
osx-cf.0.1.1: fix topkg constraint to be >= 0.7.4 for Topkg.Pkg.test

### DIFF
--- a/packages/osx-cf/osx-cf.0.1.1/opam
+++ b/packages/osx-cf/osx-cf.0.1.1/opam
@@ -33,7 +33,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "topkg" {build & >= "0.7.2"}
+  "topkg" {build & >= "0.7.4"}
   "alcotest" {test}
   "base-bytes"
   "ctypes" {>= "0.4.0"}


### PR DESCRIPTION
Fixed upstream in dsheets/ocaml-osx-cf#7.