### PR TITLE
emit a warning when using old versions of Alt-Ergo

### DIFF
--- a/packages/alt-ergo/alt-ergo.0.95.2/opam
+++ b/packages/alt-ergo/alt-ergo.0.95.2/opam
@@ -32,3 +32,7 @@ depends:
   "zarith"
   "ocamlgraph" {>= "1.8.2"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/alt-ergo/alt-ergo.0.99.1/opam
+++ b/packages/alt-ergo/alt-ergo.0.99.1/opam
@@ -31,3 +31,7 @@ depends: [
 	"zarith"
 	"ocamlgraph" {>= "1.8.2"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/alt-ergo/alt-ergo.1.01/opam
+++ b/packages/alt-ergo/alt-ergo.1.01/opam
@@ -31,3 +31,8 @@ remove:
 depends: [
 	"zarith"
 ]
+
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/altgr-ergo/altgr-ergo.0.95.2/opam
+++ b/packages/altgr-ergo/altgr-ergo.0.95.2/opam
@@ -35,3 +35,7 @@ depends:
 	"lablgtk"
 	"conf-gtksourceview" {= "2"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/altgr-ergo/altgr-ergo.0.99.1/opam
+++ b/packages/altgr-ergo/altgr-ergo.0.99.1/opam
@@ -35,3 +35,7 @@ depends:
 	"lablgtk"
 	"conf-gtksourceview" {= "2"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/altgr-ergo/altgr-ergo.1.01/opam
+++ b/packages/altgr-ergo/altgr-ergo.1.01/opam
@@ -34,3 +34,7 @@ depends:
 	"lablgtk"
 	"conf-gtksourceview" {= "2"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/fm-simplex-plugin/fm-simplex-plugin.1.01/opam
+++ b/packages/fm-simplex-plugin/fm-simplex-plugin.1.01/opam
@@ -32,3 +32,7 @@ depends:
         "zarith"
         "alt-ergo" {= "1.01"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/profiler-plugin/profiler-plugin.1.01/opam
+++ b/packages/profiler-plugin/profiler-plugin.1.01/opam
@@ -32,3 +32,7 @@ depends:
         "zarith"
         "alt-ergo" {= "1.01"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/satML-plugin/satML-plugin.0.99.1/opam
+++ b/packages/satML-plugin/satML-plugin.0.99.1/opam
@@ -33,3 +33,7 @@ depends:
 	"ocamlgraph" {>= "1.8.2"}
 	"alt-ergo" {= "0.99.1"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]

--- a/packages/satML-plugin/satML-plugin.1.01/opam
+++ b/packages/satML-plugin/satML-plugin.1.01/opam
@@ -32,3 +32,7 @@ depends:
         "zarith"
         "alt-ergo" {= "1.01"}
 ]
+
+messages: [
+   "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements"
+]


### PR DESCRIPTION
Remove older (unmaintained) versions of Alt-Ergo, AltGr-Ergo and their plugins: they are "subsumed" by versions 1.30