### PR TITLE
add switch for improved-errors branch

### DIFF
--- a/compilers/4.02.2/4.02.2+improved-errors/4.02.2+improved-errors.comp
+++ b/compilers/4.02.2/4.02.2+improved-errors/4.02.2+improved-errors.comp
@@ -1,0 +1,19 @@
+opam-version: "1"
+version: "4.02.2"
+src: "https://github.com/charguer/ocaml/archive/4.02.2+improved-errors.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+  "base-ocamlbuild"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]
+
+
+

--- a/compilers/4.02.2/4.02.2+improved-errors/4.02.2+improved-errors.descr
+++ b/compilers/4.02.2/4.02.2+improved-errors/4.02.2+improved-errors.descr
@@ -1,0 +1,1 @@
+Switch for 4.02.2 improved-errors branch by Arthur Charguéraud


### PR DESCRIPTION
To activate the new errors, use the  -easy-type-errors compiler flag, e.g.:
`ocamlc -easy-type-errors foo.ml`

Documentation from:
- paper:  http://www.chargueraud.org/research/2015/ocaml_errors/ocaml_errors.pdf
- slides:  http://www.chargueraud.org/talks/2014_09_05_talk_ocaml_errors.pdf
- video:  https://www.youtube.com/watch?v=V_ipQZeBueg