### PR TITLE
hamt.1.0.0 - via opam-publish

### DIFF
--- a/packages/hamt/hamt.1.0.0/descr
+++ b/packages/hamt/hamt.1.0.0/descr
@@ -1,0 +1,5 @@
+Hash Array Mapped Tries
+
+HAMT data structure implemented in OCaml
+
+http://gallium.inria.fr/blog/implementing-hamt-for-ocaml/

--- a/packages/hamt/hamt.1.0.0/opam
+++ b/packages/hamt/hamt.1.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Thibault Suzanne" "Gabriel Scherer" "Rudi Grinberg"]
+homepage: "https://github.com/rgrinberg/ocaml-hamt"
+bug-reports: "https://github.com/rgrinberg/ocaml-hamt/issues"
+license: "MIT"
+dev-repo: "https://github.com/rgrinberg/ocaml-hamt.git"
+build: [
+  [make "configure"]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [
+  [make "configure-test"]
+  [make "build"]
+  [make "test"]
+]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "hamt"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ounit" {test & >= " 1.0.2"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/hamt/hamt.1.0.0/url
+++ b/packages/hamt/hamt.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ocaml-hamt/archive/1.0.0.tar.gz"
+checksum: "47b2625ffcede0652d0e9b4e2ba13722"


### PR DESCRIPTION
Hash Array Mapped Tries

HAMT data structure implemented in OCaml

http://gallium.inria.fr/blog/implementing-hamt-for-ocaml/


---
* Homepage: https://github.com/rgrinberg/ocaml-hamt
* Source repo: https://github.com/rgrinberg/ocaml-hamt.git
* Bug tracker: https://github.com/rgrinberg/ocaml-hamt/issues

---

Pull-request generated by opam-publish v0.3.2