### PR TITLE
bindlib 4.0.3

### DIFF
--- a/packages/bindlib/bindlib.4.0.3/descr
+++ b/packages/bindlib/bindlib.4.0.3/descr
@@ -1,0 +1,10 @@
+OCaml Bindlib library for bound variables
+
+Bindlib is a library for the Objective-Caml language providing
+reasonable tools to write programs manipulating data structures with
+bound variables (like lambda-calculus or quantified formulae). It is
+quite efficient and easy to use.
+
+Authors
+	* Christophe Raffalli
+	* Rodolphe Lepigre

--- a/packages/bindlib/bindlib.4.0.3/opam
+++ b/packages/bindlib/bindlib.4.0.3/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Christophe Raffalli <raffalli@univ-savoie.fr>"
+bug-reports:  "http://lama.univ-savoie.fr/mantis/view_all_bug_page.php?project_id=3"
+authors:
+  [ "Christophe Raffalli <raffalli@univ-savoie.fr>"
+    "Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>" ]
+homepage: "http://lama.univ-savoie.fr/~raffalli/bindlib"
+license: "LGPL-3.0"
+dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/bindlib/repos"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "bindlib"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/bindlib/bindlib.4.0.3/url
+++ b/packages/bindlib/bindlib.4.0.3/url
@@ -1,2 +1,2 @@
 archive: "https://lama.univ-savoie.fr/~raffalli/bindlib/bindlib-4.0.3.tar.gz"
-checksum: "cb53465fbf188f0262551b0d7180e17f"
+checksum: "49f7dcb45ebe49765dc850db7b842e32"

--- a/packages/bindlib/bindlib.4.0.3/url
+++ b/packages/bindlib/bindlib.4.0.3/url
@@ -1,0 +1,2 @@
+archive: "https://lama.univ-savoie.fr/~raffalli/bindlib/bindlib-4.0.3.tar.gz"
+checksum: "cb53465fbf188f0262551b0d7180e17f"


### PR DESCRIPTION
New version of bindlib:
- renaming of some types e.g: 'a variable -> 'a var
- a few more functions
- better semantics of copy_var
- updated and imporved doc