### PR TITLE
ocaml-migrate-parsetree.0.3 - via opam-publish

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.3/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.3/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.3/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+  "Alain Frisch <alain.frisch@lexifi.com>"
+]
+homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
+license: "LGPL-2.1"
+tags: "syntax"
+dev-repo: "git://github.com/let-def/ocaml-migrate-parsetree.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ocaml-migrate-parsetree"]
+depends: [
+  "ocamlfind" {build & >= "1.5.0"}
+  "result"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.3/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.3/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/let-def/ocaml-migrate-parsetree/archive/v0.3.tar.gz"
+checksum: "891b4f3f52f50301f7982ee43629edd6"


### PR DESCRIPTION
Convert OCaml parsetrees between different versions 

This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
High-level functions help making PPX rewriters independent of a compiler version.


---
* Homepage: https://github.com/let-def/ocaml-migrate-parsetree
* Source repo: git://github.com/let-def/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/let-def/ocaml-migrate-parsetree/issues

---

Pull-request generated by opam-publish v0.3.3