### PR TITLE
msgpack: Fix camlp4 patch

### DIFF
--- a/packages/msgpack/msgpack.1.0.0/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.0.0/files/no-camlp4.patch
@@ -11,3 +11,63 @@ index f3733a5..4a7bec5 100644
  
  # ------------------------------------------------------------
  # Flags
+diff --git a/setup.ml b/setup.ml
+index 26f0f36..2a51166 100644
+--- a/setup.ml
++++ b/setup.ml
+@@ -6991,8 +6991,7 @@ let setup_t =
+                            FindlibPackage ("extlib", None);
+                            FindlibPackage ("num", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7054,8 +7053,7 @@ let setup_t =
+                            FindlibPackage ("meta_conv", None);
+                            InternalLibrary "msgpack"
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7102,8 +7100,7 @@ let setup_t =
+                            InternalLibrary "msgpack";
+                            FindlibPackage ("oUnit", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7141,8 +7138,7 @@ let setup_t =
+                            FindlibPackage ("oUnit", None);
+                            FindlibPackage ("meta_conv.syntax", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7185,7 +7181,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_core"
+                         ]
+                    });
+@@ -7221,7 +7216,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_conv"
+                         ]
+                    });

--- a/packages/msgpack/msgpack.1.1.0/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.1.0/files/no-camlp4.patch
@@ -11,3 +11,63 @@ index f3733a5..4a7bec5 100644
  
  # ------------------------------------------------------------
  # Flags
+diff --git a/setup.ml b/setup.ml
+index 26f0f36..2a51166 100644
+--- a/setup.ml
++++ b/setup.ml
+@@ -6991,8 +6991,7 @@ let setup_t =
+                       bs_path = "lib/core";
+                       bs_compiled_object = Best;
+                       bs_build_depends = [FindlibPackage ("num", None)];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7054,8 +7053,7 @@ let setup_t =
+                            FindlibPackage ("meta_conv", None);
+                            InternalLibrary "msgpack"
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7102,8 +7100,7 @@ let setup_t =
+                            InternalLibrary "msgpack";
+                            FindlibPackage ("oUnit", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7141,8 +7138,7 @@ let setup_t =
+                            FindlibPackage ("oUnit", None);
+                            FindlibPackage ("meta_conv.syntax", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7185,7 +7181,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_core"
+                         ]
+                    });
+@@ -7221,7 +7216,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_conv"
+                         ]
+                    });

--- a/packages/msgpack/msgpack.1.1.1/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.1.1/files/no-camlp4.patch
@@ -11,3 +11,63 @@ index f3733a5..4a7bec5 100644
  
  # ------------------------------------------------------------
  # Flags
+diff --git a/setup.ml b/setup.ml
+index 26f0f36..2a51166 100644
+--- a/setup.ml
++++ b/setup.ml
+@@ -6991,8 +6991,7 @@ let setup_t =
+                       bs_path = "lib/core";
+                       bs_compiled_object = Best;
+                       bs_build_depends = [FindlibPackage ("num", None)];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7054,8 +7053,7 @@ let setup_t =
+                            FindlibPackage ("meta_conv", None);
+                            InternalLibrary "msgpack"
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7102,8 +7100,7 @@ let setup_t =
+                            InternalLibrary "msgpack";
+                            FindlibPackage ("oUnit", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7141,8 +7138,7 @@ let setup_t =
+                            FindlibPackage ("oUnit", None);
+                            FindlibPackage ("meta_conv.syntax", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7185,7 +7181,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_core"
+                         ]
+                    });
+@@ -7221,7 +7216,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_conv"
+                         ]
+                    });

--- a/packages/msgpack/msgpack.1.2.0/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.2.0/files/no-camlp4.patch
@@ -11,3 +11,63 @@ index f3733a5..4a7bec5 100644
  
  # ------------------------------------------------------------
  # Flags
+diff --git a/setup.ml b/setup.ml
+index 26f0f36..2a51166 100644
+--- a/setup.ml
++++ b/setup.ml
+@@ -6991,8 +6991,7 @@ let setup_t =
+                       bs_path = "lib/core";
+                       bs_compiled_object = Best;
+                       bs_build_depends = [FindlibPackage ("num", None)];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7054,8 +7053,7 @@ let setup_t =
+                            FindlibPackage ("meta_conv", None);
+                            InternalLibrary "msgpack"
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7102,8 +7100,7 @@ let setup_t =
+                            InternalLibrary "msgpack";
+                            FindlibPackage ("oUnit", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7141,8 +7138,7 @@ let setup_t =
+                            FindlibPackage ("oUnit", None);
+                            FindlibPackage ("meta_conv.syntax", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7185,7 +7181,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_core"
+                         ]
+                    });
+@@ -7221,7 +7216,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_conv"
+                         ]
+                    });

--- a/packages/msgpack/msgpack.1.2.1/files/no-camlp4.patch
+++ b/packages/msgpack/msgpack.1.2.1/files/no-camlp4.patch
@@ -11,3 +11,63 @@ index f3733a5..4a7bec5 100644
  
  # ------------------------------------------------------------
  # Flags
+diff --git a/setup.ml b/setup.ml
+index 26f0f36..2a51166 100644
+--- a/setup.ml
++++ b/setup.ml
+@@ -6991,8 +6991,7 @@ let setup_t =
+                       bs_path = "lib/core";
+                       bs_compiled_object = Best;
+                       bs_build_depends = [FindlibPackage ("num", None)];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7054,8 +7053,7 @@ let setup_t =
+                            FindlibPackage ("meta_conv", None);
+                            InternalLibrary "msgpack"
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7102,8 +7100,7 @@ let setup_t =
+                            InternalLibrary "msgpack";
+                            FindlibPackage ("oUnit", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7141,8 +7138,7 @@ let setup_t =
+                            FindlibPackage ("oUnit", None);
+                            FindlibPackage ("meta_conv.syntax", None)
+                         ];
+-                      bs_build_tools =
+-                        [ExternalTool "ocamlbuild"; ExternalTool "camlp4"];
++                      bs_build_tools = [ExternalTool "ocamlbuild"];
+                       bs_c_sources = [];
+                       bs_data_files = [];
+                       bs_ccopt = [(OASISExpr.EBool true, [])];
+@@ -7185,7 +7181,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_core"
+                         ]
+                    });
+@@ -7221,7 +7216,6 @@ let setup_t =
+                       test_tools =
+                         [
+                            ExternalTool "ocamlbuild";
+-                           ExternalTool "camlp4";
+                            InternalExecutable "test_conv"
+                         ]
+                    });


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/7836 I forgot to update the `setup.ml` so it didn't work as expected :(

I had tested that locally, I don't know why oasis was searching for `camlp4` outside the local opam switch: I tried on a fresh ocaml 4.03.0 switch but oasis found the camlp4 binary in the 4.02.3 switch…
cc @gildor478