### PR TITLE
ocamlnet: Set ocamlbuild & ocamlfind as build depend

### DIFF
--- a/packages/ocamlnet/ocamlnet.3.2.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.2.1/opam
@@ -25,7 +25,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "pcre"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.5.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.5.1/opam
@@ -41,7 +41,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "pcre"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.6.0/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.0/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "ocamlfind" {build}
+  "camlp4"
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.6.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.3/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "ocamlfind" {build}
+  "camlp4"
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.6.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.5/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "camlp4" ]
+depends: [
+  "ocamlfind" {build}
+  "camlp4"
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.3/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "ocamlfind" {build}
+  "camlp4"
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.4-1/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4-1/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "ocamlfind" {build}
+  "camlp4"
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.4/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "camlp4"]
+depends: [
+  "ocamlfind" {build}
+  "camlp4"
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.5/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "ocamlbuild"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.6/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.6/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "ocamlbuild"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -44,7 +44,10 @@ remove: [
   ["ocamlfind" "remove" "shell"]
   ["ocamlfind" "remove" "smtp"]
 ]
-depends: ["ocamlfind" "ocamlbuild"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
 depopts: [
   "lablgtk"
   "pcre"

--- a/packages/ocamlnet/ocamlnet.4.0.1/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.1/opam
@@ -45,7 +45,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild"
+  "ocamlbuild" {build}
 ]
 depopts: [
   "conf-gnutls"

--- a/packages/ocamlnet/ocamlnet.4.0.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.2/opam
@@ -45,7 +45,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild"
+  "ocamlbuild" {build}
 ]
 depopts: [
   "conf-gnutls"

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -46,7 +46,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild"
+  "ocamlbuild" {build}
 ]
 depopts: [
   "conf-gnutls"

--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -48,7 +48,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild"
+  "ocamlbuild" {build}
   "base-bytes"
 ]
 depopts: [


### PR DESCRIPTION
Correct me if I'm wrong but I think those dependencies should be tagged as ```build``` depends (to avoid unnecessary recompilation).