### PR TITLE
uutf.1.0.1 - via opam-publish

### DIFF
--- a/packages/uutf/uutf.1.0.1/descr
+++ b/packages/uutf/uutf.1.0.1/descr
@@ -1,0 +1,12 @@
+Non-blocking streaming Unicode codec for OCaml
+
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values.
+
+Uutf has no dependency and is distributed under the ISC license.

--- a/packages/uutf/uutf.1.0.1/opam
+++ b/packages/uutf/uutf.1.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uutf"
+doc: "http://erratique.ch/software/uutf/doc/Uutf"
+dev-repo: "http://erratique.ch/repos/uutf.git"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uchar"
+]
+depopts: ["cmdliner"]
+conflicts: ["cmdliner" { < "0.9.6"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]

--- a/packages/uutf/uutf.1.0.1/url
+++ b/packages/uutf/uutf.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uutf/releases/uutf-1.0.1.tbz"
+checksum: "b8535f974027357094c5cdb4bf03a21b"


### PR DESCRIPTION
Non-blocking streaming Unicode codec for OCaml

Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
work character by character without blocking on IO. Decoders perform
character position tracking and support newline normalization.

Functions are also provided to fold over the characters of UTF encoded
OCaml string values and to directly encode characters in OCaml
Buffer.t values.

Uutf has no dependency and is distributed under the ISC license.


---
* Homepage: http://erratique.ch/software/uutf
* Source repo: http://erratique.ch/repos/uutf.git
* Bug tracker: https://github.com/dbuenzli/uutf/issues

---


---
v1.0.1 2016-03-07 La Forclaz (VS)
---------------------------------

- OCaml 4.05.0 compatibility (removal of `Uchar.dump`).
Pull-request generated by opam-publish v0.3.3