### PR TITLE
maki.0.2 - via opam-publish

### DIFF
--- a/packages/maki/maki.0.2/descr
+++ b/packages/maki/maki.0.2/descr
@@ -1,0 +1,4 @@
+Persistent incremental computations, for repeatable tests and benchmarks.
+
+See http://cedeela.fr/maki-on-disk-memoization-for-deterministic-fun-and-profit.html for
+more information.

--- a/packages/maki/maki.0.2/opam
+++ b/packages/maki/maki.0.2/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/maki/"
+bug-reports: "https://github.com/c-cube/maki/issues/"
+doc: "http://cedeela.fr/~simon/software/maki/"
+tags: ["incremental" "persistent" "memoization"]
+dev-repo: "https://github.com/c-cube/maki.git"
+build: [
+  ["./configure" "--prefix" prefix "--%{yojson:enable}%-yojson"]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: [
+  ["ocamlfind" "remove" "maki"]
+  ["rm" "%{bin}%/maki_gc"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "result"
+  "lwt"
+  "base-unix"
+  "bencode"
+  "sha"
+  "base-threads"
+]
+depopts: "yojson"
+available: [ocaml-version >= "4.02.0"]

--- a/packages/maki/maki.0.2/url
+++ b/packages/maki/maki.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/maki/archive/0.2.tar.gz"
+checksum: "22a852f703ef37d27c63a519f430cea6"


### PR DESCRIPTION
Persistent incremental computations, for repeatable tests and benchmarks.

See http://cedeela.fr/maki-on-disk-memoization-for-deterministic-fun-and-profit.html for
more information.


---
* Homepage: https://github.com/c-cube/maki/
* Source repo: https://github.com/c-cube/maki.git
* Bug tracker: https://github.com/c-cube/maki/issues/

---

Pull-request generated by opam-publish v0.3.4