### PR TITLE
tar-format.0.7.1 - via opam-publish

### DIFF
--- a/packages/tar-format/tar-format.0.7.1/descr
+++ b/packages/tar-format/tar-format.0.7.1/descr
@@ -1,0 +1,6 @@
+Decode and encode tar files
+
+tar-format is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.

--- a/packages/tar-format/tar-format.0.7.1/opam
+++ b/packages/tar-format/tar-format.0.7.1/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer:   "dave@recoil.org"
+authors:      [ "Dave Scott" "Thomas Gazagnaire" "David Allsopp" ]
+tags:         ["org:xapi-project" "org:mirage"]
+homepage:     "https://github.com/mirage/ocaml-tar"
+bug-reports:  "https://github.com/mirage/ocaml-tar/issues"
+dev-repo:     "https://github.com/mirage/ocaml-tar.git"
+doc:          "https://mirage.github.io/ocaml-tar/"
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+    "--with-mirage" "%{mirage-types-lwt+mirage-block+mirage-block-lwt+io-page:installed}%"
+    "--with-lwt" "%{lwt:installed}%" ]
+]
+
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" "--with-lwt" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+
+depends: [
+  "ocamlbuild"        {build}
+  "ocamlfind"         {build}
+  "topkg"             {build & >= "0.8.0"}
+  "ppx_tools"         {build}
+  "cstruct"           {>= "1.9.0"}
+  "re"
+  "result"
+  "mirage-block-unix" {test & >= "2.5.0"}
+  "mirage-types-lwt"  {test & >= "3.0.0"}
+  "ounit"             {test}
+  "lwt"               {test}
+]
+depopts: ["lwt" "mirage-types-lwt" "mirage-block" "mirage-block-lwt" "io-page"]
+conflicts: [
+  "mirage-types-lwt" {< "3.0.0"}
+]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/tar-format/tar-format.0.7.1/url
+++ b/packages/tar-format/tar-format.0.7.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-tar/releases/download/v0.7.1/tar-format-0.7.1.tbz"
+checksum: "554ee6120f06017828f8f4e74515cbfa"


### PR DESCRIPTION
Decode and encode tar files

tar-format is a simple library to read and write tar files with an emphasis on
streaming.

This is pure OCaml code, no C bindings.

---
* Homepage: https://github.com/mirage/ocaml-tar
* Source repo: https://github.com/mirage/ocaml-tar.git
* Bug tracker: https://github.com/mirage/ocaml-tar/issues

---


---
## v0.7.1 (2017-02-03)

- convert build system to topkg (#43, @hannesm)
Pull-request generated by opam-publish v0.3.2