### PR TITLE
npy.0.0.2 - via opam-publish

### DIFF
--- a/packages/npy/npy.0.0.2/descr
+++ b/packages/npy/npy.0.0.2/descr
@@ -1,0 +1,3 @@
+Numpy npy file format reading/writing.
+
+Provide simple read/write function using the numpy npy file format. These can be used to save a bigarray to disk and then load it from python using numpy.

--- a/packages/npy/npy.0.0.2/opam
+++ b/packages/npy/npy.0.0.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Laurent Mazare <lmazare@gmail.com>"
+authors: "Laurent Mazare"
+homepage: "https://github.com/LaurentMazare/npy-ocaml"
+bug-reports: "https://github.com/LaurentMazare/npy-ocaml/issues"
+dev-repo: "git+https://github.com/LaurentMazare/npy-ocaml.git"
+build: [make "npy.lib"]
+
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/npy/npy.0.0.2/url
+++ b/packages/npy/npy.0.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/LaurentMazare/npy-ocaml/archive/0.0.3.tar.gz"
+checksum: "c1bb7d987a2b005da7ab6d279c3572b5"


### PR DESCRIPTION
Numpy npy file format reading/writing.

Provide simple read/write function using the numpy npy file format. These can be used to save a bigarray to disk and then load it from python using numpy.


---
* Homepage: https://github.com/LaurentMazare/npy-ocaml
* Source repo: git+https://github.com/LaurentMazare/npy-ocaml.git
* Bug tracker: https://github.com/LaurentMazare/npy-ocaml/issues

---

Pull-request generated by opam-publish v0.3.2