### PR TITLE
unison: add bound on OCaml version

### DIFF
--- a/packages/unison/unison.2.48.3/opam
+++ b/packages/unison/unison.2.48.3/opam
@@ -10,3 +10,4 @@ bug-reports: "mailto:unison-users@yahoogroups.com "
 depends: ["lablgtk"]
 patches: ["opam.patch"]
 install: [make "install" "OCAMLLIBDIR=%{lib}%" "HOME=%{prefix}%"]
+available: [ocaml-version < "4.03.0"]


### PR DESCRIPTION
`unison` does not compile with OCaml 4.04.0 because of the new optional argument to `Unix.symlink`.

@AltGr @juergenhoetzel quick fix:
```
diff -u -r unison-2.48.3/system/system_generic.ml unison-2.48.3.fix/system/system_generic.ml
--- unison-2.48.3/system/system_generic.ml	2014-12-29 19:34:45.000000000 +0100
+++ unison-2.48.3.fix/system/system_generic.ml	2016-09-07 17:48:24.000000000 +0200
@@ -57,7 +57,7 @@
 let readdir = Unix.readdir
 let closedir = Unix.closedir
 let readlink = Unix.readlink
-let symlink = Unix.symlink
+let symlink target source = Unix.symlink target source
 let chdir = Sys.chdir
 let getcwd = Sys.getcwd

```