### PR TITLE
BAP add a conflict with fileutils 0.5.0

### DIFF
--- a/packages/bap-std/bap-std.1.0.0/opam
+++ b/packages/bap-std/bap-std.1.0.0/opam
@@ -60,4 +60,5 @@ depexts: [
     ]
 ]
 
+conflicts: ["fileutils" {= "0.5.0"}]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
This version is [broken][1] with respect to the copying the links. The
fix was [proposed][2].

This will resolve resolve BinaryAnalysisPlatform/bap#581.

[1]: https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1649&group_id=128&atid=589
[2]: https://github.com/gildor478/ocaml-fileutils/pull/3