### PR TITLE
ocurl: fix deps

### DIFF
--- a/packages/ocurl/ocurl.0.7.1/opam
+++ b/packages/ocurl/ocurl.0.7.1/opam
@@ -9,7 +9,7 @@ build: [
 ]
 build-doc: [[make "doc"]]
 remove: [["ocamlfind" "remove" "curl"]]
-depends: ["ocamlfind" "base-unix"]
+depends: ["ocamlfind" "base-unix" "camlp4"]
 depopts: ["lwt"]
 depexts: [
   [["debian"] ["libcurl4-gnutls-dev"]]

--- a/packages/ocurl/ocurl.0.7.1/opam
+++ b/packages/ocurl/ocurl.0.7.1/opam
@@ -1,7 +1,8 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
 homepage: "http://ocurl.forge.ocamlcore.org"
 license: "MIT"
+authors: [ "Lars Nilsson" "ygrek" ]
 doc: ["http://ocurl.forge.ocamlcore.org/api/index.html"]
 build: [
   ["./configure"]

--- a/packages/ocurl/ocurl.0.7.2/opam
+++ b/packages/ocurl/ocurl.0.7.2/opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
 homepage: "http://ocurl.forge.ocamlcore.org"
 license: "MIT"
+authors: [ "Lars Nilsson" "ygrek" ]
 doc: ["http://ocurl.forge.ocamlcore.org/api/index.html"]
 #dev-repo: "git://github.com/ygrek/ocurl.git"
 #bug-reports: "https://github.com/ygrek/ocurl/issues"

--- a/packages/ocurl/ocurl.0.7.2/opam
+++ b/packages/ocurl/ocurl.0.7.2/opam
@@ -14,7 +14,7 @@ install: [
 ]
 build-doc: [[make "doc"]]
 remove: [["ocamlfind" "remove" "curl"]]
-depends: ["ocamlfind" "base-unix"]
+depends: ["ocamlfind" "base-unix" "camlp4"]
 depopts: ["lwt"]
 depexts: [
   [["debian"] ["libcurl4-gnutls-dev"]]


### PR DESCRIPTION
`ocurl.0.7.1` and `ocurl.0.7.2` do not work when `lwt` is present and `camlp4` absent.
I don't know how to explain this constraint exactly to OPAM, so my solution is to add `camlp4` as a hard dependency (it's very likely to be installed for another reason anyway).

Note: more recent versions of `ocurl` have fixed this problem, presumably by fixing the configure script.
