### PR TITLE
exenum: fix build instructions

### DIFF
--- a/packages/exenum/exenum.0.7/opam
+++ b/packages/exenum/exenum.0.7/opam
@@ -6,7 +6,7 @@ homepage: "http://exenum.forge.ocamlcore.org/"
 dev-repo: "https://forge.ocamlcore.org/anonscm/git/exenum/exenum.git"
 bug-reports: "http://exenum.forge.ocamlcore.org/"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{lwt:enable}%-lwt"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{lwt+camlp4:enable}%-lwt"]
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "exenum"]
 ]
 build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests" "--%{lwt:enable}%-lwt"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests" "--%{lwt+camlp4:enable}%-lwt"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
@@ -25,4 +25,5 @@ depends: [
 ]
 depopts: [
   "lwt"
+  "camlp4"
 ]


### PR DESCRIPTION
`exenum.0.7` cannot use `lwt` when `camlp4` is absent.
