### PR TITLE
javalib: add upper bound on extlib-compat

### DIFF
--- a/packages/javalib/javalib.2.2.2/opam
+++ b/packages/javalib/javalib.2.2.2/opam
@@ -13,6 +13,6 @@ remove: [
 depends: [
   "ocamlfind"
   "camlzip" {= "1.04"}
-  ("extlib" {<= "1.6.0"} | "extlib-compat")
+  ("extlib" {<= "1.6.0"} | "extlib-compat" {< "1.7.0"})
 ]
 install: [make "install"]

--- a/packages/javalib/javalib.2.2.2/opam
+++ b/packages/javalib/javalib.2.2.2/opam
@@ -1,5 +1,7 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: "sawja@inria.fr"
+homepage: "http://javalib.gforge.inria.fr"
+authors: " "
 build: [
   ["./configure.sh"]
   [make "ptrees"]

--- a/packages/javalib/javalib.2.3.2/opam
+++ b/packages/javalib/javalib.2.3.2/opam
@@ -6,9 +6,9 @@ build: [
   [make "installptrees"]
   [make]
 ]
-bug-reports: "sawja@inria.fr"
+#bug-reports: "sawja@inria.fr"
 author: "Javalib development team"
-licence: "LGPL-2.1 with OCaml linking exception"
+#licence: "LGPL-2.1 with OCaml linking exception"
 install: [
   [make "install"]
 ]

--- a/packages/javalib/javalib.2.3.2/opam
+++ b/packages/javalib/javalib.2.3.2/opam
@@ -23,7 +23,5 @@ depends: [
   "ocamlfind"
   "camlzip" {>= "1.05"}
   "camlp4" 
-  "extlib-compat"
+  "extlib-compat" {< "1.7.0"}
 ]
-
-


### PR DESCRIPTION
`javalib.2.3.2` doesn't compile with `extlib-compat.1.7.0` because the META file for `extlib-compat` contains a non-standard version number that breaks `javalib`'s configure file.

`javalib.2.2.2` also fails for some other reason.

/cc @ygrek 