### PR TITLE
Add opam-lib 1.3.0

### DIFF
--- a/packages/mirror/mirror.0.0.1/opam
+++ b/packages/mirror/mirror.0.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "cmdliner"
   "cohttp" {>= "0.15.2"}
   "lwt" {>= "2.4.3"}
-  "opam-lib" {>= "1.2.0"}
+  "opam-lib" {>= "1.2.0" & < "1.3"}
   "tls"
   "lambda-term"
   "ocamlbuild" {build}

--- a/packages/odig/odig.0.0.1/opam
+++ b/packages/odig/odig.0.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner"
   "mtime"
   "webbrowser"
-  "opam-lib"
+  "opam-lib" {< "1.3"}
 ]
 depopts: []
 build: [

--- a/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/opam
+++ b/packages/opam-build-revdeps/opam-build-revdeps.0.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "jingoo" {build & >= "1.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
-  "opam-lib" {build & >= "1.2.2"}
+  "opam-lib" {build & = "1.2.2"}
   "re" {build & >= "1.7"}
   "uuidm" {build & >= "0.9.6"}
   "ocamlify" {build}

--- a/packages/opam-lib/opam-lib.1.3.0/descr
+++ b/packages/opam-lib/opam-lib.1.3.0/descr
@@ -1,0 +1,10 @@
+The OPAM library
+
+OPAM is The OCaml PAckage Manager. This package contains the OPAM
+libraries, that may be used by external tools to access OPAM
+installation, state and data.
+
+Note: this version does not correspond to a released version of opam, but has
+some improvements over the 1.2.2 opam-lib while retaining the compatibility with
+the ~/.opam format; later versions (2.0) are no longer compatible. This can be
+sused as a first step for migration.

--- a/packages/opam-lib/opam-lib.1.3.0/opam
+++ b/packages/opam-lib/opam-lib.1.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+homepage:     "https://opam.ocaml.org/"
+dev-repo:     "https://github.com/ocaml/opam.git"
+bug-reports:  "https://github.com/ocaml/opam/issues"
+authors: [
+   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+   "Anil Madhavapeddy   <anil@recoil.org>"
+   "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+   "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+   "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+   "Vincent Bernardoff  <vb@luminar.eu.org>"
+   "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+build: [
+  ["./configure"]
+  [make]
+  [make "-C" "src" "../opam-lib.install"]
+]
+depends: [
+  "ocamlgraph"
+  "cmdliner"
+  "dose3" {>= "5.0"}
+  "cudf"
+  "re" {>= "1.2.0"}
+  "ocamlfind" {build}
+  "jsonm"
+]

--- a/packages/opam-lib/opam-lib.1.3.0/url
+++ b/packages/opam-lib/opam-lib.1.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/1.3.0.tar.gz"
+checksum: "b73fa01ffc1a1bce3a9097d8fb519933"

--- a/packages/opamfu/opamfu.0.1.3/opam
+++ b/packages/opamfu/opamfu.0.1.3/opam
@@ -19,7 +19,7 @@ install: [
 remove: [[make "uninstall"]]
 depends: [
   "ocamlfind"
-  "opam-lib" { >= "1.2.1" }
+  "opam-lib" { >= "1.2.1" & < "1.3" }
   "uri" { >= "1.3.11" }
 ]
 depopts: ["cmdliner"]

--- a/packages/topkg-care/topkg-care.0.7.5/opam
+++ b/packages/topkg-care/topkg-care.0.7.5/opam
@@ -17,7 +17,7 @@ depends: [
   "logs"
   "bos"
   "cmdliner"
-  "opam-lib" {>= "1.2.2"}
+  "opam-lib" {= "1.2.2"}
 ]
 build:[[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/topkg-care/topkg-care.0.7.6/opam
+++ b/packages/topkg-care/topkg-care.0.7.6/opam
@@ -17,7 +17,7 @@ depends: [
   "logs"
   "bos"
   "cmdliner"
-  "opam-lib" {>= "1.2.2"}
+  "opam-lib" {= "1.2.2"}
 ]
 build:[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/topkg-care/topkg-care.0.7.7/opam
+++ b/packages/topkg-care/topkg-care.0.7.7/opam
@@ -17,7 +17,7 @@ depends: [
   "logs"
   "bos"
   "cmdliner"
-  "opam-lib" {>= "1.2.2"}
+  "opam-lib" {= "1.2.2"}
 ]
 build:[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/topkg-care/topkg-care.0.7.8/opam
+++ b/packages/topkg-care/topkg-care.0.7.8/opam
@@ -18,7 +18,7 @@ depends: [
   "bos"
   "cmdliner"
   "webbrowser"
-  "opam-lib" {>= "1.2.2"}
+  "opam-lib" {= "1.2.2"}
 ]
 build:[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/topkg-care/topkg-care.0.7.9/opam
+++ b/packages/topkg-care/topkg-care.0.7.9/opam
@@ -19,7 +19,7 @@ depends: [
   "bos"
   "cmdliner"
   "webbrowser"
-  "opam-lib" {>= "1.2.2"}
+  "opam-lib" {= "1.2.2"}
 ]
 build:[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/topkg-care/topkg-care.0.8.0/opam
+++ b/packages/topkg-care/topkg-care.0.8.0/opam
@@ -18,7 +18,7 @@ depends: [
   "bos"
   "cmdliner"
   "webbrowser"
-  "opam-lib" {>= "1.2.2"}
+  "opam-lib" {= "1.2.2"}
 ]
 build:[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/topkg-care/topkg-care.0.8.1/opam
+++ b/packages/topkg-care/topkg-care.0.8.1/opam
@@ -18,7 +18,7 @@ depends: [
   "bos"
   "cmdliner"
   "webbrowser"
-  "opam-lib" {>= "1.2.2"}
+  "opam-lib" {= "1.2.2"}
 ]
 build:[
   "ocaml" "pkg/pkg.ml" "build"


### PR DESCRIPTION
Hopefully this can be a first, easier step to migrate the tooling to
2.0; this version is still fully compatible with the 1.2.2 format
repository, but already has a few of the improvements of opam 2, and
e.g. a more complete opam lint.

This is intended to be the new base for the tooling (e.g. Camelus,
opam2web...) while the repository is still on opam 1.2.2; it will
also, later, be needed for the 2.0.0 to 1.2.2 format downgrade tool)