### PR TITLE
assimp.0.3 - via opam-publish

### DIFF
--- a/packages/assimp/assimp.0.3/descr
+++ b/packages/assimp/assimp.0.3/descr
@@ -1,0 +1,7 @@
+OCaml bindings to Assimp, Open Asset Import Library
+
+Assimp homepage: http://assimp.sourceforge.net/
+Assimp is licensed under 3-clause BSD.
+This binding is licensed under CC0.
+
+Assimp needs to be installed first.

--- a/packages/assimp/assimp.0.3/opam
+++ b/packages/assimp/assimp.0.3/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/def-lkb/assimp"
+bug-reports: "https://github.com/def-lkb/assimp"
+license: "CC0"
+dev-repo: "https://github.com/def-lkb/assimp.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "assimp"]
+depends: [
+  "ocamlfind" {build}
+  "result"
+]
+depexts: [
+  [["debian"] ["libassimp-dev"]]
+  [["ubuntu"] ["libassimp-dev"]]
+  [["osx" "homebrew"] ["assimp"]]
+]

--- a/packages/assimp/assimp.0.3/url
+++ b/packages/assimp/assimp.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/assimp/archive/v0.3.tar.gz"
+checksum: "810fb0f99e0708a1d83e0474fc90a432"


### PR DESCRIPTION
OCaml bindings to Assimp, Open Asset Import Library

Assimp homepage: http://assimp.sourceforge.net/
Assimp is licensed under 3-clause BSD.
This binding is licensed under CC0.

Assimp needs to be installed first.


---
* Homepage: https://github.com/def-lkb/assimp
* Source repo: https://github.com/def-lkb/assimp.git
* Bug tracker: https://github.com/def-lkb/assimp

---

Pull-request generated by opam-publish v0.3.2