### PR TITLE
conf-libcurl.1: OS X ships with curl/libcurl so don't attempt detection

### DIFF
--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -3,7 +3,9 @@ maintainer: "blue-prawn"
 authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"
 license: "BSD-like"
-build: [["pkg-config" "libcurl"]]
+build: [
+  ["pkg-config" "libcurl"] { os != "darwin" }
+]
 depexts: [
   [["debian"] ["libcurl4-gnutls-dev"]]
   [["mageia"] ["libcurl-devel"]]


### PR DESCRIPTION
Fixes the issue found in #7358.