### PR TITLE
records.0.8.0 - via opam-publish

### DIFF
--- a/packages/records/records.0.8.0/descr
+++ b/packages/records/records.0.8.0/descr
@@ -1,0 +1,3 @@
+Records
+
+This library enables you to define and manipulate dynamic records in OCaml.

--- a/packages/records/records.0.8.0/opam
+++ b/packages/records/records.0.8.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/records"
+bug-reports: "https://github.com/cryptosense/records/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/records.git"
+doc: "https://cryptosense.github.io/records/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ounit" {test}
+  "yojson"
+  "result"
+  "topkg" {build}
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/records/records.0.8.0/url
+++ b/packages/records/records.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/records/releases/download/v0.8.0/records-0.8.0.tbz"
+checksum: "d67b3315208072bf9a3e99d834a1cbec"


### PR DESCRIPTION
Records

This library enables you to define and manipulate dynamic records in OCaml.


---
* Homepage: https://github.com/cryptosense/records
* Source repo: https://github.com/cryptosense/records.git
* Bug tracker: https://github.com/cryptosense/records/issues

---


---
## v0.8.0

*2017-01-03*

### Breaking changes

- Remove `Record.format` (#32) - was previously deprecated.
  The alternative is to invoke `yojson` by hand.

### Deprecated functions

- Deprecate `Type.list` and `Type.product_2` (#30).
  The alternative is to write converter functions by hand or by using
  `ppx_deriving_yojson`.

### New features

- Add `Type.int{32,64}` (#28)

### Build system

- Use docker in Travis (#31)
- Add `descr` file for `topkg opam`.
- Add `org:cryptosense` tag.
- Add merlin configuration (#29).

Pull-request generated by opam-publish v0.3.2