### PR TITLE
add a camlp4.4.04+system to account for preinstalled camlp4

### DIFF
--- a/packages/camlp4/camlp4.4.04+1/opam
+++ b/packages/camlp4/camlp4.4.04+1/opam
@@ -21,6 +21,6 @@ remove: [
              "%{bin}%/camlp4o" "%{bin}%/camlp4of"   "%{bin}%/camlp4oof"
              "%{bin}%/camlp4prof"]
 ]
-available: [ (ocaml-version >= "4.04") & (ocaml-version < "4.05") ]
+available: [ (!preinstalled) & (ocaml-version >= "4.04") & (ocaml-version < "4.05") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.04+system/descr
+++ b/packages/camlp4/camlp4.4.04+system/descr
@@ -1,0 +1,13 @@
+Camlp4 is a system for writing extensible parsers for programming languages
+
+It provides a set of OCaml libraries that are used to define grammars as well
+as loadable syntax extensions of such grammars. Camlp4 stands for Caml
+Preprocessor and Pretty-Printer and one of its most important applications is
+the definition of domain-specific extensions of the syntax of OCaml.
+
+Camlp4 was part of the official OCaml distribution until its version 4.01.0.
+Since then it has been replaced by a simpler system which is easier to maintain
+and to learn: ppx rewriters and extension points.
+
+This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
+you were using `+I camlp4` to directly locate Camlp4, this will no longer work.

--- a/packages/camlp4/camlp4.4.04+system/opam
+++ b/packages/camlp4/camlp4.4.04+system/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+homepage: "https://github.com/ocaml/camlp4"
+license: "LGPLv2"
+build: [
+  ["sh" "./make.sh"]
+]
+available: [ preinstalled & (ocaml-version >= "4.04") & (ocaml-version < "4.05") ]
+bug-reports: "https://github.com/ocaml/camlp4/issues"
+dev-repo: "https://github.com/ocaml/camlp4.git"
+depexts: [
+  [["debian"] ["camlp4-extra"]]
+  [["ubuntu"] ["camlp4-extra"]]
+  [["osx" "homebrew"] ["camlp4"]]
+]

--- a/packages/camlp4/camlp4.4.04+system/url
+++ b/packages/camlp4/camlp4.4.04+system/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/camlp4/archive/system.0.tar.gz"
+checksum: "2ed2db83471da3f6668689492590e7d7"


### PR DESCRIPTION
Adjust camlp4.4.04+1 to only activate for !preinstalled camlp4 case

Debugging via @ilovezfs in #7986