### PR TITLE
pkcs11.0.7.0 - via opam-publish

### DIFF
--- a/packages/pkcs11/pkcs11.0.7.0/descr
+++ b/packages/pkcs11/pkcs11.0.7.0/descr
@@ -1,0 +1,6 @@
+Bindings to the PKCS#11 cryptographic API
+
+This library contains ctypes bindings to the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.

--- a/packages/pkcs11/pkcs11.0.7.0/opam
+++ b/packages/pkcs11/pkcs11.0.7.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--with-cmdliner" "%{cmdliner:installed}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" "--with-cmdliner" "%{cmdliner:installed}%" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ctypes" { >= "0.6.0" }
+  "ctypes-foreign" { >= "0.4.0" }
+  "hex" { >= "1.0.0" }
+  "key-parsers" { >= "0.5.0" & != "0.6.0" }
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+depopts: [
+  "cmdliner"
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.02.0" & os != "darwin"]

--- a/packages/pkcs11/pkcs11.0.7.0/url
+++ b/packages/pkcs11/pkcs11.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/pkcs11/releases/download/v0.7.0/pkcs11-0.7.0.tbz"
+checksum: "e274917fb536ea4f876d36c20e01d570"


### PR DESCRIPTION
Bindings to the PKCS#11 cryptographic API

This library contains ctypes bindings to the PKCS#11 API.

This API is used by smartcards and Hardware Security Modules to perform
cryptographic operations such as signature or encryption.


---
* Homepage: https://github.com/cryptosense/pkcs11
* Source repo: https://github.com/cryptosense/pkcs11.git
* Bug tracker: https://github.com/cryptosense/pkcs11/issues

---


---
v0.7.0 2016-01-23
=================

Breaking changes:

- Remove `typ` values from `records`, deprecated in 0.6.0, and the associated
  dependency (#26)
- Rework the `P11_keys_attributes` module (#27):
  + rename it to `P11_key_attributes`
  + rename `possibles` to `possibles`
  + remove `kinds` and `is`
- Remove most "not implemented" attributes (#28, #29)

Fixes:

- Detect Linux hosts more robustly (#25)

New features:

- Provide optional `cmdliner` support through a new `Pkcs11_cli` module (in
  `pkcs11.cli`) (#31)

Build system:

- Forbid `key-parsers.0.6.0`
- Refer to the `Result` compatibility module only through a global `-open` (#30)
- Install `cmti` files (#32)
- Add missing `ounit` test-dependency (#32)
Pull-request generated by opam-publish v0.3.3