### PR TITLE
tsdl.0.9.1 - via opam-publish

### DIFF
--- a/packages/tsdl/tsdl.0.9.1/descr
+++ b/packages/tsdl/tsdl.0.9.1/descr
@@ -1,0 +1,11 @@
+Thin bindings to SDL for OCaml
+
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.1][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the BSD3 license.
+
+[sdl]: http://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes

--- a/packages/tsdl/tsdl.0.9.1/opam
+++ b/packages/tsdl/tsdl.0.9.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/tsdl"
+doc: "http://erratique.ch/software/tsdl/doc/Tsdl"
+dev-repo: "http://erratique.ch/repos/tsdl.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
+        "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+  "ctypes" {>= "0.9.0"}
+  "ctypes-foreign" ]
+depexts: [
+ [["debian"] ["libsdl2-dev"]]
+ [["ubuntu"] ["libsdl2-dev"]]
+ [["mageia"] ["libsdl2.0-devel"]]
+ [["osx" "homebrew"] ["sdl2"]]
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/tsdl/tsdl.0.9.1/url
+++ b/packages/tsdl/tsdl.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/tsdl/releases/tsdl-0.9.1.tbz"
+checksum: "cad911bc8d7dd6dc5c231417c9e5906b"


### PR DESCRIPTION
Thin bindings to SDL for OCaml

Tsdl is an OCaml library providing thin bindings to the cross-platform
SDL C library.

Tsdl depends on the [SDL 2.0.1][sdl] C library (or later),
[ocaml-ctypes][ctypes] and the `result` compatibility package.
Tsdl is distributed under the ISC license.

[sdl]: http://www.libsdl.org/
[ctypes]: https://github.com/ocamllabs/ocaml-ctypes


---
* Homepage: http://erratique.ch/software/tsdl
* Source repo: http://erratique.ch/repos/tsdl.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---


---
v0.9.1 2016-09-27 Zagreb
------------------------

- Release runtime lock on `Sdl.delay`.
- Reinstate support for audio callbacks, `ocaml-ctypes`
  is getting smarter (#13).
- Really fix signature of `Sdl.blit_surface`, thanks to
  Richard Davison for the report (#25).
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.2