### PR TITLE
named-pipe.0.4.0 - via opam-publish

### DIFF
--- a/packages/named-pipe/named-pipe.0.4.0/descr
+++ b/packages/named-pipe/named-pipe.0.4.0/descr
@@ -1,0 +1,5 @@
+Bindings for named pipes
+
+Named pipes are used on Windows for local (and remote) IPC. Where a Unix
+system would use a Unix domain socket, a Windows system will probably used
+a named pipe.

--- a/packages/named-pipe/named-pipe.0.4.0/opam
+++ b/packages/named-pipe/named-pipe.0.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "dave@recoil.org"
+authors:      [ "David Scott" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-named-pipe"
+dev-repo:     "https://github.com/mirage/ocaml-named-pipe.git"
+bug-reports:  "https://github.com/mirage/ocaml-named-pipe/issues"
+doc:          "https://mirage.github.io/ocaml-named-pipe/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test:[
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlfind"   {build}
+  "ocamlbuild"  {build & >= "0.9.3"}
+  "topkg"       {build & >= "0.8.1"}
+  "ocb-stubblr" {build & >= "0.1.0"}
+  "base-bytes"
+  "lwt" {>= "2.4.7"}
+  "base-unix"
+  "cmdliner"
+  "alcotest" {test & >= "0.4.0"}
+]
+
+available: [ ocaml-version >= "3.12.1" ]

--- a/packages/named-pipe/named-pipe.0.4.0/url
+++ b/packages/named-pipe/named-pipe.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-named-pipe/releases/download/0.4.0/named-pipe-0.4.0.tbz"
+checksum: "ec3a7aaec3cc0efd6560dd1668da6def"


### PR DESCRIPTION
Bindings for named pipes

Named pipes are used on Windows for local (and remote) IPC. Where a Unix
system would use a Unix domain socket, a Windows system will probably used
a named pipe.

---
* Homepage: https://github.com/mirage/ocaml-named-pipe
* Source repo: https://github.com/mirage/ocaml-named-pipe.git
* Bug tracker: https://github.com/mirage/ocaml-named-pipe/issues

---


---
### 0.4.0 (2016-10-11)

- Clean up the C bindings, improve the accept API, fix memory leaks and raise
  proper Unix.Error exceptions on errors (14, @samoht)
- Use topkg (#15, @samoht)
Pull-request generated by opam-publish v0.3.2