### PR TITLE
psq.0.1.0 - via opam-publish

### DIFF
--- a/packages/psq/psq.0.1.0/descr
+++ b/packages/psq/psq.0.1.0/descr
@@ -1,0 +1,16 @@
+Functional Priority Search Queues
+
+
+psq provides a functional priority search queue for OCaml. This structure
+behaves both as a finite map, containing bindings `k -> p`, and a priority queue
+over `p`. It provides efficient access along more than one axis: to any binding
+by `k`, and to the binding(s) with the least `p`.
+
+Typical applications are searches, schedulers and caches. If you ever scratched
+your head because that A\* didn't look quite right, a PSQ is what you needed.
+
+The implementation is backed by [priority search pennants][hinze].
+
+psq is distributed under the ISC license.
+
+[hinze]: https://www.cs.ox.ac.uk/ralf.hinze/publications/ICFP01.pdf

--- a/packages/psq/psq.0.1.0/opam
+++ b/packages/psq/psq.0.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/psq"
+doc: "https://pqwy.github.io/psq/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/psq.git"
+bug-reports: "https://github.com/pqwy/psq/issues"
+tags: []
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "alcotest" {test} ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]

--- a/packages/psq/psq.0.1.0/url
+++ b/packages/psq/psq.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/psq/releases/download/v0.1.0/psq-0.1.0.tbz"
+checksum: "21d6abc3db996888887ec61b7d38f885"


### PR DESCRIPTION
Functional Priority Search Queues


psq provides a functional priority search queue for OCaml. This structure
behaves both as a finite map, containing bindings `k -> p`, and a priority queue
over `p`. It provides efficient access along more than one axis: to any binding
by `k`, and to the binding(s) with the least `p`.

Typical applications are searches, schedulers and caches. If you ever scratched
your head because that A\* didn't look quite right, a PSQ is what you needed.

The implementation is backed by [priority search pennants][hinze].

psq is distributed under the ISC license.

[hinze]: https://www.cs.ox.ac.uk/ralf.hinze/publications/ICFP01.pdf

---
* Homepage: https://github.com/pqwy/psq
* Source repo: https://github.com/pqwy/psq.git
* Bug tracker: https://github.com/pqwy/psq/issues

---


---
## v0.1.0 2016-11-20

First release. 
Pull-request generated by opam-publish v0.3.2