### PR TITLE
logtk.0.8.1 - via opam-publish

### DIFF
--- a/packages/logtk/logtk.0.8.1/descr
+++ b/packages/logtk/logtk.0.8.1/descr
@@ -1,0 +1,4 @@
+Logic Toolkit
+
+Maintenance release, updated to be compatible with more recent version
+of the libraries.

--- a/packages/logtk/logtk.0.8.1/opam
+++ b/packages/logtk/logtk.0.8.1/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/logtk"
+bug-reports: "https://github.com/c-cube/logtk/issues"
+tags: ["logic" "unification" "term"]
+dev-repo: "https://github.com/c-cube/logtk.git"
+build: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--%{menhir:enable}%-meta"
+    "--disable-qcheck"
+    "--disable-docs"
+    "--%{menhir:enable}%-parsers"
+    "--disable-solving"
+    "--disable-tests"
+    "--disable-tools"
+    "--enable-meta"
+  ]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "logtk"]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+  "zarith"
+  "containers" {>= "0.3" < "1.0"}
+  "sequence" {>= "0.4"}
+  "base-bytes"
+]
+depopts: [
+  "menhir" {build}
+  "qcheck" {test}
+  "msat"
+]
+conflicts: [
+  "msat" { < "0.5" }
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/logtk/logtk.0.8.1/url
+++ b/packages/logtk/logtk.0.8.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/logtk/archive/0.8.1.tar.gz"
+checksum: "4d20e91b06d20a256d5939ac0c0fec68"


### PR DESCRIPTION
Logic Toolkit

Maintenance release, updated to be compatible with more recent version
of the libraries.


---
* Homepage: https://github.com/c-cube/logtk
* Source repo: https://github.com/c-cube/logtk.git
* Bug tracker: https://github.com/c-cube/logtk/issues

---

Pull-request generated by opam-publish v0.3.3