### PR TITLE
solvuu-build.0.1.0 - via opam-publish

### DIFF
--- a/packages/solvuu-build/solvuu-build.0.1.0/descr
+++ b/packages/solvuu-build/solvuu-build.0.1.0/descr
@@ -1,0 +1,1 @@
+Solvuu's build system.

--- a/packages/solvuu-build/solvuu-build.0.1.0/opam
+++ b/packages/solvuu-build/solvuu-build.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Ashish Agarwal <ashish@solvuu.com>"
+authors: "Solvuu"
+homepage: "https://github.com/solvuu/solvuu-build"
+bug-reports: "https://github.com/solvuu/solvuu-build/issues"
+license: "ISC"
+tags: "org:solvuu"
+dev-repo: "https://github.com/solvuu/solvuu-build.git"
+build: [
+  [make "byte"]
+  [make "native"]
+]
+install: [
+  [make "_build/META"]
+  [make "solvuu-build.install"]
+]
+depends: ["ocamlfind" "ocamlbuild" "ocamlgraph"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/solvuu-build/solvuu-build.0.1.0/url
+++ b/packages/solvuu-build/solvuu-build.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/solvuu/solvuu-build/archive/v0.1.0.tar.gz"
+checksum: "9dbd89223f15e7b09b3241e727f7d491"


### PR DESCRIPTION
Solvuu's build system.


---
* Homepage: https://github.com/solvuu/solvuu-build
* Source repo: https://github.com/solvuu/solvuu-build.git
* Bug tracker: https://github.com/solvuu/solvuu-build/issues

---
### opam-lint failures
- **WARNING** 27 No field 'remove' while a field 'install' is present, uncomplete uninstallation suspected
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.2