### PR TITLE
constraint mirage-tcpip-unix/xen packages to an upper bound on clock

### DIFF
--- a/packages/mirage-tcpip-unix/mirage-tcpip-unix.0.9.5/opam
+++ b/packages/mirage-tcpip-unix/mirage-tcpip-unix.0.9.5/opam
@@ -10,7 +10,7 @@ depends: [
   "io-page-unix"
   "mirage-types" {= "0.5.0"}
   "mirage-unix" {>= "0.9.9" & < "1.1.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.2"}
   "mirage-net-unix" {>= "1.0.0" & < "1.1.0"}
   "ipaddr" {>= "1.0.0" & < "2.0.0"}
   "ocamlbuild" {build}

--- a/packages/mirage-tcpip-xen/mirage-tcpip-xen.0.9.5/opam
+++ b/packages/mirage-tcpip-xen/mirage-tcpip-xen.0.9.5/opam
@@ -10,7 +10,7 @@ depends: [
   "io-page-xen"
   "mirage-types" {= "0.5.0"}
   "mirage-xen" {= "0.9.9"}
-  "mirage-clock-xen" {>= "1.0.0"}
+  "mirage-clock-xen" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-xen" {>= "0.9.0"}
   "ipaddr" {>= "1.0.0" & < "2.0.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
in preparation for the mirageos3 release