### PR TITLE
cfgen.1.0 - via opam-publish

### DIFF
--- a/packages/cfgen/cfgen.1.0/descr
+++ b/packages/cfgen/cfgen.1.0/descr
@@ -1,0 +1,8 @@
+Context-free grammar based random text generator
+
+cfgen generated random text based on context-free grammars
+defined in BNF-like syntax. It's primarily meant for parser
+fuzzing. If a rule has multiple alternative, they are selected
+randomly. To influence the choice, you can specify weight for
+each alternative, as in
+<start> ::= 10 "aaa" <start> | 5 "bbb" <start> | "ccc";

--- a/packages/cfgen/cfgen.1.0/opam
+++ b/packages/cfgen/cfgen.1.0/opam
@@ -4,7 +4,7 @@ authors: "Daniil Baturin <daniil@baturin.org>"
 homepage: "https://github.com/dmbaturin/cfgen"
 bug-reports: "https://github.com/dmbaturin/cfgen/issues"
 license: "MIT"
-dev-repo: "https://github.com/dmbaturin/cfgen"
+dev-repo: "git+https://github.com/dmbaturin/cfgen"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/cfgen/cfgen.1.0/opam
+++ b/packages/cfgen/cfgen.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniil Baturin <daniil@baturin.org>"
+authors: "Daniil Baturin <daniil@baturin.org>"
+homepage: "https://github.com/dmbaturin/cfgen"
+bug-reports: "https://github.com/dmbaturin/cfgen/issues"
+license: "MIT"
+dev-repo: "https://github.com/dmbaturin/cfgen"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "cfgen"]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+]

--- a/packages/cfgen/cfgen.1.0/opam
+++ b/packages/cfgen/cfgen.1.0/opam
@@ -4,7 +4,7 @@ authors: "Daniil Baturin <daniil@baturin.org>"
 homepage: "https://github.com/dmbaturin/cfgen"
 bug-reports: "https://github.com/dmbaturin/cfgen/issues"
 license: "MIT"
-dev-repo: "git+https://github.com/dmbaturin/cfgen"
+dev-repo: "https://github.com/dmbaturin/cfgen.git"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/cfgen/cfgen.1.0/url
+++ b/packages/cfgen/cfgen.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dmbaturin/cfgen/archive/1.0.zip"
+checksum: "8036d9283ae8c83a710872a9455f4435"


### PR DESCRIPTION
Context-free grammar based random text generator

cfgen generated random text based on context-free grammars
defined in BNF-like syntax. It's primarily meant for parser
fuzzing. If a rule has multiple alternative, they are selected
randomly. To influence the choice, you can specify weight for
each alternative, as in
<start> ::= 10 "aaa" <start> | 5 "bbb" <start> | "ccc";


---
* Homepage: https://github.com/dmbaturin/cfgen
* Source repo: https://github.com/dmbaturin/cfgen
* Bug tracker: https://github.com/dmbaturin/cfgen/issues

---

Pull-request generated by opam-publish v0.3.2