### PR TITLE
mark solvuu_build as deprecated

### DIFF
--- a/packages/solvuu_build/solvuu_build.0.0.1/descr
+++ b/packages/solvuu_build/solvuu_build.0.0.1/descr
@@ -1,1 +1,1 @@
-Solvuu's build system.
+DEPRECATED. Please use solvuu-build.

--- a/packages/solvuu_build/solvuu_build.0.0.2/descr
+++ b/packages/solvuu_build/solvuu_build.0.0.2/descr
@@ -1,1 +1,1 @@
-Solvuu's build system.
+DEPRECATED. Please use solvuu-build.


### PR DESCRIPTION
This package has been renamed to solvuu-build. Adding a note to the `descr` field to hopefully reduce confusion for users.