### PR TITLE
Add ocsigen-toolkit (0.99 preview version)

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/descr
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/descr
@@ -1,0 +1,1 @@
+Reusable UI components for Eliom applications (client only, or client-server)

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+author: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+homepage: "https://www.ocsigen.org/ocsigen-toolkit"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "https://github.com/ocsigen/ocsigen-toolkit.git"
+build: [ make ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "eliom" {>= "6.0"}
+  "calendar"
+]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/url
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/ocsigen-toolkit/archive/v0.99.tar.gz"
+checksum: "4f854228c0b3770ef7dd083a830d277b"


### PR DESCRIPTION
Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.

This is a preview release.