### PR TITLE
cconv.0.4 - via opam-publish

### DIFF
--- a/packages/cconv/cconv.0.4/descr
+++ b/packages/cconv/cconv.0.4/descr
@@ -1,0 +1,9 @@
+Combinators for Type Conversion in OCaml, and ppx_deriving plugin.
+
+CConv provides type-safe combinators for describing how to read/build OCaml
+values of a given type. Those combinators can be used for serializing and
+deserializing the values into several formats. The library ships with
+conversion to Json (yojson), S-expressions (sexplib) and B-encode.
+
+The library cconv.ppx contains a ppx_deriving plugin for automatically derive
+encoders and decoders.

--- a/packages/cconv/cconv.0.4/opam
+++ b/packages/cconv/cconv.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/cconv/"
+bug-reports: "https://github.com/c-cube/cconv/issues/"
+doc: "http://cedeela.fr/~simon/software/cconv/"
+tags: ["conversion" "gadt" "serialization"]
+dev-repo: "https://github.com/c-cube/cconv.git"
+build: [
+  [
+    "./configure"
+    "--%{yojson:enable}%-yojson"
+    "--%{bencode:enable}%-bencode"
+    "--%{sexplib:enable}%-sexp"
+    "--%{ppx_deriving:enable}%-ppx"
+    "--disable-tests"
+    "--%{doc:enable}%-docs"
+  ]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "cconv"]
+depends: [
+  "cppo" {build}
+  "ocamlfind" {build}
+]
+depopts: ["bencode" "sexplib" "yojson" "ppx_deriving"]
+conflicts: [
+  "ppx_deriving" {< "2.0"}
+]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/cconv/cconv.0.4/url
+++ b/packages/cconv/cconv.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/cconv/archive/0.4.tar.gz"
+checksum: "25d873aa26a0521ab3b015fdb7f26e28"


### PR DESCRIPTION
Combinators for Type Conversion in OCaml, and ppx_deriving plugin.

CConv provides type-safe combinators for describing how to read/build OCaml
values of a given type. Those combinators can be used for serializing and
deserializing the values into several formats. The library ships with
conversion to Json (yojson), S-expressions (sexplib) and B-encode.

The library cconv.ppx contains a ppx_deriving plugin for automatically derive
encoders and decoders.


---
* Homepage: https://github.com/c-cube/cconv/
* Source repo: https://github.com/c-cube/cconv.git
* Bug tracker: https://github.com/c-cube/cconv/issues/

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them

---

Pull-request generated by opam-publish v0.3.2