### PR TITLE
Added version constraint to lwt package (< 3.0.0)

### DIFF
--- a/packages/facebook-sdk/facebook-sdk.0.2.12/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.2.12/opam
@@ -20,7 +20,7 @@ depends: [
   "bolt"
   "calendar"
   "cohttp" {>= "0.10.0" & < "0.12.0"}
-  "lwt"
+  "lwt" {< "3.0.0"}
   "oasis"
   "ssl"
   "uri"

--- a/packages/facebook-sdk/facebook-sdk.0.3.1/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.1/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core"
   "csv"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "meta_conv"
   "oasis"
   "ssl"

--- a/packages/facebook-sdk/facebook-sdk.0.3.3/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.3/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core"
   "csv"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "meta_conv"
   "oasis"
   "ssl"

--- a/packages/facebook-sdk/facebook-sdk.0.3.4/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.4/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core"
   "csv"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "meta_conv"
   "oasis"
   "ssl"

--- a/packages/facebook-sdk/facebook-sdk.0.3.5/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.5/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core"
   "csv"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "meta_conv"
   "oasis"
   "ssl"

--- a/packages/receive-mail/receive-mail.0.1.2/opam
+++ b/packages/receive-mail/receive-mail.0.1.2/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "bolt"
   "core" {< "113.24.00"}
-  "lwt"
+  "lwt" {< "3.0.0"}
   "oasis"
   "ocamlnet"
   "re"

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "cohttp" {>= "0.12.0" & < "0.18.0"}
   "core_kernel"
   "csv"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "meta_conv"
   "oasis"
   "ssl"

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
@@ -26,7 +26,7 @@ depends: [
   "cohttp" {>= "0.18.0"}
   "core_kernel"
   "csv"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "oasis"
   "ppx_meta_conv"
   "ssl"

--- a/packages/sociaml-oauth-client/sociaml-oauth-client.0.4.0/opam
+++ b/packages/sociaml-oauth-client/sociaml-oauth-client.0.4.0/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "oasis"
   "core"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "ssl"
   "uri"
   "cohttp" {< "0.12.0"}

--- a/packages/sociaml-oauth-client/sociaml-oauth-client.0.4.1/opam
+++ b/packages/sociaml-oauth-client/sociaml-oauth-client.0.4.1/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "oasis"
   "core"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "ssl"
   "uri"
   "cohttp" {< "0.12.0"}

--- a/packages/sociaml-oauth-client/sociaml-oauth-client.0.5.0/opam
+++ b/packages/sociaml-oauth-client/sociaml-oauth-client.0.5.0/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "oasis"
   "core_kernel"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "ssl"
   "uri"
   "cohttp" {>= "0.12.0" & < "0.14.0"}

--- a/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.1.0/opam
+++ b/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.1.0/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "oasis"
   "core"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "meta_conv"
   "tiny_json"
   "tiny_json_conv"

--- a/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.2.0/opam
+++ b/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.2.0/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "oasis"
   "core_kernel"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "meta_conv"
   "tiny_json"
   "tiny_json_conv"


### PR DESCRIPTION
Due to upcoming breaking changes in the 3.0.0 version of LWT, an upper
bound version constraint has been added to all packages of which I am
maintainer:
 - facebook-sdk
 - receive-mail
 - sociaml-facebook-api
 - sociaml-oauth-client
 - sociaml-tumblr-api

The changes were made as advised in https://github.com/ocsigen/lwt/issues/308