### PR TITLE
inuit.0.1 - via opam-publish

### DIFF
--- a/packages/inuit/inuit.0.1/descr
+++ b/packages/inuit/inuit.0.1/descr
@@ -1,0 +1,7 @@
+An abstraction for text-oriented UI
+
+Inuit is a library making it easy to design simple interactive text
+applications.  
+This library is only a frontend, managing state and processing event.
+It needs an external backend to do the actual display.  Currently, the only
+backend is provided by Sturgeon which display UIs in an emacs buffer.

--- a/packages/inuit/inuit.0.1/opam
+++ b/packages/inuit/inuit.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: "Frédéric Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/inuit"
+bug-reports: "https://github.com/let-def/inuit/issues"
+license: "ISC"
+doc: "https://let-def.github.io/inuit/doc"
+dev-repo: "https://github.com/let-def/inuit.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "grenier"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/inuit/inuit.0.1/url
+++ b/packages/inuit/inuit.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/inuit/archive/v0.1.tar.gz"
+checksum: "a8e70d667b39649ef2e8dc1561200f14"


### PR DESCRIPTION
An abstraction for text-oriented UI

Inuit is a library making it easy to design simple interactive text
applications.  
This library is only a frontend, managing state and processing event.
It needs an external backend to do the actual display.  Currently, the only
backend is provided by Sturgeon which display UIs in an emacs buffer.


---
* Homepage: https://github.com/let-def/inuit
* Source repo: https://github.com/let-def/inuit.git
* Bug tracker: https://github.com/let-def/inuit/issues

---

Pull-request generated by opam-publish v0.3.2