### PR TITLE
irmin-watcher.0.2.0 - via opam-publish

### DIFF
--- a/packages/irmin-watcher/irmin-watcher.0.2.0/descr
+++ b/packages/irmin-watcher/irmin-watcher.0.2.0/descr
@@ -1,0 +1,9 @@
+Portable Irmin watch backends using FSevents or Inotify
+
+
+irmin-watcher implements [Irmin's watch hooks][watch] for various OS,
+using FSevents in OSX and Inotify on Linux.
+
+irmin-watcher is distributed under the ISC license.
+
+[watch]: http://mirage.github.io/irmin/Irmin.Private.Watch.html

--- a/packages/irmin-watcher/irmin-watcher.0.2.0/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage: "https://github.com/samoht/irmin-watcher"
+doc: "https://samoht.github.io/irmin-watcher/"
+license: "ISC"
+dev-repo: "https://github.com/samoht/irmin-watcher.git"
+bug-reports: "https://github.com/samoht/irmin-watcher/issues"
+available: [ ocaml-version >= "4.02.0" & opam-version >= "1.2.2" ]
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "cppo"       {build}
+  "alcotest"   {test}
+  "mtime"      {test}
+  "ocb-stubblr"
+  "lwt" "logs" "fmt" "astring"
+]
+depopts: ["inotify" "osx-fsevents"]
+conflicts: [ "osx-fsevents" {< "0.2.0"} ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--tests" "false"
+    "--pinned" pinned
+    "--with-fsevents" osx-fsevents:installed
+    "--with-inotify" inotify:installed
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
+     "--pinned" pinned
+     "--with-fsevents" osx-fsevents:installed
+     "--with-inotify" inotify:installed]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]

--- a/packages/irmin-watcher/irmin-watcher.0.2.0/url
+++ b/packages/irmin-watcher/irmin-watcher.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/irmin-watcher/releases/download/0.2.0/irmin-watcher-0.2.0.tbz"
+checksum: "2f0c8acc45f96f71d93c8e639654e7b0"


### PR DESCRIPTION
Portable Irmin watch backends using FSevents or Inotify


irmin-watcher implements [Irmin's watch hooks][watch] for various OS,
using FSevents in OSX and Inotify on Linux.

irmin-watcher is distributed under the ISC license.

[watch]: http://mirage.github.io/irmin/Irmin.Private.Watch.html

---
* Homepage: https://github.com/samoht/irmin-watcher
* Source repo: https://github.com/samoht/irmin-watcher.git
* Bug tracker: https://github.com/samoht/irmin-watcher/issues

---


---
### 0.2.0 (2016-11-14)

- Allow to watch non-existing directories (#8, @samoht)
- Expose `Irmin_watches.stats` to get stats about the numbers
  of active watchdogs, and callback dispatchers (#7, @samoht)
- When using fsevents/inotify do not scan the whole tree everytime
  (#6, @samoht)
- Use realpath(3) on Linux and GetFullPathName on Windows to
  normalise the path to watch (#6, @samoht)
- inotify: close the inotify file descriptor when stopping the
  watch (#6. @samoht)
- inotify: fix the path of watched events (inotify uses relative
  patch, unless fsevents which uses absolute paths) (#6, @samoht)
- fix detection of removed files (#6, @samoht)
Pull-request generated by opam-publish v0.3.2