### PR TITLE
codept.0.9.0 - via opam-publish

### DIFF
--- a/packages/codept/codept.0.9.0/descr
+++ b/packages/codept/codept.0.9.0/descr
@@ -1,0 +1,11 @@
+alternative ocaml dependency analyzer
+
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+   when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis.

--- a/packages/codept/codept.0.9.0/opam
+++ b/packages/codept/codept.0.9.0/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "octachron <octa@polychoron.fr>"
+authors: "octachron <octa@polychoron.fr>"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+license: "gpl-3"
+dev-repo: "https://github.com/Octachron/codept.git"
+build: [make "all"]
+build-test: [make "alt2-tests"]
+build-doc: [make "alt2-docs"]
+depopts: "ocamlbuild"
+available: [ocaml-version = "4.04.0"]

--- a/packages/codept/codept.0.9.0/url
+++ b/packages/codept/codept.0.9.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Octachron/codept/archive/0.9.0.tar.gz"
+checksum: "a71b9fa6b4247eeab7532963fd126a40"


### PR DESCRIPTION
alternative ocaml dependency analyzer

Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:

 * whole project analysis
 * exhaustive warning and error messages
 * uniform handling of delayed alias dependencies
 * (experimental) full dependencies,
   when dependencies up to transitive closure are not enough

Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis.


---
* Homepage: https://github.com/Octachron/codept
* Source repo: https://github.com/Octachron/codept
* Bug tracker: https://github.com/Octachron/codept/issues

---

Pull-request generated by opam-publish v0.3.4