### PR TITLE
duppy.0.5.0 depends on camlp4

### DIFF
--- a/packages/duppy/duppy.0.5.0/opam
+++ b/packages/duppy/duppy.0.5.0/opam
@@ -11,6 +11,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "duppy"]]
 depends: [
+  "camlp4"
   "ocamlfind"
   "pcre"
 ]

--- a/packages/duppy/duppy.0.5.0/opam
+++ b/packages/duppy/duppy.0.5.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "smimram@gmail.com"
 authors: [
   "Romain Beauxis"
@@ -16,3 +16,5 @@ depends: [
   "pcre"
 ]
 install: [make "install"]
+bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
+dev-repo: "https://github.com/savonet/ocaml-duppy.git"


### PR DESCRIPTION
The logs for #8601 show a [camlp4-related duppy.0.5.0 build failure](https://ci.ocaml.io/log/saved/docker-build-3ad498831de02f2a2b3ecb85b3d85791/d82133770dc64ad6a14e5926aad3d7d7fce5c5db):

```
#=== ERROR while compiling duppy.0.5.0 ========================================#
# command              make
# path                 /home/opam/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/duppy.0.5.0
# exit-code            2
# env-file             /home/opam/.opam/log/duppy-31-de96f2.env
# output-file          /home/opam/.opam/log/duppy-31-de96f2.out
### output ###
# make -C src all
# make[1]: Entering directory '/home/opam/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/duppy.0.5.0/src'
# ocamlfind ocamlc -c -package camlp4 -package camlp4.quotations.o -package camlp4.extend -syntax camlp4o pa_duppy.mli
# ocamlfind: Package `camlp4.quotations.o' not found
# Makefile:50: recipe for target 'pa_duppy.cmi' failed
# make[1]: *** [pa_duppy.cmi] Error 2
# make[1]: Leaving directory '/home/opam/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/duppy.0.5.0/src'
# Makefile:12: recipe for target 'all' failed
# make: *** [all] Error 2
```

This PR adds `camlp4` as a `duppy.0.5.0` dependency.

/cc @toots