### PR TITLE
Ocp-build.1.99.17-beta: fix ocaml-versions < 4.05.0

### DIFF
--- a/packages/ocp-build/ocp-build.1.99.17-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.17-beta/opam
@@ -8,4 +8,4 @@ dev-repo: "https://github.com/OCamlPro/typerex-build.git"
 bug-reports: "https://github.com/OCamlPro/typerex-build/issues"
 depends: [ "typerex-build" {= "1.99.17-beta" } ]
 conflicts: [ "typerex"  {< "1.99.7"} ]
-available: [ocaml-version >= "3.12.0"]
+available: [ocaml-version >= "3.12.0" & ocaml-version < "4.05.0"]

--- a/packages/typerex-build/typerex-build.1.99.17-beta/opam
+++ b/packages/typerex-build/typerex-build.1.99.17-beta/opam
@@ -37,7 +37,7 @@ remove: [
   [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/installed.ocp"   ]
   [ "sh" "-exc" "rmdir %{prefix}%/lib/ocaml/typerex || true"   ]
 ]
-available: [ocaml-version >= "3.12.1"]
+available: [ocaml-version >= "3.12.1" & ocaml-version < "4.05.0" ]
 
 (**************************************************************)
 (*                                                            *)


### PR DESCRIPTION
`ocp-build.1.99.17-beta` is not compatible with OCaml >= 4.05, because of a change in the arity of some Unix primitives. This is fixed in 1.99.18-beta, but we still need to fix the constraint on the packages.