### PR TITLE
Bap fixes

### DIFF
--- a/packages/bap-std/bap-std.1.0.0/opam
+++ b/packages/bap-std/bap-std.1.0.0/opam
@@ -30,23 +30,22 @@ remove: [
 ]
 
 depends: [
-    "base-unix"
-    "bap-future"
-    "camlzip"
-    "core_kernel"       {>= "113.33.00"}
-    "fileutils"
-    "graphlib"
-    "oasis"             {build & = "0.4.7" }
-    "ocamlfind"         {>= "1.5.6" & < "2.0"}
-    "ppx_jane"          {>= "113.33.00" & < "113.34.00"}
-    "regular"
-    "uri"
-    "utop"
-    "uuidm"
-    "zarith"
+  "base-unix"
+  "bap-future"
+  "camlzip"
+  "core_kernel" {>= "113.33.00"}
+  "fileutils"
+  "graphlib"
+  "oasis" {build & = "0.4.7"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ppx_jane" {>= "113.33.00" & < "113.34.00"}
+  "regular"
+  "uri"
+  "utop"
+  "uuidm"
+  "zarith"
+  "cmdliner"
 ]
-
-
 depexts: [
     [["ubuntu"] [
         "libgmp-dev"

--- a/packages/bap-std/bap-std.1.1.0/opam
+++ b/packages/bap-std/bap-std.1.1.0/opam
@@ -30,23 +30,22 @@ remove: [
 ]
 
 depends: [
-    "base-unix"
-    "bap-future"
-    "camlzip"
-    "core_kernel"       {>= "113.33.00"}
-    "fileutils"
-    "graphlib"
-    "oasis"             {build & = "0.4.7" }
-    "ocamlfind"         {>= "1.5.6" & < "2.0"}
-    "ppx_jane"          {>= "113.33.00" & < "113.34.00"}
-    "regular"
-    "uri"
-    "utop"
-    "uuidm"
-    "zarith"
+  "base-unix"
+  "bap-future"
+  "camlzip"
+  "core_kernel" {>= "113.33.00"}
+  "fileutils"
+  "graphlib"
+  "oasis" {build & = "0.4.7"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ppx_jane" {>= "113.33.00" & < "113.34.00"}
+  "regular"
+  "uri"
+  "utop"
+  "uuidm"
+  "zarith"
+  "cmdliner"
 ]
-
-
 depexts: [
     [["ubuntu"] [
         "libgmp-dev"

--- a/packages/bap-std/bap-std.1.2.0/opam
+++ b/packages/bap-std/bap-std.1.2.0/opam
@@ -30,23 +30,22 @@ remove: [
 ]
 
 depends: [
-    "base-unix"
-    "bap-future"
-    "camlzip"           {>= "1.07"}
-    "core_kernel"       {>= "113.33.00"}
-    "fileutils"
-    "graphlib"
-    "oasis"             {build & = "0.4.7" }
-    "ocamlfind"         {>= "1.5.6" & < "2.0"}
-    "ppx_jane"          {>= "113.33.00" & < "113.34.00"}
-    "regular"
-    "uri"
-    "utop"
-    "uuidm"
-    "zarith"
+  "base-unix"
+  "bap-future"
+  "camlzip" {>= "1.07"}
+  "core_kernel" {>= "113.33.00"}
+  "fileutils"
+  "graphlib"
+  "oasis" {build & = "0.4.7"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ppx_jane" {>= "113.33.00" & < "113.34.00"}
+  "regular"
+  "uri"
+  "utop"
+  "uuidm"
+  "zarith"
+  "cmdliner"
 ]
-
-
 depexts: [
     [["ubuntu"] [
         "libgmp-dev"

--- a/packages/bap/bap.1.0.0/opam
+++ b/packages/bap/bap.1.0.0/opam
@@ -36,4 +36,4 @@ depends: [
     "bap-x86" {= "1.0.0"}
 ]
 
-available: [ocaml-version >= "4.02.3" ]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04"]

--- a/packages/bap/bap.1.1.0/opam
+++ b/packages/bap/bap.1.1.0/opam
@@ -36,4 +36,4 @@ depends: [
     "bap-x86" {= "1.1.0"}
 ]
 
-available: [ocaml-version >= "4.02.3" ]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04"]


### PR DESCRIPTION
There are not related to 4.05 compatibility. The `bap-*` metatadata as a whole seems incomplete enough that most package fail to build with minimal dependencies on most OCaml versions right now, and several iterations of fixing things in the opam-repository will be necessary before the air clears up.

(In opam-builder, notice the sea of red following http://opam.ocamlpro.com/builder/html/report-full.html#bap .)