### PR TITLE
asn1-combinators.0.1.3 - via opam-publish

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.1.3/descr
+++ b/packages/asn1-combinators/asn1-combinators.0.1.3/descr
@@ -1,0 +1,10 @@
+Define ASN.1 grammars in OCaml
+
+
+asn1-combinators is a library for declarative definitions of ASN.1 grammars,
+embedded in OCaml. These definitions are strongly typed and allow parsing and
+serialization.
+
+Presently, only BER and DER encoding and supported.
+
+asn1-combinators is distributed under the ISC license.

--- a/packages/asn1-combinators/asn1-combinators.0.1.3/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.3/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+tags: [ "org:mirage" ]
+available: [ ocaml-version >= "4.01.0" ]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" {>= "1.2.0"}
+  "result"
+  "zarith"
+  "ounit" {test}
+]
+depopts: []
+conflicts: [ "cstruct" {< "1.2.0"} ]

--- a/packages/asn1-combinators/asn1-combinators.0.1.3/url
+++ b/packages/asn1-combinators/asn1-combinators.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.1.3/asn1-combinators-0.1.3.tbz"
+checksum: "ce625d1fb6903aa8d40b27671ccf742c"


### PR DESCRIPTION
Define ASN.1 grammars in OCaml


asn1-combinators is a library for declarative definitions of ASN.1 grammars,
embedded in OCaml. These definitions are strongly typed and allow parsing and
serialization.

Presently, only BER and DER encoding and supported.

asn1-combinators is distributed under the ISC license.

---
* Homepage: https://github.com/mirleft/ocaml-asn1-combinators
* Source repo: https://github.com/mirleft/ocaml-asn1-combinators.git
* Bug tracker: https://github.com/mirleft/ocaml-asn1-combinators/issues

---


---
## v0.1.3 (2016-11-12)
* relicense to ISC
* drop oasis
* fix a bug in tests on 32 bit
Pull-request generated by opam-publish v0.3.2