### PR TITLE
sequoia.0.1.0 - via opam-publish

### DIFF
--- a/packages/sequoia/sequoia.0.1.0/descr
+++ b/packages/sequoia/sequoia.0.1.0/descr
@@ -1,0 +1,4 @@
+Type-safe query builder for OCaml
+
+Sequoia is a type-safe query builder for OCaml. Queries are composable and it
+supports multiple database drivers (currently MySQL and SQLite).

--- a/packages/sequoia/sequoia.0.1.0/opam
+++ b/packages/sequoia/sequoia.0.1.0/opam
@@ -13,4 +13,5 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "sequoia"]
 depends: [
   "ocamlfind" {build}
+  "ppx_tools"
 ]

--- a/packages/sequoia/sequoia.0.1.0/opam
+++ b/packages/sequoia/sequoia.0.1.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andrenth/sequoia"
 bug-reports: "https://github.com/andrenth/sequoia"
 license: "MIT"
 dev-repo: "https://github.com/andrenth/sequoia.git"
+available: [ ocaml-version >= "4.04.0" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/sequoia/sequoia.0.1.0/opam
+++ b/packages/sequoia/sequoia.0.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/sequoia"
+bug-reports: "https://github.com/andrenth/sequoia"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/sequoia"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "sequoia"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/sequoia/sequoia.0.1.0/opam
+++ b/packages/sequoia/sequoia.0.1.0/opam
@@ -4,7 +4,7 @@ authors: "Andre Nathan <andrenth@gmail.com>"
 homepage: "https://github.com/andrenth/sequoia"
 bug-reports: "https://github.com/andrenth/sequoia"
 license: "MIT"
-dev-repo: "https://github.com/andrenth/sequoia"
+dev-repo: "https://github.com/andrenth/sequoia.git"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/sequoia/sequoia.0.1.0/url
+++ b/packages/sequoia/sequoia.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/sequoia/archive/0.1.0.tar.gz"
+checksum: "9a314cd5452224be688f2902f27bedb4"


### PR DESCRIPTION
Type-safe query builder for OCaml

Sequoia is a type-safe query builder for OCaml. Queries are composable and it
supports multiple database drivers (currently MySQL and SQLite).


---
* Homepage: https://github.com/andrenth/sequoia
* Source repo: https://github.com/andrenth/sequoia
* Bug tracker: https://github.com/andrenth/sequoia

---

Pull-request generated by opam-publish v0.3.3