### PR TITLE
tls: add upper bounds on mirage-types-lwt in prep for mirage3 release

### DIFF
--- a/packages/tls/tls.0.5.0/opam
+++ b/packages/tls/tls.0.5.0/opam
@@ -32,6 +32,7 @@ depopts: [
 conflicts: [
   "lwt" {<"2.4.8"}
   "mirage-types-lwt" {<"2.3.0"}
+  "mirage-types-lwt" {>="3.0.0"}
   "mirage-net-xen" {<"1.3.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/tls/tls.0.6.0/opam
+++ b/packages/tls/tls.0.6.0/opam
@@ -34,6 +34,7 @@ depopts: [
 conflicts: [
   "lwt" {<"2.4.8"}
   "mirage-types-lwt" {<"2.3.0"}
+  "mirage-types-lwt" {>="3.0.0"}
   "mirage-net-xen" {<"1.3.0"}
 ]
 

--- a/packages/tls/tls.0.7.0/opam
+++ b/packages/tls/tls.0.7.0/opam
@@ -34,6 +34,7 @@ depopts: [
 conflicts: [
   "lwt" {<"2.4.8"}
   "mirage-types-lwt" {<"2.3.0"}
+  "mirage-types-lwt" {>="3.0.0"}
   "mirage-net-xen" {<"1.3.0"}
 ]
 

--- a/packages/tls/tls.0.7.1/opam
+++ b/packages/tls/tls.0.7.1/opam
@@ -36,6 +36,7 @@ depopts: [
 conflicts: [
   "lwt" {<"2.4.8"}
   "mirage-types-lwt" {<"2.3.0"}
+  "mirage-types-lwt" {>="3.0.0"}
   "mirage-net-xen" {<"1.3.0"}
 ]
 


### PR DESCRIPTION
This helps with revdeps testing e.g. https://travis-ci.org/mirage/mirage/jobs/164359908