### PR TITLE
ocaml4.04.0+copatterns extends OCaml with copatterns and codatatypes.

### DIFF
--- a/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
+++ b/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
@@ -1,0 +1,13 @@
+opam-version: "1"
+version: "4.04.0"
+source: "https://github.com/yurug/ocaml4.04.0-copatterns/archive/V0.1.tar.gz"
+build: [
+ ["%{make}%" "install"]
+]
+packages: [
+ "base-unix" "base-bigarray" "base-threads"
+]
+env: [
+ [ CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs" ]
+]
+

--- a/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.descr
+++ b/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.descr
@@ -1,0 +1,1 @@
+An extension of OCaml with copatterns


### PR DESCRIPTION
Dear opam-repository moderators,

Paul Laforgue @phink and I are pleased to announce the availability of an extension of OCaml with copatterns and codatatypes. This implementation is still a prototype but we would like to offer it as an alternative compiler to get some feedback.
