### PR TITLE
msat.0.4.1 - via opam-publish

### DIFF
--- a/packages/msat/msat.0.4.1/descr
+++ b/packages/msat/msat.0.4.1/descr
@@ -1,0 +1,8 @@
+Modular sat/smt solver
+
+This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
+- proof output
+- push/pop operations
+- CNF transformation tools
+
+This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.

--- a/packages/msat/msat.0.4.1/opam
+++ b/packages/msat/msat.0.4.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes@inria.fr"]
+authors: [
+  "Sylvain Conchon"
+  "Alain Mebsout"
+  "Stephane Lecuyer"
+  "Simon Cruanes"
+  "Guillaume Bury"
+]
+homepage: "https://github.com/Gbury/mSAT"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+license: "Apache"
+tags: ["sat" "smt"]
+dev-repo: "https://github.com/Gbury/mSAT.git"
+build: [
+  [make "disable_log"]
+  [make "lib"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "msat"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/msat/msat.0.4.1/url
+++ b/packages/msat/msat.0.4.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Gbury/mSAT/archive/v0.4.1.tar.gz"
+checksum: "e5a09e49d9bc9f5358af94c84e53a822"


### PR DESCRIPTION
Modular sat/smt solver

This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
- proof output
- push/pop operations
- CNF transformation tools

This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.


---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---

Pull-request generated by opam-publish v0.3.2