### PR TITLE
mirage-block-unix.2.4.0 needs at least mirage-types.2.3.0

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0"}
   "lwt" {>= "2.4.3"}
-  "mirage-types" {>= "1.1.0"}
+  "mirage-types" {>= "2.3.0"}
   "io-page" {>= "1.0.0"}
   "uri"
   "logs"


### PR DESCRIPTION
See #7841

Signed-off-by: David Scott <dave@recoil.org>