### PR TITLE
depyt.0.1.0 - via opam-publish

### DIFF
--- a/packages/depyt/depyt.0.1.0/descr
+++ b/packages/depyt/depyt.0.1.0/descr
@@ -1,0 +1,19 @@
+Yet-an-other type combinator library
+
+Depyt provides type combinators to define runtime representation for
+OCaml types and generic operations to manipulate values with a runtime
+type representation.
+
+The type combinators supports all the usual type primitives but also
+compact definitions of records and variants. It also allows to define
+the runtime representation of recursive types.
+
+Depyt is a modern reboot of
+[Dyntype](https://github.com/mirage/dyntype) but using
+[GADT](https://en.wikipedia.org/wiki/Generalized_algebraic_data_type)s-based
+combinators instead of syntax-extensions. When we originally wrote
+Dyntype (in 2012) GADTs were not available in OCaml and
+[camlp4](https://github.com/ocaml/camlp4) was everywhere -- this is
+not the case anymore. Finally, Depyt avoids some of the performance
+caveats present in Dyntype by avoiding allocating and converting
+between intermediate formats.

--- a/packages/depyt/depyt.0.1.0/opam
+++ b/packages/depyt/depyt.0.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/samoht/depyt"
+dev-repo:     "https://github.com/samoht/depyt.git"
+bug-reports:  "https://github.com/samoht/depyt/issues"
+doc:          "https://samoht.github.io/depyt/doc"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" "fmt" "result" "jsonm" "ocplib-endian"
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.0"]

--- a/packages/depyt/depyt.0.1.0/url
+++ b/packages/depyt/depyt.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/depyt/releases/download/0.1.0/depyt-0.1.0.tbz"
+checksum: "723487f8e7ac3e3ff08d601e837875f7"


### PR DESCRIPTION
Yet-an-other type combinator library

Depyt provides type combinators to define runtime representation for
OCaml types and generic operations to manipulate values with a runtime
type representation.

The type combinators supports all the usual type primitives but also
compact definitions of records and variants. It also allows to define
the runtime representation of recursive types.

Depyt is a modern reboot of
[Dyntype](https://github.com/mirage/dyntype) but using
[GADT](https://en.wikipedia.org/wiki/Generalized_algebraic_data_type)s-based
combinators instead of syntax-extensions. When we originally wrote
Dyntype (in 2012) GADTs were not available in OCaml and
[camlp4](https://github.com/ocaml/camlp4) was everywhere -- this is
not the case anymore. Finally, Depyt avoids some of the performance
caveats present in Dyntype by avoiding allocating and converting
between intermediate formats.

---
* Homepage: https://github.com/samoht/depyt
* Source repo: https://github.com/samoht/depyt.git
* Bug tracker: https://github.com/samoht/depyt/issues

---


---
### 0.1.0 (2016-11-27)

First release.
Pull-request generated by opam-publish v0.3.2