### PR TITLE
[BAP] Fix bap llvm build on travis

### DIFF
--- a/packages/bap-llvm/bap-llvm.1.0.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.0.0/opam
@@ -8,10 +8,12 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
 dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
+  ["sh" "-x" "detect.travis"]
   ["./configure"
                  "--prefix=%{prefix}%"
                  "--with-cxx=`which clang++`"
-                 "--with-llvm-version=%{conf-llvm:version}%"
+                 "--with-llvm-version=3.4" {conf-env-travis:active}
+                 "--with-llvm-version=%{conf-llvm:version}%" {!conf-env-travis:active}
                  "--enable-llvm"]
   [make]
 ]
@@ -28,6 +30,7 @@ depends: [
     "bap-std"
     "cmdliner"
     "conf-llvm"
+    "conf-env-travis"
 ]
 
 depexts: [

--- a/packages/bap-llvm/bap-llvm.1.0.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.0.0/opam
@@ -8,7 +8,6 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
 dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
-  ["sh" "-x" "detect.travis"]
   ["./configure"
                  "--prefix=%{prefix}%"
                  "--with-cxx=`which clang++`"

--- a/packages/conf-env-travis/conf-env-travis.1/descr
+++ b/packages/conf-env-travis/conf-env-travis.1/descr
@@ -1,0 +1,9 @@
+Detect Travis CI and lift its environment to opam.
+
+
+This package will expose variable an environment variable
+`TRAVIS_<VAR>` as an opam variable `conf-env-travis:<var>`, e.g.,
+`TRAVIS_OS_NAME` can be accessed as `conf-env-travis:os_name`.
+
+A variable `active` would be set to true, if travis environment was
+detected.  All variables except `active` are delimited with quotes.

--- a/packages/conf-env-travis/conf-env-travis.1/files/configure
+++ b/packages/conf-env-travis/conf-env-travis.1/files/configure
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+cat > conf-env-travis.config <<EOF
+ active : ${TRAVIS:-false}
+ branch : "${TRAVIS_BRANCH}"
+ build_id : "${TRAVIS_BUILD_ID}"
+ build_dir : "${TRAVIS_BUILD_DIR}"
+ build_number : "${TRAVIS_BUILD_NUMBER}"
+ commit : "${TRAVIS_COMMIT}"
+ commit_range : "${TRAVIS_COMMIT_RANGE}"
+ event_type : "${TRAVIS_EVENT_TYPE}"
+ job_id : "${TRAVIS_JOB_ID}"
+ job_number : "${TRAVIS_JOB_NUMBER}"
+ os_name : "${TRAVIS_OS_NAME}"
+ pull_request : "${TRAVIS_PULL_REQUEST}"
+ pull_request_branch : "${TRAVIS_PULL_REQUEST_BRANCH}"
+ pull_request_sha : "${TRAVIS_PULL_REQUEST_SHA}"
+ repo_slug : "${TRAVIS_REPO_SLUG}"
+ secure_env_vars : "${TRAVIS_SECURE_ENV_VARS}"
+ test_result : "${TRAVIS_TEST_RESULT}"
+ tag : "${TRAVIS_TAG}"
+EOF

--- a/packages/conf-env-travis/conf-env-travis.1/opam
+++ b/packages/conf-env-travis/conf-env-travis.1/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+homepage: "https://travis-ci.org/"
+authors: "Ivan Gotovchits <ivg@ieee.org>"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: [
+  ["sh" "-x" "configure" os]
+]


### PR DESCRIPTION
Ubuntu image on Travis is specially alterated, so that the `llvm-config`
is relinked from the default (and installed 3.4) into
`llvm-config-3.5`, that is not supported by BAP.

All dependencies are installed correctly by the depext (including
llvm-3.4), but due to some hardcoded specifics of travis, the
`llvm-config` file still points to 3.5 that we even didn't install. It
looks like, that travis team didn't use the `update-alternative` mechanism
to choose a particular version of llvm, but did some hardcode linking.

To prevent the failures, the following is proposed:

1. new `conf-env-llvm` package is added that will make the Travis
environment available as opam variables

2. use `conf-env-llvm` package to specialize configuration on Travis.
