### PR TITLE
Add Archlinux depexts

### DIFF
--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -12,4 +12,5 @@ depexts: [
   [["ubuntu"] ["libcurl4-gnutls-dev"]]
   [["centos"] ["libcurl-devel" "openssl-devel"]]
   [["nixpkgs"] ["curl"]]
+  [["archlinux"] ["curl"]]
 ]

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -16,4 +16,5 @@ depexts: [
   [["centos"] ["m4"]]
   [["alpine"] ["m4"]]
   [["oraclelinux"] ["m4"]]
+  [["archlinux"] ["m4"]]
 ]

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -19,6 +19,7 @@ depexts: [
   [["centos"] ["ncurses-devel"]]
   [["rhel"] ["ncurses-devel"]]
   [["opensuse"] ["ncurses-devel"]] # note: doesnt use pkg-config
+  [["archlinux"] ["ncurses"]]
 ]
 ## For BSD-like where 'ncurses' is preinstalled but `pkg-config` is not,
 ## see 'conf-ncurses.1+bsd'

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -16,4 +16,5 @@ depexts: [
   [["osx" "homebrew"] ["openssl"]]
   [["alpine"] ["openssl-dev"]]
   [["nixpkgs"] ["openssl"]]
+  [["archlinux"] ["openssl"]]
 ]

--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -10,4 +10,5 @@ depexts: [
   [["ubuntu"] ["perl"]]
   [["alpine"]["perl"]]
   [["nixpkgs"] ["perl"]]
+  [["archlinux"] ["perl"]]
 ]

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -9,4 +9,5 @@ depexts: [
   [["debian"] ["debianutils"]]
   [["ubuntu"] ["debianutils"]]
   [["nixpkgs"] ["which"]]
+  [["archlinux"] ["which"]]
 ]

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -14,4 +14,5 @@ depexts: [
   [["centos"] ["zlib-devel"]]
   [["nixpkgs"] ["zlib"]]
   [["homebrew" "osx"] ["lzlib"]]
+  [["archlinux"] ["zlib"]]
 ]


### PR DESCRIPTION
*depexts* was missing for
 
- conf-libcurl                                                                                                                                                                                                       
- conf-m4                                                                                                                                                                                                            
- conf-ncurses                                                                                                                                                                                                       
- conf-openssl                                                                                                                                                                                                       
- conf-perl                                                                                                                                                                                                          
- conf-which                                                                                                                                                                                                         
- conf-zlib                                                                                                                                                                                                          
              