### PR TITLE
Fixed installation issue of omake which happens when PREFIX env var is defined

### DIFF
--- a/packages/omake/omake.0.10.1/opam
+++ b/packages/omake/omake.0.10.1/opam
@@ -14,11 +14,11 @@ bug-reports: "https://github.com/ocaml-omake/issues"
 
 build: [
   ["./configure" "-prefix" "%{prefix}%"]
-  [make]
+  [make "PREFIX=%{prefix}%"]
 ]
 
 install: [
-  [make "install"]
+  [make "install" "PREFIX=%{prefix}%"]
 ]
 
 remove: [


### PR DESCRIPTION
This should fix the installation issue of https://github.com/ocaml/opam-repository/issues/7960 .  `configure --prefix <prefix>` does not affect `PREFIX` in the later build and install processes.  We need to specify `PREFIX=%{prefix}%` otherwise `make install` copies files in a different place, when `PREFIX` variable is defined elsewhere.
