### PR TITLE
tuntap.1.4.0 - via opam-publish

### DIFF
--- a/packages/tuntap/tuntap.1.4.0/descr
+++ b/packages/tuntap/tuntap.1.4.0/descr
@@ -1,0 +1,14 @@
+TUN/TAP bindings
+
+This is an OCaml library for handling TUN/TAP devices.  TUN refers to layer 3
+virtual interfaces whereas TAP refers to layer 2 Ethernet ones.
+
+See <http://en.wikipedia.org/wiki/TUN/TAP> for more information.
+
+Linux, FreeBSD, OpenBSD and MacOS X should all be supported.  You will need
+to install the third-party <http://tuntaposx.sourceforge.net/> on OSX before
+using this library.
+
+WWW:    <https://github.com/mirage/ocaml-tuntap>
+Issues: <https://github.com/mirage/mirage/issues>
+E-mail: <mirageos-devel@lists.openmirage.org>

--- a/packages/tuntap/tuntap.1.4.0/opam
+++ b/packages/tuntap/tuntap.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "vb@luminar.eu.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/mirage/ocaml-tuntap"
+bug-reports: "https://github.com/mirage/ocaml-tuntap/issues"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/ocaml-tuntap.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "topkg" {build & >= "0.8.0"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ipaddr" {>= "2.4.0"}
+  "ounit" {test}
+  "lwt" {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/tuntap/tuntap.1.4.0/opam
+++ b/packages/tuntap/tuntap.1.4.0/opam
@@ -22,4 +22,7 @@ depends: [
   "ounit" {test}
   "lwt" {test}
 ]
+depexts: [
+  [ ["alpine"] ["linux-headers"] ]
+]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/tuntap/tuntap.1.4.0/url
+++ b/packages/tuntap/tuntap.1.4.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/mirage/ocaml-tuntap/releases/download/1.4.0/tuntap-1.4.0.tbz"
+checksum: "b7f0f6cdf52c0f5ab7b3ec80301d3d74"


### PR DESCRIPTION
TUN/TAP bindings

This is an OCaml library for handling TUN/TAP devices.  TUN refers to layer 3
virtual interfaces whereas TAP refers to layer 2 Ethernet ones.

See <http://en.wikipedia.org/wiki/TUN/TAP> for more information.

Linux, FreeBSD, OpenBSD and MacOS X should all be supported.  You will need
to install the third-party <http://tuntaposx.sourceforge.net/> on OSX before
using this library.

WWW:    <https://github.com/mirage/ocaml-tuntap>
Issues: <https://github.com/mirage/mirage/issues>
E-mail: <mirageos-devel@lists.openmirage.org>


---
* Homepage: https://github.com/mirage/ocaml-tuntap
* Source repo: https://github.com/mirage/ocaml-tuntap.git
* Bug tracker: https://github.com/mirage/ocaml-tuntap/issues

---

Pull-request generated by opam-publish v0.3.3