### PR TITLE
mirage-block-unix 2.4.0 broke back compat for qcow-format 0.4 and 0.4.1

### DIFF
--- a/packages/qcow-format/qcow-format.0.4.1/opam
+++ b/packages/qcow-format/qcow-format.0.4.1/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-types-lwt"
   "lwt"
   "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" }
+  "mirage-block-unix" {>= "2.1.0" & < "2.4.0" }
   "cmdliner"
   "sexplib"
   "logs"

--- a/packages/qcow-format/qcow-format.0.4/opam
+++ b/packages/qcow-format/qcow-format.0.4/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-types-lwt"
   "lwt"
   "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" }
+  "mirage-block-unix" {>= "2.1.0" & < "2.4.0" }
   "cmdliner"
   "sexplib"
   "logs"


### PR DESCRIPTION
/cc @djs55