### PR TITLE
Jbuilder 1.0+beta2

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta2/descr
+++ b/packages/jbuilder/jbuilder.1.0+beta2/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+jbuilder is a build system that was designed to simplify the release
+of Jane Street packages. It reads metadata from "jbuild" files
+following a very simple s-expression syntax.
+
+jbuilder is fast, it has very low-overhead and support parallel builds
+on all platforms. It has no system dependencies, all you need to build
+jbuilder and packages using jbuilder is OCaml. You don't need or make
+or bash as long as the packages themselves don't use bash explicitely.
+
+jbuilder supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/jbuilder/jbuilder.1.0+beta2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta2/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+version: "1.0+beta2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/jbuilder"
+bug-reports: "https://github.com/janestreet/jbuilder/issues"
+dev-repo: "https://github.com/janestreet/jbuilder.git"
+license: "Apache-2.0"
+build: [
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "-j" jobs]
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/jbuilder/jbuilder.1.0+beta2/url
+++ b/packages/jbuilder/jbuilder.1.0+beta2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/jbuilder/archive/1.0+beta2.tar.gz"
+checksum: "cb1758018865d5d7ed26960df2a75e5a"


### PR DESCRIPTION
This fixes the bug where `jbuilder` would often use the home directory as compilation root