### PR TITLE
extlib.1.7.1 - via opam-publish

### DIFF
--- a/packages/extlib/extlib.1.7.1/descr
+++ b/packages/extlib/extlib.1.7.1/descr
@@ -1,0 +1,5 @@
+A complete yet small extension for OCaml standard library (reduced, recommended)
+The purpose of this library is to add new functions to OCaml standard library
+modules, to modify some functions in order to get better performances or
+safety (tail-recursive) and also to provide new modules which should be useful
+for day to day programming.

--- a/packages/extlib/extlib.1.7.1/opam
+++ b/packages/extlib/extlib.1.7.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+  "Markus Mottl"
+  "Jesse Guardiani"
+  "John Skaller"
+  "Bardur Arantsson"
+  "Janne Hellsten"
+  "Richard W.M. Jones"
+  "ygrek"
+  "Gabriel Scherer"
+  "Pietro Abate"
+]
+homepage: "https://github.com/ygrek/ocaml-extlib"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+build: [make "minimal=1" "build"]
+install: [make "minimal=1" "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "extlib"]
+depends: [
+  "ocamlfind" {build}
+  "cppo" {build}
+  "base-bytes"
+]

--- a/packages/extlib/extlib.1.7.1/url
+++ b/packages/extlib/extlib.1.7.1/url
@@ -1,0 +1,3 @@
+http: "http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.1.tar.gz"
+mirrors: ["https://github.com/ygrek/ocaml-extlib/releases/download/1.7.1/extlib-1.7.1.tar.gz"]
+checksum: "381b8f3099f26eec0e8b3597361d5645"


### PR DESCRIPTION
A complete yet small extension for OCaml standard library (reduced, recommended)
The purpose of this library is to add new functions to OCaml standard library
modules, to modify some functions in order to get better performances or
safety (tail-recursive) and also to provide new modules which should be useful
for day to day programming.


---
* Homepage: https://github.com/ygrek/ocaml-extlib
* Source repo: git://github.com/ygrek/ocaml-extlib.git
* Bug tracker: https://github.com/ygrek/ocaml-extlib/issues

---

Pull-request generated by opam-publish v0.3.2