### PR TITLE
github-hooks.0.1.1 - via opam-publish

### DIFF
--- a/packages/github-hooks/github-hooks.0.1.1/descr
+++ b/packages/github-hooks/github-hooks.0.1.1/descr
@@ -1,0 +1,3 @@
+GitHub API web hook listener library
+
+Library to create GitHub webhook server.

--- a/packages/github-hooks/github-hooks.0.1.1/opam
+++ b/packages/github-hooks/github-hooks.0.1.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "David Sheets"
+  "Thomas Gazagnaire"
+]
+homepage: "https://github.com/dsheets/ocaml-github-hooks"
+bug-reports: "https://github.com/dsheets/ocaml-github-hooks/issues"
+dev-repo: "https://github.com/dsheets/ocaml-github-hooks.git"
+doc: "https://dsheets.github.io/ocaml-github-hooks/"
+
+tags: [
+  "git"
+  "github"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" { build }
+  "ocamlbuild" { build }
+  "topkg" { build }
+  "base-unix"
+  "fmt"
+  "logs"
+  "lwt"
+  "cohttp"
+  "github" {>= "2.0.1"}
+  "nocrypto"
+  "hex"
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/github-hooks/github-hooks.0.1.1/url
+++ b/packages/github-hooks/github-hooks.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dsheets/ocaml-github-hooks/releases/download/0.1.1/github-hooks-0.1.1.tbz"
+checksum: "37f08f1721e976b75101669ca97348e5"


### PR DESCRIPTION
GitHub API web hook listener library

Library to create GitHub webhook server.

---
* Homepage: https://github.com/dsheets/ocaml-github-hooks
* Source repo: https://github.com/dsheets/ocaml-github-hooks.git
* Bug tracker: https://github.com/dsheets/ocaml-github-hooks/issues

---


---
### 0.1.1

- Update for github 2.0.1 which fixes a GitHub hook config type issue
Pull-request generated by opam-publish v0.3.2