### PR TITLE
ocb-stubblr.0.0.1 - via opam-publish

### DIFF
--- a/packages/ocb-stubblr/ocb-stubblr.0.0.1/descr
+++ b/packages/ocb-stubblr/ocb-stubblr.0.0.1/descr
@@ -1,0 +1,18 @@
+OCamlbuild plugin for C stubs
+
+Do you get excited by C stubs? Do they sometimes make you swoon, and even faint,
+and in the end no `cmxa`s get properly linked -- not to mention correct
+multi-lib support?
+
+Do you wish that the things that excite you the most, would excite you just a
+little less? Then ocb-stubblr is just the library for you.
+
+ocb-stubblr is about ten lines of code that you need to repeat over, over, over
+and over again if you are using `ocamlbuild` to build OCaml projects that
+contain C stubs -- now with 100% more lib!
+
+It does what everyone wants to do with `.clib` files in their project
+directories. It can also clone the `.clib` and arrange for multiple compilations
+with different sets of discovered `cflags`.
+
+ocb-stubblr is distributed under the ISC license.

--- a/packages/ocb-stubblr/ocb-stubblr.0.0.1/opam
+++ b/packages/ocb-stubblr/ocb-stubblr.0.0.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/ocb-stubblr"
+doc: "https://pqwy.github.io/ocb-stubblr/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/ocb-stubblr.git"
+bug-reports: "https://github.com/pqwy/ocb-stubblr/issues"
+tags: []
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {>="0.9.3"}
+  "topkg"
+  "astring" ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]

--- a/packages/ocb-stubblr/ocb-stubblr.0.0.1/url
+++ b/packages/ocb-stubblr/ocb-stubblr.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/ocb-stubblr/releases/download/v0.0.1/ocb-stubblr-0.0.1.tbz"
+checksum: "0a7c257f618775fa3215ecd0c900f164"


### PR DESCRIPTION
OCamlbuild plugin for C stubs

Do you get excited by C stubs? Do they sometimes make you swoon, and even faint,
and in the end no `cmxa`s get properly linked -- not to mention correct
multi-lib support?

Do you wish that the things that excite you the most, would excite you just a
little less? Then ocb-stubblr is just the library for you.

ocb-stubblr is about ten lines of code that you need to repeat over, over, over
and over again if you are using `ocamlbuild` to build OCaml projects that
contain C stubs -- now with 100% more lib!

It does what everyone wants to do with `.clib` files in their project
directories. It can also clone the `.clib` and arrange for multiple compilations
with different sets of discovered `cflags`.

ocb-stubblr is distributed under the ISC license.

---
* Homepage: https://github.com/pqwy/ocb-stubblr
* Source repo: https://github.com/pqwy/ocb-stubblr.git
* Bug tracker: https://github.com/pqwy/ocb-stubblr/issues

---


---
v0.0.1 2016-10-26
--------------------------

First release. 
Pull-request generated by opam-publish v0.3.2