### PR TITLE
JavaScriptCore.0.0.1 - via opam-publish

### DIFF
--- a/packages/JavaScriptCore/JavaScriptCore.0.0.1/descr
+++ b/packages/JavaScriptCore/JavaScriptCore.0.0.1/descr
@@ -1,0 +1,3 @@
+OCaml bindings to JavaScriptCore
+
+Create, Control, Execute JavaScript values directly in OCaml. 

--- a/packages/JavaScriptCore/JavaScriptCore.0.0.1/opam
+++ b/packages/JavaScriptCore/JavaScriptCore.0.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-javascriptcore"
+bug-reports: "https://github.com/fxfactorial/ocaml-javascriptcore/issues"
+license: "BSD-3-clause"
+tags: ["clib:javascriptcoregtk" "clib:c"]
+dev-repo: "https://github.com/fxfactorial/ocaml-javascriptcore.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "javascriptcore"]
+depends: [
+  "cohttp" {build}
+  "lwt" {build & >= "2.5.2"}
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "alcotest" {build}
+  "ocamlfind" {build}
+]
+depexts: [
+  [["debian"] ["libc++-dev" "libjavascriptcoregtk-3.0-dev"]]
+  [["ubuntu"] ["libc++-dev" "libjavascriptcoregtk-3.0-dev"]]
+]
+available: [ocaml-version >= "4.03.0"]
+messages: [
+  "Installation might fail on Linux, follow depext instructions and try again."
+    {os = "linux"}
+]

--- a/packages/JavaScriptCore/JavaScriptCore.0.0.1/url
+++ b/packages/JavaScriptCore/JavaScriptCore.0.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/fxfactorial/ocaml-javascriptcore/archive/v0.0.1.tar.gz"
+checksum: "2bfd6aeb95e0bd5894a5f2d421e8c8d6"


### PR DESCRIPTION
OCaml bindings to JavaScriptCore

Create, Control, Execute JavaScript values directly in OCaml. 


---
* Homepage: https://github.com/fxfactorial/ocaml-javascriptcore
* Source repo: https://github.com/fxfactorial/ocaml-javascriptcore.git
* Bug tracker: https://github.com/fxfactorial/ocaml-javascriptcore/issues

---

Pull-request generated by opam-publish v0.3.2