### PR TITLE
Fix opam files to remove OPAM 1.2.0 warnings

### DIFF
--- a/packages/sawja/sawja.1.5.2/opam
+++ b/packages/sawja/sawja.1.5.2/opam
@@ -7,9 +7,8 @@ build: [
 remove: [
   ["ocamlfind" "remove" "sawja"]
 ]
-bug-reports: "sawja@inria.fr"
 author: "Sawja development team"
-licence: "GPLv3"
+license: "GPLv3"
 install: [
   [make "install"]
 ]

--- a/packages/sosa/sosa.0.1.0/opam
+++ b/packages/sosa/sosa.0.1.0/opam
@@ -19,6 +19,5 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/smondet/sosa"
 available: [ocaml-version >= "4.00.0"]
 install: [make "install"]


### PR DESCRIPTION
```
[WARNING] duplicate fields in /home/opam/.opam/repo/default/packages/sawja/sawja.1.5.2/opam: { bug-reports }
[WARNING] licence is an unknown field in /home/opam/.opam/repo/default/packages/sawja/sawja.1.5.2/opam.
[WARNING] duplicate fields in /home/opam/.opam/repo/default/packages/sosa/sosa.0.1.0/opam: { dev-repo }
```