### PR TITLE
jekyll-format.0.1.0 - via opam-publish

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.1.0/descr
+++ b/packages/jekyll-format/jekyll-format.0.1.0/descr
@@ -1,0 +1,8 @@
+Jekyll post parsing library
+
+[Jekyll](https://jekyllrb.com) is a simple, blog-aware static site
+generator that takes a template directory of files and turns them into
+a website. This library exists to parse those blog posts and make them
+easy to manipulate from OCaml code.
+
+jekyll-format is distributed under the ISC license.

--- a/packages/jekyll-format/jekyll-format.0.1.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/jekyll-format"
+doc: "https://avsm.github.io/jekyll-format/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/jekyll-format.git"
+bug-reports: "https://github.com/avsm/jekyll-format/issues"
+tags: ["org:ocamllabs" "org:mirage"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+  "astring"
+  "omd"
+  "fmt"
+  "rresult"
+  "ptime"
+  "fpath"
+  "alcotest" {test & >="0.7.0"}
+  "bos" {test}
+]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+build-test: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]

--- a/packages/jekyll-format/jekyll-format.0.1.0/url
+++ b/packages/jekyll-format/jekyll-format.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/jekyll-format/releases/download/v0.1.0/jekyll-format-0.1.0.tbz"
+checksum: "a16f308684848ba53b7166589b8a802f"


### PR DESCRIPTION
Jekyll post parsing library

[Jekyll](https://jekyllrb.com) is a simple, blog-aware static site
generator that takes a template directory of files and turns them into
a website. This library exists to parse those blog posts and make them
easy to manipulate from OCaml code.

jekyll-format is distributed under the ISC license.


---
* Homepage: https://github.com/avsm/jekyll-format
* Source repo: https://github.com/avsm/jekyll-format.git
* Bug tracker: https://github.com/avsm/jekyll-format/issues

---


---
v0.1.0 2016-11-04 Cambridge
---------------------------

Initial public release.
Pull-request generated by opam-publish v0.3.3