### PR TITLE
linenoise.1.0.0 - via opam-publish

### DIFF
--- a/packages/linenoise/linenoise.1.0.0/descr
+++ b/packages/linenoise/linenoise.1.0.0/descr
@@ -1,0 +1,43 @@
+Simple readline like functionality with nice hints feature.
+
+These are self contained OCaml bindings to linenoise,
+no system libraries needed at all.
+
+Here's a simple program:
+
+let rec user_input prompt cb =
+  match LNoise.linenoise prompt with
+  | None -> ()
+  | Some v ->
+    cb v;
+    user_input prompt cb
+
+let () =
+  LNoise.set_hints_callback (fun line ->
+      if line <> "git remote add " then None
+      else Some (" <this is the remote name> <this is the remote URL>",
+                 LNoise.Yellow,
+                 true)
+    );
+  LNoise.history_load ~filename:"history.txt" |> ignore;
+  LNoise.history_set ~max_length:100 |> ignore;
+  LNoise.set_completion_callback begin fun line_so_far ln_completions ->
+    if line_so_far <> "" && line_so_far.[0] = 'h' then
+      ["Hey"; "Howard"; "Hughes";"Hocus"]
+      |> List.iter (LNoise.add_completion ln_completions);
+  end;
+  ["These are OCaml bindings to linenoise";
+   "get tab completion with <TAB>, type h then hit <TAB>";
+   "type quit to exit gracefully";
+   "By Edgar Aroutiounian\n"]
+  |> List.iter print_endline;
+  (fun from_user ->
+     if from_user = "quit" then exit 0;
+     LNoise.history_add from_user |> ignore;
+     LNoise.history_save ~filename:"history.txt" |> ignore;
+     Printf.sprintf "Got: %s" from_user |> print_endline
+  )
+  |> user_input "test_program> "
+
+and compile with:
+$ ocamlfind ocamlopt ex.ml -package linenoise -linkpkg -o T

--- a/packages/linenoise/linenoise.1.0.0/opam
+++ b/packages/linenoise/linenoise.1.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-linenoise"
+bug-reports: "https://github.com/fxfactorial/ocaml-linenoise/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-linenoise.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "linenoise"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/linenoise/linenoise.1.0.0/url
+++ b/packages/linenoise/linenoise.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-linenoise/archive/v1.0.0.tar.gz"
+checksum: "ea88336d4231b02c1ae4ed142c66be2c"


### PR DESCRIPTION
Simple readline like functionality with nice hints feature.

These are self contained OCaml bindings to linenoise,
no system libraries needed at all.

Here's a simple program:
```ocaml
let rec user_input prompt cb =
  match LNoise.linenoise prompt with
  | None -> ()
  | Some v ->
    cb v;
    user_input prompt cb

let () =
  LNoise.set_hints_callback (fun line ->
      if line <> "git remote add " then None
      else Some (" <this is the remote name> <this is the remote URL>",
                 LNoise.Yellow,
                 true)
    );
  LNoise.history_load ~filename:"history.txt" |> ignore;
  LNoise.history_set ~max_length:100 |> ignore;
  LNoise.set_completion_callback begin fun line_so_far ln_completions ->
    if line_so_far <> "" && line_so_far.[0] = 'h' then
      ["Hey"; "Howard"; "Hughes";"Hocus"]
      |> List.iter (LNoise.add_completion ln_completions);
  end;
  ["These are OCaml bindings to linenoise";
   "get tab completion with <TAB>, type h then hit <TAB>";
   "type quit to exit gracefully";
   "By Edgar Aroutiounian\n"]
  |> List.iter print_endline;
  (fun from_user ->
     if from_user = "quit" then exit 0;
     LNoise.history_add from_user |> ignore;
     LNoise.history_save ~filename:"history.txt" |> ignore;
     Printf.sprintf "Got: %s" from_user |> print_endline
  )
  |> user_input "test_program> "
```

and compile with:
$ ocamlfind ocamlopt ex.ml -package linenoise -linkpkg -o T

Check out this gif: 

https://github.com/fxfactorial/ocaml-linenoise/blob/master/example.gif

---
* Homepage: https://github.com/fxfactorial/ocaml-linenoise
* Source repo: https://github.com/fxfactorial/ocaml-linenoise.git
* Bug tracker: https://github.com/fxfactorial/ocaml-linenoise/issues

---

Pull-request generated by opam-publish v0.3.2