### PR TITLE
topkg-care.0.7.9 - via opam-publish

### DIFF
--- a/packages/topkg-care/topkg-care.0.7.9/descr
+++ b/packages/topkg-care/topkg-care.0.7.9/descr
@@ -1,0 +1,25 @@
+The transitory OCaml software packager
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml OPAM repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-lib`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser

--- a/packages/topkg-care/topkg-care.0.7.9/opam
+++ b/packages/topkg-care/topkg-care.0.7.9/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild" {build}
+  "topkg" {= "0.7.9"}
+  "result"
+  "fmt"
+  "logs"
+  "bos"
+  "cmdliner"
+  "webbrowser"
+  "opam-lib" {>= "1.2.2"}
+]
+build:[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--pinned" "%{pinned}%"
+]

--- a/packages/topkg-care/topkg-care.0.7.9/url
+++ b/packages/topkg-care/topkg-care.0.7.9/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/topkg/releases/topkg-0.7.9.tbz"
+checksum: "6884403eebd3b41a58f59559767ec5b1"


### PR DESCRIPTION
The transitory OCaml software packager

Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml OPAM repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
[webbrowser][webbrowser] and `opam-lib`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner
[webbrowser]: http://erratique.ch/software/webbrowser


---
* Homepage: http://erratique.ch/software/topkg
* Source repo: http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---


---
v0.7.9 2016-09-21 Zagreb
------------------------

- Better package parsing in ocamlbuild _tags files. Thanks
  to Thomas Gazagnaire for the report.
- Remove references to internal names in the API.
Pull-request generated by opam-publish v0.3.2