### PR TITLE
inuit.0.2 - via opam-publish

### DIFF
--- a/packages/inuit/inuit.0.2/descr
+++ b/packages/inuit/inuit.0.2/descr
@@ -1,0 +1,9 @@
+Make interactive text-based user-interfaces in OCaml
+
+Inuit is an abstraction for interactively updating a text buffer. 
+It is designed to be use with a backend that will present the buffer to the
+end user.
+[Sturgeon](https://github.com/let-def/sturgeon) is a backend targeting emacs
+buffers.
+
+Inuit is distributed under the ISC license.

--- a/packages/inuit/inuit.0.2/opam
+++ b/packages/inuit/inuit.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: ["Frédéric Bour <frederic.bour@lakaban.net>"]
+homepage: "https://github.com/let-def/inuit"
+doc: "https://let-def.github.io/inuit/doc"
+license: "ISC"
+dev-repo: "https://github.com/let-def/inuit.git"
+bug-reports: "https://github.com/let-def/inuit/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "grenier" {>= "0.4"}
+]
+depopts: []
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/inuit/inuit.0.2/url
+++ b/packages/inuit/inuit.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/let-def/inuit/releases/download/v0.2/inuit-0.2.tbz"
+checksum: "5e4e94cd631580d5f08771002d1760e9"


### PR DESCRIPTION
Make interactive text-based user-interfaces in OCaml

Inuit is an abstraction for interactively updating a text buffer. 
It is designed to be use with a backend that will present the buffer to the
end user.
[Sturgeon](https://github.com/let-def/sturgeon) is a backend targeting emacs
buffers.

Inuit is distributed under the ISC license.


---
* Homepage: https://github.com/let-def/inuit
* Source repo: https://github.com/let-def/inuit.git
* Bug tracker: https://github.com/let-def/inuit/issues

---


---
v0.2 2017-01-22 London
--------------------------

Update grenier dependency.
Remove some exotic unicode characters in widgets.
Indent tree by one character instead of two.
Pull-request generated by opam-publish v0.3.3