### PR TITLE
ppx_tools are required only at build time, mirage-clock-unix only for testing

### DIFF
--- a/packages/tcpip/tcpip.2.7.0/opam
+++ b/packages/tcpip/tcpip.2.7.0/opam
@@ -44,12 +44,12 @@ remove: ["ocamlfind" "remove" "tcpip"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "channel"
   "mirage-types" {>= "2.6.0"}
   "mirage-unix" {>= "1.1.0"}
   "mirage-console"
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {test & >= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}
   "mirage-flow" {test}

--- a/packages/tcpip/tcpip.2.8.0/opam
+++ b/packages/tcpip/tcpip.2.8.0/opam
@@ -45,12 +45,12 @@ depends: [
   "ocamlfind" {build}
   "result"
   "cstruct" {>= "1.9.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "channel"
   "mirage-types" {>= "2.8.0"}
   "mirage-unix" {>= "1.1.0"}
   "mirage-console"
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {test & >= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}
   "mirage-flow" {test}


### PR DESCRIPTION
see https://github.com/mirage/mirage-tcpip/pull/242