### PR TITLE
gdbprofiler 0.1

### DIFF
--- a/packages/gdbprofiler/gdbprofiler.0.1/descr
+++ b/packages/gdbprofiler/gdbprofiler.0.1/descr
@@ -1,0 +1,3 @@
+gdbprofiler, a profiler for native OCaml and other executables
+
+gdbprofiler (aka rich man's profiler) is a gdb-based sampling profiler that uses gdb or lldb

--- a/packages/gdbprofiler/gdbprofiler.0.1/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.1/opam
@@ -18,6 +18,6 @@ depends: [
   "lwt" {>= "2.4.6"}
   "ppx_deriving_yojson" {>= "2.0"}
   "oasis" {build & >= "0.4"}
-  "containers"
+  "containers" {>= "0.20"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/gdbprofiler/gdbprofiler.0.1/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "copy@copy.sh"
+authors: "copy"
+homepage: "https://github.com/copy/gdbprofiler"
+bug-reports: "https://github.com/copy/gdbprofiler/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "https://github.com/copy/gdbprofiler.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "gdbprofiler"]
+depends: [
+  "ocamlfind" {build}
+  "menhir"
+  ("extlib" | "extlib-compat")
+  "lwt" {>= "2.4.6"}
+  "ppx_deriving_yojson" {>= "2.0"}
+  "oasis" {build & >= "0.4"}
+  "containers"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/gdbprofiler/gdbprofiler.0.1/url
+++ b/packages/gdbprofiler/gdbprofiler.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/copy/gdbprofiler/archive/0.1.tar.gz"
-checksum: "927a5135ffe98de04442a71e7c6577c6"
+checksum: "d7843b0a6674c4493097b363aaba6e71"

--- a/packages/gdbprofiler/gdbprofiler.0.1/url
+++ b/packages/gdbprofiler/gdbprofiler.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/copy/gdbprofiler/archive/0.1.tar.gz"
-checksum: "d7843b0a6674c4493097b363aaba6e71"
+checksum: "2aa855591d164a1b8fa682c4a4e0ceb7"

--- a/packages/gdbprofiler/gdbprofiler.0.1/url
+++ b/packages/gdbprofiler/gdbprofiler.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/copy/gdbprofiler/archive/0.1.tar.gz"
+checksum: "927a5135ffe98de04442a71e7c6577c6"


### PR DESCRIPTION
gdbprofiler (aka rich man's profiler) is a gdb-based sampling profiler that uses gdb or lldb.