### PR TITLE
xxhash.0.1 - via opam-publish

### DIFF
--- a/packages/xxhash/xxhash.0.1/descr
+++ b/packages/xxhash/xxhash.0.1/descr
@@ -1,0 +1,1 @@
+Bindings for xxHash, an extremely fast hash algorithm.

--- a/packages/xxhash/xxhash.0.1/opam
+++ b/packages/xxhash/xxhash.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Pieter Goetschalckx <3.14.e.ter@gmail.com>"
+authors: "Pieter Goetschalckx <3.14.e.ter@gmail.com>"
+homepage: "https://github.com/314eter/ocaml-xxhash"
+bug-reports: "https://github.com/314eter/ocaml-xxhash/issues"
+license: "MIT"
+doc: "https://314eter.github.io/ocaml-xxhash"
+dev-repo: "git://github.com/314eter/ocaml-xxhash.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "xxhash"]
+depends: [
+  "oasis" {build}
+  "ctypes"
+]
+depexts: [
+  [["osx" "homebrew"] ["xxhash"]]
+]

--- a/packages/xxhash/xxhash.0.1/url
+++ b/packages/xxhash/xxhash.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/314eter/ocaml-xxhash/archive/v0.1.tar.gz"
+checksum: "c5142adfe682acb70a9b1705e920c0ef"


### PR DESCRIPTION
Bindings for xxHash, an extremely fast hash algorithm.


---
* Homepage: https://github.com/314eter/ocaml-xxhash
* Source repo: git://github.com/314eter/ocaml-xxhash.git
* Bug tracker: https://github.com/314eter/ocaml-xxhash/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.2