### PR TITLE
pcre: fix deps

### DIFF
--- a/packages/pcre/pcre.7.0.2/opam
+++ b/packages/pcre/pcre.7.0.2/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+homepage: "http://mmottl.github.io/pcre-ocaml"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: make
 remove: [["ocamlfind" "remove" "pcre"]]
 depends: [

--- a/packages/pcre/pcre.7.0.2/opam
+++ b/packages/pcre/pcre.7.0.2/opam
@@ -5,7 +5,7 @@ remove: [["ocamlfind" "remove" "pcre"]]
 depends: [
   "ocamlfind"
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 dev-repo: "git://github.com/mmottl/pcre-ocaml"
 install: [make "install"]

--- a/packages/pcre/pcre.7.0.3/opam
+++ b/packages/pcre/pcre.7.0.3/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+homepage: "http://mmottl.github.io/pcre-ocaml"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: make
 remove: [["ocamlfind" "remove" "pcre"]]
 depends: [

--- a/packages/pcre/pcre.7.0.3/opam
+++ b/packages/pcre/pcre.7.0.3/opam
@@ -5,7 +5,7 @@ remove: [["ocamlfind" "remove" "pcre"]]
 depends: [
   "ocamlfind"
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 dev-repo: "git://github.com/mmottl/pcre-ocaml"
 install: [make "install"]

--- a/packages/pcre/pcre.7.0.4/opam
+++ b/packages/pcre/pcre.7.0.4/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+homepage: "http://mmottl.github.io/pcre-ocaml"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: make
 remove: [["ocamlfind" "remove" "pcre"]]
 depends: [

--- a/packages/pcre/pcre.7.0.4/opam
+++ b/packages/pcre/pcre.7.0.4/opam
@@ -5,7 +5,7 @@ remove: [["ocamlfind" "remove" "pcre"]]
 depends: [
   "ocamlfind"
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 dev-repo: "git://github.com/mmottl/pcre-ocaml"
 install: [make "install"]

--- a/packages/pcre/pcre.7.1.0/opam
+++ b/packages/pcre/pcre.7.1.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+homepage: "http://mmottl.github.io/pcre-ocaml"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: make
 remove: [["ocamlfind" "remove" "pcre"]]
 depends: [

--- a/packages/pcre/pcre.7.1.0/opam
+++ b/packages/pcre/pcre.7.1.0/opam
@@ -5,7 +5,7 @@ remove: [["ocamlfind" "remove" "pcre"]]
 depends: [
   "ocamlfind"
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 dev-repo: "git://github.com/mmottl/pcre-ocaml"
 install: [make "install"]

--- a/packages/pcre/pcre.7.1.1/opam
+++ b/packages/pcre/pcre.7.1.1/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "markus.mottl@gmail.com"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+homepage: "http://mmottl.github.io/pcre-ocaml"
+dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: make
 remove: [["ocamlfind" "remove" "pcre"]]
 depends: [

--- a/packages/pcre/pcre.7.1.1/opam
+++ b/packages/pcre/pcre.7.1.1/opam
@@ -5,6 +5,6 @@ remove: [["ocamlfind" "remove" "pcre"]]
 depends: [
   "ocamlfind"
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 install: [make "install"]

--- a/packages/pcre/pcre.7.1.2/opam
+++ b/packages/pcre/pcre.7.1.2/opam
@@ -3,6 +3,8 @@ maintainer: "markus.mottl@gmail.com"
 authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
 license: "LGPL-2.1+ with OCaml linking exception"
 homepage: "http://mmottl.github.io/pcre-ocaml"
+dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/pcre/pcre.7.1.2/opam
+++ b/packages/pcre/pcre.7.1.2/opam
@@ -14,7 +14,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "ocamlfind" {>= "1.5"}
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/pcre/pcre.7.1.3/opam
+++ b/packages/pcre/pcre.7.1.3/opam
@@ -3,6 +3,8 @@ maintainer: "markus.mottl@gmail.com"
 authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
 license: "LGPL-2.1+ with OCaml linking exception"
 homepage: "http://mmottl.github.io/pcre-ocaml"
+dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/pcre/pcre.7.1.3/opam
+++ b/packages/pcre/pcre.7.1.3/opam
@@ -14,7 +14,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "ocamlfind" {>= "1.5"}
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 conflicts: [
   "pcre" {= "6.2.5"}

--- a/packages/pcre/pcre.7.1.5/opam
+++ b/packages/pcre/pcre.7.1.5/opam
@@ -6,6 +6,7 @@ authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
 license: "LGPL-2.1+ with OCaml linking exception"
 homepage: "http://mmottl.github.io/pcre-ocaml"
 dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/pcre/pcre.7.1.5/opam
+++ b/packages/pcre/pcre.7.1.5/opam
@@ -18,7 +18,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {>= "1.5"}
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/pcre/pcre.7.1.6/opam
+++ b/packages/pcre/pcre.7.1.6/opam
@@ -24,6 +24,6 @@ depends: [
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build}
   "conf-libpcre"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 available: [ ocaml-version >= "3.12" ]

--- a/packages/pcre/pcre.7.2.2/opam
+++ b/packages/pcre/pcre.7.2.2/opam
@@ -22,7 +22,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   # Included from _opam file
   "conf-libpcre"
 ]

--- a/packages/pcre/pcre.7.2.3/opam
+++ b/packages/pcre/pcre.7.2.3/opam
@@ -22,7 +22,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   # Included from _opam file
   "conf-libpcre"
 ]


### PR DESCRIPTION
pcre does not compile with ocamlbuild.0.9.0 so exclude this version.
