### PR TITLE
Add opamconfig.v0.3.0

### DIFF
--- a/packages/opamconfig/opamconfig.0.3.0/descr
+++ b/packages/opamconfig/opamconfig.0.3.0/descr
@@ -1,0 +1,6 @@
+Virtual package owning parameters of opam installation.
+
+This package detects some important parameters when it is installed,
+e.g. to determine appropriate parameters to pass to configure scripts.
+These parameters are saved as package variables that can be used in
+build instructions for other packages.

--- a/packages/opamconfig/opamconfig.0.3.0/opam
+++ b/packages/opamconfig/opamconfig.0.3.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "michipili@gmail.com"
+authors: "Michael Le Barbier Grünewald"
+version: "0.3.0"
+license: "MIT"
+homepage: "https://github.com/michipili/opamconfig"
+bug-reports: "https://github.com/michipili/opamconfig/issues"
+dev-repo: "https://github.com/michipili/opamconfig.git"
+tags: [
+  "opam" "configure"
+]
+build: [
+  ["./configure" "--prefix" prefix]
+]
+install: [
+  ["sh" "opamconfig_install.sh" prefix]
+]
+remove: [
+  ["rm" "%{prefix}%/bin/opamconfig"]
+]

--- a/packages/opamconfig/opamconfig.0.3.0/url
+++ b/packages/opamconfig/opamconfig.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/michipili/opamconfig/releases/download/v0.3.0/opamconfig-0.3.0.tar.xz"
+checksum: "76df1e0b2695929aa98b9a276a09ae62"


### PR DESCRIPTION
This is the update for opamconfig necessary to complete #8352.

The version 0.3.0 of opamconfig supports all systems also supported by the depext plugin.

WWW: https://github.com/michipili/opamconfig/commit/8af6ff41d64a4d41f4ba8bf1bd0b6d3a686d5c71