### PR TITLE
ocaml-migrate-parsetree.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.1/opam
@@ -7,7 +7,7 @@ authors: [
 ]
 homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
-license: "MIT"
+license: "LGPL-2.1"
 tags: "syntax"
 dev-repo: "git://github.com/let-def/ocaml-migrate-parsetree.git"
 build: [make "all"]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.1/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.1/url
@@ -1,3 +1,3 @@
 http:
   "https://github.com/let-def/ocaml-migrate-parsetree/archive/v0.1.tar.gz"
-checksum: "89e2681a46a3386199f5b24eb5328df4"
+checksum: "d744f582b4f54b3e679049c48dbc76e8"


### PR DESCRIPTION
Convert OCaml parsetrees between different major versions 

This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
High-level functions help making PPX rewriters independent of a compiler version.


---
* Homepage: https://github.com/let-def/ocaml-migrate-parsetree
* Source repo: git://github.com/let-def/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/let-def/ocaml-migrate-parsetree/issues

---

Pull-request generated by opam-publish v0.3.3