### PR TITLE
dose does not build on ocaml 4.04

### DIFF
--- a/packages/dose/dose.3.1.2/opam
+++ b/packages/dose/dose.3.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "contact@ocamlpro.com"
+maintainer: "roberto@dicosmo.org"
 authors: [
   "Roberto Di Cosmo"
   "Ralf Treinen"

--- a/packages/dose/dose.3.1.2/opam
+++ b/packages/dose/dose.3.1.2/opam
@@ -11,6 +11,9 @@ authors: [
   "Johannes Schauer"
 ]
 homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gforge.inria.fr/projects/dose"
+dev-repo: "https://scm.gforge.inria.fr/anonscm/git/dose/dose.git"
+available: [ ocaml-version < "4.04.0" ]
 license: "LGPL-v3+ with OCaml linking exception"
 substs: ["dose.ocp"]
 build: [

--- a/packages/dose/dose.3.2.2+opam/opam
+++ b/packages/dose/dose.3.2.2+opam/opam
@@ -11,6 +11,9 @@ authors: [
   "Johannes Schauer"
 ]
 homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gforge.inria.fr/projects/dose"
+dev-repo: "https://scm.gforge.inria.fr/anonscm/git/dose/dose.git"
+available: [ ocaml-version < "4.04.0" ]
 license: "LGPL-v3+ with OCaml linking exception"
 build: [
   ["./configure" "--with-ocamlgraph" "--bindir=%{bin}%"]

--- a/packages/dose/dose.3.2.2/opam
+++ b/packages/dose/dose.3.2.2/opam
@@ -11,6 +11,9 @@ authors: [
   "Johannes Schauer"
 ]
 homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gforge.inria.fr/projects/dose"
+dev-repo: "https://scm.gforge.inria.fr/anonscm/git/dose/dose.git"
+available: [ ocaml-version < "4.04.0" ]
 license: "LGPL-v3+ with OCaml linking exception"
 build: [
   ["./configure" "--with-ocamlgraph" "--bindir=%{bin}%"]


### PR DESCRIPTION
```
In module Defaultgraphs.SyntacticDependencyGraph.G:
Type declarations do not match:
type t =
Graph.Imperative.Digraph.ConcreteBidirectionalLabeled(Defaultgraphs.SyntacticDependencyGraph.PkgV)(Defaultgraphs.SyntacticDependencyGraph.PkgE).t
is not included in
type t =
Graph.Imperative.Digraph.ConcreteBidirectionalLabeled(PkgV)(PkgE).t
```

see #7722 for failure