### PR TITLE
github.2.0.0 - via opam-publish

### DIFF
--- a/packages/github/github.2.0.0/descr
+++ b/packages/github/github.2.0.0/descr
@@ -1,0 +1,5 @@
+GitHub APIv3 client bindings
+
+This library provides access to many of the most used GitHub API
+endpoints while making authorization, two-factor authentication, rate
+limit monitoring, event delivery, and polling easy to use.

--- a/packages/github/github.2.0.0/opam
+++ b/packages/github/github.2.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+homepage: "https://github.com/mirage/ocaml-github"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+tags: ["org:mirage" "org:xapi-project" "git"]
+dev-repo: "https://github.com/mirage/ocaml-github.git"
+build: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--%{base-unix:enable}%-unix"
+    "--%{js_of_ocaml:enable}%-js"
+    "--prefix"
+    prefix
+  ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "github"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "tls"
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.17.0"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "1.10.0"}
+  "yojson" {>= "1.2.0"}
+  "stringext"
+  "lambda-term"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+depopts: "js_of_ocaml"
+conflicts: [
+  "js_of_ocaml" {< "2.4.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/github/github.2.0.0/url
+++ b/packages/github/github.2.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-github/archive/v2.0.0.tar.gz"
+checksum: "e0bd3235ffe6bf23a60db581104f6132"


### PR DESCRIPTION
GitHub APIv3 client bindings

This library provides access to many of the most used GitHub API
endpoints while making authorization, two-factor authentication, rate
limit monitoring, event delivery, and polling easy to use.


---
* Homepage: https://github.com/mirage/ocaml-github
* Source repo: https://github.com/mirage/ocaml-github.git
* Bug tracker: https://github.com/mirage/ocaml-github/issues

---

Pull-request generated by opam-publish v0.3.1