### PR TITLE
ocamlnet.4.1.2 doesn't build with flambda (Mantis PR 7426)

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -58,5 +58,5 @@ depopts: [
   "pcre"
   "camlzip"
 ]
-available: [ ocaml-version >= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & compiler != "4.04.0+flambda"]
 install: [make "install"]


### PR DESCRIPTION
The ocamlnet.4.1.2 build fails with 4.04.0+flambda with a fatal error:

```
# >> Fatal error: Assignment of a float to a specialised non-float array: (array.unsafe_set[addr]<>
#                                                           self/5708
#                                                           timeout/5703
#                                                           Parraysetu_arg/5735)
# Fatal error: exception Misc.Fatal_error
# make[1]: *** [rpc_transport.cmx] Error 2
# make: *** [opt] Error 2
```

See [Mantis PR 7426](https://caml.inria.fr/mantis/view.php?id=7434) and [GitHub PR 965](https://github.com/ocaml/ocaml/pull/965) for details.