### PR TITLE
distwit.0.1.0 - via opam-publish

### DIFF
--- a/packages/distwit/distwit.0.1.0/descr
+++ b/packages/distwit/distwit.0.1.0/descr
@@ -1,0 +1,4 @@
+Distribute/marshal exceptions and extensible variants
+
+Distwit -- "Distributed Witnesses" -- make it possible to use exceptions and
+extensible variant types with Marshalling.

--- a/packages/distwit/distwit.0.1.0/opam
+++ b/packages/distwit/distwit.0.1.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: "Frédéric Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/distwit"
+bug-reports: "https://github.com/let-def/distwit/issues"
+license: "ISC"
+doc: "https://let-def.github.io/distwit/"
+dev-repo: "https://github.com/let-def/distwit.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.05"]

--- a/packages/distwit/distwit.0.1.0/url
+++ b/packages/distwit/distwit.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/distwit/archive/v0.1.0.tar.gz"
+checksum: "e179b38ae27e925530b752b301f3b8f8"


### PR DESCRIPTION
Distribute/marshal exceptions and extensible variants

Distwit -- "Distributed Witnesses" -- make it possible to use exceptions and
extensible variant types with Marshalling.


---
* Homepage: https://github.com/let-def/distwit
* Source repo: https://github.com/let-def/distwit.git
* Bug tracker: https://github.com/let-def/distwit/issues

---

Pull-request generated by opam-publish v0.3.2