### PR TITLE
tip-parser.0.3 - via opam-publish

### DIFF
--- a/packages/tip-parser/tip-parser.0.3/descr
+++ b/packages/tip-parser/tip-parser.0.3/descr
@@ -1,0 +1,5 @@
+Parser for TIP (Tons of Inductive Problems)
+
+A simple AST and parser/printer for TIP (https://tip-org.github.io/), a simple
+format for writing problems in a typed logic with computable functions,
+datatypes, and axioms.

--- a/packages/tip-parser/tip-parser.0.3/opam
+++ b/packages/tip-parser/tip-parser.0.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/tip-parser/"
+bug-reports: "https://github.com/c-cube/tip-parser/issues"
+tags: ["TIP" "parse" "inductive" "logic"]
+dev-repo: "https://github.com/c-cube/tip-parser.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "tip_parser"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/tip-parser/tip-parser.0.3/url
+++ b/packages/tip-parser/tip-parser.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/tip-parser/archive/0.3.tar.gz"
+checksum: "c80de6832afe720df7f14a1c107625bf"


### PR DESCRIPTION
Parser for TIP (Tons of Inductive Problems)

A simple AST and parser/printer for TIP (https://tip-org.github.io/), a simple
format for writing problems in a typed logic with computable functions,
datatypes, and axioms.


---
* Homepage: https://github.com/c-cube/tip-parser/
* Source repo: https://github.com/c-cube/tip-parser.git
* Bug tracker: https://github.com/c-cube/tip-parser/issues

---

Pull-request generated by opam-publish v0.3.3