### PR TITLE
fix missing async_core dependency on old gen_server versions

### DIFF
--- a/packages/gen_server/gen_server.1.0.1/opam
+++ b/packages/gen_server/gen_server.1.0.1/opam
@@ -6,6 +6,7 @@ depends: [
   "ocamlfind"
   "core" {>= "109.12.00"}
   "async"
+  "async_core"
 ]
 dev-repo: "git://github.com/orbitz/gen_server"
 install: [make "install"]

--- a/packages/gen_server/gen_server.2.0.1/opam
+++ b/packages/gen_server/gen_server.2.0.1/opam
@@ -6,6 +6,7 @@ depends: [
   "ocamlfind"
   "core" {>= "109.12.00"}
   "async"
+  "async_core"
 ]
 dev-repo: "git://github.com/orbitz/gen_server"
 install: [make "install"]


### PR DESCRIPTION
@orbitz removed async_core as a dependency from the package's build
system, but only in the recent commit

  https://github.com/orbitz/gen_server/commit/4f53c2a0f068775b10cc7b3016312bc419128b37

that is part of the 2.0.2 release, but not earlier version. Those need
an async_core dependency or fail at build time.

opam-builder report:
  http://opam.ocamlpro.com/builder/html/gen_server/gen_server.2.0.1/5ea2a837063a8e845be8ae8ef2ba3e84

Independently, gen_server seems to have had a few releases since 2.0.2
(2.1.0, 2.1.1), but they are not package in opam. Is this intentional?