### PR TITLE
initial logs-syslog release

### DIFF
--- a/packages/logs-syslog/logs-syslog.0.0.1/descr
+++ b/packages/logs-syslog/logs-syslog.0.0.1/descr
@@ -1,0 +1,15 @@
+Logs output via syslog
+
+This library provides log reporters over syslog with various effectful layers:
+Unix, Lwt, MirageOS.  It integrated the
+[Logs](http://erratique.ch/software/logs) library, which provides logging
+infrastructure for OCaml, with the
+[syslog-message](http://verbosemo.de/syslog-message/) library, which provides
+encoding and decoding of syslog messages ([RFC
+3164](https://tools.ietf.org/html/rfc3164)).
+
+Six ocamlfind libraries are provided: the bare `Logs-syslog`, a minimal
+dependency Unix `Logs-syslog-unix`, a Lwt one `Logs-syslog-lwt`, another one
+with Lwt and TLS ([RFC 5425](https://tools.ietf.org/html/rfc5425)) support
+`Logs-syslog-lwt-tls`, a MirageOS one `Logs-syslog-mirage`, and a MirageOS one
+using TLS `Logs-syslog-mirage-tls`.

--- a/packages/logs-syslog/logs-syslog.0.0.1/opam
+++ b/packages/logs-syslog/logs-syslog.0.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/logs-syslog"
+doc: "https://hannesm.github.io/logs-syslog/doc"
+dev-repo: "https://github.com/hannesm/logs-syslog.git"
+bug-reports: "https://github.com/hannesm/logs-syslog/issues"
+license: "ISC"
+available: [ ocaml-version >= "4.02.0"]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "logs"
+  "ptime"
+  "syslog-message" {>= "0.0.2"}
+  "result"
+]
+
+depopts: [
+  "lwt" "x509" "tls" "mirage-types" "cstruct" "ipaddr" "io-page"
+]
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+    "--with-lwt" "%{lwt+x509+tls:installed}%"
+    "--with-mirage" "%{mirage-types+lwt+cstruct+ipaddr+io-page:installed}%"
+    "--with-tls" "%{x509+tls+cstruct:installed}%" ]
+]
+

--- a/packages/logs-syslog/logs-syslog.0.0.1/url
+++ b/packages/logs-syslog/logs-syslog.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hannesm/logs-syslog/releases/download/0.0.1/logs-syslog-0.0.1.tbz"
+checksum: "1a293d1396ab2c360cfecca5bb29c569"


### PR DESCRIPTION
report log messages (from the `Logs` library) via syslog on Unix/Lwt/MirageOS using UDP/TCP/TLS.

released with topkg release, apart from the opam publish bits...

example usage (for Mirage): https://github.com/hannesm/Canopy/commit/ef882129cc682ce6a6e4eacbf9899328a95e8efe (syslog-ng or BSD syslog on the other side)

documentation including example usage at https://hannesm.github.io/logs-syslog/doc/Logs_syslog.html