### PR TITLE
nbd: add upper bound on mirage-block-unix

### DIFF
--- a/packages/nbd/nbd.2.0.1/opam
+++ b/packages/nbd/nbd.2.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "cstruct" {> "1.0.0" & < "2.0.0"}
   "cmdliner"
   "sexplib" {< "113.24.00"}
-  "mirage-block-unix"
+  "mirage-block-unix" {< "2.5.0"}
   "io-page"
   "mirage" {< "3.0.0"}
   "uri"

--- a/packages/nbd/nbd.2.1.0/opam
+++ b/packages/nbd/nbd.2.1.0/opam
@@ -31,7 +31,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "cmdliner"
   "sexplib"
-  "mirage-block-unix"
+  "mirage-block-unix" {< "2.5.0"}
   "io-page"
   "mirage" {>= "1.1.0" & < "3.0.0"}
   "uri"

--- a/packages/nbd/nbd.2.1.1/opam
+++ b/packages/nbd/nbd.2.1.1/opam
@@ -30,7 +30,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "cmdliner"
   "sexplib"
-  "mirage-block-unix"
+  "mirage-block-unix" {< "2.5.0"}
   "io-page"
   "mirage" {>= "1.1.0" & < "3.0.0"}
   "uri"


### PR DESCRIPTION
Noticed on [mirage/mirageos-3-beta#21]

Signed-off-by: David Scott <dave@recoil.org>