### PR TITLE
atdgen: disable broken tests

### DIFF
--- a/packages/atdgen/atdgen.1.10.0/opam
+++ b/packages/atdgen/atdgen.1.10.0/opam
@@ -10,11 +10,6 @@ build: [ [make] ]
 
 install: [make "findlib-install"]
 
-build-test: [
-  [make]
-  [make "test"]
-]
-
 remove: [
     ["ocamlfind" "remove" "atdgen"]
 ]


### PR DESCRIPTION
See https://travis-ci.org/docker/datakit/jobs/165479176 /cc @mjambon 

```
#=== ERROR while installing atdgen.1.10.0 =====================================#
# opam-version 1.2.2
# os           linux
# command      make test
# path         /home/travis/.opam/4.03.0/build/atdgen.1.10.0
# compiler     4.03.0
# exit-code    2
# env-file     /home/travis/.opam/4.03.0/build/atdgen.1.10.0/atdgen-4831-cec83f.env
# stdout-file  /home/travis/.opam/4.03.0/build/atdgen.1.10.0/atdgen-4831-cec83f.out
# stderr-file  /home/travis/.opam/4.03.0/build/atdgen.1.10.0/atdgen-4831-cec83f.err
### stdout ###
# [...]
# ../src/atdgen -json test4.atd -o test4j
# ../src/atdgen -validate -extend Test test.atd -o testv
# ../src/atdgen -o-name-overlap -t test5.atd
# ../src/atdgen -o-name-overlap -j test5.atd
# ../src/atdgen -o-name-overlap -b test5.atd
# ../src/atdgen -t test_type_conv.atd -type-conv sexp -open "Sexplib.Std"
# ocamlfind ocamlc -c -package atdgen \
# 		test5_t.mli test5_t.ml test5_j.mli test5_j.ml
# make[2]: Leaving directory `/home/travis/.opam/4.03.0/build/atdgen.1.10.0/test'
# make[1]: Leaving directory `/home/travis/.opam/4.03.0/build/atdgen.1.10.0/test'
### stderr ###
# ocamlfind: Package `atdgen' not found
# make[2]: *** [really-test] Error 2
# make[1]: *** [test] Error 2
# make: *** [test] Error 2
```
