### PR TITLE
nlp.0.0.1 - via opam-publish

### DIFF
--- a/packages/nlp/nlp.0.0.1/descr
+++ b/packages/nlp/nlp.0.0.1/descr
@@ -1,0 +1,6 @@
+Natural Language Processing tools for OCaml
+
+nlp provides functions to make it easy to perform simple natural language processing
+tasks in OCaml
+
+nlp is distributed under the ISC license.

--- a/packages/nlp/nlp.0.0.1/opam
+++ b/packages/nlp/nlp.0.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Dave Tucker <dave@dtucker.co.uk>"
+authors: ["Dave Tucker <dave@dtucker.co.uk>"]
+homepage: "https://github.com/dave-tucker/ocaml-nlp"
+doc: "https://dave-tucker.github.io/ocaml-nlp/doc"
+license: "ISC"
+dev-repo: "https://github.com/dave-tucker/ocaml-nlp.git"
+bug-reports: "https://github.com/dave-tucker/ocaml-nlp/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} 
+  "astring"]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]

--- a/packages/nlp/nlp.0.0.1/url
+++ b/packages/nlp/nlp.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dave-tucker/ocaml-nlp/releases/download/v0.0.1/nlp-0.0.1.tbz"
+checksum: "07e696728d5a4a0a7112bc67280ba424"


### PR DESCRIPTION
Natural Language Processing tools for OCaml

nlp provides functions to make it easy to perform simple natural language processing
tasks in Ocaml

nlp is distributed under the ISC license.


---
* Homepage: https://github.com/dave-tucker/ocaml-nlp
* Source repo: https://github.com/dave-tucker/ocaml-nlp.git
* Bug tracker: https://github.com/dave-tucker/ocaml-nlp/issues

---


---
0.0.1 2017-02-16
----------------

First release. 
