### PR TITLE
 package the last release of ppx_tools, with 4.05 support

### DIFF
--- a/packages/ppx_tools/ppx_tools.5.0+4.05.0/descr
+++ b/packages/ppx_tools/ppx_tools.5.0+4.05.0/descr
@@ -1,0 +1,1 @@
+Tools for authors of ppx rewriters and other syntactic tools

--- a/packages/ppx_tools/ppx_tools.5.0+4.05.0/findlib
+++ b/packages/ppx_tools/ppx_tools.5.0+4.05.0/findlib
@@ -1,0 +1,1 @@
+ppx_tools

--- a/packages/ppx_tools/ppx_tools.5.0+4.05.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.0+4.05.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+license: "MIT"
+homepage: "https://github.com/alainfrisch/ppx_tools"
+bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
+dev-repo: "git://github.com/alainfrisch/ppx_tools.git#4.05"
+tags: [ "syntax" ]
+build: [[make "all"]]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "ppx_tools"]]
+depends: [
+  "ocamlfind" {>= "1.5.0"}
+]
+available: [ ocaml-version >= "4.05" ]

--- a/packages/ppx_tools/ppx_tools.5.0+4.05.0/url
+++ b/packages/ppx_tools/ppx_tools.5.0+4.05.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/alainfrisch/ppx_tools/archive/5.0+4.05.0.tar.gz"
+checksum: "cf455545d5df2ed447a101f1d44454e9"

--- a/packages/ppx_tools/ppx_tools.5.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.0/opam
@@ -12,4 +12,4 @@ remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: [
   "ocamlfind" {>= "1.5.0"}
 ]
-available: ocaml-version >= "4.04.0"
+available: [ ocaml-version >= "4.04.0" & ocaml-version < "4.05" ]


### PR DESCRIPTION
Absence of ppx_tools has been a major source of breakage in the 4.05
opam repository so far. This should unlock the test of many more opam
packages during the beta period.

(Thanks to Alain Frisch for his extremely quick release of a new
ppx_tools versions when I raised the issue.)