### PR TITLE
opam-lib.1.3.1 — via opam-publish

### DIFF
--- a/packages/opam-lib/opam-lib.1.3.1/descr
+++ b/packages/opam-lib/opam-lib.1.3.1/descr
@@ -1,0 +1,10 @@
+The OPAM library
+
+OPAM is The OCaml PAckage Manager. This package contains the OPAM
+libraries, that may be used by external tools to access OPAM
+installation, state and data.
+
+Note: this version does not correspond to a released version of opam, but has
+some improvements over the 1.2.2 opam-lib while retaining the compatibility with
+the ~/.opam format; later versions (2.0) are no longer compatible. This can be
+used as a first step for migration.

--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+homepage:     "https://opam.ocaml.org/"
+dev-repo:     "https://github.com/ocaml/opam.git"
+bug-reports:  "https://github.com/ocaml/opam/issues"
+authors: [
+   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+   "Anil Madhavapeddy   <anil@recoil.org>"
+   "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+   "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+   "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+   "Vincent Bernardoff  <vb@luminar.eu.org>"
+   "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+build: [
+  ["./configure"]
+  [make]
+  [make "-C" "src" "../opam-lib.install"]
+]
+depends: [
+  "ocamlgraph"
+  "cmdliner"
+  "dose3" {>= "5.0"}
+  "cudf"
+  "re" {>= "1.2.0"}
+  "ocamlfind" {build}
+  "jsonm"
+]

--- a/packages/opam-lib/opam-lib.1.3.1/url
+++ b/packages/opam-lib/opam-lib.1.3.1/url
@@ -1,0 +1,2 @@
+src: "https://github.com/ocaml/opam/archive/1.3.1.tar.gz"
+checksum: "e0688c0cf9a55f93ee93f62d07cf6b74"


### PR DESCRIPTION
The OPAM library

OPAM is The OCaml PAckage Manager. This package contains the OPAM
libraries, that may be used by external tools to access OPAM
installation, state and data.

Note: this version does not correspond to a released version of opam, but has
some improvements over the 1.2.2 opam-lib while retaining the compatibility with
the ~/.opam format; later versions (2.0) are no longer compatible. This can be
used as a first step for migration.


---
* Homepage: https://opam.ocaml.org/
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
### opam-lint failures
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4