### PR TITLE
update switches for release 4.04.0

### DIFF
--- a/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.comp
+++ b/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/ocaml/ocaml/archive/4.04.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]

--- a/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.descr
+++ b/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.descr
@@ -1,0 +1,1 @@
+Official 4.04.0 release with flambda activated

--- a/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.comp
+++ b/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.comp
@@ -1,10 +1,10 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/ocaml/ocaml/archive/4.04.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.descr
+++ b/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.descr
@@ -1,0 +1,1 @@
+Official 4.04.0 release with frame-pointers and flambda activated

--- a/compilers/4.04.0/4.04.0+fp/4.04.0+fp.comp
+++ b/compilers/4.04.0/4.04.0+fp/4.04.0+fp.comp
@@ -1,10 +1,10 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/ocaml/ocaml/archive/4.04.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+fp/4.04.0+fp.descr
+++ b/compilers/4.04.0/4.04.0+fp/4.04.0+fp.descr
@@ -1,0 +1,1 @@
+Official 4.04.0 release with frame-pointers

--- a/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.comp
+++ b/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/ocaml/ocaml/archive/4.04.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
   [make "world"]

--- a/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.descr
+++ b/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.descr
@@ -1,0 +1,1 @@
+Official 4.04.0 release with -safe-string enabled.

--- a/compilers/4.04.0/4.04.0+trunk+flambda/4.04.0+trunk+flambda.descr
+++ b/compilers/4.04.0/4.04.0+trunk+flambda/4.04.0+trunk+flambda.descr
@@ -1,1 +1,0 @@
-latest 4.04 snapshot with flambda activated

--- a/compilers/4.04.0/4.04.0+trunk+fp+flambda/4.04.0+trunk+fp+flambda.descr
+++ b/compilers/4.04.0/4.04.0+trunk+fp+flambda/4.04.0+trunk+fp+flambda.descr
@@ -1,1 +1,0 @@
-latest 4.04 snapshot with frame-pointers and flambda activated

--- a/compilers/4.04.0/4.04.0+trunk+fp/4.04.0+trunk+fp.descr
+++ b/compilers/4.04.0/4.04.0+trunk+fp/4.04.0+trunk+fp.descr
@@ -1,1 +1,0 @@
-latest 4.04 snapshot with frame-pointers

--- a/compilers/4.04.0/4.04.0+trunk+safe-string/4.04.0+trunk+safe-string.descr
+++ b/compilers/4.04.0/4.04.0+trunk+safe-string/4.04.0+trunk+safe-string.descr
@@ -1,1 +1,0 @@
-OCaml 4.04.0 with -safe-string enabled.

--- a/compilers/4.04.0/4.04.0+trunk/4.04.0+trunk.descr
+++ b/compilers/4.04.0/4.04.0+trunk/4.04.0+trunk.descr
@@ -1,1 +1,0 @@
-latest 4.04 snapshot 

--- a/compilers/4.04.0/4.04.0/4.04.0.comp
+++ b/compilers/4.04.0/4.04.0/4.04.0.comp
@@ -1,10 +1,10 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/ocaml/ocaml/archive/4.04.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0/4.04.0.descr
+++ b/compilers/4.04.0/4.04.0/4.04.0.descr
@@ -1,0 +1,1 @@
+Official 4.04.0 release


### PR DESCRIPTION
Note: I haven't touched `4.04.0+trunk+forced_lto` because it doesn't use the same tarball as the others.
