### PR TITLE
vg.0.9.0 - via opam-publish

### DIFF
--- a/packages/vg/vg.0.9.0/descr
+++ b/packages/vg/vg.0.9.0/descr
@@ -1,0 +1,21 @@
+Declarative 2D vector graphics for OCaml
+
+Vg is an OCaml module for declarative 2D vector graphics. In Vg,
+images are values that denote functions mapping points of the
+cartesian plane to colors. The module provides combinators to define
+and compose these values.
+
+Renderers for PDF, SVG, Cairo and the HTML canvas are distributed with the
+module. An API allows to implement new renderers.
+     
+Vg depends only on [Gg][gg]. The SVG renderer has no dependency, the
+PDF renderer depends on [Uutf][uutf] and [Otfm][otfm], the HTML canvas
+renderer depends on [js_of_ocaml][jsoo], the Cairo renderer depends on
+[cairo2][cairo2]. Vg and its renderers are distributed under the ISC
+license.
+     
+[gg]: http://erratique.ch/software/gg
+[uutf]: http://erratique.ch/software/uutf
+[otfm]: http://erratique.ch/software/otfm
+[jsoo]: http://ocsigen.org/js_of_ocaml/ 
+[cairo2]: https://forge.ocamlcore.org/projects/cairo/

--- a/packages/vg/vg.0.9.0/opam
+++ b/packages/vg/vg.0.9.0/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/vg"
+authors: [
+  "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  "Arthur Wendling"
+]
+doc: "http://erratique.ch/software/vg/doc/Vg"
+dev-repo: "http://erratique.ch/repos/vg.git"
+bug-reports: "https://github.com/dbuenzli/vg/issues"
+tags: [
+  "pdf" "svg" "html-canvas" "cairo" "declarative" "graphics"
+  "org:erratique"
+]
+license: "ISC"
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "gg" {>= "0.9.0"}
+  "result"
+  "uchar"
+  "js_of_ocaml" # Can be moved to depopt once this is distributed:
+                # https://github.com/ocsigen/js_of_ocaml/pull/541
+]
+depopts: [
+  "uutf"
+  "otfm"
+  "cairo2"
+]
+conflicts: [
+  "otfm" {< "0.3.0"}
+  "uutf" {< "1.0.0"}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-uutf" "%{uutf:installed}%"
+          "--with-otfm" "%{otfm:installed}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-cairo2" "%{cairo2:installed}%" ]]

--- a/packages/vg/vg.0.9.0/url
+++ b/packages/vg/vg.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/vg/releases/vg-0.9.0.tbz"
+checksum: "1ce6a1ca64b16ac492073c5fe07632eb"


### PR DESCRIPTION
Declarative 2D vector graphics for OCaml

Vg is an OCaml module for declarative 2D vector graphics. In Vg,
images are values that denote functions mapping points of the
cartesian plane to colors. The module provides combinators to define
and compose these values.

Renderers for PDF, SVG, Cairo and the HTML canvas are distributed with the
module. An API allows to implement new renderers.
     
Vg depends only on [Gg][gg]. The SVG renderer has no dependency, the
PDF renderer depends on [Uutf][uutf] and [Otfm][otfm], the HTML canvas
renderer depends on [js_of_ocaml][jsoo], the Cairo renderer depends on
[cairo2][cairo2]. Vg and its renderers are distributed under the ISC
license.
     
[gg]: http://erratique.ch/software/gg
[uutf]: http://erratique.ch/software/uutf
[otfm]: http://erratique.ch/software/otfm
[jsoo]: http://ocsigen.org/js_of_ocaml/ 
[cairo2]: https://forge.ocamlcore.org/projects/cairo/


---
* Homepage: http://erratique.ch/software/vg
* Source repo: http://erratique.ch/repos/vg.git
* Bug tracker: https://github.com/dbuenzli/vg/issues

---


---
v0.9.0 2015-11-25 Zagreb
------------------------

- Automated migration from camlp4 to ppx. Many thanks to the authors
  of camlp4-to-ppx.
- Use standard library `result` type. This changes the dubious interface
  of `Vgr_pdf.otf_font`.
- Support uutf v1.0.0 and otfm v0.3.0.
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.3