### PR TITLE
tgls.0.8.5 - via opam-publish

### DIFF
--- a/packages/tgls/tgls.0.8.5/descr
+++ b/packages/tgls/tgls.0.8.5/descr
@@ -1,0 +1,10 @@
+Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml
+
+Tgls is a set of independent OCaml libraries providing thin bindings
+to OpenGL libraries. It has support for core OpenGL 3.{2,3} and
+4.{0,1,2,3,4} and OpenGL ES 2 and 3.{0,1,2}.
+
+Tgls depends on [ocaml-ctypes][ctypes] and the C OpenGL library of your
+platform. It is distributed under the ISC license.
+          
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes

--- a/packages/tgls/tgls.0.8.5/opam
+++ b/packages/tgls/tgls.0.8.5/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/tgls"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/tgls/doc/"
+dev-repo: "http://erratique.ch/repos/tgls.git"
+bug-reports: "https://github.com/dbuenzli/tgls/issues"
+tags: [ "bindings" "opengl" "opengl-es" "graphics" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bytes"
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "tsdl" {test}
+  "result" {test}
+#  "xmlm" {dev}
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]

--- a/packages/tgls/tgls.0.8.5/url
+++ b/packages/tgls/tgls.0.8.5/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/tgls/releases/tgls-0.8.5.tbz"
+checksum: "edef81b61515f9fceb21ffa5c122847e"


### PR DESCRIPTION
Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml

Tgls is a set of independent OCaml libraries providing thin bindings
to OpenGL libraries. It has support for core OpenGL 3.{2,3} and
4.{0,1,2,3,4} and OpenGL ES 2 and 3.{0,1,2}.

Tgls depends on [ocaml-ctypes][ctypes] and the C OpenGL library of your
platform. It is distributed under the ISC license.
          
[ctypes]: https://github.com/ocamllabs/ocaml-ctypes


---
* Homepage: http://erratique.ch/software/tgls
* Source repo: http://erratique.ch/repos/tgls.git
* Bug tracker: https://github.com/dbuenzli/tgls/issues

---


---
v0.8.5 2016-11-25 Zagreb
------------------------

* Allow to optionally build GL and GL ES. Thanks to Peter Zotov for
  the patch.
Pull-request generated by opam-publish v0.3.3