### PR TITLE
simple-diff.0.2.1 - via opam-publish

### DIFF
--- a/packages/simple-diff/simple-diff.0.2.1/descr
+++ b/packages/simple-diff/simple-diff.0.2.1/descr
@@ -1,0 +1,4 @@
+Simple_diff is a pure OCaml diffing algorithm.
+
+This diffing algorithm is a port of https://github.com/paulgb/simplediff with
+some minor differences in the implementation.

--- a/packages/simple-diff/simple-diff.0.2.1/opam
+++ b/packages/simple-diff/simple-diff.0.2.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer:   "Gabriel Jaldon <gjaldon85@gmail.com>"
+authors:      [ "Gabriel Jaldon" ]
+homepage:     "https://github.com/gjaldon/simple_diff"
+bug-reports:  "https://github.com/gjaldon/simple_diff/issues"
+license:      "ISC"
+dev-repo:     "https://github.com/gjaldon/simple_diff.git"
+
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+
+depends: [
+  "topkg"      {build}
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "re"         {>= "1.7.1"}
+]
+
+
+available: [ocaml-version >= "4.00.0"]

--- a/packages/simple-diff/simple-diff.0.2.1/url
+++ b/packages/simple-diff/simple-diff.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/gjaldon/simple-diff/archive/v0.2.1.tar.gz"
+checksum: "3694fd83a00203bfb0ce861310643217"


### PR DESCRIPTION
Simple_diff is a pure OCaml diffing algorithm.

This diffing algorithm is a port of https://github.com/paulgb/simplediff with
some minor differences in the implementation.


---
* Homepage: https://github.com/gjaldon/simple_diff
* Source repo: https://github.com/gjaldon/simple_diff.git
* Bug tracker: https://github.com/gjaldon/simple_diff/issues

---


---
## 1.2.1 (2017-2-7)
- Fix packaging by using Topkg instead of doing everything from scratch (package could not be found by Ocamlfind and compiled files are copied to Opam lib)
Pull-request generated by opam-publish v0.3.2