### PR TITLE
topkg.0.8.0 - via opam-publish

### DIFF
--- a/packages/topkg/topkg.0.8.0/descr
+++ b/packages/topkg/topkg.0.8.0/descr
@@ -1,0 +1,25 @@
+The transitory OCaml software packager
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml OPAM repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-lib`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser

--- a/packages/topkg/topkg.0.8.0/opam
+++ b/packages/topkg/topkg.0.8.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild" {build}
+  "result" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--pinned" "%{pinned}%" ]

--- a/packages/topkg/topkg.0.8.0/url
+++ b/packages/topkg/topkg.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/topkg/releases/topkg-0.8.0.tbz"
+checksum: "ba516062765211e6c3c26360fe9393b7"


### PR DESCRIPTION
The transitory OCaml software packager

Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution, creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml OPAM repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
[webbrowser][webbrowser] and `opam-lib`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner
[webbrowser]: http://erratique.ch/software/webbrowser


---
* Homepage: http://erratique.ch/software/topkg
* Source repo: http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---


---
v0.8.0 2016-10-20 Zagreb
------------------------

- Add `Conf.debugger_support` a configuration key to inform to the
  build system it should build and install build artefacts for
  debuggers. Packages using `Pkg.{mlib,clib}` descriptions will handle
  this automatically. The key can be set globally in a switch via the
  `TOPKG_CONF_DEBUGGER_SUPPORT` environment variable (#77).
- Add `Pkg.{ocb_tag,ocb_bool_tag,ocb_bool_tags}` to easily extend
  `ocamlbuild` invocations according to the build configuration (#78). Thanks
  to David Kaloper Meršinjak for the idea and the patch.
- Add `Exts.interface` for installing `mli` only compilation units (#74).
- `Pkg.mllib` description. Correct support for mllib which have subpaths (#75).
- Documentation generation. Fix support in the presence of `ocamlbuild`
  plugins (#80). Thanks to David Kaloper Meršinjak for the report
  and the patch.
- Documentation generation. If there is no `doc/style.css` but `odig` is
  installed, use its `ocamldoc` stylesheet. This allows to see how it will
  be rendered by `odig` and avoids maintaining stylesheets in repos.
Pull-request generated by opam-publish v0.3.2