### PR TITLE
Bump cstruct dependency for angstrom

### DIFF
--- a/packages/angstrom/angstrom.0.1.0/opam
+++ b/packages/angstrom/angstrom.0.1.0/opam
@@ -23,7 +23,7 @@ build-test: [
 ]
 depends: [
   "alcotest" {test & >= "0.4.1"}
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.7.0"}
   "ocamlfind" {build}
   "result"
   "ocplib-endian" {>= "0.6"}

--- a/packages/angstrom/angstrom.0.1.1/opam
+++ b/packages/angstrom/angstrom.0.1.1/opam
@@ -23,7 +23,7 @@ build-test: [
 ]
 depends: [
   "alcotest" {test & >= "0.4.1"}
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "0.7.0"}
   "ocamlfind" {build}
   "result"
   "ocplib-endian" {>= "0.6"}


### PR DESCRIPTION
Both versions use `Cstruct.of_string` which was only introduced in cstruct 0.7.0.

A PR to upstream is available as well: https://github.com/inhabitedtype/angstrom/pull/57