### PR TITLE
containers.0.20 - via opam-publish

### DIFF
--- a/packages/containers/containers.0.20/descr
+++ b/packages/containers/containers.0.20/descr
@@ -1,0 +1,10 @@
+A modular extension of the OCaml standard library with a focus on data structures.
+
+Containers is an extension of OCaml's standard library (under BSD license)
+focused on data structures, combinators and iterators, without dependencies on
+unix, str or num. Every module is independent and is prefixed with 'CC' in the
+global namespace. Some modules extend the stdlib (e.g. CCList provides safe
+map/fold_right/append, and additional functions on lists).
+
+It also features sub-libraries for dealing with strings, helpers for unix,
+threads, and S-expressions.

--- a/packages/containers/containers.0.20/opam
+++ b/packages/containers/containers.0.20/opam
@@ -1,0 +1,54 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+doc: "http://cedeela.fr/~simon/software/containers/"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+dev-repo: "https://github.com/c-cube/ocaml-containers.git"
+build: [
+  [
+    "./configure"
+    "--prefix"
+    prefix
+    "--%{base-threads:enable}%-thread"
+    "--disable-bench"
+    "--disable-tests"
+    "--%{base-bigarray:enable}%-bigarray"
+    "--%{sequence:enable}%-advanced"
+    "--%{base-unix:enable}%-unix"
+    "--enable-docs"
+  ]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "containers"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "result"
+  "cppo" {build}
+  "ocamlbuild" {build}
+]
+depopts: [
+  "sequence"
+  "base-bigarray"
+  "base-unix"
+  "base-threads"
+  "qtest" {test}
+]
+conflicts: [
+  "sequence" {< "0.5"}
+  "qtest" {< "2.2"}
+  "qcheck"
+]
+available: [ocaml-version >= "4.00.0"]
+post-messages:
+  "
+Small release with bugfixes in `CCArray`, and a few new functions.
+Some types are now more general.
+
+changelog: https://github.com/c-cube/ocaml-containers/blob/0.20/CHANGELOG.adoc
+  "

--- a/packages/containers/containers.0.20/url
+++ b/packages/containers/containers.0.20/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-containers/archive/0.20.tar.gz"
+checksum: "e6da892f190470536c5cf89b57812209"


### PR DESCRIPTION
A modular extension of the OCaml standard library with a focus on data structures.

Containers is an extension of OCaml's standard library (under BSD license)
focused on data structures, combinators and iterators, without dependencies on
unix, str or num. Every module is independent and is prefixed with 'CC' in the
global namespace. Some modules extend the stdlib (e.g. CCList provides safe
map/fold_right/append, and additional functions on lists).

It also features sub-libraries for dealing with strings, helpers for unix,
threads, and S-expressions.


---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---

Pull-request generated by opam-publish v0.3.2