### PR TITLE
Constrain depexts to cmdliner <= 0.9.8.

### DIFF
--- a/packages/depext/depext.0.2/opam
+++ b/packages/depext/depext.0.2/opam
@@ -6,6 +6,6 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml/opam-depext.git"
 build: [make]
-depends: [ "cmdliner" "ocamlfind" {build} ]
+depends: [ "ocamlfind" "cmdliner" {build & <= "0.9.8"} ]
 available: [ ocaml-version >= "4.02" ]
 tags: [ "flags:plugin" ]

--- a/packages/depext/depext.0.3/opam
+++ b/packages/depext/depext.0.3/opam
@@ -13,5 +13,5 @@ build: [
     "-o" "opam-depext" "depext.ml" ]
     {!ocaml-native}
 ]
-depends: [ "cmdliner" {build} ]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 tags: [ "flags:plugin" ]

--- a/packages/depext/depext.0.4/opam
+++ b/packages/depext/depext.0.4/opam
@@ -18,5 +18,5 @@ build: [
      "-o" "opam-depext" "depext.ml"
   ] {!ocaml-native}
 ]
-depends: "cmdliner"
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 tags: [ "flags:plugin" ]

--- a/packages/depext/depext.0.5/opam
+++ b/packages/depext/depext.0.5/opam
@@ -14,5 +14,5 @@ build: [
      "-o" "opam-depext" "depext.ml"]
     { !ocaml-native }
 ]
-depends: [ "cmdliner" {build} ]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 tags: "flags:plugin"

--- a/packages/depext/depext.0.6/opam
+++ b/packages/depext/depext.0.6/opam
@@ -33,6 +33,4 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]

--- a/packages/depext/depext.0.7/opam
+++ b/packages/depext/depext.0.7/opam
@@ -33,6 +33,4 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]

--- a/packages/depext/depext.0.8.1/opam
+++ b/packages/depext/depext.0.8.1/opam
@@ -33,7 +33,5 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.0.8/opam
+++ b/packages/depext/depext.0.8/opam
@@ -33,7 +33,5 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.0.9.0/opam
+++ b/packages/depext/depext.0.9.0/opam
@@ -33,7 +33,5 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.0.9.1/opam
+++ b/packages/depext/depext.0.9.1/opam
@@ -33,7 +33,5 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.1.0.0/opam
+++ b/packages/depext/depext.1.0.0/opam
@@ -33,7 +33,5 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.1.0.1/opam
+++ b/packages/depext/depext.1.0.1/opam
@@ -33,7 +33,5 @@ build: [
   ]
     {!ocaml-native}
 ]
-depends: [
-  "cmdliner" {build}
-]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.1.0.2/opam
+++ b/packages/depext/depext.1.0.2/opam
@@ -15,6 +15,6 @@ build: [
      "-o" "opam-depext" "depext.ml"]
     { !ocaml-native }
 ]
-depends: [ "cmdliner" {build} ]
+depends: [ "cmdliner" {build & <= "0.9.8"} ]
 available: [ opam-version >= "1.1.0" ]
 tags: "flags:plugin"


### PR DESCRIPTION
Hopefully this can unlock https://github.com/ocaml/opam-repository/pull/8588

Note that formally the constraint is only for ocaml-version < 4.02.0 but I don't know how to express this.