### PR TITLE
anycache.0.6.0 - via opam-publish

### DIFF
--- a/packages/anycache/anycache.0.6.0/descr
+++ b/packages/anycache/anycache.0.6.0/descr
@@ -1,0 +1,8 @@
+Scan-resistant LRU/2Q cache
+
+anycache is a scan-resistant LRU/2Q cache.
+See the [documentation][basics] for details on the algorithm used.
+
+[basics]: https://edwintorok.gitlab.io/ocaml-anycache/doc/Anycache.html#basics
+
+anycache is distributed under the ISC license.

--- a/packages/anycache/anycache.0.6.0/opam
+++ b/packages/anycache/anycache.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "Török Edwin <edwin@skylable.com>"
+authors: ["Török Edwin <edwin@skylable.com>"]
+homepage: "https://gitlab.com/edwintorok/ocaml-anycache"
+doc: "https://edwintorok.gitlab.io/ocaml-anycache/doc"
+license: "ISC"
+dev-repo: "https://gitlab.com/edwintorok/ocaml-anycache.git"
+bug-reports: "https://gitlab.com/edwintorok/ocaml-anycache/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "alcotest" { test & >= "0.7.2" }
+  "base-bytes"
+  "result"
+]
+depopts: [
+    "lwt"
+    "async"
+]
+build: [ "ocaml" "pkg/pkg.ml" "build"
+       "--pinned" "%{pinned}%"
+       "--with-lwt" "%{lwt:installed}%"
+       "--with-async" "%{async:installed}%"
+       "--tests" "false"
+       ]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build"
+       "--pinned" "%{pinned}%"
+       "--with-lwt" "%{lwt:installed}%"
+       "--with-async" "%{async:installed}%"
+       "--tests" "true"
+  ]
+  ["ocaml" "pkg/pkg.ml" "test"]]

--- a/packages/anycache/anycache.0.6.0/url
+++ b/packages/anycache/anycache.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://gitlab.com/edwintorok/ocaml-anycache/uploads/78722628e5af42b59da2abe17939ff89/anycache-0.6.0.tbz"
+checksum: "5edf38601cee4aefec6b7d6e922f208f"


### PR DESCRIPTION
Scan-resistant LRU/2Q cache

anycache is a scan-resistant LRU/2Q cache.
See the [documentation][basics] for details on the algorithm used.

[basics]: https://edwintorok.gitlab.io/ocaml-anycache/doc/Anycache.html#basics

anycache is distributed under the ISC license.


---
* Homepage: https://gitlab.com/edwintorok/ocaml-anycache
* Source repo: https://gitlab.com/edwintorok/ocaml-anycache.git
* Bug tracker: https://gitlab.com/edwintorok/ocaml-anycache/issues

---


---
v0.6.0 2016-11-24
-----------------

Extract caching code from LibreS3 into its own library.
Pull-request generated by opam-publish v0.3.3