### PR TITLE
omake 0.10.1 release

### DIFF
--- a/packages/omake/omake.0.10.1/descr
+++ b/packages/omake/omake.0.10.1/descr
@@ -1,0 +1,1 @@
+Build system designed for scalability and portability

--- a/packages/omake/omake.0.10.1/files/omake.install
+++ b/packages/omake/omake.0.10.1/files/omake.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/main/omake.opt" {"osh"}
+  "src/main/omake.opt" {"omake"}
+]

--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -18,4 +18,4 @@ build: [
 ]
 
 depends: ["ocamlfind"]
-available: [ ocaml-version >= "4.02.3" & {ocaml-native} ]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -18,4 +18,4 @@ build: [
 ]
 
 depends: ["ocamlfind"]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & {ocaml-native} ]

--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -18,4 +18,4 @@ build: [
 ]
 
 depends: ["ocamlfind"]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & ocaml-native ]

--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "omake"
+maintainer: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+authors: [
+  "Aleksey Nogin"
+  "Jason Hickey"
+  "Gerd Stolpmann"
+]
+
+license: "GPL2"
+dev-repo: "https://github.com/ocaml-omake/omake.git"
+homepage: "http://projects.camlcity.org/projects/omake.html"
+bug-reports: "https://github.com/ocaml-omake/issues"
+
+build: [
+  ["./configure"]
+  [make]
+]
+
+depends: ["ocamlfind"]

--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -18,3 +18,4 @@ build: [
 ]
 
 depends: ["ocamlfind"]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/omake/omake.0.10.1/url
+++ b/packages/omake/omake.0.10.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-omake/omake/archive/omake-0.10.1.tar.gz"
+checksum: "6d66d68bbf39d5f241778ab1e70a78cf"


### PR DESCRIPTION
All the patches applied to the previous version are no longer valid.
Should be reported as issues to the upstream repo if you have any
questions about the patches.