### PR TITLE
+ocamlfind.1.7.1

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.7.1/descr
+++ b/packages/ocamlfind/ocamlfind.1.7.1/descr
@@ -1,0 +1,6 @@
+A library manager for OCaml
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.

--- a/packages/ocamlfind/ocamlfind.1.7.1/files/ocaml-stub
+++ b/packages/ocamlfind/ocamlfind.1.7.1/files/ocaml-stub
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+BINDIR=$(dirname "$(command -v ocamlc)")
+"$BINDIR/ocaml" -I "$OCAML_TOPLEVEL_PATH" "$@"

--- a/packages/ocamlfind/ocamlfind.1.7.1/files/ocamlfind.install
+++ b/packages/ocamlfind/ocamlfind.1.7.1/files/ocamlfind.install
@@ -1,0 +1,6 @@
+bin: [
+  "src/findlib/ocamlfind" {"ocamlfind"}
+  "?src/findlib/ocamlfind_opt" {"ocamlfind"}
+  "?tools/safe_camlp4"
+]
+toplevel: ["src/findlib/topfind"]

--- a/packages/ocamlfind/ocamlfind.1.7.1/findlib
+++ b/packages/ocamlfind/ocamlfind.1.7.1/findlib
@@ -1,0 +1,13 @@
+bigarray
+bytes
+compiler-libs
+dynlink
+findlib
+graphics
+labltk
+num
+num-top
+stdlib
+str
+threads
+unix

--- a/packages/ocamlfind/ocamlfind.1.7.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+  [make "opt"] { ocaml-native }
+]
+install: [
+  [make "install"]
+  ["cp" "ocaml-stub" "%{bin}%/ocaml"] {preinstalled}
+]
+remove: [
+  ["ocamlfind" "remove" "bytes"]
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
+  [make "uninstall"]
+  ["rm" "-f" "%{bin}%/ocaml"] {preinstalled}
+]
+available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+depends: [
+  "conf-m4" {build}
+]

--- a/packages/ocamlfind/ocamlfind.1.7.1/url
+++ b/packages/ocamlfind/ocamlfind.1.7.1/url
@@ -1,0 +1,2 @@
+archive: "http://download.camlcity.org/download/findlib-1.7.1.tar.gz"
+checksum: "108717618e724295d8a01c21ba3f7311"


### PR DESCRIPTION
-  1.7.0: New command "ocamlfind printppx" that outputs  how the ppx 
   preprocessor would be called (Hendrik Tews).
   Support for the raw_spacetime library that comes with  OCaml 4.04 (Gerd 
   Stolpmann with help from Mark Shinwell).
   Require that ocamlc and ocamlc.opt are installed to the  same directory for 
   emitting the "opt" setting in the generated  config file - same for 
   ocamlopt.opt, ocamldep.opt, ocamldoc.opt.
