### PR TITLE
sessions.0.1.0 - via opam-publish

### DIFF
--- a/packages/sessions/sessions.0.1.0/descr
+++ b/packages/sessions/sessions.0.1.0/descr
@@ -1,0 +1,5 @@
+Library to provide session types to allow for static verification of protocols between concurrent computations.
+
+Provides sessions types (currently binary session type) for statically verifying protocols between concurrent computations.
+A pair of processes which are parametrized by binary session types can only be run if they have compatible (dual) session types. 
+This library is based on the paper "Haskell Session Types with (Almost) No Class".

--- a/packages/sessions/sessions.0.1.0/opam
+++ b/packages/sessions/sessions.0.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "essdotteedot <essdotteedot@gmail.com>"
+authors: "essdotteedot <essdotteedot@gmail.com>"
+homepage: "https://github.com/essdotteedot/sessions"
+bug-reports: "https://github.com/essdotteedot/sessions/issues"
+license: "MIT"
+dev-repo: "https://github.com/essdotteedot/sessions.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{lwt:enable}%-lwt"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests" "--%{lwt:enable}%-lwt"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "sessions"]
+depends: [
+  "base-threads"
+  "base-unix"
+  "lwt"
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/sessions/sessions.0.1.0/url
+++ b/packages/sessions/sessions.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/essdotteedot/sessions/archive/0.1.0.tar.gz"
+checksum: "c2d5f085a0aa0f6b5cf7cac2568560fb"


### PR DESCRIPTION
Library to provide session types to allow for static verification of protocols between concurrent computations.

Provides sessions types (currently binary session type) for statically verifying protocols between concurrent computations.
A pair of processes which are parametrized by binary session types can only be run if they have compatible (dual) session types. 
This library is based on the paper "Haskell Session Types with (Almost) No Class".

---
* Homepage: https://github.com/essdotteedot/sessions
* Source repo: https://github.com/essdotteedot/sessions.git
* Bug tracker: https://github.com/essdotteedot/sessions/issues

---

Pull-request generated by opam-publish v0.3.2