### PR TITLE
otfm.0.3.0 - via opam-publish

### DIFF
--- a/packages/otfm/otfm.0.3.0/descr
+++ b/packages/otfm/otfm.0.3.0/descr
@@ -1,0 +1,12 @@
+OpenType font decoder for OCaml
+Release %%VERSION%%
+
+Otfm is an in-memory decoder for the OpenType font data format. It
+provides low-level access to font tables and functions to decode some
+of them.
+
+Otfm is made of a single module and depends on [Uutf][1]. It is distributed 
+under the ISC license.
+
+[1]: http://erratique.ch/software/uutf
+     

--- a/packages/otfm/otfm.0.3.0/opam
+++ b/packages/otfm/otfm.0.3.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/otfm"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/otfm/doc/Otfm"
+dev-repo: "http://erratique.ch/repos/otfm.git"
+bug-reports: "https://github.com/dbuenzli/otfm/issues"
+tags: [ "OpenType" "ttf" "font" "decoder" "graphics" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0" ]
+depends: [
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "result"
+ "uchar"
+ "uutf" {>= "1.0.0"}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/otfm/otfm.0.3.0/url
+++ b/packages/otfm/otfm.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/otfm/releases/otfm-0.3.0.tbz"
+checksum: "e8e0ecb91048983b09a7fbe593042c89"


### PR DESCRIPTION
OpenType font decoder for OCaml
Release %%VERSION%%

Otfm is an in-memory decoder for the OpenType font data format. It
provides low-level access to font tables and functions to decode some
of them.

Otfm is made of a single module and depends on [Uutf][1]. It is distributed 
under the ISC license.

[1]: http://erratique.ch/software/uutf
     

---
* Homepage: http://erratique.ch/software/otfm
* Source repo: http://erratique.ch/repos/otfm.git
* Bug tracker: https://github.com/dbuenzli/otfm/issues

---


---
v0.3.0 2016-11-25 Zagreb
------------------------

- Use standard library `result` type.
- Support uutf 1.0.0.
- Safe string support.
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.3