### PR TITLE
scrypt-kdf.0.4.0 - via opam-publish

### DIFF
--- a/packages/scrypt-kdf/scrypt-kdf.0.4.0/descr
+++ b/packages/scrypt-kdf/scrypt-kdf.0.4.0/descr
@@ -1,0 +1,3 @@
+Scrypt Password-Based Key Derivation Function
+
+A pure OCaml implementation of [scrypt](https://en.wikipedia.org/wiki/Scrypt) password based key derivation function, as defined in [The scrypt Password-Based Key Derivation Function internet draft](https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-04), including test cases from the RFC.

--- a/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+homepage:     "https://github.com/abeaumont/ocaml-scrypt-kdf"
+dev-repo:     "https://github.com/abeaumont/ocaml-scrypt-kdf.git"
+bug-reports:  "https://github.com/abeaumont/ocaml-scrypt-kdf/issues"
+authors:      ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
+maintainer:   ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
+license:      "BSD2"
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.3"}
+  "pbkdf" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0"}
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/scrypt-kdf/scrypt-kdf.0.4.0/url
+++ b/packages/scrypt-kdf/scrypt-kdf.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/abeaumont/ocaml-scrypt-kdf/archive/0.4.0.tar.gz"
+checksum: "0665c7a2bf92a23ad960922b0ce04a3c"


### PR DESCRIPTION
Scrypt Password-Based Key Derivation Function

A pure OCaml implementation of [scrypt](https://en.wikipedia.org/wiki/Scrypt) password based key derivation function, as defined in [The scrypt Password-Based Key Derivation Function internet draft](https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-04), including test cases from the RFC.

---
* Homepage: https://github.com/abeaumont/ocaml-scrypt-kdf
* Source repo: https://github.com/abeaumont/ocaml-scrypt-kdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-scrypt-kdf/issues

---


---
# 0.4.0 (2017-03-09)

* Removed Makefile, unneeded with topkg
* Made pkg.ml executable
* Added salsa20-core as a dependency and remove related code
Pull-request generated by opam-publish v0.3.3