### PR TITLE
zlist.0.1.2 - via opam-publish

### DIFF
--- a/packages/zlist/zlist.0.1.2/descr
+++ b/packages/zlist/zlist.0.1.2/descr
@@ -1,0 +1,4 @@
+Lazy lists for OCaml
+
+
+`zlist` consists of the definition of a lazy list type and a number of useful functions for manipulating and constructing lazy lists.

--- a/packages/zlist/zlist.0.1.2/opam
+++ b/packages/zlist/zlist.0.1.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Jesse Haber-Kucharsky <jesse@haberkucharsky.com>"
+authors: "Jesse Haber-Kucharsky <jesse@haberkucharsky.com>"
+homepage: "https://gitlab.com/jhaberku/Zlist"
+bug-reports: "https://gitlab.com/jhaberku/Zlist/issues"
+license: "Apache 2.0"
+dev-repo: "https://gitlab.com/jhaberku/Zlist.git"
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "alcotest" {test & >= "0.7.2"}
+  "ocamlbuild" {build & >= "0.9.2"}
+  "ocamlfind" {build & >= "1.6.2"}
+  "topkg" {build & >= "0.7.8"}
+]

--- a/packages/zlist/zlist.0.1.2/url
+++ b/packages/zlist/zlist.0.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://gitlab.com/jhaberku/Zlist/uploads/40bc789f3d176514d07b068b936543b6/zlist-0.1.2.tbz"
+checksum: "bdade429cbb5150067407dccb353525e"


### PR DESCRIPTION
Lazy lists for OCaml


`zlist` consists of the definition of a lazy list type and a number of useful functions for manipulating and constructing lazy lists.

---
* Homepage: https://gitlab.com/jhaberku/Zlist
* Source repo: https://gitlab.com/jhaberku/Zlist.git
* Bug tracker: https://gitlab.com/jhaberku/Zlist/issues

---

Pull-request generated by opam-publish v0.3.3