### PR TITLE
alcotest.0.7.0 - via opam-publish

### DIFF
--- a/packages/alcotest/alcotest.0.7.0/descr
+++ b/packages/alcotest/alcotest.0.7.0/descr
@@ -1,0 +1,11 @@
+Alcotest is a lightweight and colourful test framework.
+
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple `TESTABLE` module type, a `check` function to assert test
+predicates and a `run` function to perform a list of `unit -> unit`
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.

--- a/packages/alcotest/alcotest.0.7.0/opam
+++ b/packages/alcotest/alcotest.0.7.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "fmt"
+  "astring"
+  "result"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/alcotest/alcotest.0.7.0/url
+++ b/packages/alcotest/alcotest.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/alcotest/releases/download/0.7.0/alcotest-0.7.0.tbz"
+checksum: "61d8fec7aed6d648134d1c05fb80568e"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework.

Alcotest exposes simple interface to perform unit tests. It exposes
a simple `TESTABLE` module type, a `check` function to assert test
predicates and a `run` function to perform a list of `unit -> unit`
test callbacks.

Alcotest provides a quiet and colorful output where only faulty runs
are fully displayed at the end of the run (with the full logs ready to
inspect), with a simple (yet expressive) query language to select the
tests to run.


---
* Homepage: https://github.com/mirage/alcotest/
* Source repo: https://github.com/mirage/alcotest.git
* Bug tracker: https://github.com/mirage/alcotest/issues/

---


---
### 0.7.0 (2016-10-25)

- Add a `unit` testable (useful for functions with side-effects) (#79, @avsm)
- Add a `testable` combinator to easily build `'a testable` values (#75, @pqwy)
- Add `pp` and `equal` to extract the pretty-printer and equality functions
  from an `'a testable` (#75, @pqwy)
- Add an `array` testable (#75, @pqwy)
Pull-request generated by opam-publish v0.3.2