### PR TITLE
lru.0.1.1 - via opam-publish

### DIFF
--- a/packages/lru/lru.0.1.1/descr
+++ b/packages/lru/lru.0.1.1/descr
@@ -1,0 +1,9 @@
+Scalable LRU caches
+
+
+lru provides LRU caches for OCaml. These are size-bounded finite maps that
+remove the least-recently-used (LRU) bindings to maintain their size constraint.
+
+The library has two implementations: one is functional, the other imperative.
+
+lru is distributed under the ISC license.

--- a/packages/lru/lru.0.1.1/opam
+++ b/packages/lru/lru.0.1.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/lru"
+doc: "https://pqwy.github.io/lru/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/lru.git"
+bug-reports: "https://github.com/pqwy/lru/issues"
+tags: ["data-structure"]
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "psq"
+  "alcotest" {test} ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]

--- a/packages/lru/lru.0.1.1/url
+++ b/packages/lru/lru.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/lru/releases/download/v0.1.1/lru-0.1.1.tbz"
+checksum: "da7b90c2c635064b5f5646ff40bca25b"


### PR DESCRIPTION
Scalable LRU caches


lru provides LRU caches for OCaml. These are size-bounded finite maps that
remove the least-recently-used (LRU) bindings to maintain their size constraint.

The library has two implementations: one is functional, the other imperative.

lru is distributed under the ISC license.


---
* Homepage: https://github.com/pqwy/lru
* Source repo: https://github.com/pqwy/lru.git
* Bug tracker: https://github.com/pqwy/lru/issues

---


---
## v0.1.1 2016-11-28

* Fix missing dep on `psq` in META
Pull-request generated by opam-publish v0.3.3