### PR TITLE
terminal_size.0.1.0 - via opam-publish

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.0/descr
+++ b/packages/terminal_size/terminal_size.0.1.0/descr
@@ -1,0 +1,4 @@
+Get the dimensions of the terminal
+
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.

--- a/packages/terminal_size/terminal_size.0.1.0/opam
+++ b/packages/terminal_size/terminal_size.0.1.0/opam
@@ -7,7 +7,7 @@ license: "BSD-2"
 dev-repo: "https://github.com/cryptosense/terminal_size.git"
 doc: "https://cryptosense.github.io/terminal_size/doc"
 build: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 ]
 depends: [
   "ocamlbuild" {build}

--- a/packages/terminal_size/terminal_size.0.1.0/opam
+++ b/packages/terminal_size/terminal_size.0.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/terminal_size/terminal_size.0.1.0/url
+++ b/packages/terminal_size/terminal_size.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/terminal_size/releases/download/v0.1.0/terminal_size-0.1.0.tbz"
+checksum: "1ae2f8533917b21d986a2a34846c4df1"


### PR DESCRIPTION
Get the dimensions of the terminal

You can use this small library to detect the dimensions of the terminal window
attached to a process.


---
* Homepage: https://github.com/cryptosense/terminal_size
* Source repo: https://github.com/cryptosense/terminal_size.git
* Bug tracker: https://github.com/cryptosense/terminal_size/issues

---


---
v0.1.0
------

First release.
Pull-request generated by opam-publish v0.3.2