### PR TITLE
obandit.0.1.38 - via opam-publish

### DIFF
--- a/packages/obandit/obandit.0.1.38/descr
+++ b/packages/obandit/obandit.0.1.38/descr
@@ -1,0 +1,6 @@
+Ocaml Multi-Armed Bandits
+
+Obandit is an OCaml module for basic multi-armed bandits. It supports the
+EXP3, UCB1 and Epsilon-greedy algorithms.
+
+Obandit is distributed under the ISC license.

--- a/packages/obandit/obandit.0.1.38/opam
+++ b/packages/obandit/obandit.0.1.38/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Valentin Reis <fre@freux.fr>"
+authors: ["Valentin Reis <fre@freux.fr>"]
+homepage: "http://freux.fr/obandit"
+doc: "http://freux.fr/obandit/doc"
+license: "ISC"
+dev-repo: "http://git.freux.fr/cgit/obandit.git"
+bug-reports: "ocaml@freux.fr"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "batteries" ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%" ]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]]

--- a/packages/obandit/obandit.0.1.38/url
+++ b/packages/obandit/obandit.0.1.38/url
@@ -1,0 +1,2 @@
+archive: "http://freux.fr/obandit/releases/obandit-0.1.38.tbz"
+checksum: "76cd434c6106f5fec5714c6dc80d2cb0"


### PR DESCRIPTION
Ocaml Multi-Armed Bandits

Obandit is an OCaml module for basic multi-armed bandits. It supports the
EXP3, UCB1 and Epsilon-greedy algorithms.

Obandit is distributed under the ISC license.


---
* Homepage: http://freux.fr/obandit
* Source repo: http://git.freux.fr/cgit/obandit.git
* Bug tracker: ocaml@freux.fr

---


---
v0.1.38 2017-02-07 Grenoble
--------------------------

* fix build command.
Pull-request generated by opam-publish v0.3.3