### PR TITLE
pcap-format.0.5.0 - via opam-publish

### DIFF
--- a/packages/pcap-format/pcap-format.0.5.0/descr
+++ b/packages/pcap-format/pcap-format.0.5.0/descr
@@ -1,0 +1,4 @@
+Decode and encode PCAP (packet capture) files
+
+pcap-format provides an interface to encode and decode pcap files, dealing with
+both endianess, including endianess detection.

--- a/packages/pcap-format/pcap-format.0.5.0/opam
+++ b/packages/pcap-format/pcap-format.0.5.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer:   "Dave Scott <dave@recoil.org>"
+authors:      [ "Anil Madhavapeddy" "Dave Scott" "Richard Mortier" ]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-pcap"
+dev-repo:     "https://github.com/mirage/ocaml-pcap.git"
+bug-reports:  "https://github.com/mirage/ocaml-pcap/issues"
+doc:          "https://mirage.github.io/ocaml-pcap/"
+tags:         [ "org:mirage" "org:xapi-project" ]
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build & >= "0.8.0"}
+  "ppx_tools"  {build}
+  "cstruct"            {>= "1.9.0"}
+  "ounit"      {test}
+]

--- a/packages/pcap-format/pcap-format.0.5.0/url
+++ b/packages/pcap-format/pcap-format.0.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-pcap/releases/download/0.5.0/pcap-format-0.5.0.tbz"
+checksum: "8044256e21080e6dcf3fbdc9144f1328"


### PR DESCRIPTION
Decode and encode PCAP (packet capture) files

pcap-format provides an interface to encode and decode pcap files, dealing with
both endianess, including endianess detection.

---
* Homepage: https://github.com/mirage/ocaml-pcap
* Source repo: https://github.com/mirage/ocaml-pcap.git
* Bug tracker: https://github.com/mirage/ocaml-pcap/issues

---


---
## 0.5.0 (2017-02-03)

* removed mirage and print sublibrary
* converted build system to topkg
Pull-request generated by opam-publish v0.3.3