### PR TITLE
ocaml-top.1.1.3 - via opam-publish

### DIFF
--- a/packages/ocaml-top/ocaml-top.1.1.3/descr
+++ b/packages/ocaml-top/ocaml-top.1.1.3/descr
@@ -1,0 +1,6 @@
+The OCaml interactive editor for education
+
+OCaml-top is a GTK-based editor coupled with an OCaml top-level, providing
+straight forward evaluation controls, built-in syntax coloring and forced visual
+indentation. It's cross-platform and specially tailored for students and
+practicals.

--- a/packages/ocaml-top/ocaml-top.1.1.3/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "contact@ocamlpro.com"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "http://www.typerex.org/ocaml-top.html"
+tags: [ "org:ocamlpro" "gui" "teaching" "toplevel" ]
+license: "GPL 3"
+build: [
+  ["ocp-build" "init"]
+  ["ocp-build" "ocaml-top"]
+]
+depends: [
+  "ocp-build" {>= "1.99.6-beta"}
+  "lablgtk" {>= "2.16.0"}
+  "conf-gtksourceview" {= "2"}
+  "ocp-indent" {>= "1.4.0"}
+  "ocp-index" {>= "1.0.0"}
+]

--- a/packages/ocaml-top/ocaml-top.1.1.3/url
+++ b/packages/ocaml-top/ocaml-top.1.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocaml-top/archive/1.1.3.tar.gz"
+checksum: "0b66f061a4464ccec6006bc342a47884"


### PR DESCRIPTION
The OCaml interactive editor for education

OCaml-top is a GTK-based editor coupled with an OCaml top-level, providing
straight forward evaluation controls, built-in syntax coloring and forced visual
indentation. It's cross-platform and specially tailored for students and
practicals.


---
* Homepage: http://www.typerex.org/ocaml-top.html
* Source repo: 
* Bug tracker: 

---
### opam-lint failures
- **WARNING** 37 Missing field 'dev-repo'
- **WARNING** 36 Missing field 'bug-reports'

---

Pull-request generated by opam-publish v0.3.4