### PR TITLE
ppx_distr_guards.0.1 - via opam-publish

### DIFF
--- a/packages/ppx_distr_guards/ppx_distr_guards.0.1/descr
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.1/descr
@@ -1,0 +1,3 @@
+Extension to distribute guards over or-patterns.
+
+`function%distr A x, _ | _, A x when p x -> e` will result in `function A x, _ when p x -> e | _, A x when p x -> e`

--- a/packages/ppx_distr_guards/ppx_distr_guards.0.1/opam
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Ralf Vogler <ralf.vogler@gmail.com>"
+authors: "Ralf Vogler <ralf.vogler@gmail.com>"
+homepage: "https://github.com/vogler/ppx_distr_guards"
+bug-reports: "https://github.com/vogler/ppx_distr_guards/issues"
+license: "MIT"
+dev-repo: "https://github.com/vogler/ppx_distr_guards.git"
+substs: "META"
+build: [make]
+install: ["ocamlfind" "install" name "META" "ppx_distr_guards.native"]
+remove: ["ocamlfind" "remove" name]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_tools" {test}
+]
+available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_distr_guards/ppx_distr_guards.0.1/url
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vogler/ppx_distr_guards/archive/v0.1.tar.gz"
+checksum: "0c4ce5c0fdc7977ebedc0cd837678ec2"


### PR DESCRIPTION
Extension to distribute guards over or-patterns.

`function%distr A x, _ | _, A x when p x -> e` will result in `function A x, _ when p x -> e | _, A x when p x -> e`


---
* Homepage: https://github.com/vogler/ppx_distr_guards
* Source repo: https://github.com/vogler/ppx_distr_guards.git
* Bug tracker: https://github.com/vogler/ppx_distr_guards/issues

---

Pull-request generated by opam-publish v0.3.3