### PR TITLE
oasis: remove tests

### DIFF
--- a/packages/oasis/oasis.0.4.8/opam
+++ b/packages/oasis/oasis.0.4.8/opam
@@ -13,23 +13,13 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocaml" "%{etc}%/oasis/_oasis_remove_.ml" "%{etc}%/oasis"]
 ]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-unix"
-  "camlp4" {test}
-  "fileutils" {test & >= "0.4.2"}
   "ocamlbuild"
   "ocamlfind" {>= "1.3.1"}
   "ocamlify" {build}
   "ocamlmod" {build}
-  "omake" {test}
-  "ounit" {test & >= "2.0.0"}
-  "pcre" {test}
 ]
 depopts: [
   "benchmark"


### PR DESCRIPTION
They seems broken, /cc @gildor478 

The error I get:

```
#=== ERROR while installing oasis.0.4.8 =======================================#
# opam-version 1.2.2
# os           linux
# command      ocaml setup.ml -configure --enable-tests
# path         /home/travis/.opam/4.03.0/build/oasis.0.4.8
# compiler     4.03.0
# exit-code    1
# env-file     /home/travis/.opam/4.03.0/build/oasis.0.4.8/oasis-4721-ad29c8.env
# stdout-file  /home/travis/.opam/4.03.0/build/oasis.0.4.8/oasis-4721-ad29c8.out
# stderr-file  /home/travis/.opam/4.03.0/build/oasis.0.4.8/oasis-4721-ad29c8.err
### stderr ###
# ocamlfind: Package `expect.pcre' not found
# W: Field 'pkg_expect_pcre' is not set: Command ''/home/travis/.opam/4.03.0/bin/ocamlfind' query -format %d expect.pcre > '/tmp/oasis-402383.txt'' terminated with error code 2
# E: Cannot find findlib package expect.pcre (>= 0.0.4)
# E: Failure("1 configuration error")
```