### PR TITLE
oasis-mirage: add bound on ocamlbuild

### DIFF
--- a/packages/oasis-mirage/oasis-mirage.0.3.0/opam
+++ b/packages/oasis-mirage/oasis-mirage.0.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml-data-notation"
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild"
+  "ocamlbuild" { < "0.9.0" }
 ]
 conflicts: ["oasis"]
 dev-repo: "git://github.com/avsm/oasis"

--- a/packages/oasis-mirage/oasis-mirage.0.3.0/opam
+++ b/packages/oasis-mirage/oasis-mirage.0.3.0/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors: ["Sylvain Le Gall" "Anil Madhavapeddy"]
+homepage: "http://github.com/avsm/oasis"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/oasis-mirage/oasis-mirage.0.3.0a/opam
+++ b/packages/oasis-mirage/oasis-mirage.0.3.0a/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml-data-notation"
   "ocamlify"
   "ocamlmod"
-  "ocamlbuild"
+  "ocamlbuild" { < "0.9.0" }
 ]
 conflicts: ["oasis"]
 dev-repo: "git://github.com/avsm/oasis"

--- a/packages/oasis-mirage/oasis-mirage.0.3.0a/opam
+++ b/packages/oasis-mirage/oasis-mirage.0.3.0a/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors: ["Sylvain Le Gall" "Anil Madhavapeddy"]
+homepage: "http://github.com/avsm/oasis"
 tags: [
   "org:mirage"
   "org:xapi-project"


### PR DESCRIPTION
`oasis-mirage` depends on module `Ocamlbuild_plugin`, which is not provided by the latest versions of `ocamlbuild` (as far as I can tell).

/cc @avsm @gasche 

@avsm: Please also check the `authors` and `homepage` fields.
