### PR TITLE
mirage-block-unix.2.4.0 needs uri >= 1.3.2

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "2.3.0"}
   "io-page" {>= "1.0.0"}
-  "uri"
+  "uri" {>= "1.3.2"}
   "logs"
   "ounit" {test}
   "ocamlbuild" {build}


### PR DESCRIPTION
Build failure seen on #7908

Signed-off-by: David Scott <dave@recoil.org>