### PR TITLE
cpuid.0.0.1 - via opam-publish

### DIFF
--- a/packages/cpuid/cpuid.0.0.1/descr
+++ b/packages/cpuid/cpuid.0.0.1/descr
@@ -1,0 +1,6 @@
+Detect CPU features
+
+
+`cpuid` allows detection of CPU features from OCaml.
+
+cpuid is distributed under the ISC license.

--- a/packages/cpuid/cpuid.0.0.1/opam
+++ b/packages/cpuid/cpuid.0.0.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/cpuid"
+doc: "https://pqwy.github.io/cpuid/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/cpuid.git"
+bug-reports: "https://github.com/pqwy/cpuid/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build & >="0.9.3"}
+  "topkg" {build}
+  "result" ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]

--- a/packages/cpuid/cpuid.0.0.1/url
+++ b/packages/cpuid/cpuid.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/cpuid/releases/download/v0.0.1/cpuid-0.0.1.tbz"
+checksum: "163387039f01a369796eb21866ce21a7"


### PR DESCRIPTION
Detect CPU features


`cpuid` allows detection of CPU features from OCaml.

cpuid is distributed under the ISC license.

---
* Homepage: https://github.com/pqwy/cpuid
* Source repo: https://github.com/pqwy/cpuid.git
* Bug tracker: https://github.com/pqwy/cpuid/issues

---


---
## v0.0.1 2016-10-12

First release.
Pull-request generated by opam-publish v0.3.2