### PR TITLE
nbd: missing metadata and constraints

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "2.3.0"}
   "io-page" {>= "1.0.0"}
-  "uri"
+  "uri" {>= "1.3.2"}
   "logs"
   "ounit" {test}
   "ocamlbuild" {build}

--- a/packages/nbd/nbd.0.9.0/opam
+++ b/packages/nbd/nbd.0.9.0/opam
@@ -9,7 +9,7 @@ remove: [[make "uninstall" "BINDIR=%{bin}%"]]
 depends: [
   "ocamlfind"
   "obuild"
-  "lwt"
+  "lwt" {>= "2.4.3" & < "2.6.0"}
   "bitstring"
 ]
 dev-repo: "git://github.com/xen-org/nbd"

--- a/packages/nbd/nbd.0.9.0/opam
+++ b/packages/nbd/nbd.0.9.0/opam
@@ -1,5 +1,11 @@
 opam-version: "1.2"
 maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: [ "Jonathan Ludlam" "David Scott" ]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/xapi-project/nbd"
+dev-repo: "https://github.com/xapi-project/nbd.git"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
+
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -12,5 +18,4 @@ depends: [
   "lwt" {>= "2.4.3" & < "2.6.0"}
   "bitstring"
 ]
-dev-repo: "git://github.com/xen-org/nbd"
 install: [make "install" "BINDIR=%{bin}%"]

--- a/packages/nbd/nbd.0.9.2/opam
+++ b/packages/nbd/nbd.0.9.2/opam
@@ -1,5 +1,11 @@
 opam-version: "1.2"
 maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: [ "Jonathan Ludlam" "David Scott" ]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/xapi-project/nbd"
+dev-repo: "https://github.com/xapi-project/nbd.git"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
+
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -13,5 +19,4 @@ depends: [
   "cstruct" {>= "0.7.1" & <"2.0.0"}
   "cmdliner"
 ]
-dev-repo: "git://github.com/xapi-project/nbd"
 install: [make "install" "BINDIR=%{bin}%"]

--- a/packages/nbd/nbd.0.9.2/opam
+++ b/packages/nbd/nbd.0.9.2/opam
@@ -9,7 +9,7 @@ remove: [[make "uninstall" "BINDIR=%{bin}%"]]
 depends: [
   "ocamlfind"
   "obuild"
-  "lwt"
+  "lwt" {>= "2.4.3" & < "2.6.0"}
   "cstruct" {>= "0.7.1" & <"2.0.0"}
   "cmdliner"
 ]

--- a/packages/nbd/nbd.1.0.1/opam
+++ b/packages/nbd/nbd.1.0.1/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "2.6.0"}
   "cstruct" {>= "1.0.1"}
   "cmdliner"
   "camlp4"

--- a/packages/nbd/nbd.1.0.1/opam
+++ b/packages/nbd/nbd.1.0.1/opam
@@ -1,5 +1,11 @@
 opam-version: "1.2"
 maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: [ "Jonathan Ludlam" "David Scott" ]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/xapi-project/nbd"
+dev-repo: "https://github.com/xapi-project/nbd.git"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
+
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -20,5 +26,4 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xapi-project/nbd"
 install: [make "install"]

--- a/packages/nbd/nbd.1.0.1/opam
+++ b/packages/nbd/nbd.1.0.1/opam
@@ -21,9 +21,9 @@ remove: [
 depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "2.6.0"}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "2.0.0"}
   "cmdliner"
-  "camlp4"
+  "camlp4"     {build}
   "ocamlbuild" {build}
 ]
 install: [make "install"]

--- a/packages/nbd/nbd.1.0.2/opam
+++ b/packages/nbd/nbd.1.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt" {>= "2.4.5" & < "2.6.0"}
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "cmdliner"
-  "camlp4"
+  "type_conv"  {build}
   "ocamlbuild" {build}
 ]
 tags: [ "org:mirage" "org:xapi-project" ]

--- a/packages/nbd/nbd.1.0.2/opam
+++ b/packages/nbd/nbd.1.0.2/opam
@@ -1,5 +1,11 @@
 opam-version: "1.2"
 maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: [ "Jonathan Ludlam" "David Scott" ]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/xapi-project/nbd"
+dev-repo: "https://github.com/xapi-project/nbd.git"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
+
 build: [
   ["./configure" "--prefix" prefix]
   [make]
@@ -18,5 +24,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "org:mirage" "org:xapi-project" ]
-dev-repo: "git://github.com/xapi-project/nbd"
 install: [make "install" "BINDIR=%{bin}%"]

--- a/packages/nbd/nbd.1.0.2/opam
+++ b/packages/nbd/nbd.1.0.2/opam
@@ -11,7 +11,7 @@ remove: [
 depends: [
   "ocamlfind"
   "obuild"
-  "lwt"
+  "lwt" {>= "2.4.5" & < "2.6.0"}
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "cmdliner"
   "camlp4"

--- a/packages/nbd/nbd.2.0.1/opam
+++ b/packages/nbd/nbd.2.0.1/opam
@@ -27,7 +27,7 @@ depends: [
   "oasis" {build}
   "ounit" {test}
   "ocamlfind" {build}
-  "lwt"
+  "lwt" {>= "2.4.5" & < "2.6.0"}
   "cstruct" {> "1.0.0" & <"2.0.0"}
   "cmdliner"
   "sexplib" {<"113.24.00"}

--- a/packages/nbd/nbd.2.0.1/opam
+++ b/packages/nbd/nbd.2.0.1/opam
@@ -27,11 +27,11 @@ depends: [
   "oasis" {build}
   "ounit" {test}
   "ocamlfind" {build}
+  "type_conv" {build}
   "lwt" {>= "2.4.5" & < "2.6.0"}
   "cstruct" {> "1.0.0" & <"2.0.0"}
   "cmdliner"
   "sexplib" {<"113.24.00"}
-  "type_conv"
   "mirage-block-unix"
   "io-page"
   "mirage"

--- a/packages/nbd/nbd.2.1.0/opam
+++ b/packages/nbd/nbd.2.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "oasis" {build}
   "ounit" {test}
   "ocamlfind" {build}
-  "type_conv" {build}
+  "ppx_tools" {build}
   "lwt" {>= "2.4.5" & < "2.6.0"}
   "cstruct" {>= "1.9.0"}
   "cmdliner"

--- a/packages/nbd/nbd.2.1.0/opam
+++ b/packages/nbd/nbd.2.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ounit" {test}
   "ocamlfind" {build}
   "type_conv" {build}
-  "lwt"
+  "lwt" {>= "2.4.5" & < "2.6.0"}
   "cstruct" {>= "1.9.0"}
   "cmdliner"
   "sexplib"


### PR DESCRIPTION
- current versions clash with `lwt.2.6.0` over `module Result`: add upper-bounds
- older versions lack modern opam metadata

Clash over `module Result` is fixed in [xapi-project/nbd#29]