### PR TITLE
irmin.0.12.0 - via opam-publish

### DIFF
--- a/packages/irmin/irmin.0.12.0/descr
+++ b/packages/irmin/irmin.0.12.0/descr
@@ -1,0 +1,10 @@
+A distributed database that follows the same design principles as Git
+
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+
+[![Build Status](https://travis-ci.org/mirage/irmin.svg)](https://travis-ci.org/mirage/irmin)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/irmin/)

--- a/packages/irmin/irmin.0.12.0/opam
+++ b/packages/irmin/irmin.0.12.0/opam
@@ -1,0 +1,65 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+      "--with-http"   "%{cohttp:installed}%"
+      "--with-git"    "%{git:installed}%"
+      "--with-unix"   "%{irmin-watcher+git-unix:installed}%"
+      "--with-mirage" "%{mirage-git:installed}%"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
+      "--with-http"   "%{cohttp:installed}%"
+      "--with-git"    "%{git:installed}%"
+      "--with-unix"   "%{irmin-watcher+git-unix:installed}%"
+      "--with-mirage" "%{mirage-git:installed}%"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.7.8"}
+  "ezjsonm" {>= "0.4.2"}
+  "fmt"
+  "ocamlgraph"
+  "lwt" {>= "2.4.7"}
+  "logs" {>= "0.5.0"}
+  "fmt"
+  "cstruct" {>= "1.6.0"}
+  "mirage-tc" {>= "0.3.0"}
+  "mstruct"
+  "uri" {>= "1.3.12"}
+  "astring"
+  "hex"
+  "re"
+  "cmdliner"
+  "crunch"
+  "mtime"         {test}
+  "git-unix"      {test}
+  "cohttp"        {test}
+  "alcotest"      {test & >="0.4.1"}
+  "irmin-watcher" {test & >= "0.2.0"}
+]
+depopts: [
+  "git"
+  "git-unix"
+  "cohttp"
+  "mirage-git"
+  "irmin-watcher"
+]
+conflicts: [
+  "cohttp"        {< "0.18.3"}
+  "git"           {< "1.8.0"}
+  "conduit"       {< "0.9.0"}
+  "mirage-types"  {>="3.0.0"}
+  "irmin-watcher" {<"0.2.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin/irmin.0.12.0/url
+++ b/packages/irmin/irmin.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/0.12.0/irmin-0.12.0.tbz"
+checksum: "04158d3e093add7b556323aeb117219c"


### PR DESCRIPTION
A distributed database that follows the same design principles as Git

Irmin is a library for persistent stores with built-in snapshot,
branching and reverting mechanisms. It is designed to use a large
variety of backends. Irmin is written in pure OCaml and does not
depend on external C stubs; it aims to run everywhere, from Linux,
to browsers and Xen unikernels.

[![Build Status](https://travis-ci.org/mirage/irmin.svg)](https://travis-ci.org/mirage/irmin)
[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/irmin/)

---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 0.12.0 (2016-11-17)

* Depends on irmin-watcher 0.2.0 to use portable file-system watches
  (fsevents on OSX or inotify on Linux) to replace the slow and CPU
  intensive file-system polling that was the default (#380, @samoht)
* Do not use `Lwt_unix.fork` in the tests anymore (#383, @samoht)
* Switch from Stringext to Astring (#382, @samoht)
* Fix regression in the tests for using Git over HTTP (#376, @samoht)
* Catch top-level exceptions in watch callbacks (#375, @samoht)
* Fix merge of assoc list with no common ancestor (#374, @samoht)
* Improve documentation for Git bare repositories (#363, @kayceesrk)
* New functor `Make_with_metadata` to customize the type of the
  nodes metadata (#364, @samoht)
* Remove mentions of private modules from the public interface
  (#364, @samoht)
Pull-request generated by opam-publish v0.3.2