### PR TITLE
ocamlnet: add dependency on base-bytes

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -49,6 +49,7 @@ remove: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild"
+  "base-bytes"
 ]
 depopts: [
   "conf-gnutls"


### PR DESCRIPTION
Without this dependency, compiling `ocamlnet.4.1.2` fails when an older version of `ocamlfind` is installed (<= 1.4.1).
