### PR TITLE
devkit.0.3 doesn't build with OCaml 4.03 onwards (duplicate exception definitions)

### DIFF
--- a/packages/devkit/devkit.0.3/opam
+++ b/packages/devkit/devkit.0.3/opam
@@ -38,4 +38,4 @@ depends: [
   "base-threads"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"]


### PR DESCRIPTION
reported upstream: https://github.com/ahrefs/devkit/issues/1