### PR TITLE
printbox.0.1 - via opam-publish

### DIFF
--- a/packages/printbox/printbox.0.1/descr
+++ b/packages/printbox/printbox.0.1/descr
@@ -1,0 +1,4 @@
+Allows to print nested boxes, lists, arrays, tables in several formats
+
+Box combinators for structured data, with printers for text and HTML
+Doc: https://c-cube.github.io/printbox/

--- a/packages/printbox/printbox.0.1/opam
+++ b/packages/printbox/printbox.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+homepage: "https://github.com/c-cube/printbox/"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+tags: ["print" "box" "table" "tree"]
+dev-repo: "https://github.com/c-cube/printbox.git"
+build: [
+  ["./configure" "--%{tyxml:enable}%-html" "--enable-docs"]
+  [make "build"]
+]
+install: [make "install"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "printbox"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-bytes"
+]
+depopts: "tyxml"
+available: [ocaml-version >= "4.00.0"]

--- a/packages/printbox/printbox.0.1/url
+++ b/packages/printbox/printbox.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/printbox/archive/0.1.tar.gz"
+checksum: "514ace85f9ceef9578fc3000eb7cf164"


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

Box combinators for structured data, with printers for text and HTML
Doc: https://c-cube.github.io/printbox/


---
* Homepage: https://github.com/c-cube/printbox/
* Source repo: https://github.com/c-cube/printbox.git
* Bug tracker: https://github.com/c-cube/printbox/issues/

---

Pull-request generated by opam-publish v0.3.3