### PR TITLE
sequence.0.10 - via opam-publish

### DIFF
--- a/packages/sequence/sequence.0.10/descr
+++ b/packages/sequence/sequence.0.10/descr
@@ -1,0 +1,6 @@
+Simple and lightweight sequence abstract data type.
+
+Simple sequence abstract data type, intended to transfer a finite number of
+elements from one data structure to another. Some transformations on sequences,
+like `filter`, `map`, `take`, `drop` and `append` can be performed before the
+sequence is iterated/folded on.

--- a/packages/sequence/sequence.0.10/opam
+++ b/packages/sequence/sequence.0.10/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/sequence/"
+bug-reports: "https://github.com/c-cube/sequence/issues"
+license: "BSD-2-clauses"
+doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
+tags: ["sequence" "iterator" "iter" "fold"]
+dev-repo: "https://github.com/c-cube/sequence.git"
+build: [
+  [
+    "./configure"
+    "--disable-docs"
+    "--%{delimcc:enable}%-invert"
+    "--%{base-bigarray:enable}%-bigarray"
+  ]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+build-doc: [
+  ["./configure" "--enable-docs"]
+  [make "doc"]
+]
+remove: ["ocamlfind" "remove" "sequence"]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
+depopts: ["delimcc" "base-bigarray"]

--- a/packages/sequence/sequence.0.10/url
+++ b/packages/sequence/sequence.0.10/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/sequence/archive/0.10.tar.gz"
+checksum: "da3ce107161a663d00ae674c2e51a120"


### PR DESCRIPTION
Simple and lightweight sequence abstract data type.

Simple sequence abstract data type, intended to transfer a finite number of
elements from one data structure to another. Some transformations on sequences,
like `filter`, `map`, `take`, `drop` and `append` can be performed before the
sequence is iterated/folded on.


---
* Homepage: https://github.com/c-cube/sequence/
* Source repo: https://github.com/c-cube/sequence.git
* Bug tracker: https://github.com/c-cube/sequence/issues

---

Pull-request generated by opam-publish v0.3.4