### PR TITLE
fd-send-recv: fix metadata

### DIFF
--- a/packages/fd-send-recv/fd-send-recv.1.0.0/opam
+++ b/packages/fd-send-recv/fd-send-recv.1.0.0/opam
@@ -1,5 +1,15 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+authors: [
+  "David Scott"
+  "David Sheets"
+  "Euan Harris"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/xapi-project/ocaml-fd-send-recv"
+bug-reports:  "https://github.com/xapi-project/ocaml-fd-send-recv/issues"
+dev-repo:     "https://github.com/xapi-project/ocaml-fd-send-recv.git"
+doc:          "https://github.com/xapi-project/ocaml-fd-send-recv/blob/master/lib/fd_send_recv.mli"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -10,5 +20,4 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xen-org/ocaml-fd-send-recv"
 install: [make "install"]

--- a/packages/fd-send-recv/fd-send-recv.1.0.0/opam
+++ b/packages/fd-send-recv/fd-send-recv.1.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/fd-send-recv/fd-send-recv.1.0.0/opam
+++ b/packages/fd-send-recv/fd-send-recv.1.0.0/opam
@@ -21,3 +21,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+depexts: [
+  [["alpine"] ["linux-headers"]]
+]
+available: [os != "darwin"]

--- a/packages/fd-send-recv/fd-send-recv.1.0.0/url
+++ b/packages/fd-send-recv/fd-send-recv.1.0.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/xen-org/ocaml-fd-send-recv/archive/ocaml-fd-send-recv-1.0.0.tar.gz"
+archive: "https://github.com/xapi-project/ocaml-fd-send-recv/archive/ocaml-fd-send-recv-1.0.0.tar.gz"
 checksum: "3df3194bd16f93f3c0ec5a7d3c994e76"

--- a/packages/fd-send-recv/fd-send-recv.1.0.1/opam
+++ b/packages/fd-send-recv/fd-send-recv.1.0.1/opam
@@ -1,5 +1,15 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+authors: [
+  "David Scott"
+  "David Sheets"
+  "Euan Harris"
+  "Vincent Bernardoff"
+]
+homepage:     "https://github.com/xapi-project/ocaml-fd-send-recv"
+bug-reports:  "https://github.com/xapi-project/ocaml-fd-send-recv/issues"
+dev-repo:     "https://github.com/xapi-project/ocaml-fd-send-recv.git"
+doc:          "https://github.com/xapi-project/ocaml-fd-send-recv/blob/master/lib/fd_send_recv.mli"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -10,5 +20,4 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/xen-org/ocaml-fd-send-recv"
 install: [make "install"]

--- a/packages/fd-send-recv/fd-send-recv.1.0.1/opam
+++ b/packages/fd-send-recv/fd-send-recv.1.0.1/opam
@@ -21,3 +21,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [os != "darwin"]
+

--- a/packages/fd-send-recv/fd-send-recv.1.0.1/opam
+++ b/packages/fd-send-recv/fd-send-recv.1.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "dave.scott@eu.citrix.com"
+maintainer: "dave@recoil.org"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/fd-send-recv/fd-send-recv.1.0.1/url
+++ b/packages/fd-send-recv/fd-send-recv.1.0.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/xen-org/ocaml-fd-send-recv/archive/ocaml-fd-send-recv-1.0.1.tar.gz"
+archive: "https://github.com/xapi-project/ocaml-fd-send-recv/archive/ocaml-fd-send-recv-1.0.1.tar.gz"
 checksum: "17049f4dece193bfb2df52527f27af08"


### PR DESCRIPTION
- fix maintainer email
- add missing metadata to please `opam lint`
- use the current github organisation name rather than the old one which redirected