### PR TITLE
cmdliner.1.0.0 - via opam-publish

### DIFF
--- a/packages/cmdliner/cmdliner.1.0.0/descr
+++ b/packages/cmdliner/cmdliner.1.0.0/descr
@@ -1,0 +1,15 @@
+Declarative definition of command line interfaces for OCaml
+
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html

--- a/packages/cmdliner/cmdliner.1.0.0/opam
+++ b/packages/cmdliner/cmdliner.1.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+available: [ocaml-version >= "4.01.0"]
+depends:[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+]]

--- a/packages/cmdliner/cmdliner.1.0.0/url
+++ b/packages/cmdliner/cmdliner.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.0.tbz"
+checksum: "6baa375f393fbe9ca1fcb0a7a875e001"


### PR DESCRIPTION
Declarative definition of command line interfaces for OCaml

Cmdliner allows the declarative definition of command line interfaces
for OCaml.

It provides a simple and compositional mechanism to convert command
line arguments to OCaml values and pass them to your functions. The
module automatically handles syntax errors, help messages and UNIX man
page generation. It supports programs with single or multiple commands
and respects most of the [POSIX][1] and [GNU][2] conventions.

Cmdliner has no dependencies and is distributed under the ISC license.

[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html


---
* Homepage: http://erratique.ch/software/cmdliner
* Source repo: http://erratique.ch/repos/cmdliner.git
* Bug tracker: https://github.com/dbuenzli/cmdliner/issues

---


---
v1.0.0 2017-03-02 La Forclaz (VS)
---------------------------------

**IMPORTANT** The `Arg.converter` type is deprecated in favor of the
`Arg.conv` type. For this release both types are equal but the next
major release will drop the former and make the latter abstract. All
users are kindly requested to migrate to use the new type and **only**
via the new `Arg.[p]conv` and `Arg.conv_{parser,printer}` functions.

- Allow terms to be used more than once in terms without tripping out
  documentation generation (#77). Thanks to François Bobot and Gabriel
  Radanne.
- Disallow defining the same option (resp. command) name twice via two
  different arguments (resp. terms). Raises Invalid_argument, used
  to be undefined behaviour (in practice, an arbitrary one would be
  ignored).
- Improve converter API (see important message above).
- Add `Term.exit[_status]` and `Term.exit_status_of[_status]_result`.
  improves composition with `Pervasives.exit`.
- Add `Term.term_result` and `Term.cli_parse_result` improves composition
  with terms evaluating to `result` types.
- Add `Arg.parser_of_kind_of_string`.
- Change semantics of `Arg.pos_left` (see #76 for details).
- Deprecate `Term.man_format` in favor of `Arg.man_format`.
- Reserve the `--cmdliner` option for library use. This is unused for now
  but will be in the future.
- Relicense from BSD3 to ISC.
- Safe-string support.
- Build depend on topkg.

### End-user visible changes

The following changes affect the end-user behaviour of all binaries using
cmdliner.

- Required positional arguments. All missing required position
  arguments are now reported to the end-user, in the correct
  order (#39). Thanks to Dmitrii Kashin for the report.
- Optional arguments. All unknown and ambiguous optional argument
  arguments are now reported to the end-user (instead of only
  the first one).
- Change default behaviour of `--help[=FMT]` option. `FMT` no longer
  defaults to `pager` if unspecified.  It defaults to the new value
  `auto` which prints the help as `pager` or `plain` whenever the
  `TERM` environment variable is `dumb` or undefined (#43). At the API
  level this changes the signature of the type `Term.ret` and values
  `Term.ret`, `Term.man_format` (deprecated) and `Manpage.print` to add the
  new `` `Auto`` case to manual formats. These are now represented by the
  `Manpage.format` type rather than inlined polyvars.

### Doc specification improvements and fixes

- Add `?envs` optional argument to `Term.info`. Documents environment
  variables that influence a term's evaluation and automatically
  integrate them in the manual.
- Add `?exits` optional argument to `Term.info`. Documents exit statuses of
  the program. Use `Term.default_exits` if you are using the new `Term.exit`
  functions.
- Add `?man_xrefs` optional argument to `Term.info`. Documents
  references to other manpages. Automatically formats a `SEE ALSO` section
  in the manual.
- Add `Manpage.escape` to escape a string from the documentation markup
  language.
- Add `Manpage.s_*` constants for standard man page section names.
- Add a `` `Blocks`` case to `Manpage.blocks` to allow block splicing
  (#69).  This avoids having to concatenate block lists at the
  toplevel of your program.
- `Arg.env_var`, change default environment variable section to the
   standard `ENVIRONMENT` manual section rather than `ENVIRONMENT
   VARIABLES`.  If you previously manually positioned that section in
   your man page you will have to change the name. See also next point.
- Fix automatic placement of default environment variable section (#44)
  whenever unspecified in the man page.
- Better automatic insertions of man page sections (#73). See the API
  docs about manual specification. As a side effect the `NAME` section
  can now also be overriden manually.
- Fix repeated environment variable printing for flags (#64). Thanks to
  Thomas Gazagnaire for the report.
- Fix rendering of env vars in man pages, bold is standard (#71).
- Fix plain help formatting for commands with empty
  description. Thanks to Maciek Starzyk for the patch.
- Fix (implement really) groff man page escaping (#48).
- Request `an` macros directly in the man page via `.mso` this
  makes man pages self-describing and avoids having to call `groff` with
  the `-man` option.
- Document required optional arguments as such (#82). Thanks to Isaac Hodes
  for the report.

### Doc language sanitization

This release tries to bring sanity to the doc language. This may break
the rendering of some of your man pages. Thanks to Gabriel Scherer,
Ivan Gotovchits and Nicolás Ojeda Bär for the feedback.

- It is only allowed to use the variables `$(var)` that are mentioned in
  the docs (`$(docv)`, `$(opt)`, etc.) and the markup directives
  `$({i,b},text)`. Any other unknown `$(var)` will generate errors
  on standard error during documentation generation.
- Markup directives `$({i,b},text)` treat `text` as is, modulo escapes;
  see next point.
- Characters `$`, `(`, `)` and `\` can respectively be escaped by `\$`,
  `\(`, `\)` and `\\`. Escaping `$` and `\` is mandatory everywhere.
  Escaping `)` is mandatory only in markup directives. Escaping `(`
  is only here for your symmetric pleasure. Any other sequence of
  character starting with a `\` is an illegal sequence.
- Variables `$(mname)` and `$(tname)` are now marked up with bold when
  substituted. If you used to write `$(b,$(tname))` this will generate
  an error on standard output, since `$` is not escaped in the markup
  directive. Simply replace these by `$(tname)`.


Pull-request generated by opam-publish v0.3.3