### PR TITLE
Add a 4.04+fPIC switch

### DIFF
--- a/compilers/4.04.0/4.04.0+fPIC/4.04.0+fPIC.comp
+++ b/compilers/4.04.0/4.04.0+fPIC/4.04.0+fPIC.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "4.04.0"
+src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
+build: [
+  ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
+  ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.04.0/4.04.0+fPIC/4.04.0+fPIC.descr
+++ b/compilers/4.04.0/4.04.0+fPIC/4.04.0+fPIC.descr
@@ -1,0 +1,1 @@
+OCaml 4.04.0 compiled with -fPIC runtime libs


### PR DESCRIPTION
This makes it possible to create DLLs which contain the OCaml runtime. Naming scheme and implementation copied from `4.03.0+fPIC`.