### PR TITLE
decompress.0.5 - via opam-publish

### DIFF
--- a/packages/decompress/decompress.0.5/descr
+++ b/packages/decompress/decompress.0.5/descr
@@ -1,0 +1,3 @@
+Pure OCaml implementation of Zlib
+
+Pure OCaml implementation of Zlib

--- a/packages/decompress/decompress.0.5/opam
+++ b/packages/decompress/decompress.0.5/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/oklm-wsh/Decompress"
+bug-reports: "https://github.com/oklm-wsh/Decompress/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/oklm-wsh/Decompress.git"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "base-bytes"
+  "camlzip" {test}
+  "re" {test}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/decompress/decompress.0.5/url
+++ b/packages/decompress/decompress.0.5/url
@@ -1,2 +1,2 @@
 http: "https://github.com/oklm-wsh/Decompress/archive/0.5.tar.gz"
-checksum: "c053eb834a5b66d2a701af9c4de2ef05"
+checksum: "667fdfa64423e01ef38242f305e80e7f743bc0db"

--- a/packages/decompress/decompress.0.5/url
+++ b/packages/decompress/decompress.0.5/url
@@ -1,2 +1,2 @@
 http: "https://github.com/oklm-wsh/Decompress/archive/0.5.tar.gz"
-checksum: "667fdfa64423e01ef38242f305e80e7f743bc0db"
+checksum: "4bfd0e37dc9b946bf5aa195fd7e2f236"

--- a/packages/decompress/decompress.0.5/url
+++ b/packages/decompress/decompress.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/oklm-wsh/Decompress/archive/0.5.tar.gz"
+checksum: "c053eb834a5b66d2a701af9c4de2ef05"


### PR DESCRIPTION
Pure OCaml implementation of Zlib

Pure OCaml implementation of Zlib


---
* Homepage: https://github.com/oklm-wsh/Decompress
* Source repo: git+https://github.com/oklm-wsh/Decompress.git
* Bug tracker: https://github.com/oklm-wsh/Decompress/issues

---

Pull-request generated by opam-publish v0.3.4