### PR TITLE
grenier.0.4 - via opam-publish

### DIFF
--- a/packages/grenier/grenier.0.4/descr
+++ b/packages/grenier/grenier.0.4/descr
@@ -1,0 +1,11 @@
+Collection of algorithms (HyperLogLog, order maintenance, ...)
+
+Included:
+- baltree : Generic balanced-tree
+- trope : Track objects accross rope-like operations
+- orderme : Order-maintenance problem
+- binpacking : Maxrects rectangle packing implementation
+- doubledouble : Floating points with around 107-bits precision
+- hll : HyperLogLog
+- jmphash : Jump consistent hashing
+- physh : Physical hashtable

--- a/packages/grenier/grenier.0.4/opam
+++ b/packages/grenier/grenier.0.4/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/grenier"
+bug-reports: "https://github.com/let-def/grenier"
+license: "ISC"
+dev-repo: "https://github.com/let-def/grenier.git"
+build: [make]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "grenier"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/grenier/grenier.0.4/url
+++ b/packages/grenier/grenier.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/grenier/archive/v0.4.tar.gz"
+checksum: "ee283333fc0bb9036e336556aa345274"


### PR DESCRIPTION
Collection of algorithms (HyperLogLog, order maintenance, ...)

Included:
- baltree : Generic balanced-tree
- trope : Track objects accross rope-like operations
- orderme : Order-maintenance problem
- binpacking : Maxrects rectangle packing implementation
- doubledouble : Floating points with around 107-bits precision
- hll : HyperLogLog
- jmphash : Jump consistent hashing
- physh : Physical hashtable


---
* Homepage: https://github.com/let-def/grenier
* Source repo: https://github.com/let-def/grenier.git
* Bug tracker: https://github.com/let-def/grenier

---

Pull-request generated by opam-publish v0.3.2