### PR TITLE
biocaml: runs in an infinite select loop with latest omake

### DIFF
--- a/packages/biocaml/biocaml.0.3.0/opam
+++ b/packages/biocaml/biocaml.0.3.0/opam
@@ -35,7 +35,7 @@ depends: [
   "xmlm"
   "pcre"
   "cfstream"
-  "omake"
+  "omake" {build & < "0.10"}
   "flow" {>= "0.2"}
   "lwt" {< "2.5.0"}
 ]

--- a/packages/biocaml/biocaml.0.3.1/opam
+++ b/packages/biocaml/biocaml.0.3.1/opam
@@ -35,7 +35,7 @@ depends: [
   "xmlm"
   "pcre"
   "cfstream"
-  "omake"
+  "omake" {build & < "0.10"}
   "flow" {>= "0.2"}
   "lwt" {< "2.5.0"}
 ]

--- a/packages/biocaml/biocaml.0.4.0/opam
+++ b/packages/biocaml/biocaml.0.4.0/opam
@@ -27,7 +27,7 @@ build-doc: [
 
 depends: [
   "ocamlfind" {build}
-  "omake" {build}
+  "omake" {build & < "0.10"}
   "core" {>= "111.13.00" & <= "113.00.00"}
   "sexplib"
   "camlzip" {>= "1.05"}


### PR DESCRIPTION
only happens on 4.02.3 but kills our CI, so constraining this
for older versions to the known-good omake

/cc @rgrinberg @agarwal 

Error is:

```
Select: select, , Invalid argument
```
