### PR TITLE
minios-xen: add a wrapper which unsets an environment variable

### DIFF
--- a/packages/minios-xen/minios-xen.0.9/files/build-opam.sh
+++ b/packages/minios-xen/minios-xen.0.9/files/build-opam.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -ex
+
+# The MiniOS build is sensitive to some external variables
+# like EXTRA_DEPS being set, even to blank values.
+# See: https://github.com/mirage/mirage-xen-minios/issues/15
+# This wrapper script explicitly unexports them from the
+# environment before invoking Make
+
+unset EXTRA_DEPS
+
+make debug=n CONFIG_VERBOSE_BOOT=n

--- a/packages/minios-xen/minios-xen.0.9/opam
+++ b/packages/minios-xen/minios-xen.0.9/opam
@@ -7,7 +7,7 @@ license: "BSD + some optional GPL components"
 dev-repo: "https://github.com/talex5/mini-os.git"
 available: [ os != "darwin" ]
 build: [
-  [make "debug=n" "CONFIG_VERBOSE_BOOT=n"]
+  ["./build-opam.sh"]
 ]
 install: [
   [make "install" "LIBDIR=%{prefix}%/lib" "INCLUDEDIR=%{prefix}%/include"]


### PR DESCRIPTION
EXTRA_DEPS causes a build failure (mirage/mirage-xen-minios#15)
so we explicitly unset it here.  Due to the vagaries of make, unset
is different from setting it to a blank value (EXTRA_DEPS="" causes
the build failure)