### PR TITLE
stog.0.17.0 - via opam-publish

### DIFF
--- a/packages/stog/stog.0.17.0/descr
+++ b/packages/stog/stog.0.17.0/descr
@@ -1,0 +1,18 @@
+A static web site compiler, handling blog posts, or XML document in general.
+
+Main features:
+- generate static XML/HTML documents: easy to deploy, less security problems,
+- handling of blog posts, with dates, topics, keywords and associated RSS feeds,
+- no new syntax,
+- based on a XML rewrite engine allowing to apply substitutions (rewrite rules)
+  on some tags. Some substitutions are pre-defined, and others can be defined
+  in your documents or added by plugins. Content can then be written with
+  semantic tags,
+- support multi-language sites,
+- a lot of predefined functions can be used to handle sectionning, table of
+  contents, verified cross-references, ...,
+- OCaml code can be interpreted at compilation time and the result included in
+  the generated documents, which is nice to write tutorials on OCaml libraries,
+- some plugins ease the inclusion of graphviz graphs, and pictures generated
+  by Aysmptote or LaTeX,
+- ...

--- a/packages/stog/stog.0.17.0/files/stog.install
+++ b/packages/stog/stog.0.17.0/files/stog.install
@@ -1,0 +1,16 @@
+bin: [
+  "src/stog"
+  "src/stog.byte"
+  "src/stog-ocaml-session"
+  "src/mk-stog"
+  "src/mk-stog.byte"
+  "src/mk-stog-ocaml-session"
+  "?src/stog-server"
+  "?src/stog-server.byte"
+  "?src/stog-multi-server"
+  "?src/stog-multi-server.byte"
+  "src/latex2stog"
+  "src/latex2stog.byte"
+  "src/stog-tmpl"
+  "src/stog-tmpl.byte"
+]

--- a/packages/stog/stog.0.17.0/opam
+++ b/packages/stog/stog.0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/stog/"
+bug-reports: "https://github.com/zoggy/stog/issues"
+license: "GNU General Public License version 3"
+doc: "http://zoggy.github.io/stog/doc.html"
+tags: ["publication" "xml" "documentation" "blog" "web" "website"]
+dev-repo: "https://github.com/zoggy/stog.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install-lib" "install-share"]
+remove: ["ocamlfind" "remove" "stog"]
+depends: [
+  "ocamlfind"
+  "xtmpl" {>= "0.16.0"}
+  "ocf" {>= "0.5.0"}
+  "higlo" {>= "0.6"}
+  "ppx_blob" {>= "0.1"}
+  "ptime" {>= "0.8.2"}
+  "uri" {>= "1.9.2"}
+  "omd" {>= "1.3.0"}
+  "lwt" {>= "2.5"}
+  "uutf" {>= "1.0.0"}
+]
+depopts: ["js_of_ocaml" "xmldiff" "websocket" "ojs-base" "cryptokit"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/stog/stog.0.17.0/url
+++ b/packages/stog/stog.0.17.0/url
@@ -1,0 +1,2 @@
+http: "https://zoggy.github.io/stog/stog-0.17.0.tar.gz"
+checksum: "741124e3c4f5ba7aa9135f03c69b9c19"


### PR DESCRIPTION
A static web site compiler, handling blog posts, or XML document in general.

Main features:
- generate static XML/HTML documents: easy to deploy, less security problems,
- handling of blog posts, with dates, topics, keywords and associated RSS feeds,
- no new syntax,
- based on a XML rewrite engine allowing to apply substitutions (rewrite rules)
  on some tags. Some substitutions are pre-defined, and others can be defined
  in your documents or added by plugins. Content can then be written with
  semantic tags,
- support multi-language sites,
- a lot of predefined functions can be used to handle sectionning, table of
  contents, verified cross-references, ...,
- OCaml code can be interpreted at compilation time and the result included in
  the generated documents, which is nice to write tutorials on OCaml libraries,
- some plugins ease the inclusion of graphviz graphs, and pictures generated
  by Aysmptote or LaTeX,
- ...

---
* Homepage: http://zoggy.github.io/stog/
* Source repo: https://github.com/zoggy/stog.git
* Bug tracker: https://github.com/zoggy/stog/issues

---

Pull-request generated by opam-publish v0.3.3