### PR TITLE
git-unix.1.10.1 - via opam-publish

### DIFF
--- a/packages/git-unix/git-unix.1.10.1/descr
+++ b/packages/git-unix/git-unix.1.10.1/descr
@@ -1,0 +1,5 @@
+Unix backend for the Git protocol(s)
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git-unix/git-unix.1.10.1/opam
+++ b/packages/git-unix/git-unix.1.10.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "cmdliner"
+  "git-http" {>= "1.10.0"}
+  "conduit"  {>= "0.8.4"}
+  "camlzip"  {>= "1.06"}
+  "nocrypto" {>= "0.2.0"}
+  "mtime"
+  "base-unix"
+  "alcotest"       {test}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-unix/git-unix.1.10.1/url
+++ b/packages/git-unix/git-unix.1.10.1/url
@@ -1,0 +1,2 @@
+archive: "git+https://github.com/mirage/ocaml-git/releases/download/1.10.1/git-1.10.1.tbz"
+checksum: "a228ae03ea69b6180d731bac8677f2c7"

--- a/packages/git-unix/git-unix.1.10.1/url
+++ b/packages/git-unix/git-unix.1.10.1/url
@@ -1,2 +1,2 @@
-archive: "git+https://github.com/mirage/ocaml-git/releases/download/1.10.1/git-1.10.1.tbz"
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.10.1/git-1.10.1.tbz"
 checksum: "a228ae03ea69b6180d731bac8677f2c7"


### PR DESCRIPTION
Unix backend for the Git protocol(s)

The library comes with a command-line tool called `ogit` which shares
a similar interface with `git`, but where all operations are mapped to
the API exposed `ocaml-git` (and hence using only OCaml code).


---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---


---
### 1.10.1 (2016-09-15)

* Improve API docs (#201, @olleolleolle)
* Compat with cmdliner 1.0 (#202, @samoht)
* Fix typos and links in docs (@smeruelo and @olleolleolle)
Pull-request generated by opam-publish v0.3.2