### PR TITLE
zxcvbn.2.0+1 - via opam-publish

### DIFF
--- a/packages/zxcvbn/zxcvbn.2.0+1/descr
+++ b/packages/zxcvbn/zxcvbn.2.0+1/descr
@@ -1,0 +1,3 @@
+Bindings for the zxcvbn password strength estimation library
+
+This library provide functions to estimate the strength of a password.

--- a/packages/zxcvbn/zxcvbn.2.0+1/opam
+++ b/packages/zxcvbn/zxcvbn.2.0+1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/ocaml-zxcvbn"
+bug-reports: "https://github.com/cryptosense/ocaml-zxcvbn/issues"
+license: "BSD-2"
+dev-repo:  "https://github.com/cryptosense/ocaml-zxcvbn.git"
+doc: "https://cryptosense.github.io/ocaml-zxcvbn/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {test}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "topkg" {build}
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/zxcvbn/zxcvbn.2.0+1/url
+++ b/packages/zxcvbn/zxcvbn.2.0+1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/ocaml-zxcvbn/releases/download/v2.0%2B1/zxcvbn-2.0.1.tbz"
+checksum: "83f97d3f3aa5cf4372de09126012a581"


### PR DESCRIPTION
Bindings for the zxcvbn password strength estimation library

This library provide functions to estimate the strength of a password.


---
* Homepage: https://github.com/cryptosense/ocaml-zxcvbn
* Source repo: https://github.com/cryptosense/ocaml-zxcvbn.git
* Bug tracker: https://github.com/cryptosense/ocaml-zxcvbn/issues

---


---
v2.0+1
------

*2017-02-06*

Inital release
Pull-request generated by opam-publish v0.3.3