### PR TITLE
mirage-os-shim.0.0.1 - via opam-publish

### DIFF
--- a/packages/mirage-os-shim/mirage-os-shim.0.0.1/descr
+++ b/packages/mirage-os-shim/mirage-os-shim.0.0.1/descr
@@ -1,0 +1,20 @@
+Portable shim for MirageOS APIs
+
+mirage-os-shim is the intersection of the Mirage OS APIs exported under the `OS`
+modules by various Mirage backends. It shims out this interface under the same
+`cmi`, and installs several implementations, that pass through to their
+respective backends.
+
+Clients need to be compiled against the common `mirage_OS.cmi`, and use the
+module `Mirage_OS`. Final applications need to be linked using `ocamlfind`, and
+have to define one of the `ocamlfind` predicates corresponding to the actual
+`OS` implementations: `unix`, `xen`, or `solo5`.
+
+When using `ocamlbuild`, this is
+`ocamlfind -use-ocamlfind -tag 'predicate(unix)'` or similar.
+
+**WARNING** Direct access to the `OS` interface is largely deprecated. The
+interface is pretty volatile. It is highly likely that you, in fact, do not need
+this package at all.
+
+mirage-os-shim is distributed under the ISC license.

--- a/packages/mirage-os-shim/mirage-os-shim.0.0.1/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.0.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/mirage-os-shim"
+doc: "https://pqwy.github.io/mirage-os-shim/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/mirage-os-shim.git"
+bug-reports: "https://github.com/pqwy/mirage-os-shim/issues"
+tags: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-mirage-unix" "%{mirage-unix:installed}%"
+          "--with-mirage-xen" "%{mirage-xen:installed}%"
+          "--with-mirage-solo5" "%{mirage-solo5:installed}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-unix"
+]
+depopts: [
+  "mirage-solo5"
+  "mirage-xen"
+]
+available: [ ocaml-version >= "4.02.0"]
+conflicts: ["mirage-types" {>= "3.0.0"}]

--- a/packages/mirage-os-shim/mirage-os-shim.0.0.1/url
+++ b/packages/mirage-os-shim/mirage-os-shim.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/mirage-os-shim/releases/download/v0.0.1/mirage-os-shim-0.0.1.tbz"
+checksum: "e9fe8b2703a664aa854c82b0a47dd82d"


### PR DESCRIPTION
Portable shim for MirageOS APIs

mirage-os-shim is the intersection of the Mirage OS APIs exported under the `OS`
modules by various Mirage backends. It shims out this interface under the same
`cmi`, and installs several implementations, that pass through to their
respective backends.

Clients need to be compiled against the common `mirage_OS.cmi`, and use the
module `Mirage_OS`. Final applications need to be linked using `ocamlfind`, and
have to define one of the `ocamlfind` predicates corresponding to the actual
`OS` implementations: `unix`, `xen`, or `solo5`.

When using `ocamlbuild`, this is
`ocamlfind -use-ocamlfind -tag 'predicate(unix)'` or similar.

**WARNING** Direct access to the `OS` interface is largely deprecated. The
interface is pretty volatile. It is highly likely that you, in fact, do not need
this package at all.

mirage-os-shim is distributed under the ISC license.

---
* Homepage: https://github.com/pqwy/mirage-os-shim
* Source repo: https://github.com/pqwy/mirage-os-shim.git
* Bug tracker: https://github.com/pqwy/mirage-os-shim/issues

---


---
## v0.0.1 2016-10-26

First release.

Synced to `mirage-types-2.80`.
Pull-request generated by opam-publish v0.3.2