### PR TITLE
tyre.0.1.1 - via opam-publish

### DIFF
--- a/packages/tyre/tyre.0.1.1/descr
+++ b/packages/tyre/tyre.0.1.1/descr
@@ -1,0 +1,4 @@
+Typed Regular Expressions
+
+Tyre is a set of combinators to build type-safe regular expressions, allowing automatic extraction and modification of matched groups.
+Tyre is bi-directional: a typed regular expressions can be used for parsing and unparsing. It also allows routing, by providing a list of regexs/routes and their handlers.

--- a/packages/tyre/tyre.0.1.1/opam
+++ b/packages/tyre/tyre.0.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+authors: "Gabriel Radanne <drupyog@zoho.com>"
+homepage: "https://github.com/Drup/tyre"
+doc: "https://drup.github.io/tyre/0.1.1/Tyre.html"
+bug-reports: "https://github.com/Drup/tyre/issues"
+license: "ISC"
+tags: "regex"
+dev-repo: "https://github.com/Drup/tyre.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "tyre"]
+depends: [
+  "ocamlfind" {build}
+  "re" {>= "1.6.0"}
+  "alcotest" {test & >= "0.6.0"}
+  "result"
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/tyre/tyre.0.1.1/url
+++ b/packages/tyre/tyre.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Drup/tyre/archive/0.1.1.tar.gz"
+checksum: "f99c76c3385de770f56e8591bbf21fa4"


### PR DESCRIPTION
Typed Regular Expressions

Tyre is a set of combinators to build type-safe regular expressions, allowing automatic extraction and modification of matched groups.
Tyre is bi-directional: a typed regular expressions can be used for parsing and unparsing. It also allows routing, by providing a list of regexs/routes and their handlers.

---
* Homepage: https://github.com/Drup/tyre
* Source repo: https://github.com/Drup/tyre.git
* Bug tracker: https://github.com/Drup/tyre/issues

---
## 0.1.1
* Fix a bug with nested repetitions. Also avoid some copying of the original string.
* Add Tyre.execp

---

Pull-request generated by opam-publish v0.3.2