### PR TITLE
Add integers 0.1.0

### DIFF
--- a/packages/integers/integers.0.1.0/descr
+++ b/packages/integers/integers.0.1.0/descr
@@ -1,0 +1,1 @@
+Various signed and unsigned integer types for OCaml

--- a/packages/integers/integers.0.1.0/findlib
+++ b/packages/integers/integers.0.1.0/findlib
@@ -1,0 +1,1 @@
+integers

--- a/packages/integers/integers.0.1.0/opam
+++ b/packages/integers/integers.0.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+version: "0.1.0"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop"
+          "Demi Obenour"
+          "Stephane Glondu"
+          "Andreas Hauptmann"]
+homepage: "https://github.com/yallop/ocaml-integers"
+bug-reports: "https://github.com/yallop/ocaml-integers/issues"
+dev-repo: "https://github.com/yallop/ocaml-integers.git"
+license: "MIT"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"]]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+]

--- a/packages/integers/integers.0.1.0/url
+++ b/packages/integers/integers.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/yallop/ocaml-integers/archive/0.1.0.tar.gz"
+checksum: "1a9ed75b36d6a839bb42aa84582ec038"


### PR DESCRIPTION
# ocaml-integers

The `ocaml-integers` library provides a number of 8-, 16-, 32- and 64-bit signed and unsigned integer types, together with aliases such as `long` and `size_t` whose sizes depend on the host platform.

### Features

* The interfaces follow the pattern of the signatures of the [`Int32`][int32], [`Int64`][int64], and [`Nativeint`][nativeint] modules in the OCaml standard library.

  The behaviour also follows the standard library; for example, conversions such as `of_int` truncate, and operations are "modulo" in general:

   ```ocaml
   # Unsigned.UInt8.(pred zero);;
   - : Unsigned.UInt8.t = <uint8 255>
   ```

* Top-level printers for each type are included

   ```ocaml
   # Unsigned.UInt32.[of_int 103; one; of_string "1000"];; 
   - : Unsigned.UInt32.t list = [<uint32 103>; <uint32 1>; <uint32 1000>]
   ```

* Infix operators are available:

   ```ocaml
   # Unsigned.UInt32.(Infix.(one + one));;
   - : Unsigned.UInt32.t = <uint32 2>
   ```

* Polymorphic operations such as comparison behave correctly: 

   ```ocaml
   # open Unsigned.UInt32
   # zero < one;;
   - : bool = true
   # max_int < zero;;
   - : bool = false
   ```

* Integers 32 bits and above are boxed; integers below 32 bits are unboxed.

   ```ocaml
   # Obj.(tag (repr Unsigned.UInt32.zero));;
   - : int = 255
   # Obj.(tag (repr Unsigned.UInt16.zero));;
   - : int = 1000
   ```

[int32]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Int32.html
[int64]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Int64.html
[nativeint]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Nativeint.html
