### PR TITLE
syslog-message.0.0.2 - via opam-publish

### DIFF
--- a/packages/syslog-message/syslog-message.0.0.2/descr
+++ b/packages/syslog-message/syslog-message.0.0.2/descr
@@ -1,0 +1,4 @@
+Syslog message parser
+
+
+This is a library for parsing and generating RFC 3164 compatible Syslog messages.

--- a/packages/syslog-message/syslog-message.0.0.2/opam
+++ b/packages/syslog-message/syslog-message.0.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Jochen Bartl <jochenbartl@mailbox.org>"
+authors: [ "Jochen Bartl <jochenbartl@mailbox.org>" ]
+license: "BSD2"
+homepage: "https://github.com/verbosemode/syslog-message"
+dev-repo: "https://github.com/verbosemode/syslog-message.git"
+bug-reports: "https://github.com/verbosemode/syslog-message/issues"
+doc: "https://verbosemode.github.io/syslog-message/doc"
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "astring"
+  "ptime"
+  "qcheck" {test}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/syslog-message/syslog-message.0.0.2/url
+++ b/packages/syslog-message/syslog-message.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/verbosemode/syslog-message/releases/download/0.0.2/syslog-message-0.0.2.tbz"
+checksum: "0894adad6e936975d5aaf7ed32ec2908"


### PR DESCRIPTION
Syslog message parser

This is a library for parsing and generating RFC 3164 compatible Syslog messages.
---
- Homepage: https://github.com/verbosemode/syslog-message
- Source repo: https://github.com/verbosemode/syslog-message.git
- Bug tracker: https://github.com/verbosemode/syslog-message/issues
---
---
## 0.0.2 (2016-10-29)
- simplify API: no set_hostname, hostname anymore #11
- introduce Rfc3164_timestamp module #11
- parse is now decode, to_string encode #11
- pp_string is now to_string #11
- provide pp : Format.formatter -> t -> unit
- remove int_to_severity/severity_to_int/int_to_facility/facility_to_int #11
- use topkg instead of oasis
- cleanups #8 #9
  Pull-request generated by opam-publish v0.3.2
