### PR TITLE
text.0.8.0: add camlp4 as dependency

### DIFF
--- a/packages/text/text.0.8.0/opam
+++ b/packages/text/text.0.8.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}
+  "camlp4"
 ]
 depopts: ["pcre"]
 dev-repo: "git://github.com/vbmithr/ocaml-text"


### PR DESCRIPTION
See [this issue on ocsigen-start](https://github.com/ocsigen/ocsigen-start/issues/162).