### PR TITLE
publish.0.3.3: restrict to github < 2.2.0 due to namespace ambiguity

### DIFF
--- a/packages/publish/publish.0.3.3/opam
+++ b/packages/publish/publish.0.3.3/opam
@@ -14,5 +14,5 @@ depends: [
   "opam-lib" {build & = "1.2.2"}
   "ocamlfind" {build}
   "cmdliner" {build}
-  "github" {build & >= "2.0.0"}
+  "github" {build & >= "2.0.0" & < "2.2.0"}
 ]


### PR DESCRIPTION
`github` 2.2.0 exports values that collide with `Lwt` values (`catch` and `fail`) and `publish` 0.3.3 refers to these names in a scope where `Github.Monad` is nearer than `Lwt`.