### PR TITLE
hvsock.0.13.0 - via opam-publish

### DIFF
--- a/packages/hvsock/hvsock.0.13.0/descr
+++ b/packages/hvsock/hvsock.0.13.0/descr
@@ -1,0 +1,5 @@
+Bindings to Hyper-V AF_HVSOCK
+
+AF_HVSOCK sockets allow host <-> VM communication on Hyper-V hosts. A typical
+use is to run some kind of agent in a VM, and connect to it from software
+running on the host. AF_HVSOCK is similar to AF_VSOCK as used by virtio-vsock.

--- a/packages/hvsock/hvsock.0.13.0/opam
+++ b/packages/hvsock/hvsock.0.13.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hvsock"
+dev-repo: "https://github.com/mirage/ocaml-hvsock.git"
+bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--%{alcotest:enable}%-tests" ]
+  [make]
+]
+
+build-test:[
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "hvsock"]
+
+depends: [
+  "base-bytes"
+  "lwt" {>= "2.4.7"}
+  "logs"
+  "fmt"
+  "base-unix"
+  "cmdliner"
+  "mirage-types-lwt" {>= "2.0" & <"3.0"}
+  "mirage-flow" {<="1.1.0"}
+  "cstruct"
+  "duration"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "alcotest" {test & >= "0.4.0"}
+]
+
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/hvsock/hvsock.0.13.0/url
+++ b/packages/hvsock/hvsock.0.13.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-hvsock/archive/v0.13.0.tar.gz"
+checksum: "c8a791e9aeaabf9378c6259adc24a15b"


### PR DESCRIPTION
Bindings to Hyper-V AF_HVSOCK

AF_HVSOCK sockets allow host <-> VM communication on Hyper-V hosts. A typical
use is to run some kind of agent in a VM, and connect to it from software
running on the host. AF_HVSOCK is similar to AF_VSOCK as used by virtio-vsock.


---
* Homepage: https://github.com/mirage/ocaml-hvsock
* Source repo: https://github.com/mirage/ocaml-hvsock.git
* Bug tracker: https://github.com/mirage/ocaml-hvsock/issues

---

Pull-request generated by opam-publish v0.3.3