### PR TITLE
conf-gmp: add opensuse depext

### DIFF
--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -17,4 +17,5 @@ depexts: [
   [["openbsd"] ["gmp"]]
   [["freebsd"] ["gmp"]]
   [["alpine"] ["gmp-dev"]]
+  [["opensuse"] ["gmp-devel"]]
 ]


### PR DESCRIPTION
missing depext spotted by @djs55 in mirage/ocaml-cstruct#258