### PR TITLE
Constrain depexts to cmdliner 0.9.8.

### DIFF
--- a/packages/depext/depext.1.0.2/opam
+++ b/packages/depext/depext.1.0.2/opam
@@ -15,6 +15,6 @@ build: [
      "-o" "opam-depext" "depext.ml"]
     { !ocaml-native }
 ]
-depends: [ "cmdliner" {build & <= "0.9.8"} ]
+depends: [ "cmdliner" {build & = "0.9.8"} ]
 available: [ opam-version >= "1.1.0" ]
 tags: "flags:plugin"


### PR DESCRIPTION
Still for https://github.com/ocaml/opam-repository/pull/8588 it seems https://github.com/ocaml/opam-repository/pull/8593 was too lax. 