### PR TITLE
conf-perl: install pod2html in Fedora

### DIFF
--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -11,4 +11,5 @@ depexts: [
   [["alpine"]["perl"]]
   [["nixpkgs"] ["perl"]]
   [["archlinux"] ["perl"]]
+  [["fedora"] ["perl-Pod-Html"]]
 ]


### PR DESCRIPTION
pod2html appears to be installed in most system distros of perl,
except for Fedora. This commit fixes that, and a common CI problem
with installing dose3 with Fedora in the mix (mirage/ocaml-github#196)