### PR TITLE
mariadb.0.7.0 - via opam-publish

### DIFF
--- a/packages/mariadb/mariadb.0.7.0/descr
+++ b/packages/mariadb/mariadb.0.7.0/descr
@@ -1,0 +1,4 @@
+OCaml bindings to MariaDB
+
+OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its
+nonblocking API.

--- a/packages/mariadb/mariadb.0.7.0/opam
+++ b/packages/mariadb/mariadb.0.7.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/ocaml-mariadb"
+bug-reports: "https://github.com/andrenth/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-mariadb.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "mariadb"]
+  ["ocamlfind" "remove" "mariadb_bindings"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ctypes" {>= "0.7.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/mariadb/mariadb.0.7.0/url
+++ b/packages/mariadb/mariadb.0.7.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-mariadb/archive/0.7.0.tar.gz"
+checksum: "cab2b39fb1c38a777622c8ee4f8a27a8"


### PR DESCRIPTION
OCaml bindings to MariaDB

OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its
nonblocking API.


---
* Homepage: https://github.com/andrenth/ocaml-mariadb
* Source repo: https://github.com/andrenth/ocaml-mariadb.git
* Bug tracker: https://github.com/andrenth/ocaml-mariadb/issues

---

Pull-request generated by opam-publish v0.3.3