### PR TITLE
hardcaml-bloop is incompatible with uutf 1.0.0

### DIFF
--- a/packages/hardcaml-bloop/hardcaml-bloop.0.1.0/opam
+++ b/packages/hardcaml-bloop/hardcaml-bloop.0.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "sattools"
   "bdd"
   "uchar"
-  "uutf"
+  "uutf" {>= "1.0.0"}
   "gg"
   "vg"
 ]


### PR DESCRIPTION
opam-builder report:
  http://opam.ocamlpro.com/builder/html/hardcaml-bloop/hardcaml-bloop.0.1.0/dca756685ef5ab57177792dd943dfa96

> + ocamlfind ocamlc -c -g -package sattools -package
>  hardcaml -package bdd -package uutf -package gg -package
>  vg -for-pack HardCamlBloop -I src -I test -o src/kmap.cmo
>  src/kmap.ml
>
> File "src/kmap.ml", line 22, characters 80-84:
> Error: This expression has type Uutf.uchar list -> string
>        but an expression was expected of type Uchar.t list -> 'a
>        Type Uutf.uchar = int is not compatible with type Uchar.t

The changelog for uutf mentions that the transition from Uutf.uchar to
Uchar.to happened at 1.0.0:
  https://github.com/dbuenzli/uutf/blob/master/CHANGES.md