### PR TITLE
base-bytes: fix ocamlfind version

### DIFF
--- a/packages/base-bytes/base-bytes.base/opam
+++ b/packages/base-bytes/base-bytes.base/opam
@@ -1,4 +1,6 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: " "
+authors: " "
+homepage: " "
 depends: ["ocamlfind" {>= "1.5.3"}]
-ocaml-version: [>= "4.02.0"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/base-bytes/base-bytes.base/opam
+++ b/packages/base-bytes/base-bytes.base/opam
@@ -1,4 +1,4 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-depends: ["ocamlfind" {>= "1.5.1"}]
+depends: ["ocamlfind" {>= "1.5.3"}]
 ocaml-version: [>= "4.02.0"]

--- a/packages/base-bytes/base-bytes.legacy/opam
+++ b/packages/base-bytes/base-bytes.legacy/opam
@@ -1,4 +1,4 @@
 opam-version: "1"
 maintainer: "contact@ocamlpro.com"
-depends: ["ocamlfind" {>= "1.5.1"}]
+depends: ["ocamlfind" {>= "1.5.3"}]
 ocaml-version: [< "4.02.0"]

--- a/packages/base-bytes/base-bytes.legacy/opam
+++ b/packages/base-bytes/base-bytes.legacy/opam
@@ -1,4 +1,6 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: " "
+authors: " "
+homepage: " "
 depends: ["ocamlfind" {>= "1.5.3"}]
-ocaml-version: [< "4.02.0"]
+available: [ocaml-version < "4.02.0"]


### PR DESCRIPTION
Trying to compile `bencode.1.0.2` under OCaml 4.00.1 with `ocamlfind.1.5.1` installed, I get this error:
```
  File "lib/bencode_streaming.ml", line 43, characters 6-23:
  Error: Unbound value Bytes.blit_string
```

Same error with `ocamlfind.1.5.2`. Things start working with 1.5.3.

I'm really surprised that this problem wasn't discovered earlier. /cc @gasche 

See also #7427