### PR TITLE
Fix uninstall for omake 0.10.1

### DIFF
--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -15,6 +15,9 @@ bug-reports: "https://github.com/ocaml-omake/issues"
 build: [
   ["./configure" "-prefix" "%{prefix}%"]
   [make]
+]
+
+install: [
   [make "install"]
 ]
 

--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -18,5 +18,11 @@ build: [
   [make "install"]
 ]
 
+remove: [
+  [ "rm" "-f" "%{prefix}%/bin/omake" ]
+  [ "rm" "-f" "%{prefix}%/bin/osh" ]
+  [ "rm" "-rf" "%{prefix}%/lib/omake" ]
+]
+
 depends: ["ocamlfind"]
 available: [ ocaml-version >= "4.02.3" & ocaml-native ]


### PR DESCRIPTION
Manually remove binaries and lib directory.

Note that this fix should also apply to omake 0.9.8.6-rc1, which exhibits the
same problem. I didn't bother applying the fix on 0.9.8.6, since I didn't test it
there. Anyone who is interested in fixing old omake, feel free to backport this.

cc @camlspotter.