### PR TITLE
minisat.0.1 - via opam-publish

### DIFF
--- a/packages/minisat/minisat.0.1/descr
+++ b/packages/minisat/minisat.0.1/descr
@@ -1,0 +1,2 @@
+Bindings to Minisat, with the solver included (no external dependency)
+

--- a/packages/minisat/minisat.0.1/opam
+++ b/packages/minisat/minisat.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "simon.cruanes@inria.fr"
+homepage: "https://github.com/c-cube/ocaml-minisat/"
+bug-reports: "https://github.com/c-cube/ocaml-minisat/issues"
+tags: ["minisat" "solver" "SAT"]
+dev-repo: "https://github.com/c-cube/ocaml-minisat.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--docdir=%{doc}%" "--disable-docs"]
+  [make "build"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "minisat"]
+depends: "ocamlfind"
+available: [ocaml-version >= "4.00.0"]

--- a/packages/minisat/minisat.0.1/url
+++ b/packages/minisat/minisat.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-minisat/archive/0.1.tar.gz"
+checksum: "35b2a371c0a59150c025b72184169bec"


### PR DESCRIPTION
Bindings to Minisat, with the solver included (no external dependency)



---
* Homepage: https://github.com/c-cube/ocaml-minisat/
* Source repo: https://github.com/c-cube/ocaml-minisat.git
* Bug tracker: https://github.com/c-cube/ocaml-minisat/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.4