### PR TITLE
irmin-watcher: add lower bound on lwt

### DIFF
--- a/packages/irmin-watcher/irmin-watcher.0.1.0/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.1.0/opam
@@ -13,7 +13,10 @@ depends: [
   "topkg"      {build}
   "cppo"       {build}
   "alcotest"   {test}
-  "lwt" "logs" "fmt" "astring"
+  "lwt"        { >= "2.4.7" }
+  "logs"
+  "fmt"
+  "astring"
 ]
 depopts: ["inotify" "osx-fsevents"]
 build: [

--- a/packages/irmin-watcher/irmin-watcher.0.1.1/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.1.1/opam
@@ -13,7 +13,10 @@ depends: [
   "topkg"      {build}
   "cppo"       {build}
   "alcotest"   {test}
-  "lwt" "logs" "fmt" "astring"
+  "lwt" { >= "2.4.7" }
+  "logs"
+  "fmt"
+  "astring"
 ]
 depopts: ["inotify" "osx-fsevents"]
 build: [

--- a/packages/irmin-watcher/irmin-watcher.0.1.2/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.1.2/opam
@@ -13,7 +13,10 @@ depends: [
   "topkg"      {build}
   "cppo"       {build}
   "alcotest"   {test}
-  "lwt" "logs" "fmt" "astring"
+  "lwt" { >= "2.4.7" }
+  "logs"
+  "fmt"
+  "astring"
 ]
 depopts: ["inotify" "osx-fsevents"]
 build: [

--- a/packages/irmin-watcher/irmin-watcher.0.1.3/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.1.3/opam
@@ -13,7 +13,10 @@ depends: [
   "topkg"      {build}
   "cppo"       {build}
   "alcotest"   {test}
-  "lwt" "logs" "fmt" "astring"
+  "lwt" { >= "2.4.7" }
+  "logs"
+  "fmt"
+  "astring"
 ]
 depopts: ["inotify" "osx-fsevents"]
 build: [

--- a/packages/irmin-watcher/irmin-watcher.0.1.4/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.1.4/opam
@@ -13,7 +13,10 @@ depends: [
   "topkg"      {build}
   "cppo"       {build}
   "alcotest"   {test}
-  "lwt" "logs" "fmt" "astring"
+  "lwt" { >= "2.4.7" }
+  "logs"
+  "fmt"
+  "astring"
 ]
 depopts: ["inotify" "osx-fsevents"]
 conflicts: [ "osx-fsevents" {< "0.2.0"} ]


### PR DESCRIPTION
`irmin-watcher` uses `Lwt.Infix`, which was introduced in `lwt.2.4.7`.
