### PR TITLE
lwt_named_threads doesn't depend on devkit

### DIFF
--- a/packages/lwt_named_threads/lwt_named_threads.0.1/opam
+++ b/packages/lwt_named_threads/lwt_named_threads.0.1/opam
@@ -10,6 +10,7 @@ remove: [["ocamlfind" "remove" "lwt_named_threads"]]
 depends: [
   "ocamlfind" {build}
   "lwt"
-  "devkit"
+  "extlib"
   "objsize"
 ]
+available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
see https://github.com/ahrefs/lwt_named_threads/commit/c922727a73da16b451a292dce024805f01f1f7bd
_oasis in the tarball says it depends on extlib, but opam still said devkit

/cc @gdsfh 