### PR TITLE
radare2.0.0.1 - via opam-publish

### DIFF
--- a/packages/radare2/radare2.0.0.1/descr
+++ b/packages/radare2/radare2.0.0.1/descr
@@ -1,0 +1,12 @@
+OCaml interface to r2
+
+Interact with radare2,
+See the mli for documentation, example usage in utop:
+
+#require "radare2";;
+let result = R2.with_command_j ~cmd:"/j chown" "/bin/ls";;
+val result : Yojson.Basic.json =
+`List 
+  [`Assoc
+    [("offset", `Int 4294987375); ("id:", `Int 0);
+     ("data", `String "ywritesecuritychownfile_inheritdi")]]"

--- a/packages/radare2/radare2.0.0.1/opam
+++ b/packages/radare2/radare2.0.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-radare2"
+bug-reports: "https://github.com/fxfactorial/ocaml-radare2/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-radare2.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "radare2"]
+depends: [
+  "base-unix"
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  ("yojson" {>= "1.3.2"} | "yojson-android" {>= "1.3.2"})
+]
+depexts: [
+  [["debian"] ["radare2"]]
+  [["homebrew" "osx"] ["radare2"]]
+  [["ubuntu"] ["radare2"]]
+]
+available: [ocaml-version >= "4.03.0"]
+messages: [
+  "You need to have r2 (radare2) installed and in your path"
+  "Use `opam depext radare2` to get it installed with your system package manager"
+]
+post-messages: [
+  "Play with radare2 interactively from within an OCaml repl like utop"
+  "Example in utop:"
+  ""
+  "#require \"radare2\";;"
+  "
+let result = R2.with_command_j ~cmd:\"/j chown\" \"/bin/ls\";;
+val result : Yojson.Basic.json =
+`List 
+  [`Assoc
+       [(\"offset\", `Int 4294987375); (\"id:\", `Int 0);
+        (\"data\", `String \"ywritesecuritychownfile_inheritdi\")]]
+  "
+    {success}
+]

--- a/packages/radare2/radare2.0.0.1/url
+++ b/packages/radare2/radare2.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-radare2/archive/v0.0.1.tar.gz"
+checksum: "bcd91f5a13dec7b4420b403ab3557b59"


### PR DESCRIPTION
OCaml interface to r2

Interact with radare2,
See the mli for documentation, example usage in utop:

```ocaml
#require "radare2";;
let result = R2.with_command_j ~cmd:"/j chown" "/bin/ls";;
val result : Yojson.Basic.json =
`List 
  [`Assoc
    [("offset", `Int 4294987375); ("id:", `Int 0);
     ("data", `String "ywritesecuritychownfile_inheritdi")]]"
```

---
* Homepage: https://github.com/fxfactorial/ocaml-radare2
* Source repo: https://github.com/fxfactorial/ocaml-radare2.git
* Bug tracker: https://github.com/fxfactorial/ocaml-radare2/issues

---

Pull-request generated by opam-publish v0.3.2