### PR TITLE
uri.1.9.2: update ppx_sexp_conv constraint for bug fix

### DIFF
--- a/packages/uri/uri.1.9.2/opam
+++ b/packages/uri/uri.1.9.2/opam
@@ -35,7 +35,7 @@ depends: [
   "ocamlfind" {build}
   "re"
   "sexplib" {>= "109.53.00"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {>= "113.33.01"}
   "base-bytes"
   "stringext" {>= "1.4.0"}
   "ounit" {test & >= "1.0.2"}


### PR DESCRIPTION
Fixes mirage/ocaml-uri#92.