### PR TITLE
opkg.0.0.1 - via opam-publish

### DIFF
--- a/packages/opkg/opkg.0.0.1/descr
+++ b/packages/opkg/opkg.0.0.1/descr
@@ -1,0 +1,7 @@
+Mine installed OCaml packages
+
+opkg is a library and command line tool to mine installed OCaml
+packages. It supports package distribution documentation and metadata
+lookups and generates cross-referenced API documentation.
+
+opkg is distributed under the ISC license.

--- a/packages/opkg/opkg.0.0.1/opam
+++ b/packages/opkg/opkg.0.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/opkg"
+doc: "http://erratique.ch/software/opkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/opkg.git"
+bug-reports: "https://github.com/dbuenzli/opkg/issues"
+tags: []
+available: [ ocaml-version >= "4.03"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-unix"
+  "rresult" {>= "0.5.0"}
+  "asetmap"
+  "fpath"
+  "fmt"
+  "logs"
+  "bos"
+  "cmdliner"
+  "mtime"
+  "webbrowser"
+  "opam-lib"
+]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+           "--etc-dir" opkg:etc ]

--- a/packages/opkg/opkg.0.0.1/url
+++ b/packages/opkg/opkg.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/opkg/releases/opkg-0.0.1.tbz"
+checksum: "ec64b16f724ab997b75642ec710ad703"


### PR DESCRIPTION
Mine installed OCaml packages

opkg is a library and command line tool to mine installed OCaml
packages. It supports package distribution documentation and metadata
lookups and generates cross-referenced API documentation.

opkg is distributed under the ISC license.


---
* Homepage: http://erratique.ch/software/opkg
* Source repo: http://erratique.ch/repos/opkg.git
* Bug tracker: https://github.com/dbuenzli/opkg/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them

---


---
v0.0.1 2016-09-23 Zagreb
------------------------

First release. The ocamldoc release.
Pull-request generated by opam-publish v0.3.2