### PR TITLE
simple-diff.0.2 - via opam-publish

### DIFF
--- a/packages/simple-diff/simple-diff.0.2/descr
+++ b/packages/simple-diff/simple-diff.0.2/descr
@@ -1,0 +1,4 @@
+Simple_diff is a pure OCaml diffing algorithm.
+
+This diffing algorithm is a port of https://github.com/paulgb/simplediff with
+some minor differences in the implementation.

--- a/packages/simple-diff/simple-diff.0.2/opam
+++ b/packages/simple-diff/simple-diff.0.2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Gabriel Jaldon <gjaldon85@gmail.com>"
+authors: "Gabriel Jaldon <gjaldon85@gmail.com>"
+homepage: "https://github.com/gjaldon/simple_diff"
+bug-reports: "https://github.com/gjaldon/simple_diff/issues"
+license: "MIT"
+dev-repo: "https://github.com/gjaldon/simple_diff"
+build: [make]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "re" {>= "1.7.1"}
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/simple-diff/simple-diff.0.2/url
+++ b/packages/simple-diff/simple-diff.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/gjaldon/simple-diff/archive/v0.2.tar.gz"
+checksum: "f7bad9e7f2b7f9049253ec185922671c"


### PR DESCRIPTION
Simple_diff is a pure OCaml diffing algorithm.

This diffing algorithm is a port of https://github.com/paulgb/simplediff with
some minor differences in the implementation.


---
* Homepage: https://github.com/gjaldon/simple_diff
* Source repo: https://github.com/gjaldon/simple_diff
* Bug tracker: https://github.com/gjaldon/simple_diff/issues

---


---
## 1.2.1 (2017-2-7)
- Fix packaging by using Topkg instead of doing everything from scratch (package could not be found by Ocamlfind and compiled files are copied to Opam lib)
Pull-request generated by opam-publish v0.3.2