### PR TITLE
parse-argv.0.0.3 - via opam-publish

### DIFF
--- a/packages/parse-argv/parse-argv.0.0.3/descr
+++ b/packages/parse-argv/parse-argv.0.0.3/descr
@@ -1,0 +1,3 @@
+process strings into sets of command-line arguments
+
+parse-argv is a small implementation of a simple argv parser.

--- a/packages/parse-argv/parse-argv.0.0.3/opam
+++ b/packages/parse-argv/parse-argv.0.0.3/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Mindy Preston <mindy.preston@docker.com>"
+authors: ["Jon Ludlam" "Magnus Skjegstad" "Mindy Preston"]
+homepage: "https://github.com/mirage/parse-argv"
+bug-reports: "https://github.com/mirage/parse-argv/issues"
+doc: "https://docs.mirage.io/parse-argv"
+tags: "org:mirage"
+dev-repo: "https://github.com/mirage/parse-argv.git"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+  "astring"
+  "result"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/parse-argv/parse-argv.0.0.3/url
+++ b/packages/parse-argv/parse-argv.0.0.3/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/mirage/parse-argv/releases/download/v0.0.3/parse-argv-0.0.3.tbz"
+checksum: "b607219f9fcc97a3bac006dc69860937"


### PR DESCRIPTION
process strings into sets of command-line arguments

parse-argv is a small implementation of a simple argv parser.


---
* Homepage: https://github.com/mirage/parse-argv
* Source repo: https://github.com/mirage/parse-argv.git
* Bug tracker: https://github.com/mirage/parse-argv/issues

---

Pull-request generated by opam-publish v0.3.3