### PR TITLE
scid.1.0 - via opam-publish

### DIFF
--- a/packages/scid/scid.1.0/descr
+++ b/packages/scid/scid.1.0/descr
@@ -1,0 +1,5 @@
+Sierra Chart's Intraday Data File Format library
+
+The scid file format is used by Sierra Chart to store intra-day market
+data.
+Specification: http://www.sierrachart.com/index.php?page=doc/IntradayDataFileFormat.html

--- a/packages/scid/scid.1.0/opam
+++ b/packages/scid/scid.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/scid"
+bug-reports: "https://github.com/vbmithr/scid/issues"
+license: "ISC"
+doc: "https://vbmithr.github.io/scid/doc"
+dev-repo: "https://github.com/vbmithr/scid.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ounit" {test}
+  "result"
+  "ocplib-endian" {>= "1.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/scid/scid.1.0/url
+++ b/packages/scid/scid.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vbmithr/ocaml-scid/archive/1.0.tar.gz"
+checksum: "6fb1bd0e286c36d92bb0cf5c6e7c0c35"


### PR DESCRIPTION
Sierra Chart's Intraday Data File Format library

The scid file format is used by Sierra Chart to store intra-day market
data.
Specification: http://www.sierrachart.com/index.php?page=doc/IntradayDataFileFormat.html

---
* Homepage: https://github.com/vbmithr/scid
* Source repo: https://github.com/vbmithr/scid.git
* Bug tracker: https://github.com/vbmithr/scid/issues

---

Pull-request generated by opam-publish v0.3.4