### PR TITLE
qcheck.0.5.3 - via opam-publish

### DIFF
--- a/packages/qcheck/qcheck.0.5.3/descr
+++ b/packages/qcheck/qcheck.0.5.3/descr
@@ -1,0 +1,6 @@
+QuickCheck inspired property-based testing for OCaml.
+
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them.
+

--- a/packages/qcheck/qcheck.0.5.3/opam
+++ b/packages/qcheck/qcheck.0.5.3/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+author: [ "Simon Cruanes <simon.cruanes@inria.fr>" ]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://cedeela.fr/~simon/software/qcheck/QCheck.html"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "build"]
+]
+build-doc: [
+  ["./configure" "--enable-docs" "--docdir" "%{doc}%"]
+  [make "doc"]
+]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "qcheck"]
+]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "base-unix"
+  "ounit"
+]
+available: [ ocaml-version >= "4.00.0" ]
+dev-repo: "https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]

--- a/packages/qcheck/qcheck.0.5.3/url
+++ b/packages/qcheck/qcheck.0.5.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/qcheck/archive/0.5.3.tar.gz"
+checksum: "779d8b7d2a8cd25a2f0a08dc6643792d"


### PR DESCRIPTION
QuickCheck inspired property-based testing for OCaml.

This module allows to check invariants (properties of some types) over
randomly generated instances of the type. It provides combinators for
generating instances and printing them.



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---

Pull-request generated by opam-publish v0.3.3