### PR TITLE
mirage-types-lwt: put strong constraints on their ties to mirage-types

### DIFF
--- a/packages/mirage-types-lwt/mirage-types-lwt.2.6.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.2.6.0/opam
@@ -12,5 +12,5 @@ depends: [
   "cstruct" {>="1.4.0"}
   "io-page" {>="1.4.0"}
   "ipaddr"
-  "mirage-types" {>="2.6.0"}
+  "mirage-types" {="2.6.0"}
 ]

--- a/packages/mirage-types-lwt/mirage-types-lwt.2.8.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.2.8.0/opam
@@ -12,5 +12,5 @@ depends: [
   "cstruct" {>="1.4.0"}
   "io-page" {>="1.4.0"}
   "ipaddr"
-  "mirage-types" {>="2.8.0"}
+  "mirage-types" {="2.8.0"}
 ]


### PR DESCRIPTION
otherwise its possible to depend on mirage-types-lwt<3 and get a
different underlying mirage-types-lwt