### PR TITLE
tsdl-image.0.2.0 - via opam-publish

### DIFF
--- a/packages/tsdl-image/tsdl-image.0.2.0/descr
+++ b/packages/tsdl-image/tsdl-image.0.2.0/descr
@@ -1,0 +1,4 @@
+SDL2_Image bindings to go with Tsdl
+
+Tsdl_image provides bindings to SDL2_Image intended to be used with
+Tsdl.

--- a/packages/tsdl-image/tsdl-image.0.2.0/opam
+++ b/packages/tsdl-image/tsdl-image.0.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Julian Squires <julian@cipht.net>"
+authors: "Julian Squires <julian@cipht.net>"
+homepage: "http://github.com/tokenrove/tsdl-image"
+bug-reports: "http://github.com/tokenrove/tsdl-image/issues"
+license: "BSD3"
+tags: ["bindings" "graphics"]
+dev-repo: "https://github.com/tokenrove/tsdl-image.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tsdl_image"]
+depends: [
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "tsdl" {>= "0.9.0"}
+  "result"
+  "oasis" {build}
+]
+depexts: [
+  [["debian"] ["libsdl2-image-dev"]]
+  [["homebrew" "osx"] ["sdl2_image"]]
+  [["ubuntu"] ["libsdl2-image-dev"]]
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/tsdl-image/tsdl-image.0.2.0/url
+++ b/packages/tsdl-image/tsdl-image.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/tokenrove/tsdl-image/archive/0.2.0.tar.gz"
+checksum: "db28fc8090a0098d6c10bb144ed04c3f"


### PR DESCRIPTION
SDL2_Image bindings to go with Tsdl

Tsdl_image provides bindings to SDL2_Image intended to be used with
Tsdl.


---
* Homepage: http://github.com/tokenrove/tsdl-image
* Source repo: https://github.com/tokenrove/tsdl-image.git
* Bug tracker: http://github.com/tokenrove/tsdl-image/issues

---

Pull-request generated by opam-publish v0.3.3