### PR TITLE
flow_parser.0.32.0 - Include .a file in findlib

### DIFF
--- a/packages/flow_parser/flow_parser.0.32.0/opam
+++ b/packages/flow_parser/flow_parser.0.32.0/opam
@@ -26,7 +26,7 @@ build: [
 ]
 
 install: [
-  ["sh" "-c" "cd src/parser/ && ocamlfind install flow_parser META _build/parser_flow.cma _build/parser_flow.cmxa _build/*.cmi"]
+  ["sh" "-c" "cd src/parser/ && ocamlfind install flow_parser META _build/parser_flow.a _build/parser_flow.cma _build/parser_flow.cmxa _build/*.cmi"]
 ]
 remove: ["ocamlfind" "remove" "flow_parser"]
 depends: "ocamlfind" {build}


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/7348 was my first time using `ocamlfind install`, and I only experimented with it enough to make the ocaml top work. However, building native binaries does not work.

So, given a file, `foo.ml`, containing only `print_string "hi\n"`,

```
ocamlbuild -package flow_parser foo.byte # this worked
ocamlbuild -package flow_parser foo.native # this didn't work
```

When I tried it, I got this error

```
$ ocamlbuild -package flow_parser interop.native
+ /Users/glevi/.opam/4.02.1/bin/ocamlopt.opt -I /Users/glevi/.opam/4.02.1/lib/flow_parser /Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.cmxa interop.cmx -o interop.native
clang: error: no such file or directory: '/Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.a'
```

Pinning this formula, and updating it to also install `parser_flow.a` fixed the problem for me.