### PR TITLE
Do not add -L/usr/lib to camlzip.cm{x}a on OSX

### DIFF
--- a/packages/camlzip/camlzip.1.06/files/no-L.patch
+++ b/packages/camlzip/camlzip.1.06/files/no-L.patch
@@ -1,0 +1,52 @@
+commit 66bf764adf66ded8c47717b816742fbf2df09b12
+Author: Thomas Gazagnaire <thomas@gazagnaire.org>
+Date:   Tue Nov 15 10:40:40 2016 +0000
+
+    Do not add -L<dir> to the cm{x}a
+    
+    This breaks on OSX when using libffi and ctypes, as ctypes requires
+    the version of libffi installed by brew, not the system one (installed
+    in /usr/lib`).
+    
+    As we have no way to keep the order of linker flags (due to
+    https://caml.inria.fr/mantis/view.php?id=7150) it is safer to just not
+    use -L if possible. In the case of camlzip, this doesn't seem needed.
+
+diff --git a/Makefile b/Makefile
+index 8f2fba9..37daba2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -3,10 +3,6 @@
+ # The name of the Zlib library.  Usually -lz
+ ZLIB_LIB=-lz
+ 
+-# The directory containing the Zlib library (libz.a or libz.so)
+-ZLIB_LIBDIR=/usr/lib
+-# ZLIB_LIBDIR=/usr/local/lib
+-
+ # The directory containing the Zlib header file (zlib.h)
+ ZLIB_INCLUDE=/usr/include
+ # ZLIB_INCLUDE=/usr/local/include
+@@ -36,19 +32,16 @@ all: libcamlzip.a zip.cma
+ allopt: libcamlzip.a zip.cmxa $(CMXS)
+ 
+ zip.cma: $(OBJS)
+-	$(OCAMLMKLIB) -o zip -oc camlzip $(OBJS) \
+-            -L$(ZLIB_LIBDIR) $(ZLIB_LIB)
++	$(OCAMLMKLIB) -o zip -oc camlzip $(OBJS) $(ZLIB_LIB)
+ 
+ zip.cmxa: $(OBJS:.cmo=.cmx)
+-	$(OCAMLMKLIB) -o zip -oc camlzip $(OBJS:.cmo=.cmx) \
+-            -L$(ZLIB_LIBDIR) $(ZLIB_LIB)
++	$(OCAMLMKLIB) -o zip -oc camlzip $(OBJS:.cmo=.cmx) $(ZLIB_LIB)
+ 
+ zip.cmxs: zip.cmxa
+ 	$(OCAMLOPT) -shared -linkall -I ./ -o $@ $^
+ 
+ libcamlzip.a: $(C_OBJS)
+-	$(OCAMLMKLIB) -oc camlzip $(C_OBJS) \
+-            -L$(ZLIB_LIBDIR) $(ZLIB_LIB)
++	$(OCAMLMKLIB) -oc camlzip $(C_OBJS) $(ZLIB_LIB)
+ 
+ .SUFFIXES: .mli .ml .cmo .cmi .cmx
+ 

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -24,6 +24,7 @@ depexts: [
 patches: [
   "fix-install.patch"
   "build_with_trunk.patch"
+  "no-L.patch" {os = "darwin"}
 ]
 install: [make "install-findlib"]
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
This breaks when trying to use libffi (and thus ctypes), because
OSX has a old version of libffi in /usr/lib and we rely to the
version installed by homebrew.

Due to https://caml.inria.fr/mantis/view.php?id=7150 we don't have
any control on the order of -L arguments passed to the linker, so
it's just better to not add one.

/cc @yallop and @dsheets (who suggested the fix) and @xavierleroy who maintain the package.

btw, I have created https://github.com/samoht/camlzip/tree/opam to keep track of the patches that we maintain for opam on top of the official tree. That would be great if they all go upstream at one point :-)