### PR TITLE
restrict fat-filesystem to lwt<2.6.0

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.10.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "0.5.0" & < "1.1.0"}
   "mirage-block-unix" {>= "1.2.0"}
   "io-page-unix" {>= "0.9.9"}

--- a/packages/fat-filesystem/fat-filesystem.0.10.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.1/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "1.1.0" & < "2.3.0"}
   "mirage-block-unix" {>= "1.2.0"}
   "io-page" {>= "1.0.0" & < "1.3.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.10.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.2/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "1.1.0" & < "2.3.0"}
   "mirage-block-unix" {>= "1.2.0"}
   "io-page" {>= "1.2.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.10.3/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.3/opam
@@ -16,7 +16,7 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "1.1.0"}
   "mirage-block-unix" {>= "1.2.0"}
   "io-page" {>= "1.4.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.11.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.11.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "2.0.0"}
   "ppx_tools"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "2.6.1"}
   "mirage-block-unix" {>= "1.2.0"}
   "io-page" {>= "1.6.1"}

--- a/packages/fat-filesystem/fat-filesystem.0.6.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.6.0/opam
@@ -5,7 +5,7 @@ remove: [[make "uninstall"]]
 depends: [
   "cstruct" {>= "0.8.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {= "0.3.0"}
   "mirage-block-unix" {>= "0.2.0"}
   "io-page-unix" {>= "0.9.9"}

--- a/packages/fat-filesystem/fat-filesystem.0.6.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.6.2/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "0.8.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {= "0.3.0"}
   "mirage-block-unix" {>= "0.2.0"}
   "io-page-unix" {>= "0.9.9"}

--- a/packages/fat-filesystem/fat-filesystem.0.7.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.7.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "0.4.0" & < "1.1.0"}
   "mirage-block-unix" {>= "0.2.0"}
   "io-page-unix" {>= "0.9.9"}

--- a/packages/fat-filesystem/fat-filesystem.0.8.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.8.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "0.5.0" & < "1.1.0"}
   "mirage-block-unix" {>= "0.2.0"}
   "io-page-unix" {>= "0.9.9"}

--- a/packages/fat-filesystem/fat-filesystem.0.9.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.9.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & <"2.6.0"}
   "mirage-types" {>= "0.5.0" & < "1.1.0"}
   "mirage-block-unix" {>= "0.2.0"}
   "io-page-unix" {>= "0.9.9"}


### PR DESCRIPTION
both define a module Result, which fails to co-exist.  a sample travis failure is at https://travis-ci.org/mirage/mirage-www/jobs/176125723#L8796 (upstream fat-filesystem is already fixed, but awaiting MirageOS3)