### PR TITLE
Update extlib urls

### DIFF
--- a/packages/extlib/extlib.1.5.2/url
+++ b/packages/extlib/extlib.1.5.2/url
@@ -1,2 +1,2 @@
-archive: "http://ocaml-extlib.googlecode.com/files/extlib-1.5.2.tar.gz"
+archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.2.tar.gz"
 checksum: "839f9bf5a971fa07935c96ba7e209f86"

--- a/packages/extlib/extlib.1.5.2/url
+++ b/packages/extlib/extlib.1.5.2/url
@@ -1,2 +1,3 @@
 archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.2.tar.gz"
+mirrors: ["http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.5.2.tar.gz"]
 checksum: "839f9bf5a971fa07935c96ba7e209f86"

--- a/packages/extlib/extlib.1.5.3/url
+++ b/packages/extlib/extlib.1.5.3/url
@@ -1,2 +1,2 @@
-archive: "http://ocaml-extlib.googlecode.com/files/extlib-1.5.3.tar.gz"
+archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.3.tar.gz"
 checksum: "3de5f4e0a95fda7b2f3819c4a655b17c"

--- a/packages/extlib/extlib.1.5.3/url
+++ b/packages/extlib/extlib.1.5.3/url
@@ -1,2 +1,3 @@
 archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.3.tar.gz"
+mirrors: ["http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.5.3.tar.gz"]
 checksum: "3de5f4e0a95fda7b2f3819c4a655b17c"

--- a/packages/extlib/extlib.1.5.4/url
+++ b/packages/extlib/extlib.1.5.4/url
@@ -1,2 +1,2 @@
-archive: "http://ocaml-extlib.googlecode.com/files/extlib-1.5.4.tar.gz"
+archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.4.tar.gz"
 checksum: "329041625309b9e49051e5b097a9185d"

--- a/packages/extlib/extlib.1.5.4/url
+++ b/packages/extlib/extlib.1.5.4/url
@@ -1,2 +1,3 @@
 archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.4.tar.gz"
+mirrors: ["http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.5.4.tar.gz"]
 checksum: "329041625309b9e49051e5b097a9185d"

--- a/packages/extlib/extlib.1.6.1/url
+++ b/packages/extlib/extlib.1.6.1/url
@@ -1,2 +1,2 @@
-archive: "http://ocaml-extlib.googlecode.com/files/extlib-1.6.1.tar.gz"
+archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.6.1.tar.gz"
 checksum: "5643237a6410dc915347956cff97df86"

--- a/packages/extlib/extlib.1.6.1/url
+++ b/packages/extlib/extlib.1.6.1/url
@@ -1,2 +1,3 @@
 archive: "http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.6.1.tar.gz"
+mirrors: ["http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.6.1.tar.gz"]
 checksum: "5643237a6410dc915347956cff97df86"


### PR DESCRIPTION
/cc @ygrek 

```
$ wget -qS http://ocaml-extlib.googlecode.com/files/extlib-1.5.2.tar.gz
  HTTP/1.1 404 Not Found
  Content-Type: text/html; charset=UTF-8
  Content-Length: 1586
  Date: Wed, 07 Sep 2016 11:01:42 GMT
```

```
$ wget -qS http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.2.tar.gz -O - | md5sum
  HTTP/1.1 200 OK
  X-GUploader-UploadID: AEnB2UrVZPswZTr68BeOGEmsk-bYMQ0BI71XboMC7gVPV5AMc6PCG0H4nFARcE2ZqXoj7Nj69KRdddr0ONGFBBuYjx0Mz7z7JQ
  Expires: Wed, 07 Sep 2016 12:00:55 GMT
  Date: Wed, 07 Sep 2016 11:00:55 GMT
  Last-Modified: Sat, 23 Jan 2016 04:33:25 GMT
  ETag: "839f9bf5a971fa07935c96ba7e209f86"
  x-goog-generation: 1453523605724000
  x-goog-metageneration: 1
  x-goog-stored-content-encoding: identity
  x-goog-stored-content-length: 70197
  Content-Type: application/octet-stream
  x-goog-hash: crc32c=IEQRaA==
  x-goog-hash: md5=g5+b9alx+geTXJa6fiCfhg==
  x-goog-storage-class: NEARLINE
  Accept-Ranges: bytes
  Content-Length: 70197
  Server: UploadServer
  Cache-Control: public, max-age=3600
  Age: 51
839f9bf5a971fa07935c96ba7e209f86  -
```
