### PR TITLE
mtime.0.8.4 - via opam-publish

### DIFF
--- a/packages/mtime/mtime.0.8.4/descr
+++ b/packages/mtime/mtime.0.8.4/descr
@@ -1,0 +1,11 @@
+Monotonic wall-clock time for OCaml
+
+Mtime is an OCaml module to access monotonic wall-clock time. It
+allows to measure time spans without being subject to operating system
+calendar time adjustments.
+
+Mtime depends only on your platform system library. The optional
+JavaScript support depends on [js_of_ocaml][jsoo]. It is distributed
+under the ISC license.
+
+[jsoo]: http://ocsigen.org/js_of_ocaml/

--- a/packages/mtime/mtime.0.8.4/opam
+++ b/packages/mtime/mtime.0.8.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/mtime"
+doc: "http://erratique.ch/software/mtime"
+dev-repo: "http://erratique.ch/repos/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+tags: [ "time" "monotonic" "system" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends:
+[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+depopts: [ "js_of_ocaml" ]
+build: [[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]

--- a/packages/mtime/mtime.0.8.4/url
+++ b/packages/mtime/mtime.0.8.4/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/mtime/releases/mtime-0.8.4.tbz"
+checksum: "6261cb1a621412b7195615c2dbce57f3"


### PR DESCRIPTION
Monotonic wall-clock time for OCaml

Mtime is an OCaml module to access monotonic wall-clock time. It
allows to measure time spans without being subject to operating system
calendar time adjustments.

Mtime depends only on your platform system library. The optional
JavaScript support depends on [js_of_ocaml][jsoo]. It is distributed
under the ISC license.

[jsoo]: http://ocsigen.org/js_of_ocaml/


---
* Homepage: http://erratique.ch/software/mtime
* Source repo: http://erratique.ch/repos/mtime.git
* Bug tracker: https://github.com/dbuenzli/mtime/issues

---


---
v0.8.4 2017-02-05 La Forclaz (VS)
---------------------------------

* Fix package for -custom linking. Thanks to @orbitz for the report.
* Build depend on topkg.
* Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.3