### PR TITLE
Add ocsigen-start (0.99 preview version)

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.0.99/descr
+++ b/packages/ocsigen-start/ocsigen-start.0.99/descr
@@ -1,0 +1,2 @@
+Skeleton for building client-server Eliom applications
+(with users, notifications, etc.)

--- a/packages/ocsigen-start/ocsigen-start.0.99/opam
+++ b/packages/ocsigen-start/ocsigen-start.0.99/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "https://github.com/ocsigen/ocsigen-start.git"
+build: [ make ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "imagemagick"
+  "pgocaml" {>= "2.3"}
+  "macaque" {>= "0.7.4"}
+  "safepass"
+  "eliom" {>= "6.0"}
+  "ocsigen-toolkit" {>= "0.99"}
+  "yojson"
+]
+depexts: [
+  [["debian"] ["imagemagick"]]
+  [["debian"] ["ruby-sass"]]
+  [["debian"] ["postgresql"]]
+  [["ubuntu"] ["imagemagick"]]
+  [["ubuntu"] ["ruby-sass"]]
+  [["ubuntu"] ["postgresql"]]
+  [["osx" "homebrew"] ["postgresql"]]
+]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/ocsigen-start/ocsigen-start.0.99/url
+++ b/packages/ocsigen-start/ocsigen-start.0.99/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/ocsigen-start/archive/v0.99.tar.gz"
+checksum: "94dfe6df6438af994f2523aee15eecf0"


### PR DESCRIPTION
Ocsigen Start is a skeleton for building client-server Eliom applications, providing functionality like users and notifications.

This is a preview release.
