### PR TITLE
raise upper bound on mirage-clock-unix to keep mirage-unix installable

### DIFF
--- a/packages/mirage-clock-unix/mirage-clock-unix.1.0.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.0.0/opam
@@ -1,13 +1,14 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
 author: "anil@recoil.org"
-homepage: "https://github.com/mirage/mirage-clock-unix"
+homepage: "https://github.com/mirage/mirage-clock"
+dev-repo: "https://github.com/mirage/mirage-clock.git"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+install: [make "unix-install"]
 tags: ["org:mirage" "org:xapi-project"]
 build: [make "unix-build"]
 remove: ["ocamlfind" "remove" "mirage-clock-unix"]
 depends: [
   "ocamlfind"
-  "mirage-types" {>= "0.3.0" & < "1.0.0"}
+  "mirage-types" {>= "0.3.0" & < "3.0.0"}
 ]
-dev-repo: "git://github.com/mirage/mirage-clock"
-install: [make "unix-install"]


### PR DESCRIPTION
I confused this package with a deprecated one when adding upper bounds to mirage packages and mistakenly set its upper bound to 1.0.0 .  It should be 3.0.0 as this is still how we come about obtaining the correct clock when building MirageOS applications targeting the Unix backend in a pre-3.0 world.