### PR TITLE
records.0.7.0 - via opam-publish

### DIFF
--- a/packages/records/records.0.7.0/descr
+++ b/packages/records/records.0.7.0/descr
@@ -1,0 +1,3 @@
+Records
+
+This library enables you to define and manipulate dynamic records in OCaml.

--- a/packages/records/records.0.7.0/opam
+++ b/packages/records/records.0.7.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/records"
+bug-reports: "https://github.com/cryptosense/records/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/records.git"
+doc: "https://cryptosense.github.io/records/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ounit" {test}
+  "yojson"
+  "result"
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/records/records.0.7.0/url
+++ b/packages/records/records.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/records/releases/download/v0.7.0/records-0.7.0.tbz"
+checksum: "30e69590355367dc1dbc1c6cfde80b50"


### PR DESCRIPTION
Records

This library enables you to define and manipulate dynamic records in OCaml.

---
* Homepage: https://github.com/cryptosense/records
* Source repo: https://github.com/cryptosense/records.git
* Bug tracker: https://github.com/cryptosense/records/issues

---


---
## v0.7.0

*2016-09-21*

- Support OCaml 4.04
- Build using topkg:
  - Autogenerate API docs
  - Build example
- Add `Record.Type.result` for `result` values
- Deprecate `Record.format`
Pull-request generated by opam-publish v0.3.2