### PR TITLE
BAP 1.1.0 Release

### DIFF
--- a/packages/bap-abi/bap-abi.1.1.0/descr
+++ b/packages/bap-abi/bap-abi.1.1.0/descr
@@ -1,0 +1,1 @@
+A pass that applies ABI specific information

--- a/packages/bap-abi/bap-abi.1.1.0/opam
+++ b/packages/bap-abi/bap-abi.1.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+name: "bap-abi"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-abi"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-abi"]
+         ["ocamlfind" "remove" "bap-abi"]
+         ["bapbundle" "remove" "abi.plugin"]
+         ]
+depends: ["bap-std" "cmdliner"]

--- a/packages/bap-abi/bap-abi.1.1.0/url
+++ b/packages/bap-abi/bap-abi.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-api/bap-api.1.1.0/descr
+++ b/packages/bap-api/bap-api.1.1.0/descr
@@ -1,0 +1,1 @@
+A pass that adds parameters to subroutines based on known API

--- a/packages/bap-api/bap-api.1.1.0/opam
+++ b/packages/bap-api/bap-api.1.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+name: "bap-api"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-api"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-api"]
+         ["ocamlfind" "remove" "bap-api"]
+         [ "bapbundle" "remove" "api.plugin"]
+         ]
+depends: ["bap-std" "cmdliner"]

--- a/packages/bap-api/bap-api.1.1.0/url
+++ b/packages/bap-api/bap-api.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-arm/bap-arm.1.1.0/descr
+++ b/packages/bap-arm/bap-arm.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP ARM lifter

--- a/packages/bap-arm/bap-arm.1.1.0/opam
+++ b/packages/bap-arm/bap-arm.1.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "bap-arm"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-arm"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-arm"]
+        ["ocamlfind" "remove" "bap-plugin-arm"]
+        ["bapbundle"   "remove" "arm.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "bap-llvm"
+    "bap-abi"
+    "bap-c"
+]

--- a/packages/bap-arm/bap-arm.1.1.0/url
+++ b/packages/bap-arm/bap-arm.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/descr
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/descr
@@ -1,0 +1,1 @@
+A frontend for the Byteweight library

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-byteweight-frontend"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight-frontend"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+    "bap-std"
+    "bap-byteweight"
+    "cmdliner"
+    "ocurl"
+    "fileutils"
+    "re"
+]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/url
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-byteweight/bap-byteweight.1.1.0/descr
+++ b/packages/bap-byteweight/bap-byteweight.1.1.0/descr
@@ -1,0 +1,1 @@
+A library and a plugin for finding function starts.

--- a/packages/bap-byteweight/bap-byteweight.1.1.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "bap-byteweight"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-byteweight"]
+        ["ocamlfind" "remove" "bap-plugin-byteweight"]
+        [ "bapbundle" "remove" "byteweight.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "bap-signatures"
+]

--- a/packages/bap-byteweight/bap-byteweight.1.1.0/url
+++ b/packages/bap-byteweight/bap-byteweight.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-c/bap-c.1.1.0/descr
+++ b/packages/bap-c/bap-c.1.1.0/descr
@@ -1,0 +1,1 @@
+A C language support library for BAP

--- a/packages/bap-c/bap-c.1.1.0/opam
+++ b/packages/bap-c/bap-c.1.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "bap-c"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-c"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-c"]]
+depends: ["bap-std" "bap-api"]

--- a/packages/bap-c/bap-c.1.1.0/url
+++ b/packages/bap-c/bap-c.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-cache/bap-cache.1.1.0/descr
+++ b/packages/bap-cache/bap-cache.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP caching service

--- a/packages/bap-cache/bap-cache.1.1.0/opam
+++ b/packages/bap-cache/bap-cache.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-cache"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-cache"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cache"]
+        [ "bapbundle" "remove" "cache.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-cache/bap-cache.1.1.0/url
+++ b/packages/bap-cache/bap-cache.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-callsites/bap-callsites.1.1.0/descr
+++ b/packages/bap-callsites/bap-callsites.1.1.0/descr
@@ -1,0 +1,1 @@
+Inject data definition terms at callsites

--- a/packages/bap-callsites/bap-callsites.1.1.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "bap-callsites"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-callsites"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-callsites"]
+        [ "bapbundle" "remove" "callsites.plugin"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-callsites/bap-callsites.1.1.0/url
+++ b/packages/bap-callsites/bap-callsites.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-demangle/bap-demangle.1.1.0/descr
+++ b/packages/bap-demangle/bap-demangle.1.1.0/descr
@@ -1,0 +1,1 @@
+Library for name demangling

--- a/packages/bap-demangle/bap-demangle.1.1.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "bap-demangle"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-demangle"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-demangle"]
+        ["ocamlfind" "remove" "bap-plugin-demangle"]
+        ["bapbundle"   "remove" "demangle.plugin"]
+        ]
+
+depends: [
+    "core_kernel"       {>= "113.24.00"}
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-demangle/bap-demangle.1.1.0/url
+++ b/packages/bap-demangle/bap-demangle.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/descr
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP plugin that dumps symbols information from a binary

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-dump-symbols"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dump-symbols"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-dump_symbols"]
+        ["bapbundle" "remove" "dump_symbols.plugin"]
+]
+
+depends: [
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/url
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-dwarf/bap-dwarf.1.1.0/descr
+++ b/packages/bap-dwarf/bap-dwarf.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP DWARF parsing library

--- a/packages/bap-dwarf/bap-dwarf.1.1.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.1.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "bap-dwarf"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dwarf"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-dwarf"]]
+depends: ["bap-std"]

--- a/packages/bap-dwarf/bap-dwarf.1.1.0/url
+++ b/packages/bap-dwarf/bap-dwarf.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-elf/bap-elf.1.1.0/descr
+++ b/packages/bap-elf/bap-elf.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP ELF parser and loader written in native OCaml

--- a/packages/bap-elf/bap-elf.1.1.0/opam
+++ b/packages/bap-elf/bap-elf.1.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "bap-elf"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-elf"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-elf"]
+        ["ocamlfind" "remove" "bap-plugin-elf_loader"]
+        ["bapbundle" "remove" "elf_loader.plugin"]
+]
+
+depends: [
+    "bap-std"
+    "bap-dwarf"
+    "camlp4"
+    "bitstring"
+]

--- a/packages/bap-elf/bap-elf.1.1.0/url
+++ b/packages/bap-elf/bap-elf.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-frontc/bap-frontc.1.1.0/descr
+++ b/packages/bap-frontc/bap-frontc.1.1.0/descr
@@ -1,0 +1,1 @@
+A C language frontend for based on FrontC library.

--- a/packages/bap-frontc/bap-frontc.1.1.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "bap-frontc"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-frontc-parser"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
+        ["bapbundle" "remove" "frontc_parser.plugin"]]
+depends: ["bap-std" "bap-c" "FrontC"]

--- a/packages/bap-frontc/bap-frontc.1.1.0/url
+++ b/packages/bap-frontc/bap-frontc.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-frontend/bap-frontend.1.1.0/descr
+++ b/packages/bap-frontend/bap-frontend.1.1.0/descr
@@ -1,0 +1,3 @@
+BAP frontend
+
+The command-line interface to the Binary Analysis Platform.

--- a/packages/bap-frontend/bap-frontend.1.1.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "bap-frontend"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-frontend"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap"]
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-frontend/bap-frontend.1.1.0/url
+++ b/packages/bap-frontend/bap-frontend.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/descr
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP function start identification benchmark game

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-fsi-benchmark"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-fsi-benchmark"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+    "bap-std"
+    "bap-ida"
+    "bap-byteweight-frontend"
+    "cmdliner"
+    "fileutils"
+    "re"
+]

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/url
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-future/bap-future.1.1.0/descr
+++ b/packages/bap-future/bap-future.1.1.0/descr
@@ -1,0 +1,4 @@
+Library for asynchronous values
+
+A library for reasoning about state based dynamic system. This can
+be seen as a common denominator between Lwt and Async libraries.

--- a/packages/bap-future/bap-future.1.1.0/opam
+++ b/packages/bap-future/bap-future.1.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "bap-future"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-future"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-future"]]
+
+depends: [
+    "core_kernel"       {>= "113.24.00"}
+    "oasis"             {build & >= "0.4.7"}
+]

--- a/packages/bap-future/bap-future.1.1.0/url
+++ b/packages/bap-future/bap-future.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/descr
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/descr
@@ -1,0 +1,1 @@
+Plugins for IDA and BAP integration

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "bap-ida-plugin"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ida-plugin"]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-emit_ida_script"]
+        [ "bapbundle" "remove" "emit_ida_script.plugin"]
+
+]
+depends: ["bap" "cmdliner"]

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/url
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-ida-python/bap-ida-python.1.0.0/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0/opam
@@ -21,6 +21,6 @@ remove: [
     ["rm" "-f" "%{conf-ida:path}%/cfg/bap.cfg"]
 ]
 depends: [
-    "bap"
+    "bap" {= "1.0.0"}
     "conf-ida"
 ]

--- a/packages/bap-ida-python/bap-ida-python.1.1.0/descr
+++ b/packages/bap-ida-python/bap-ida-python.1.1.0/descr
@@ -1,0 +1,1 @@
+An IDA Pro integration library

--- a/packages/bap-ida-python/bap-ida-python.1.1.0/files/bap.cfg.in
+++ b/packages/bap-ida-python/bap-ida-python.1.1.0/files/bap.cfg.in
@@ -1,0 +1,2 @@
+.default
+bap_executable_path    %{bap:bin}%/bap

--- a/packages/bap-ida-python/bap-ida-python.1.1.0/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-ida-python"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+license: "MIT"
+substs: [
+    "bap.cfg"
+]
+install: [
+    ["cp" "-v" "plugins/plugin_loader_bap.py" "%{conf-ida:path}%/plugins/"]
+    ["cp" "-rv" "plugins/bap" "%{conf-ida:path}%/plugins/bap"]
+    ["cp" "-v" "bap.cfg" "%{conf-ida:path}%/cfg/"]
+]
+remove: [
+    ["rm" "-f" "%{conf-ida:path}%/plugins/plugin_loader_bap.py"]
+    ["rm" "-rf" "%{conf-ida:path}%/plugins/bap/"]
+    ["rm" "-f" "%{conf-ida:path}%/cfg/bap.cfg"]
+]
+depends: [
+    "bap" {= "1.1.0"}
+    "conf-ida"
+]

--- a/packages/bap-ida-python/bap-ida-python.1.1.0/url
+++ b/packages/bap-ida-python/bap-ida-python.1.1.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/archive/1.1.0.tar.gz"
-checksum: "50cfaf3889bf65870a1589b3e5a58c19"
+checksum: "91596e844ad933f8078ab3a3bd96cdbf"

--- a/packages/bap-ida-python/bap-ida-python.1.1.0/url
+++ b/packages/bap-ida-python/bap-ida-python.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/archive/1.1.0.tar.gz"
+checksum: "50cfaf3889bf65870a1589b3e5a58c19"

--- a/packages/bap-ida/bap-ida.1.1.0/descr
+++ b/packages/bap-ida/bap-ida.1.1.0/descr
@@ -1,0 +1,1 @@
+An IDA Pro integration library

--- a/packages/bap-ida/bap-ida.1.1.0/opam
+++ b/packages/bap-ida/bap-ida.1.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "bap-ida"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+     "--prefix=%{prefix}%"
+     "--enable-ida"
+     "--ida-path=%{conf-ida:path}%"
+     "--ida-headless=%{conf-ida:headless}%"
+]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-ida"]
+        ["ocamlfind" "remove" "bap-plugin-ida"]
+        ["bapbundle" "remove" "ida.plugin"]
+]
+depends: [
+         "conf-ida"
+         "bap-ida-python"
+         "core_kernel"       {>= "113.24.00"}
+         "oasis"             {build & = "0.4.7"}
+         "ppx_jane"          {>= "113.24.01"}
+         "fileutils"
+         "re"
+         "bap-ida-plugin"
+]

--- a/packages/bap-ida/bap-ida.1.1.0/url
+++ b/packages/bap-ida/bap-ida.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-llvm/bap-llvm.1.0.0/files/detect.travis
+++ b/packages/bap-llvm/bap-llvm.1.0.0/files/detect.travis
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > bap-llvm.config <<EOF
+ travis : ${TRAVIS:-false}
+EOF

--- a/packages/bap-llvm/bap-llvm.1.1.0/descr
+++ b/packages/bap-llvm/bap-llvm.1.1.0/descr
@@ -1,0 +1,3 @@
+BAP LLVM backend
+
+Provides a loader and a disassembler, based on LLVM-MC library.

--- a/packages/bap-llvm/bap-llvm.1.1.0/files/detect.travis
+++ b/packages/bap-llvm/bap-llvm.1.1.0/files/detect.travis
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > bap-llvm.config <<EOF
+ travis : ${TRAVIS:-false}
+EOF

--- a/packages/bap-llvm/bap-llvm.1.1.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+name: "bap-llvm"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+  "--prefix=%{prefix}%"
+  "--with-cxx=`which clang++`"
+  "--with-llvm-version=%{conf-bap-llvm:version}%" {conf-bap-llvm:installed}
+  "--with-llvm-version=%{conf-llvm:version}%"     {conf-llvm:installed}
+  "--with-llvm-config=%{conf-bap-llvm:config}%" {conf-bap-llvm:installed}
+  "--with-llvm-config=%{conf-llvm:config}%"     {conf-llvm:installed}
+  "--enable-llvm"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-llvm"]
+]
+
+depends: [
+    "bap-std"
+    "cmdliner"
+    ("conf-bap-llvm" | "conf-llvm")
+    "conf-env-travis"
+]
+
+depexts: [
+    [["ubuntu"] ["clang"]]
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/bap-llvm/bap-llvm.1.1.0/url
+++ b/packages/bap-llvm/bap-llvm.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-mc/bap-mc.1.1.0/descr
+++ b/packages/bap-mc/bap-mc.1.1.0/descr
@@ -1,0 +1,3 @@
+BAP machine instruction playground
+
+A BAP version of llvm-mc tool.

--- a/packages/bap-mc/bap-mc.1.1.0/opam
+++ b/packages/bap-mc/bap-mc.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "bap-mc"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-mc"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap-mc"]
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-mc/bap-mc.1.1.0/url
+++ b/packages/bap-mc/bap-mc.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-microx/bap-microx.1.1.0/descr
+++ b/packages/bap-microx/bap-microx.1.1.0/descr
@@ -1,0 +1,1 @@
+A micro execution framework

--- a/packages/bap-microx/bap-microx.1.1.0/opam
+++ b/packages/bap-microx/bap-microx.1.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "bap-microx"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-microx"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-microx"]]
+depends: ["bap-std"]

--- a/packages/bap-microx/bap-microx.1.1.0/url
+++ b/packages/bap-microx/bap-microx.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-objdump/bap-objdump.1.1.0/descr
+++ b/packages/bap-objdump/bap-objdump.1.1.0/descr
@@ -1,0 +1,1 @@
+extract symbols from binary, using binutils objdump

--- a/packages/bap-objdump/bap-objdump.1.1.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "bap-objdump"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-objdump"
+                 "--objdump-targets=%{conf-binutils:targets}%"
+                 "--objdump-path=%{conf-binutils:objdump}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
+	 ["bapbundle" "remove" "objdump.plugin"]
+]
+depends: ["bap-std" "re" "cmdliner" "conf-binutils"]

--- a/packages/bap-objdump/bap-objdump.1.1.0/url
+++ b/packages/bap-objdump/bap-objdump.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-phoenix/bap-phoenix.1.1.0/descr
+++ b/packages/bap-phoenix/bap-phoenix.1.1.0/descr
@@ -1,0 +1,3 @@
+BAP plugin that dumps information in a phoenix decompiler format
+
+Useful for visualization and project exploration

--- a/packages/bap-phoenix/bap-phoenix.1.1.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "bap-phoenix"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-phoenix"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-phoenix"]
+        ["bapbundle" "remove" "phoenix.plugin"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+    "text-tags"
+    "ocamlgraph"
+    "ezjsonm"
+]

--- a/packages/bap-phoenix/bap-phoenix.1.1.0/url
+++ b/packages/bap-phoenix/bap-phoenix.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-piqi/bap-piqi.1.1.0/descr
+++ b/packages/bap-piqi/bap-piqi.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP plugin for serialization based on piqi library

--- a/packages/bap-piqi/bap-piqi.1.1.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+name: "bap-piqi"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-piqi"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-piqi_printers"]
+        [ "ocamlfind" "remove" "bap-piqi"]
+        [ "bapbundle" "remove" "piqi_printers.plugin"]
+
+
+]
+
+depends: [
+    "oasis"             {build & >= "0.4.7"}
+    "bap-std"
+    "cmdliner"
+    "piqi" {>= "0.7.4"}
+
+]

--- a/packages/bap-piqi/bap-piqi.1.1.0/url
+++ b/packages/bap-piqi/bap-piqi.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-print/bap-print.1.1.0/descr
+++ b/packages/bap-print/bap-print.1.1.0/descr
@@ -1,0 +1,1 @@
+Print plugin - print project in various formats

--- a/packages/bap-print/bap-print.1.1.0/opam
+++ b/packages/bap-print/bap-print.1.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "bap-print"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-print"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-print"]
+        ["bapbundle" "remove" "print.plugin"]
+
+        ]
+
+depends: [
+    "bap-std"
+    "bap-demangle"
+    "text-tags"
+]

--- a/packages/bap-print/bap-print.1.1.0/url
+++ b/packages/bap-print/bap-print.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-std/bap-std.1.1.0/descr
+++ b/packages/bap-std/bap-std.1.1.0/descr
@@ -1,0 +1,3 @@
+Binary Analysis Platform Standard Library
+
+Provides the main BAP library.

--- a/packages/bap-std/bap-std.1.1.0/opam
+++ b/packages/bap-std/bap-std.1.1.0/opam
@@ -1,0 +1,64 @@
+opam-version: "1.2"
+name: "bap-std"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--with-cxx=`which clang++`"
+                 "--mandir=%{man}%"
+                 "--enable-bap-std"]
+  [make]
+]
+
+install: [
+  [make "reinstall"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap"]
+  ["ocamlfind" "remove" "bap-build"]
+  ["rm" "-f" "%{bin}%/baptop"]
+  ["rm" "-f" "%{bin}%/ppx-bap"]
+  ["rm" "-f" "%{bin}%/bapbuild"]
+  ["rm" "-f" "%{bin}%/bapbundle"]
+]
+
+depends: [
+    "base-unix"
+    "bap-future"
+    "camlzip"
+    "core_kernel"       {>= "113.33.00"}
+    "fileutils"
+    "graphlib"
+    "oasis"             {build & = "0.4.7" }
+    "ocamlfind"         {>= "1.5.6" & < "2.0"}
+    "ppx_jane"          {>= "113.33.00" & < "113.34.00"}
+    "regular"
+    "uri"
+    "utop"
+    "uuidm"
+    "zarith"
+]
+
+
+depexts: [
+    [["ubuntu"] [
+        "libgmp-dev"
+        "libzip-dev"
+        "clang"
+     ]]
+     [["osx" "macports"] [
+        "gmp"
+        "libzip"
+     ]
+    ]
+]
+
+conflicts: ["fileutils" {= "0.5.0"}]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/bap-std/bap-std.1.1.0/url
+++ b/packages/bap-std/bap-std.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/descr
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP plugin to read symbols information from file

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "bap-symbol-reader"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-symbol-reader"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-read_symbols"]
+        [ "bapbundle" "remove" "read_symbols.plugin"]
+
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/url
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/descr
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/descr
@@ -1,0 +1,1 @@
+Taint propagation engine using based on microexecution.

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "bap-taint-propagator"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-propagate-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
+         ["bapbundle" "remove" "propagate_taint.plugin"]]
+depends: ["bap-std" "cmdliner" "bap-microx"]

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/url
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-taint/bap-taint.1.1.0/descr
+++ b/packages/bap-taint/bap-taint.1.1.0/descr
@@ -1,0 +1,1 @@
+Introduce taint into a program.

--- a/packages/bap-taint/bap-taint.1.1.0/opam
+++ b/packages/bap-taint/bap-taint.1.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "bap-taint"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-taint"]
+         ["bapbundle" "remove" "taint.plugin"]]
+depends: ["bap-std" "cmdliner"]

--- a/packages/bap-taint/bap-taint.1.1.0/url
+++ b/packages/bap-taint/bap-taint.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-term-mapper/bap-term-mapper.1.1.0/descr
+++ b/packages/bap-term-mapper/bap-term-mapper.1.1.0/descr
@@ -1,0 +1,1 @@
+A DSL for program transformations

--- a/packages/bap-term-mapper/bap-term-mapper.1.1.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "bap-term-mapper"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-map-terms"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
+         [ "ocamlfind" "remove" "bap-bml"]
+         [ "bapbundle" "remove" "map_terms.plugin"]
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-term-mapper/bap-term-mapper.1.1.0/url
+++ b/packages/bap-term-mapper/bap-term-mapper.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-trace/bap-trace.1.1.0/descr
+++ b/packages/bap-trace/bap-trace.1.1.0/descr
@@ -1,0 +1,1 @@
+A plugin to load and run program execution traces

--- a/packages/bap-trace/bap-trace.1.1.0/opam
+++ b/packages/bap-trace/bap-trace.1.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "bap-trace"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-trace"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-trace"]
+        ["bapbundle" "remove" "trace.plugin"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "bap-traces"
+    "cmdliner"
+]

--- a/packages/bap-trace/bap-trace.1.1.0/url
+++ b/packages/bap-trace/bap-trace.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-traces/bap-traces.1.1.0/descr
+++ b/packages/bap-traces/bap-traces.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP Library for loading and parsing execution traces

--- a/packages/bap-traces/bap-traces.1.1.0/opam
+++ b/packages/bap-traces/bap-traces.1.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "bap-traces"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-traces"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-traces"]
+]
+
+depends: [
+    "oasis"             {build & >= "0.4.7"}
+    "bap-std"
+    "uri"               {>= "1.9.0"}
+    "uuidm"
+]

--- a/packages/bap-traces/bap-traces.1.1.0/url
+++ b/packages/bap-traces/bap-traces.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-warn-unused/bap-warn-unused.1.1.0/descr
+++ b/packages/bap-warn-unused/bap-warn-unused.1.1.0/descr
@@ -1,0 +1,1 @@
+Emit a warning if an unused result may cause a bug or security issue

--- a/packages/bap-warn-unused/bap-warn-unused.1.1.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "bap-warn-unused"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-warn-unused"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
+        ["bapbundle" "remove" "warn_unused.plugin"]]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-warn-unused/bap-warn-unused.1.1.0/url
+++ b/packages/bap-warn-unused/bap-warn-unused.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap-x86/bap-x86.1.1.0/descr
+++ b/packages/bap-x86/bap-x86.1.1.0/descr
@@ -1,0 +1,1 @@
+BAP x86 lifter

--- a/packages/bap-x86/bap-x86.1.1.0/files/setup-llvm-version.sh
+++ b/packages/bap-x86/bap-x86.1.1.0/files/setup-llvm-version.sh
@@ -1,0 +1,12 @@
+VERSION=3.4
+
+if `opam config var conf-bap-llvm:installed` == "true"; then
+    VERSION=`opam config var conf-bap-llvm:version`
+else
+    VERSION=`opam config var conf-llvm:version`
+fi
+
+cat > plugins/x86/x86_llvm_config.ml.ab <<EOF
+let llvm_version = "$VERSION"
+
+EOF

--- a/packages/bap-x86/bap-x86.1.1.0/opam
+++ b/packages/bap-x86/bap-x86.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "bap-x86"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-x86-cpu"]
+        ["ocamlfind" "remove" "bap-plugin-x86"]
+        ["bapbundle" "remove" "x86.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "bap-abi"
+    "bap-c"
+    "bap-llvm"
+    "cmdliner"
+]

--- a/packages/bap-x86/bap-x86.1.1.0/opam
+++ b/packages/bap-x86/bap-x86.1.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
 dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
-  ["sh" "./setup-llvm-version"]
+  ["sh" "-x" "setup-llvm-version.sh"]
   ["./configure" "--prefix=%{prefix}%" "--enable-x86"]
   [make]
 ]

--- a/packages/bap-x86/bap-x86.1.1.0/opam
+++ b/packages/bap-x86/bap-x86.1.1.0/opam
@@ -8,6 +8,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
 dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
+  ["sh" "./setup-llvm-version"]
   ["./configure" "--prefix=%{prefix}%" "--enable-x86"]
   [make]
 ]

--- a/packages/bap-x86/bap-x86.1.1.0/url
+++ b/packages/bap-x86/bap-x86.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/bap/bap.1.1.0/descr
+++ b/packages/bap/bap.1.1.0/descr
@@ -1,0 +1,9 @@
+Binary Analysis Platform.
+
+Binary Analysis Platform is a framework for writing program analysis
+tools, that target binary files. The framework consists of a plethora
+of libraries, plugins, and frontends. The libraries provide code
+reusability, the plugins facilitate extensibility, and the frontends
+serve as entry points.
+
+This is a meta package that installs essential parts of BAP.

--- a/packages/bap/bap.1.1.0/opam
+++ b/packages/bap/bap.1.1.0/opam
@@ -9,31 +9,31 @@ dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [
-    "bap-abi" {= "1.0.0"}
-    "bap-api" {= "1.0.0"}
-    "bap-arm" {= "1.0.0"}
-    "bap-byteweight" {= "1.0.0"}
-    "bap-c" {= "1.0.0"}
-    "bap-cache" {= "1.0.0"}
-    "bap-callsites" {= "1.0.0"}
-    "bap-demangle" {= "1.0.0"}
-    "bap-dump-symbols" {= "1.0.0"}
-    "bap-frontend" {= "1.0.0"}
-    "bap-frontc" {= "1.0.0"}
-    "bap-llvm" {= "1.0.0"}
-    "bap-mc" {= "1.0.0"}
-    "bap-microx" {= "1.0.0"}
-    "bap-objdump" {= "1.0.0"}
-    "bap-print" {= "1.0.0"}
-    "bap-std" {= "1.0.0"}
-    "bap-symbol-reader" {= "1.0.0"}
-    "bap-taint" {= "1.0.0"}
-    "bap-taint-propagator" {= "1.0.0"}
-    "bap-term-mapper" {= "1.0.0"}
-    "bap-trace" {= "1.0.0"}
-    "bap-traces" {= "1.0.0"}
-    "bap-warn-unused" {= "1.0.0"}
-    "bap-x86" {= "1.0.0"}
+    "bap-abi" {= "1.1.0"}
+    "bap-api" {= "1.1.0"}
+    "bap-arm" {= "1.1.0"}
+    "bap-byteweight" {= "1.1.0"}
+    "bap-c" {= "1.1.0"}
+    "bap-cache" {= "1.1.0"}
+    "bap-callsites" {= "1.1.0"}
+    "bap-demangle" {= "1.1.0"}
+    "bap-dump-symbols" {= "1.1.0"}
+    "bap-frontend" {= "1.1.0"}
+    "bap-frontc" {= "1.1.0"}
+    "bap-llvm" {= "1.1.0"}
+    "bap-mc" {= "1.1.0"}
+    "bap-microx" {= "1.1.0"}
+    "bap-objdump" {= "1.1.0"}
+    "bap-print" {= "1.1.0"}
+    "bap-std" {= "1.1.0"}
+    "bap-symbol-reader" {= "1.1.0"}
+    "bap-taint" {= "1.1.0"}
+    "bap-taint-propagator" {= "1.1.0"}
+    "bap-term-mapper" {= "1.1.0"}
+    "bap-trace" {= "1.1.0"}
+    "bap-traces" {= "1.1.0"}
+    "bap-warn-unused" {= "1.1.0"}
+    "bap-x86" {= "1.1.0"}
 ]
 
 available: [ocaml-version >= "4.02.3" ]

--- a/packages/bap/bap.1.1.0/opam
+++ b/packages/bap/bap.1.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+name: "bap"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+
+depends: [
+    "bap-abi" {= "1.0.0"}
+    "bap-api" {= "1.0.0"}
+    "bap-arm" {= "1.0.0"}
+    "bap-byteweight" {= "1.0.0"}
+    "bap-c" {= "1.0.0"}
+    "bap-cache" {= "1.0.0"}
+    "bap-callsites" {= "1.0.0"}
+    "bap-demangle" {= "1.0.0"}
+    "bap-dump-symbols" {= "1.0.0"}
+    "bap-frontend" {= "1.0.0"}
+    "bap-frontc" {= "1.0.0"}
+    "bap-llvm" {= "1.0.0"}
+    "bap-mc" {= "1.0.0"}
+    "bap-microx" {= "1.0.0"}
+    "bap-objdump" {= "1.0.0"}
+    "bap-print" {= "1.0.0"}
+    "bap-std" {= "1.0.0"}
+    "bap-symbol-reader" {= "1.0.0"}
+    "bap-taint" {= "1.0.0"}
+    "bap-taint-propagator" {= "1.0.0"}
+    "bap-term-mapper" {= "1.0.0"}
+    "bap-trace" {= "1.0.0"}
+    "bap-traces" {= "1.0.0"}
+    "bap-warn-unused" {= "1.0.0"}
+    "bap-x86" {= "1.0.0"}
+]
+
+available: [ocaml-version >= "4.02.3" ]

--- a/packages/bap/bap.1.1.0/url
+++ b/packages/bap/bap.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/graphlib/graphlib.1.1.0/descr
+++ b/packages/graphlib/graphlib.1.1.0/descr
@@ -1,0 +1,9 @@
+Generic Graph library
+
+Graphlib is a generic library that extends a well known OCamlGraph
+library. Graphlib uses its own, more reach, Graph interface that
+is isomorphic to OCamlGraph's `Sigs.P` signature for persistant
+graphs. Two functors witness the isomorphism of the interfaces:
+`Graphlib.To_ocamlgraph` and `Graphlib.Of_ocamlgraph`. Thanks to
+these functors, any algorithm written for OCamlGraph can be used on
+`Graphlibs` graph and vice verse.

--- a/packages/graphlib/graphlib.1.1.0/opam
+++ b/packages/graphlib/graphlib.1.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "graphlib"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-graphlib"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "graphlib"]
+]
+
+depends: [
+    "core_kernel"       {>= "113.24.00"}
+    "oasis"             {build & >= "0.4.7"}
+    "ppx_jane"          {>= "113.24.01"}
+    "ocamlgraph"
+    "regular"
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/graphlib/graphlib.1.1.0/url
+++ b/packages/graphlib/graphlib.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/regular/regular.1.0.0/opam
+++ b/packages/regular/regular.1.0.0/opam
@@ -29,4 +29,4 @@ depends: [
     "ppx_jane"          {>= "113.24.01"}
 ]
 
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04"]

--- a/packages/regular/regular.1.1.0/descr
+++ b/packages/regular/regular.1.1.0/descr
@@ -1,0 +1,13 @@
+Library for regular data types
+
+Provides functors and typeclasses implementing functionality expected
+for a regular data type, like i/o, containers, printing, etc.
+
+In particular, the library includes:
+
+- module Data that adds generic i/o routines for each regular data type.
+- module Cache that adds caching service for data types
+- module Regular that glues everything together
+- module Opaque for regular but opaque data types
+- module Seq that extends Core_kernel's sequence module
+- module Bytes that provides a rich core-like interface for Bytes data type.

--- a/packages/regular/regular.1.1.0/opam
+++ b/packages/regular/regular.1.1.0/opam
@@ -29,4 +29,4 @@ depends: [
     "ppx_jane"          {>= "113.24.01"}
 ]
 
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04"]

--- a/packages/regular/regular.1.1.0/opam
+++ b/packages/regular/regular.1.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "regular"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-regular"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "regular"]
+]
+
+depends: [
+    "core_kernel"       {>= "113.24.00"}
+    "oasis"             {build & = "0.4.7"}
+    "ppx_jane"          {>= "113.24.01"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/regular/regular.1.1.0/url
+++ b/packages/regular/regular.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"

--- a/packages/text-tags/text-tags.1.1.0/descr
+++ b/packages/text-tags/text-tags.1.1.0/descr
@@ -1,0 +1,1 @@
+A library for rich formatting using semantics tags

--- a/packages/text-tags/text-tags.1.1.0/opam
+++ b/packages/text-tags/text-tags.1.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "text-tags"
+version: "1.1.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-text-tags"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "text-tags"]]
+
+depends: [
+    "core_kernel"       {>= "113.24.00"}
+    "oasis"             {build & = "0.4.7" }
+]

--- a/packages/text-tags/text-tags.1.1.0/url
+++ b/packages/text-tags/text-tags.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"
+checksum: "92e7f703d58ce1835bfeeed9ec523242"


### PR DESCRIPTION
Bug fixes
=========

BinaryAnalysisPlatform/bap#586 segfault with short or damaged files fed to bap.
BinaryAnalysisPlatform/bap#590 llvm 3.8 specific issues
BinaryAnalysisPlatform/bap#592 a bug in lifting x86 PSHUFD/PSHUFB instructions
BinaryAnalysisPlatform/bap#595 bap exit status
BinaryAnalysisPlatform/bap#596 most of the compilation warnings

Features
========

BinaryAnalysisPlatform/bap#593 bapbundle: it is no longer needed to specify the .plugin extension
BinaryAnalysisPlatform/bap#597 API pass will stop processing in case of the error
BinaryAnalysisPlatform/bap#599 print backtraces from passes
BinaryAnalysisPlatform/bap#600 documented memory interface