### PR TITLE
mirage-net-macosx.1.2.0 - via opam-publish

### DIFF
--- a/packages/mirage-net-macosx/mirage-net-macosx.1.2.0/descr
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.2.0/descr
@@ -1,0 +1,14 @@
+MacOS X implementation of the Mirage NETWORK interface.
+
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+
+For a complete system that uses this, please see the
+[MirageOS](http://mirage.io) homepage.
+
+- docs: <https://mirage.github.io/mirage-net-macosx/>
+- Issues: <https://github.com/mirage/mirage-net-macosx/issues>
+- Email: <mirageos-devel@lists.xenproject.org>

--- a/packages/mirage-net-macosx/mirage-net-macosx.1.2.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+
+maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
+authors:     "Anil Madhavapeddy <anil@recoil.org>"
+homepage:    "https://github.com/mirage/mirage-net-macosx"
+bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
+dev-repo:    "https://github.com/mirage/mirage-net-macosx.git"
+doc:         "https://mirage.github.io/mirage-net-macosx/"
+
+license: "ISC"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+
+depends: [
+  "ocamlfind" {build}
+  "topkg"     {build}
+  "cstruct" {>= "1.4.0"}
+  "ipaddr"
+  "sexplib"
+  "lwt" {>= "2.4.3"}
+  "mirage-types"
+  "mirage-types-lwt"
+  "io-page" {>= "1.4.0"}
+  "vmnet"
+]

--- a/packages/mirage-net-macosx/mirage-net-macosx.1.2.0/url
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net-macosx/releases/download/1.2.0/mirage-net-macosx-1.2.0.tbz"
+checksum: "0b5537c8dacf9e0d7a7181f87bee61e7"


### PR DESCRIPTION
MacOS X implementation of the Mirage NETWORK interface.

This interface exposes raw Ethernet frames using the
[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
is available on MacOS X Yosemite onwards.  It is suitable for
use with an OCaml network stack such as the one found at
<https://github.com/mirage/mirage-tcpip>.

For a complete system that uses this, please see the
[MirageOS](http://mirage.io) homepage.

- docs: <https://mirage.github.io/mirage-net-macosx/>
- Issues: <https://github.com/mirage/mirage-net-macosx/issues>
- Email: <mirageos-devel@lists.xenproject.org>

---
* Homepage: https://github.com/mirage/mirage-net-macosx
* Source repo: https://github.com/mirage/mirage-net-macosx.git
* Bug tracker: https://github.com/mirage/mirage-net-macosx/issues

---


---
### 1.2.0 (2016-11-11)

- Switch to topkg (#11, @hannesm and @samoht)
- Remove camlp4 (#7, @samoht)
Pull-request generated by opam-publish v0.3.2