### PR TITLE
dockerfile.2.2.1 - via opam-publish

### DIFF
--- a/packages/dockerfile/dockerfile.2.2.1/descr
+++ b/packages/dockerfile/dockerfile.2.2.1/descr
@@ -1,0 +1,18 @@
+Typed interface for constructing Docker container descriptions
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+- **HTML Documentation**: https://avsm.github.io/ocaml-dockerfile
+- **Source:**: https://github.com/avsm/ocaml-dockerfile
+- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
+- **Email**: <mirageos-devel@lists.xenproject.org>
+

--- a/packages/dockerfile/dockerfile.2.2.1/opam
+++ b/packages/dockerfile/dockerfile.2.2.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+license: "ISC"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+tags: ["org:mirage" "org:ocamllabs"]
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_sexp_conv" {build}
+  "topkg" {build}
+  "cmdliner"
+  "sexplib"
+  "base-bytes"
+  "fmt"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/dockerfile/dockerfile.2.2.1/url
+++ b/packages/dockerfile/dockerfile.2.2.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/avsm/ocaml-dockerfile/releases/download/v2.2.1/dockerfile-2.2.1.tbz"
+checksum: "1c476efd74bd1eb6d2c28edd7a7cd815"


### PR DESCRIPTION
Typed interface for constructing Docker container descriptions

[Docker](http://docker.com) is a container manager that can build images
automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
a text document that contains all the commands you would normally execute
manually in order to build a Docker image. By calling `docker build` from your
terminal, you can have Docker build your image step-by-step, executing the
instructions successively.  Read more at <http://docker.com>

This library provides a typed OCaml interface to generating Dockerfiles
programmatically without having to resort to lots of shell scripting and
awk/sed-style assembly.

- **HTML Documentation**: https://avsm.github.io/ocaml-dockerfile
- **Source:**: https://github.com/avsm/ocaml-dockerfile
- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
- **Email**: <mirageos-devel@lists.xenproject.org>



---
* Homepage: https://github.com/avsm/ocaml-dockerfile
* Source repo: https://github.com/avsm/ocaml-dockerfile.git
* Bug tracker: https://github.com/avsm/ocaml-dockerfile/issues

---

Pull-request generated by opam-publish v0.3.3