### PR TITLE
frama-c-base: add (ocaml < 4.04) bound on older versions

### DIFF
--- a/packages/frama-c-base/frama-c-base.20150201/opam
+++ b/packages/frama-c-base/frama-c-base.20150201/opam
@@ -23,6 +23,7 @@ authors: [
 ]
 homepage: "http://frama-c.com/"
 license: "GNU Lesser General Public License version 2.1"
+dev-repo: "https://github.com/Frama-C/Frama-C-snapshot.git"
 doc: ["http://frama-c.com/download/user-manual-Sodium-20150201.pdf"]
 bug-reports: "https://bts.frama-c.com/"
 tags: [
@@ -87,4 +88,8 @@ conflicts: [
   "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1
 ]
 
-available: [ ocaml-version >= "3.12" & ocaml-version != "4.02.0" ]
+available: [
+  ocaml-version >= "4.0"
+  & ocaml-version != "4.02.0"
+  & ocaml-version < "4.04.0"
+]

--- a/packages/frama-c-base/frama-c-base.20151002/opam
+++ b/packages/frama-c-base/frama-c-base.20151002/opam
@@ -29,6 +29,7 @@ authors: [
 ]
 homepage: "http://frama-c.com/"
 license: "GNU Lesser General Public License version 2.1"
+dev-repo: "https://github.com/Frama-C/Frama-C-snapshot.git"
 doc: ["http://frama-c.com/download/user-manual-Magnesium-20151002.pdf"]
 bug-reports: "https://bts.frama-c.com/"
 tags: [
@@ -101,4 +102,9 @@ conflicts: [
   "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1
 ]
 
-available: [ ocaml-version >= "4.00.1" & ocaml-version != "4.02.0" & ocaml-version != "4.02.2" ]
+available: [
+  ocaml-version >= "4.0"
+  & ocaml-version != "4.02.0"
+  & ocaml-version != "4.02.2"
+  & ocaml-version < "4.04.0"
+]


### PR DESCRIPTION
This reproduces the change in d8e6c704d400698515dd9a803d80fac21615dcc4,
but also applies it to older Frama-C versions.

opam-lint will complain, but this is not related to this change.