### PR TITLE
ppx_netblob.0.1 - via opam-publish

### DIFF
--- a/packages/ppx_netblob/ppx_netblob.0.1/descr
+++ b/packages/ppx_netblob/ppx_netblob.0.1/descr
@@ -1,0 +1,4 @@
+fill strings with data collected from the internet
+
+this package is based on ppx_blob, except it uses cohttp to fetch blobs from
+the internet rather than from the local file system

--- a/packages/ppx_netblob/ppx_netblob.0.1/opam
+++ b/packages/ppx_netblob/ppx_netblob.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "christophermcalpine@gmail.com"
+authors: ["John Whitington" "John Christopher McAlpine"]
+homepage: "https://github.com/chrismamo1/ppx_netblob"
+bug-reports: "https://github.com/chrismamo1/ppx_netblob/issues/"
+dev-repo: "https://github.com/chrismamo1/ppx_netblob.git"
+build: [
+  [make "native-code"] {ocaml-native}
+  [make "byte-code"] {!ocaml-native}
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ppx_netblob"]
+depends: [
+  "ocamlfind" {build & >= "1.5.2"}
+  "ppx_tools" {build}
+  "cohttp" {build}
+  "lwt" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_netblob/ppx_netblob.0.1/url
+++ b/packages/ppx_netblob/ppx_netblob.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/chrismamo1/ppx_netblob/archive/master.tar.gz"
+checksum: "328502a31f49eac7a70073f542bc62f2"


### PR DESCRIPTION
fill strings with data collected from the internet

this package is based on ppx_blob, except it uses cohttp to fetch blobs from
the internet rather than from the local file system


---
* Homepage: https://github.com/chrismamo1/ppx_netblob
* Source repo: https://github.com/chrismamo1/ppx_netblob.git
* Bug tracker: https://github.com/chrismamo1/ppx_netblob/issues/

---

Pull-request generated by opam-publish v0.3.2