### PR TITLE
dead_code_analyzer.0.9 does not support OCaml 4.05

### DIFF
--- a/packages/dead_code_analyzer/dead_code_analyzer.0.9/opam
+++ b/packages/dead_code_analyzer/dead_code_analyzer.0.9/opam
@@ -11,4 +11,4 @@ bug-reports: "https://github.com/LexiFi/dead_code_analyzer/issues"
 license: "MIT"
 dev-repo: "https://github.com/LexiFi/dead_code_analyzer.git"
 build: [make "all" "opt" "man"]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.05" ]


### PR DESCRIPTION
Issue found through opam-builder:
  http://opam.ocamlpro.com/builder/html/dead_code_analyzer/dead_code_analyzer.0.9/0627c887ab907709033399c231aa2005

I sent a PR upstream to fix the incompatibilities:
  https://github.com/LexiFi/dead_code_analyzer/pull/5