### PR TITLE
terminal_size.0.1.1 - via opam-publish

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.1/descr
+++ b/packages/terminal_size/terminal_size.0.1.1/descr
@@ -1,0 +1,4 @@
+Get the dimensions of the terminal
+
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.

--- a/packages/terminal_size/terminal_size.0.1.1/opam
+++ b/packages/terminal_size/terminal_size.0.1.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "alcotest" {test}
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/terminal_size/terminal_size.0.1.1/url
+++ b/packages/terminal_size/terminal_size.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/terminal_size/releases/download/v0.1.1/terminal_size-0.1.1.tbz"
+checksum: "46fe5f36bf485b47b4d88cbdb2cc17f2"


### PR DESCRIPTION
Get the dimensions of the terminal

You can use this small library to detect the dimensions of the terminal window
attached to a process.


---
* Homepage: https://github.com/cryptosense/terminal_size
* Source repo: https://github.com/cryptosense/terminal_size.git
* Bug tracker: https://github.com/cryptosense/terminal_size/issues

---


---
v0.1.1
------

*2016-09-08*

Add a test suite.
Pull-request generated by opam-publish v0.3.3