### PR TITLE
rubytt.0.1 - via opam-publish

### DIFF
--- a/packages/rubytt/rubytt.0.1/descr
+++ b/packages/rubytt/rubytt.0.1/descr
@@ -1,0 +1,3 @@
+rubytt is a static Ruby code analyzer
+
+rubytt dump out Ruby code type infomation, analysis unused variable bugs.

--- a/packages/rubytt/rubytt.0.1/opam
+++ b/packages/rubytt/rubytt.0.1/opam
@@ -3,7 +3,7 @@ maintainer: "Yukang <moorekang@gmail.com>"
 authors: "Yukang <moorekang@gmail.com>"
 homepage: "https://github.com/chenyukang/rubytt"
 bug-reports: "https://github.com/chenyukang/rubytt/issues"
-dev-repo: "git@github.com:chenyukang/rubytt.git"
+dev-repo: "https://github.com/chenyukang/rubytt.git"
 license: "MIT"
 tags: ["ruby" "analyzer"]
 build: [make "native"]

--- a/packages/rubytt/rubytt.0.1/opam
+++ b/packages/rubytt/rubytt.0.1/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "Yukang <moorekang@gmail.com>"
 authors: "Yukang <moorekang@gmail.com>"
+version: "0.1"
 homepage: "https://github.com/chenyukang/rubytt"
 bug-reports: "https://github.com/chenyukang/rubytt/issues"
 dev-repo: "https://github.com/chenyukang/rubytt.git"

--- a/packages/rubytt/rubytt.0.1/opam
+++ b/packages/rubytt/rubytt.0.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Yukang <moorekang@gmail.com>"
+authors: "Yukang <moorekang@gmail.com>"
+homepage: "https://github.com/chenyukang/rubytt"
+bug-reports: "https://github.com/chenyukang/rubytt/issues"
+dev-repo: "git@github.com:chenyukang/rubytt.git"
+license: "MIT"
+tags: ["ruby" "analyzer"]
+build: [make "native"]
+install: [make "install"]
+remove: [make "remove"]
+depends: [
+  "ocamlfind" {build}
+  "core" {build}
+  "yojson" {build}
+  "alcotest" {build}
+  "stringext" {build}
+]
+
+available: [ocaml-version > "4.01"]

--- a/packages/rubytt/rubytt.0.1/url
+++ b/packages/rubytt/rubytt.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/chenyukang/rubytt/archive/v0.1.tar.gz"
+checksum: "9e7f414e6a966076f8f1e38f9c63f031"


### PR DESCRIPTION
rubytt is a static Ruby code analyzer

rubytt dump out Ruby code type infomation, analysis unused variable bugs.

---
* Homepage: https://github.com/chenyukang/rubytt
* Source repo: https://github.com/chenyukang/rubytt.git
* Bug tracker: https://github.com/chenyukang/rubytt/issues

---

Pull-request generated by opam-publish v0.3.1