### PR TITLE
new ocamlbuild release: 0.11.0

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.11.0/descr
+++ b/packages/ocamlbuild/ocamlbuild.0.11.0/descr
@@ -1,0 +1,1 @@
+OCamlbuild is a build system with builtin rules to easily build most OCaml projects.

--- a/packages/ocamlbuild/ocamlbuild.0.11.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.11.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+name: "ocamlbuild"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+version: "0.11.0"
+
+authors: [
+  "Nicolas Pouillard"
+  "Berke Durak"
+]
+
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml/ocamlbuild.git"
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+
+build: [
+  [make "-f" "configure.make" "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml-native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml-native}%"]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+
+available: [ocaml-version >= "4.03"]
+depends: [ ]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]

--- a/packages/ocamlbuild/ocamlbuild.0.11.0/url
+++ b/packages/ocamlbuild/ocamlbuild.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/ocamlbuild/archive/0.11.0.tar.gz"
+checksum: "e3b83c842f82ef909b6d2a2d2035f0fe"


### PR DESCRIPTION
The `.cmxs` issue which plagued the 0.10 release should now have been fixed, see testing reports in #176.