### PR TITLE
Added R2Pipe for OCaml language

### DIFF
--- a/packages/r2pipe/r2pipe.0.0.1/descr
+++ b/packages/r2pipe/r2pipe.0.0.1/descr
@@ -1,0 +1,6 @@
+OCaml binding of R2Pipe
+
+r2pipe-ocaml is an OCaml binding of R2Pipe which used to 
+automate radare2. 
+It has simple internal. It just spawn a r2 with quiet mode
+and then interact through In/Out channel. 

--- a/packages/r2pipe/r2pipe.0.0.1/opam
+++ b/packages/r2pipe/r2pipe.0.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Jeong Jihoon <binoopang@gmail.com>"
+authors: "Jeong Jihoon <binoopang@gmail.com>"
+homepage: ""
+bug-reports: ""
+license: "LGPL"
+dev-repo: "https://github.com/binoopang/r2pipe-ocaml.git"
+build: [make]
+install: [make "install-lib"]
+remove: [make "uninstall-lib"]
+depends: [
+  "ocamlfind" {build}
+  "yojson"
+]

--- a/packages/r2pipe/r2pipe.0.0.1/opam
+++ b/packages/r2pipe/r2pipe.0.0.1/opam
@@ -1,8 +1,8 @@
 opam-version: "1.2"
 maintainer: "Jeong Jihoon <binoopang@gmail.com>"
 authors: "Jeong Jihoon <binoopang@gmail.com>"
-homepage: ""
-bug-reports: ""
+homepage: "http://github.com/binoopang/r2pipe-ocaml"
+bug-reports: "binoopang@gmail.com"
 license: "LGPL"
 dev-repo: "https://github.com/binoopang/r2pipe-ocaml.git"
 build: [make]

--- a/packages/r2pipe/r2pipe.0.0.1/url
+++ b/packages/r2pipe/r2pipe.0.0.1/url
@@ -1,2 +1,2 @@
-http: "https://github.com/binoopang/r2pipe-ocaml/archive/v0.0.1.zip"
-checksum: "588bad57c3ebea57e89bc15a4d1be2df"
+http: "https://github.com/binoopang/r2pipe-ocaml/archive/v0.0.2.zip"
+checksum: "3c9ccfdf81a10d3e865b50bf5e9cf97a"

--- a/packages/r2pipe/r2pipe.0.0.1/url
+++ b/packages/r2pipe/r2pipe.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/binoopang/r2pipe-ocaml/archive/v0.0.1.zip"
+checksum: "588bad57c3ebea57e89bc15a4d1be2df"


### PR DESCRIPTION
# R2Pipe for OCaml language

r2pipe-ocaml is an OCaml binding of R2Pipe which used to
automate [radare2](http://rada.re/r/).
It has simple internal. It just spawn a r2 with quiet mode
and then interact through In/Out channel.
