### PR TITLE
ppx_deriving: apply one-line build-system patch to (>= 3.1) versions

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.3.1/files/fix_ppx_deriving_make_mllib.patch
+++ b/packages/ppx_deriving/ppx_deriving.3.1/files/fix_ppx_deriving_make_mllib.patch
@@ -1,0 +1,18 @@
+From a4428407e974361d872e0a70e036bc7ee20e8467 Mon Sep 17 00:00:00 2001
+From: whitequark <whitequark@whitequark.org>
+Date: Tue, 28 Feb 2017 00:37:56 +0000
+Subject: [PATCH] Fix ppx_deriving_make.mllib.
+
+This is a bug that goes back all the way to c2fb119f, but it was
+hidden by a matching bug in ocamlbuild <0.11.
+---
+ src_plugins/ppx_deriving_make.mllib | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src_plugins/ppx_deriving_make.mllib b/src_plugins/ppx_deriving_make.mllib
+index 1b2681b..7f23204 100644
+--- a/src_plugins/ppx_deriving_make.mllib
++++ b/src_plugins/ppx_deriving_make.mllib
+@@ -1 +1 @@
+-ppx_deriving_create
++ppx_deriving_make

--- a/packages/ppx_deriving/ppx_deriving.3.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.1/opam
@@ -29,3 +29,4 @@ depends: [
   "ounit" {test}
 ]
 available: [ocaml-version >= "4.02.1" & ocaml-version < "4.03" & opam-version >= "1.2"]
+patches: [ "fix_ppx_deriving_make_mllib.patch" ]

--- a/packages/ppx_deriving/ppx_deriving.3.2/files/fix_ppx_deriving_make_mllib.patch
+++ b/packages/ppx_deriving/ppx_deriving.3.2/files/fix_ppx_deriving_make_mllib.patch
@@ -1,0 +1,18 @@
+From a4428407e974361d872e0a70e036bc7ee20e8467 Mon Sep 17 00:00:00 2001
+From: whitequark <whitequark@whitequark.org>
+Date: Tue, 28 Feb 2017 00:37:56 +0000
+Subject: [PATCH] Fix ppx_deriving_make.mllib.
+
+This is a bug that goes back all the way to c2fb119f, but it was
+hidden by a matching bug in ocamlbuild <0.11.
+---
+ src_plugins/ppx_deriving_make.mllib | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src_plugins/ppx_deriving_make.mllib b/src_plugins/ppx_deriving_make.mllib
+index 1b2681b..7f23204 100644
+--- a/src_plugins/ppx_deriving_make.mllib
++++ b/src_plugins/ppx_deriving_make.mllib
+@@ -1 +1 @@
+-ppx_deriving_create
++ppx_deriving_make

--- a/packages/ppx_deriving/ppx_deriving.3.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.2/opam
@@ -26,3 +26,4 @@ depends: [
   "ounit"      {test}
 ]
 available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" & opam-version >= "1.2" ]
+patches: [ "fix_ppx_deriving_make_mllib.patch" ]

--- a/packages/ppx_deriving/ppx_deriving.3.3/files/fix_ppx_deriving_make_mllib.patch
+++ b/packages/ppx_deriving/ppx_deriving.3.3/files/fix_ppx_deriving_make_mllib.patch
@@ -1,0 +1,18 @@
+From a4428407e974361d872e0a70e036bc7ee20e8467 Mon Sep 17 00:00:00 2001
+From: whitequark <whitequark@whitequark.org>
+Date: Tue, 28 Feb 2017 00:37:56 +0000
+Subject: [PATCH] Fix ppx_deriving_make.mllib.
+
+This is a bug that goes back all the way to c2fb119f, but it was
+hidden by a matching bug in ocamlbuild <0.11.
+---
+ src_plugins/ppx_deriving_make.mllib | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src_plugins/ppx_deriving_make.mllib b/src_plugins/ppx_deriving_make.mllib
+index 1b2681b..7f23204 100644
+--- a/src_plugins/ppx_deriving_make.mllib
++++ b/src_plugins/ppx_deriving_make.mllib
+@@ -1 +1 @@
+-ppx_deriving_create
++ppx_deriving_make

--- a/packages/ppx_deriving/ppx_deriving.3.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.3/opam
@@ -27,3 +27,4 @@ depends: [
   "ounit"      {test}
 ]
 available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+patches: [ "fix_ppx_deriving_make_mllib.patch" ]

--- a/packages/ppx_deriving/ppx_deriving.4.0/files/fix_ppx_deriving_make_mllib.patch
+++ b/packages/ppx_deriving/ppx_deriving.4.0/files/fix_ppx_deriving_make_mllib.patch
@@ -1,0 +1,18 @@
+From a4428407e974361d872e0a70e036bc7ee20e8467 Mon Sep 17 00:00:00 2001
+From: whitequark <whitequark@whitequark.org>
+Date: Tue, 28 Feb 2017 00:37:56 +0000
+Subject: [PATCH] Fix ppx_deriving_make.mllib.
+
+This is a bug that goes back all the way to c2fb119f, but it was
+hidden by a matching bug in ocamlbuild <0.11.
+---
+ src_plugins/ppx_deriving_make.mllib | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src_plugins/ppx_deriving_make.mllib b/src_plugins/ppx_deriving_make.mllib
+index 1b2681b..7f23204 100644
+--- a/src_plugins/ppx_deriving_make.mllib
++++ b/src_plugins/ppx_deriving_make.mllib
+@@ -1 +1 @@
+-ppx_deriving_create
++ppx_deriving_make

--- a/packages/ppx_deriving/ppx_deriving.4.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.0/opam
@@ -28,3 +28,4 @@ depends: [
   "ounit"      {test}
 ]
 available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+patches: [ "fix_ppx_deriving_make_mllib.patch" ]

--- a/packages/ppx_deriving/ppx_deriving.4.1/files/fix_ppx_deriving_make_mllib.patch
+++ b/packages/ppx_deriving/ppx_deriving.4.1/files/fix_ppx_deriving_make_mllib.patch
@@ -1,0 +1,18 @@
+From a4428407e974361d872e0a70e036bc7ee20e8467 Mon Sep 17 00:00:00 2001
+From: whitequark <whitequark@whitequark.org>
+Date: Tue, 28 Feb 2017 00:37:56 +0000
+Subject: [PATCH] Fix ppx_deriving_make.mllib.
+
+This is a bug that goes back all the way to c2fb119f, but it was
+hidden by a matching bug in ocamlbuild <0.11.
+---
+ src_plugins/ppx_deriving_make.mllib | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src_plugins/ppx_deriving_make.mllib b/src_plugins/ppx_deriving_make.mllib
+index 1b2681b..7f23204 100644
+--- a/src_plugins/ppx_deriving_make.mllib
++++ b/src_plugins/ppx_deriving_make.mllib
+@@ -1 +1 @@
+-ppx_deriving_create
++ppx_deriving_make

--- a/packages/ppx_deriving/ppx_deriving.4.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1/opam
@@ -28,3 +28,4 @@ depends: [
   "ounit"      {test}
 ]
 available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+patches: [ "fix_ppx_deriving_make_mllib.patch" ]


### PR DESCRIPTION
The patch is
  https://github.com/whitequark/ppx_deriving/commit/a4428407e974361d872e0a70e036bc7ee20e8467

See discussion in
  https://github.com/ocaml/opam-repository/pull/8656
  https://github.com/whitequark/ppx_deriving/issues/124

I checked that the patch applies to all these versions.