### PR TITLE
solvuu-build.0.2.0 - via opam-publish

### DIFF
--- a/packages/solvuu-build/solvuu-build.0.2.0/descr
+++ b/packages/solvuu-build/solvuu-build.0.2.0/descr
@@ -1,0 +1,1 @@
+Solvuu's build system.

--- a/packages/solvuu-build/solvuu-build.0.2.0/opam
+++ b/packages/solvuu-build/solvuu-build.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Ashish Agarwal <ashish@solvuu.com>"
+authors: "Solvuu"
+homepage: "https://github.com/solvuu/solvuu-build"
+bug-reports: "https://github.com/solvuu/solvuu-build/issues"
+dev-repo: "https://github.com/solvuu/solvuu-build.git"
+license: "ISC"
+tags: ["org:solvuu"]
+
+build: [
+  [make "byte"]
+  [make "native"]
+  [make "_build/META"]
+  [make "%{name}%.install"]
+]
+
+depends: [
+  "ocamlfind"
+  "ocamlbuild"
+  "ocamlgraph"
+]
+
+available: [
+  ocaml-version >= "4.02.0"
+]

--- a/packages/solvuu-build/solvuu-build.0.2.0/url
+++ b/packages/solvuu-build/solvuu-build.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/solvuu/solvuu-build/archive/v0.2.0.tar.gz"
+checksum: "5471602c946b7ea2ce4c424cb3650cd0"


### PR DESCRIPTION
Solvuu's build system.


---
* Homepage: https://github.com/solvuu/solvuu-build
* Source repo: https://github.com/solvuu/solvuu-build.git
* Bug tracker: https://github.com/solvuu/solvuu-build/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.0