### PR TITLE
Add tyxml and tyxml-ppx version 4.0.1

### DIFF
--- a/packages/tyxml-ppx/tyxml-ppx.4.0.1/descr
+++ b/packages/tyxml-ppx/tyxml-ppx.4.0.1/descr
@@ -1,0 +1,1 @@
+Virtual package for tyxml's ppx

--- a/packages/tyxml-ppx/tyxml-ppx.4.0.1/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "dev@ocsigen.org"
+author: "The ocsigen team"
+homepage: "https://ocsigen.org/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+build: ["ocamlfind" "query" "tyxml.ppx"]
+depends: [
+  "tyxml" {>= "4.0.1"}
+  "markup" {>= "0.7.2"}
+  "ppx_tools"
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/tyxml/tyxml.4.0.1/descr
+++ b/packages/tyxml/tyxml.4.0.1/descr
@@ -1,0 +1,6 @@
+TyXML is a library for building statically correct HTML5 and SVG documents
+
+TyXML allows you to build HTML5 and SVG trees whose validity is ensured by the typechecker.
+It provides a printer for said XML trees, along with a ppx syntax extension.
+Finally it also provides a functorial interface to choose your XML datastructure.
+It's part of the ocsigen project and is used in js_of_ocaml and eliom.

--- a/packages/tyxml/tyxml.4.0.1/files/tyxml.install
+++ b/packages/tyxml/tyxml.4.0.1/files/tyxml.install
@@ -1,0 +1,6 @@
+lib: "tyxml.opam" { "opam" }
+doc: [
+  "README.md"
+  "CHANGES"
+  "COPYING" { "LICENSE" }
+]

--- a/packages/tyxml/tyxml.4.0.1/opam
+++ b/packages/tyxml/tyxml.4.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+
+maintainer: "dev@ocsigen.org"
+author: "The ocsigen team"
+homepage: "https://ocsigen.org/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--%{markup+ppx_tools:enable}%-ppx"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--%{markup+ppx_tools:enable}%-ppx"
+      "--enable-tests"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tyxml"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "uutf" {<= "0.9.4"}
+  "base-bytes"
+  "re" {>= "1.5.0"}
+  "alcotest" {test}
+]
+depopts: [
+  "camlp4"
+  "markup"
+  "ppx_tools"
+]
+conflicts: [
+  "ppx_tools" { < "5.0" }
+]
+available: [ocaml-version >= "4.02"]
+messages: [
+  "For tyxml's ppx, please install tyxml-ppx."
+  {!markup:installed | !ppx_tools:installed}
+]

--- a/packages/tyxml/tyxml.4.0.1/url
+++ b/packages/tyxml/tyxml.4.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/tyxml/archive/4.0.1.tar.gz"
+checksum: "7e80bfe81bd9fb1063ee12e35198211a"


### PR DESCRIPTION
# Version 4.0.1
- Fix handling of comments in the ppx.
- Fix printing of utf8 in attributes.
- Properly flush ppx errors. This bug was causing some blank error messages.
- Fix handling of whitespaces in `<select>` in the ppx.
---

The file `tyxml.install` is here to test out the odig support (before having something baked in oasis).
