### PR TITLE
flock: add upper bound on ctypes

### DIFF
--- a/packages/flock/flock.1.0.0/opam
+++ b/packages/flock/flock.1.0.0/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "flock_bindings"]
 ]
 depends: [
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.9.1"}
   "ctypes-foreign" {>= "0.4.0"}
   "ocamlfind" {build}
   "oasis" {build}


### PR DESCRIPTION
For some reason I don't understand, `flock` does not compile on `ctypes.0.9.1` although it works fine with `ctypes.0.9.0`.

/cc @simonjbeaumont 
