### PR TITLE
coclobas.0.0.0 - via opam-publish

### DIFF
--- a/packages/coclobas/coclobas.0.0.0/descr
+++ b/packages/coclobas/coclobas.0.0.0/descr
@@ -1,0 +1,5 @@
+HPC scheduler on top of Kubernetes
+
+Coclobas is a scheduler for “classic HPC-style” jobs on the Google
+Container Engine; it is mostly used as a Ketrew plugin, but can be
+driven separately.

--- a/packages/coclobas/coclobas.0.0.0/opam
+++ b/packages/coclobas/coclobas.0.0.0/opam
@@ -4,7 +4,7 @@ authors: "Seb Mondet <seb@mondet.org>"
 homepage: "https://github.com/hammerlab/coclobas"
 bug-reports: "https://github.com/hammerlab/coclobas/issues"
 license: "Apache 2.0"
-dev-repo: "https://github.com/hammerlab/coclobas"
+dev-repo: "https://github.com/hammerlab/coclobas.git"
 build: [
   [make "byte"]
   [make "native"]

--- a/packages/coclobas/coclobas.0.0.0/opam
+++ b/packages/coclobas/coclobas.0.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: "Seb Mondet <seb@mondet.org>"
+homepage: "https://github.com/hammerlab/coclobas"
+bug-reports: "https://github.com/hammerlab/coclobas/issues"
+license: "Apache 2.0"
+dev-repo: "https://github.com/hammerlab/coclobas"
+build: [
+  [make "byte"]
+  [make "native"]
+  [make "META"]
+  [make "coclobas.install"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "solvuu-build" {build}
+  "nonstd"
+  "sosa"
+  "pvem_lwt_unix"
+  "cohttp"
+  "lwt"
+  "trakeva"
+  "cmdliner"
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.0"}
+  "uuidm"
+  "base64"
+  "odate"
+]
+depopts: "ketrew"
+available: [ocaml-version >= "4.02.3"]
+

--- a/packages/coclobas/coclobas.0.0.0/url
+++ b/packages/coclobas/coclobas.0.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/coclobas/archive/0.0.0.tar.gz"
+checksum: "2ca556f40657af9487dc5e6bbde1e7ec"


### PR DESCRIPTION
HPC scheduler on top of Kubernetes

Coclobas is a scheduler for “classic HPC-style” jobs on the Google
Container Engine; it is mostly used as a Ketrew plugin, but can be
driven separately.


---
* Homepage: https://github.com/hammerlab/coclobas
* Source repo: https://github.com/hammerlab/coclobas
* Bug tracker: https://github.com/hammerlab/coclobas/issues

---

Pull-request generated by opam-publish v0.3.3