### PR TITLE
coccinelle: use 1.0.2 distfile from upstream GH tag as existing distf…

### DIFF
--- a/packages/coccinelle/coccinelle.1.0.2/url
+++ b/packages/coccinelle/coccinelle.1.0.2/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/coccinelle/coccinelle/archive/coccinelle-1.0.2.tar.gz"
-checksum: "36727f88317d7a21a0f9905b89fe68bd"
+archive: "https://github.com/coccinelle/coccinelle/archive/1.0.2.tar.gz"
+checksum: "5170cdf7d42bdd83d8f78d2a6a957830"


### PR DESCRIPTION
…ile missing