### PR TITLE
stog-writing.0.17.0 - via opam-publish

### DIFF
--- a/packages/stog-writing/stog-writing.0.17.0/descr
+++ b/packages/stog-writing/stog-writing.0.17.0/descr
@@ -1,0 +1,3 @@
+Plugin for Stog to use footnotes and bibliographies in stog-generated web sites.
+
+No longer description :)

--- a/packages/stog-writing/stog-writing.0.17.0/opam
+++ b/packages/stog-writing/stog-writing.0.17.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/stog/plugins/writing.html"
+bug-reports: "https://github.com/zoggy/stog-writing/issues"
+license: "GNU General Public License version 3"
+doc: "http://zoggy.github.io/stog/plugins/writing.html"
+tags: ["publication" "web" "blog" "bibliography"]
+dev-repo: "https://github.com/zoggy/stog-writing.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "stog-writing"]
+depends: [
+  "stog" {= "0.17.0"}
+  "menhir" {>= "20120123"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/stog-writing/stog-writing.0.17.0/url
+++ b/packages/stog-writing/stog-writing.0.17.0/url
@@ -1,0 +1,2 @@
+http: "https://zoggy.github.io/stog/plugins/stog-writing-0.17.0.tar.gz"
+checksum: "f9dd509b250e79cc9caba6c12a5d5f15"


### PR DESCRIPTION
Plugin for Stog to use footnotes and bibliographies in stog-generated web sites.

No longer description :)


---
* Homepage: http://zoggy.github.io/stog/plugins/writing.html
* Source repo: https://github.com/zoggy/stog-writing.git
* Bug tracker: https://github.com/zoggy/stog-writing/issues

---

Pull-request generated by opam-publish v0.3.3