### PR TITLE
astring.0.8.3 - via opam-publish

### DIFF
--- a/packages/astring/astring.0.8.3/descr
+++ b/packages/astring/astring.0.8.3/descr
@@ -1,0 +1,15 @@
+Alternative String module for OCaml
+
+Astring exposes an alternative `String` module for OCaml. This module
+tries to balance minimality and expressiveness for basic, index-free,
+string processing and provides types and functions for substrings,
+string sets and string maps.
+
+Remaining compatible with the OCaml `String` module is a non-goal. The
+`String` module exposed by Astring has exception safe functions,
+removes deprecated and rarely used functions, alters some signatures
+and names, adds a few missing functions and fully exploits OCaml's
+newfound string immutability.
+
+Astring depends only on the OCaml standard library. It is distributed
+under the ISC license.

--- a/packages/astring/astring.0.8.3/opam
+++ b/packages/astring/astring.0.8.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/astring"
+doc: "http://erratique.ch/software/astring/doc"
+dev-repo: "http://erratique.ch/repos/astring.git"
+bug-reports: "https://github.com/dbuenzli/astring/issues"
+tags: [ "string" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/astring/astring.0.8.3/url
+++ b/packages/astring/astring.0.8.3/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/astring/releases/astring-0.8.3.tbz"
+checksum: "c5bf6352b9ac27fbeab342740f4fa870"


### PR DESCRIPTION
Alternative String module for OCaml

Astring exposes an alternative `String` module for OCaml. This module
tries to balance minimality and expressiveness for basic, index-free,
string processing and provides types and functions for substrings,
string sets and string maps.

Remaining compatible with the OCaml `String` module is a non-goal. The
`String` module exposed by Astring has exception safe functions,
removes deprecated and rarely used functions, alters some signatures
and names, adds a few missing functions and fully exploits OCaml's
newfound string immutability.

Astring depends only on the OCaml standard library. It is distributed
under the ISC license.


---
* Homepage: http://erratique.ch/software/astring
* Source repo: http://erratique.ch/repos/astring.git
* Bug tracker: https://github.com/dbuenzli/astring/issues

---


---
v0.8.3 2016-09-12 Zagreb
------------------------

- Fix potential segfault on 32-bit platforms due to overflow in
  `String[.Sub].concat`. Spotted by Jeremy Yallop in the standard
  library. The same bug was present in Astring.
Pull-request generated by opam-publish v0.3.2