### PR TITLE
Opam 2.0 development version & libraries

### DIFF
--- a/packages/opam-client/opam-client.2.0~alpha4/descr
+++ b/packages/opam-client/opam-client.2.0~alpha4/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Actions on the opam root, switches, installations, and front-end.

--- a/packages/opam-client/opam-client.2.0~alpha4/opam
+++ b/packages/opam-client/opam-client.2.0~alpha4/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-state" {= "2.0~alpha4"}
+  "opam-solver" {= "2.0~alpha4"}
+  "cmdliner" {>= "0.9.8"}
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/opam-client/opam-client.2.0~alpha4/url
+++ b/packages/opam-client/opam-client.2.0~alpha4/url
@@ -1,0 +1,1 @@
+src: "https://github.com/ocaml/opam/archive/2.0-alpha4.tar.gz"

--- a/packages/opam-core/opam-core.2.0~alpha4/descr
+++ b/packages/opam-core/opam-core.2.0~alpha4/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Small standard library extensions, and generic system interaction modules used
+by opam.

--- a/packages/opam-core/opam-core.2.0~alpha4/opam
+++ b/packages/opam-core/opam-core.2.0~alpha4/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocp-build" {build & >= "1.99.7"}
+  "ocamlgraph" {>= "1.8.5"}
+  "re" {>= "1.5.0"}
+  "jsonm"
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/opam-core/opam-core.2.0~alpha4/url
+++ b/packages/opam-core/opam-core.2.0~alpha4/url
@@ -1,0 +1,1 @@
+src: "https://github.com/ocaml/opam/archive/2.0-alpha4.tar.gz"

--- a/packages/opam-devel/opam-devel.2.0~alpha4/descr
+++ b/packages/opam-devel/opam-devel.2.0~alpha4/descr
@@ -1,0 +1,5 @@
+opam 2.0 development version
+
+This package compiles the development version of opam 2.0. For consistency and
+safety of the installation, the binaries are not installed into the PATH, but
+into lib/opam-devel, from where the user can manually install them system-wide.

--- a/packages/opam-devel/opam-devel.2.0~alpha4/opam
+++ b/packages/opam-devel/opam-devel.2.0~alpha4/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "opam-devel"]
+]
+build-test: [make "tests"]
+depends: [
+  "opam-client" {= "2.0~alpha4"}
+  "cmdliner" {>= "0.9.8"}
+]
+post-messages: [
+"The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/* /usr/local/bin"
+  {success}
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/opam-devel/opam-devel.2.0~alpha4/url
+++ b/packages/opam-devel/opam-devel.2.0~alpha4/url
@@ -1,0 +1,1 @@
+src: "https://github.com/ocaml/opam/archive/2.0-alpha4.tar.gz"

--- a/packages/opam-format/opam-format.2.0~alpha4/descr
+++ b/packages/opam-format/opam-format.2.0~alpha4/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Definition of opam datastructures and its file interface.

--- a/packages/opam-format/opam-format.2.0~alpha4/opam
+++ b/packages/opam-format/opam-format.2.0~alpha4/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0~alpha4"}
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/opam-format/opam-format.2.0~alpha4/url
+++ b/packages/opam-format/opam-format.2.0~alpha4/url
@@ -1,0 +1,1 @@
+src: "https://github.com/ocaml/opam/archive/2.0-alpha4.tar.gz"

--- a/packages/opam-repository/opam-repository.2.0~alpha4/descr
+++ b/packages/opam-repository/opam-repository.2.0~alpha4/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+This library includes repository and remote sources handling, including
+curl/wget, rsync, git, mercurial, darcs backends.

--- a/packages/opam-repository/opam-repository.2.0~alpha4/opam
+++ b/packages/opam-repository/opam-repository.2.0~alpha4/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0~alpha4"}
+  "opam-format" {= "2.0~alpha4"}
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/opam-repository/opam-repository.2.0~alpha4/url
+++ b/packages/opam-repository/opam-repository.2.0~alpha4/url
@@ -1,0 +1,1 @@
+src: "https://github.com/ocaml/opam/archive/2.0-alpha4.tar.gz"

--- a/packages/opam-solver/opam-solver.2.0~alpha4/descr
+++ b/packages/opam-solver/opam-solver.2.0~alpha4/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Solver and Cudf interaction. This library is based on the Cudf and Dose
+libraries, and handles calls to the external solver from opam.

--- a/packages/opam-solver/opam-solver.2.0~alpha4/opam
+++ b/packages/opam-solver/opam-solver.2.0~alpha4/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0~alpha4"}
+  "opam-format" {= "2.0~alpha4"}
+  "dose" {>= "3.3"}
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/opam-solver/opam-solver.2.0~alpha4/url
+++ b/packages/opam-solver/opam-solver.2.0~alpha4/url
@@ -1,0 +1,1 @@
+src: "https://github.com/ocaml/opam/archive/2.0-alpha4.tar.gz"

--- a/packages/opam-state/opam-state.2.0~alpha4/descr
+++ b/packages/opam-state/opam-state.2.0~alpha4/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Handling of the ~/.opam hierarchy, repository and switch states.

--- a/packages/opam-state/opam-state.2.0~alpha4/opam
+++ b/packages/opam-state/opam-state.2.0~alpha4/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0~alpha4"}
+  "opam-format" {= "2.0~alpha4"}
+  "opam-repository" {= "2.0~alpha4"}
+]
+available: ocaml-version >= "4.01.0"

--- a/packages/opam-state/opam-state.2.0~alpha4/url
+++ b/packages/opam-state/opam-state.2.0~alpha4/url
@@ -1,0 +1,1 @@
+src: "https://github.com/ocaml/opam/archive/2.0-alpha4.tar.gz"


### PR DESCRIPTION
Not sure if this should be merged, or at least not right now, but I wanted to open the discussion.

We have a repository https://github.com/OcamlPro/opam-dev-repo which
contains basically the same packages (just not bound to the alpha4
release), so we can already prompt users to use that if they want to
bootstrap opam 2 from opam 1.2.

This can be particularly useful for updating packages depending on
opam-lib. There is no conflict since the package names (and library
names) are all different -- although, that could lead to confusion.

The `opam-devel` package installs opam, opam-admin, opam-installer
(based on the separately packaged libs) to its `lib/opam-devel`
directory and displays a message showing the location and suggesting
to copy them to PATH, outside of the opam installation.