### PR TITLE
ojs-base.0.5.0 - via opam-publish

### DIFF
--- a/packages/ojs-base/ojs-base.0.5.0/descr
+++ b/packages/ojs-base/ojs-base.0.5.0/descr
@@ -1,0 +1,4 @@
+Components to create web applications using js_of_ocaml and websockets.
+
+Components include directories, file editor, message box.
+

--- a/packages/ojs-base/ojs-base.0.5.0/opam
+++ b/packages/ojs-base/ojs-base.0.5.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/ojs-base/"
+bug-reports: "https://github.com/zoggy/ojs-base/issues"
+license: "GNU Public License version 3"
+doc: "http://zoggy.github.io/ojs-base/refdoc/"
+tags: ["javascript" "web" "components"]
+dev-repo: "https://github.com/zoggy/ojs-base.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ojs"]
+depends: [
+  "ocamlfind"
+  "js_of_ocaml" {>= "2.5"}
+  "websocket" {>= "2.6"}
+  "lwt" {>= "2.5"}
+  "cohttp" {>= "0.19.3"}
+  "yojson" {>= "1.1.8"}
+  "ppx_deriving_yojson" {>= "3.0"}
+  "xtmpl" {>= "0.15.0"}
+  "magic-mime" {>= "1.0"}
+  "base64" {>= "2.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ojs-base/ojs-base.0.5.0/url
+++ b/packages/ojs-base/ojs-base.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://zoggy.github.io/ojs-base/ojs-base-0.5.0.tar.gz"
+checksum: "7e01fb0baa6d7f16551e4a901fc5fff7"


### PR DESCRIPTION
Components to create web applications using js_of_ocaml and websockets.

Components include directories, file editor, message box.



---
* Homepage: http://zoggy.github.io/ojs-base/
* Source repo: https://github.com/zoggy/ojs-base.git
* Bug tracker: https://github.com/zoggy/ojs-base/issues

---

Pull-request generated by opam-publish v0.3.2