### PR TITLE
sturgeon.0.1 - via opam-publish

### DIFF
--- a/packages/sturgeon/sturgeon.0.1/descr
+++ b/packages/sturgeon/sturgeon.0.1/descr
@@ -1,0 +1,16 @@
+A toolkit for communicating with Emacs from OCaml
+
+Sturgeon provides various tool to manipulates Emacs from OCaml.
+This is work-in-progress.
+
+Sturgeon_sexp manipulates Emacs flavor of s-expression.
+
+Sturgeon_session is a session-protocol implemented in Emacs and OCaml.  
+It enables asynchronous RPC between the two languages and referencing OCaml
+(resp. Emacs) closures from Emacs (resp. OCaml), etc.
+
+Sturgeon_stui is an Inuit frontend, turning an Emacs buffer into a UI.
+
+Sturgeon_recipes offers different rendez-vous point to connect Emacs & OCaml:
+client (using stdin/stdout) and server (via Unix domain socket), local and
+remote (over SSH).

--- a/packages/sturgeon/sturgeon.0.1/opam
+++ b/packages/sturgeon/sturgeon.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: "Frédéric Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/sturgeon"
+bug-reports: "https://github.com/let-def/sturgeon/issues"
+license: "ISC"
+doc: "https://let-def.github.io/sturgeon/doc"
+dev-repo: "https://github.com/let-def/sturgeon.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "inuit"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/sturgeon/sturgeon.0.1/url
+++ b/packages/sturgeon/sturgeon.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/sturgeon/archive/v0.1.tar.gz"
+checksum: "87f8441f38407fe1d941488b7d976d45"


### PR DESCRIPTION
A toolkit for communicating with Emacs from OCaml

Sturgeon provides various tool to manipulates Emacs from OCaml.
This is work-in-progress.

Sturgeon_sexp manipulates Emacs flavor of s-expression.

Sturgeon_session is a session-protocol implemented in Emacs and OCaml.  
It enables asynchronous RPC between the two languages and referencing OCaml
(resp. Emacs) closures from Emacs (resp. OCaml), etc.

Sturgeon_stui is an Inuit frontend, turning an Emacs buffer into a UI.

Sturgeon_recipes offers different rendez-vous point to connect Emacs & OCaml:
client (using stdin/stdout) and server (via Unix domain socket), local and
remote (over SSH).


---
* Homepage: https://github.com/let-def/sturgeon
* Source repo: https://github.com/let-def/sturgeon.git
* Bug tracker: https://github.com/let-def/sturgeon/issues

---

Pull-request generated by opam-publish v0.3.2