### PR TITLE
Release mirage-vnetif 0.2.0

### DIFF
--- a/packages/mirage-vnetif/mirage-vnetif.0.2.0/descr
+++ b/packages/mirage-vnetif/mirage-vnetif.0.2.0/descr
@@ -1,0 +1,6 @@
+Virtual network interface and software switch for Mirage.
+
+Provides the module Vnetif which can be used as a replacement for the
+regular Netif implementation in Xen and Unix. Stacks built using
+Vnetif are connected to a software switch that allows the stacks to
+communicate as if they were connected to the same LAN.

--- a/packages/mirage-vnetif/mirage-vnetif.0.2.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/MagnusS/mirage-vnetif"
+bug-reports: "https://github.com/MagnusS/mirage-vnetif/issues/"
+license: "ISC"
+dev-repo: "https://github.com/MagnusS/mirage-vnetif.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-vnetif"]
+depends: [
+  "lwt"
+  "mirage-types"
+  "cstruct"
+  "ipaddr"
+  "io-page"
+  "mirage-profile"
+  "ocamlbuild" {build}
+]

--- a/packages/mirage-vnetif/mirage-vnetif.0.2.0/url
+++ b/packages/mirage-vnetif/mirage-vnetif.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/MagnusS/mirage-vnetif/archive/0.2.0.tar.gz"
+checksum: "712966a3d9ad813145f0b67af8b3d8ae"


### PR DESCRIPTION
Changes:

- New call unregister_and_flush lets a node wait for all its listener callbacks to return before unregistering from the backend
- Support more than 254 connected nodes