### PR TITLE
ocurl.0.7.9 - via opam-publish

### DIFF
--- a/packages/ocurl/ocurl.0.7.9/descr
+++ b/packages/ocurl/ocurl.0.7.9/descr
@@ -1,0 +1,3 @@
+Bindings to libcurl
+Client-side URL transfer library, supporting HTTP and a multitude of
+other network protocols (FTP/SMTP/RTSP/etc).

--- a/packages/ocurl/ocurl.0.7.9/opam
+++ b/packages/ocurl/ocurl.0.7.9/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+homepage: "http://ocurl.forge.ocamlcore.org"
+license: "MIT"
+authors: [ "Lars Nilsson" "ygrek" ]
+doc: ["http://ocurl.forge.ocamlcore.org/api/index.html"]
+dev-repo: "git://github.com/ygrek/ocurl.git"
+bug-reports: "https://github.com/ygrek/ocurl/issues"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+build-test: [
+  [make "test"]
+]
+build-doc: [[make "doc"]]
+remove: [["ocamlfind" "remove" "curl"]]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+  "conf-libcurl"
+]
+depopts: ["lwt"]

--- a/packages/ocurl/ocurl.0.7.9/url
+++ b/packages/ocurl/ocurl.0.7.9/url
@@ -1,0 +1,2 @@
+http: "http://ygrek.org.ua/p/release/ocurl/ocurl-0.7.9.tar.gz"
+checksum: "3ffd81825e4c6f139942a2d6e7543378"


### PR DESCRIPTION
Bindings to libcurl
Client-side URL transfer library, supporting HTTP and a multitude of
other network protocols (FTP/SMTP/RTSP/etc).


---
* Homepage: http://ocurl.forge.ocamlcore.org
* Source repo: git://github.com/ygrek/ocurl.git
* Bug tracker: https://github.com/ygrek/ocurl/issues

---

Pull-request generated by opam-publish v0.3.2