### PR TITLE
ipaddr.7057270 - via opam-publish

### DIFF
--- a/packages/ipaddr/ipaddr.7057270/descr
+++ b/packages/ipaddr/ipaddr.7057270/descr
@@ -1,0 +1,21 @@
+IP (and MAC) address manipulation
+
+A library for manipulation of IP (and MAC) address representations.
+
+Features:
+
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers

--- a/packages/ipaddr/ipaddr.7057270/opam
+++ b/packages/ipaddr/ipaddr.7057270/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer:   "sheets@alum.mit.edu"
+authors: [
+              "David Sheets"
+              "Anil Madhavapeddy"
+              "Hugo Heuzard"
+]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-ipaddr"
+bug-reports:  "https://github.com/mirage/ocaml-ipaddr/issues"
+dev-repo:     "https://github.com/mirage/ocaml-ipaddr.git"
+doc:          "https://mirage.github.io/ocaml-ipaddr/"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+    "--with-base-unix" "%{base-unix:installed}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bytes"
+  "sexplib"
+  "ppx_sexp_conv"
+  "ounit" {test}
+]
+depopts: [ "base-unix" ]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/ipaddr/ipaddr.7057270/url
+++ b/packages/ipaddr/ipaddr.7057270/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-ipaddr/releases/download/2.7.1/ipaddr-2.7.1.tbz"
+checksum: "45b81a6b59723cd8ae0a56fb280e07e1"


### PR DESCRIPTION
IP (and MAC) address manipulation

A library for manipulation of IP (and MAC) address representations.

Features:

 * Depends only on sexplib (conditionalization under consideration)
 * oUnit-based tests
 * IPv4 and IPv6 support
 * IPv4 and IPv6 CIDR prefix support
 * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
 * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
 * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
 * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
 * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
 * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
 * IP address scope classification
 * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
 * MAC-48 (Ethernet) address support
 * `Macaddr` is a `Map.OrderedType`
 * All types have sexplib serializers/deserializers

---
* Homepage: https://github.com/mirage/ocaml-ipaddr
* Source repo: https://github.com/mirage/ocaml-ipaddr.git
* Bug tracker: https://github.com/mirage/ocaml-ipaddr/issues

---


---
## 2.7.1 (2016-11-16)

* Use topkg for build (#60 from Jochen Bartl)
Pull-request generated by opam-publish v0.3.3