### PR TITLE
landmarks.1.1 - via opam-publish

### DIFF
--- a/packages/landmarks/landmarks.1.1/descr
+++ b/packages/landmarks/landmarks.1.1/descr
@@ -1,0 +1,6 @@
+A simple profiling library
+
+Landmarks is a simple profiling library for OCaml. It provides primitives to
+measure time spent in portion of instrumented code. The instrumentation of the
+code may either done by hand, automatically or semi-automatically using a PPX
+extension.

--- a/packages/landmarks/landmarks.1.1/opam
+++ b/packages/landmarks/landmarks.1.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Marc Lasson <marc.lasson@lexifi.com>"
+authors: "Marc Lasson <marc.lasson@lexifi.com>"
+homepage: "http://lexifi.github.io/landmarks/"
+bug-reports: "https://github.com/LexiFi/landmarks/issues"
+license: "MIT"
+dev-repo: "https://github.com/LexiFi/landmarks.git"
+build: [make]
+install: [make "install"]
+build-test: [make "tests"]
+remove: ["ocamlfind" "remove" "landmarks"]
+depends: [
+  "ocamlfind" {build}
+]
+depopts: ["gen_js_api" "js_of_ocaml"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/landmarks/landmarks.1.1/url
+++ b/packages/landmarks/landmarks.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/LexiFi/landmarks/archive/v1.1.zip"
+checksum: "58304a56716a943d5b6e91de5778f516"


### PR DESCRIPTION
A simple profiling library

Landmarks is a simple profiling library for OCaml. It provides primitives to
measure time spent in portion of instrumented code. The instrumentation of the
code may either done by hand, automatically or semi-automatically using a PPX
extension.


---
* Homepage: http://lexifi.github.io/landmarks/
* Source repo: https://github.com/LexiFi/landmarks.git
* Bug tracker: https://github.com/LexiFi/landmarks/issues

---

Pull-request generated by opam-publish v0.3.3