### PR TITLE
4.04.0 switch: include a backport of PR#7403

### DIFF
--- a/compilers/4.04.0/4.04.0/4.04.0.comp
+++ b/compilers/4.04.0/4.04.0/4.04.0.comp
@@ -1,6 +1,13 @@
 opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
+patches:[
+  "https://github.com/ocaml/ocaml/commit/cbd5adced71a8f90375561765d90000558f3e734.diff"
+  # minor Change modification without which the patch below does not apply
+
+  "https://github.com/ocaml/ocaml/commit/06c627f43384b108c53805302f6b671ff57f77ba.patch"
+  # PR#7403, GPR#894: fix a bug in the new Set.map function
+]
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]

--- a/compilers/4.04.0/4.04.0/4.04.0.comp
+++ b/compilers/4.04.0/4.04.0/4.04.0.comp
@@ -2,7 +2,10 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 patches:[
-  "https://github.com/ocaml/ocaml/commit/cbd5adced71a8f90375561765d90000558f3e734.diff"
+  "https://github.com/ocaml/ocaml/commit/5fa968cfcffd48134bbeb6e2c11d12d0b7a885b2.patch"
+  # increment version number to 4.04.1+dev0-2016-11-04
+
+  "https://github.com/ocaml/ocaml/commit/cbd5adced71a8f90375561765d90000558f3e734.patch"
   # minor Change modification without which the patch below does not apply
 
   "https://github.com/ocaml/ocaml/commit/06c627f43384b108c53805302f6b671ff57f77ba.patch"


### PR DESCRIPTION
> <https://caml.inria.fr/mantis/view.php?id=7403>
>
> The new function Set.map had a pesky bug which may create ill-ordered
> map structures. This change backports the bugfix present in the
> upstream 4.04 branch.

I understand that backporting non-build-breaking fixes in a released OPAM compiler is controversial -- @avsm seemed to not like the idea very much.

However, I think that it is a bit too soon to make a 4.04.1 bugfix version right now, both in terms of managing the release manager's workload and because there are still lot of early-adopters that have yet to give 4.04.0 a try -- a potential new issue (should `Compplugin` be in compiler-libs.common?) emerged on caml-list just this afternoon.

I see no strong downside to backporting a bugfix from the 4.04 branch to the 4.04.0 opam switch. It will let early-adopters do their testing in strictly better conditions as long as 4.04.1 is not released.

(cc @yallop who pushed the 4.04.0 compiler description.)