### PR TITLE
protocol-9p.0.7.4 - via opam-publish

### DIFF
--- a/packages/protocol-9p/protocol-9p.0.7.4/descr
+++ b/packages/protocol-9p/protocol-9p.0.7.4/descr
@@ -1,0 +1,26 @@
+An implementation of the 9p protocol in pure OCaml
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)
+
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style.
+
+Please read the [API documentation](https://mirage.github.io/ocaml-9p).
+
+Example of the CLI example program:
+```
+o9p ls --username vagrant   /var
+drwxr-xr-x ? root root 4096 Feb 2  2015 lib
+drwxr-xr-x ? root root 4096 Mar 15 2015 cache
+-rwxrwxrwx ? root root 9    May 10 2014 lock
+drwxrwxrwx ? root root 4096 Jul 6  2015 tmp
+drwxr-xr-x ? root root 4096 May 11 2014 spool
+drwxrwxr-x ? root sshd 4096 Sep 28 2015 log
+drwxr-xr-x ? root root 4096 Sep 21 2015 backups
+drwxrwxr-x ? root mail 4096 Apr 16 2014 mail
+drwxr-xr-x ? root root 4096 Apr 16 2014 opt
+drwxrwxr-x ? root 50   4096 Apr 10 2014 local
+-rwxrwxrwx ? root root 4    May 10 2014 run
+```
+
+This library supports the [9P2000.u extension](http://ericvh.github.io/9p-rfc/rfc9p2000.u.html)

--- a/packages/protocol-9p/protocol-9p.0.7.4/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.4/opam
@@ -1,0 +1,43 @@
+opam-version: "1.2"
+maintainer:   "dave@recoil.org"
+authors:      [ "David Scott" "David Sheets" "Thomas Leonard" ]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-9p"
+dev-repo:     "https://github.com/mirage/ocaml-9p.git"
+bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
+doc:          "https://mirage.github.io/ocaml-9p/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+          "--with-lambda-term" "%{lambda-term:installed}%"]
+
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
+     "--with-lambda-term" "%{lambda-term:installed}%"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "base-bytes"
+  "cstruct" {>= "1.9.0"}
+  "sexplib" {> "113.00.00" }
+  "result"
+  "mirage-types-lwt"
+  "channel" {>= "1.1.0" }
+  "lwt" {>= "2.4.7"}
+  "base-unix"
+  "cmdliner"
+  "astring"
+  "named-pipe"
+  "fmt"
+  "logs" {>= "0.5.0"}
+  "win-error"
+  "ppx_deriving" {build}
+  "ppx_sexp_conv" {build}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_tools" {build}
+  "topkg" {build & >= "0.7.3"}
+  "alcotest" {test & >= "0.4.0"}
+]
+depopts: ["lambda-term"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/protocol-9p/protocol-9p.0.7.4/url
+++ b/packages/protocol-9p/protocol-9p.0.7.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-9p/releases/download/v0.7.4/protocol-9p-0.7.4.tbz"
+checksum: "4b906e1ba9a91d351288f0f0a7dc3836"


### PR DESCRIPTION
An implementation of the 9p protocol in pure OCaml

[![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

ocaml-9p is an implementation of the 9P protocol, written in
a Mirage-friendly style.

Please read the [API documentation](https://mirage.github.io/ocaml-9p).

Example of the CLI example program:
```
o9p ls --username vagrant   /var
drwxr-xr-x ? root root 4096 Feb 2  2015 lib
drwxr-xr-x ? root root 4096 Mar 15 2015 cache
-rwxrwxrwx ? root root 9    May 10 2014 lock
drwxrwxrwx ? root root 4096 Jul 6  2015 tmp
drwxr-xr-x ? root root 4096 May 11 2014 spool
drwxrwxr-x ? root sshd 4096 Sep 28 2015 log
drwxr-xr-x ? root root 4096 Sep 21 2015 backups
drwxrwxr-x ? root mail 4096 Apr 16 2014 mail
drwxr-xr-x ? root root 4096 Apr 16 2014 opt
drwxrwxr-x ? root 50   4096 Apr 10 2014 local
-rwxrwxrwx ? root root 4    May 10 2014 run
```

This library supports the [9P2000.u extension](http://ericvh.github.io/9p-rfc/rfc9p2000.u.html)

---
* Homepage: https://github.com/mirage/ocaml-9p
* Source repo: https://github.com/mirage/ocaml-9p.git
* Bug tracker: https://github.com/mirage/ocaml-9p/issues

---


---
## v0.7.4 (2016-11-10)

* Protect flow reads from EPIPE exceptions (this can happens on Windows)
  (#104, @samoht)
* Log a message when FID pool is exhausted (#98, @talex5)
* Close socket if we get an error trying to connect (#97, @talex5)
Pull-request generated by opam-publish v0.3.2