### PR TITLE
inotify: missing ocamlbuild dependency

### DIFF
--- a/packages/inotify/inotify.2.2/opam
+++ b/packages/inotify/inotify.2.2/opam
@@ -27,6 +27,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "fileutils" {test}
+  "ocamlbuild" {build}
 ]
 depopts: ["lwt"]
 available: [os = "linux"]

--- a/packages/inotify/inotify.2.3/opam
+++ b/packages/inotify/inotify.2.3/opam
@@ -21,6 +21,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "fileutils" {test}
+  "ocamlbuild" {build}
 ]
 depopts: ["lwt"]
 available: [os = "linux"]


### PR DESCRIPTION
ocamlbuild dependencies were correctly added upto 2.1 by
ed759213ac2ac84ebedbb1efdb2a62d84c13104f. Recent releases have
forgotten the dependency. Contacting upstream.

opam-builder report:
  http://opam.ocamlpro.com/builder/html/inotify/inotify.2.3/19bc6afde04dac3a6db996a121a94c03