### PR TITLE
key-parsers.0.6.0 - via opam-publish

### DIFF
--- a/packages/key-parsers/key-parsers.0.6.0/descr
+++ b/packages/key-parsers/key-parsers.0.6.0/descr
@@ -1,0 +1,3 @@
+Parsers for multiple key formats
+
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or Elliptic curve public and private keys.

--- a/packages/key-parsers/key-parsers.0.6.0/opam
+++ b/packages/key-parsers/key-parsers.0.6.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+author: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/key-parsers.git"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
+  "ounit" {test & >= "2.0.0"}
+  "ppx_blob" {test & >= "0.2"}
+  "hex" {test & >= "1.0.0"}
+  "asn1-combinators" {>= "0.1.2"}
+  "zarith" {>= "1.4.1"}
+  "result" {>= "1.2"}
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/key-parsers/key-parsers.0.6.0/url
+++ b/packages/key-parsers/key-parsers.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/key-parsers/releases/download/v0.6.0/key-parsers-0.6.0.tbz"
+checksum: "5df95391f8c7bf01128318a32158b869"


### PR DESCRIPTION
Parsers for multiple key formats

This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or Elliptic curve public and private keys.


---
* Homepage: https://github.com/cryptosense/key-parsers
* Source repo: https://github.com/cryptosense/key-parsers.git
* Bug tracker: https://github.com/cryptosense/key-parsers/issues

---


---
## v0.6.0

*2016-11-14*

- Build using `topkg`
- Add `ppx_deriving.runtime` to `META`
- Add support for parsing CVC keys
Pull-request generated by opam-publish v0.3.2