### PR TITLE
Constrain 0install to ocamlbuild <= 0.9.3.

### DIFF
--- a/packages/0install/0install.2.10/opam
+++ b/packages/0install/0install.2.10/opam
@@ -17,7 +17,7 @@ depends: [
   "ocurl"
   "sha"
   "camlp4"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & <= "0.9.3"}
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [

--- a/packages/0install/0install.2.11/opam
+++ b/packages/0install/0install.2.11/opam
@@ -17,7 +17,7 @@ depends: [
   "ocurl"
   "sha"
   "camlp4" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & <= "0.9.3"}
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [

--- a/packages/0install/0install.2.12/opam
+++ b/packages/0install/0install.2.12/opam
@@ -17,7 +17,7 @@ depends: [
   "ocurl"
   "sha"
   "camlp4" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & <= "0.9.3"}
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [

--- a/packages/0install/0install.2.6.2/opam
+++ b/packages/0install/0install.2.6.2/opam
@@ -14,7 +14,7 @@ depends: [
   "extlib"
   "ssl"
   "ocurl"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & <= "0.9.3"}
   "camlp4" {build}
 ]
 depopts: [ "obus" "lablgtk" ]

--- a/packages/0install/0install.2.8/opam
+++ b/packages/0install/0install.2.8/opam
@@ -14,7 +14,7 @@ depends: [
   "extlib"
   "ocurl"
   "sha"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & <= "0.9.3"}
   "camlp4" {build}
 ]
 depopts: [ "obus" "lablgtk" ]

--- a/packages/0install/0install.2.9.1/opam
+++ b/packages/0install/0install.2.9.1/opam
@@ -16,7 +16,7 @@ depends: [
   "extlib"
   "ocurl"
   "sha"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & <= "0.9.3"}
   "camlp4" {build}
 ]
 depopts: [ "obus" "lablgtk" ]


### PR DESCRIPTION
/cc @talex5

See https://github.com/ocaml/ocamlbuild/issues/176#issuecomment-284480941

N.B. This was likely not found out by the CI revdeps because it needs a the gtk depopt to show up. 