### PR TITLE
edn.0.1.5 - via opam-publish

### DIFF
--- a/packages/edn/edn.0.1.5/descr
+++ b/packages/edn/edn.0.1.5/descr
@@ -1,0 +1,3 @@
+Parsing OCaml library for EDN format
+
+This library implements [EDN][edn] parser and generator for OCaml.

--- a/packages/edn/edn.0.1.5/opam
+++ b/packages/edn/edn.0.1.5/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+license: "MIT"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+dev-repo: "https://github.com/prepor/ocaml-edn.git"
+doc: "https://prepor.github.io/ocaml-edn/doc"
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]
+build-test: [[
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+  "ocaml" "pkg/pkg.ml" "test" ]]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+  "topkg" {build}
+  "oUnit" {test}
+]
+depopts: [
+  "cconv"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.5/opam
+++ b/packages/edn/edn.0.1.5/opam
@@ -17,8 +17,6 @@ depends: [
   "menhir" {build}
   "topkg" {build}
   "oUnit" {test}
-]
-depopts: [
   "cconv"
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.5/opam
+++ b/packages/edn/edn.0.1.5/opam
@@ -17,6 +17,6 @@ depends: [
   "menhir" {build}
   "topkg" {build}
   "oUnit" {test}
-  "cconv" {>= "0.2"}
+  "cconv" {>= "0.4"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.5/opam
+++ b/packages/edn/edn.0.1.5/opam
@@ -17,6 +17,6 @@ depends: [
   "menhir" {build}
   "topkg" {build}
   "oUnit" {test}
-  "cconv"
+  "cconv" {>= "0.2"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.5/url
+++ b/packages/edn/edn.0.1.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/prepor/ocaml-edn/releases/download/v0.1.5/edn-0.1.5.tbz"
+checksum: "13de4b1232a5305c2684d63df8583c95"


### PR DESCRIPTION
Parsing OCaml library for EDN format

This library implements [EDN][edn] parser and generator for OCaml.


---
* Homepage: http://github.com/prepor/ocaml-edn
* Source repo: https://github.com/prepor/ocaml-edn.git
* Bug tracker: http://github.com/prepor/ocaml-edn/issues

---


---
v0.1.5 2016-12-30
--------------------------

- better formatting in wirte (thanks to @ul)
- char represented by string not bytes
Pull-request generated by opam-publish v0.3.2