### PR TITLE
Add constrain on ocamlbuild for ppx_deriving

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.3.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.1/opam
@@ -23,7 +23,7 @@ build-test: [
 ]
 build-doc: [make "doc"]
 depends: [
-  "ocamlbuild" {build}
+  "ocamlbuild" { build & <= "0.9.3" }
   "ppx_tools" {>= "0.99.2"}
   "ocamlfind" {build & >= "1.5.4"}
   "ounit" {test}

--- a/packages/ppx_deriving/ppx_deriving.3.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.2/opam
@@ -20,7 +20,7 @@ build-doc: [
   make "doc"
 ]
 depends: [
-  "ocamlbuild" {build}
+  "ocamlbuild" { build & <= "0.9.3" }
   "ocamlfind"  {build & >= "1.5.4"}
   "ppx_tools"  {>= "0.99.2"}
   "ounit"      {test}

--- a/packages/ppx_deriving/ppx_deriving.3.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.3/opam
@@ -20,7 +20,7 @@ build-doc: [
   make "doc"
 ]
 depends: [
-  "ocamlbuild" {build}
+  "ocamlbuild" { build & <= "0.9.3" }
   "ocamlfind"  {build & >= "1.5.4"}
   "cppo"       {build & >= "1.2.2"}
   "ppx_tools"  {>= "4.02.3"}

--- a/packages/ppx_deriving/ppx_deriving.4.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.0/opam
@@ -20,7 +20,7 @@ build-doc: [
   make "doc"
 ]
 depends: [
-  "ocamlbuild" {build}
+  "ocamlbuild" { build & <= "0.9.3" }
   "ocamlfind"  {build & >= "1.6.0"}
   "cppo"       {build & >= "1.2.2"}
   "ppx_tools"  {>= "4.02.3"}

--- a/packages/ppx_deriving/ppx_deriving.4.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1/opam
@@ -20,7 +20,7 @@ build-doc: [
   make "doc"
 ]
 depends: [
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & <= "0.9.3"}
   "ocamlfind"  {build & >= "1.6.0"}
   "cppo"       {build}
   "ppx_tools"  {>= "4.02.3"}


### PR DESCRIPTION
OCamlbuild 0.11.0 exposes a build bug that breaks packages using `ppx_deriving.make`.

See https://github.com/whitequark/ppx_deriving/issues/124
And https://github.com/whitequark/ppx_deriving/commit/a4428407e974361d872e0a70e036bc7ee20e8467.

