### PR TITLE
Cryptokit.1.11 improvements

### DIFF
--- a/packages/cryptokit/cryptokit.1.11/files/aesni-align.patch
+++ b/packages/cryptokit/cryptokit.1.11/files/aesni-align.patch
@@ -1,0 +1,63 @@
+From ac8c748268091d98d341ad38a5a8a83832f53a46 Mon Sep 17 00:00:00 2001
+From: Etienne Millon <etienne@cryptosense.com>
+Date: Mon, 21 Nov 2016 15:32:32 +0100
+Subject: [PATCH] Align key_schedule on a 16 byte boundary
+
+Memory access to/from XMM registers require the memory operand to be
+aligned in order to have good performance (using the `MOVDQA`
+operation). To ensure that, the compiler is supposed to align stack
+variables, but it can not always do that. In particular, old GCC
+versions (4.4.7, present in Centos 6) fail to do that. It is thus
+necessary to align it manually using extra space.
+---
+ src/aesni.c | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/src/aesni.c b/src/aesni.c
+index f2ff483..fde8669 100644
+--- a/src/aesni.c
++++ b/src/aesni.c
+@@ -19,6 +19,7 @@
+ #ifdef __AES__
+ #include <wmmintrin.h>
+ #include <cpuid.h>
++#include <stdint.h>
+ 
+ int aesni_available = -1;
+ 
+@@ -216,11 +217,21 @@ static int aesni_key_expansion(const unsigned char * userkey,
+   }
+ }
+ 
++static __m128i *align16(__m128i *p)
++{
++  uintptr_t n = (uintptr_t) p;
++  if (n & 0xf) {
++    n = n + 16 - (n & 0xf);
++  }
++  return (__m128i *) n;
++}
++
+ int aesniKeySetupEnc(unsigned char * ckey,
+                      const unsigned char * key,
+                      int keylength)
+ {
+-  __m128i key_schedule[15];
++  __m128i unaligned_key_schedule[15 + 15];
++  __m128i *key_schedule = align16(unaligned_key_schedule);
+   int nrounds, i;
+ 
+   nrounds = aesni_key_expansion(key, keylength, key_schedule);
+@@ -234,7 +245,8 @@ int aesniKeySetupDec(unsigned char * ckey,
+                      const unsigned char * key,
+                      int keylength)
+ {
+-  __m128i key_schedule[15];
++  __m128i unaligned_key_schedule[15 + 15];
++  __m128i *key_schedule = align16(unaligned_key_schedule);
+   int nrounds, i;
+ 
+   nrounds = aesni_key_expansion(key, keylength, key_schedule);
+-- 
+2.10.2
+

--- a/packages/cryptokit/cryptokit.1.11/files/aesni-detect.patch
+++ b/packages/cryptokit/cryptokit.1.11/files/aesni-detect.patch
@@ -1,0 +1,46 @@
+From 933fcba1f1851dc3a0e254746373c5c8fb87131c Mon Sep 17 00:00:00 2001
+From: Etienne Millon <etienne@cryptosense.com>
+Date: Fri, 18 Nov 2016 16:15:56 +0100
+Subject: [PATCH] Reliably detect AES-NI
+
+As reported in [1], the original detection code fails on 32 bit
+targets. This improves the patch a bit by falling back to the software
+implementation if CPUID fails.
+
+[1]: https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1646&group_id=133&atid=628
+---
+ src/aesni.c | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/src/aesni.c b/src/aesni.c
+index 57a8ae7..f2ff483 100644
+--- a/src/aesni.c
++++ b/src/aesni.c
+@@ -18,16 +18,19 @@
+ 
+ #ifdef __AES__
+ #include <wmmintrin.h>
++#include <cpuid.h>
+ 
+ int aesni_available = -1;
+ 
+ int aesni_check_available(void)
+ {
+-  unsigned int ax, bx, cx, dx;
+-  __asm__ __volatile__ ("cpuid"
+-                        : "=a" (ax), "=b" (bx), "=c" (cx), "=d" (dx)
+-                        : "a" (1));
+-  return (aesni_available = (cx & 0x2000000) != 0);
++  unsigned int eax, ebx, ecx, edx;
++  if(__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
++    aesni_available = (ecx & 0x2000000) != 0;
++  } else {
++    aesni_available = 0;
++  }
++  return aesni_available;
+ }
+ 
+ static inline __m128i aesni_128_assist(__m128i t1, __m128i t2)
+-- 
+2.10.2
+

--- a/packages/cryptokit/cryptokit.1.11/opam
+++ b/packages/cryptokit/cryptokit.1.11/opam
@@ -10,6 +10,9 @@ depends: [
   "conf-zlib"
   "zarith" { >= "1.4" }
 ]
+patches: [
+  "aesni-detect.patch"
+]
 build: make
 install: [make "install"]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/cryptokit/cryptokit.1.11/opam
+++ b/packages/cryptokit/cryptokit.1.11/opam
@@ -8,7 +8,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-zlib"
-  "zarith"
+  "zarith" { >= "1.4" }
 ]
 build: make
 install: [make "install"]

--- a/packages/cryptokit/cryptokit.1.11/opam
+++ b/packages/cryptokit/cryptokit.1.11/opam
@@ -12,6 +12,7 @@ depends: [
 ]
 patches: [
   "aesni-detect.patch"
+  "aesni-align.patch"
 ]
 build: make
 install: [make "install"]


### PR DESCRIPTION
This improves `cryptokit.1.11` on several points:
- add a missing version constraint on zarith
- fix AES-NI detection on 32 bit systems
- fix AES-NI implementation with old versions of GCC
- fall back to non-constant-time modexp (as it was in version 1.10) if only an old GMP is available

All these patches have been either picked from the upstream bug tracker, or forwarded there.

Thanks!