### PR TITLE
Ketrew 3.0.0: fix omake version

### DIFF
--- a/packages/ketrew/ketrew.3.0.0/opam
+++ b/packages/ketrew/ketrew.3.0.0/opam
@@ -10,7 +10,7 @@ authors : [
 homepage: "http://www.hammerlab.org/docs/ketrew/master/index.html"
 dev-repo: "https://github.com/hammerlab/ketrew.git"
 bug-reports: "https://github.com/hammerlab/ketrew/issues"
-available : [ ocaml-version >= "4.02.2" ]
+available : [ ocaml-version >= "4.02.2"  & ocaml-version < "4.04.0" ]
 install: [
   ["omake"]
   ["omake" "install" "BINDIR=%{bin}%"]

--- a/packages/ketrew/ketrew.3.0.0/opam
+++ b/packages/ketrew/ketrew.3.0.0/opam
@@ -21,7 +21,8 @@ remove: [
   ["rm" "-f" "%{bin}%/ketrew"]
 ]
 depends: [
-  "omake" "ocamlfind" "ocamlify"
+  "omake"  {= "0.9.8.6-0.rc1" }
+  "ocamlfind" "ocamlify"
   "trakeva" {>= "0.1.0" }
   "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"


### PR DESCRIPTION
Ketrew does not build with the new version of omake, see e.g. there:
 <https://travis-ci.org/hammerlab/biokepi/jobs/180576476>.