### PR TITLE
mpp: add missing ocamlbuild dependencies

### DIFF
--- a/packages/mpp/mpp.0.1.7/opam
+++ b/packages/mpp/mpp.0.1.7/opam
@@ -20,4 +20,5 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]

--- a/packages/mpp/mpp.0.1.8/opam
+++ b/packages/mpp/mpp.0.1.8/opam
@@ -20,4 +20,5 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]

--- a/packages/mpp/mpp.0.2.0/opam
+++ b/packages/mpp/mpp.0.2.0/opam
@@ -20,5 +20,6 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/mpp/mpp.0.2.1/opam
+++ b/packages/mpp/mpp.0.2.1/opam
@@ -20,4 +20,5 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]

--- a/packages/mpp/mpp.0.3.0/opam
+++ b/packages/mpp/mpp.0.3.0/opam
@@ -20,4 +20,5 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]


### PR DESCRIPTION
mpp versions 0.1.5 and below were correct thanks to
ed759213ac2ac84ebedbb1efdb2a62d84c13104f, but recent versions were
broken. Contacting upstream.

opam-builder report:
  http://opam.ocamlpro.com/builder/html/mpp/mpp.0.3.0/ad16906675fc9f5dbee3f2203f64b634