### PR TITLE
extlib, extlib-compat: works on 4.04+beta2, set weaker bound < 4.05

### DIFF
--- a/packages/extlib-compat/extlib-compat.1.6.1/opam
+++ b/packages/extlib-compat/extlib-compat.1.6.1/opam
@@ -15,4 +15,4 @@ remove: [
 ]
 conflicts: ["extlib"]
 depends: ["ocamlfind" "camlp4" {build}]
-available: [ ocaml-version < "4.04.0" ]
+available: [ ocaml-version < "4.05.0" ]

--- a/packages/extlib-compat/extlib-compat.1.7.0/opam
+++ b/packages/extlib-compat/extlib-compat.1.7.0/opam
@@ -34,4 +34,4 @@ depends: [
   "cppo" {build}
   "base-bytes" {build}
 ]
-available: [ ocaml-version < "4.04.0" ]
+available: [ ocaml-version < "4.05.0" ]

--- a/packages/extlib/extlib.1.5.3/opam
+++ b/packages/extlib/extlib.1.5.3/opam
@@ -8,4 +8,4 @@ build: [
 remove: [["ocamlfind" "remove" "extlib"]]
 depends: ["ocamlfind" "camlp4"]
 install: [make "install"]
-available: [ ocaml-version < "4.04.0" ]
+available: [ ocaml-version < "4.05.0" ]

--- a/packages/extlib/extlib.1.5.3/opam
+++ b/packages/extlib/extlib.1.5.3/opam
@@ -1,5 +1,13 @@
-opam-version: "1"
-maintainer: "contact@ocamlpro.com"
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/ygrek/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+]
 build: [
   [make "all"]
   [make "opt"]

--- a/packages/extlib/extlib.1.5.4/opam
+++ b/packages/extlib/extlib.1.5.4/opam
@@ -1,6 +1,13 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
 homepage: "http://code.google.com/p/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+]
 license: "LGPL-2.1 with OCaml linking exception"
 doc: ["http://ocaml-extlib.googlecode.com/svn/doc/apiref/index.html"]
 build: [

--- a/packages/extlib/extlib.1.5.4/opam
+++ b/packages/extlib/extlib.1.5.4/opam
@@ -11,4 +11,4 @@ build: [
 remove: [["ocamlfind" "remove" "extlib"]]
 depends: ["ocamlfind" "camlp4"]
 install: [make "install"]
-available: [ ocaml-version < "4.04.0" ]
+available: [ ocaml-version < "4.05.0" ]

--- a/packages/extlib/extlib.1.6.1/opam
+++ b/packages/extlib/extlib.1.6.1/opam
@@ -8,4 +8,4 @@ remove: [
 ]
 depends: ["ocamlfind" "camlp4"]
 install: [make "minimal=1" "build" "install"]
-available: [ ocaml-version < "4.04.0" ]
+available: [ ocaml-version < "4.05.0" ]

--- a/packages/extlib/extlib.1.6.1/opam
+++ b/packages/extlib/extlib.1.6.1/opam
@@ -1,6 +1,16 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "ygrek@autistici.org"
 homepage: "http://code.google.com/p/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+  "Janne Hellsten"
+  "Richard W.M. Jones"
+  "ygrek"
+]
 license: "LGPL-2.1 with OCaml linking exception"
 doc: ["http://ocaml-extlib.googlecode.com/svn/doc/apiref/index.html"]
 remove: [

--- a/packages/extlib/extlib.1.7.0/opam
+++ b/packages/extlib/extlib.1.7.0/opam
@@ -33,4 +33,4 @@ depends: [
   "cppo" {build}
   "base-bytes" {build}
 ]
-available: [ ocaml-version < "4.04.0" ]
+available: [ ocaml-version < "4.05.0" ]


### PR DESCRIPTION
The dependency "< 4.04" was set in #7164 and #7173 because extlib was
broken by the string/bytes-primitives name change. This change has
been reverted from 4.04, precisely to improve compatibility, so these
extlib versions are compatible with 4.04 again.

(As far as I can tell the discussion in ygrek/ocaml-extlib#37 is now
irrelevant due to the revert of the backward-incompatible change:
there is no extlib change required for 4.04 compatibility, so there is
no specific need for a new extlib release.)

Having extlib installable is important as it appears in dependency
chains. For example, opkg <- opam-lib <- cudf <- extlib.