### PR TITLE
msyql: add upper bound on OCaml

### DIFF
--- a/packages/mysql/mysql.1.0.4/opam
+++ b/packages/mysql/mysql.1.0.4/opam
@@ -1,5 +1,11 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+authors: [
+  "Christian Lindig <lindig@eecs.harvard.edu>"
+  "Shawn Wagner <shawnw@speakeasy.org>"
+  "ygrek <ygrek@autistici.org>"
+]
+homepage: "http://ocaml-mysql.forge.ocamlcore.org"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/mysql/mysql.1.0.4/opam
+++ b/packages/mysql/mysql.1.0.4/opam
@@ -11,3 +11,4 @@ depexts: [
   [["ubuntu"] ["libmysqlclient-dev"]]
 ]
 install: [make "install"]
+available: [ ocaml-version < "4.03" ]

--- a/packages/mysql/mysql.1.1.1/opam
+++ b/packages/mysql/mysql.1.1.1/opam
@@ -14,3 +14,4 @@ depexts: [
   [["ubuntu"] ["libmysqlclient-dev"]]
 ]
 install: [make "install"]
+available: [ ocaml-version < "4.03" ]

--- a/packages/mysql/mysql.1.1.1/opam
+++ b/packages/mysql/mysql.1.1.1/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
+authors: [
+  "Christian Lindig <lindig@eecs.harvard.edu>"
+  "Shawn Wagner <shawnw@speakeasy.org>"
+  "ygrek <ygrek@autistici.org>"
+]
 homepage: "http://ocaml-mysql.forge.ocamlcore.org"
 doc: ["http://ocaml-mysql.forge.ocamlcore.org/doc/index.html"]
 build: [

--- a/packages/mysql/mysql.1.1.2/opam
+++ b/packages/mysql/mysql.1.1.2/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
+authors: [
+  "Christian Lindig <lindig@eecs.harvard.edu>"
+  "Shawn Wagner <shawnw@speakeasy.org>"
+  "ygrek <ygrek@autistici.org>"
+]
 homepage: "http://ocaml-mysql.forge.ocamlcore.org"
 doc: "http://ocaml-mysql.forge.ocamlcore.org/doc/index.html"
 build: [

--- a/packages/mysql/mysql.1.1.2/opam
+++ b/packages/mysql/mysql.1.1.2/opam
@@ -18,3 +18,4 @@ depexts: [
   [ [ "ubuntu" ] [ "libmysqlclient-dev" ] ]
 ]
 install: [make "install"]
+available: [ ocaml-version < "4.03" ]

--- a/packages/mysql/mysql.1.1.3/opam
+++ b/packages/mysql/mysql.1.1.3/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
+authors: [
+  "Christian Lindig <lindig@eecs.harvard.edu>"
+  "Shawn Wagner <shawnw@speakeasy.org>"
+  "ygrek <ygrek@autistici.org>"
+]
 homepage: "http://ocaml-mysql.forge.ocamlcore.org"
 doc: "http://ocaml-mysql.forge.ocamlcore.org/doc/index.html"
 build: [

--- a/packages/mysql/mysql.1.1.3/opam
+++ b/packages/mysql/mysql.1.1.3/opam
@@ -26,3 +26,4 @@ depexts: [
   [ [ "ubuntu" ] [ "libmysqlclient-dev" ] ]
 ]
 install: [make "install"]
+available: [ ocaml-version < "4.03" ]

--- a/packages/mysql/mysql.1.2.0/opam
+++ b/packages/mysql/mysql.1.2.0/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
+authors: [
+  "Christian Lindig <lindig@eecs.harvard.edu>"
+  "Shawn Wagner <shawnw@speakeasy.org>"
+  "ygrek <ygrek@autistici.org>"
+]
 homepage: "http://ocaml-mysql.forge.ocamlcore.org"
 doc: "http://ocaml-mysql.forge.ocamlcore.org/doc/index.html"
 build: [

--- a/packages/mysql/mysql.1.2.0/opam
+++ b/packages/mysql/mysql.1.2.0/opam
@@ -18,3 +18,4 @@ depexts: [
   [ [ "ubuntu" ] [ "libmysqlclient-dev" ] ]
 ]
 install: [make "install"]
+available: [ ocaml-version < "4.03" ]


### PR DESCRIPTION
Older versions of `mysql` do not work with 4.03.0 and later because the definition of `int64` was removed from the C headers.

The problem is fixed in `mysql.1.2.1`.
