### PR TITLE
cstruct: update opam meta to correctly depend on base-unix

### DIFF
--- a/packages/cstruct/cstruct.1.6.0/opam
+++ b/packages/cstruct/cstruct.1.6.0/opam
@@ -12,7 +12,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{camlp4:enable}%-camlp4"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"
@@ -44,6 +44,7 @@ depopts: [
   "camlp4"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.01.0"]
 depexts: [

--- a/packages/cstruct/cstruct.1.7.0/opam
+++ b/packages/cstruct/cstruct.1.7.0/opam
@@ -12,7 +12,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{camlp4:enable}%-camlp4"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"
@@ -50,6 +50,7 @@ depopts: [
   "camlp4"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.01.0"]
 depexts: [

--- a/packages/cstruct/cstruct.1.7.1/opam
+++ b/packages/cstruct/cstruct.1.7.1/opam
@@ -12,7 +12,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{camlp4:enable}%-camlp4"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"
@@ -50,6 +50,7 @@ depopts: [
   "camlp4"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.01.0"]
 depexts: [

--- a/packages/cstruct/cstruct.1.8.0/opam
+++ b/packages/cstruct/cstruct.1.8.0/opam
@@ -13,7 +13,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{camlp4:enable}%-camlp4"
       "--%{ppx_tools:enable}%-ppx"
       "--%{async:enable}%-async"
@@ -53,6 +53,7 @@ depopts: [
   "ppx_tools"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0"]
 depexts: [

--- a/packages/cstruct/cstruct.1.9.0/opam
+++ b/packages/cstruct/cstruct.1.9.0/opam
@@ -13,7 +13,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{camlp4:enable}%-camlp4"
       "--%{ppx_tools:enable}%-ppx"
       "--%{async:enable}%-async"
@@ -53,6 +53,7 @@ depopts: [
   "ppx_tools"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0"]
 depexts: [

--- a/packages/cstruct/cstruct.2.0.0/opam
+++ b/packages/cstruct/cstruct.2.0.0/opam
@@ -13,7 +13,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{ppx_tools:enable}%-ppx"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"]
@@ -49,6 +49,7 @@ depopts: [
   "ppx_tools"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
 depexts: [

--- a/packages/cstruct/cstruct.2.1.0/opam
+++ b/packages/cstruct/cstruct.2.1.0/opam
@@ -13,7 +13,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{ppx_tools:enable}%-ppx"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"]
@@ -49,6 +49,7 @@ depopts: [
   "ppx_tools"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
 depexts: [

--- a/packages/cstruct/cstruct.2.2.0/opam
+++ b/packages/cstruct/cstruct.2.2.0/opam
@@ -13,7 +13,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{ppx_tools:enable}%-ppx"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"]
@@ -49,6 +49,7 @@ depopts: [
   "ppx_tools"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
 depexts: [

--- a/packages/cstruct/cstruct.2.3.0/opam
+++ b/packages/cstruct/cstruct.2.3.0/opam
@@ -13,7 +13,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{ppx_tools:enable}%-ppx"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"]
@@ -49,6 +49,7 @@ depopts: [
   "ppx_tools"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.02.3"]
 depexts: [


### PR DESCRIPTION
see also mirage/ocaml-cstruct#115