### PR TITLE
datakit-github.0.8.1 - via opam-publish

### DIFF
--- a/packages/datakit-github/datakit-github.0.8.1/descr
+++ b/packages/datakit-github/datakit-github.0.8.1/descr
@@ -1,0 +1,8 @@
+A bi-directional bridge between the GitHub API and Datakit
+
+The package provides a bi-directional bridge between the GitHub API
+and Datakit, so you can talk to the GitHub API using filesystem and
+Git-like commands only. The `datakit-github` programs can start a
+webhook server to listen for GitHub events in real time, and project
+it into a Git repository. It also monitors that Git repository for
+user-provided changes, and translate them into GitHub API calls.

--- a/packages/datakit-github/datakit-github.0.8.1/opam
+++ b/packages/datakit-github/datakit-github.0.8.1/opam
@@ -19,9 +19,10 @@ depends: [
   "cmdliner"
   "lwt" "asetmap"
   "logs" "fmt" "mtime" "asl" "win-eventlog" "hvsock"
+  "named-pipe" {>= "0.4.0"}
   "hex" "nocrypto" "conduit"
   "datakit-server" {>= "0.7.0"}
   "datakit-client" {>= "0.7.0"}
   "github-hooks" {>= "0.1.1"}
-  "github" {>= "2.1.0"}
+  "github" {>= "2.2.0"}
 ]

--- a/packages/datakit-github/datakit-github.0.8.1/opam
+++ b/packages/datakit-github/datakit-github.0.8.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/docker/datakit"
+bug-reports:  "https://github.com/docker/datakit/issues"
+dev-repo:     "https://github.com/docker/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" "datakit-github"
+]
+
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "cmdliner"
+  "lwt" "asetmap"
+  "logs" "fmt" "mtime" "asl" "win-eventlog" "hvsock"
+  "hex" "nocrypto" "conduit"
+  "datakit-server" {>= "0.7.0"}
+  "datakit-client" {>= "0.7.0"}
+  "github-hooks" {>= "0.1.1"}
+  "github" {>= "2.1.0"}
+]

--- a/packages/datakit-github/datakit-github.0.8.1/url
+++ b/packages/datakit-github/datakit-github.0.8.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/docker/datakit/releases/download/0.8.1/datakit-0.8.1.tbz"
+checksum: "72c918be8a5b66754e1a29b439605f7c"


### PR DESCRIPTION
A bi-directional bridge between the GitHub API and Datakit

The package provides a bi-directional bridge between the GitHub API
and Datakit, so you can talk to the GitHub API using filesystem and
Git-like commands only. The `datakit-github` programs can start a
webhook server to listen for GitHub events in real time, and project
it into a Git repository. It also monitors that Git repository for
user-provided changes, and translate them into GitHub API calls.

---
* Homepage: https://github.com/docker/datakit
* Source repo: https://github.com/docker/datakit.git
* Bug tracker: https://github.com/docker/datakit/issues

---


---
### 0.8.1 (2016-12-02)

**datakit-github**

- fix regression in comparison between build status (#388, @samoht @avsm)
Pull-request generated by opam-publish v0.3.2