### PR TITLE
ezirmin.0.1.0 - via opam-publish

### DIFF
--- a/packages/ezirmin/ezirmin.0.1.0/descr
+++ b/packages/ezirmin/ezirmin.0.1.0/descr
@@ -1,0 +1,81 @@
+An easy interface on top of the Irmin library.
+
+Ezirmin is an easy interface on top of the
+[Irmin](https://github.com/mirage/irmin) library. It comes with set of mergeable
+datatypes, instantiated to specific backends to quickly get on with it. For
+example,
+
+```ocaml
+$ utop
+utop # #require "ezirmin";;
+utop # module M = Ezirmin.FS_queue(Tc.String);; (* Mergeable queue of strings *)
+utop # open M;;
+utop # open Lwt.Infix;;
+utop # let m = Lwt_main.run (init ~root:"/tmp/ezirminq" ~bare:true () >>= master);;
+val m : branch = <abstr>
+utop # push m ["home"; "todo"] "buy milk";;
+- : unit = ()
+utop # push m ["work"; "todo"] "publish ezirmin";;
+- : unit = ()
+```
+
+This persistent mergeable queue is saved in the git repository at
+`/tmp/ezirminq`. In another terminal,
+
+```ocaml
+$ utop
+utop # #require "ezirmin";;
+utop # module M = Ezirmin.FS_queue(Tc.String);; (* Mergeable queue of strings *)
+utop # open M;;
+utop # open Lwt.Infix;;
+utop # let m = Lwt_main.run (init ~root:"/tmp/ezirminq" ~bare:true () >>= master);;
+val m : branch = <abstr>
+utop # pop m ["work"; "todo"];;
+- : string option = Some "buy milk"
+```
+
+For concurrency control, use branches. In the first terminal,
+
+```ocaml
+utop # let wip_t1 = Lwt_main.run @@ clone_force m "wip_t1";;
+utop # push wip_t1 ["home"; "todo"] "walk dog";;
+- : unit = ()
+utop # push wip_t1 ["home"; "todo"] "take out trash";;
+- : unit = ()
+```
+
+The changes are not visible until the branches are merged.
+
+```ocaml
+utop # to_list m ["home"; "todo"];;
+- : string list = []
+utop # merge wip_t1 ~into:m;;
+- : unit = ()
+utop # to_list m ["home"; "todo"];;
+- : string list = ["walk dog"; "take out trash"]
+```
+
+The mergeable datatypes currently available are:
+
+* [Blog_log](http://kcsrk.info/ezirmin/Ezirmin.Blob_log.html): An append-only
+  log stored as [blobs](). Append is an `O(n)` operation where `n` is the size
+  of the log.
+* [Log](http://kcsrk.info/ezirmin/Ezirmin.Log.html): An append-only
+  write-optimized log with support for paginated reads. Append is an `O(1)`
+  operation
+* [Queue](http://kcsrk.info/ezirmin/Ezirmin.Queue.html): An efficient queue with
+  `O(1)` push and pop operations.
+* [Lww_register](http://kcsrk.info/ezirmin/Ezirmin.Lww_register.html):
+  Last-writer-wins register.
+
+Since these datatypes are defined such that a merge is always possible and that
+merges in different orders converge, they are
+[CRDTs](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type).
+
+The backends available are:
+
+* Git file system backend
+* Git in-memory backend
+
+Ezirmin is distributed under the ISC license.
+

--- a/packages/ezirmin/ezirmin.0.1.0/opam
+++ b/packages/ezirmin/ezirmin.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+authors:      ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+homepage:     "https://github.com/kayceesrk/ezirmin"
+doc:          "https://kayceesrk.github.io/ezirmin/"
+license:      "ISC"
+dev-repo:     "https://github.com/kayceesrk/ezirmin.git"
+bug-reports:  "https://github.com/kayceesrk/ezirmin/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind"   {build}
+  "ocamlbuild"  {build}
+  "topkg"       {build}
+  "lwt"
+  "git-unix"
+  "irmin"				{>= "0.12.0"}
+	"irmin-watcher"
+  "ptime"
+	"ppx_jane"
+]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" pinned ]

--- a/packages/ezirmin/ezirmin.0.1.0/opam
+++ b/packages/ezirmin/ezirmin.0.1.0/opam
@@ -15,11 +15,11 @@ depends: [
   "lwt"
   "git-unix"
   "irmin"				{>= "0.12.0"}
-	"irmin-watcher"
+  "irmin-watcher"
   "ptime"
-	"ppx_jane"
+  "ppx_jane"
 ]
 depopts: []
 build: [
   "ocaml" "pkg/pkg.ml" "build"
-          "--pinned" pinned ]
+          "--pinned" "%{pinned}%" ]

--- a/packages/ezirmin/ezirmin.0.1.0/url
+++ b/packages/ezirmin/ezirmin.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/kayceesrk/ezirmin/releases/download/0.1.0/ezirmin-0.1.0.tbz"
+checksum: "cd9ea932b471fb237ec478c867455b69"


### PR DESCRIPTION
An easy interface on top of the Irmin library.

Ezirmin is an easy interface on top of the
[Irmin](https://github.com/mirage/irmin) library. It comes with set of mergeable
datatypes, instantiated to specific backends to quickly get started. For
example,

```ocaml
$ utop
utop # #require "ezirmin";;
utop # module M = Ezirmin.FS_queue(Tc.String);; (* Mergeable queue of strings *)
utop # open M;;
utop # open Lwt.Infix;;
utop # let m = Lwt_main.run (init ~root:"/tmp/ezirminq" ~bare:true () >>= master);;
val m : branch = <abstr>
utop # push m ["home"; "todo"] "buy milk";;
- : unit = ()
utop # push m ["work"; "todo"] "publish ezirmin";;
- : unit = ()
```

This persistent mergeable queue is saved in the git repository at
`/tmp/ezirminq`. In another terminal,

```ocaml
$ utop
utop # #require "ezirmin";;
utop # module M = Ezirmin.FS_queue(Tc.String);; (* Mergeable queue of strings *)
utop # open M;;
utop # open Lwt.Infix;;
utop # let m = Lwt_main.run (init ~root:"/tmp/ezirminq" ~bare:true () >>= master);;
val m : branch = <abstr>
utop # pop m ["work"; "todo"];;
- : string option = Some "buy milk"
```

For concurrency control, use branches. In the first terminal,

```ocaml
utop # let wip_t1 = Lwt_main.run @@ clone_force m "wip_t1";;
utop # push wip_t1 ["home"; "todo"] "walk dog";;
- : unit = ()
utop # push wip_t1 ["home"; "todo"] "take out trash";;
- : unit = ()
```

The changes are not visible until the branches are merged.

```ocaml
utop # to_list m ["home"; "todo"];;
- : string list = []
utop # merge wip_t1 ~into:m;;
- : unit = ()
utop # to_list m ["home"; "todo"];;
- : string list = ["walk dog"; "take out trash"]
```

The mergeable datatypes currently available are:

* [Blog_log](http://kcsrk.info/ezirmin/Ezirmin.Blob_log.html): An append-only
  log stored as [blobs](). Append is an `O(n)` operation where `n` is the size
  of the log.
* [Log](http://kcsrk.info/ezirmin/Ezirmin.Log.html): An append-only
  write-optimized log with support for paginated reads. Append is an `O(1)`
  operation
* [Queue](http://kcsrk.info/ezirmin/Ezirmin.Queue.html): An efficient queue with
  `O(1)` push and pop operations.
* [Lww_register](http://kcsrk.info/ezirmin/Ezirmin.Lww_register.html):
  Last-writer-wins register.

Since these datatypes are defined such that a merge is always possible and that
merges in different orders converge, they are
[CRDTs](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type).

The backends available are:

* Git file system backend
* Git in-memory backend

Ezirmin is distributed under the ISC license.



---
* Homepage: https://github.com/kayceesrk/ezirmin
* Source repo: https://github.com/kayceesrk/ezirmin.git
* Bug tracker: https://github.com/kayceesrk/ezirmin/issues

---


---
0.1.0 2016-12-27 Cambridge
--------------------------

* First release.
* Datastructures: Append-only log, Queue & Last-write-wins register.
* Backends: git filesystem & git in-memory.
Pull-request generated by opam-publish v0.3.3