### PR TITLE
ISO8601.0.2.5: restore the ocamlbuild dependency

### DIFF
--- a/packages/ISO8601/ISO8601.0.2.5/opam
+++ b/packages/ISO8601/ISO8601.0.2.5/opam
@@ -26,4 +26,7 @@ install: [ make "install" ]
 
 remove: [ "ocamlfind" "remove" "ISO8601" ]
 
-depends: [ "ocamlfind" {build} ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]


### PR DESCRIPTION
Previous opam files have been fixed by Fabrice in 85d52918c999c38b47a6e5a2129b71ece91e3f3a, but the upstream opam was not changed, so 0.2.5 was proposed again with broken dependencies. I sent a PR upstream ( sagotch/ISO8601.ml#8 ) to make sure it does not happen again.