### PR TITLE
stb_image_write.0.2 - via opam-publish

### DIFF
--- a/packages/stb_image_write/stb_image_write.0.2/descr
+++ b/packages/stb_image_write/stb_image_write.0.2/descr
@@ -1,0 +1,8 @@
+OCaml bindings to stb_image_write, a public domain image writer 
+
+Stb_image_write is an OCaml binding to stb_image_write from Sean Barrett, [Nothings](http://nothings.org/).
+
+  stb_image_write.h writes out PNG/BMP/TGA images to C stdio.
+
+The OCaml binding is released under CC-0 license.  It has no dependency beside
+working OCaml and C compilers (stb_image_write is self-contained).

--- a/packages/stb_image_write/stb_image_write.0.2/opam
+++ b/packages/stb_image_write/stb_image_write.0.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/def-lkb/stb_image_write"
+bug-reports: "https://github.com/def-lkb/stb_image_write"
+license: "CC0"
+dev-repo: "https://github.com/def-lkb/stb_image_write.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "stb_image_write"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ocaml-version != "4.01.0"]

--- a/packages/stb_image_write/stb_image_write.0.2/url
+++ b/packages/stb_image_write/stb_image_write.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/stb_image_write/archive/v0.2.tar.gz"
+checksum: "79cb1d610f2fc16231d4f1d4064166d0"


### PR DESCRIPTION
OCaml bindings to stb_image_write, a public domain image writer 

Stb_image_write is an OCaml binding to stb_image_write from Sean Barrett, [Nothings](http://nothings.org/).

  stb_image_write.h writes out PNG/BMP/TGA images to C stdio.

The OCaml binding is released under CC-0 license.  It has no dependency beside
working OCaml and C compilers (stb_image_write is self-contained).


---
* Homepage: https://github.com/def-lkb/stb_image_write
* Source repo: https://github.com/def-lkb/stb_image_write.git
* Bug tracker: https://github.com/def-lkb/stb_image_write

---

Pull-request generated by opam-publish v0.3.2