### PR TITLE
minima-theme.1.0.0 - via opam-publish

### DIFF
--- a/packages/minima-theme/minima-theme.1.0.0/descr
+++ b/packages/minima-theme/minima-theme.1.0.0/descr
@@ -1,0 +1,8 @@
+OCaml port of the Jekyll Minima theme
+
+minima-theme is an OCaml port of the Jekyll Minima that is the default blog
+format for many users. It provides a typed interface for easy use from OCaml
+code.
+
+minima-theme is distributed under the ISC license. The original Minima HTML
+templates bundled with this repository remain under the MIT license.

--- a/packages/minima-theme/minima-theme.1.0.0/opam
+++ b/packages/minima-theme/minima-theme.1.0.0/opam
@@ -23,4 +23,4 @@ depends: [
   "ptime"
   "bos"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/minima-theme/minima-theme.1.0.0/opam
+++ b/packages/minima-theme/minima-theme.1.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/avsm/ocaml-minima-theme"
+bug-reports: "https://github.com/avsm/ocaml-minima-theme/issues"
+license: "ISC"
+doc: "http://docs.mirage.io/minima-theme/"
+tags: ["org:mirage" "org:ocamllabs"]
+dev-repo: "https://github.com/avsm/ocaml-minima-theme.git"
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+]
+build-test: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "fmt"
+  "lambdasoup"
+  "uri"
+  "ptime"
+  "bos"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/minima-theme/minima-theme.1.0.0/url
+++ b/packages/minima-theme/minima-theme.1.0.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/avsm/ocaml-minima-theme/releases/download/v1.0.0/minima-theme-1.0.0.tbz"
+checksum: "630e144d08468b62fb353df969dbc4ea"


### PR DESCRIPTION
OCaml port of the Jekyll Minima theme

minima-theme is an OCaml port of the Jekyll Minima that is the default blog
format for many users. It provides a typed interface for easy use from OCaml
code.

minima-theme is distributed under the ISC license. The original Minima HTML
templates bundled with this repository remain under the MIT license.


---
* Homepage: https://github.com/avsm/ocaml-minima-theme
* Source repo: https://github.com/avsm/ocaml-minima-theme.git
* Bug tracker: https://github.com/avsm/ocaml-minima-theme/issues

---

Pull-request generated by opam-publish v0.3.3