### PR TITLE
mirage 2.9.x needs a functoria-runtime dependency

### DIFF
--- a/packages/mirage/mirage.2.9.0/opam
+++ b/packages/mirage/mirage.2.9.0/opam
@@ -23,6 +23,7 @@ depends: [
   "functoria" {>= "1.1.0"}
   "astring"
   "logs"
+  "functoria-runtime" {>= "2.0.0"}
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}

--- a/packages/mirage/mirage.2.9.1/opam
+++ b/packages/mirage/mirage.2.9.1/opam
@@ -23,6 +23,7 @@ depends: [
   "functoria" {>= "1.1.0"}
   "astring"
   "logs"
+  "functoria-runtime" {>= "2.0.0"}
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}


### PR DESCRIPTION
Starting at 3.x, mirage is split in mirage (which depends
on functoria) and mirage-runtime (which depends on functoria-runtime),
and mirage depends on mirage-runtime (and thus transitively on
functoria-runtime). But mirage-runtime does not exist in 2.9.x, so
mirage needs to depend on functoria-runtime directly.

opam-builder report:
  http://opam.ocamlpro.com/builder/html/mirage/mirage.2.9.1/c6dc21594da9cde7afac543707ccafcb

> ocamlfind: Package `functoria.runtime' not found