### PR TITLE
jsonm.1.0.1 - via opam-publish

### DIFF
--- a/packages/jsonm/jsonm.1.0.1/descr
+++ b/packages/jsonm/jsonm.1.0.1/descr
@@ -1,0 +1,13 @@
+Non-blocking streaming JSON codec for OCaml
+
+Jsonm is a non-blocking streaming codec to decode and encode the JSON
+data format. It can process JSON text without blocking on IO and
+without a complete in-memory representation of the data.
+
+The alternative "uncut" codec also processes whitespace and
+(non-standard) JSON with JavaScript comments.
+
+Jsonm is made of a single module and depends on [Uutf][uutf]. It is distributed
+under the ISC license.
+
+[uutf]: http://erratique.ch/software/uutf

--- a/packages/jsonm/jsonm.1.0.1/opam
+++ b/packages/jsonm/jsonm.1.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/jsonm"
+doc: "http://erratique.ch/software/jsonm/doc/Jsonm"
+dev-repo: "http://erratique.ch/repos/jsonm.git"
+bug-reports: "https://github.com/dbuenzli/jsonm/issues"
+tags: [ "json" "codec" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uchar"
+  "uutf" ]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/jsonm/jsonm.1.0.1/url
+++ b/packages/jsonm/jsonm.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/jsonm/releases/jsonm-1.0.1.tbz"
+checksum: "e2ca39eaefd55b8d155c4f1ec5885311"


### PR DESCRIPTION
Non-blocking streaming JSON codec for OCaml

Jsonm is a non-blocking streaming codec to decode and encode the JSON
data format. It can process JSON text without blocking on IO and
without a complete in-memory representation of the data.

The alternative "uncut" codec also processes whitespace and
(non-standard) JSON with JavaScript comments.

Jsonm is made of a single module and depends on [Uutf][uutf]. It is distributed
under the ISC license.

[uutf]: http://erratique.ch/software/uutf


---
* Homepage: http://erratique.ch/software/jsonm
* Source repo: http://erratique.ch/repos/jsonm.git
* Bug tracker: https://github.com/dbuenzli/jsonm/issues

---


---
v1.0.1 2016-03-07 La Forclaz (VS)
---------------------------------

- OCaml 4.05.0 compatibility (removal of `Uchar.dump`).
Pull-request generated by opam-publish v0.3.3