### PR TITLE
obandit.0.2 - via opam-publish

### DIFF
--- a/packages/obandit/obandit.0.2/descr
+++ b/packages/obandit/obandit.0.2/descr
@@ -1,0 +1,6 @@
+Ocaml Multi-Armed Bandits
+
+Obandit is an OCaml module for basic multi-armed bandits. It supports the
+EXP3, UCB1 and Epsilon-greedy algorithms.
+
+Obandit is distributed under the ISC license.

--- a/packages/obandit/obandit.0.2/opam
+++ b/packages/obandit/obandit.0.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Valentin Reis <fre@freux.fr>"
+authors: ["Valentin Reis <fre@freux.fr>"]
+homepage: "http://freux.fr/obandit"
+doc: "http://freux.fr/obandit/doc"
+license: "ISC"
+dev-repo: "http://git.freux.fr/cgit/obandit.git"
+bug-reports: "ocaml@freux.fr"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "batteries" ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%" ]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]]

--- a/packages/obandit/obandit.0.2/url
+++ b/packages/obandit/obandit.0.2/url
@@ -1,0 +1,2 @@
+archive: "http://freux.fr/obandit/releases/obandit-0.2.tbz"
+checksum: "ab6d991193a637c188cc421effcd1889"


### PR DESCRIPTION
Ocaml Multi-Armed Bandits

Obandit is an OCaml module for basic multi-armed bandits. It supports the
EXP3, UCB1 and Epsilon-greedy algorithms.

Obandit is distributed under the ISC license.


---
* Homepage: http://freux.fr/obandit
* Source repo: http://git.freux.fr/cgit/obandit.git
* Bug tracker: ocaml@freux.fr

---


---
v0.2 2017-02-17 Grenoble
--------------------------

* Interface changes. Introducing immutable versions of the algorithms.
* Documentation overhaul with mathematical aspects.
* Use the formalism from S.Bubeck and N.Cesa-Bianchi's survey
  "Regret analysis of Stochastic and Nonstochastic Multi-Armed
  Bandit Problems".
Pull-request generated by opam-publish v0.3.3