### PR TITLE
Update opam2 beta to beta2, with `opam build` fixes

### DIFF
--- a/packages/opam-client/opam-client.2.0.0~beta/url
+++ b/packages/opam-client/opam-client.2.0.0~beta/url
@@ -1,2 +1,2 @@
-src: "https://github.com/ocaml/opam/archive/2.0.0-beta.tar.gz"
-checksum: "f4f1794dbaa36ccc16f57d75ee775fdc"
+src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
+checksum: "e27cfdb0b8c6f4c3133f983e4c50b7dd"

--- a/packages/opam-core/opam-core.2.0.0~beta/url
+++ b/packages/opam-core/opam-core.2.0.0~beta/url
@@ -1,2 +1,2 @@
-src: "https://github.com/ocaml/opam/archive/2.0.0-beta.tar.gz"
-checksum: "f4f1794dbaa36ccc16f57d75ee775fdc"
+src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
+checksum: "e27cfdb0b8c6f4c3133f983e4c50b7dd"

--- a/packages/opam-devel/opam-devel.2.0.0~beta/url
+++ b/packages/opam-devel/opam-devel.2.0.0~beta/url
@@ -1,2 +1,2 @@
-src: "https://github.com/ocaml/opam/archive/2.0.0-beta.tar.gz"
-checksum: "f4f1794dbaa36ccc16f57d75ee775fdc"
+src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
+checksum: "e27cfdb0b8c6f4c3133f983e4c50b7dd"

--- a/packages/opam-format/opam-format.2.0.0~beta/url
+++ b/packages/opam-format/opam-format.2.0.0~beta/url
@@ -1,2 +1,2 @@
-src: "https://github.com/ocaml/opam/archive/2.0.0-beta.tar.gz"
-checksum: "f4f1794dbaa36ccc16f57d75ee775fdc"
+src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
+checksum: "e27cfdb0b8c6f4c3133f983e4c50b7dd"

--- a/packages/opam-repository/opam-repository.2.0.0~beta/url
+++ b/packages/opam-repository/opam-repository.2.0.0~beta/url
@@ -1,2 +1,2 @@
-src: "https://github.com/ocaml/opam/archive/2.0.0-beta.tar.gz"
-checksum: "f4f1794dbaa36ccc16f57d75ee775fdc"
+src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
+checksum: "e27cfdb0b8c6f4c3133f983e4c50b7dd"

--- a/packages/opam-solver/opam-solver.2.0.0~beta/url
+++ b/packages/opam-solver/opam-solver.2.0.0~beta/url
@@ -1,2 +1,2 @@
-src: "https://github.com/ocaml/opam/archive/2.0.0-beta.tar.gz"
-checksum: "f4f1794dbaa36ccc16f57d75ee775fdc"
+src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
+checksum: "e27cfdb0b8c6f4c3133f983e4c50b7dd"

--- a/packages/opam-state/opam-state.2.0.0~beta/url
+++ b/packages/opam-state/opam-state.2.0.0~beta/url
@@ -1,2 +1,2 @@
-src: "https://github.com/ocaml/opam/archive/2.0.0-beta.tar.gz"
-checksum: "f4f1794dbaa36ccc16f57d75ee775fdc"
+src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
+checksum: "e27cfdb0b8c6f4c3133f983e4c50b7dd"


### PR DESCRIPTION
Not sure what the policy is regarding dev versions: is it OK to keep
the package version and update the source as I did ?

I can see 2 other options:

1. do the same, but change the package version
2. add the new version and keep also the first beta

These are intended as short-lived dev packages, so I don't think
multiplying the instances as in 2. is preferred. In any case, these
versions should be removed after release. 1. would be seen as an
upgrade instead of a reinstall due to changes by opam, and reported
with a different version, but would result in beta1 becoming an orphan
package (without upstream). That should be correctly handled though.