### PR TITLE
tsdl.0.9.2 - via opam-publish

### DIFF
--- a/packages/tsdl/tsdl.0.9.2/descr
+++ b/packages/tsdl/tsdl.0.9.2/descr
@@ -1,0 +1,11 @@
+Thin bindings to SDL for OCaml
+
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.1][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the ISC license.
+
+[sdl]: http://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes

--- a/packages/tsdl/tsdl.0.9.2/opam
+++ b/packages/tsdl/tsdl.0.9.2/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/tsdl"
+doc: "http://erratique.ch/software/tsdl/doc/Tsdl"
+dev-repo: "http://erratique.ch/repos/tsdl.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
+        "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "result"
+  "ctypes" {>= "0.9.0"}
+  "ctypes-foreign" ]
+depexts: [
+ [["debian"] ["libsdl2-dev"]]
+ [["ubuntu"] ["libsdl2-dev"]]
+ [["mageia"] ["libsdl2.0-devel"]]
+ [["osx" "homebrew"] ["sdl2"]]
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/tsdl/tsdl.0.9.2/url
+++ b/packages/tsdl/tsdl.0.9.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/tsdl/releases/tsdl-0.9.2.tbz"
+checksum: "08c18fed8909499c63e59c14af6c7f3d"


### PR DESCRIPTION
Thin bindings to SDL for OCaml

Tsdl is an OCaml library providing thin bindings to the cross-platform
SDL C library.

Tsdl depends on the [SDL 2.0.1][sdl] C library (or later),
[ocaml-ctypes][ctypes] and the `result` compatibility package.
Tsdl is distributed under the ISC license.

[sdl]: http://www.libsdl.org/
[ctypes]: https://github.com/ocamllabs/ocaml-ctypes


---
* Homepage: http://erratique.ch/software/tsdl
* Source repo: http://erratique.ch/repos/tsdl.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---


---
v0.9.2 2016-12-07 Cambridge (UK)
--------------------------------

- Safe-string support.
- Build depend on `ocb-stubblr`.
- Add support for 2.0.{4,5} events and the stubs more robust
  to additions of events.
Pull-request generated by opam-publish v0.3.3