### PR TITLE
js_of_ocaml.2.8.2 - via opam-publish

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/descr
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/descr
@@ -1,0 +1,1 @@
+Compiler from OCaml bytecode to Javascript

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/findlib
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/findlib
@@ -1,0 +1,1 @@
+js_of_ocaml

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer: "dev@ocsigen.org"
+authors: "Ocsigen team"
+homepage:    "http://ocsigen.org/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+dev-repo:    "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [make "build"]
+install: [make "install-lib" "BINDIR=%{bin}%"]
+remove: ["ocamlfind" "remove" "js_of_ocaml"]
+depends: [
+  "cmdliner"
+  "base-unix"
+  "ocamlfind" {>= "1.5.1"}
+  "lwt" {>= "2.4.4"}
+  "menhir"
+  "cppo" {>= "1.1.0"}
+  "camlp4"
+  "base64" {>= "2.0.0"}
+  ("base-no-ppx" | "ppx_tools")
+  "ocamlbuild"
+  "uchar"
+]
+depopts: [
+  "deriving"
+  "ppx_deriving"
+  "tyxml"
+  "reactiveData"
+  "async_kernel"
+  "ppx_driver"
+]
+conflicts: [
+  "deriving" {< "0.6"}
+  "tyxml" {< "4.0.0"}
+  "ppx_deriving" {< "3.0"}
+  "reactiveData" {< "0.2"}
+  "async_kernel" {< "113.33.00"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/url
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/js_of_ocaml/archive/2.8.2.tar.gz"
+checksum: "c4f3eead00150de75df6f93b138c3962"


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript


---
* Homepage: http://ocsigen.org/js_of_ocaml
* Source repo: git+https://github.com/ocsigen/js_of_ocaml.git
* Bug tracker: https://github.com/ocsigen/js_of_ocaml/issues

---
### opam-lint failures
- **WARNING** 92 extra file "findlib"
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.2