### PR TITLE
ketrew.3.0.0 - via opam-publish

### DIFF
--- a/packages/ketrew/ketrew.3.0.0/descr
+++ b/packages/ketrew/ketrew.3.0.0/descr
@@ -1,0 +1,3 @@
+Ketrew is a workflow engine
+
+Ketrew keeps track of complex experimental computationally heavy workflows.

--- a/packages/ketrew/ketrew.3.0.0/opam
+++ b/packages/ketrew/ketrew.3.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "seb@mondet.org"
+authors : [
+  "Sebastien Mondet <seb@mondet.org>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Arun Ahuja <aahuja11@gmail.com>"
+  "Jeff Hammerbacher <jeff.hammerbacher@gmail.com>"
+  "Isaac Hodes <isaachodes@gmail.com>"
+]
+homepage: "http://www.hammerlab.org/docs/ketrew/master/index.html"
+dev-repo: "https://github.com/hammerlab/ketrew.git"
+bug-reports: "https://github.com/hammerlab/ketrew/issues"
+available : [ ocaml-version >= "4.02.2" ]
+install: [
+  ["omake"]
+  ["omake" "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "ketrew"]
+  ["ocamlfind" "remove" "ketrew_pure"]
+  ["rm" "-f" "%{bin}%/ketrew"]
+]
+depends: [
+  "omake" "ocamlfind" "ocamlify"
+  "trakeva" {>= "0.1.0" }
+  "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
+  "cmdliner" "yojson" "uri"
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.0"}
+  "cohttp" {>= "0.21.0" } "lwt"
+  "conduit"
+  "js_of_ocaml" {>= "2.6" } "tyxml" {>= "4.0.0"} "reactiveData" {>= "0.2"}
+  ]
+depopts: [
+  "sqlite3" "postgresql"
+]

--- a/packages/ketrew/ketrew.3.0.0/url
+++ b/packages/ketrew/ketrew.3.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/ketrew/archive/ketrew.3.0.0.tar.gz"
+checksum: "75c53c767c98571488b542fe5337b7dd"


### PR DESCRIPTION
Ketrew is a workflow engine

Ketrew keeps track of complex experimental computationally heavy workflows.


---
* Homepage: http://www.hammerlab.org/docs/ketrew/master/index.html
* Source repo: https://github.com/hammerlab/ketrew.git
* Bug tracker: https://github.com/hammerlab/ketrew/issues

---

Pull-request generated by opam-publish v0.3.2