### PR TITLE
msat.0.6 - via opam-publish

### DIFF
--- a/packages/msat/msat.0.6/descr
+++ b/packages/msat/msat.0.6/descr
@@ -1,0 +1,8 @@
+Modular sat/smt solver
+
+This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
+- proof output
+- push/pop operations
+- CNF transformation tools
+
+This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.

--- a/packages/msat/msat.0.6/opam
+++ b/packages/msat/msat.0.6/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes@inria.fr"]
+authors: [
+  "Sylvain Conchon"
+  "Alain Mebsout"
+  "Stephane Lecuyer"
+  "Simon Cruanes"
+  "Guillaume Bury"
+]
+homepage: "https://github.com/Gbury/mSAT"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+license: "Apache"
+tags: ["sat" "smt"]
+dev-repo: "https://github.com/Gbury/mSAT.git"
+build: [
+  [make "disable_log"]
+  [make "lib"]
+]
+install: [make "DOCDIR=%{msat:doc}%" "install"]
+build-doc: [make "doc"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/msat/msat.0.6/url
+++ b/packages/msat/msat.0.6/url
@@ -1,2 +1,2 @@
 http: "https://github.com/Gbury/mSAT/archive/v0.6.tar.gz"
-checksum: "d4a764de8a03998106273e5e48151c9a"
+checksum: "614f47053a4d7589075914885619a209"

--- a/packages/msat/msat.0.6/url
+++ b/packages/msat/msat.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Gbury/mSAT/archive/v0.6.tar.gz"
+checksum: "d4a764de8a03998106273e5e48151c9a"


### PR DESCRIPTION
Modular sat/smt solver

This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
- proof output
- push/pop operations
- CNF transformation tools

This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.


---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them

---

Pull-request generated by opam-publish v0.3.3