### PR TITLE
xtmpl.0.16.0 - via opam-publish

### DIFF
--- a/packages/xtmpl/xtmpl.0.16.0/descr
+++ b/packages/xtmpl/xtmpl.0.16.0/descr
@@ -1,0 +1,4 @@
+XML templating library and ppx.
+
+Provide an XML parser, templating and rewrite engine for XML documents.
+

--- a/packages/xtmpl/xtmpl.0.16.0/opam
+++ b/packages/xtmpl/xtmpl.0.16.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/xtmpl/"
+bug-reports: "https://github.com/zoggy/xtmpl/issues"
+license: "GNU Lesser General Public License version 3"
+doc: "http://zoggy.github.io/xtmpl/doc.html"
+tags: ["xml" "template" "javascript"]
+dev-repo: "https://github.com/zoggy/xtmpl.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "xtmpl"]
+depends: [
+  "ocamlfind"
+  "sedlex" {>= "1.99.3"}
+  "uutf" {>= "1.0.0"}
+  "js_of_ocaml" {>= "2.6"}
+  "re" {>= "1.7.1"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/xtmpl/xtmpl.0.16.0/url
+++ b/packages/xtmpl/xtmpl.0.16.0/url
@@ -1,0 +1,2 @@
+http: "https://zoggy.github.io/xtmpl/xtmpl-0.16.0.tar.gz"
+checksum: "015643924a70789f8ff062f5a211a449"


### PR DESCRIPTION
XML templating library and ppx.

Provide an XML parser, templating and rewrite engine for XML documents.



---
* Homepage: http://zoggy.github.io/xtmpl/
* Source repo: https://github.com/zoggy/xtmpl.git
* Bug tracker: https://github.com/zoggy/xtmpl/issues

---

Pull-request generated by opam-publish v0.3.3