### PR TITLE
Fix `opam lint` errors on older versions of fat-filesystem

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.10.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.0/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -18,6 +22,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/fat-filesystem/fat-filesystem.0.10.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.1/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -19,6 +23,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/fat-filesystem/fat-filesystem.0.10.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.2/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -19,6 +23,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/fat-filesystem/fat-filesystem.0.6.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.6.0/opam
@@ -5,7 +5,10 @@ homepage:     "https://github.com/mirage/ocaml-fat"
 bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
 dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: make
-remove: [[make "uninstall"]]
+remove: [
+  [make "uninstall"]
+  ["ocamlfind" "remove" "fat-filesystem" ]
+]
 depends: [
   "cstruct" {>= "0.8.1" & <"2.0.0"}
   "ocamlfind"

--- a/packages/fat-filesystem/fat-filesystem.0.6.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.6.0/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: make
 remove: [[make "uninstall"]]
 depends: [
@@ -13,6 +17,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/fat-filesystem/fat-filesystem.0.6.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.6.2/opam
@@ -9,6 +9,7 @@ build: [
   [make]
 ]
 remove: [
+  ["./configure" "--bindir" "%{bin}%"]
   [make "uninstall"]
 ]
 depends: [

--- a/packages/fat-filesystem/fat-filesystem.0.6.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.6.2/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -18,6 +22,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/fat-filesystem/fat-filesystem.0.7.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.7.0/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -18,6 +22,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/fat-filesystem/fat-filesystem.0.8.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.8.0/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -18,6 +22,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/fat-filesystem/fat-filesystem.0.9.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.9.0/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
 maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -18,6 +22,5 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-fat"
 available: ocaml-version >= "4.00.0"
 install: [make "install"]


### PR DESCRIPTION
Reported on #7827

Signed-off-by: David Scott <dave@recoil.org>