### PR TITLE
reason.1.3.0 - via opam-publish

### DIFF
--- a/packages/reason/reason.1.3.0/descr
+++ b/packages/reason/reason.1.3.0/descr
@@ -1,0 +1,5 @@
+Reason: Meta Language Toolchain
+
+reason allows development of Meta Language syntax trees in non-text format. It
+allows a development model that is equivalent to collaborating on syntax trees
+that have been committed to a source code repository.

--- a/packages/reason/reason.1.3.0/opam
+++ b/packages/reason/reason.1.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: "Jordan Walke <jordojw@gmail.com>"
+homepage: "https://github.com/facebook/reason"
+bug-reports: "https://github.com/facebook/reason/issues"
+license: "BSD"
+doc: "http://facebook.github.io/reason"
+tags: "syntax"
+dev-repo: "git://github.com/facebook/reason.git"
+substs: "pkg/META"
+build: [
+  [make "compile_error"]
+  [
+    "ocaml"
+    "pkg/build.ml"
+    "native=%{ocaml-native}%"
+    "native-dynlink=%{ocaml-native-dynlink}%"
+    "utop=%{utop:installed}%"
+  ]
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_reason.byte"
+  "--"
+]
+depends: [
+  "easy-format" {>= "1.2.0"}
+  "ocamlfind" {build}
+  "utop" {>= "1.17"}
+  "BetterErrors" {>= "0.0.1"}
+  "menhir" {>= "20160303"}
+  "merlin" {>= "2.5.0"}
+  "merlin-extend" {>= "0.3"}
+  "re" {>= "1.5.0"}
+]
+conflicts: [
+  "utop" {< "1.17"}
+]
+available: [ocaml-version = "4.02.3"]

--- a/packages/reason/reason.1.3.0/url
+++ b/packages/reason/reason.1.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/facebook/reason/archive/1.3.0.zip"
+checksum: "b8a94ad7b8803b716ee41c006ebcafa8"


### PR DESCRIPTION
Reason: Meta Language Toolchain

reason allows development of Meta Language syntax trees in non-text format. It
allows a development model that is equivalent to collaborating on syntax trees
that have been committed to a source code repository.


---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

Pull-request generated by opam-publish v0.3.2