### PR TITLE
gdb: add upper bound on OCaml

### DIFF
--- a/packages/gdb/gdb.0.3/opam
+++ b/packages/gdb/gdb.0.3/opam
@@ -26,4 +26,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["lambda-term" {build}]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocam-version < "4.03.0"]


### PR DESCRIPTION
`gdb` doesn't work on OCaml 4.03.0 and later because of a change in the AST.

/cc @ygrek 
