### PR TITLE
herdtools7.7.42 - via opam-publish

### DIFF
--- a/packages/herdtools7/herdtools7.7.42/descr
+++ b/packages/herdtools7/herdtools7.7.42/descr
@@ -1,0 +1,10 @@
+This is herdtools7, a tool suite to test weak memory models.
+
+We provide the following tools:
+
+ - herd7: a generic simulator for weak memory models
+ - litmus7: run litmus tests (given as assembler programs for Power, ARM or X86) to test the memory model of the executing machine
+ - diy7: produce litmus tests from concise specifications
+ - some tools to analyse run logs of both herd and litmus
+
+herdtools7 is the successor of the diy tool suite.

--- a/packages/herdtools7/herdtools7.7.42/opam
+++ b/packages/herdtools7/herdtools7.7.42/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@russian-dolls-sunflowers.com>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+  "Vincent Jacques <vincent@russian-dolls-sunflowers.com>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "https://github.com/herd/herdtools7.git"
+build: ["./build.sh" "%{prefix}%"]
+install: ["./install.sh" "%{prefix}%"]
+remove: ["./uninstall.sh" "%{prefix}%"]
+depends: [
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/herdtools7/herdtools7.7.42/url
+++ b/packages/herdtools7/herdtools7.7.42/url
@@ -1,0 +1,2 @@
+http: "https://github.com/herd/herdtools7/archive/7.42.tar.gz"
+checksum: "033c4a9fef494cb08ccc07e8f111415a"


### PR DESCRIPTION
This is herdtools7, a tool suite to test weak memory models.

We provide the following tools:

 - herd7: a generic simulator for weak memory models
 - litmus7: run litmus tests (given as assembler programs for Power, ARM or X86) to test the memory model of the executing machine
 - diy7: produce litmus tests from concise specifications
 - some tools to analyse run logs of both herd and litmus

herdtools7 is the successor of the diy tool suite.


---
* Homepage: http://diy.inria.fr/
* Source repo: https://github.com/herd/herdtools7.git
* Bug tracker: http://github.com/herd/herdtools7/issues/

---

Pull-request generated by opam-publish v0.3.2