### PR TITLE
Restrict github-hooks 0.1.0 to github 2.0.0

### DIFF
--- a/packages/github-hooks/github-hooks.0.1.0/opam
+++ b/packages/github-hooks/github-hooks.0.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "lwt"
   "cohttp"
-  "github" {>= "2.0.0"}
+  "github" {= "2.0.0"}
   "nocrypto"
   "hex"
 ]


### PR DESCRIPTION
GitHub has a bug which caused a minor hook type change in 2.0.1