### PR TITLE
Fix msgpack dependencies

### DIFF
--- a/packages/msgpack/msgpack.1.0.0/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.0.0/files/no-camlp4.patch
@@ -1,0 +1,13 @@
+diff --git a/_oasis b/_oasis
+index f3733a5..4a7bec5 100644
+--- a/_oasis
++++ b/_oasis
+@@ -13,7 +13,7 @@ Description:
+   MessagePack is an efficient binary serialization format.
+   If meta_conv is installed, conv module will be installed.
+ 
+-BuildTools: ocamlbuild, camlp4
++BuildTools: ocamlbuild
+ 
+ # ------------------------------------------------------------
+ # Flags

--- a/packages/msgpack/msgpack.1.0.0/opam
+++ b/packages/msgpack/msgpack.1.0.0/opam
@@ -1,5 +1,11 @@
 opam-version: "1.2"
 maintainer: "mzp.ppp@gmail.com"
+authors: "MIZUNO Hiroki <mzp.ppp@gmail.com>"
+homepage: "http://github.com/msgpack/msgpack-ocaml/"
+bug-reports: "https://github.com/msgpack/msgpack-ocaml/issues"
+patches: [
+  "no-camlp4.patch"
+]
 build: [
   [
     "ocaml"
@@ -14,7 +20,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "msgpack"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   ("extlib" | "extlib-compat")
   "ocamlbuild" {build}
 ]

--- a/packages/msgpack/msgpack.1.1.0/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.1.0/files/no-camlp4.patch
@@ -1,0 +1,13 @@
+diff --git a/_oasis b/_oasis
+index f3733a5..4a7bec5 100644
+--- a/_oasis
++++ b/_oasis
+@@ -13,7 +13,7 @@ Description:
+   MessagePack is an efficient binary serialization format.
+   If meta_conv is installed, conv module will be installed.
+ 
+-BuildTools: ocamlbuild, camlp4
++BuildTools: ocamlbuild
+ 
+ # ------------------------------------------------------------
+ # Flags

--- a/packages/msgpack/msgpack.1.1.0/opam
+++ b/packages/msgpack/msgpack.1.1.0/opam
@@ -4,6 +4,11 @@ version: "1.1.0"
 available: [ocaml-version >= "4.01.0"]
 maintainer: "mzp.ppp@gmail.com"
 authors: "MIZUNO Hiroki <mzp.ppp@gmail.com>"
+homepage: "http://github.com/msgpack/msgpack-ocaml/"
+bug-reports: "https://github.com/msgpack/msgpack-ocaml/issues"
+patches: [
+  "no-camlp4.patch"
+]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--enable-core" "--%{meta_conv:enable}%-conv"]
   ["ocaml" "setup.ml" "-build"]
@@ -14,7 +19,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "msgpack"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
 depopts: "meta_conv"

--- a/packages/msgpack/msgpack.1.1.1/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.1.1/files/no-camlp4.patch
@@ -1,0 +1,13 @@
+diff --git a/_oasis b/_oasis
+index f3733a5..4a7bec5 100644
+--- a/_oasis
++++ b/_oasis
+@@ -13,7 +13,7 @@ Description:
+   MessagePack is an efficient binary serialization format.
+   If meta_conv is installed, conv module will be installed.
+ 
+-BuildTools: ocamlbuild, camlp4
++BuildTools: ocamlbuild
+ 
+ # ------------------------------------------------------------
+ # Flags

--- a/packages/msgpack/msgpack.1.1.1/opam
+++ b/packages/msgpack/msgpack.1.1.1/opam
@@ -4,6 +4,11 @@ version: "1.1.1"
 available: [ocaml-version >= "4.01.0"]
 maintainer: "mzp.ppp@gmail.com"
 authors: "MIZUNO Hiroki <mzp.ppp@gmail.com>"
+homepage: "http://github.com/msgpack/msgpack-ocaml/"
+bug-reports: "https://github.com/msgpack/msgpack-ocaml/issues"
+patches: [
+  "no-camlp4.patch"
+]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--enable-core" "--%{meta_conv:enable}%-conv"]
   ["ocaml" "setup.ml" "-build"]
@@ -14,7 +19,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "msgpack"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
 depopts: "meta_conv"

--- a/packages/msgpack/msgpack.1.2.0/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.2.0/files/no-camlp4.patch
@@ -1,0 +1,13 @@
+diff --git a/_oasis b/_oasis
+index f3733a5..4a7bec5 100644
+--- a/_oasis
++++ b/_oasis
+@@ -13,7 +13,7 @@ Description:
+   MessagePack is an efficient binary serialization format.
+   If meta_conv is installed, conv module will be installed.
+ 
+-BuildTools: ocamlbuild, camlp4
++BuildTools: ocamlbuild
+ 
+ # ------------------------------------------------------------
+ # Flags

--- a/packages/msgpack/msgpack.1.2.0/opam
+++ b/packages/msgpack/msgpack.1.2.0/opam
@@ -4,6 +4,9 @@ author: "mzp <mzp.ppp@gmail.com>"
 homepage: "http://github.com/msgpack/msgpack-ocaml/"
 dev-repo: "https://github.com/msgpack/msgpack-ocaml.git"
 bug-reports: "https://github.com/msgpack/msgpack-ocaml/issues"
+patches: [
+  "no-camlp4.patch"
+]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--enable-core" "--%{meta_conv:enable}%-conv"]
   ["ocaml" "setup.ml" "-build"]
@@ -14,7 +17,10 @@ install: [
 remove: [
   ["ocamlfind" "remove" "msgpack"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 
 depopts: ["meta_conv"]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/msgpack/msgpack.1.2.1/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.2.1/files/no-camlp4.patch
@@ -1,0 +1,13 @@
+diff --git a/_oasis b/_oasis
+index f3733a5..4a7bec5 100644
+--- a/_oasis
++++ b/_oasis
+@@ -13,7 +13,7 @@ Description:
+   MessagePack is an efficient binary serialization format.
+   If meta_conv is installed, conv module will be installed.
+ 
+-BuildTools: ocamlbuild, camlp4
++BuildTools: ocamlbuild
+ 
+ # ------------------------------------------------------------
+ # Flags

--- a/packages/msgpack/msgpack.1.2.1/opam
+++ b/packages/msgpack/msgpack.1.2.1/opam
@@ -4,6 +4,9 @@ author: "mzp <mzp.ppp@gmail.com>"
 homepage: "http://github.com/msgpack/msgpack-ocaml/"
 dev-repo: "https://github.com/msgpack/msgpack-ocaml.git"
 bug-reports: "https://github.com/msgpack/msgpack-ocaml/issues"
+patches: [
+  "no-camlp4.patch"
+]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%" "--enable-core" "--%{meta_conv:enable}%-conv"]
   ["ocaml" "setup.ml" "-build"]
@@ -14,7 +17,10 @@ install: [
 remove: [
   ["ocamlfind" "remove" "msgpack"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 
 depopts: ["meta_conv"]
 available: [ ocaml-version >= "4.01.0" ]


### PR DESCRIPTION
msgpack doesn't really depend on camlp4. It only needs it to execute tests and yet camlp4 doesn't need to be checked at configure time because the test uses a camlp4 library.

cc @mzp