### PR TITLE
conduit: disable tests

### DIFF
--- a/packages/conduit/conduit.0.14.4/opam
+++ b/packages/conduit/conduit.0.14.4/opam
@@ -13,10 +13,6 @@ build: [
   [make]
 ]
 install: [make "install"]
-build-test: [
-  ["./configure"]
-  [make "test"]
-]
 build-doc: [make "doc"]
 remove: ["ocamlfind" "remove" "conduit"]
 depends: [


### PR DESCRIPTION
They seem to be still broken /cc @edwintorok and @rgrinberg 

```
#=== ERROR while installing conduit.0.14.4 ====================================#
# opam-version 1.2.2
# os           linux
# command      make test
# path         /home/travis/.opam/4.03.0/build/conduit.0.14.4
# compiler     4.03.0
# exit-code    2
# env-file     /home/travis/.opam/4.03.0/build/conduit.0.14.4/conduit-14025-131e61.env
# stdout-file  /home/travis/.opam/4.03.0/build/conduit.0.14.4/conduit-14025-131e61.out
# stderr-file  /home/travis/.opam/4.03.0/build/conduit.0.14.4/conduit-14025-131e61.err
### stdout ###
# [...]
# OpenSSL 1.0.1f 6 Jan 2014
# ! ocamlfind query lwt.unix tls.lwt ipaddr.unix lwt.ssl || ! openssl version || (make cdtest && ./cdtest.native)
# ! ocamlfind query lwt.unix tls.lwt ipaddr.unix || ! openssl version || (make cdtest_tls && ./cdtest_tls.native)
# /home/travis/.opam/4.03.0/lib/lwt
# /home/travis/.opam/4.03.0/lib/tls
# /home/travis/.opam/4.03.0/lib/ipaddr
# OpenSSL 1.0.1f 6 Jan 2014
# make[1]: Entering directory `/home/travis/.opam/4.03.0/build/conduit.0.14.4'
# make[1]: Nothing to be done for `cdtest_tls'.
# make[1]: Leaving directory `/home/travis/.opam/4.03.0/build/conduit.0.14.4'
### stderr ###
# Generating a 2048 bit RSA private key
# .........................+++
# ..........................+++
# writing new private key to 'server.key'
# -----
# ocamlfind: Package `lwt.ssl' not found
# cdtest_tls.native: main: Server running on port 17895
# ./cdtest_tls.native: "connect" failed: Cannot assign requested address
# make: *** [test] Error 2
```