### PR TITLE
salsa20-core.0.1.0 - via opam-publish

### DIFF
--- a/packages/salsa20-core/salsa20-core.0.1.0/descr
+++ b/packages/salsa20-core/salsa20-core.0.1.0/descr
@@ -1,0 +1,3 @@
+Salsa20 core functions, in pure OCaml
+
+A pure OCaml implementation of [Salsa20 Core](http://cr.yp.to/salsa20.html) functions, both Salsa20/20 Core and the reduced Salsa20/8 Core and Salsa20/12 Core functions.

--- a/packages/salsa20-core/salsa20-core.0.1.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+homepage:     "https://github.com/abeaumont/ocaml-salsa20-core"
+dev-repo:     "https://github.com/abeaumont/ocaml-salsa20-core.git"
+bug-reports:  "https://github.com/abeaumont/ocaml-salsa20-core/issues"
+author:       "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+maintainer:   "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+license:      "BSD2"
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.3"}
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/salsa20-core/salsa20-core.0.1.0/url
+++ b/packages/salsa20-core/salsa20-core.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/abeaumont/ocaml-salsa20-core/archive/0.1.0.tar.gz"
+checksum: "af18d92311544e8482f8447c50232a0b"


### PR DESCRIPTION
Salsa20 core functions, in pure OCaml

A pure OCaml implementation of [Salsa20 Core](http://cr.yp.to/salsa20.html) functions, both Salsa20/20 Core and the reduced Salsa20/8 Core and Salsa20/12 Core functions.

---
* Homepage: https://github.com/abeaumont/ocaml-salsa20-core
* Source repo: https://github.com/abeaumont/ocaml-salsa20-core.git
* Bug tracker: https://github.com/abeaumont/ocaml-salsa20-core/issues

---


---
# 0.1.0 (2017-03-04)

* Initial release, with code taken from the scrypt-kdf repo.
Pull-request generated by opam-publish v0.3.2