### PR TITLE
datakit-client.0.7.0 - via opam-publish

### DIFF
--- a/packages/datakit-client/datakit-client.0.7.0/descr
+++ b/packages/datakit-client/datakit-client.0.7.0/descr
@@ -1,0 +1,5 @@
+A library to connect to datakit servers
+
+The library currently only provides only a 9p client to talk to
+Datakit, but other filesystem protocols will be available in the
+future.

--- a/packages/datakit-client/datakit-client.0.7.0/opam
+++ b/packages/datakit-client/datakit-client.0.7.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/docker/datakit"
+bug-reports:  "https://github.com/docker/datakit/issues"
+dev-repo:     "https://github.com/docker/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" "datakit-client"
+]
+
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "base-bytes"
+  "astring" "logs" "uri" "rresult" "cstruct" "fmt"
+  "protocol-9p" {>= "0.7.4"}
+  "cmdliner"
+]

--- a/packages/datakit-client/datakit-client.0.7.0/url
+++ b/packages/datakit-client/datakit-client.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/docker/datakit/releases/download/0.7.0/datakit-0.7.0.tbz"
+checksum: "0576d33105586cf656d73d431ba4045f"


### PR DESCRIPTION
A library to connect to datakit servers

The library currently only provides only a 9p client to talk to
Datakit, but other filesystem protocols will be available in the
future.


---
* Homepage: https://github.com/docker/datakit
* Source repo: https://github.com/docker/datakit.git
* Bug tracker: https://github.com/docker/datakit/issues

---


---
### 0.7.0 (2016-11-17)

The highlight of that release is `datakit-ci`: a new library to help
creating new CI pipelines built on top of DataKit.

- ci: improve UI for viewing logs (#341, #342, @talex5)
- ci: specify a metadata store default that matches datakit (#330, @avsm)
- ci: let CI binaries specify custom CLI term info (#329, @avsm)
- ci: add GitHub-based login to web UI (#328, @talex5)
- ci: return some HTML body text for more errors (#325, @talex5)
- ci: add .monitor files automatically (#324, @talex5)
- ci: add setting to configure a public CI (#320, @talex5)
- ci: add a CI script to test DataKit itself (#314, @talex5)
- ci: allow configuring CI name, dashboard config in config file (@306, @talex5)
- ci: Add library for writing DataKit-based Continuous Integration systems
  (#302, @talex5)

- github: add a more specific error when there is no datakit-github token
  (#323, @avsm)
- github: major refactoring to use only one branch in datakit to persist
  the data and keep the rest in memory otherwise. Also use a stronger model
  of ownership to decide whether datakit or GitHub is right (#311, @samoht)

- datakit: update to irmin.0.12.0 to use faster native watch notifications
  instead of file-system polling and full scanning (#347, @samoht)

- client: simplify path handling: when creating things, pass the full
  path as one argument rather than a directory and a name. (#306, @talex5)

- server: Fix log-destination command-line arguments (#340, @samoht)
- server: improve named-pipe support (#333, by @simonferquel and @samoht)
- server: Catch top level Lwt.async exceptions (#327, @samoht)
- server: expose `Vfs.Logs` to expose the state of `Logs.Src` over 9p. This
  is used by datakit and datakit-bridge to expose `/debug` and let other
  datakit servers to easily do the same thing (#295, @samoht)
Pull-request generated by opam-publish v0.3.2