### PR TITLE
msgpck.1.2 - via opam-publish

### DIFF
--- a/packages/msgpck/msgpck.1.2/descr
+++ b/packages/msgpck/msgpck.1.2/descr
@@ -1,0 +1,9 @@
+Fast MessagePack (http://msgpack.org) library
+
+msgpck is written in pure OCaml.
+
+MessagePack is an efficient binary serialization format. It lets you
+exchange data among multiple languages like JSON. But it's faster and
+smaller. Small integers are encoded into a single byte, and typical
+short strings require only one extra byte in addition to the strings
+themselves.

--- a/packages/msgpck/msgpck.1.2/opam
+++ b/packages/msgpck/msgpck.1.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-msgpck"
+bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
+license: "ISC"
+dev-repo: "https://github.com/vbmithr/ocaml-msgpck.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocplib-endian" {>= "1.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/msgpck/msgpck.1.2/url
+++ b/packages/msgpck/msgpck.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vbmithr/ocaml-msgpck/archive/1.2.tar.gz"
+checksum: "b3823f1cf2447a98dab5b2b8d1b663fe"


### PR DESCRIPTION
Fast MessagePack (http://msgpack.org) library

msgpck is written in pure OCaml.

MessagePack is an efficient binary serialization format. It lets you
exchange data among multiple languages like JSON. But it's faster and
smaller. Small integers are encoded into a single byte, and typical
short strings require only one extra byte in addition to the strings
themselves.

---
* Homepage: https://github.com/vbmithr/ocaml-msgpck
* Source repo: https://github.com/vbmithr/ocaml-msgpck.git
* Bug tracker: https://github.com/vbmithr/ocaml-msgpck/issues

---

Pull-request generated by opam-publish v0.3.4