### PR TITLE
Adds ppx_fun -- lighter syntax for anonymous funcs

### DIFF
--- a/packages/ppx_fun/ppx_fun.0.0.1/descr
+++ b/packages/ppx_fun/ppx_fun.0.0.1/descr
@@ -1,0 +1,1 @@
+ppx_fun is PPX rewriter that provides simplified syntax for anonymous functions via extensions: `[%f ...]` and `[%f_ ...]`.

--- a/packages/ppx_fun/ppx_fun.0.0.1/opam
+++ b/packages/ppx_fun/ppx_fun.0.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+version: "0.0.1"
+maintainer: "Roma Sokolov <sokolov.r.v@gmail.com>"
+authors: ["Roma Sokolov <sokolov.r.v@gmail.com>"]
+homepage: "https://github.com/little-arhat/ppx_fun"
+doc: "github.com/little-arhat/ppx_fun/doc"
+license: "MIT"
+dev-repo: "https://github.com/little-arhat/ppx_fun.git"
+bug-reports: "https://github.com/little-arhat/ppx_fun/issues"
+tags: []
+available: [ ocaml-version >= "4.03.0"]
+depends: [
+  "ppx_driver"
+  "ppx_core"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--tests" "true"]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]]

--- a/packages/ppx_fun/ppx_fun.0.0.1/url
+++ b/packages/ppx_fun/ppx_fun.0.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/little-arhat/ppx_fun/archive/v0.0.1.tar.gz"
+checksum: "1feb97a80779b0eaddd27f1659d26e78"


### PR DESCRIPTION
ppx_fun provides [%f ...] and [%f_ ...] as alternative syntax for anonymous
functions.