### PR TITLE
odig.0.0.1 - via opam-publish

### DIFF
--- a/packages/odig/odig.0.0.1/descr
+++ b/packages/odig/odig.0.0.1/descr
@@ -1,0 +1,7 @@
+Mine installed OCaml packages
+
+odig is a library and command line tool to mine installed OCaml
+packages. It supports package distribution documentation and metadata
+lookups and generates cross-referenced API documentation.
+
+odig is distributed under the ISC license.

--- a/packages/odig/odig.0.0.1/opam
+++ b/packages/odig/odig.0.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/odig"
+doc: "http://erratique.ch/software/odig/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/odig.git"
+bug-reports: "https://github.com/dbuenzli/odig/issues"
+tags: []
+available: [ ocaml-version >= "4.03"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-unix"
+  "rresult" {>= "0.5.0"}
+  "asetmap"
+  "fpath"
+  "fmt"
+  "logs"
+  "bos"
+  "cmdliner"
+  "mtime"
+  "webbrowser"
+  "opam-lib"
+]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+           "--etc-dir" odig:etc ]

--- a/packages/odig/odig.0.0.1/url
+++ b/packages/odig/odig.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/odig/releases/odig-0.0.1.tbz"
+checksum: "79cb3978f87fc428007317ed5e6ba497"


### PR DESCRIPTION
Mine installed OCaml packages

odig is a library and command line tool to mine installed OCaml
packages. It supports package distribution documentation and metadata
lookups and generates cross-referenced API documentation.

odig is distributed under the ISC license.


---
* Homepage: http://erratique.ch/software/odig
* Source repo: http://erratique.ch/repos/odig.git
* Bug tracker: https://github.com/dbuenzli/odig/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them

---


---
v0.0.1 2016-09-23 Zagreb
------------------------

First release. The ocamldoc release.
Pull-request generated by opam-publish v0.3.2