### PR TITLE
base64.2.1.2 - via opam-publish

### DIFF
--- a/packages/base64/base64.2.1.2/descr
+++ b/packages/base64/base64.2.1.2/descr
@@ -1,0 +1,10 @@
+For OCaml
+
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in [RFC 4648][rfc4648].
+
+See also [documentation][docs].
+
+[rfc4648]: https://tools.ietf.org/html/rfc4648
+[docs]: http://mirage.github.io/ocaml-base64

--- a/packages/base64/base64.2.1.2/opam
+++ b/packages/base64/base64.2.1.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "https://github.com/mirage/ocaml-base64.git"
+depends: [
+  "base-bytes"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "bos" {test}
+  "rresult" {test}
+  "alcotest" {test}
+]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]

--- a/packages/base64/base64.2.1.2/url
+++ b/packages/base64/base64.2.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-base64/releases/download/v2.1.2/base64-2.1.2.tbz"
+checksum: "acef73296915b4f8052868f182862dc8"


### PR DESCRIPTION
For OCaml

Base64 is a group of similar binary-to-text encoding schemes that represent
binary data in an ASCII string format by translating it into a radix-64
representation.  It is specified in [RFC 4648][rfc4648].

See also [documentation][docs].

[rfc4648]: https://tools.ietf.org/html/rfc4648
[docs]: http://mirage.github.io/ocaml-base64

---
* Homepage: https://github.com/mirage/ocaml-base64
* Source repo: https://github.com/mirage/ocaml-base64.git
* Bug tracker: https://github.com/mirage/ocaml-base64/issues

---


---
v2.1.2 2016-10-18
-------------------

* Fix version number (#11, @hannesm)
Pull-request generated by opam-publish v0.3.2