### PR TITLE
add back 4.04.0+trunk compiler description

### DIFF
--- a/compilers/4.04.0/4.04.0+trunk/4.04.0+trunk.comp
+++ b/compilers/4.04.0/4.04.0+trunk/4.04.0+trunk.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "4.04.0"
+src: "https://github.com/ocaml/ocaml/archive/4.04.tar.gz"
+build: [
+  ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.04.0/4.04.0+trunk/4.04.0+trunk.descr
+++ b/compilers/4.04.0/4.04.0+trunk/4.04.0+trunk.descr
@@ -1,0 +1,1 @@
+latest 4.04 snapshot 


### PR DESCRIPTION
We already have the flambda variants, just not the vanilla one.
It's used in the container builds to get the latest tracking 4.04
branch, so useful to have

/cc @damiendoligez 