### PR TITLE
datakit-ci.0.8.0 - via opam-publish

### DIFF
--- a/packages/datakit-ci/datakit-ci.0.8.0/descr
+++ b/packages/datakit-ci/datakit-ci.0.8.0/descr
@@ -1,0 +1,4 @@
+CI orchestration using Datakit
+
+Datakit CI offers primitives to create new CI / build pipeline workflow
+based on Datakit.

--- a/packages/datakit-ci/datakit-ci.0.8.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.8.0/opam
@@ -34,8 +34,5 @@ depends: [
   "github"
   "ppx_sexp_conv" {build}
   "crunch" {build}
-  "datakit" {test}
-  "irmin-unix" {test}
-  "alcotest" {test}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/datakit-ci/datakit-ci.0.8.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.8.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocamlfind" {build}
   "multipart-form-data"
-  "datakit-client" {<= "0.8.0}
+  "datakit-client"
   "protocol-9p" {>= "0.7.4"}
   "astring"
   "cmdliner"

--- a/packages/datakit-ci/datakit-ci.0.8.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer:   "datakit@docker.com"
+authors:      ["Thomas Leonard" "Anil Madhavapeddy"
+               "Dave Tucker" "Thomas Gazagnaire" ]
+license:      "Apache"
+homepage:     "https://github.com/docker/datakit-ci"
+bug-reports:  "https://github.com/docker/datakit-ci/issues"
+dev-repo:     "https://github.com/docker/datakit-ci.git"
+doc:          "https://docker.github.io/datakit-ci/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+  "-n" "datakit-ci"
+]
+
+depends: [
+  "ocamlfind" {build}
+  "multipart-form-data"
+  "datakit-client"
+  "protocol-9p" {>= "0.7.4"}
+  "astring"
+  "cmdliner"
+  "fmt"
+  "logs"
+  "tyxml" {>= "4.0.0"}
+  "tls"
+  "channel"
+  "conduit"
+  "io-page"
+  "pbkdf"
+  "webmachine"
+  "session"
+  "asetmap"
+  "github"
+  "ppx_sexp_conv" {build}
+  "crunch" {build}
+  "datakit" {test}
+  "irmin-unix" {test}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/datakit-ci/datakit-ci.0.8.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.8.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocamlfind" {build}
   "multipart-form-data"
-  "datakit-client"
+  "datakit-client" {<= "0.8.0}
   "protocol-9p" {>= "0.7.4"}
   "astring"
   "cmdliner"

--- a/packages/datakit-ci/datakit-ci.0.8.0/url
+++ b/packages/datakit-ci/datakit-ci.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/docker/datakit/releases/download/0.8.0/datakit-0.8.0.tbz"
+checksum: "eee43f96d223465e4759015aba3ffa00"


### PR DESCRIPTION
CI orchestration using Datakit

Datakit CI offers primitives to create new CI / build pipeline workflow
based on Datakit.

---
* Homepage: https://github.com/docker/datakit-ci
* Source repo: https://github.com/docker/datakit-ci.git
* Bug tracker: https://github.com/docker/datakit-ci/issues

---


---
### 0.8.0 (2016-12-02)

- ci: add Prometheus metric reporting (#352, #353, @talex5)
- ci: allow hiding some arguments when logging commands (#369, @talex5)
- ci: add Term.wait_for, wait_for_all and without_logs (#370, @talex5)
- ci: report GC and system metrics (#379, @talex5)
- ci: better commit messages when updating the state (#385, @talex5

- github: set user-agents (#362, @samoht)
- github: Add a `--resync-interval` option to resync the database regularly
  (#368, @samoht)
- github: Add `.dirty` files to tell the bridge to resync on repo/prs
  (#368, @samoht)
- github: split the package into `datakit-github.client`,
  `datakit-github.server` and `datakit-github` (#375, @samoht)
- github: add `Snapshot.find` (#376, @samoht)
- github: add `Repo.Map`, `Repo.of_string` (#376, @samoht)
- github: add `Satus.compare_id` (#376, @samoht)
- github: replace `create` functions by `v` to be consistent (#376, @samoht)
- github: add `Index` modules for PRs, refs and build status (#377, @samoht)
- github: rename Commit.id into Commit.has (#378, @samoht)
- github: make Status.url an Uri.t option instead of string option
  (#383, @samoht)
- github: github: expose Conv.{pr,ref,status} (#386, @samoht)

- client: more consistent handling of urls arguments. `tcp:foo`
  becomes `tcp://foo` and `fd:42` becomes `fd://42` (#358, @samoht)
- client: client: add Datakit_path.{basename,dirname} (#373, @samoht)

- server: remove the `--sandbox` argument (#357, @samoht)
- server: more consistent handling of urls arguments. `tcp:foo`
  becomes `tcp://foo` and `fd:42` becomes `fd://42` (#358, @samoht)
- server: use hvsock 0.11.1 (#356, @djs55)
Pull-request generated by opam-publish v0.3.2