### PR TITLE
javascriptcore.0.0.1 - via opam-publish

### DIFF
--- a/packages/javascriptcore/javascriptcore.0.0.1/descr
+++ b/packages/javascriptcore/javascriptcore.0.0.1/descr
@@ -1,0 +1,3 @@
+OCaml bindings to JavaScriptCore
+
+Create, Control, Execute JavaScript values directly in OCaml. 

--- a/packages/javascriptcore/javascriptcore.0.0.1/opam
+++ b/packages/javascriptcore/javascriptcore.0.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-javascriptcore"
+bug-reports: "https://github.com/fxfactorial/ocaml-javascriptcore/issues"
+license: "BSD-3-clause"
+tags: ["clib:javascriptcoregtk" "clib:c"]
+dev-repo: "https://github.com/fxfactorial/ocaml-javascriptcore.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "javascriptcore"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+depexts: [
+  [["debian"] ["libc++-dev" "libjavascriptcoregtk-3.0-dev"]]
+  [["ubuntu"] ["libc++-dev" "libjavascriptcoregtk-3.0-dev"]]
+]
+available: [ocaml-version >= "4.03.0"]
+messages: [
+  "Installation might fail on Linux, follow depext instructions and try again."
+    {os = "linux"}
+]

--- a/packages/javascriptcore/javascriptcore.0.0.1/url
+++ b/packages/javascriptcore/javascriptcore.0.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/fxfactorial/ocaml-javascriptcore/archive/v0.0.1.tar.gz"
+checksum: "4dbccd3f09ceb97e970aa9b0a6a13a39"


### PR DESCRIPTION
OCaml bindings to JavaScriptCore

Create, Control, Execute JavaScript values directly in OCaml. 


---
* Homepage: https://github.com/fxfactorial/ocaml-javascriptcore
* Source repo: https://github.com/fxfactorial/ocaml-javascriptcore.git
* Bug tracker: https://github.com/fxfactorial/ocaml-javascriptcore/issues

---

Pull-request generated by opam-publish v0.3.2


@samoht  I'm super confused how some state is persisting between me creating packages. I think the opam publish tool is keeping some state in between and its super annoying for me during this PR process. Its adding things like alcotest even though I don't have it anymore in my _oasis or in my opam file. 