### PR TITLE
depyt: minimum version of ocplib-endian required

### DIFF
--- a/packages/depyt/depyt.0.1.0/opam
+++ b/packages/depyt/depyt.0.1.0/opam
@@ -13,7 +13,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" "fmt" "result" "jsonm" "ocplib-endian"
+  "cstruct" "fmt" "result" "jsonm"
+  "ocplib-endian" {>="0.7"}
   "alcotest" {test}
 ]
 available: [ ocaml-version >= "4.02.0"]


### PR DESCRIPTION
see https://github.com/samoht/depyt/pull/14