### PR TITLE
odig support for package lwt

### DIFF
--- a/packages/lwt/lwt.2.7.0/files/lwt.install
+++ b/packages/lwt/lwt.2.7.0/files/lwt.install
@@ -1,0 +1,6 @@
+lib: "lwt.opam" { "opam" }
+doc: [
+  "README.md"
+  "CHANGES"
+  "doc/COPYING" { "LICENSE" }
+]


### PR DESCRIPTION
This is only for the main package `lwt` and only for version 2.7.0.

@dbuenzli What should be done for the new `lwt_ssl`, `lwt_glib`, `lwt_react`? They currently share changelogs, READMEs, and licenses with the main `lwt`.