### PR TITLE
utp: add lower bound on lwt

### DIFF
--- a/packages/utp/utp.0.9.0/opam
+++ b/packages/utp/utp.0.9.0/opam
@@ -7,5 +7,5 @@ license: "MIT"
 dev-repo: "https://www.github.com/nojb/ocaml-utp.git"
 build: [make "all"]
 build-doc: [make "doc"]
-depends: ["base-bytes" "ocamlfind" {build} "lwt"]
+depends: ["base-bytes" "ocamlfind" {build} "lwt" {>= "2.4.7"}]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
`utp` uses `Lwt.Infix`, which was introduced in `lwt.2.4.7`.
