### PR TITLE
cpuid.0.1.0 - via opam-publish

### DIFF
--- a/packages/cpuid/cpuid.0.1.0/descr
+++ b/packages/cpuid/cpuid.0.1.0/descr
@@ -1,0 +1,6 @@
+Detect CPU features
+
+
+cpuid allows detection of CPU features from OCaml.
+
+cpuid is distributed under the ISC license.

--- a/packages/cpuid/cpuid.0.1.0/opam
+++ b/packages/cpuid/cpuid.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/cpuid"
+doc: "https://pqwy.github.io/cpuid/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/cpuid.git"
+bug-reports: "https://github.com/pqwy/cpuid/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build & >= "0.1.0"}
+  "result" ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]

--- a/packages/cpuid/cpuid.0.1.0/url
+++ b/packages/cpuid/cpuid.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/cpuid/releases/download/v0.1.0/cpuid-0.1.0.tbz"
+checksum: "3455fc5b92033168608ca11d58424e9f"


### PR DESCRIPTION
Detect CPU features


cpuid allows detection of CPU features from OCaml.

cpuid is distributed under the ISC license.

---
* Homepage: https://github.com/pqwy/cpuid
* Source repo: https://github.com/pqwy/cpuid.git
* Bug tracker: https://github.com/pqwy/cpuid/issues

---


---
## v0.1.0 2016-12-04

* `model` (with family, model, and stepping)
* `cores`
Pull-request generated by opam-publish v0.3.2