### PR TITLE
mqtt.0.0.2 needs ocplib-endian >= 0.6 for EndianBytes.

### DIFF
--- a/packages/mqtt/mqtt.0.0.2/opam
+++ b/packages/mqtt/mqtt.0.0.2/opam
@@ -12,7 +12,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "ocplib-endian"
+  "ocplib-endian" { >= "0.6"}
   "ounit"
   "lwt" {>= "2.7.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
See #8503