### PR TITLE
Add {< 3.0.0} constraint for depends: mirage-types{-lwt} .

### DIFF
--- a/packages/channel/channel.1.1.1/opam
+++ b/packages/channel/channel.1.1.1/opam
@@ -7,12 +7,12 @@ license: "ISC"
 dev-repo: "https://github.com/mirage/mirage-channel.git"
 bug-reports: "https://github.com/mirage/mirage-channel/issues"
 tags: ["org:mirage"]
-available: [ ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build} 
-  "mirage-types-lwt"
+  "topkg" {build}
+  "mirage-types-lwt" {< "3.0.0"}
   "io-page"
   "lwt" {>= "2.4.7"}
   "cstruct"
@@ -21,7 +21,13 @@ depends: [
   "ounit" {test}
   "mirage-flow" {test}
 ]
-conflicts: [ "tcpip" {<"2.5.0"} ]
-depopts: []
-build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
-build-test: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+conflicts: [
+  "tcpip" {< "2.5.0"}
+]
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+]
+build-test: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+]

--- a/packages/fat-filesystem/fat-filesystem.0.10.3/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.10.3/opam
@@ -16,8 +16,8 @@ remove: [
 depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3" & <"2.6.0"}
-  "mirage-types" {>= "1.1.0"}
+  "lwt" {>= "2.4.3" & < "2.6.0"}
+  "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "mirage-block-unix" {>= "1.2.0"}
   "io-page" {>= "1.4.0"}
   "re"

--- a/packages/fat-filesystem/fat-filesystem.0.11.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.11.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "2.0.0"}
   "ppx_tools"
-  "lwt" {>= "2.4.3" & <"2.6.0"}
-  "mirage-types" {>= "2.6.1"}
+  "lwt" {>= "2.4.3" & < "2.6.0"}
+  "mirage-types" {>= "2.6.1" & < "3.0.0"}
   "mirage-block-unix" {>= "1.2.0"}
   "io-page" {>= "1.6.1"}
   "re"

--- a/packages/mbr-format/mbr-format.0.3/opam
+++ b/packages/mbr-format/mbr-format.0.3/opam
@@ -7,16 +7,16 @@ remove: [
 depends: [
   "ocamlfind"
   "lwt"
-  "cstruct" {>="1.0.1" & <"2.0.0"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ounit"
   "re"
-  "mirage-types"
+  "mirage-types" {< "3.0.0"}
   "ipaddr"
   "io-page"
   "cmdliner"
   "ocamlbuild" {build}
 ]
-tags: [ "org:mirage" ]
+tags: ["org:mirage"]
 dev-repo: "git://github.com/mirage/ocaml-mbr"
 available: ocaml-version >= "4.01.0"
 install: [make "install" "BINDIR=%{bin}%"]

--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.1/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.1/opam
@@ -2,33 +2,27 @@ opam-version: "1.2"
 name: "mirage-block-ramdisk"
 maintainer: "dave@recoil.org"
 version: "0.1"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block-ramdisk"
 dev-repo: "https://github.com/mirage/mirage-block-ramdisk.git"
 bug-reports: "https://github.com/mirage/mirage-block-ramdisk/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [["ocamlfind" "remove" "mirage-block-ramdisk"]]
-
+remove: [
+  ["ocamlfind" "remove" "mirage-block-ramdisk"]
+]
 depends: [
   "base-bytes"
   "cstruct"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "ocamlfind" {build}
   "oasis" {build}
   "ocamlbuild" {build}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.2/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.2/opam
@@ -1,33 +1,27 @@
 opam-version: "1.2"
 name: "mirage-block-ramdisk"
 maintainer: "dave@recoil.org"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block-ramdisk"
 dev-repo: "https://github.com/mirage/mirage-block-ramdisk.git"
 bug-reports: "https://github.com/mirage/mirage-block-ramdisk/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [["ocamlfind" "remove" "mirage-block-ramdisk"]]
-
+remove: [
+  ["ocamlfind" "remove" "mirage-block-ramdisk"]
+]
 depends: [
   "base-bytes"
   "cstruct"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "ocamlfind" {build}
   "oasis" {build}
   "ocamlbuild" {build}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
@@ -1,20 +1,23 @@
 opam-version: "1.2"
-maintainer:   "martin@lucina.net"
-homepage:     "https://github.com/mirage/mirage-block-solo5"
-dev-repo:     "https://github.com/mirage/mirage-block-solo5.git"
-bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
-authors:      "Dan Williams <djwllia@us.ibm.com>"
-tags: [
-  "org:mirage"
+maintainer: "martin@lucina.net"
+homepage: "https://github.com/mirage/mirage-block-solo5"
+dev-repo: "https://github.com/mirage/mirage-block-solo5.git"
+bug-reports: "https://github.com/mirage/mirage-block-solo5/issues"
+authors: "Dan Williams <djwllia@us.ibm.com>"
+tags: ["org:mirage"]
+build: [
+  [make]
 ]
-build: [ [make] ]
-install: [ [make "install" "BINDIR=%{bin}%"] ]
-remove: [ [make "uninstall" "BINDIR=%{bin}%"] ]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  [make "uninstall" "BINDIR=%{bin}%"]
+]
 depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
-  "mirage-types" {>= "1.1.0"}
+  "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "mirage-solo5"
-  
 ]

--- a/packages/mirage-block-xen/mirage-block-xen.1.3.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.3.1/opam
@@ -1,21 +1,20 @@
 opam-version: "1.2"
-maintainer:   "dave@recoil.org"
-homepage:     "https://github.com/mirage/mirage-block-xen"
-dev-repo:     "https://github.com/mirage/mirage-block-xen.git"
-bug-reports:  "https://github.com/mirage/mirage-block-xen/issues"
-authors: [
-  "Anil Madhavapeddy"
-  "David Scott"
-  "Thomas Leonard"
-]
+maintainer: "dave@recoil.org"
+homepage: "https://github.com/mirage/mirage-block-xen"
+dev-repo: "https://github.com/mirage/mirage-block-xen.git"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
 license: "ISC"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
+tags: ["org:mirage" "org:xapi-project"]
+build: [
+  [make]
 ]
-build: [ [make] ]
-install: [ [make "install" "BINDIR=%{bin}%"] ]
-remove: [ [make "uninstall" "BINDIR=%{bin}%"] ]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  [make "uninstall" "BINDIR=%{bin}%"]
+]
 depends: [
   "ocamlfind"
   "cmdliner"
@@ -23,10 +22,10 @@ depends: [
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"
   "shared-memory-ring" {>= "0.4.1"}
-  "mirage-types" {>= "1.1.0"}
+  "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}
   "mirage-xen" {>= "1.0.1"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & os = "linux" ]
+available: [ocaml-version >= "4.00.0" & os = "linux"]

--- a/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
@@ -1,21 +1,20 @@
 opam-version: "1.2"
-maintainer:   "dave@recoil.org"
-homepage:     "https://github.com/mirage/mirage-block-xen"
-dev-repo:     "https://github.com/mirage/mirage-block-xen.git"
-bug-reports:  "https://github.com/mirage/mirage-block-xen/issues"
-authors: [
-  "Anil Madhavapeddy"
-  "David Scott"
-  "Thomas Leonard"
-]
+maintainer: "dave@recoil.org"
+homepage: "https://github.com/mirage/mirage-block-xen"
+dev-repo: "https://github.com/mirage/mirage-block-xen.git"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
 license: "ISC"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
+tags: ["org:mirage" "org:xapi-project"]
+build: [
+  [make]
 ]
-build: [ [make] ]
-install: [ [make "install" "BINDIR=%{bin}%"] ]
-remove: [ [make "uninstall" "BINDIR=%{bin}%"] ]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  [make "uninstall" "BINDIR=%{bin}%"]
+]
 depends: [
   "ocamlfind"
   "cmdliner"
@@ -25,11 +24,9 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
   "shared-memory-ring" {>= "0.4.1"}
-  "mirage-types" {>= "1.1.0"}
+  "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}
-  "mirage-xen" {>= "1.0.1" }
+  "mirage-xen" {>= "1.0.1"}
 ]
-available: [
-  ocaml-version >= "4.02.0" & os = "linux"
-]
+available: [ocaml-version >= "4.02.0" & os = "linux"]

--- a/packages/mirage-block/mirage-block.0.1/opam
+++ b/packages/mirage-block/mirage-block.0.1/opam
@@ -2,28 +2,23 @@ opam-version: "1.2"
 name: "mirage-block"
 maintainer: "dave@recoil.org"
 version: "0.1"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block"
 dev-repo: "https://github.com/mirage/mirage-block.git"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [["ocamlfind" "remove" "mirage-block"]]
-
+remove: [
+  ["ocamlfind" "remove" "mirage-block"]
+]
 depends: [
   "base-bytes"
   "cstruct"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "ocamlfind" {build}
   "oasis" {build}
@@ -32,11 +27,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-block/mirage-block.0.2/opam
+++ b/packages/mirage-block/mirage-block.0.2/opam
@@ -2,28 +2,23 @@ opam-version: "1.2"
 name: "mirage-block"
 maintainer: "dave@recoil.org"
 version: "0.2"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block"
 dev-repo: "https://github.com/mirage/mirage-block.git"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [["ocamlfind" "remove" "mirage-block"]]
-
+remove: [
+  ["ocamlfind" "remove" "mirage-block"]
+]
 depends: [
   "base-bytes"
   "cstruct"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "ocamlfind" {build}
   "oasis" {build}
@@ -32,11 +27,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.0.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.0.0/opam
@@ -1,14 +1,11 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [make "unix-build"]
 remove: ["ocamlfind" "remove" "mirage-clock-unix"]
 depends: [
   "ocamlfind"
-  "mirage-types" {>= "0.3.0"}
+  "mirage-types" {>= "0.3.0" & < "3.0.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-clock"
 install: [make "unix-install"]

--- a/packages/mirage-clock-xen/mirage-clock-xen.1.0.0/opam
+++ b/packages/mirage-clock-xen/mirage-clock-xen.1.0.0/opam
@@ -1,14 +1,13 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [make "xen-build"]
-remove: [["ocamlfind" "remove" "mirage-clock-xen"]]
+remove: [
+  ["ocamlfind" "remove" "mirage-clock-xen"]
+]
 depends: [
   "ocamlfind"
-  "mirage-types" {>="0.3.0"}
+  "mirage-types" {>= "0.3.0" & < "3.0.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-clock"
 install: [make "xen-install"]

--- a/packages/mirage-clock-xen/mirage-clock-xen.1.1/opam
+++ b/packages/mirage-clock-xen/mirage-clock-xen.1.1/opam
@@ -3,15 +3,12 @@ authors: "The MirageOS team"
 maintainer: "anil@recoil.org"
 homepage: "https://github.com/mirage/mirage-clock"
 bug-reports: "https://github.com/mirage/mirage-clock/issues"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [make "xen-build"]
 install: [make "xen-install"]
 remove: ["ocamlfind" "remove" "mirage-clock-xen"]
 depends: [
   "ocamlfind"
-  "mirage-types" {>= "0.3.0"}
+  "mirage-types" {>= "0.3.0" & < "3.0.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-clock"

--- a/packages/mirage-conduit/mirage-conduit.2.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.0.0/opam
@@ -1,17 +1,15 @@
 opam-version: "1"
 version: "2.0.0"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-]
+tags: ["org:mirage"]
 build: [
- [ "ocamlfind" "query" "conduit.mirage" ]
+  ["ocamlfind" "query" "conduit.mirage"]
 ]
 depends: [
-  "mirage-types" {>="2.0.0"}
-  "mirage-dns" {>="2.0.0"}
+  "mirage-types" {>= "2.0.0" & < "3.0.0"}
+  "mirage-dns" {>= "2.0.0"}
   "tcpip"
   "vchan"
-  "conduit" {="0.7.2"}
+  "conduit" {= "0.7.2"}
 ]
-ocaml-version: [>="4.01.0"]
+ocaml-version: [>= "4.01.0"]

--- a/packages/mirage-conduit/mirage-conduit.2.1.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.1.0/opam
@@ -1,20 +1,19 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
-authors:      ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
-homepage:     "https://github.com/mirage/ocaml-conduit"
-dev-repo:     "https://github.com/mirage/ocaml-conduit.git"
-bug-reports:  "https://github.com/mirage/ocaml-conduit/issues"
-tags:         "org:mirage"
-
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+homepage: "https://github.com/mirage/ocaml-conduit"
+dev-repo: "https://github.com/mirage/ocaml-conduit.git"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+tags: "org:mirage"
 build: [
- [ "ocamlfind" "query" "conduit.mirage" ]
+  ["ocamlfind" "query" "conduit.mirage"]
 ]
 depends: [
-  "mirage-types" {>="2.0.0"}
-  "mirage-dns" {>="2.0.0"}
+  "mirage-types" {>= "2.0.0" & < "3.0.0"}
+  "mirage-dns" {>= "2.0.0"}
   "tcpip"
   "vchan"
-  "conduit" {>="0.8.0"}
+  "conduit" {>= "0.8.0"}
   "tls" {>= "0.4.0"}
 ]
-available: [ocaml-version >="4.01.0"]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-conduit/mirage-conduit.2.2.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.2.0/opam
@@ -1,23 +1,19 @@
 opam-version: "1.2"
-maintainer:   "anil@recoil.org"
-authors:      ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
-homepage:     "https://github.com/mirage/ocaml-conduit"
-dev-repo:     "https://github.com/mirage/ocaml-conduit.git"
-bug-reports:  "https://github.com/mirage/ocaml-conduit/issues"
-tags:         "org:mirage"
-license:      "ISC"
-
-build:   ["ocamlfind" "query" "conduit.mirage"]
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+homepage: "https://github.com/mirage/ocaml-conduit"
+dev-repo: "https://github.com/mirage/ocaml-conduit.git"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+tags: "org:mirage"
+license: "ISC"
+build: ["ocamlfind" "query" "conduit.mirage"]
 depends: [
-  "mirage-types-lwt" {>= "2.3.0"}
+  "mirage-types-lwt" {>= "2.3.0" & < "3.0.0"}
   "mirage-dns" {>= "2.0.0"}
-  "conduit"    {>= "0.8.4"}
+  "conduit" {>= "0.8.4"}
 ]
-depopts: [
-  "vchan"
-  "tls"
-]
+depopts: ["vchan" "tls"]
 conflicts: [
   "tls" {< "0.5.0"}
 ]
-available: [ocaml-version >="4.01.0"]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/opam
@@ -1,28 +1,23 @@
 opam-version: "1.2"
-maintainer:    "martin@lucina.net"
-homepage:      "https://github.com/mirage/mirage-console-solo5"
-bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
-dev-repo:      "https://github.com/mirage/mirage-console-solo5.git"
-license:       "ISC"
+maintainer: "martin@lucina.net"
+homepage: "https://github.com/mirage/mirage-console-solo5"
+bug-reports: "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo: "https://github.com/mirage/mirage-console-solo5.git"
+license: "ISC"
 authors: [
   "Anil Madhavapeddy <anil@recoil.org>"
   "Dan Williams <djwillia@us.ibm.com>"
   "Martin Lucina <martin@lucina.net>"
 ]
-tags: [
-  "org:mirage"
-]
-build: [make
-         "PREFIX=%{prefix}%" ]
+tags: ["org:mirage"]
+build: [make "PREFIX=%{prefix}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["ocamlfind" "remove" "mirage-console-solo5"]
 depends: [
   "ocamlfind" {build}
   "mirage-console"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "mirage-solo5"
 ]
-depopts: [
-]
-conflicts: [
-]
+
+

--- a/packages/mirage-console/mirage-console.2.0.0/opam
+++ b/packages/mirage-console/mirage-console.2.0.0/opam
@@ -1,16 +1,13 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: make
 remove: [
   ["ocamlfind" "remove" "mirage-console"]
 ]
 depends: [
   "ocamlfind"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-console/mirage-console.2.0.0/opam
+++ b/packages/mirage-console/mirage-console.2.0.0/opam
@@ -7,7 +7,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types-lwt" {< "2.3.0" & >= "2.0.0"}
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-console/mirage-console.2.1.0/opam
+++ b/packages/mirage-console/mirage-console.2.1.0/opam
@@ -1,16 +1,13 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: make
 remove: [
   ["ocamlfind" "remove" "mirage-console"]
 ]
 depends: [
   "ocamlfind"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-console/mirage-console.2.1.1/opam
+++ b/packages/mirage-console/mirage-console.2.1.1/opam
@@ -1,16 +1,13 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: make
 remove: [
   ["ocamlfind" "remove" "mirage-console"]
 ]
 depends: [
   "ocamlfind"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-console/mirage-console.2.1.2/opam
+++ b/packages/mirage-console/mirage-console.2.1.2/opam
@@ -1,26 +1,22 @@
 opam-version: "1.2"
-maintainer:    "anil@recoil.org"
-homepage:      "https://github.com/mirage/mirage-console"
-bug-reports:   "https://github.com/mirage/mirage-console/issues"
-dev-repo:      "https://github.com/mirage/mirage-console.git"
-authors: [
-  "Anil Madhavapeddy"
-  "David Scott"
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-console"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+dev-repo: "https://github.com/mirage/mirage-console.git"
+authors: ["Anil Madhavapeddy" "David Scott"]
+tags: ["org:mirage" "org:xapi-project"]
+build: [
+  make
+  "PREFIX=%{prefix}%"
+  "ENABLE_MIRAGE_XEN=--%{mirage-xen+xenstore+xen-gnt+xen-evtchn:enable}%-miragexen"
+  "ENABLE_XEN=--%{shared-memory-ring+xen-gnt+xen-evtchn+xenstore+xenstore_transport:enable}%-xen"
+  "ENABLE_UNIX=--enable-unix"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
-build: [make
-         "PREFIX=%{prefix}%"
-         "ENABLE_MIRAGE_XEN=--%{mirage-xen+xenstore+xen-gnt+xen-evtchn:enable}%-miragexen"
-         "ENABLE_XEN=--%{shared-memory-ring+xen-gnt+xen-evtchn+xenstore+xenstore_transport:enable}%-xen" 
-         "ENABLE_UNIX=--enable-unix" ]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["ocamlfind" "remove" "mirage-console"]
 depends: [
   "ocamlfind" {build}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "cmdliner"
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
@@ -35,5 +31,5 @@ depopts: [
   "xenstore_transport"
 ]
 conflicts: [
-  "mirage-xen" { <"1.1.0" }
+  "mirage-xen" {< "1.1.0"}
 ]

--- a/packages/mirage-console/mirage-console.2.1.3/opam
+++ b/packages/mirage-console/mirage-console.2.1.3/opam
@@ -1,26 +1,22 @@
 opam-version: "1.2"
-maintainer:    "anil@recoil.org"
-homepage:      "https://github.com/mirage/mirage-console"
-bug-reports:   "https://github.com/mirage/mirage-console/issues"
-dev-repo:      "https://github.com/mirage/mirage-console.git"
-authors: [
-  "Anil Madhavapeddy"
-  "David Scott"
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-console"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+dev-repo: "https://github.com/mirage/mirage-console.git"
+authors: ["Anil Madhavapeddy" "David Scott"]
+tags: ["org:mirage" "org:xapi-project"]
+build: [
+  make
+  "PREFIX=%{prefix}%"
+  "ENABLE_MIRAGE_XEN=--%{mirage-xen+xenstore+xen-gnt+xen-evtchn:enable}%-miragexen"
+  "ENABLE_XEN=--%{shared-memory-ring+xen-gnt+xen-evtchn+xenstore+xenstore_transport:enable}%-xen"
+  "ENABLE_XENCTRL=--%{xenctrl+xen-evtchn+xen-gnt:enable}%-xenctrl"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
-build: [make
-         "PREFIX=%{prefix}%"
-         "ENABLE_MIRAGE_XEN=--%{mirage-xen+xenstore+xen-gnt+xen-evtchn:enable}%-miragexen"
-         "ENABLE_XEN=--%{shared-memory-ring+xen-gnt+xen-evtchn+xenstore+xenstore_transport:enable}%-xen" 
-         "ENABLE_XENCTRL=--%{xenctrl+xen-evtchn+xen-gnt:enable}%-xenctrl" ]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["ocamlfind" "remove" "mirage-console"]
 depends: [
   "ocamlfind" {build}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "cmdliner"
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
@@ -35,5 +31,5 @@ depopts: [
   "xenstore_transport"
 ]
 conflicts: [
-  "mirage-xen" { <"1.1.0" }
+  "mirage-xen" {< "1.1.0"}
 ]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.1.4/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.1.4/opam
@@ -1,18 +1,22 @@
 opam-version: "1.2"
-authors: [ "Anil Madhavapeddy <anil@recoil.org>" ]
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
 maintainer: "anil@recoil.org"
-homepage:     "https://github.com/mirage/mirage-fs-unix"
-dev-repo:     "https://github.com/mirage/mirage-fs-unix.git"
-bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
-tags: [ "org:mirage" ]
-build: [ [make] ]
-install: [ [make "install"] ]
+homepage: "https://github.com/mirage/mirage-fs-unix"
+dev-repo: "https://github.com/mirage/mirage-fs-unix.git"
+bug-reports: "https://github.com/mirage/mirage-fs-unix/issues"
+tags: ["org:mirage"]
+build: [
+  [make]
+]
+install: [
+  [make "install"]
+]
 remove: ["ocamlfind" "remove" "mirage-fs-unix"]
 depends: [
   "ocamlfind" {build}
   "camlp4"
   "cstruct" {>= "1.4.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
@@ -1,29 +1,30 @@
 opam-version: "1.2"
-authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
-                "Thomas Gazagnaire" ]
-maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org"]
-homepage:     "https://github.com/mirage/mirage-fs-unix"
-dev-repo:     "https://github.com/mirage/mirage-fs-unix.git"
-bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
-tags: [ "org:mirage" ]
+authors: [
+  "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy" "Thomas Gazagnaire"
+]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+homepage: "https://github.com/mirage/mirage-fs-unix"
+dev-repo: "https://github.com/mirage/mirage-fs-unix.git"
+bug-reports: "https://github.com/mirage/mirage-fs-unix/issues"
+tags: ["org:mirage"]
 build: [
   ["./configure" "--prefix" prefix]
   [make]
 ]
 build-test: [
   ["./configure" "--prefix" prefix "--enable-tests"]
-  [make "test" ]
+  [make "test"]
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-fs-unix"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.4.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "camlp4"
   "mirage-clock-unix" {test}
   "alcotest" {test}
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.2.1/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.2.1/opam
@@ -1,27 +1,28 @@
 opam-version: "1.2"
-authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
-                "Thomas Gazagnaire" ]
-maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org"]
-homepage:     "https://github.com/mirage/mirage-fs-unix"
-dev-repo:     "https://github.com/mirage/mirage-fs-unix.git"
-bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
-tags: [ "org:mirage" ]
+authors: [
+  "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy" "Thomas Gazagnaire"
+]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+homepage: "https://github.com/mirage/mirage-fs-unix"
+dev-repo: "https://github.com/mirage/mirage-fs-unix.git"
+bug-reports: "https://github.com/mirage/mirage-fs-unix/issues"
+tags: ["org:mirage"]
 build: [
   ["./configure" "--prefix" prefix]
   [make]
 ]
 build-test: [
   ["./configure" "--prefix" prefix "--enable-tests"]
-  [make "test" ]
+  [make "test"]
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-fs-unix"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.4.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "mirage-clock-unix" {test}
-  "alcotest"          {test}
-  "ounit"             {test}
+  "alcotest" {test}
+  "ounit" {test}
 ]
-available: [ ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/mirage-logs/mirage-logs.0.1/opam
+++ b/packages/mirage-logs/mirage-logs.0.1/opam
@@ -1,30 +1,24 @@
 opam-version: "1.2"
 maintainer: "talex5@gmail.com"
-authors: [ "Thomas Leonard" ]
+authors: ["Thomas Leonard"]
 license: "ISC"
 homepage: "https://github.com/talex5/mirage-logs"
 dev-repo: "https://github.com/talex5/mirage-logs.git"
 bug-reports: "https://github.com/talex5/mirage-logs/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [["ocamlfind" "remove" "mirage-logs"]]
-
+remove: [
+  ["ocamlfind" "remove" "mirage-logs"]
+]
 depends: [
-  "logs" { >= "0.5.0" }
+  "logs" {>= "0.5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "mirage-types"
+  "mirage-types" {< "3.0.0"}
   "mirage-profile"
   "lwt"
 ]
-
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage/mirage.2.0.0/opam
+++ b/packages/mirage/mirage.2.0.0/opam
@@ -1,18 +1,9 @@
 opam-version: "1.2"
-maintainer: [
-  "anil@recoil.org"
-  "thomas@gazagnaire.org"
-]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors: [
-  "Anil Madhavapeddy"
-  "Thomas Gazagnaire"
-  "Dave Scott"
-  "Richard Mortier"
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -23,7 +14,7 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.0.0"}
+  "mirage-types" {>= "2.0.0" & < "3.0.0"}
   "re" {>= "1.2.1"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage/mirage.2.0.1/opam
+++ b/packages/mirage/mirage.2.0.1/opam
@@ -1,18 +1,9 @@
 opam-version: "1.2"
-maintainer: [
-  "anil@recoil.org"
-  "thomas@gazagnaire.org"
-]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors: [
-  "Anil Madhavapeddy"
-  "Thomas Gazagnaire"
-  "Dave Scott"
-  "Richard Mortier"
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -23,7 +14,7 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.0.1"}
+  "mirage-types" {>= "2.0.1" & < "3.0.0"}
   "re" {>= "1.2.1"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage/mirage.2.1.0/opam
+++ b/packages/mirage/mirage.2.1.0/opam
@@ -1,18 +1,9 @@
 opam-version: "1.2"
-maintainer: [
-  "anil@recoil.org"
-  "thomas@gazagnaire.org"
-]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors: [
-  "Anil Madhavapeddy"
-  "Thomas Gazagnaire"
-  "Dave Scott"
-  "Richard Mortier"
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -23,7 +14,7 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.1.0"}
+  "mirage-types" {>= "2.1.0" & < "3.0.0"}
   "re" {>= "1.2.1"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage/mirage.2.1.1/opam
+++ b/packages/mirage/mirage.2.1.1/opam
@@ -1,18 +1,9 @@
 opam-version: "1.2"
-maintainer: [
-  "anil@recoil.org"
-  "thomas@gazagnaire.org"
-]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors: [
-  "Anil Madhavapeddy"
-  "Thomas Gazagnaire"
-  "Dave Scott"
-  "Richard Mortier"
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -23,7 +14,7 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.1.1"}
+  "mirage-types" {>= "2.1.1" & < "3.0.0"}
   "re" {>= "1.2.1"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage/mirage.2.2.1/opam
+++ b/packages/mirage/mirage.2.2.1/opam
@@ -1,18 +1,9 @@
 opam-version: "1.2"
-maintainer: [
-  "anil@recoil.org"
-  "thomas@gazagnaire.org"
-]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors: [
-  "Anil Madhavapeddy"
-  "Thomas Gazagnaire"
-  "Dave Scott"
-  "Richard Mortier"
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -23,7 +14,7 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.2.0"}
+  "mirage-types" {>= "2.2.0" & < "3.0.0"}
   "re" {>= "1.2.1"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage/mirage.2.3.0/opam
+++ b/packages/mirage/mirage.2.3.0/opam
@@ -1,18 +1,9 @@
 opam-version: "1.2"
-maintainer: [
-  "anil@recoil.org"
-  "thomas@gazagnaire.org"
-]
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors: [
-  "Anil Madhavapeddy"
-  "Thomas Gazagnaire"
-  "Dave Scott"
-  "Richard Mortier"
+  "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -23,7 +14,7 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.3.0"}
+  "mirage-types" {>= "2.3.0" & < "3.0.0"}
   "re" {>= "1.2.1"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage/mirage.2.4.0/opam
+++ b/packages/mirage/mirage.2.4.0/opam
@@ -1,13 +1,12 @@
 opam-version: "1.2"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
-authors:      [
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
   "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-homepage:     "https://mirage.io"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
-dev-repo:     "https://github.com/mirage/mirage.git"
-tags:         ["org:mirage" "org:xapi-project"]
-
+homepage: "https://mirage.io"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+dev-repo: "https://github.com/mirage/mirage.git"
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -17,9 +16,8 @@ remove: [
   ["rm" "-f" "%{bin}%/mirage"]
   ["ocamlfind" "remove" "mirage"]
 ]
-
 depends: [
-  "mirage-types-lwt" {>= "2.3.0"}
+  "mirage-types-lwt" {>= "2.3.0" & < "3.0.0"}
   "ipaddr" {>= "1.0.0"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage/mirage.2.5.0/opam
+++ b/packages/mirage/mirage.2.5.0/opam
@@ -1,13 +1,12 @@
 opam-version: "1.2"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
-authors:      [
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
   "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-homepage:     "https://mirage.io"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
-dev-repo:     "https://github.com/mirage/mirage.git"
-tags:         ["org:mirage" "org:xapi-project"]
-
+homepage: "https://mirage.io"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+dev-repo: "https://github.com/mirage/mirage.git"
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -18,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
 depends: [
-  "mirage-types-lwt" {>= "2.3.0"}
+  "mirage-types-lwt" {>= "2.3.0" & < "3.0.0"}
   "ipaddr" {>= "1.0.0"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}
@@ -27,6 +26,6 @@ depends: [
 conflicts: [
   "mirage-conduit" {< "2.2.0"}
   "nocrypto" {< "0.4.0"}
-  "crunch"   {< "1.2.2"}
+  "crunch" {< "1.2.2"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage/mirage.2.6.0/opam
+++ b/packages/mirage/mirage.2.6.0/opam
@@ -1,13 +1,12 @@
 opam-version: "1.2"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
-authors:      [
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
   "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-homepage:     "https://mirage.io"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
-dev-repo:     "https://github.com/mirage/mirage.git"
-tags:         ["org:mirage" "org:xapi-project"]
-
+homepage: "https://mirage.io"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+dev-repo: "https://github.com/mirage/mirage.git"
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -19,16 +18,16 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.6.0"}
+  "mirage-types" {>= "2.6.0" & < "3.0.0"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "ocamlbuild" {build}
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage/mirage.2.6.1/opam
+++ b/packages/mirage/mirage.2.6.1/opam
@@ -1,13 +1,12 @@
 opam-version: "1.2"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
-authors:      [
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
   "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-homepage:     "https://mirage.io"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
-dev-repo:     "https://github.com/mirage/mirage.git"
-tags:         ["org:mirage" "org:xapi-project"]
-
+homepage: "https://mirage.io"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+dev-repo: "https://github.com/mirage/mirage.git"
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
@@ -19,16 +18,16 @@ remove: [
 ]
 depends: [
   "ipaddr" {>= "1.0.0"}
-  "mirage-types" {>= "2.6.0"}
+  "mirage-types" {>= "2.6.0" & < "3.0.0"}
   "cmdliner" {>= "0.9.2"}
   "lwt" {>= "2.4.3"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "ocamlbuild" {build}
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage/mirage.2.7.3/opam
+++ b/packages/mirage/mirage.2.7.3/opam
@@ -1,18 +1,14 @@
 opam-version: "1.2"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
-authors:      [
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
   "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-homepage:     "https://mirage.io/"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
-dev-repo:     "https://github.com/mirage/mirage.git"
-tags:         ["org:mirage" "org:xapi-project"]
-
+homepage: "https://mirage.io/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+dev-repo: "https://github.com/mirage/mirage.git"
+tags: ["org:mirage" "org:xapi-project"]
 build: [
-  ["ocaml" "setup.ml" "-configure"
-   "--prefix" prefix
-   "--bindir" bin
-  ]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--bindir" bin]
   [make]
 ]
 install: [make "install"]
@@ -21,16 +17,16 @@ remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
 depends: [
-  "mirage-types-lwt"
-  "mirage-types" {>= "2.6.0"}
-  "ipaddr"       {>= "2.6.0"}
-  "functoria"    {=  "1.0.0"}
+  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types" {>= "2.6.0" & < "3.0.0"}
+  "ipaddr" {>= "2.6.0"}
+  "functoria" {= "1.0.0"}
   "astring"
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage/mirage.2.8.0/opam
+++ b/packages/mirage/mirage.2.8.0/opam
@@ -1,18 +1,14 @@
 opam-version: "1.2"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
-authors:      [
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
   "Anil Madhavapeddy" "Thomas Gazagnaire" "Dave Scott" "Richard Mortier"
 ]
-homepage:     "https://mirage.io/"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
-dev-repo:     "https://github.com/mirage/mirage.git"
-tags:         ["org:mirage" "org:xapi-project"]
-
+homepage: "https://mirage.io/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+dev-repo: "https://github.com/mirage/mirage.git"
+tags: ["org:mirage" "org:xapi-project"]
 build: [
-  ["ocaml" "setup.ml" "-configure"
-   "--prefix" prefix
-   "--bindir" bin
-  ]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--bindir" bin]
   [make]
 ]
 install: [make "install"]
@@ -21,16 +17,16 @@ remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
 depends: [
-  "mirage-types-lwt"
-  "mirage-types" {>= "2.8.0"}
-  "ipaddr"       {>= "2.6.0"}
-  "functoria"    {=  "1.0.0"}
+  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types" {>= "2.8.0" & < "3.0.0"}
+  "ipaddr" {>= "2.6.0"}
+  "functoria" {= "1.0.0"}
   "astring"
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/mirage/mirage.2.9.0/opam
+++ b/packages/mirage/mirage.2.9.0/opam
@@ -17,8 +17,8 @@ remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
 depends: [
-  "mirage-types-lwt"
-  "mirage-types" {>= "2.8.0"}
+  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types" {>= "2.8.0" & < "3.0.0"}
   "ipaddr" {>= "2.6.0"}
   "functoria" {>= "1.1.0"}
   "astring"

--- a/packages/mirage/mirage.2.9.1/opam
+++ b/packages/mirage/mirage.2.9.1/opam
@@ -17,8 +17,8 @@ remove: [
   ["ocamlfind" "remove" "mirage"]
 ]
 depends: [
-  "mirage-types-lwt"
-  "mirage-types" {>= "2.8.0"}
+  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types" {>= "2.8.0" & < "3.0.0"}
   "ipaddr" {>= "2.6.0"}
   "functoria" {>= "1.1.0"}
   "astring"

--- a/packages/qcow-format/qcow-format.0.1/opam
+++ b/packages/qcow-format/qcow-format.0.1/opam
@@ -2,29 +2,24 @@ opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
 version: "0.1"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [[make "PREFIX=%{prefix}%" "uninstall"]]
-
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
 depends: [
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "mirage-block" {>= "0.2"}
   "mirage-block-unix" {>= "2.1.0"}
@@ -37,11 +32,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/qcow-format/qcow-format.0.2/opam
+++ b/packages/qcow-format/qcow-format.0.2/opam
@@ -2,34 +2,29 @@ opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
 version: "0.2"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [[make "PREFIX=%{prefix}%" "uninstall"]]
-
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
 depends: [
   "camlp4"
   "type_conv"
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
-  "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" }
+  "mirage-block" {>= "0.2"}
+  "mirage-block-unix" {>= "2.1.0"}
   "cmdliner"
   "sexplib" {< "113.24.00"}
   "ocamlfind" {build}
@@ -40,11 +35,9 @@ depends: [
   "nbd" {test & >= "2.0.1"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/qcow-format/qcow-format.0.3/opam
+++ b/packages/qcow-format/qcow-format.0.3/opam
@@ -1,32 +1,27 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [[make "PREFIX=%{prefix}%" "uninstall"]]
-
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
 depends: [
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
-  "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" }
+  "mirage-block" {>= "0.2"}
+  "mirage-block-unix" {>= "2.1.0"}
   "cmdliner"
   "sexplib"
   "ocamlfind" {build}
@@ -38,11 +33,9 @@ depends: [
   "nbd" {test & >= "2.0.1"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/qcow-format/qcow-format.0.4.1/opam
+++ b/packages/qcow-format/qcow-format.0.4.1/opam
@@ -1,32 +1,27 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [[make "PREFIX=%{prefix}%" "uninstall"]]
-
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
 depends: [
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
-  "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" & < "2.4.0" }
+  "mirage-block" {>= "0.2"}
+  "mirage-block-unix" {>= "2.1.0" & < "2.4.0"}
   "cmdliner"
   "sexplib"
   "logs"
@@ -43,11 +38,9 @@ depends: [
   "nbd" {test & >= "2.0.1"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/qcow-format/qcow-format.0.4.2/opam
+++ b/packages/qcow-format/qcow-format.0.4.2/opam
@@ -1,32 +1,27 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [[make "PREFIX=%{prefix}%" "uninstall"]]
-
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
 depends: [
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
-  "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" }
+  "mirage-block" {>= "0.2"}
+  "mirage-block-unix" {>= "2.1.0"}
   "cmdliner"
   "sexplib"
   "logs"
@@ -43,11 +38,9 @@ depends: [
   "nbd" {test & >= "2.0.1"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/qcow-format/qcow-format.0.4/opam
+++ b/packages/qcow-format/qcow-format.0.4/opam
@@ -1,32 +1,27 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [[make "PREFIX=%{prefix}%" "uninstall"]]
-
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
 depends: [
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "lwt"
-  "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" & < "2.4.0" }
+  "mirage-block" {>= "0.2"}
+  "mirage-block-unix" {>= "2.1.0" & < "2.4.0"}
   "cmdliner"
   "sexplib"
   "logs"
@@ -43,11 +38,9 @@ depends: [
   "nbd" {test & >= "2.0.1"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/vhd-format/vhd-format.0.7.0/opam
+++ b/packages/vhd-format/vhd-format.0.7.0/opam
@@ -1,16 +1,15 @@
 opam-version: "1.2"
 maintainer: "dave.scott@eu.citrix.com"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: make
-remove: [[make "uninstall"]]
+remove: [
+  [make "uninstall"]
+]
 depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.0.1" & <"2.0.0"}
-  "mirage-types" {>= "1.1.0"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
+  "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page"
   "uuidm"

--- a/packages/vhd-format/vhd-format.0.7.1/opam
+++ b/packages/vhd-format/vhd-format.0.7.1/opam
@@ -1,16 +1,15 @@
 opam-version: "1.2"
 maintainer: "dave.scott@eu.citrix.com"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: make
-remove: [[make "uninstall"]]
+remove: [
+  [make "uninstall"]
+]
 depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.0.1" & <"2.0.0"}
-  "mirage-types" {>= "1.1.0"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
+  "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page"
   "uuidm"

--- a/packages/vhd-format/vhd-format.0.8.0/opam
+++ b/packages/vhd-format/vhd-format.0.8.0/opam
@@ -1,19 +1,18 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
-authors: [ "Dave Scott" "Jon Ludlam" ]
+tags: ["org:mirage" "org:xapi-project"]
+authors: ["Dave Scott" "Jon Ludlam"]
 homepage: "https://github.com/mirage/ocaml-vhd"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 build: make
-remove: [[make "uninstall"]]
+remove: [
+  [make "uninstall"]
+]
 depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.0.0"}
   "ipaddr"
   "io-page"
   "uuidm"
@@ -22,8 +21,8 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
- [["alpine"]["linux-headers"]]
+  [["alpine"] ["linux-headers"]]
 ]
 dev-repo: "git://github.com/mirage/ocaml-vhd"
-available: [ (os = "linux" | os = "darwin") & ocaml-version >= "4.02.3" ]
+available: [(os = "linux" | os = "darwin") & ocaml-version >= "4.02.3"]
 install: [make "install"]


### PR DESCRIPTION
Some whitespace changes; the edits were done mechanically by a program using `opam-file-format` and great pains weren't taken to ensure that whitespace was preserved.