### PR TITLE
osx-membership.0.1.0 - via opam-publish

### DIFF
--- a/packages/osx-membership/osx-membership.0.1.0/descr
+++ b/packages/osx-membership/osx-membership.0.1.0/descr
@@ -1,0 +1,3 @@
+OS X membership.h bindings for user, group, and UUID translation
+
+Provides access to OS X functions for translating between UUIDs and uids/gids.

--- a/packages/osx-membership/osx-membership.0.1.0/opam
+++ b/packages/osx-membership/osx-membership.0.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-osx-membership"
+bug-reports: "https://github.com/dsheets/ocaml-osx-membership/issues"
+license: "ISC"
+tags: ["osx" "membership" "uid" "gid" "guid" "uuid" "opendirectoryd"]
+dev-repo: "https://github.com/dsheets/ocaml-osx-membership.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "ctypes" {>= "0.10.2"}
+  "unix-errno" {>= "0.5.0"}
+  "posix-types"
+  "base-unix"
+]
+depopts: "lwt"
+available: [os = "darwin"]

--- a/packages/osx-membership/osx-membership.0.1.0/url
+++ b/packages/osx-membership/osx-membership.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-membership/archive/0.1.0.tar.gz"
+checksum: "d87a80c7835b23b3fb63d30004ffbb6f"


### PR DESCRIPTION
OS X membership.h bindings for user, group, and UUID translation

Provides access to OS X functions for translating between UUIDs and uids/gids.


---
* Homepage: https://github.com/dsheets/ocaml-osx-membership
* Source repo: https://github.com/dsheets/ocaml-osx-membership.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-membership/issues

---

Pull-request generated by opam-publish v0.3.3