### PR TITLE
sequence: missing ocamlbuild dependency for old versions

### DIFF
--- a/packages/sequence/sequence.0.1/opam
+++ b/packages/sequence/sequence.0.1/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.2/opam
+++ b/packages/sequence/sequence.0.2/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.1/opam
+++ b/packages/sequence/sequence.0.3.1/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.2/opam
+++ b/packages/sequence/sequence.0.3.2/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.3/opam
+++ b/packages/sequence/sequence.0.3.3/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.4/opam
+++ b/packages/sequence/sequence.0.3.4/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.5/opam
+++ b/packages/sequence/sequence.0.3.5/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.6.1/opam
+++ b/packages/sequence/sequence.0.3.6.1/opam
@@ -10,6 +10,9 @@ tags: [
 ]
 build: [make "all" "doc"]
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.6/opam
+++ b/packages/sequence/sequence.0.3.6/opam
@@ -10,6 +10,9 @@ tags: [
 ]
 build: [make "all" "doc"]
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]

--- a/packages/sequence/sequence.0.3.7/opam
+++ b/packages/sequence/sequence.0.3.7/opam
@@ -4,7 +4,10 @@ build: [make "all" "doc"]
 remove: [
     ["ocamlfind" "remove" "sequence"]
 ]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 tags: [ "sequence" "iterator" "iter" "fold" ]
 homepage: "https://github.com/c-cube/sequence/"
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"

--- a/packages/sequence/sequence.0.3/opam
+++ b/packages/sequence/sequence.0.3/opam
@@ -3,6 +3,9 @@ maintainer: "simon.cruanes@inria.fr"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
-depends: ["ocamlfind"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]


### PR DESCRIPTION
Newer versions of the libraries are just fine.

opam-builder report:
  http://opam.ocamlpro.com/builder/html/sequence/sequence.0.3.7/e6446383da39af3afd5291fbaeb45003