### PR TITLE
constrain mirage 2.9.x to functoria < 2

### DIFF
--- a/packages/mirage/mirage.2.9.0/opam
+++ b/packages/mirage/mirage.2.9.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-types-lwt" {< "3.0.0"}
   "mirage-types" {>= "2.8.0" & < "3.0.0"}
   "ipaddr" {>= "2.6.0"}
-  "functoria" {>= "1.1.0"}
+  "functoria" {>= "1.1.0" & < "2.0.0"}
   "astring"
   "logs"
 ]

--- a/packages/mirage/mirage.2.9.1/opam
+++ b/packages/mirage/mirage.2.9.1/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-types-lwt" {< "3.0.0"}
   "mirage-types" {>= "2.8.0" & < "3.0.0"}
   "ipaddr" {>= "2.6.0"}
-  "functoria" {>= "1.1.0"}
+  "functoria" {>= "1.1.0" & < "2.0.0"}
   "astring"
   "logs"
 ]


### PR DESCRIPTION
Earlier versions which require `functoria` require a version `= 1.0.0`.