### PR TITLE
[BAP] fix bap-server package

### DIFF
--- a/packages/bap-server/bap-server.0.1.0/opam
+++ b/packages/bap-server/bap-server.0.1.0/opam
@@ -23,8 +23,9 @@ remove: [
 
 depends: [
     "core-lwt"
+    "regular"
     "bap-std" "bap-arm"
-    "cohttp" {>= "0.20.0 & <= 0.21.0"}
+    "cohttp" {>= "0.20.0" & <= "0.21.0"}
     "core_kernel" {>= "113.33.00"}
     "ezjsonm" {>= "0.4.0" & < "0.4.4" }
     "lwt"

--- a/packages/bap-server/bap-server.0.1.0/url
+++ b/packages/bap-server/bap-server.0.1.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/BinaryAnalysisPlatform/bap-server/archive/v0.1.0.tar.gz"
-checksum: "9b5e9c5d0067971d7501d99d44db8ad0"
+checksum: "9bb465ad8f216009cfb0eda23509e02e"


### PR DESCRIPTION
Note: this PR will fail, as a required version of LLVM is not
available on opam-repository travis build.

Will resolve #7588.