### PR TITLE
integers.0.2.0 - via opam-publish

### DIFF
--- a/packages/integers/integers.0.2.0/descr
+++ b/packages/integers/integers.0.2.0/descr
@@ -1,0 +1,1 @@
+Various signed and unsigned integer types for OCaml

--- a/packages/integers/integers.0.2.0/opam
+++ b/packages/integers/integers.0.2.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop"
+          "Demi Obenour"
+          "Stephane Glondu"
+          "Andreas Hauptmann"]
+homepage: "https://github.com/ocamllabs/ocaml-integers"
+bug-reports: "https://github.com/ocamllabs/ocaml-integers/issues"
+dev-repo: "https://github.com/ocamllabs/ocaml-integers.git"
+license: "MIT"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"]]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+]
+
+doc: "http://ocamllabs.github.io/ocaml-integers/"

--- a/packages/integers/integers.0.2.0/url
+++ b/packages/integers/integers.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocamllabs/ocaml-integers/releases/download/0.2.0/integers-0.2.0.tbz"
+checksum: "0d485413bf08a238a424c0f573d5c3c3"


### PR DESCRIPTION
Various signed and unsigned integer types for OCaml


---
* Homepage: https://github.com/ocamllabs/ocaml-integers
* Source repo: https://github.com/ocamllabs/ocaml-integers.git
* Bug tracker: https://github.com/ocamllabs/ocaml-integers/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.2.0 2016-10-04
-----------------
* Expose from_byte_size functions in Unsigned and Signed
* Support for platforms where standard integer types are macros
* Add 'max' and 'min' functions to Unsigned.S.
* Expose private types for UChar, UInt8, UInt16.
Pull-request generated by opam-publish v0.3.2