### PR TITLE
opam-build-revdeps.0.1.0 - via opam-publish

### DIFF
--- a/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/descr
+++ b/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/descr
@@ -1,0 +1,8 @@
+Build reverse dependencies of a package in OPAM.
+opam-build-revdeps builds the reverse dependencies of a given OPAM
+package. It can also build two different versions of the same package,
+in order to compare the results.
+This program has been designed to test what can other packages can
+break in OPAM, if we inject a new version. It was specifically
+targeted to check OASIS reverse dependencies.
+

--- a/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/files/_oasis_remove_.ml
+++ b/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/files/_oasis_remove_.ml
@@ -1,0 +1,7 @@
+open Printf
+
+let () =
+  let dir = Sys.argv.(1) in
+  (try Sys.chdir dir
+   with _ -> eprintf "Cannot change directory to %s\n%!" dir);
+  exit (Sys.command "ocaml setup.ml -uninstall")

--- a/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/files/opam-build-revdeps.install
+++ b/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/files/opam-build-revdeps.install
@@ -1,0 +1,6 @@
+etc: [
+  "setup.ml"
+  "setup.data"
+  "setup.log"
+  "_oasis_remove_.ml"
+]

--- a/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/opam
+++ b/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "Sylvain Le Gall <sylvain@le-gall.net>>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/gildor478/opam-build-revdeps"
+dev-repo: "git://github.com/gildor478/opam-build-revdeps.git"
+bug-reports: "https://github.com/gildor478/opam-build-revdeps/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocaml" "%{etc}%/opam-build-revdeps/_oasis_remove_.ml"
+    "%{etc}%/opam-build-revdeps"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+depends: [
+  "base-unix" {build}
+  "calendar" {build & >= "2.03"}
+  "cmdliner" {build & >= "0.9"}
+  "fileutils" {build & >= "0.5.1"}
+  "jingoo" {build & >= "1.2"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build & >= "1.3.1"}
+  "opam-lib" {build & >= "1.2.2"}
+  "re" {build & >= "1.7"}
+  "uuidm" {build & >= "0.9.6"}
+]
+available: [ ocaml-version >= "3.12.1" ]

--- a/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/opam
+++ b/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/opam
@@ -30,5 +30,6 @@ depends: [
   "opam-lib" {build & >= "1.2.2"}
   "re" {build & >= "1.7"}
   "uuidm" {build & >= "0.9.6"}
+  "ocamlify" {build}
 ]
 available: [ ocaml-version >= "3.12.1" ]

--- a/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/url
+++ b/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/gildor478/opam-build-revdeps/releases/download/0.1.0/opam-build-revdeps-0.1.0.tar.gz"
+checksum: "07d04ea5b2df5f18e9a12bc5db43855f"


### PR DESCRIPTION
Build reverse dependencies of a package in OPAM.
opam-build-revdeps builds the reverse dependencies of a given OPAM
package. It can also build two different versions of the same package,
in order to compare the results.
This program has been designed to test what can other packages can
break in OPAM, if we inject a new version. It was specifically
targeted to check OASIS reverse dependencies.



---
* Homepage: https://github.com/gildor478/opam-build-revdeps
* Source repo: git://github.com/gildor478/opam-build-revdeps.git
* Bug tracker: https://github.com/gildor478/opam-build-revdeps/issues

---

Pull-request generated by opam-publish v0.3.2