### PR TITLE
xenctrl.0.9.31 - via opam-publish

### DIFF
--- a/packages/xenctrl/xenctrl.0.9.31/descr
+++ b/packages/xenctrl/xenctrl.0.9.31/descr
@@ -1,0 +1,3 @@
+Low-level Xen hypercall bindings.
+
+This package should compile and work against Xen 4.2, 4.3, 4.4, 4.5 and 4.6.

--- a/packages/xenctrl/xenctrl.0.9.31/opam
+++ b/packages/xenctrl/xenctrl.0.9.31/opam
@@ -1,0 +1,47 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: [
+  "David Scott"
+  "Jonathan Ludlam"
+  "Andrew Cooper"
+  "Bob Ball"
+  "Euan Harris"
+  "John Else"
+  "Mike McClurg"
+  "Rob Hoes"
+  "Si Beaumont"
+  "Thomas Sanders"
+  "Vincent Bernadoff"
+]
+homepage: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs"
+bug-reports: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/issues"
+license: "LGPL"
+dev-repo: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs.git"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["./configure"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "lwt"
+  "cmdliner"
+  "ocamlbuild" {build}
+]
+depexts: [
+  [["debian"] ["libxen-dev" "uuid-dev"]]
+  [["ubuntu"] ["libxen-dev" "uuid-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/xenctrl/xenctrl.0.9.31/url
+++ b/packages/xenctrl/xenctrl.0.9.31/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/archive/v0.9.31.tar.gz"
+checksum: "0bd8f8c7d1006c530676f5000257748b"


### PR DESCRIPTION
Low-level Xen hypercall bindings.

This package should compile and work against Xen 4.2, 4.3, 4.4, 4.5 and 4.6.


---
* Homepage: https://github.com/xapi-project/ocaml-xen-lowlevel-libs
* Source repo: https://github.com/xapi-project/ocaml-xen-lowlevel-libs.git
* Bug tracker: https://github.com/xapi-project/ocaml-xen-lowlevel-libs/issues

---

Pull-request generated by opam-publish v0.3.3