### PR TITLE
ansi-parse.0.3.0 - via opam-publish

### DIFF
--- a/packages/ansi-parse/ansi-parse.0.3.0/descr
+++ b/packages/ansi-parse/ansi-parse.0.3.0/descr
@@ -1,0 +1,7 @@
+Escape sequences to HTML
+%%1.0.2%%
+
+Ansiparse is a library for converting raw terminal output,
+replete with escape codes, into formatted HTML.
+
+Ansiparse is distributed under the ISC license.

--- a/packages/ansi-parse/ansi-parse.0.3.0/opam
+++ b/packages/ansi-parse/ansi-parse.0.3.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+license: "ISC"
+maintainer: "Joel Jakubovic"
+authors: "Joel Jakubovic"
+dev-repo: "https://github.com/jdjakub/ansi-parse.git"
+homepage: "https://github.com/jdjakub/ansiparse"
+bug-reports: "https://github.com/jdjakub/ansiparse/issues"
+build: [ "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" pinned ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} 
+  "angstrom"
+  "ppx_deriving" {build}
+  "tyxml" ]
+doc: "https://jdjakub.github.io/ansi-parse/doc"

--- a/packages/ansi-parse/ansi-parse.0.3.0/url
+++ b/packages/ansi-parse/ansi-parse.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/jdjakub/ansi-parse/releases/download/v0.3.0/ansi-parse-0.3.0.tbz"
+checksum: "b69eb4375c918be7cddd2e744eec636d"


### PR DESCRIPTION
Escape sequences to HTML
%%1.0.2%%

Ansiparse is a library for converting raw terminal output,
replete with escape codes, into formatted HTML.

Ansiparse is distributed under the ISC license.


---
* Homepage: https://github.com/jdjakub/ansiparse
* Source repo: https://github.com/jdjakub/ansi-parse.git
* Bug tracker: https://github.com/jdjakub/ansiparse/issues

---


---
v0.3.0 2016-11-09 Cambridge
---------------------------

Fixed OPAM
Pull-request generated by opam-publish v0.3.3