### PR TITLE
sendmsg.0.0.1 - via opam-publish

### DIFF
--- a/packages/sendmsg/sendmsg.0.0.1/descr
+++ b/packages/sendmsg/sendmsg.0.0.1/descr
@@ -1,0 +1,9 @@
+In _my_ kernel?
+
+Higher-order sockets, oh my!
+
+
+sendmsg is a straightforward OCaml binding to POSIX `sendmsg(3)` and `recvmsg(3)`
+API. Provides scatter-gather IO and passing file descriptors as ancillary data.
+
+sendmsg is distributed under the ISC license.

--- a/packages/sendmsg/sendmsg.0.0.1/opam
+++ b/packages/sendmsg/sendmsg.0.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/sendmsg"
+doc: "https://pqwy.github.io/sendmsg/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/sendmsg.git"
+bug-reports: "https://github.com/pqwy/sendmsg/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build & >= "0.1.0"}
+  "alcotest" {test} ]
+depopts: [ "lwt" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+          "--with-lwt" "%{lwt:installed}%"
+]

--- a/packages/sendmsg/sendmsg.0.0.1/url
+++ b/packages/sendmsg/sendmsg.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/sendmsg/releases/download/v0.0.1/sendmsg-0.0.1.tbz"
+checksum: "a8f4d0f7a3acdc2692c4f0ec157e4247"


### PR DESCRIPTION
In _my_ kernel?

Higher-order sockets, oh my!


sendmsg is a straightforward OCaml binding to POSIX `sendmsg(3)` and `recvmsg(3)`
API. Provides scatter-gather IO and passing file descriptors as ancillary data.

sendmsg is distributed under the ISC license.

---
* Homepage: https://github.com/pqwy/sendmsg
* Source repo: https://github.com/pqwy/sendmsg.git
* Bug tracker: https://github.com/pqwy/sendmsg/issues

---


---
## v0.0.1 2016-11-04

First release. 
Pull-request generated by opam-publish v0.3.2