### PR TITLE
datakit-server.0.8.0: add upper bound on mirage-types-lwt

### DIFF
--- a/packages/datakit-server/datakit-server.0.8.0/opam
+++ b/packages/datakit-server/datakit-server.0.8.0/opam
@@ -19,5 +19,6 @@ depends: [
   "base-bytes"
   "astring" "logs" "uri" "rresult" "cstruct" "fmt"
   "protocol-9p" {>= "0.7.4"}
-  "sexplib" "mirage-types-lwt"
+  "sexplib"
+  "mirage-types-lwt" {< "3.0.0" }
 ]


### PR DESCRIPTION
See the revdeps failure of [mirage/mirageos-3-beta#23]

Also note the bound is already present on older versions of this package.

Signed-off-by: David Scott <dave@recoil.org>