### PR TITLE
Imagemagick: add homebrew depext

### DIFF
--- a/packages/imagemagick/imagemagick.0.34-1/opam
+++ b/packages/imagemagick/imagemagick.0.34-1/opam
@@ -10,4 +10,5 @@ depends: ["ocamlfind"]
 depexts: [
   [["debian"] ["libgraphicsmagick1-dev" "libmagickcore-dev"]]
   [["ubuntu"] ["libmagickcore-dev"]]
+  [["homebrew" "osx"] ["imagemagick"]]
 ]


### PR DESCRIPTION
I hope it will fix the error on Mac OSX:
```
=-=- imagemagick.0.34-1 troobleshooting -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=   
=> This package relies on external (system) dependencies that may be missing.
   `opam depext imagemagick.0.34-1' may help you find the correct installation
   for your system.
```