### PR TITLE
posix-getopt: add missing ocamlbuild dependency

### DIFF
--- a/packages/posix-getopt/posix-getopt.0.1.0/opam
+++ b/packages/posix-getopt/posix-getopt.0.1.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ctypes" {>= "0.4"}
   "ctypes-foreign"
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ounit" {test}
   "extunix" {test}
 ]


### PR DESCRIPTION
opam-builder report:
  http://opam.ocamlpro.com/builder/html/posix-getopt/posix-getopt.0.1.0/f7e06f88d6c41ab9c59a75f1351a6ddb