### PR TITLE
qcheck.0.5 - via opam-publish

### DIFF
--- a/packages/qcheck/qcheck.0.5/descr
+++ b/packages/qcheck/qcheck.0.5/descr
@@ -1,0 +1,6 @@
+QuickCheck inspired property-based testing for OCaml.
+
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them.
+

--- a/packages/qcheck/qcheck.0.5/opam
+++ b/packages/qcheck/qcheck.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+author: [ "Simon Cruanes <simon.cruanes@inria.fr>" ]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://cedeela.fr/~simon/software/qcheck/QCheck.html"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "build"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "qcheck"]
+]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "base-unix"
+  "ounit"
+]
+available: [ ocaml-version >= "4.00.0" ]
+dev-repo: "https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+post-messages:
+  "New release of QCheck, split back from qtest.
+
+This release breaks the API compared to qcheck.0.4,
+do not update before checking the new `QCheck.mli` and `QCheck_runner` module.
+This new version includes shrinking of counter-examples and combinators
+that also embed printers.
+  "

--- a/packages/qcheck/qcheck.0.5/url
+++ b/packages/qcheck/qcheck.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/qcheck/archive/0.5.tar.gz"
+checksum: "9798f3d99409b900cb4fb87520cd03bc"


### PR DESCRIPTION
QuickCheck inspired property-based testing for OCaml.

This module allows to check invariants (properties of some types) over
randomly generated instances of the type. It provides combinators for
generating instances and printing them.



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---

Pull-request generated by opam-publish v0.3.3