### PR TITLE
patch Cubicle 1.0.2 to be able to compile with ocaml-version >= "4.03.0"

### DIFF
--- a/packages/cubicle/cubicle.1.0.2/files/patch_syntax_ocaml_4_03_0.patch
+++ b/packages/cubicle/cubicle.1.0.2/files/patch_syntax_ocaml_4_03_0.patch
@@ -1,0 +1,13 @@
+diff --git a/enumerative.ml b/enumerative.ml
+index 31e6054..1374cd7 100644
+--- a/enumerative.ml
++++ b/enumerative.ml
+@@ -285,7 +285,7 @@ let init_tables procs s =
+   let ht = HT.create (nb_vars + nb_consts) in
+   let i = ref 0 in
+   Term.Set.iter (fun t -> HT.add ht t !i; incr i) var_terms;
+-  let max_id_vars = !i - 1in
++  let max_id_vars = !i - 1 in
+   let proc_ids = ref [] in
+   let first_proc = !i in
+   List.iter (fun t -> HT.add ht t !i; proc_ids := !i :: !proc_ids; incr i)

--- a/packages/cubicle/cubicle.1.0.2/opam
+++ b/packages/cubicle/cubicle.1.0.2/opam
@@ -6,6 +6,10 @@ authors: [
 ]
 homepage: "http://cubicle.lri.fr"
 license: "Apache Software License version 2.0"
+
+patches:[
+  "patch_syntax_ocaml_4_03_0.patch"
+]
 build: [
   ["./configure" "--prefix" prefix]
   [make]
@@ -15,5 +19,4 @@ depopts: ["functory"]
 conflicts: [
   "functory" {< "0.5"}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.03.0" ]
-install: [make "install" "MANDIR=%{man}%"]
+available: [ ocaml-version >= "4.00.0"]


### PR DESCRIPTION
* A small patch in enumerative.ml due to a recent change in OCaml (>= 4.03.0):

+-  let max_id_vars = !i - 1in
++  let max_id_vars = !i - 1 in


* install field in opam file is not needed since files/cubicle.install is provided