### PR TITLE
trakeva.0.1.1 - via opam-publish

### DIFF
--- a/packages/trakeva/trakeva.0.1.1/descr
+++ b/packages/trakeva/trakeva.0.1.1/descr
@@ -1,0 +1,6 @@
+Transactions, Keys, and Values; with Postgresql and/or Sqlite.
+
+A common key-value API with transactions on top of Postgresql or Sqlite.
+The library `trakeva_of_uri` does dynamic loading based on a configuration URI
+(`postgresql://` or `sqlite://`, depending on backends available at
+compile-time).

--- a/packages/trakeva/trakeva.0.1.1/opam
+++ b/packages/trakeva/trakeva.0.1.1/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "Sebastien Mondet <seb@mondet.org>"
+authors: "Sebastien Mondet <seb@mondet.org>"
+homepage: "http://www.hammerlab.org/docs/trakeva/master/index.html"
+bug-reports: "https://github.com/smondet/trakeva/issues"
+license: "Apache-2.0"
+dev-repo: "https://github.com/smondet/trakeva.git"
+build: [
+  [
+    "./configure"
+    "--%{sqlite3:enable}%-sqlite"
+    "--%{postgresql:enable}%-postgresql"
+    "--disable-test"
+    prefix
+  ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "trakeva"]
+  ["ocamlfind" "remove" "trakeva_sqlite"]
+  ["ocamlfind" "remove" "trakeva_postgresql"]
+  ["ocamlfind" "remove" "trakeva_of_uri"]
+]
+depends: [
+  "base-threads"
+  "nonstd"
+  "oasis" {build & >= "0.4"}
+  "ocamlfind" {build}
+  "pvem_lwt_unix"
+  "uri"
+]
+depopts: ["postgresql" "sqlite3"]

--- a/packages/trakeva/trakeva.0.1.1/url
+++ b/packages/trakeva/trakeva.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/smondet/trakeva/archive/trakeva.0.1.1.tar.gz"
+checksum: "6e37bdc1059e84c3836e9bfadd7da56b"


### PR DESCRIPTION
Transactions, Keys, and Values; with Postgresql and/or Sqlite.

A common key-value API with transactions on top of Postgresql or Sqlite.
The library `trakeva_of_uri` does dynamic loading based on a configuration URI
(`postgresql://` or `sqlite://`, depending on backends available at
compile-time).


---
* Homepage: http://www.hammerlab.org/docs/trakeva/master/index.html
* Source repo: https://github.com/smondet/trakeva.git
* Bug tracker: https://github.com/smondet/trakeva/issues

---

Pull-request generated by opam-publish v0.3.3