### PR TITLE
higlo.0.6 - via opam-publish

### DIFF
--- a/packages/higlo/higlo.0.6/descr
+++ b/packages/higlo/higlo.0.6/descr
@@ -1,0 +1,3 @@
+Library for syntax highlighting.
+
+The purpose of Higlo is not to provide syntax highlighting for every language, nor target every format (HTML, LaTeX, ...). It provides a simple way to support additional languages and develop the generator for the output format you need. 

--- a/packages/higlo/higlo.0.6/files/higlo.install
+++ b/packages/higlo/higlo.0.6/files/higlo.install
@@ -1,0 +1,5 @@
+bin: [
+  "higlo"
+  "higlo.byte"
+  "mk-higlo"
+]

--- a/packages/higlo/higlo.0.6/opam
+++ b/packages/higlo/higlo.0.6/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/higlo/"
+bug-reports: "https://github.com/zoggy/higlo/issues"
+license: "GNU Lesser General Public License version 3"
+doc: "https://zoggy.github.io/higlo/doc.html"
+tags: ["syntax highlighting" "xml"]
+dev-repo: "https://github.com/zoggy/higlo.git"
+build: [make "all"]
+install: [make "install-lib"]
+remove: ["ocamlfind" "remove" "higlo"]
+depends: [
+  "ocamlfind"
+  "ulex"
+  "xtmpl" {>= "0.13.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/higlo/higlo.0.6/url
+++ b/packages/higlo/higlo.0.6/url
@@ -1,0 +1,2 @@
+http: "http://zoggy.github.io/higlo/higlo-0.6.tar.gz"
+checksum: "52e89a71fddfff701ff5bba21990a1ec"


### PR DESCRIPTION
Library for syntax highlighting.

The purpose of Higlo is not to provide syntax highlighting for every language, nor target every format (HTML, LaTeX, ...). It provides a simple way to support additional languages and develop the generator for the output format you need. 


---
* Homepage: http://zoggy.github.io/higlo/
* Source repo: https://github.com/zoggy/higlo.git
* Bug tracker: https://github.com/zoggy/higlo/issues

---

Pull-request generated by opam-publish v0.3.2