### PR TITLE
corecount.1.0.0 - via opam-publish

### DIFF
--- a/packages/corecount/corecount.1.0.0/descr
+++ b/packages/corecount/corecount.1.0.0/descr
@@ -1,0 +1,3 @@
+Get count of cores on machine
+Get a count of cores on machine via C++11s stdlib
+

--- a/packages/corecount/corecount.1.0.0/opam
+++ b/packages/corecount/corecount.1.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-corecount"
+bug-reports: "https://github.com/fxfactorial/ocaml-corecount/issues"
+license: "BSD-3-clause"
+tags: "clib:stdc"
+dev-repo: "https://github.com/fxfactorial/ocaml-corecount.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "corecount"]
+depends: [
+  "oasis" {build & >= "0.4"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/corecount/corecount.1.0.0/url
+++ b/packages/corecount/corecount.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-corecount/archive/v1.0.0.tar.gz"
+checksum: "e73e83bfaa0fc9f2434ebbd8cad590b6"


### PR DESCRIPTION
Get count of cores on machine
Get a count of cores on machine via C++11s stdlib



---
* Homepage: http://hyegar.com
* Source repo: https://github.com/fxfactorial/ocaml-corecount.git
* Bug tracker: https://github.com/fxfactorial/ocaml-corecount/issues

---

Pull-request generated by opam-publish v0.3.3