### PR TITLE
Release ogen.0.1.4

### DIFF
--- a/packages/ogen/ogen.0.1.4/descr
+++ b/packages/ogen/ogen.0.1.4/descr
@@ -1,0 +1,6 @@
+A tool for creating new OCaml projects with OPAM, Oasis, and Merlin
+ogen is a command-line program to help generate some of the boilerplate involved
+in creating OCaml projects, such as the opam, _oasis, and .merlin files. ogen
+features a simple-to-use dialog that allows the user to input specific options for their
+repository, as well as a number of additional commands that allow the user to set options
+separately.

--- a/packages/ogen/ogen.0.1.4/opam
+++ b/packages/ogen/ogen.0.1.4/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/ogen"
+bug-reports: "https://github.com/nv-vn/ogen/issues"
+license: "GPL"
+dev-repo: "https://github.com/nv-vn/ogen.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: ["cp" "./main.native" "%{bin}%/ogen"]
+remove: ["rm" "%{bin}%/ogen"]
+available: [
+  ocaml-version >= "4.02"
+]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "batteries" {>= "2.0.0" & < "3.0.0"}
+  "linenoise" {>= "1.0.0"}
+  "ocaml-inifiles" {>= "1.2" & < "2.0"}
+  "yojson" {>= "1.3.0" & < "2.0.0"}
+  "ppx_blob" {>= "0.1"}
+  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving_yojson" {>= "3.0"}
+]

--- a/packages/ogen/ogen.0.1.4/url
+++ b/packages/ogen/ogen.0.1.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/ogen/archive/v0.1.3.tar.gz"
+checksum: "ff01bacaaf2a0ed3a1c4866739a65141"

--- a/packages/ogen/ogen.0.1.4/url
+++ b/packages/ogen/ogen.0.1.4/url
@@ -1,2 +1,2 @@
-http: "https://github.com/nv-vn/ogen/archive/v0.1.3.tar.gz"
-checksum: "ff01bacaaf2a0ed3a1c4866739a65141"
+http: "https://github.com/nv-vn/ogen/archive/v0.1.4.tar.gz"
+checksum: "9eb1dcf6d66b5a22249c90d268766ddc"


### PR DESCRIPTION
Fixes bug with ogen on certain systems, where ocaml-linenoise would crash with a segfault: https://github.com/nv-vn/ogen/issues/3.
Hopefully this doesn't break anything with OPAM, since it's using the same github release as ogen.0.1.3?