### PR TITLE
cow.2.2.0 - via opam-publish

### DIFF
--- a/packages/cow/cow.2.2.0/descr
+++ b/packages/cow/cow.2.2.0/descr
@@ -1,0 +1,7 @@
+XML, JSON, HTML and Markdown libraries
+
+Writing web-applications requires a lot of skills: HTML, CSS, XML,
+JSON and Markdown, to name but a few! This library provides OCaml
+combinators for these web formats.
+
+More documentation at <https://mirage.github.io/ocaml-cow>.

--- a/packages/cow/cow.2.2.0/opam
+++ b/packages/cow/cow.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Gazagnaire"
+  "David Sheets"
+  "Rudi Grinberg"
+  "Timothy Bourke"
+]
+homepage: "https://github.com/mirage/ocaml-cow"
+bug-reports: "https://github.com/mirage/ocaml-cow/issues"
+license: "ISC"
+doc: "http://mirage.github.io/ocaml-cow"
+tags: [
+  "org:mirage" "org:xapi-project" "www" "html" "xml" "css" "json" "markdown"
+]
+dev-repo: "https://github.com/mirage/ocaml-cow.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uri" {>= "1.3.9"}
+  "xmlm" {>= "1.1.1"}
+  "omd" {>= "0.8.2"}
+  "ezjsonm" {>= "0.4.0"}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/cow/cow.2.2.0/url
+++ b/packages/cow/cow.2.2.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/mirage/ocaml-cow/releases/download/v2.2.0/cow-2.2.0.tbz"
+checksum: "a880cc867cea10fe68c36e6501407365"


### PR DESCRIPTION
XML, JSON, HTML and Markdown libraries

Writing web-applications requires a lot of skills: HTML, CSS, XML,
JSON and Markdown, to name but a few! This library provides OCaml
combinators for these web formats.

More documentation at <https://mirage.github.io/ocaml-cow>.


---
* Homepage: https://github.com/mirage/ocaml-cow
* Source repo: https://github.com/mirage/ocaml-cow.git
* Bug tracker: https://github.com/mirage/ocaml-cow/issues

---

Pull-request generated by opam-publish v0.3.2