### PR TITLE
git.1.9.3 - via opam-publish

### DIFF
--- a/packages/git/git.1.9.3/descr
+++ b/packages/git/git.1.9.3/descr
@@ -1,0 +1,22 @@
+Git format and protocol in pure OCaml
+
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects. For instance, it is
+possible to make a pack file position independent (as the Zlib
+compression might change the relative offsets between the packed
+objects), to generate pack indexes from pack files, or to expand
+the filesystem of a given commit.
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).
+
+The API documentation is available
+[online](http://mirage.github.io/ocaml-git/).
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-git.png?branch=master)](https://travis-ci.org/mirage/ocaml-git)

--- a/packages/git/git.1.9.3/opam
+++ b/packages/git/git.1.9.3/opam
@@ -1,0 +1,67 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+      "--with-http"   "%{cohttp:installed}%"
+      "--with-unix"   "%{conduit+cohttp+camlzip+nocrypto+base-unix:installed}%"
+      "--with-mirage" "%{mirage-http+mirage-flow+mirage-types-lwt+channel:installed}%"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
+      "--with-http"   "%{cohttp:installed}%"
+      "--with-unix"   "%{conduit+cohttp+camlzip+nocrypto+base-unix:installed}%"
+      "--with-mirage" "%{mirage-http+mirage-flow+mirage-types-lwt+channel:installed}%"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "cmdliner"
+  "mstruct"    {>= "1.3.1"}
+  "ocamlgraph"
+  "uri"        {>= "1.3.12"}
+  "lwt"        {>= "2.4.7"}
+  "mtime"
+  "logs"
+  "fmt"
+  "hex"
+  "astring"
+  "alcotest"         {test}
+  "mirage-types-lwt" {test}
+  "mirage-http"      {test}
+  "mirage-flow"      {test}
+  "channel"          {test}
+  "mirage-fs-unix"   {test & >="1.1.4"}
+  "cohttp"           {test}
+  "conduit"          {test}
+  "base-unix"        {test}
+  "camlzip"          {test & >= "1.06"}
+  "nocrypto"         {test}
+]
+depopts: [
+  # --enable-mirage
+  "mirage-types-lwt"
+  "mirage-http"
+  "mirage-flow"
+  "channel"
+  # --enable-unix
+  "cohttp"
+  "conduit"
+  "base-unix"
+  "camlzip"
+  "nocrypto"
+]
+conflicts: [
+ "cohttp"   {< "0.19.1"}
+ "conduit"  {< "0.8.4"}
+ "alcotest" {< "0.4.0"}
+ "camlzip"  {< "1.06"}
+ "nocrypto" {< "0.2.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.9.3/url
+++ b/packages/git/git.1.9.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.9.3/git-1.9.3.tbz"
+checksum: "07c7fc074023e794abb76806b176970d"


### PR DESCRIPTION
Git format and protocol in pure OCaml

Support for on-disk and in-memory Git stores. Can read and write all
the Git objects: the usual blobs, trees, commits and tags but also
the pack files, pack indexes and the index file (where the staging area
lives).

All the objects share a consistent API, and convenience functions are
provided to manipulate the different objects. For instance, it is
possible to make a pack file position independent (as the Zlib
compression might change the relative offsets between the packed
objects), to generate pack indexes from pack files, or to expand
the filesystem of a given commit.

The library comes with a command-line tool called `ogit` which shares
a similar interface with `git`, but where all operations are mapped to
the API exposed `ocaml-git` (and hence using only OCaml code).

The API documentation is available
[online](http://mirage.github.io/ocaml-git/).

[![Build Status](https://travis-ci.org/mirage/ocaml-git.png?branch=master)](https://travis-ci.org/mirage/ocaml-git)

---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---


---
### 1.9.3 (2016-11-09)

* Turn a bunch of info message into debug statements (#169, @samoht)
Pull-request generated by opam-publish v0.3.2