### PR TITLE
brotli.1.2.1 - via opam-publish

### DIFF
--- a/packages/brotli/brotli.1.2.1/descr
+++ b/packages/brotli/brotli.1.2.1/descr
@@ -1,0 +1,5 @@
+Bindings to Google's Brotli compresion algorithm
+
+OCaml Bindings to brotli, Google's compression algorithm for the web
+Source: https://github.com/google/brotli/ RFC:
+http://www.ietf.org/id/draft-alakuijala-brotli

--- a/packages/brotli/brotli.1.2.1/opam
+++ b/packages/brotli/brotli.1.2.1/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "http://hyegar.com"
+bug-reports: "https://github.com/fxfactorial/ocaml-brotli/issues"
+license: "BSD-3-clause"
+tags: ["clib:stdc" "clib:brotli"]
+dev-repo: "https://github.com/fxfactorial/ocaml-brotli.git"
+build: [
+  ["oasis" "setup" "-setup-update" "dynamic"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "brotli"]
+depends: [
+  "oasis" {build}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.03.0"]
+messages:
+  "Note, you'll need to have libbrotli installed: https://github.com/bagder/libbrotli"
+post-messages: [
+  "Make sure you had libbrotli installed, get it at:https://github.com/bagder/libbrotli"
+    {failure}
+]

--- a/packages/brotli/brotli.1.2.1/url
+++ b/packages/brotli/brotli.1.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-brotli/archive/v1.2.1.tar.gz"
+checksum: "e5ab408e5fef8081cae28a7ec1e05a29"


### PR DESCRIPTION
Bindings to Google's Brotli compresion algorithm

OCaml Bindings to brotli, Google's compression algorithm for the web
Source: https://github.com/google/brotli/ RFC:
http://www.ietf.org/id/draft-alakuijala-brotli


I'm having to do this minor release because apparently there is no way to correctly make the ocaml compilers use `clang` on Linux which is a major annoyance to me and now I have to limit the features that I wanted to use simply because of infrastructure problems with the OCaml ecosystem, giving in and using `gcc` on Linux. 

I very much don't like having to change my coding because of build system problems. 

Expected to fail since the travis machines don't have libbrotli installed. 