### PR TITLE
Upgrade to pds 5.18.  This fixes a bug in trying to build in parallel…

### DIFF
--- a/packages/pds/pds.5.18/descr
+++ b/packages/pds/pds.5.18/descr
@@ -1,0 +1,2 @@
+A tool to build Makefiles for Ocaml projects
+

--- a/packages/pds/pds.5.18/opam
+++ b/packages/pds/pds.5.18/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "orbitz@gmail.com"
+build: [
+	[make "-j%{jobs}%"]
+]
+
+build-test: [
+	[make "-j%{jobs}%" "test"]
+]
+
+install: [
+	[make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+	[make "PREFIX=%{prefix}%" "remove"]
+]
+
+depends: [
+	"cmdliner"
+	"crunch"
+	"ocamlfind"
+	"toml"
+]
+
+authors: [
+	"dklee@dklee.org"
+	"orbitz@gmail.com"
+]
+
+homepage: "https://bitbucket.org/mimirops/pds"
+bug-reports: "https://bitbucket.org/mimirops/pds/issues"
+dev-repo: "git@bitbucket.org:mimirops/pds.git"
+available: [ocaml-version >= "4.02"]
+

--- a/packages/pds/pds.5.18/url
+++ b/packages/pds/pds.5.18/url
@@ -1,0 +1,3 @@
+archive: "https://bitbucket.org/mimirops/pds/get/5.18.tar.gz"
+checksum: "cdf053cf6e361f698f3aa77bdd37d0b8"
+


### PR DESCRIPTION
… projects that are not safe to.  Instead it builds a project in serial if it detects that it cannot safely be built in parallel