### PR TITLE
Add conf-gmp-powm-sec

### DIFF
--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/descr
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/descr
@@ -1,0 +1,3 @@
+Virtual package relying on a GMP lib with constant-time modular exponentiation.
+This package can only install if the GMP lib is installed on the system and
+corresponds to a version that has the mpz_powm_sec function.

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/files/test.c
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/files/test.c
@@ -1,0 +1,11 @@
+#include <gmp.h>
+#ifndef __GMP_H__
+#error "No GMP header"
+#endif
+#if __GNU_MP_VERSION < 5
+#error "GMP >= 5 is required to support mpz_powm_sec"
+#endif
+
+void test(void) {
+	__gmp_init();
+}

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
@@ -8,13 +8,6 @@ license: "GPL"
 build: [
   ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
 ]
-depexts: [
-  [["debian"] ["libgmp-dev"]]
-  [["ubuntu"] ["libgmp-dev"]]
-  [["osx" "homebrew"] ["gmp"]]
-  [["centos"] ["gmp" "gmp-devel"]]
-  [["fedora"] ["gmp" "gmp-devel"]]
-  [["openbsd"] ["gmp"]]
-  [["freebsd"] ["gmp"]]
-  [["alpine"] ["gmp-dev"]]
+depends: [
+    "conf-gmp"
 ]

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+author: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+license: "GPL"
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
+]
+depexts: [
+  [["debian"] ["libgmp-dev"]]
+  [["ubuntu"] ["libgmp-dev"]]
+  [["osx" "homebrew"] ["gmp"]]
+  [["centos"] ["gmp" "gmp-devel"]]
+  [["fedora"] ["gmp" "gmp-devel"]]
+  [["openbsd"] ["gmp"]]
+  [["freebsd"] ["gmp"]]
+  [["alpine"] ["gmp-dev"]]
+]

--- a/packages/cryptokit/cryptokit.1.11/opam
+++ b/packages/cryptokit/cryptokit.1.11/opam
@@ -8,6 +8,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-zlib"
+  "conf-gmp-powm-sec"
   "zarith" { >= "1.4" }
 ]
 patches: [


### PR DESCRIPTION
This adds a conf-gmp-powm-sec package that checks that the GMP library installed supports `mpz_powm_sec`, a function to perform modular exponentiation in constant time. `cryptokit.1.11` relies on this function being available in its RSA implementation (through `zarith`), or otherwise fails at runtime.

cc @avsm @xavierleroy that's the followup we discussed in #7892.

Thanks!