### PR TITLE
add bytecode-only compiler for 4.04

### DIFF
--- a/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.comp
+++ b/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.comp
@@ -1,0 +1,16 @@
+opam-version: "1"
+version: "4.04.0"
+src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
+build: [
+  ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+  [make "world"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.descr
+++ b/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.descr
@@ -1,0 +1,1 @@
+Official 4.04.0 release, without the native-code compiler.


### PR DESCRIPTION
Compiler build instructions with this new configure option: https://github.com/ocaml/ocaml/pull/387
`4.02.3+bytecode-only` is not really useful for testing, because it generates a `Makefile.config` that confuses many build scripts and Makefiles.
