### PR TITLE
oml.0.0.7 - via opam-publish

### DIFF
--- a/packages/oml/oml.0.0.7/descr
+++ b/packages/oml/oml.0.0.7/descr
@@ -1,0 +1,10 @@
+Math Library
+
+
+[![Build Status](https://travis-ci.org/hammerlab/oml.svg?branch=master)](https://travis-ci.org/hammerlab/oml/)
+[![Coverage Status](https://coveralls.io/repos/hammerlab/oml/badge.svg?branch=HEAD&service=github)](https://coveralls.io/github/hammerlab/oml?branch=HEAD)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hammerlab/oml?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
+
+A collection of OCaml Math and Statistics functions.
+The API is available [online](http://hammerlab.github.io/oml/index.html).

--- a/packages/oml/oml.0.0.7/opam
+++ b/packages/oml/oml.0.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+name: "oml"
+version: "0.0.7"
+available: [ ocaml-version >= "4.03" ]
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/hammerlab/oml/"
+dev-repo: "https://github.com/hammerlab/oml.git"
+bug-reports: "https://github.com/hammerlab/oml/issues"
+license: "Apache2"
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "kaputt" {test}
+  "dsfo" {test}
+]
+depopts: [
+  "lacaml"
+  "lbfgs"
+  "ocephes"
+]
+
+build: [[
+   "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+           "--with-lacaml" lacaml:installed
+           "--with-lbfgs" lbfgs:installed
+           "--with-ocephes" ocephes:installed
+]]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build"
+      "--pinned" "%{pinned}%"
+      "--build-dir" "_test"
+      "-n" "omltest"
+      "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test"
+      "--build-dir" "_test"
+  ]
+]

--- a/packages/oml/oml.0.0.7/url
+++ b/packages/oml/oml.0.0.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hammerlab/oml/releases/download/0.0.7/oml-0.0.7.tbz"
+checksum: "ce2b5241f66da5d25781dab2e07e6990"


### PR DESCRIPTION
Math Library


[![Build Status](https://travis-ci.org/hammerlab/oml.svg?branch=master)](https://travis-ci.org/hammerlab/oml/)
[![Coverage Status](https://coveralls.io/repos/hammerlab/oml/badge.svg?branch=HEAD&service=github)](https://coveralls.io/github/hammerlab/oml?branch=HEAD)
[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hammerlab/oml?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


A collection of OCaml Math and Statistics functions.
The API is available [online](http://hammerlab.github.io/oml/index.html).

---
* Homepage: https://github.com/hammerlab/oml/
* Source repo: https://github.com/hammerlab/oml.git
* Bug tracker: https://github.com/hammerlab/oml/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
Version 0.0.7 (2017-02-21):
--------------------------
  - Reworked separation of library in Oml (OCaml only) and Oml_full
    (includes C/Fortran source links), such that the former is a
    functional (types and modules work together) subset of the latter.
  - Split up the various interfaces and changed some type names
    used to describe classification and regression.
  - Implemented discrete KL divergence.
Pull-request generated by opam-publish v0.3.3