### PR TITLE
qcow, qcow-format: add upper-bounds on mirage-block-unix

### DIFF
--- a/packages/qcow-format/qcow-format.0.4.2/opam
+++ b/packages/qcow-format/qcow-format.0.4.2/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "mirage-block" {>= "0.2"}
-  "mirage-block-unix" {>= "2.1.0"}
+  "mirage-block-unix" {>= "2.1.0" & < "2.5.0"}
   "cmdliner"
   "sexplib"
   "logs"

--- a/packages/qcow-format/qcow-format.0.5.0/opam
+++ b/packages/qcow-format/qcow-format.0.5.0/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "mirage-block" {>= "0.2"}
-  "mirage-block-unix" {>= "2.1.0"}
+  "mirage-block-unix" {>= "2.1.0" & < "2.5.0"}
   "cmdliner"
   "sexplib"
   "logs"

--- a/packages/qcow/qcow.0.6.0/opam
+++ b/packages/qcow/qcow.0.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "mirage-block" {>= "0.2"}
-  "mirage-block-unix" {>= "2.1.0"}
+  "mirage-block-unix" {>= "2.1.0" & < "2.5.0"}
   "cmdliner"
   "sexplib"
   "logs"

--- a/packages/qcow/qcow.0.7.0/opam
+++ b/packages/qcow/qcow.0.7.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-types-lwt" {< "3.0.0"}
   "lwt"
   "mirage-block" {>= "0.2"}
-  "mirage-block-unix" {>= "2.1.0"}
+  "mirage-block-unix" {>= "2.1.0" & < "2.5.0"}
   "cmdliner"
   "sexplib"
   "logs"


### PR DESCRIPTION
The Mirage 3 APIs have changed

Related to [mirage/mirageos-3-beta#21]

Signed-off-by: David Scott <dave@recoil.org>