### PR TITLE
prometheus.0.1 - via opam-publish

### DIFF
--- a/packages/prometheus/prometheus.0.1/descr
+++ b/packages/prometheus/prometheus.0.1/descr
@@ -1,0 +1,11 @@
+Client library for Prometheus monitoring
+
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+
+This repository contains code to report metrics to a Prometheus monitoring server.

--- a/packages/prometheus/prometheus.0.1/opam
+++ b/packages/prometheus/prometheus.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "datakit@docker.com"
+authors:      ["Thomas Leonard"]
+license:      "Apache"
+homepage:     "https://github.com/mirage/prometheus"
+bug-reports:  "https://github.com/mirage/prometheus/issues"
+dev-repo:     "https://github.com/mirage/prometheus.git"
+doc:          "https://mirage.github.io/prometheus/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+  "-n" "prometheus"
+]
+
+depends: [
+  "ocamlfind" {build}
+  "astring"
+  "asetmap"
+  "fmt"
+  "lwt" {>="2.5.0"}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/prometheus/prometheus.0.1/url
+++ b/packages/prometheus/prometheus.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/prometheus/releases/download/v0.1/prometheus-0.1.tbz"
+checksum: "b0f3f5e3ef839d3b7ef672e5dd060d77"


### PR DESCRIPTION
Client library for Prometheus monitoring

To run services reliably, it is useful if they can report various metrics
(for example, heap size, queue lengths, number of warnings logged, etc).

A monitoring service can be configured to collect this data regularly.
The data can be graphed to help understand the performance of the service over time,
or to help debug problems quickly.
It can also be used to send alerts if a service is down or behaving poorly.

This repository contains code to report metrics to a Prometheus monitoring server.


---
* Homepage: https://github.com/mirage/prometheus
* Source repo: https://github.com/mirage/prometheus.git
* Bug tracker: https://github.com/mirage/prometheus/issues

---


---
v0.1
----

Initial release.
Pull-request generated by opam-publish v0.3.3