### PR TITLE
enumerators.0.2.0 - via opam-publish

### DIFF
--- a/packages/enumerators/enumerators.0.2.0/descr
+++ b/packages/enumerators/enumerators.0.2.0/descr
@@ -1,0 +1,5 @@
+Finite lazy enumerators
+
+This library enables you to work with large sequences of elements.  It provides
+constructors and combinators to build finite sequences that can be iterated through with a
+low memory footprint.

--- a/packages/enumerators/enumerators.0.2.0/opam
+++ b/packages/enumerators/enumerators.0.2.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Bertrand Bonnefoy-Claudet <bertrand@cryptosense.com>"
+authors: "Bertrand Bonnefoy-Claudet <bertrand@cryptosense.com>"
+homepage: "https://github.com/cryptosense/enumerators"
+bug-reports: "https://github.com/cryptosense/enumerators/issues"
+license: "BSD-2"
+tags: "org:cryptosense"
+dev-repo: "https://github.com/cryptosense/enumerators.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/enumerators/enumerators.0.2.0/url
+++ b/packages/enumerators/enumerators.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/cryptosense/enumerators/archive/v0.2.0.tar.gz"
+checksum: "93a00bdf11508962915b50be9c7d914a"


### PR DESCRIPTION
Finite lazy enumerators

This library enables you to work with large sequences of elements.  It provides
constructors and combinators to build finite sequences that can be iterated through with a
low memory footprint.


---
* Homepage: https://github.com/cryptosense/enumerators
* Source repo: https://github.com/cryptosense/enumerators.git
* Bug tracker: https://github.com/cryptosense/enumerators/issues

---

Pull-request generated by opam-publish v0.3.2