### PR TITLE
include 4.05 compatibility patch for fury-puyo

### DIFF
--- a/packages/fury-puyo/fury-puyo.0.5/files/4.05-compatibility.patch
+++ b/packages/fury-puyo/fury-puyo.0.5/files/4.05-compatibility.patch
@@ -1,0 +1,29 @@
+From 5e30975c8bb5bb6ed279287c4b2ca2d00a220d3c Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Sat, 25 Feb 2017 17:10:12 -0500
+Subject: [PATCH] Fix a non-generalized variable issue for 4.05 compatibility
+
+See https://github.com/ocaml/ocaml/pull/929
+
+opam-builder report:
+  http://opam.ocamlpro.com/builder/html/fury-puyo/fury-puyo.0.5/c867894506caedd7d7e8a3406dfc7df5
+---
+ IO.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/IO.ml b/IO.ml
+index 8f16926..8c1607d 100644
+--- a/IO.ml
++++ b/IO.ml
+@@ -317,7 +317,7 @@ module MakeReader(A: ACTION) = struct
+   let auto = ref KeyMap.empty
+   let pressed_keys = ref KeyMap.empty
+ 
+-  let action mapref key acc =
++  let action mapref key acc : A.t list =
+     try KeyMap.find key !mapref :: acc
+     with Not_found -> acc
+ 
+-- 
+2.9.3
+

--- a/packages/fury-puyo/fury-puyo.0.5/opam
+++ b/packages/fury-puyo/fury-puyo.0.5/opam
@@ -1,4 +1,6 @@
 opam-version: "1.2"
+authors: "Romain Bardou <romain@bardou.fr>"
+homepage: "http://furypuyo.forge.ocamlcore.org/"
 maintainer: "pierre.chambart@ocamlpro.com"
 substs: ["data_dir.patch"]
 build: [[make]]
@@ -10,4 +12,7 @@ depends: [
   "conf-sdl-mixer"
   "ocamlbuild" {build}
 ]
-patches: ["data_dir.patch"]
+patches: [
+  "data_dir.patch"
+  "4.05-compatibility.patch"
+]


### PR DESCRIPTION
The package does not appear to be actively maintained, but it remains
valuable as an example of SDL game. I have not sent the patch upstream
yet, but I do plan to send an email to the author about it -- and
considering moving off the deprecated OCaml Forge.