### PR TITLE
scrypt-kdf.0.3.0 - via opam-publish

### DIFF
--- a/packages/scrypt-kdf/scrypt-kdf.0.3.0/descr
+++ b/packages/scrypt-kdf/scrypt-kdf.0.3.0/descr
@@ -1,0 +1,3 @@
+The scrypt Password-Based Key Derivation Function in pure OCaml
+
+A pure OCaml implementation of scrypt password based key derivation function, as defined in The scrypt Password-Based Key Derivation Function internet draft, including test cases from the RFC. It also includes a pure OCaml implementation of Salsa20 Core functions, both Salsa20/20 Core and the reduced Salsa20/8 Core (required by scrypt) and Salsa20/12 Core functions, including test cases from the spec.

--- a/packages/scrypt-kdf/scrypt-kdf.0.3.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+authors: [
+  "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+  "Sonia Meruelo <smeruelo@gmail.com>"
+]
+homepage: "https://github.com/abeaumont/ocaml-scrypt-kdf"
+bug-reports: "https://github.com/abeaumont/ocaml-scrypt-kdf/issues"
+license: "BSD2"
+dev-repo: "https://github.com/abeaumont/ocaml-scrypt-kdf.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.3"}
+  "pbkdf" {>= "0.1.0"}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/scrypt-kdf/scrypt-kdf.0.3.0/url
+++ b/packages/scrypt-kdf/scrypt-kdf.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/abeaumont/ocaml-scrypt-kdf/archive/0.3.0.tar.gz"
+checksum: "32a8f0e7755af3c1d8438f26d3ca77b2"


### PR DESCRIPTION
The scrypt Password-Based Key Derivation Function in pure OCaml

A pure OCaml implementation of scrypt password based key derivation function, as defined in The scrypt Password-Based Key Derivation Function internet draft, including test cases from the RFC. It also includes a pure OCaml implementation of Salsa20 Core functions, both Salsa20/20 Core and the reduced Salsa20/8 Core (required by scrypt) and Salsa20/12 Core functions, including test cases from the spec.


---
* Homepage: https://github.com/abeaumont/ocaml-scrypt-kdf
* Source repo: https://github.com/abeaumont/ocaml-scrypt-kdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-scrypt-kdf/issues

---

Pull-request generated by opam-publish v0.3.4