### PR TITLE
tip-parser.0.2 - via opam-publish

### DIFF
--- a/packages/tip-parser/tip-parser.0.2/descr
+++ b/packages/tip-parser/tip-parser.0.2/descr
@@ -1,0 +1,5 @@
+Parser for TIP (Tons of Inductive Problems)
+
+A simple AST and parser/printer for TIP (https://tip-org.github.io/), a simple
+format for writing problems in a typed logic with computable functions,
+datatypes, and axioms.

--- a/packages/tip-parser/tip-parser.0.2/opam
+++ b/packages/tip-parser/tip-parser.0.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/tip-parser/"
+bug-reports: "https://github.com/c-cube/tip-parser/issues"
+tags: ["TIP" "parse" "inductive" "logic"]
+dev-repo: "https://github.com/c-cube/tip-parser.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "tip_parser"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/tip-parser/tip-parser.0.2/url
+++ b/packages/tip-parser/tip-parser.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/tip-parser/archive/0.2.tar.gz"
+checksum: "01a16ab5936bbaa2d70007c21cda12cc"


### PR DESCRIPTION
Parser for TIP (Tons of Inductive Problems)

A simple AST and parser/printer for TIP (https://tip-org.github.io/), a simple
format for writing problems in a typed logic with computable functions,
datatypes, and axioms.


---
* Homepage: https://github.com/c-cube/tip-parser/
* Source repo: https://github.com/c-cube/tip-parser.git
* Bug tracker: https://github.com/c-cube/tip-parser/issues

---

Pull-request generated by opam-publish v0.3.2