### PR TITLE
pkcs11.0.7.1 - via opam-publish

### DIFF
--- a/packages/pkcs11/pkcs11.0.7.1/descr
+++ b/packages/pkcs11/pkcs11.0.7.1/descr
@@ -1,0 +1,6 @@
+Bindings to the PKCS#11 cryptographic API
+
+This library contains ctypes bindings to the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.

--- a/packages/pkcs11/pkcs11.0.7.1/opam
+++ b/packages/pkcs11/pkcs11.0.7.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--with-cmdliner" "%{cmdliner:installed}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" "--with-cmdliner" "%{cmdliner:installed}%" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ctypes" { >= "0.6.0" }
+  "ctypes-foreign" { >= "0.4.0" }
+  "hex" { >= "1.0.0" }
+  "key-parsers" { >= "0.5.0" & != "0.6.0" }
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+depopts: [
+  "cmdliner"
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.02.0" & os != "darwin"]

--- a/packages/pkcs11/pkcs11.0.7.1/url
+++ b/packages/pkcs11/pkcs11.0.7.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/pkcs11/releases/download/v0.7.1/pkcs11-0.7.1.tbz"
+checksum: "d571a8d771b3302886dd8c9287a7ca38"


### PR DESCRIPTION
Bindings to the PKCS#11 cryptographic API

This library contains ctypes bindings to the PKCS#11 API.

This API is used by smartcards and Hardware Security Modules to perform
cryptographic operations such as signature or encryption.


---
* Homepage: https://github.com/cryptosense/pkcs11
* Source repo: https://github.com/cryptosense/pkcs11.git
* Bug tracker: https://github.com/cryptosense/pkcs11/issues

---


---
v0.7.1 2016-01-25
=================

Build system:

- Remove `records` from `META` to make it possible to actually use `pkcs11`
  without `records` installed (#33)
Pull-request generated by opam-publish v0.3.3