### PR TITLE
add a 4.03.0+statistical-memprof compiler

### DIFF
--- a/compilers/4.03.0/4.03.0+statistical-memprof/4.03.0+statistical-memprof.comp
+++ b/compilers/4.03.0/4.03.0+statistical-memprof/4.03.0+statistical-memprof.comp
@@ -1,0 +1,15 @@
+opam-version: "1"
+version: "4.03.0"
+src: "https://github.com/jhjourdan/ocaml/archive/memprof.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.03.0/4.03.0+statistical-memprof/4.03.0+statistical-memprof.descr
+++ b/compilers/4.03.0/4.03.0+statistical-memprof/4.03.0+statistical-memprof.descr
@@ -1,0 +1,1 @@
+OCaml 4.03 plus statistical memory profiling, see <http://ocaml.org/meetings/ocaml/2016/Jourdan-statistically_profiling_memory_in_OCaml.pdf>


### PR DESCRIPTION
This provides a compiler switch for @jhjourdan's statistical memory profiler work, as described in [his OCaml workshop extended abstract](http://ocaml.org/meetings/ocaml/2016/Jourdan-statistically_profiling_memory_in_OCaml.pdf).

This is an experimental branch (in the spirit of, say, 4.02.3+curried-constr) that people interested in comparing various instrumentation approaches could be interested in.