### PR TITLE
irmin conflicts with git <1.8.0 (similar to upstream and irmin 0.11.0)

### DIFF
--- a/packages/irmin/irmin.0.11.1/opam
+++ b/packages/irmin/irmin.0.11.1/opam
@@ -47,7 +47,7 @@ depends: [
 depopts: ["base-unix" "git" "git-unix" "cohttp" "mirage-git"]
 conflicts: [
   "cohttp" {< "0.18.3"}
-  "git" {< "1.7.2"}
+  "git" {< "1.8.0"}
   "conduit" {< "0.9.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/6766