### PR TITLE
tsdl-ttf.0.2 - via opam-publish

### DIFF
--- a/packages/tsdl-ttf/tsdl-ttf.0.2/descr
+++ b/packages/tsdl-ttf/tsdl-ttf.0.2/descr
@@ -1,0 +1,3 @@
+SDL2_ttf bindings to go with Tsdl
+
+Tsdl_ttf provides bindings to SDL2_ttf intended to be used with Tsdl.

--- a/packages/tsdl-ttf/tsdl-ttf.0.2/opam
+++ b/packages/tsdl-ttf/tsdl-ttf.0.2/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Julian Squires <julian@cipht.net>"
+authors: "Julian Squires <julian@cipht.net>"
+homepage: "http://github.com/tokenrove/tsdl-ttf"
+bug-reports: "http://github.com/tokenrove/tsdl-ttf/issues"
+license: "BSD3"
+tags: ["bindings" "graphics"]
+dev-repo: "https://github.com/tokenrove/tsdl-ttf.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "tsdl_ttf"]
+depends: [
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "tsdl" {>= "0.9.0"}
+  "result"
+  "oasis" {build}
+]
+depexts: [
+  [["debian"] ["libsdl2-ttf-dev"]]
+  [["homebrew" "osx"] ["sdl2_ttf"]]
+  [["ubuntu"] ["libsdl2-ttf-dev"]]
+]

--- a/packages/tsdl-ttf/tsdl-ttf.0.2/url
+++ b/packages/tsdl-ttf/tsdl-ttf.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/tokenrove/tsdl-ttf/archive/0.2.tar.gz"
+checksum: "8ddf57c2fa30e074e453dc5a5a81eb46"


### PR DESCRIPTION
SDL2_ttf bindings to go with Tsdl

Tsdl_ttf provides bindings to SDL2_ttf intended to be used with Tsdl.


---
* Homepage: http://github.com/tokenrove/tsdl-ttf
* Source repo: https://github.com/tokenrove/tsdl-ttf.git
* Bug tracker: http://github.com/tokenrove/tsdl-ttf/issues

---

Pull-request generated by opam-publish v0.3.3