### PR TITLE
flow_parser: add missing ocamlbuild dependencies

### DIFF
--- a/packages/flow_parser/flow_parser.0.32.0/opam
+++ b/packages/flow_parser/flow_parser.0.32.0/opam
@@ -29,6 +29,9 @@ install: [
   ["sh" "-c" "cd src/parser/ && ocamlfind install flow_parser META _build/parser_flow.a _build/parser_flow.cma _build/parser_flow.cmxa _build/*.cmi"]
 ]
 remove: ["ocamlfind" "remove" "flow_parser"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 dev-repo: "https://github.com/facebook/flow.git"

--- a/packages/flow_parser/flow_parser.0.35.0/opam
+++ b/packages/flow_parser/flow_parser.0.35.0/opam
@@ -27,6 +27,9 @@ install: [
   ["sh" "-c" "cd src/parser/ && ocamlfind install flow_parser META _build/parser_flow.a _build/parser_flow.cma _build/parser_flow.cmxa _build/*.cmi"]
 ]
 remove: ["ocamlfind" "remove" "flow_parser"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 dev-repo: "https://github.com/facebook/flow.git"

--- a/packages/flow_parser/flow_parser.0.36.0/opam
+++ b/packages/flow_parser/flow_parser.0.36.0/opam
@@ -16,6 +16,9 @@ license: "BSD3"
 build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
 
 remove: ["ocamlfind" "remove" "flow_parser"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 dev-repo: "https://github.com/facebook/flow.git"

--- a/packages/flow_parser/flow_parser.0.38.0/opam
+++ b/packages/flow_parser/flow_parser.0.38.0/opam
@@ -16,6 +16,9 @@ license: "BSD3"
 build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
 
 remove: ["ocamlfind" "remove" "flow_parser"]
-depends: "ocamlfind" {build}
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 available: [ocaml-version >= "4.01.0"]
 dev-repo: "https://github.com/facebook/flow.git"


### PR DESCRIPTION
opam-builder report:
  http://opam.ocamlpro.com/builder/html/flow_parser/flow_parser.0.38.0/2655e6ced4934d8c2ab108e299ef9687

There will be `opam lint` warnings, but they do not come from this change.