### PR TITLE
ocaml-migrate-parsetree.0.4 - via opam-publish

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.4/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.4/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.4/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.4/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
+license: "LGPL-2.1"
+tags: ["syntax" "org:ocamllabs"]
+dev-repo: "git://github.com/let-def/ocaml-migrate-parsetree.git"
+build: [
+  ["jbuilder" "build" "--only-packages" "ocaml-migrate-parsetree" "--root" "." "-j" jobs "@install"]
+]
+depends: [
+  "result"
+  "jbuilder" { build & >= "1.0+beta2" }
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.4/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.4/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/let-def/ocaml-migrate-parsetree/archive/v0.4.tar.gz"
+checksum: "d69d4197111a3208ba659d7f9a98dfd0"


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
High-level functions help making PPX rewriters independent of a compiler version.


---
* Homepage: https://github.com/let-def/ocaml-migrate-parsetree
* Source repo: git://github.com/let-def/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/let-def/ocaml-migrate-parsetree/issues

---

Pull-request generated by opam-publish v0.3.4