### PR TITLE
[llvm-3.9] allow linking against static llvm

### DIFF
--- a/packages/llvm/llvm.3.9/files/build.sh
+++ b/packages/llvm/llvm.3.9/files/build.sh
@@ -17,6 +17,7 @@ for llvm_config in llvm-config-$version llvm-config-mp-$version $brew_llvm_confi
                 "shared")
                     patch -p1 < link.patch;;
                 "static")
+                    ;;
                 *)
                     echo "Error: '$llvm_config' should have returned either shared or static"
                     exit 1;;

--- a/packages/llvm/llvm.3.9/files/build.sh
+++ b/packages/llvm/llvm.3.9/files/build.sh
@@ -17,7 +17,6 @@ for llvm_config in llvm-config-$version llvm-config-mp-$version $brew_llvm_confi
                 "shared")
                     patch -p1 < link.patch;;
                 "static")
-                    continue;;
                 *)
                     echo "Error: '$llvm_config' should have returned either shared or static"
                     exit 1;;


### PR DESCRIPTION
The `continue` statement in this `switch`/`case` block skips any installed llvm libraries built with `--shared-mode=static`. Not sure, but I'm guessing that wasn't intentional.