### PR TITLE
Use opamconfig to configure conf-gmp and zarith

### DIFF
--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -6,7 +6,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
+  ["opamconfig" "-d" "gmp:" "-f" "./conf-gmp.config" "sh" "-exc" "cc -c ${CFLAGS} test.c"]
+]
+depends: [
+  "opamconfig" {build}
 ]
 depexts: [
   [["debian"] ["libgmp-dev"]]

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -9,7 +9,7 @@ build: [
   ["opamconfig" "-d" "gmp:" "-f" "./conf-gmp.config" "sh" "-exc" "cc -c ${CFLAGS} test.c"]
 ]
 depends: [
-  "opamconfig" {build}
+  "opamconfig" {build & >= "0.3.0"}
 ]
 depexts: [
   [["debian"] ["libgmp-dev"]]

--- a/packages/zarith/zarith.1.4.1/opam
+++ b/packages/zarith/zarith.1.4.1/opam
@@ -1,7 +1,9 @@
 opam-version: "1.2"
 maintainer: "thomas.braibant@gmail.com"
 authors: "Xavier Leroy"
-homepage: "https://forge.ocamlcore.org/projects/zarith"
+homepage: "https://github.com/ocaml/Zarith"
+dev-repo: "https://github.com/ocaml/Zarith"
+bug-reports: "https://github.com/ocaml/Zarith/issues"
 build: [
    ["env" "CFLAGS=%{conf-gmp:cflags}%" "LDFLAGS=%{conf-gmp:ldflags}%" "./configure"]
    [make]

--- a/packages/zarith/zarith.1.4.1/opam
+++ b/packages/zarith/zarith.1.4.1/opam
@@ -3,9 +3,8 @@ maintainer: "thomas.braibant@gmail.com"
 authors: "Xavier Leroy"
 homepage: "https://forge.ocamlcore.org/projects/zarith"
 build: [
-  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
-  ["env" "LDFLAGS=-L/usr/local/lib" "CFLAGS=-I/usr/local/include" "./configure"] { os = "openbsd" | os = "freebsd" | os = "darwin"}
-  [make]
+   ["env" "CFLAGS=%{conf-gmp:cflags}%" "LDFLAGS=%{conf-gmp:ldflags}%" "./configure"]
+   [make]
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
This is to solve long-standing issues #1464 and #3000.

The technique used and the tool `opamconfig` implementing it have been discussed in #6271 and are also documented in [the opamconfig project itself](https://github.com/michipili/opamconfig).

CC @timbertson,  @djs55 and @avsm as you recently touched these files, please add anyone you think could also be interested in this patch. Thomas Braibant (maintainer of zarith) has been emailed.