### PR TITLE
qcheck.0.5.2 - via opam-publish

### DIFF
--- a/packages/qcheck/qcheck.0.5.2/descr
+++ b/packages/qcheck/qcheck.0.5.2/descr
@@ -1,0 +1,6 @@
+QuickCheck inspired property-based testing for OCaml.
+
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them.
+

--- a/packages/qcheck/qcheck.0.5.2/opam
+++ b/packages/qcheck/qcheck.0.5.2/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+author: [ "Simon Cruanes <simon.cruanes@inria.fr>" ]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://cedeela.fr/~simon/software/qcheck/QCheck.html"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "build"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "qcheck"]
+]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "base-unix"
+  "ounit"
+]
+available: [ ocaml-version >= "4.00.0" ]
+dev-repo: "https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+post-messages:"new release that fixes some problems with 0.5.1,
+including a better handling of backtraces, safe-string awareness,
+a mode for long tests, and reverting `small_int` to being an alias to `nat`.
+
+The latter point is important for not breaking code that would use `small_int`
+to pick the size of lists, strings, etc. The new `small_signed_int` can
+be used instead."

--- a/packages/qcheck/qcheck.0.5.2/url
+++ b/packages/qcheck/qcheck.0.5.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/qcheck/archive/0.5.2.tar.gz"
+checksum: "f7c7e3c45a46bcd5b5eb2b0c93c207d6"


### PR DESCRIPTION
QuickCheck inspired property-based testing for OCaml.

This module allows to check invariants (properties of some types) over
randomly generated instances of the type. It provides combinators for
generating instances and printing them.



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---

Pull-request generated by opam-publish v0.3.3