### PR TITLE
ppx_deriving.4.1 - via opam-publish

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.1/descr
+++ b/packages/ppx_deriving/ppx_deriving.4.1/descr
@@ -1,0 +1,5 @@
+Type-driven code generation for OCaml >=4.02
+
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.

--- a/packages/ppx_deriving/ppx_deriving.4.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving"
+doc: "https://whitequark.github.io/ppx_deriving"
+bug-reports: "https://github.com/whitequark/ppx_deriving/issues"
+dev-repo: "https://github.com/whitequark/ppx_deriving.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  # If there is no native dynlink, we can't use native builds
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native-dynlink}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_deriving.byte" "--"
+]
+build-doc: [
+  make "doc"
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.6.0"}
+  "cppo"       {build}
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {test}
+]
+available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]

--- a/packages/ppx_deriving/ppx_deriving.4.1/url
+++ b/packages/ppx_deriving/ppx_deriving.4.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving/archive/v4.1.tar.gz"
+checksum: "6a0cf323c97434c5a6d8529ea7e084db"


### PR DESCRIPTION
Type-driven code generation for OCaml >=4.02

ppx_deriving provides common infrastructure for generating
code based on type definitions, and a set of useful plugins
for common tasks.


---
* Homepage: https://github.com/whitequark/ppx_deriving
* Source repo: https://github.com/whitequark/ppx_deriving.git
* Bug tracker: https://github.com/whitequark/ppx_deriving/issues

---

Pull-request generated by opam-publish v0.3.2