### PR TITLE
sendmsg.0.0.2 - via opam-publish

### DIFF
--- a/packages/sendmsg/sendmsg.0.0.2/descr
+++ b/packages/sendmsg/sendmsg.0.0.2/descr
@@ -1,0 +1,9 @@
+π-calculus? In _my_ kernel?
+
+Higher-order sockets, oh my!
+
+
+sendmsg is a straightforward OCaml binding to POSIX `sendmsg(3)` and `recvmsg(3)`
+API. Provides scatter-gather IO and passing file descriptors as ancillary data.
+
+sendmsg is distributed under the ISC license.

--- a/packages/sendmsg/sendmsg.0.0.2/opam
+++ b/packages/sendmsg/sendmsg.0.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/sendmsg"
+doc: "https://pqwy.github.io/sendmsg/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/sendmsg.git"
+bug-reports: "https://github.com/pqwy/sendmsg/issues"
+tags: []
+available: [ ocaml-version >= "4.02.0"]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+          "--with-lwt" "%{lwt:installed}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "alcotest" {test} ]
+depopts: [ "lwt" ]
+conflicts: [ "ocb-stubblr" {<"0.1.0"} ]
+

--- a/packages/sendmsg/sendmsg.0.0.2/url
+++ b/packages/sendmsg/sendmsg.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/sendmsg/releases/download/v0.0.2/sendmsg-0.0.2.tbz"
+checksum: "3efcf4186dc080e0fdb030d0fb7d4ab4"


### PR DESCRIPTION
π-calculus? In _my_ kernel?

Higher-order sockets, oh my!


sendmsg is a straightforward OCaml binding to POSIX `sendmsg(3)` and `recvmsg(3)`
API. Provides scatter-gather IO and passing file descriptors as ancillary data.

sendmsg is distributed under the ISC license.

---
* Homepage: https://github.com/pqwy/sendmsg
* Source repo: https://github.com/pqwy/sendmsg.git
* Bug tracker: https://github.com/pqwy/sendmsg/issues

---


---
## v0.0.2 2016-11-05

* Fast-forward the C compiler by a couple of decades.
Pull-request generated by opam-publish v0.3.2