### PR TITLE
github-hooks.0.1.0 - via opam-publish

### DIFF
--- a/packages/github-hooks/github-hooks.0.1.0/descr
+++ b/packages/github-hooks/github-hooks.0.1.0/descr
@@ -1,0 +1,3 @@
+GitHub API web hook listener library
+
+Library to create GitHub webhook server.

--- a/packages/github-hooks/github-hooks.0.1.0/opam
+++ b/packages/github-hooks/github-hooks.0.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "lwt"
   "cohttp"
-  "github"
+  "github" {>= "2.0.0"}
   "nocrypto"
   "hex"
 ]

--- a/packages/github-hooks/github-hooks.0.1.0/opam
+++ b/packages/github-hooks/github-hooks.0.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "David Sheets"
+  "Thomas Gazagnaire"
+]
+homepage: "https://github.com/dsheets/ocaml-github-hooks"
+bug-reports: "https://github.com/dsheets/ocaml-github-hooks/issues"
+dev-repo: "https://github.com/dsheets/ocaml-github-hooks.git"
+doc: "https://dsheets.github.io/ocaml-github-hooks/"
+
+tags: [
+  "git"
+  "github"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "topkg" { build }
+  "ocamlfind" { build }
+  "base-unix"
+  "fmt"
+  "logs"
+  "lwt"
+  "cohttp"
+  "github"
+  "nocrypto"
+  "hex"
+]

--- a/packages/github-hooks/github-hooks.0.1.0/url
+++ b/packages/github-hooks/github-hooks.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dsheets/ocaml-github-hooks/releases/download/0.1.0/github-hooks-0.1.0.tbz"
+checksum: "a731078254779950f20112cadc351565"


### PR DESCRIPTION
GitHub API web hook listener library

Library to create GitHub webhook server.

---
* Homepage: https://github.com/dsheets/ocaml-github-hooks
* Source repo: https://github.com/dsheets/ocaml-github-hooks.git
* Bug tracker: https://github.com/dsheets/ocaml-github-hooks/issues

---


---
### 0.1.0

- initial release, extracted from datakit, itself extracted from ocamlot
Pull-request generated by opam-publish v0.3.2