### PR TITLE
ppx_deriving_cmdliner.0.0.0 - via opam-publish

### DIFF
--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/descr
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/descr
@@ -1,0 +1,4 @@
+Cmdliner.Term.t generator
+
+ppx_deriving_cmdliner is a ppx_deriving plugin that generates
+Cmdliner Terms for types.

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Isaac Hodes <isaachodes@gmail.com>"
+authors: "Isaac Hodes <isaachodes@gmail.com>"
+homepage: "https://github.com/ihodes/ppx_deriving_cmdliner"
+bug-reports: "https://github.com/ihodes/ppx_deriving_cmdliner/issues"
+license: "MIT"
+doc: "http://ihodes.github.io/ppx_deriving_cmdliner"
+tags: ["syntax" "cli"]
+dev-repo: "https://github.com/ihodes/ppx_deriving_cmdliner.git"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "cmdliner"
+  "result"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ocamlfind" {build}
+  "cppo" {build}
+  "alcotest" {test}
+  "ppx_import" {test & >= "1.1"}
+]

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/url
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/hammerlab/ppx_deriving_cmdliner/archive/v0.0.0.tar.gz"
+checksum: "976fd6fac87489ad76f81f10329fe1b8"


### PR DESCRIPTION
Cmdliner.Term.t generator

ppx_deriving_cmdliner is a ppx_deriving plugin that generates
Cmdliner Terms for types.


---
* Homepage: https://github.com/ihodes/ppx_deriving_cmdliner
* Source repo: https://github.com/ihodes/ppx_deriving_cmdliner.git
* Bug tracker: https://github.com/ihodes/ppx_deriving_cmdliner/issues

---

Pull-request generated by opam-publish v0.3.4