### PR TITLE
tsdl-mixer.0.2 - via opam-publish

### DIFF
--- a/packages/tsdl-mixer/tsdl-mixer.0.2/descr
+++ b/packages/tsdl-mixer/tsdl-mixer.0.2/descr
@@ -1,0 +1,4 @@
+SDL2_mixer bindings to go with Tsdl
+
+Tsdl_mixer provides bindings to SDL2_mixer intended to be used with
+Tsdl.

--- a/packages/tsdl-mixer/tsdl-mixer.0.2/opam
+++ b/packages/tsdl-mixer/tsdl-mixer.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Julian Squires <julian@cipht.net>"
+authors: "Julian Squires <julian@cipht.net>"
+homepage: "http://github.com/tokenrove/tsdl-mixer"
+bug-reports: "http://github.com/tokenrove/tsdl-mixer/issues"
+license: "BSD3"
+tags: ["bindings" "audio"]
+dev-repo: "https://github.com/tokenrove/tsdl-mixer.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tsdl_mixer"]
+depends: [
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "tsdl" {>= "0.9.0"}
+  "result"
+  "oasis" {build}
+]
+depexts: [
+  [["debian"] ["libsdl2-mixer-dev"]]
+  [["homebrew" "osx"] ["sdl2_mixer"]]
+  [["ubuntu"] ["libsdl2-mixer-dev"]]
+]

--- a/packages/tsdl-mixer/tsdl-mixer.0.2/url
+++ b/packages/tsdl-mixer/tsdl-mixer.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/tokenrove/tsdl-mixer/archive/0.2.tar.gz"
+checksum: "0bc79088c06f15369b35c24777dabb6e"


### PR DESCRIPTION
SDL2_mixer bindings to go with Tsdl

Tsdl_mixer provides bindings to SDL2_mixer intended to be used with
Tsdl.


---
* Homepage: http://github.com/tokenrove/tsdl-mixer
* Source repo: https://github.com/tokenrove/tsdl-mixer.git
* Bug tracker: http://github.com/tokenrove/tsdl-mixer/issues

---

Pull-request generated by opam-publish v0.3.3