### PR TITLE
nunchaku.0.4 - via opam-publish

### DIFF
--- a/packages/nunchaku/nunchaku.0.4/descr
+++ b/packages/nunchaku/nunchaku.0.4/descr
@@ -1,0 +1,7 @@
+A counter-example finder for higher-order logic.
+
+Nunchaku is a counter-example finder for higher-order logic, designed to be
+used from various proof assistants, and a spiritual successor to Nitpick. It
+relies encodings and external solvers (CVC4, kodkod, paradox, smbc) to find
+models, thanks to its modular architecture.
+

--- a/packages/nunchaku/nunchaku.0.4/opam
+++ b/packages/nunchaku/nunchaku.0.4/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: ["Simon Cruanes" "Jasmin Blanchette"]
+homepage: "https://github.com/nunchaku-inria/nunchaku/"
+bug-reports: "https://github.com/nunchaku-inria/nunchaku/issues"
+dev-repo: "https://github.com/nunchaku-inria/nunchaku.git"
+build: [
+  [
+    "./configure"
+    "--prefix"
+    prefix
+    "--disable-random"
+    "--disable-tests"
+    "--enable-docs"
+  ]
+  [make "build"]
+  ["strip" "nunchaku.native"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "nunchaku"]
+depends: [
+  "ocamlfind" {build}
+  "containers" {>= "1.0"}
+  "menhir" {build}
+  "sequence"
+  "base-unix"
+  "base-threads"
+  "ocamlbuild" {build}
+]
+depopts: [
+  "qtest" {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/nunchaku/nunchaku.0.4/url
+++ b/packages/nunchaku/nunchaku.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nunchaku-inria/nunchaku/archive/0.4.tar.gz"
+checksum: "9faabbe893c651628374f79f56cb74a0"


### PR DESCRIPTION
A counter-example finder for higher-order logic.

Nunchaku is a counter-example finder for higher-order logic, designed to be
used from various proof assistants, and a spiritual successor to Nitpick. It
relies encodings and external solvers (CVC4, kodkod, paradox, smbc) to find
models, thanks to its modular architecture.



---
* Homepage: https://github.com/nunchaku-inria/nunchaku/
* Source repo: https://github.com/nunchaku-inria/nunchaku.git
* Bug tracker: https://github.com/nunchaku-inria/nunchaku/issues

---

Pull-request generated by opam-publish v0.3.4