### PR TITLE
clangml.3.8.0 only works with 4.02.3

### DIFF
--- a/packages/clangml/clangml.3.8.0/opam
+++ b/packages/clangml/clangml.3.8.0/opam
@@ -33,7 +33,8 @@ depexts: [
   [["archlinux"] ["boost" "binutils"]]
 ]
 available: [
-  ocaml-version >= "4.02.3" & !preinstalled & os != "darwin"
+  ocaml-version >= "4.02.3" & ocaml-version < "4.03.0" &
+   !preinstalled & os != "darwin"
 ]
 post-messages: [
   "This package requires llvm-3.8, clang-3.8, boost and binutils" {failure}


### PR DESCRIPTION
tools/bridgen/c++/ocaml++.h refers to the type int64 (line 323) which is
no longer defined in the 4.03.0 C API. clangml.3.8.0.1 fixes this by
using int64_t instead.