### PR TITLE
depext.1.0.3 - via opam-publish

### DIFF
--- a/packages/depext/depext.1.0.3/descr
+++ b/packages/depext/depext.1.0.3/descr
@@ -1,0 +1,7 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can perform OS and
+distribution detection, query OPAM for the right external dependencies on a set
+of packages, and call the OS's package manager in the appropriate way to install
+them.

--- a/packages/depext/depext.1.0.3/opam
+++ b/packages/depext/depext.1.0.3/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+tags: "flags:plugin"
+dev-repo: "https://github.com/ocaml/opam-depext.git"
+build: [make]
+available: [opam-version >= "1.1.0"]

--- a/packages/depext/depext.1.0.3/url
+++ b/packages/depext/depext.1.0.3/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/ocaml/opam-depext/releases/download/v1.0.3/opam-depext-full-1.0.3.tbz"
+checksum: "a9f6299da67d9d42dae640bb2aa6623d"


### PR DESCRIPTION
Query and install external dependencies of OPAM packages

opam-depext is a simple program intended to facilitate the interaction between
OPAM packages and the host package management system. It can perform OS and
distribution detection, query OPAM for the right external dependencies on a set
of packages, and call the OS's package manager in the appropriate way to install
them.


---
* Homepage: https://github.com/ocaml/opam-depext
* Source repo: https://github.com/ocaml/opam-depext.git
* Bug tracker: https://github.com/ocaml/opam-depext/issues

---

Pull-request generated by opam-publish v0.3.3