### PR TITLE
datakit-client.0.6.0 - via opam-publish

### DIFF
--- a/packages/datakit-client/datakit-client.0.6.0/descr
+++ b/packages/datakit-client/datakit-client.0.6.0/descr
@@ -1,4 +1,4 @@
-Library to connect to a datakit server
+Library to connect to a datakit servers
 
 The library currently only provides only a 9p client to talk to
 Datakit, but other filesystem protocols will be available in the

--- a/packages/datakit-client/datakit-client.0.6.0/descr
+++ b/packages/datakit-client/datakit-client.0.6.0/descr
@@ -1,0 +1,5 @@
+Library to connect to a datakit server
+
+The library currently only provides only a 9p client to talk to
+Datakit, but other filesystem protocols will be available in the
+future.

--- a/packages/datakit-client/datakit-client.0.6.0/descr
+++ b/packages/datakit-client/datakit-client.0.6.0/descr
@@ -1,4 +1,4 @@
-Library to connect to a datakit servers
+A library to connect to datakit servers
 
 The library currently only provides only a 9p client to talk to
 Datakit, but other filesystem protocols will be available in the

--- a/packages/datakit-client/datakit-client.0.6.0/opam
+++ b/packages/datakit-client/datakit-client.0.6.0/opam
@@ -18,6 +18,5 @@ depends: [
   "topkg"      {build}
   "base-bytes"
   "astring" "logs" "uri" "rresult" "cstruct" "fmt"
-  "cmdliner"
-  "protocol-9p"
+  "protocol-9p" {>= "0.7.0"}
 ]

--- a/packages/datakit-client/datakit-client.0.6.0/opam
+++ b/packages/datakit-client/datakit-client.0.6.0/opam
@@ -19,4 +19,5 @@ depends: [
   "base-bytes"
   "astring" "logs" "uri" "rresult" "cstruct" "fmt"
   "protocol-9p" {>= "0.7.0"}
+  "cmdliner"
 ]

--- a/packages/datakit-client/datakit-client.0.6.0/opam
+++ b/packages/datakit-client/datakit-client.0.6.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/docker/datakit"
+bug-reports:  "https://github.com/docker/datakit/issues"
+dev-repo:     "https://github.com/docker/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" "datakit-client"
+]
+
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "base-bytes"
+  "astring" "logs" "uri" "rresult" "cstruct" "fmt"
+  "cmdliner"
+  "protocol-9p"
+]

--- a/packages/datakit-client/datakit-client.0.6.0/url
+++ b/packages/datakit-client/datakit-client.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/docker/datakit/releases/download/0.6.0/datakit-0.6.0.tbz"
+checksum: "a502b86cea0f7f515776bc9901b36515"


### PR DESCRIPTION
Library to connect to a datakit server

The library currently only provides only a 9p client to talk to
Datakit, but other filesystem protocols will be available in the
future.


---
* Homepage: https://github.com/docker/datakit
* Source repo: https://github.com/docker/datakit.git
* Bug tracker: https://github.com/docker/datakit/issues

---


---
### 0.6.0 (2016-10-03)

- fix META files (#278, @dsj55)
- fix CI scripts (#262, @dave-tucker)
- create a new `datakit-server` library, to help adding runtime instrospection
  mechanism to servers without having to depend on irmin (#280)

- github: add documentation (#258, @talex5)
- github: add API resources capabilities (#279, @samoht)
- github: fix support for annotated tags (#274, @samoht)
- github: fix setting build status when description is larger than 140
  characters (#273, @samoht)
- github: prune the public branch too (#272, @samoht)
- github: read combined build status instead of the full build status
  history (#265)
- github: use ocaml-github 2.0.0 and ocaml-github-hooks (#264, @samoht)
- github: fix event loop (#259, #260, @talex5)

- client: speed-up 9p walks (#271, @samoht)

- server: revert back to active polling due to an bug in irmin-watcher's
  inotify support (#269, @samoht)
- server: add more debugging messages for the "GitHub auto-push" feature
  (#261, @talex5)
- server: expose the Irmin "REST" API over HTTP by using the `--listen-http`
  command-line argument (#281, @samoht)
Pull-request generated by opam-publish v0.3.2