### PR TITLE
emoji.1.1.0 - via opam-publish

### DIFF
--- a/packages/emoji/emoji.1.1.0/descr
+++ b/packages/emoji/emoji.1.1.0/descr
@@ -1,0 +1,16 @@
+Use emojis by name
+
+Names for byte code sequences of 2389 emojis
+
+```ocaml
+#require "emoji";;
+
+let () =
+  let ar = Emoji.all_emojis |> Array.of_list in
+  for i = 0 to Array.length ar - 1 do
+    if (i mod 80 = 0) then print_newline ();
+    print_string ar.(i);
+  done;
+  print_endline Emoji.camel;
+  print_endline Emoji.two_hump_camel
+```

--- a/packages/emoji/emoji.1.1.0/opam
+++ b/packages/emoji/emoji.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+homepage: "https://github.com/fxfactorial/ocaml-emoji"
+bug-reports: "https://github.com/fxfactorial/ocaml-emoji/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/fxfactorial/ocaml-emoji.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "emoji"]
+depends: [
+  "oasis" {build & >= "0.4.7"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/emoji/emoji.1.1.0/url
+++ b/packages/emoji/emoji.1.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-emoji/archive/v1.1.0.tar.gz"
+checksum: "b5f1570c58417aa3ef9d72df5dc32eac"


### PR DESCRIPTION
Use emojis by name

Names for byte code sequences of 2389 emojis

#require "emoji";;
```
let () =
  let ar = Emoji.all_emojis |> Array.of_list in
  for i = 0 to Array.length ar - 1 do
    if (i mod 80 = 0) then print_newline ();
    print_string ar.(i);
  done;
  print_endline Emoji.camel;
  print_endline Emoji.two_hump_camel
```

---
* Homepage: https://github.com/fxfactorial/ocaml-emoji
* Source repo: https://github.com/fxfactorial/ocaml-emoji.git
* Bug tracker: https://github.com/fxfactorial/ocaml-emoji/issues

---

Pull-request generated by opam-publish v0.3.3

@sternenseemann for tripling the amount of emojis and added doc strings of them so you can see them in `ocp-browser` along with code point and pretty online docs:  http://hyegar.com/ocaml-emoji/Emoji.html

<img width="378" alt="ocp-browser-emoji" src="https://cloud.githubusercontent.com/assets/3036816/22901307/0b1f333c-f1e6-11e6-936f-4f0174f3b662.png">


Now with emojis we can expect flood of widespread OCaml adoption. 