### PR TITLE
mergeable-vector.0.1.0 - via opam-publish

### DIFF
--- a/packages/mergeable-vector/mergeable-vector.0.1.0/descr
+++ b/packages/mergeable-vector/mergeable-vector.0.1.0/descr
@@ -1,11 +1,5 @@
 Mergeable vector based on operational transformation
 
-mergeable-vector is vector library with support for [3-way
-merges](https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge)
-based on [operational
-transformation](https://en.wikipedia.org/wiki/Operational_transformation). The
-library also provides diffing and patching arbitrary vectors. The diff is
-computed by [Wagner-Fischer
-algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
+mergeable-vector is vector library with support for [3-way merges](https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge) based on [operational transformation](https://en.wikipedia.org/wiki/Operational_transformation). The library also provides diffing and patching arbitrary vectors. The diff is computed by [Wagner-Fischer algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
 
 mergeable-vector is distributed under the ISC license.

--- a/packages/mergeable-vector/mergeable-vector.0.1.0/descr
+++ b/packages/mergeable-vector/mergeable-vector.0.1.0/descr
@@ -1,0 +1,11 @@
+Mergeable vector based on operational transformation
+
+mergeable-vector is vector library with support for [3-way
+merges](https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge)
+based on [operational
+transformation](https://en.wikipedia.org/wiki/Operational_transformation). The
+library also provides diffing and patching arbitrary vectors. The diff is
+computed by [Wagner-Fischer
+algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
+
+mergeable-vector is distributed under the ISC license.

--- a/packages/mergeable-vector/mergeable-vector.0.1.0/opam
+++ b/packages/mergeable-vector/mergeable-vector.0.1.0/opam
@@ -15,4 +15,4 @@ depends: [
 depopts: []
 build: [
   "ocaml" "pkg/pkg.ml" "build"
-          "--pinned" pinned ]
+          "--pinned" "%{pinned}%" ]

--- a/packages/mergeable-vector/mergeable-vector.0.1.0/opam
+++ b/packages/mergeable-vector/mergeable-vector.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+homepage: "https://github.com/kayceesrk/mergeable-vector"
+doc: "http://kcsrk.info//mergeable-vector/doc"
+license: "ISC"
+dev-repo: "https://github.com/kayceesrk/mergeable-vector.git"
+bug-reports: "https://github.com/kayceesrk/mergeable-vector/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" pinned ]

--- a/packages/mergeable-vector/mergeable-vector.0.1.0/url
+++ b/packages/mergeable-vector/mergeable-vector.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/kayceesrk/mergeable-vector/releases/download/0.1.0/mergeable-vector-0.1.0.tbz"
+checksum: "23452c339773960004f6d15d77e092d7"


### PR DESCRIPTION
Mergeable vector based on operational transformation.

mergeable-vector is vector library with support for [3-way merges](https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge) based on [operational transformation](https://en.wikipedia.org/wiki/Operational_transformation). The library also provides diffing and patching arbitrary vectors. The diff is computed by [Wagner-Fischer algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).

mergeable-vector is distributed under the ISC license.


---
* Homepage: https://github.com/kayceesrk/mergeable-vector
* Source repo: https://github.com/kayceesrk/mergeable-vector.git
* Bug tracker: https://github.com/kayceesrk/mergeable-vector/issues

---


---
v0.1.0 2017-03-05 Cambridge
--------------------------

First release. 
Pull-request generated by opam-publish v0.3.2