### PR TITLE
ocb-stubblr.0.0.2 - via opam-publish

### DIFF
--- a/packages/ocb-stubblr/ocb-stubblr.0.0.2/descr
+++ b/packages/ocb-stubblr/ocb-stubblr.0.0.2/descr
@@ -1,0 +1,18 @@
+OCamlbuild plugin for C stubs
+
+Do you get excited by C stubs? Do they sometimes make you swoon, and even faint,
+and in the end no `cmxa`s get properly linked -- not to mention correct
+multi-lib support?
+
+Do you wish that the things that excite you the most, would excite you just a
+little less? Then ocb-stubblr is just the library for you.
+
+ocb-stubblr is about ten lines of code that you need to repeat over, over, over
+and over again if you are using `ocamlbuild` to build OCaml projects that
+contain C stubs -- now with 100% more lib!
+
+It does what everyone wants to do with `.clib` files in their project
+directories. It can also clone the `.clib` and arrange for multiple compilations
+with different sets of discovered `cflags`.
+
+ocb-stubblr is distributed under the ISC license.

--- a/packages/ocb-stubblr/ocb-stubblr.0.0.2/opam
+++ b/packages/ocb-stubblr/ocb-stubblr.0.0.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/ocb-stubblr"
+doc: "https://pqwy.github.io/ocb-stubblr/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/ocb-stubblr.git"
+bug-reports: "https://github.com/pqwy/ocb-stubblr/issues"
+tags: []
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild"
+  "topkg"
+  "astring" ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]

--- a/packages/ocb-stubblr/ocb-stubblr.0.0.2/url
+++ b/packages/ocb-stubblr/ocb-stubblr.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/ocb-stubblr/releases/download/v0.0.2/ocb-stubblr-0.0.2.tbz"
+checksum: "57b37a1ff318d0baa08259e5505590f3"


### PR DESCRIPTION
OCamlbuild plugin for C stubs

Do you get excited by C stubs? Do they sometimes make you swoon, and even faint,
and in the end no `cmxa`s get properly linked -- not to mention correct
multi-lib support?

Do you wish that the things that excite you the most, would excite you just a
little less? Then ocb-stubblr is just the library for you.

ocb-stubblr is about ten lines of code that you need to repeat over, over, over
and over again if you are using `ocamlbuild` to build OCaml projects that
contain C stubs -- now with 100% more lib!

It does what everyone wants to do with `.clib` files in their project
directories. It can also clone the `.clib` and arrange for multiple compilations
with different sets of discovered `cflags`.

ocb-stubblr is distributed under the ISC license.

---
* Homepage: https://github.com/pqwy/ocb-stubblr
* Source repo: https://github.com/pqwy/ocb-stubblr.git
* Bug tracker: https://github.com/pqwy/ocb-stubblr/issues

---


---
## v0.0.2 2016-10-27

Fix the wrong dependencies in META.
Pull-request generated by opam-publish v0.3.2