### PR TITLE
Add llvm.4.0

### DIFF
--- a/packages/llvm/llvm.4.0.0/descr
+++ b/packages/llvm/llvm.4.0.0/descr
@@ -1,0 +1,3 @@
+The OCaml bindings distributed with LLVM
+
+Note: LLVM should be installed first.

--- a/packages/llvm/llvm.4.0.0/files/META.patch
+++ b/packages/llvm/llvm.4.0.0/files/META.patch
@@ -1,0 +1,186 @@
+diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/bindings/ocaml/backends/META.llvm_backend.in
++++ b/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,8 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte, -llvm.static) = "dynamic/llvm_@TARGET@.cma"
++archive(native, -llvm.static) = "dynamic/llvm_@TARGET@.cmxa"
++archive(byte, llvm.static) = "static/llvm_@TARGET@.cma"
++archive(native, llvm.static) = "static/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+index adafd788ebf..0f54ae1e4b0 100644
+--- a/bindings/ocaml/llvm/META.llvm.in
++++ b/bindings/ocaml/llvm/META.llvm.in
+@@ -1,110 +1,138 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte, -llvm.static) = "dynamic/llvm.cma"
++archive(native, -llvm.static) = "dynamic/llvm.cmxa"
++archive(byte, llvm.static) = "static/llvm.cma"
++archive(native, llvm.static) = "static/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_analysis.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_analysis.cmxa"
++    archive(byte, llvm.static) = "static/llvm_analysis.cma"
++    archive(native, llvm.static) = "static/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_bitreader.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_bitreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitreader.cma"
++    archive(native, llvm.static) = "static/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_bitwriter.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_bitwriter.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitwriter.cma"
++    archive(native, llvm.static) = "static/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_executionengine.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_executionengine.cmxa"
++    archive(byte, llvm.static) = "static/llvm_executionengine.cma"
++    archive(native, llvm.static) = "static/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_ipo.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_ipo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_ipo.cma"
++    archive(native, llvm.static) = "static/llvm_ipo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_irreader.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_irreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_irreader.cma"
++    archive(native, llvm.static) = "static/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_scalar_opts.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_scalar_opts.cmxa"
++    archive(byte, llvm.static) = "static/llvm_scalar_opts.cma"
++    archive(native, llvm.static) = "static/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_transform_utils.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_transform_utils.cmxa"
++    archive(byte, llvm.static) = "static/llvm_transform_utils.cma"
++    archive(native, llvm.static) = "static/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_vectorize.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_vectorize.cmxa"
++    archive(byte, llvm.static) = "static/llvm_vectorize.cma"
++    archive(native, llvm.static) = "static/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_passmgr_builder.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_passmgr_builder.cmxa"
++    archive(byte, llvm.static) = "static/llvm_passmgr_builder.cma"
++    archive(native, llvm.static) = "static/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_target.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_target.cmxa"
++    archive(byte, llvm.static) = "static/llvm_target.cma"
++    archive(native, llvm.static) = "static/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_linker.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_linker.cmxa"
++    archive(byte, llvm.static) = "static/llvm_linker.cma"
++    archive(native, llvm.static) = "static/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte, -llvm.static) = "dynamic/llvm_all_backends.cma"
++    archive(native, -llvm.static) = "dynamic/llvm_all_backends.cmxa"
++    archive(byte, llvm.static) = "static/llvm_all_backends.cma"
++    archive(native, llvm.static) = "static/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.4.0.0/files/dynamic-link.patch
+++ b/packages/llvm/llvm.4.0.0/files/dynamic-link.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/modules/AddOCaml.cmake b/cmake/modules/AddOCaml.cmake
+index e3dd1d8..eb3c4a2 100644
+--- a/cmake/modules/AddOCaml.cmake
++++ b/cmake/modules/AddOCaml.cmake
+@@ -68,7 +68,5 @@ function(add_ocaml_library name)
+ 
+   explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+-  foreach( llvm_lib ${llvm_libs} )
+-    list(APPEND ocaml_flags "-l${llvm_lib}" )
+-  endforeach()
++  list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}" )
+ 
+   get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)

--- a/packages/llvm/llvm.4.0.0/files/install.sh
+++ b/packages/llvm/llvm.4.0.0/files/install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -ex
+
+version=${1/%.?/}
+libdir=$2
+
+function llvm_save {
+    cp cmake/modules/AddOCaml.cmake AddOCaml.cmake.save
+}
+
+function llvm_restore {
+    cp AddOCaml.cmake.save cmake/modules/AddOCaml.cmake
+}
+
+function llvm_install {
+    patch -p1 < $1-link.patch
+
+    mkdir build
+    cd build
+
+    cmake -DLLVM_OCAML_OUT_OF_TREE=TRUE -DLLVM_OCAML_INSTALL_PATH="${libdir}" ..
+    make ocaml_all
+    make -C bindings/ocaml install/fast
+
+    cd ..
+
+    mkdir $1
+    cp "${libdir}"/llvm/*.a $1
+    mv "${libdir}"/llvm/*.cma $1
+    mv "${libdir}"/llvm/*.cmxa $1
+
+    rm -rf build
+
+    llvm_restore
+}
+
+if hash brew 2>/dev/null; then
+    brew_llvm_config="$(brew --prefix)"/llvm/${version}*/bin/llvm-config
+fi
+
+shopt -s nullglob
+for llvm_config in llvm-config-$version llvm-config${version//./} llvm-config-mp-$version ${brew_llvm_config} llvm-config; do
+    case `$llvm_config --version` in
+        $version*)
+            shopt -u nullglob
+            llvm_libdir=$($llvm_config --libdir)
+            sed -i "s,%%LIBDIR%%,${llvm_libdir}," static-link.patch
+            llvm_save
+            llvm_install static
+            llvm_install dynamic
+            mv static "${libdir}"/llvm
+            mv dynamic "${libdir}"/llvm
+            exit 0;;
+        *)
+            continue;;
+    esac
+done
+
+echo "Error: LLVM ${version} is not installed."
+exit 1

--- a/packages/llvm/llvm.4.0.0/files/install.sh
+++ b/packages/llvm/llvm.4.0.0/files/install.sh
@@ -34,7 +34,7 @@ function llvm_install {
 }
 
 if hash brew 2>/dev/null; then
-    brew_llvm_config="$(brew --prefix)"/llvm/${version}*/bin/llvm-config
+    brew_llvm_config="$(brew --cellar)"/llvm/${version}*/bin/llvm-config
 fi
 
 shopt -s nullglob

--- a/packages/llvm/llvm.4.0.0/files/static-link.patch
+++ b/packages/llvm/llvm.4.0.0/files/static-link.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/modules/AddOCaml.cmake b/cmake/modules/AddOCaml.cmake
+index 1b805c0710a..f5255f145b0 100644
+--- a/cmake/modules/AddOCaml.cmake
++++ b/cmake/modules/AddOCaml.cmake
+@@ -70,6 +70,7 @@ function(add_ocaml_library name)
+   foreach( llvm_lib ${llvm_libs} )
+     list(APPEND ocaml_flags "-l${llvm_lib}" )
+   endforeach()
++  list(APPEND ocaml_flags "-ccopt" "-L%%LIBDIR%%" )
+ 
+   get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+   foreach(system_lib ${system_libs})

--- a/packages/llvm/llvm.4.0.0/opam
+++ b/packages/llvm/llvm.4.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Jacques-Pascal Deplaix <jp.deplaix@gmail.com>"
+authors: [
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "MIT"
+doc: "http://llvm.moe/ocaml-4.0"
+bug-reports: "http://llvm.org/bugs/"
+dev-repo: "http://llvm.org/git/llvm.git"
+homepage: "http://llvm.moe"
+patches: [
+  "META.patch"
+]
+install: [
+  ["bash" "-ex" "install.sh" version lib]
+]
+remove: [
+  ["rm" "-rf" "%{lib}%/llvm"]
+  ["sh" "-c" "rm -f %{lib}%/META.llvm*"]
+]
+depends: [
+  "ctypes" {>= "0.4"}
+  "ounit" {test}
+  "ocamlfind" {build}
+]
+depexts: [
+  [["debian"] ["llvm-4.0-dev" "cmake"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/jpdeplaix/8c67a7b7619983fb49a3e315bc53ae79/raw"]]
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/llvm/llvm.4.0.0/url
+++ b/packages/llvm/llvm.4.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://releases.llvm.org/4.0.0/llvm-4.0.0.src.tar.xz"
+checksum: "ea9139a604be702454f6acf160b4f3a2"


### PR DESCRIPTION
This also should (f i x) #8265 for 4.0. @magv can you confirm ?
3.9 didn't work for static setups unless you manually put ```-ccopt -L/usr/lib/llvm-3.9/lib``` during linking phase.
This package enforce shared linking (saner since you usually don't want a tiny 40Mo executable for each of your project using LLVM). Maybe we can find a work around later but for now this is good enough.

@whitequark if you don't have time I can try to make an upstream patch to switch between static and shared using the existing flags.