### PR TITLE
obandit.0.1.37 - via opam-publish

### DIFF
--- a/packages/obandit/obandit.0.1.37/descr
+++ b/packages/obandit/obandit.0.1.37/descr
@@ -1,0 +1,6 @@
+Ocaml Multi-Armed Bandits
+
+Obandit is an OCaml module for basic multi-armed bandits. It supports the
+EXP3, UCB1 and Epsilon-greedy algorithms.
+
+Obandit is distributed under the ISC license.

--- a/packages/obandit/obandit.0.1.37/opam
+++ b/packages/obandit/obandit.0.1.37/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Valentin Reis <fre@freux.fr>"
+authors: ["Valentin Reis <fre@freux.fr>"]
+homepage: "http://freux.fr/obandit"
+doc: "http://freux.fr/obandit/doc"
+license: "ISC"
+dev-repo: "http://git.freux.fr/obandit.git"
+bug-reports: "ocaml@freux.fr"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "batteries" ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" pinned ]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]]

--- a/packages/obandit/obandit.0.1.37/url
+++ b/packages/obandit/obandit.0.1.37/url
@@ -1,0 +1,2 @@
+archive: "http://freux.fr/obandit/releases/obandit-0.1.37.tbz"
+checksum: "e7479050a374cebc90bded3a6536f9bc"


### PR DESCRIPTION
Ocaml Multi-Armed Bandits

Obandit is an OCaml module for basic multi-armed bandits. It supports the
EXP3, UCB1 and Epsilon-greedy algorithms.

Obandit is distributed under the ISC license.


---
* Homepage: http://freux.fr/obandit
* Source repo: http://git.freux.fr/obandit.git
* Bug tracker: ocaml@freux.fr

---


---
v0.1.37 2017-02-06 Grenoble
--------------------------

* distrib folder change.
Pull-request generated by opam-publish v0.3.3