### PR TITLE
Add centos depext for zmq

### DIFF
--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -10,4 +10,5 @@ depexts: [
   [["ubuntu"] ["libzmq3-dev"]]
   [["osx" "homebrew"] ["zeromq"]]
   [["alpine"] ["zeromq-dev"]]
+  [["centos"] ["zeromq-devel"]]
 ]


### PR DESCRIPTION
Add the `depext` used in the [`ocaml-zmq` package](https://github.com/ocaml/opam-repository/blob/0d848b4acac7e002663c9ffb08cffceb178b748d/packages/ocaml-zmq/ocaml-zmq.0/opam#L17).