### PR TITLE
maki: add lower bound on lwt

### DIFF
--- a/packages/maki/maki.0.1/opam
+++ b/packages/maki/maki.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "result"
-  "lwt"
+  "lwt" { >= "2.4.7" }
   "base-unix"
   "bencode"
   "sha"

--- a/packages/maki/maki.0.1/opam
+++ b/packages/maki/maki.0.1/opam
@@ -28,4 +28,4 @@ depends: [
   "base-threads"
 ]
 depopts: "yojson"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
`maki` uses `Lwt.Infix`, which was introduced in `lwt.2.4.7`.
