### PR TITLE
iso-filesystem: add upper bound on lwt

### DIFF
--- a/packages/iso-filesystem/iso-filesystem.0.1/opam
+++ b/packages/iso-filesystem/iso-filesystem.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "camlp4"
   "io-page" {build}
-  "lwt"
+  "lwt" {< "2.6.0"}
   "mirage-block-unix" {build}
   "mirage-types" {< "3.0.0"}
   "ocamlfind" {build}


### PR DESCRIPTION
This library defines a module called `Result` which clashes with the
`Result` used by recent `lwt` versions.

Noticed on [mirage/mirageos-3-beta#21]
Reported on [jonludlam/ocaml-iso-filesystem#1]

Signed-off-by: David Scott <dave@recoil.org>