### PR TITLE
irmin-unix.1.0.1 - via opam-publish

### DIFF
--- a/packages/irmin-unix/irmin-unix.1.0.1/descr
+++ b/packages/irmin-unix/irmin-unix.1.0.1/descr
@@ -1,0 +1,5 @@
+Unix backends for Irmin
+
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.

--- a/packages/irmin-unix/irmin-unix.1.0.1/opam
+++ b/packages/irmin-unix/irmin-unix.1.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.7.8"}
+  "irmin"      {>= "1.0.0"}
+  "irmin-git"  {>= "1.0.0"}
+  "irmin-http" {>= "1.0.0"}
+  "git-unix"   {>= "1.10.0"}
+  "irmin-watcher"
+  "irmin-mirage" {test & >= "1.0.0"}
+  "alcotest"     {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-unix/irmin-unix.1.0.1/url
+++ b/packages/irmin-unix/irmin-unix.1.0.1/url
@@ -1,2 +1,2 @@
-archive: "git+https://github.com/mirage/irmin/releases/download/1.0.1/irmin-1.0.1.tbz"
+archive: "https://github.com/mirage/irmin/releases/download/1.0.1/irmin-1.0.1.tbz"
 checksum: "dbe3b140e7cf8159a55adf8849faae2e"

--- a/packages/irmin-unix/irmin-unix.1.0.1/url
+++ b/packages/irmin-unix/irmin-unix.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "git+https://github.com/mirage/irmin/releases/download/1.0.1/irmin-1.0.1.tbz"
+checksum: "dbe3b140e7cf8159a55adf8849faae2e"


### PR DESCRIPTION
Unix backends for Irmin

`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
stores.

---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 1.0.1 (2017-03-14)

*** irmin ****

- Default merge function should not assume idempotence of edits
  (#420, @kayceesrk)
- Wrap the merge functions for pair and triple with the default case.
  (#420, @kayceesrk)

*** irmin-unix ***

- Support all versions of cmdliner, 1.0.0 included (@samoht)
Pull-request generated by opam-publish v0.3.2