### PR TITLE
wamp.1.1 - via opam-publish

### DIFF
--- a/packages/wamp/wamp.1.1/descr
+++ b/packages/wamp/wamp.1.1/descr
@@ -1,0 +1,8 @@
+Web Application Messaging Protocol (WAMP) library
+
+WAMP is a routed protocol that provides two messaging patterns:
+Publish & Subscribe and routed Remote Procedure Calls.  It is intended
+to connect application components in distributed applications.  WAMP
+uses WebSocket as its default transport, but can be transmitted via
+any other protocol that allows for ordered, reliable, bi-directional,
+and message-oriented communications.

--- a/packages/wamp/wamp.1.1/opam
+++ b/packages/wamp/wamp.1.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-wamp"
+bug-reports: "https://github.com/vbmithr/ocaml-wamp/issues"
+license: "ISC"
+dev-repo: "https://github.com/vbmithr/ocaml-wamp.git"
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--pinned"
+  "%{pinned}%"
+  "--with-yojson"
+  "%{yojson:installed}%"
+  "--with-msgpck"
+  "%{msgpck:installed}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+  "uri"
+]
+depopts: ["yojson" "msgpck"]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/wamp/wamp.1.1/url
+++ b/packages/wamp/wamp.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vbmithr/ocaml-wamp/archive/1.1.tar.gz"
+checksum: "8bde63fa1d63370da36248501eb3b285"


### PR DESCRIPTION
Web Application Messaging Protocol (WAMP) library

WAMP is a routed protocol that provides two messaging patterns:
Publish & Subscribe and routed Remote Procedure Calls.  It is intended
to connect application components in distributed applications.  WAMP
uses WebSocket as its default transport, but can be transmitted via
any other protocol that allows for ordered, reliable, bi-directional,
and message-oriented communications.


---
* Homepage: https://github.com/vbmithr/ocaml-wamp
* Source repo: https://github.com/vbmithr/ocaml-wamp.git
* Bug tracker: https://github.com/vbmithr/ocaml-wamp/issues

---

Pull-request generated by opam-publish v0.3.4