### PR TITLE
mirage-entropy-*: add dependency on camlp4

### DIFF
--- a/packages/mirage-entropy-unix/mirage-entropy-unix.0.1.6/opam
+++ b/packages/mirage-entropy-unix/mirage-entropy-unix.0.1.6/opam
@@ -12,7 +12,7 @@ depends: [
   "lwt"
   "io-page"
   "ipaddr"
-  "mirage-types" {>= "1.2.0"}
+  "mirage-types" {>= "1.2.0" & < "2.4.0"}
   "mirage-unix"
   "camlp4"
 ]

--- a/packages/mirage-entropy-unix/mirage-entropy-unix.0.1.6/opam
+++ b/packages/mirage-entropy-unix/mirage-entropy-unix.0.1.6/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "hannes@mehnert.org"
+homepage:     "https://github.com/mirage/mirage-entropy"
+authors:      ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
 build: [make "unix-build"]
 remove: [
   ["ocamlfind" "remove" "mirage-entropy-unix"]

--- a/packages/mirage-entropy-unix/mirage-entropy-unix.0.1.6/opam
+++ b/packages/mirage-entropy-unix/mirage-entropy-unix.0.1.6/opam
@@ -12,6 +12,7 @@ depends: [
   "ipaddr"
   "mirage-types" {>= "1.2.0"}
   "mirage-unix"
+  "camlp4"
 ]
 dev-repo: "git://github.com/mirage/mirage-entropy"
 available: ocaml-version >= "4.01.0"

--- a/packages/mirage-entropy-unix/mirage-entropy-unix.0.2.0/opam
+++ b/packages/mirage-entropy-unix/mirage-entropy-unix.0.2.0/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "hannes@mehnert.org"
+homepage:     "https://github.com/mirage/mirage-entropy"
+authors:      ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
 build: [make "unix-build"]
 remove: [
   ["ocamlfind" "remove" "mirage-entropy-unix"]

--- a/packages/mirage-entropy-unix/mirage-entropy-unix.0.2.0/opam
+++ b/packages/mirage-entropy-unix/mirage-entropy-unix.0.2.0/opam
@@ -9,6 +9,7 @@ depends: [
   "cstruct" {>= "1.3.0"}
   "mirage-types-lwt" {< "2.5.0"}
   "mirage-unix"
+  "camlp4"
 ]
 dev-repo: "git://github.com/mirage/mirage-entropy"
 available: ocaml-version >= "4.01.0"

--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.1.6/opam
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.1.6/opam
@@ -11,6 +11,7 @@ depends: [
   "io-page"
   "ipaddr"
   "mirage-types" {>= "1.2.0" & < "2.5.0"}
+  "camlp4"
 ]
 dev-repo: "git://github.com/mirage/mirage-entropy"
 available: ocaml-version >= "4.01.0"

--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.1.6/opam
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.1.6/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "hannes@mehnert.org"
+homepage:     "https://github.com/mirage/mirage-entropy"
+authors:      ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
 build: [make "xen-build"]
 remove: [
   ["ocamlfind" "remove" "mirage-entropy-xen"]


### PR DESCRIPTION
These need lwt.syntax, which implies camlp4.
