### PR TITLE
pkcs11.0.6.0 - via opam-publish

### DIFF
--- a/packages/pkcs11/pkcs11.0.6.0/descr
+++ b/packages/pkcs11/pkcs11.0.6.0/descr
@@ -1,0 +1,6 @@
+Bindings to the PKCS#11 cryptographic API
+
+This library contains ctypes bindings to the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.

--- a/packages/pkcs11/pkcs11.0.6.0/files/0001-Detect-dlfcn.h-using-__linux__.patch
+++ b/packages/pkcs11/pkcs11.0.6.0/files/0001-Detect-dlfcn.h-using-__linux__.patch
@@ -1,0 +1,26 @@
+From 23987e41515706d8d966d26f12f4e0a0c5e53891 Mon Sep 17 00:00:00 2001
+From: Etienne Millon <etienne@cryptosense.com>
+Date: Thu, 5 Jan 2017 09:16:25 +0100
+Subject: [PATCH] Detect `<dlfcn.h>` using `__linux__`
+
+Closes #24
+---
+ src/snippets/prelude.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/snippets/prelude.h b/src/snippets/prelude.h
+index 6515d39..3ad0b61 100644
+--- a/src/snippets/prelude.h
++++ b/src/snippets/prelude.h
+@@ -10,7 +10,7 @@
+ #include <windows.h>
+ #else
+ 
+-#if defined(__GLIBC__) || (defined(__sun) && defined(__SVR4))
++#if defined(__linux__) || (defined(__sun) && defined(__SVR4))
+ #include <dlfcn.h>
+ #endif
+ #ifdef _AIX
+-- 
+2.11.0
+

--- a/packages/pkcs11/pkcs11.0.6.0/opam
+++ b/packages/pkcs11/pkcs11.0.6.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ctypes" { >= "0.6.0" }
+  "ctypes-foreign" { >= "0.4.0" }
+  "hex" { >= "1.0.0" }
+  "key-parsers" { >= "0.5.0" }
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "records" { >= "0.6.0" }
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.02.0" & os != "darwin"]

--- a/packages/pkcs11/pkcs11.0.6.0/opam
+++ b/packages/pkcs11/pkcs11.0.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ctypes" { >= "0.6.0" }
   "ctypes-foreign" { >= "0.4.0" }
   "hex" { >= "1.0.0" }
-  "key-parsers" { >= "0.5.0" }
+  "key-parsers" { >= "0.5.0" & != "0.6.0" }
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }
   "records" { >= "0.6.0" }

--- a/packages/pkcs11/pkcs11.0.6.0/opam
+++ b/packages/pkcs11/pkcs11.0.6.0/opam
@@ -27,3 +27,4 @@ depends: [
 ]
 tags: ["org:cryptosense"]
 available: [ocaml-version >= "4.02.0" & os != "darwin"]
+patches: ["0001-Detect-dlfcn.h-using-__linux__.patch"]

--- a/packages/pkcs11/pkcs11.0.6.0/url
+++ b/packages/pkcs11/pkcs11.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/pkcs11/releases/download/v0.6.0/pkcs11-0.6.0.tbz"
+checksum: "ab8b847bc212d956dd845cc77e4e1427"


### PR DESCRIPTION
Bindings to the PKCS#11 cryptographic API

This library contains ctypes bindings to the PKCS#11 API.

This API is used by smartcards and Hardware Security Modules to perform
cryptographic operations such as signature or encryption.


---
* Homepage: https://github.com/cryptosense/pkcs11
* Source repo: https://github.com/cryptosense/pkcs11.git
* Bug tracker: https://github.com/cryptosense/pkcs11/issues

---


---
v0.6.0 2016-01-04
=================

Breaking changes:

- Removed deprecated operator aliases (#22)
- Remove the `P11_mechanisms` module (#23)
  + `kinds` is moved to `P11`
  + `key_type` can be replaced by `P11.Mechanism.key_type` (its results only
    depend on the mechanism type)

New features:

- Add yojson functions to several modules (#20)

Changes:

- `P11.Mechanism.key_type` is extended to non-keygen mechanisms.

Deprecated values:

- Deprecate `typ` values from `records` (#21).
  Users are expected to use the underlying `yojson` functions directly.
  The `records` dependency should be dropped in the next release.

Build system:

- Use docker for travis builds (#19)
Pull-request generated by opam-publish v0.3.2