### PR TITLE
irmin.1.0.1 - via opam-publish

### DIFF
--- a/packages/irmin/irmin.1.0.1/descr
+++ b/packages/irmin/irmin.1.0.1/descr
@@ -1,0 +1,7 @@
+Irmin, a distributed database that follows the same design principles as Git
+
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.

--- a/packages/irmin/irmin.1.0.1/opam
+++ b/packages/irmin/irmin.1.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build:
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"]
+
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.7.8"}
+  "fmt"
+  "ocamlgraph"
+  "lwt" {>= "2.4.7"}
+  "logs" {>= "0.5.0"}
+  "cstruct" {>= "1.6.0"}
+  "jsonm" {>= "1.0.0"}
+  "uri" {>= "1.3.12"}
+  "astring"
+  "hex"
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.0.1/url
+++ b/packages/irmin/irmin.1.0.1/url
@@ -1,2 +1,2 @@
-archive: "git+https://github.com/mirage/irmin/releases/download/1.0.1/irmin-1.0.1.tbz"
+archive: "https://github.com/mirage/irmin/releases/download/1.0.1/irmin-1.0.1.tbz"
 checksum: "dbe3b140e7cf8159a55adf8849faae2e"

--- a/packages/irmin/irmin.1.0.1/url
+++ b/packages/irmin/irmin.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "git+https://github.com/mirage/irmin/releases/download/1.0.1/irmin-1.0.1.tbz"
+checksum: "dbe3b140e7cf8159a55adf8849faae2e"


### PR DESCRIPTION
Irmin, a distributed database that follows the same design principles as Git

Irmin is a library for persistent stores with built-in snapshot,
branching and reverting mechanisms. It is designed to use a large
variety of backends. Irmin is written in pure OCaml and does not
depend on external C stubs; it aims to run everywhere, from Linux,
to browsers and Xen unikernels.


---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 1.0.1 (2017-03-14)

*** irmin ****

- Default merge function should not assume idempotence of edits
  (#420, @kayceesrk)
- Wrap the merge functions for pair and triple with the default case.
  (#420, @kayceesrk)

*** irmin-unix ***

- Support all versions of cmdliner, 1.0.0 included (@samoht)
Pull-request generated by opam-publish v0.3.2