### PR TITLE
websocket.2.7 - via opam-publish

### DIFF
--- a/packages/websocket/websocket.2.7/descr
+++ b/packages/websocket/websocket.2.7/descr
@@ -1,0 +1,13 @@
+Websocket library
+
+The WebSocket Protocol enables two-way communication between a client
+running untrusted code in a controlled environment to a remote host
+that has opted-in to communications from that code.  The security
+model used for this is the origin-based security model commonly used
+by web browsers.  The protocol consists of an opening handshake
+followed by basic message framing, layered over TCP.  The goal of this
+technology is to provide a mechanism for browser-based applications
+that need two-way communication with servers that does not rely on
+opening multiple HTTP connections (e.g., using XMLHttpRequest or
+<iframe>s and long polling).
+

--- a/packages/websocket/websocket.2.7/opam
+++ b/packages/websocket/websocket.2.7/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-websocket"
+bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "git://github.com/vbmithr/ocaml-websocket"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+  "lwt=%{lwt:installed}%"
+  "async=%{async:installed}%"
+  "async_ssl=%{async_ssl:installed}%"
+  "nocrypto=%{nocrypto:installed}%"
+  "cryptokit=%{cryptokit:installed}%"
+  "test=false"
+]
+depends: [
+  "cppo" {build}
+  "cohttp" {>= "0.17.1"}
+  "ocplib-endian" {>= "0.8"}
+  "ppx_deriving" {>= "2.0"}
+  "astring"
+]
+depopts: ["async" "async_ssl" "lwt" "nocrypto" "cryptokit"]
+conflicts: [
+  "lwt" {< "2.4.8"}
+  "async" {< "112.35.00"}
+  "nocrypto" {< "0.5.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/websocket/websocket.2.7/url
+++ b/packages/websocket/websocket.2.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vbmithr/ocaml-websocket/archive/2.7.tar.gz"
+checksum: "71942b2d312079630e75fdb5df2b1484"


### PR DESCRIPTION
Websocket library

The WebSocket Protocol enables two-way communication between a client
running untrusted code in a controlled environment to a remote host
that has opted-in to communications from that code.  The security
model used for this is the origin-based security model commonly used
by web browsers.  The protocol consists of an opening handshake
followed by basic message framing, layered over TCP.  The goal of this
technology is to provide a mechanism for browser-based applications
that need two-way communication with servers that does not rely on
opening multiple HTTP connections (e.g., using XMLHttpRequest or
<iframe>s and long polling).



---
* Homepage: https://github.com/vbmithr/ocaml-websocket
* Source repo: git://github.com/vbmithr/ocaml-websocket
* Bug tracker: https://github.com/vbmithr/ocaml-websocket/issues

---

Pull-request generated by opam-publish v0.3.4