### PR TITLE
osx-acl.0.1.0 - via opam-publish

### DIFF
--- a/packages/osx-acl/osx-acl.0.1.0/descr
+++ b/packages/osx-acl/osx-acl.0.1.0/descr
@@ -1,0 +1,5 @@
+OS X POSIX.1e file system access control list (ACL) bindings
+
+Provides access to OS X functions for getting and setting POSIX.1e file
+system access control lists (ACLs). This functionality offers a
+finer-grained permissions model than traditional UNIX permissions.

--- a/packages/osx-acl/osx-acl.0.1.0/opam
+++ b/packages/osx-acl/osx-acl.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: "David Sheets"
+homepage: "https://github.com/dsheets/ocaml-osx-acl"
+bug-reports: "https://github.com/dsheets/ocaml-osx-acl/issues"
+license: "ISC"
+tags: ["osx" "acl" "file system" "POSIX.1e" "security"]
+dev-repo: "https://github.com/dsheets/ocaml-osx-acl.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test}
+  "ctypes" {>= "0.9.0"}
+  "unix-errno" {>= "0.5.0"}
+  "base-unix"
+  "unix-type-representations"
+  "osx-membership"
+]
+depopts: "lwt"
+available: [os = "darwin"]

--- a/packages/osx-acl/osx-acl.0.1.0/url
+++ b/packages/osx-acl/osx-acl.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-osx-acl/archive/0.1.0.tar.gz"
+checksum: "e6e750e1fdae0a3fb3e32b48be3e757a"


### PR DESCRIPTION
OS X POSIX.1e file system access control list (ACL) bindings

Provides access to OS X functions for getting and setting POSIX.1e file
system access control lists (ACLs). This functionality offers a
finer-grained permissions model than traditional UNIX permissions.


---
* Homepage: https://github.com/dsheets/ocaml-osx-acl
* Source repo: https://github.com/dsheets/ocaml-osx-acl.git
* Bug tracker: https://github.com/dsheets/ocaml-osx-acl/issues

---

Pull-request generated by opam-publish v0.3.3