### PR TITLE
calculon.0.1 - via opam-publish

### DIFF
--- a/packages/calculon/calculon.0.1/descr
+++ b/packages/calculon/calculon.0.1/descr
@@ -1,0 +1,5 @@
+Library for writing IRC bots in OCaml, a collection of plugins, and a dramatic robotic actor.
+
+The core library is called `calculon` and revolves around
+the concept of commands that react to user messages. See the README for a small
+tutorial on how to write your own plugins.

--- a/packages/calculon/calculon.0.1/opam
+++ b/packages/calculon/calculon.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+tags: ["irc" "bot" "factoids"]
+dev-repo: "http://github.com/c-cube/calculon.git"
+build: [
+  [
+    "./configure"
+    "--bindir"
+    "%{bin}%"
+    "--%{uri+lambdasoup+cohttp+atdgen:enable}%-web"
+    "--%{re+sequence:enable}%-extras"
+  ]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "calculon"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "base-unix"
+  "result"
+  "lwt"
+  "irc-client" {>= "0.4.0"}
+  "tls"
+  "yojson"
+  "containers" {>= "1.0"}
+  "ISO8601"
+  "re"
+  "stringext"
+]
+depopts: ["uri" "cohttp" "atdgen" "lambdasoup" "sequence"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/calculon/calculon.0.1/url
+++ b/packages/calculon/calculon.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/calculon/archive/0.1.tar.gz"
+checksum: "24fb37bb915717a0497962fda9fecc5c"


### PR DESCRIPTION
Library for writing IRC bots in OCaml, a collection of plugins, and a dramatic robotic actor.

The core library is called `calculon` and revolves around
the concept of commands that react to user messages. See the README for a small
tutorial on how to write your own plugins.


---
* Homepage: https://github.com/c-cube/calculon
* Source repo: http://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---

Pull-request generated by opam-publish v0.3.4