### PR TITLE
topkg-care 0.7.9 uses rresult via bos of at least 0.4.0 (R.pp signature)

### DIFF
--- a/packages/topkg-care/topkg-care.0.7.9/opam
+++ b/packages/topkg-care/topkg-care.0.7.9/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {= "0.7.9"}
   "result"
+  "rresult" {>= "0.4.0"}
   "fmt"
   "logs"
   "bos"


### PR DESCRIPTION
`bos` 0.1.4 does not fix the interface of `Rresult.R` that it re-exports. The signature of `Rresult.R.pp` changed between 0.3.0 and 0.4.0 and `topkg-care` 0.7.9 (at least) uses this function and assumes a version of `rresult` >= 0.4.0. An alternative would be to put a bound on `rresult` for `bos` which it re-exports.

/cc @dbuenzli