### PR TITLE
tyxml-ppx: add bound on tyxml version

### DIFF
--- a/packages/tyxml-ppx/tyxml-ppx.4.0.0/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.0.0/opam
@@ -7,7 +7,7 @@ doc: "https://ocsigen.org/tyxml/manual/"
 dev-repo: "https://github.com/ocsigen/tyxml.git"
 build: ["ocamlfind" "query" "tyxml.ppx"]
 depends: [
-  "tyxml"
+  "tyxml" {>= "4.0.0"}
   "markup" {>= "0.7.2"}
   "ppx_tools"
 ]


### PR DESCRIPTION
Older versions of `tyxml` do not support ppx.
