### PR TITLE
mirage-os-shim: restrict to mirage-unix 2.4.0+ due to OS.Lifecycle

### DIFF
--- a/packages/mirage-os-shim/mirage-os-shim.0.0.1/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.0.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-unix"
+  "mirage-unix" {>="2.4.0"}
 ]
 depopts: [
   "mirage-solo5"


### PR DESCRIPTION
cc @pqwy