### PR TITLE
rubytt.0.1 - via opam-publish

### DIFF
--- a/packages/rubytt/rubytt.0.1/descr
+++ b/packages/rubytt/rubytt.0.1/descr
@@ -1,3 +1,2 @@
-rubytt is a static Ruby code analyzer
-
-rubytt dump out Ruby code type infomation, analysis unused variable bugs.
+rubytt is a static code analyzer for Ruby.
+rubytt dump out Ruby code type annotation, and analysis unused variable bugs.

--- a/packages/rubytt/rubytt.0.1/files/rubytt.install
+++ b/packages/rubytt/rubytt.0.1/files/rubytt.install
@@ -1,0 +1,1 @@
+bin: ["bin/main.native" {"rubytt"}]

--- a/packages/rubytt/rubytt.0.1/opam
+++ b/packages/rubytt/rubytt.0.1/opam
@@ -1,21 +1,11 @@
 opam-version: "1.2"
 maintainer: "Yukang <moorekang@gmail.com>"
 authors: "Yukang <moorekang@gmail.com>"
-version: "0.1"
 homepage: "https://github.com/chenyukang/rubytt"
 bug-reports: "https://github.com/chenyukang/rubytt/issues"
-dev-repo: "https://github.com/chenyukang/rubytt.git"
+dev-repo: "git@github.com:chenyukang/rubytt.git"
 license: "MIT"
 tags: ["ruby" "analyzer"]
 build: [make "native"]
-install: [make "install"]
-remove: [make "remove"]
-depends: [
-  "ocamlfind" {build}
-  "core" {build}
-  "yojson" {build}
-  "alcotest" {build}
-  "stringext" {build}
-]
-
+depends: ["ocamlfind" "core" "yojson" "alcotest" "ounit" "stringext"]
 available: [ocaml-version > "4.01"]

--- a/packages/rubytt/rubytt.0.1/opam
+++ b/packages/rubytt/rubytt.0.1/opam
@@ -3,9 +3,13 @@ maintainer: "Yukang <moorekang@gmail.com>"
 authors: "Yukang <moorekang@gmail.com>"
 homepage: "https://github.com/chenyukang/rubytt"
 bug-reports: "https://github.com/chenyukang/rubytt/issues"
-dev-repo: "git@github.com:chenyukang/rubytt.git"
+dev-repo: "https://github.com/chenyukang/rubytt.git"
 license: "MIT"
 tags: ["ruby" "analyzer"]
 build: [make "native"]
+install: [make "install"]
+remove: [make "remove"]
 depends: ["ocamlfind" "core" "yojson" "alcotest" "ounit" "stringext"]
 available: [ocaml-version > "4.01"]
+post-messages:
+  "rubytt is installed successfully, please run `rubytt -h` for usage."

--- a/packages/rubytt/rubytt.0.1/opam
+++ b/packages/rubytt/rubytt.0.1/opam
@@ -8,7 +8,7 @@ license: "MIT"
 tags: ["ruby" "analyzer"]
 build: [make "native"]
 install: [make "install"]
-remove: [make "remove"]
+remove: [make "clean"]
 depends: ["ocamlfind" "core" "yojson" "alcotest" "ounit" "stringext"]
 available: [ocaml-version > "4.01"]
 post-messages:

--- a/packages/rubytt/rubytt.0.1/url
+++ b/packages/rubytt/rubytt.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/chenyukang/rubytt/archive/v0.1.tar.gz"
-checksum: "9e7f414e6a966076f8f1e38f9c63f031"
+checksum: "f391d3853d7f27626ac38fc8b9ffa78d"

--- a/packages/rubytt/rubytt.0.1/url
+++ b/packages/rubytt/rubytt.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/chenyukang/rubytt/archive/v0.1.tar.gz"
-checksum: "f391d3853d7f27626ac38fc8b9ffa78d"
+checksum: "8d4ed34747517e2633ac3c9b01f73d07"

--- a/packages/rubytt/rubytt.0.1/url
+++ b/packages/rubytt/rubytt.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/chenyukang/rubytt/archive/v0.1.tar.gz"
-checksum: "8d4ed34747517e2633ac3c9b01f73d07"
+checksum: "b42dfee18d5d061583736a3b644133e6"


### PR DESCRIPTION
rubytt is a static code analyzer for Ruby.
rubytt dump out Ruby code type annotation, and analysis unused variable bugs.

---
* Homepage: https://github.com/chenyukang/rubytt
* Source repo: git@github.com:chenyukang/rubytt.git
* Bug tracker: https://github.com/chenyukang/rubytt/issues

---

Pull-request generated by opam-publish v0.3.3

Fix the binary install issue.