### PR TITLE
sturgeon.0.2 - via opam-publish

### DIFF
--- a/packages/sturgeon/sturgeon.0.2/descr
+++ b/packages/sturgeon/sturgeon.0.2/descr
@@ -1,0 +1,9 @@
+A toolkit for communicating with Emacs
+
+Sturgeon implements various tools for manipulating Emacs from OCaml:
+- `Sturgeon_sexp` implements the Emacs dialect of S-expressions
+- `Sturgeon_session` implements an "session protocol" to make RPC to Emacs from OCaml and vice versa
+- `Sturgeon_stui` is a session implementing an [Inuit](https://github.com/let-def/inuit) backend: one can now runs text user-interface on an Emacs buffer
+- `Sturgeon_recipes_*` offers different "rendez-vous" points to connect to Emacs
+
+Sturgeon is distributed under the ISC license.

--- a/packages/sturgeon/sturgeon.0.2/opam
+++ b/packages/sturgeon/sturgeon.0.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: ["Frédéric Bour <frederic.bour@lakaban.net>"]
+homepage: "https://github.com/let-def/sturgeon"
+doc: "https://let-def.github.io/sturgeon/doc"
+license: "ISC"
+dev-repo: "https://github.com/let-def/sturgeon.git"
+bug-reports: "https://github.com/let-def/sturgeon/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "inuit"
+  "result"
+]
+depopts: []
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/sturgeon/sturgeon.0.2/url
+++ b/packages/sturgeon/sturgeon.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/let-def/sturgeon/releases/download/v0.2/sturgeon-0.2.tbz"
+checksum: "8157a30501b04f41fd7454c3c15dffb7"


### PR DESCRIPTION
A toolkit for communicating with Emacs

Sturgeon implements various tools for manipulating Emacs from OCaml:
- `Sturgeon_sexp` implements the Emacs dialect of S-expressions
- `Sturgeon_session` implements an "session protocol" to make RPC to Emacs from OCaml and vice versa
- `Sturgeon_stui` is a session implementing an [Inuit](https://github.com/let-def/inuit) backend: one can now runs text user-interface on an Emacs buffer
- `Sturgeon_recipes_*` offers different "rendez-vous" points to connect to Emacs

Sturgeon is distributed under the ISC license.


---
* Homepage: https://github.com/let-def/sturgeon
* Source repo: https://github.com/let-def/sturgeon.git
* Bug tracker: https://github.com/let-def/sturgeon/issues

---


---
v0.2 2017-01-30 London
------------------------

For sessions:
- use result package.
- adjust terminology, rename suspended computations from "negation" to
  "continuation"
Pull-request generated by opam-publish v0.3.3