### PR TITLE
pbkdf.0.2.0 - via opam-publish

### DIFF
--- a/packages/pbkdf/pbkdf.0.2.0/descr
+++ b/packages/pbkdf/pbkdf.0.2.0/descr
@@ -1,0 +1,3 @@
+Password based key derivation functions from PKCS#5, RFC 2898
+
+An implementation of PBKDF 1 and 2 as defined by PKCS#5 (RFC 2898) in OCaml, using nocrypto.

--- a/packages/pbkdf/pbkdf.0.2.0/opam
+++ b/packages/pbkdf/pbkdf.0.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+authors: [
+  "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+  "Sonia Meruelo <smeruelo@gmail.com>"
+]
+homepage: "https://github.com/abeaumont/ocaml-pbkdf"
+bug-reports: "https://github.com/abeaumont/ocaml-pbkdf/issues"
+license: "BSD2"
+dev-repo: "https://github.com/abeaumont/ocaml-pbkdf.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.0"}
+  "alcotest" {test}
+]

--- a/packages/pbkdf/pbkdf.0.2.0/url
+++ b/packages/pbkdf/pbkdf.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/abeaumont/ocaml-pbkdf/archive/0.2.0.tar.gz"
+checksum: "ddb093e2c226058e2341e5251d41721c"


### PR DESCRIPTION
Password based key derivation functions from PKCS#5, RFC 2898

An implementation of PBKDF 1 and 2 as defined by PKCS#5 (RFC 2898) in OCaml, using nocrypto.


---
* Homepage: https://github.com/abeaumont/ocaml-pbkdf
* Source repo: https://github.com/abeaumont/ocaml-pbkdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-pbkdf/issues

---

Pull-request generated by opam-publish v0.3.2