### PR TITLE
uuseg.1.0.0 - via opam-publish

### DIFF
--- a/packages/uuseg/uuseg.1.0.0/descr
+++ b/packages/uuseg/uuseg.1.0.0/descr
@@ -1,0 +1,18 @@
+Unicode text segmentation for OCaml
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/

--- a/packages/uuseg/uuseg.1.0.0/opam
+++ b/packages/uuseg/uuseg.1.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uuseg"
+doc: "http://erratique.ch/software/uuseg"
+dev-repo: "http://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [ "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uchar"
+           "uucp" {>= "2.0.0" & < "3.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {test}
+           "cmdliner" {test} ]
+conflicts: [ "uutf" {< "0.9.4"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]

--- a/packages/uuseg/uuseg.1.0.0/url
+++ b/packages/uuseg/uuseg.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uuseg/releases/uuseg-1.0.0.tbz"
+checksum: "58082c8a644b24a785069734f365e665"


### PR DESCRIPTION
Unicode text segmentation for OCaml

Uuseg is an OCaml library for segmenting Unicode text. It implements
the locale independent [Unicode text segmentation algorithms][1] to
detect grapheme cluster, word and sentence boundaries and the
[Unicode line breaking algorithm][2] to detect line break
opportunities.

The library is independent from any IO mechanism or Unicode text data
structure and it can process text without a complete in-memory
representation.

Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
optionally on [Uutf](http://erratique.ch/software/uutf) for support on
OCaml UTF-X encoded strings. It is distributed under the ISC license.

[1]: http://www.unicode.org/reports/tr29/
[2]: http://www.unicode.org/reports/tr14/


---
* Homepage: http://erratique.ch/software/uuseg
* Source repo: http://erratique.ch/repos/uuseg.git
* Bug tracker: https://github.com/dbuenzli/uuseg/issues

---


---
v1.0.0 2016-11-23 Zagreb
------------------------

- Unicode 9.0.0 support.
- OCaml standard library `Uchar.t` support.
  - Removes and substitutes `type Uuseg.uchar = int` by the (abstract)
    `Uchar.t` type. `Uchar.{of,to}_int` allows to recover the previous
    representation.
  - Removes the `Uuseg.is_uchar`. `Uchar.is_valid` can be used instead.
- Safe string support.
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.2