### PR TITLE
tyre.0.2 - via opam-publish

### DIFF
--- a/packages/tyre/tyre.0.2/descr
+++ b/packages/tyre/tyre.0.2/descr
@@ -1,0 +1,4 @@
+Typed Regular Expressions
+
+Tyre is a set of combinators to build type-safe regular expressions, allowing automatic extraction and modification of matched groups.
+Tyre is bi-directional: a typed regular expressions can be used for parsing and unparsing. It also allows routing, by providing a list of regexs/routes and their handlers.

--- a/packages/tyre/tyre.0.2/opam
+++ b/packages/tyre/tyre.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+authors: "Gabriel Radanne <drupyog@zoho.com>"
+homepage: "https://github.com/Drup/tyre"
+doc: "https://drup.github.io/tyre/0.2/Tyre.html"
+bug-reports: "https://github.com/Drup/tyre/issues"
+license: "ISC"
+tags: "regex"
+dev-repo: "https://github.com/Drup/tyre.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "tyre"]
+depends: [
+  "ocamlfind" {build}
+  "re" {>= "1.7.0"}
+  "alcotest" {test & >= "0.6.0"}
+  "result"
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/tyre/tyre.0.2/url
+++ b/packages/tyre/tyre.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Drup/tyre/archive/0.2.tar.gz"
+checksum: "b6720777ea250641eefd3c6f8ce89443"


### PR DESCRIPTION
Typed Regular Expressions

Tyre is a set of combinators to build type-safe regular expressions, allowing automatic extraction and modification of matched groups.
Tyre is bi-directional: a typed regular expressions can be used for parsing and unparsing. It also allows routing, by providing a list of regexs/routes and their handlers.

---
* Homepage: https://github.com/Drup/tyre
* Source repo: https://github.com/Drup/tyre.git
* Bug tracker: https://github.com/Drup/tyre/issues

---

## [Version 0.2](https://github.com/Drup/tyre/releases/tag/0.2)
* Rename `<?>` to `<|>`
* Rename `<*>` to `<&>`
* Add the `str` and `char` combinators for constant patterns.
* Add the `blank` combinator.
* Add an Infix module.
* `Tyre.conv` is now separated into two combinators, `conv` which doesn't use
  an option, but is not allowed to fail, and `conv_fail` which allows failures.
* The prefix (`<*`) and suffix (`*>`) operators now accepts tyregexs on both
  sides. The old behavior can be recovered by combining with `Tyre.str`.
  This makes prefixstr/suffixstr (`**>`/`<**`) redundant, they are removed.
* The various list combinators now accept a tyregex as separator.
  The old behavior can be recovered by combining with `Tyre.str`.
* Add the `start` and `stop` combinators.
* The ~whole argument for compile and route is removed.
  tyregex don't match the whole string by default anymore.
  You can use `Tyre.whole_string` or `Tyre.start` and `Tyre.stop` instead.

----

Pull-request generated by opam-publish v0.3.2