### PR TITLE
Add packages for the OCaml system manual.

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.4.01.0/descr
+++ b/packages/ocaml-manual/ocaml-manual.4.01.0/descr
@@ -1,0 +1,1 @@
+The OCaml system manual

--- a/packages/ocaml-manual/ocaml-manual.4.01.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.01.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
+dev-repo: "https://github.com/ocaml/ocaml.git"
+bug-reports: "http://caml.inria.fr/mantis/"
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.02.0" ]
+build: [
+ [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+]

--- a/packages/ocaml-manual/ocaml-manual.4.01.0/url
+++ b/packages/ocaml-manual/ocaml-manual.4.01.0/url
@@ -1,0 +1,2 @@
+archive: "http://caml.inria.fr/distrib/ocaml-4.01/ocaml-4.01-refman-html.tar.gz"
+checksum: "73f4657680baeb200135720fbc84eb4b"

--- a/packages/ocaml-manual/ocaml-manual.4.02.0/descr
+++ b/packages/ocaml-manual/ocaml-manual.4.02.0/descr
@@ -1,0 +1,1 @@
+The OCaml system manual

--- a/packages/ocaml-manual/ocaml-manual.4.02.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.02.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
+dev-repo: "https://github.com/ocaml/ocaml.git"
+bug-reports: "http://caml.inria.fr/mantis/"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.03.0" ]
+build:
+[
+ [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+]

--- a/packages/ocaml-manual/ocaml-manual.4.02.0/url
+++ b/packages/ocaml-manual/ocaml-manual.4.02.0/url
@@ -1,0 +1,2 @@
+archive: "http://caml.inria.fr/distrib/ocaml-4.02/ocaml-4.02-refman-html.tar.gz"
+checksum: "915a1949f7af7186e16354e9682dc1e5"

--- a/packages/ocaml-manual/ocaml-manual.4.03.0/descr
+++ b/packages/ocaml-manual/ocaml-manual.4.03.0/descr
@@ -1,0 +1,1 @@
+The OCaml system manual

--- a/packages/ocaml-manual/ocaml-manual.4.03.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.03.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
+dev-repo: "https://github.com/ocaml/ocaml.git"
+bug-reports: "http://caml.inria.fr/mantis/"
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.03.0" ]
+build:
+[
+ [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+]

--- a/packages/ocaml-manual/ocaml-manual.4.03.0/url
+++ b/packages/ocaml-manual/ocaml-manual.4.03.0/url
@@ -1,0 +1,2 @@
+archive: "http://caml.inria.fr/distrib/ocaml-4.03/ocaml-4.03-refman-html.tar.gz"
+checksum: "d3e44d3984d029d2e88ba219ad8e24c2"


### PR DESCRIPTION
/cc @damiendoligez and @gasche 

I'm adding these packages that simply install the OCaml manual in `$(opam config var ocaml-manual:doc)`. The idea is that when installed, `opkg`'s documentation main index page will link directly on those according to your ocaml version rather than link to the latest version online.

I was tempted to patch the css file to "modernize" it a bit but didn't want to get into trouble with whoever is responsible for this. If there's interest in refreshing the look of the html manual upstream, I could give it a shot at some point.