### PR TITLE
gamepad.0.1.0 - via opam-publish

### DIFF
--- a/packages/gamepad/gamepad.0.1.0/descr
+++ b/packages/gamepad/gamepad.0.1.0/descr
@@ -1,0 +1,3 @@
+Bindings for the JS Gamepad API
+
+Using this and js_of_ocaml, you can use gamepads with OCaml in your browser.

--- a/packages/gamepad/gamepad.0.1.0/opam
+++ b/packages/gamepad/gamepad.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <me@emillon.org>"
+authors: "Etienne Millon <me@emillon.org>"
+homepage: "https://github.com/emillon/gamepad_of_ocaml"
+bug-reports: "https://github.com/emillon/gamepad_of_ocaml/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/emillon/gamepad_of_ocaml.git"
+doc: "https://emillon.github.io/gamepad_of_ocaml/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "lwt"
+  "js_of_ocaml" {>= "2.6"}
+]

--- a/packages/gamepad/gamepad.0.1.0/url
+++ b/packages/gamepad/gamepad.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/emillon/gamepad_of_ocaml/releases/download/v0.1.0/gamepad-0.1.0.tbz"
+checksum: "d3ecec83d63fccde2f9bff4a67e3027b"


### PR DESCRIPTION
Bindings for the JS Gamepad API

Using this and js_of_ocaml, you can use gamepads with OCaml in your browser.


---
* Homepage: https://github.com/emillon/gamepad_of_ocaml
* Source repo: https://github.com/emillon/gamepad_of_ocaml.git
* Bug tracker: https://github.com/emillon/gamepad_of_ocaml/issues

---


---
## v0.1.0

*2017-02-01*

Initial release.
Pull-request generated by opam-publish v0.3.3