### PR TITLE
jsonm.1.0.0 - via opam-publish

### DIFF
--- a/packages/jsonm/jsonm.1.0.0/descr
+++ b/packages/jsonm/jsonm.1.0.0/descr
@@ -1,0 +1,13 @@
+Non-blocking streaming JSON codec for OCaml
+
+Jsonm is a non-blocking streaming codec to decode and encode the JSON
+data format. It can process JSON text without blocking on IO and
+without a complete in-memory representation of the data.
+
+The alternative "uncut" codec also processes whitespace and
+(non-standard) JSON with JavaScript comments.
+
+Jsonm is made of a single module and depends on [Uutf][uutf]. It is distributed
+under the ISC license.
+
+[uutf]: http://erratique.ch/software/uutf

--- a/packages/jsonm/jsonm.1.0.0/opam
+++ b/packages/jsonm/jsonm.1.0.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/jsonm"
+doc: "http://erratique.ch/software/jsonm/doc/Jsonm"
+dev-repo: "http://erratique.ch/repos/jsonm.git"
+bug-reports: "https://github.com/dbuenzli/jsonm/issues"
+tags: [ "json" "codec" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uchar"
+  "uutf" {>= "1.0.0"} ]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/jsonm/jsonm.1.0.0/url
+++ b/packages/jsonm/jsonm.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/jsonm/releases/jsonm-1.0.0.tbz"
+checksum: "d1ec89c9586c5413f39f7f1fef74dc1a"


### PR DESCRIPTION
Non-blocking streaming JSON codec for OCaml

Jsonm is a non-blocking streaming codec to decode and encode the JSON
data format. It can process JSON text without blocking on IO and
without a complete in-memory representation of the data.

The alternative "uncut" codec also processes whitespace and
(non-standard) JSON with JavaScript comments.

Jsonm is made of a single module and depends on [Uutf][uutf]. It is distributed
under the ISC license.

[uutf]: http://erratique.ch/software/uutf


---
* Homepage: http://erratique.ch/software/jsonm
* Source repo: http://erratique.ch/repos/jsonm.git
* Bug tracker: https://github.com/dbuenzli/jsonm/issues

---


---
v1.0.0 2016-11-23 Zagreb
------------------------

- Support for RFC 7195/ECMA-404. This means that any JSON value can
  now be codec as JSON text, in RFC 4627 (obsoleted by 7195) this
  could only be an array or an object. If your code was relying on the
  fact the first decoded lexeme was either a `Os` or `As`,
  you will need to review that.
- Fix `Jsonm.decode` not eventually returning `End` on toplevel
  decode error.
- OCaml standard library `Uchar.t` support. At the API level only
  some cases of `Jsonm.error` change.
- Uutf 1.0.0 support.
- Safe string support.
- Build depend on topkg.
- Relicensed from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.2