### PR TITLE
integers.0.2.1 - via opam-publish

### DIFF
--- a/packages/integers/integers.0.2.1/descr
+++ b/packages/integers/integers.0.2.1/descr
@@ -1,0 +1,1 @@
+Various signed and unsigned integer types for OCaml

--- a/packages/integers/integers.0.2.1/opam
+++ b/packages/integers/integers.0.2.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop"
+          "Demi Obenour"
+          "Stephane Glondu"
+          "Andreas Hauptmann"]
+homepage: "https://github.com/ocamllabs/ocaml-integers"
+bug-reports: "https://github.com/ocamllabs/ocaml-integers/issues"
+dev-repo: "https://github.com/ocamllabs/ocaml-integers.git"
+license: "MIT"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"]]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+]
+
+doc: "http://ocamllabs.github.io/ocaml-integers/api.docdir/"

--- a/packages/integers/integers.0.2.1/url
+++ b/packages/integers/integers.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocamllabs/ocaml-integers/releases/download/0.2.1/integers-0.2.1.tbz"
+checksum: "f57d65fbfb8163ae6401fab3224bbd72"


### PR DESCRIPTION
Various signed and unsigned integer types for OCaml


---
* Homepage: https://github.com/ocamllabs/ocaml-integers
* Source repo: https://github.com/ocamllabs/ocaml-integers.git
* Bug tracker: https://github.com/ocamllabs/ocaml-integers/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.2.1 2016-11-14
-----------------
* Register the custom deserializers
Pull-request generated by opam-publish v0.3.2