### PR TITLE
conduit.0.14.2 - via opam-publish

### DIFF
--- a/packages/conduit/conduit.0.14.2/descr
+++ b/packages/conduit/conduit.0.14.2/descr
@@ -1,0 +1,15 @@
+Network connection library for TCP and SSL
+
+The `conduit` library takes care of establishing and listening for TCP and
+SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways to bind to
+a library (e.g. the C FFI, or the Ctypes library), as well as well as which
+library is used (either OpenSSL or a native OCaml TLS implementation).
+
+If you are using the `Lwt_unix` version of the library, you can set two
+environment variables to control the behaviour of the library:
+
+- `CONDUIT_DEBUG=1` will output debug information to standard error.
+- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.

--- a/packages/conduit/conduit.0.14.2/opam
+++ b/packages/conduit/conduit.0.14.2/opam
@@ -1,0 +1,56 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+license: "ISC"
+tags: "org:mirage"
+dev-repo: "https://github.com/mirage/ocaml-conduit.git"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [make "install"]
+build-test: [
+  ["./configure"]
+  [make "test"]
+]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "conduit"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_driver" {build}
+  "ppx_optcomp" {build & >= "113.24.00"}
+  "ppx_sexp_conv" {build}
+  "sexplib"
+  "stringext"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "cstruct" {>= "1.0.1"}
+  "ipaddr" {>= "2.5.0"}
+]
+depopts: [
+  "async"
+  "lwt"
+  "ssl"
+  "async_ssl"
+  "mirage-dns"
+  "vchan"
+  "launchd"
+  "tls"
+  "mirage-flow-lwt"
+]
+conflicts: [
+  "mirage-flow-lwt" {< "1.2.0"}
+  "lwt" {< "2.4.4"}
+  "async_ssl" {< "112.24.00"}
+  "async" {< "113.24.00"}
+  "dns" {< "0.10.0"}
+  "tls" {< "0.4.0"}
+  "vchan" {< "2.0.0"}
+  "nocrypto" {< "0.4.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/conduit/conduit.0.14.2/url
+++ b/packages/conduit/conduit.0.14.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-conduit/archive/v0.14.2.tar.gz"
+checksum: "e28aa0c62add461af09502192f151d99"


### PR DESCRIPTION
Network connection library for TCP and SSL

The `conduit` library takes care of establishing and listening for TCP and
SSL/TLS connections for the Lwt and Async libraries.

The reason this library exists is to provide a degree of abstraction
from the precise SSL library used, since there are a variety of ways to bind to
a library (e.g. the C FFI, or the Ctypes library), as well as well as which
library is used (either OpenSSL or a native OCaml TLS implementation).

If you are using the `Lwt_unix` version of the library, you can set two
environment variables to control the behaviour of the library:

- `CONDUIT_DEBUG=1` will output debug information to standard error.
- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.


---
* Homepage: https://github.com/mirage/ocaml-conduit
* Source repo: https://github.com/mirage/ocaml-conduit.git
* Bug tracker: https://github.com/mirage/ocaml-conduit/issues

---

Pull-request generated by opam-publish v0.3.3