### PR TITLE
mirage-clock-unix: establish upper bounds

### DIFF
--- a/packages/mirage-unix/mirage-unix.2.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.0/opam
@@ -9,10 +9,10 @@ remove: [
 ]
 depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-unix/mirage-unix.2.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-unix/mirage-unix.2.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.0/opam
@@ -9,10 +9,10 @@ remove: [
 ]
 depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.1.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.1.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.1.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.3/opam
@@ -9,10 +9,10 @@ remove: [
 ]
 depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.2.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.2.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.2.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.2/opam
@@ -9,10 +9,10 @@ remove: [
 ]
 depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.2.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.3/opam
@@ -10,10 +10,10 @@ remove: [make "unix-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.5.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.3.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.3.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.5.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.4.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.5.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.4.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.5.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.5.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.5.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.6.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.6.0/opam
@@ -12,10 +12,10 @@ remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "conf-which" {build}
   "cstruct" {>= "1.0.1"}
-  "ocamlfind"
+  "ocamlfind" {buid}
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.5.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-unix/mirage-unix.2.6.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.6.0/opam
@@ -12,7 +12,7 @@ remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "conf-which" {build}
   "cstruct" {>= "1.0.1"}
-  "ocamlfind" {buid}
+  "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
   "io-page" {>= "1.5.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}


### PR DESCRIPTION
This prevents the incoming MirageOS3 packages from causing
newer mirage-clock-unix to be selected