### PR TITLE
qtest.2.5 - via opam-publish

### DIFF
--- a/packages/qtest/qtest.2.5/descr
+++ b/packages/qtest/qtest.2.5/descr
@@ -1,0 +1,6 @@
+iTeML / qtest : Inline (Unit) Tests for OCaml.
+
+qtest extracts inline unit tests written using a special
+syntax in comments. Those tests are then run using the oUnit framework
+and the qcheck library.  The possibilities range from trivial tests --
+extremely simple to use -- to sophisticated random generation of test cases.

--- a/packages/qtest/qtest.2.5/files/qtest.install
+++ b/packages/qtest/qtest.2.5/files/qtest.install
@@ -1,0 +1,4 @@
+bin: [
+  "?qtest/_build/qtest.byte" {"qtest"}
+  "?qtest/_build/qtest.native" {"qtest"}
+]

--- a/packages/qtest/qtest.2.5/opam
+++ b/packages/qtest/qtest.2.5/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Vincent Hugot <vincent.hugot@gmail.com>"
+authors: [
+  "Vincent Hugot <vincent.hugot@gmail.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+homepage: "https://github.com/vincent-hugot/iTeML"
+bug-reports: "https://github.com/vincent-hugot/iTeML/issues"
+doc:
+  "https://github.com/vincent-hugot/iTeML/blob/master/README.adoc#introduction"
+tags: ["test" "property" "quickcheck"]
+dev-repo: "git@github.com:vincent-hugot/iTeML.git"
+build: [make "build"]
+install: [make "BIN=%{bin}%" "install"]
+remove: [
+  ["rm" "%{bin}%/qtest"]
+]
+depends: [
+  "ocamlfind"
+  "ounit" {>= "2.0.0"}
+  "ocamlbuild" {build}
+  "qcheck" {>= "0.5"}
+]
+available: [ocaml-version >= "4.00.0"]
+post-messages:
+  "Version similar to 2.4, except it uses qcheck as an external library
+  instead of embedding it. There should be no other difference.
+
+  To use it, still call `qtest` on your .ml/.mli files to extract tests,
+  then compile the resulting suite using oUnit and qcheck.
+  "

--- a/packages/qtest/qtest.2.5/url
+++ b/packages/qtest/qtest.2.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vincent-hugot/iTeML/archive/v2.5.tar.gz"
+checksum: "cb4cc482ed412c8ed41ebf5d46840667"


### PR DESCRIPTION
iTeML / qtest : Inline (Unit) Tests for OCaml.

qtest extracts inline unit tests written using a special
syntax in comments. Those tests are then run using the oUnit framework
and the qcheck library.  The possibilities range from trivial tests --
extremely simple to use -- to sophisticated random generation of test cases.


---
* Homepage: https://github.com/vincent-hugot/iTeML
* Source repo: git@github.com:vincent-hugot/iTeML.git
* Bug tracker: https://github.com/vincent-hugot/iTeML/issues

---

Pull-request generated by opam-publish v0.3.3