### PR TITLE
Upgrade to pds 5.15 and hll 2.7

### DIFF
--- a/packages/hll/hll.2.7/descr
+++ b/packages/hll/hll.2.7/descr
@@ -1,0 +1,2 @@
+Create opam package files from a repository
+

--- a/packages/hll/hll.2.7/opam
+++ b/packages/hll/hll.2.7/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "orbitz@gmail.com"
+build: [
+	[make "-j%{jobs}%"]
+]
+
+install: [
+	[make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+	[make "PREFIX=%{prefix}%" "remove"]
+]
+
+depends: [
+	"cmdliner"
+	"containers"
+	"ocamlfind"
+	"pds" { build & (>= "5" & < "6") }
+	"process"
+	"toml"
+]
+
+authors: [
+	"dklee@dklee.org"
+	"orbitz@gmail.com"
+]
+
+homepage: "https://bitbucket.org/mimirops/hll"
+bug-reports: "https://bitbucket.org/mimirops/hll/issues"
+dev-repo: "git@bitbucket.org:mimirops/hll.git"
+

--- a/packages/hll/hll.2.7/url
+++ b/packages/hll/hll.2.7/url
@@ -1,0 +1,3 @@
+archive: "https://bitbucket.org/mimirops/hll/get/2.7.tar.gz"
+checksum: "3268e2d351f91a4a0718f7daf3ff5076"
+

--- a/packages/pds/pds.5.15/descr
+++ b/packages/pds/pds.5.15/descr
@@ -1,0 +1,2 @@
+A tool to build Makefiles for Ocaml projects
+

--- a/packages/pds/pds.5.15/opam
+++ b/packages/pds/pds.5.15/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "orbitz@gmail.com"
+build: [
+	[make "-j%{jobs}%"]
+]
+
+install: [
+	[make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+	[make "PREFIX=%{prefix}%" "remove"]
+]
+
+depends: [
+	"cmdliner"
+	"crunch"
+	"ocamlfind"
+	"toml"
+]
+
+authors: [
+	"dklee@dklee.org"
+	"orbitz@gmail.com"
+]
+
+homepage: "https://bitbucket.org/mimirops/pds"
+bug-reports: "https://bitbucket.org/mimirops/pds/issues"
+dev-repo: "git@bitbucket.org:mimirops/pds.git"
+available: [ocaml-version >= "4.02"]
+

--- a/packages/pds/pds.5.15/url
+++ b/packages/pds/pds.5.15/url
@@ -1,0 +1,3 @@
+archive: "https://bitbucket.org/mimirops/pds/get/5.15.tar.gz"
+checksum: "818d47f502ae5662f27cca69950dd18d"
+


### PR DESCRIPTION
Changes for pds:

- 5.14
  - Rework builds to use the build output directory rather than building in the
  same directory as the source files.  This allows multiple build types to
  coexist, such as release and debug.
  - Remove PACK support.  Building PACKs is no longer supported.
- 5.15
  - Fix formatted output for third-party projects.
  - Add a changelog and back fill it.


Change for hll:

- 2.7
  - Add changelog
