### PR TITLE
multipart-form-data.0.1.0 - via opam-publish

### DIFF
--- a/packages/multipart-form-data/multipart-form-data.0.1.0/descr
+++ b/packages/multipart-form-data/multipart-form-data.0.1.0/descr
@@ -1,0 +1,4 @@
+multipart/form-data (RFC2388) parser
+
+This is a parser for structured form data based on `Lwt_stream` in order to use
+it with cohttp. You can use it to send POST parameters.

--- a/packages/multipart-form-data/multipart-form-data.0.1.0/opam
+++ b/packages/multipart-form-data/multipart-form-data.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/multipart-form-data"
+bug-reports: "https://github.com/cryptosense/multipart-form-data/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/multipart-form-data.git"
+doc: "https://cryptosense.github.io/multipart-form-data/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "topkg" {build}
+  "ocamlfind" {build}
+  "alcotest" {test}
+  "ppx_deriving" {test}
+  "stringext"
+  "lwt" {>= "2.5.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/multipart-form-data/multipart-form-data.0.1.0/url
+++ b/packages/multipart-form-data/multipart-form-data.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/multipart-form-data/releases/download/v0.1.0/multipart-form-data-0.1.0.tbz"
+checksum: "1369103590a077f17b7db144b7eeca6b"


### PR DESCRIPTION
multipart/form-data (RFC2388) parser

This is a parser for structured form data based on `Lwt_stream` in order to use
it with cohttp. You can use it to send POST parameters.


---
* Homepage: https://github.com/cryptosense/multipart-form-data
* Source repo: https://github.com/cryptosense/multipart-form-data.git
* Bug tracker: https://github.com/cryptosense/multipart-form-data/issues

---


---
## v0.1.0

*2016-06-12*

- Initial release
Pull-request generated by opam-publish v0.3.3