### PR TITLE
gg.0.9.2 - via opam-publish

### DIFF
--- a/packages/gg/gg.0.9.2/descr
+++ b/packages/gg/gg.0.9.2/descr
@@ -1,0 +1,10 @@
+Basic types for computer graphics in OCaml
+
+Gg is an OCaml module providing basic types for computer graphics.
+
+It defines types and functions for floats, vectors, points, sizes,
+matrices, quaternions, axis-aligned boxes, colors, color spaces, and
+raster data.
+
+Gg is made of a single module, depends on bigarrays, and is
+distributed under the ISC license.

--- a/packages/gg/gg.0.9.2/opam
+++ b/packages/gg/gg.0.9.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/gg"
+authors: [
+  "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  "Edwin Török"
+]
+doc: "http://erratique.ch/software/gg/doc/Gg"
+dev-repo: "http://erratique.ch/repos/gg.git"
+bug-reports: "https://github.com/dbuenzli/gg/issues"
+tags: [ "matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
+license: "ISC"
+available:[ ocaml-version >= "4.02.2" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bigarray"
+  "bench" {test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+]]

--- a/packages/gg/gg.0.9.2/url
+++ b/packages/gg/gg.0.9.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/gg/releases/gg-0.9.2.tbz"
+checksum: "2e9c61f4dc762499b684697face6566e"


### PR DESCRIPTION
Basic types for computer graphics in OCaml

Gg is an OCaml module providing basic types for computer graphics.

It defines types and functions for floats, vectors, points, sizes,
matrices, quaternions, axis-aligned boxes, colors, color spaces, and
raster data.

Gg is made of a single module, depends on bigarrays, and is
distributed under the ISC license.


---
* Homepage: http://erratique.ch/software/gg
* Source repo: http://erratique.ch/repos/gg.git
* Bug tracker: https://github.com/dbuenzli/gg/issues

---


---
v0.9.2 2017-01-24 La Forclaz (VS)
---------------------------------

- Add `Box{1,2,3}.add_pt`. Thanks to Christophe Troestler for the suggestion.
- `V{2,3,4}.norm` avoid {under,over}flows. Thanks to Christophe Troestler for
  the report and guidance.
- Fix `Size.of_w`. Thanks to @rand00 for the report and the fix.
- Safe-string support.
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.3