### PR TITLE
camlgpc.1.0: clarify license

### DIFF
--- a/packages/camlgpc/camlgpc.1.0/opam
+++ b/packages/camlgpc/camlgpc.1.0/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "contact@coherentgraphics.co.uk"
+license: "LGPL/non-commercial-use-only"
 build: make
 remove: [["ocamlfind" "remove" "camlgpc"]]
 depends: ["ocamlfind"]


### PR DESCRIPTION
The native code part of camlgpc comes under the following unusual license:

    Copyright: (C) Advanced Interfaces Group, University of Manchester.

    This software is free for non-commercial use. It may be copied,
    modified, and redistributed provided that this copyright notice
    is preserved on all copies. The intellectual property rights of
    the algorithms used reside with the University of Manchester
    Advanced Interfaces Group.

    You may not use this software, in whole or in part, in support
    of any commercial product without the express consent of the
    author.

    There is no warranty or other guarantee of fitness of this
    software for any purpose. It is provided solely "as is".

@ocaml/opam-repository what should we use in the license field in such cases?