### PR TITLE
uucp.2.0.0 - via opam-publish

### DIFF
--- a/packages/uucp/uucp.2.0.0/descr
+++ b/packages/uucp/uucp.2.0.0/descr
@@ -1,0 +1,9 @@
+Unicode character properties for OCaml
+
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/

--- a/packages/uucp/uucp.2.0.0/opam
+++ b/packages/uucp/uucp.2.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [
+  "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  "David Kaloper Meršinjak <david@numm.org>"
+]
+homepage: "http://erratique.ch/software/uucp"
+doc: "http://erratique.ch/software/uucp/doc/Uucp"
+dev-repo: "http://erratique.ch/repos/uucp.git"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+tags: [ "unicode" "text" "character" "org:erratique" ]
+license: "ISC"
+depends: [
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "uchar"
+ "uucd" {test} # dev really
+ "uunf" {test}
+ "uutf" {test}
+ ]
+available: [ ocaml-version >= "4.01.0" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/uucp/uucp.2.0.0/url
+++ b/packages/uucp/uucp.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uucp/releases/uucp-2.0.0.tbz"
+checksum: "a6a9d74f56d7ca56c823d9b89af39d75"


### PR DESCRIPTION
Unicode character properties for OCaml

Uucp is an OCaml library providing efficient access to a selection of
character properties of the [Unicode character database][1].

Uucp is independent from any Unicode text data structure and has no
dependencies. It is distributed under the ISC license.

[1]: http://www.unicode.org/reports/tr44/


---
* Homepage: http://erratique.ch/software/uucp
* Source repo: http://erratique.ch/repos/uucp.git
* Bug tracker: https://github.com/dbuenzli/uucp/issues

---


---
v2.0.0 2016-11-23 Zagreb
------------------------

- Unicode 9.0.0 support.
- OCaml standard library `Uchar.t` support.
  - Removes and substitutes `type Uucp.uchar = int` by the (abstract)
    `Uchar.t` type. `Uchar.{of,to}_int` allows to recover the previous
    representation.
  - Removes the `Uucp.Uchar` module, corresponding functionality can
    be found in `Uchar`.
- Safe string support.
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.2