### PR TITLE
rdf.0.11.0 - via opam-publish

### DIFF
--- a/packages/rdf/rdf.0.11.0/descr
+++ b/packages/rdf/rdf.0.11.0/descr
@@ -1,0 +1,13 @@
+Native OCaml implementation of RDF Graphs and Sparql 1.1 Query.
+
+Implemented features
+
+- Three storages available: in memory, in a MySQL or in a Postgresql database,
+- Ability to define your own storages,
+- Transactions,
+- Importing from and exporting to RDF/XML and Turtle formats,
+- Executing Sparql 1.1 queries,
+- HTTP binding of the Sparql protocol, using Lwt.
+
+
+

--- a/packages/rdf/rdf.0.11.0/opam
+++ b/packages/rdf/rdf.0.11.0/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/ocaml-rdf/"
+license: "GNU Lesser General Public License version 3"
+doc: "http://zoggy.github.io/ocaml-rdf/doc.html"
+tags: ["rdf" "semantic web" "xml" "turtle" "graph" "sparql" "utf8"]
+dev-repo: "https://github.com/zoggy/ocaml-rdf.git"
+bug-reports: "https://github.com/zoggy/ocaml-rdf/issues"
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "rdf"]
+depends: [
+  "ocamlfind"
+  "xmlm" {>= "1.2.0"}
+  "sedlex" {>= "1.99.2"}
+  "menhir" {>= "20151112"}
+  "uuidm" {>= "0.9.6"}
+  "cryptokit" {>= "1.7"}
+  "pcre" {>= "7.0.2"}
+  "yojson" {>= "1.1.8"}
+  "iri" {>= "0.4.0"}
+  "uri" {>= "1.9.1"}
+  "calendar" {>= "2.03.2"}
+  "uutf" {>= "1.0.0"}
+  "jsonm" {>= "1.0.0"}
+]
+depopts: ["mysql" "postgresql" "cohttp" "lwt"]
+conflicts: [
+  "cohttp" {< "0.11.2"}
+  "lwt" {< "2.4.5"}
+  "mysql" {< "1.1.1"}
+]
+available: [ ocaml-version >= "4.03.0"]
+

--- a/packages/rdf/rdf.0.11.0/url
+++ b/packages/rdf/rdf.0.11.0/url
@@ -1,0 +1,2 @@
+http: "https://zoggy.github.io/ocaml-rdf/ocaml-rdf-0.11.0.tar.gz"
+checksum: "7c8eb3bac17d324ea57da4696e50b66b"


### PR DESCRIPTION
Native OCaml implementation of RDF Graphs and Sparql 1.1 Query.

Implemented features

- Three storages available: in memory, in a MySQL or in a Postgresql database,
- Ability to define your own storages,
- Transactions,
- Importing from and exporting to RDF/XML and Turtle formats,
- Executing Sparql 1.1 queries,
- HTTP binding of the Sparql protocol, using Lwt.





---
* Homepage: http://zoggy.github.io/ocaml-rdf/
* Source repo: https://github.com/zoggy/ocaml-rdf.git
* Bug tracker: https://github.com/zoggy/ocaml-rdf/issues

---

Pull-request generated by opam-publish v0.3.3