### PR TITLE
Mirage protocols upperbounds

### DIFF
--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-protocols" {>= "1.0.0"}
+  "mirage-protocols" {= "1.0.0"}
   "ipaddr"
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -52,8 +52,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0"}
-  "mirage-protocols" {>= "1.0.0"}
-  "mirage-protocols-lwt" {>= "1.0.0"}
+  "mirage-protocols" {= "1.0.0"}
+  "mirage-protocols-lwt" {= "1.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}


### PR DESCRIPTION
Add upper bounds on some existing dependencies on mirage-protocols, which will shortly get a 1.1.0 release.