### PR TITLE
topkg-care.0.9.0 - via opam-publish

### DIFF
--- a/packages/topkg-care/topkg-care.0.9.0/descr
+++ b/packages/topkg-care/topkg-care.0.9.0/descr
@@ -1,0 +1,25 @@
+The transitory OCaml software packager
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser

--- a/packages/topkg-care/topkg-care.0.9.0/opam
+++ b/packages/topkg-care/topkg-care.0.9.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+  "topkg" {= "0.9.0"}
+  "result"
+  "fmt"
+  "logs"
+  "bos"
+  "cmdliner" {>= "1.0.0"}
+  "webbrowser"
+  "opam-format"
+]
+build:[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--dev-pkg" "%{pinned}%"
+]

--- a/packages/topkg-care/topkg-care.0.9.0/url
+++ b/packages/topkg-care/topkg-care.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/topkg/releases/topkg-0.9.0.tbz"
+checksum: "1700991f570b9aaf49e6aad7d886e154"


### PR DESCRIPTION
The transitory OCaml software packager 

Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution, creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml opam repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
[webbrowser][webbrowser] and `opam-format`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner
[webbrowser]: http://erratique.ch/software/webbrowser


---
* Homepage: http://erratique.ch/software/topkg
* Source repo: http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---


---
v0.9.0 La Forclaz (VS)
----------------------

- Deprecate `--pinned` in favor of `--dev-pkg` in the `build` command.
  The semantics is the same and with opam < 2.0 it should still be set
  to `"%{pinned}%"`. With opam >= 2.0 it should be set to `"%{dev}%"`
  this allows to infer the correct build context for (non-pinned) VCS
  packages (#79).
- Improve `ocamlbuild` cross-compilation support. Adds the
  `Conf.toolchain` configuration key. If specified on the command line
  or via the `TOPKG_CONF_TOOLCHAIN` environment variable, its value is
  used with the `-toolchain` option introduced in `ocamlbuild` 0.11.0
  in default build command `Pkg.build_cmd`. If unspecified the default
  build command is left unchanged. Thanks to whitequark for the patch.
- Add the `--raw ARG` repeteable option to the `build` command. Allows
  to skip package build instructions and opam install file generation
  to simply invoke the package build command with the `ARG` argument.
- `topkg doc` (ocamlbuild specific). Build the documentation using
  the package `build` command and `--raw` arguments. Avoids problems
  encountered by packages that use ocamlbuild plugins (#80).
- Add the `cma`, `cmxa` and `cmxs` optional arguments to `Pkg.mllib`.
  These allow to precisely specify what you (don't) want to build. They
  all default to `true`. Thanks to Stephen Dolan for the suggestion.
- Add `Pkg.lib_root` and `Pkg.libexec_root` install fields. Warning
  these are opam 2.0 only fields.
- Change `test` command for multi-opam packages by mirroring the way
  the `build` command works. The `--pkg-name` or `-n` option specifies
  the package's test to run or list. If unspecified the default
  package is tested, before `pkg/pkg.ml test` would list and run
  the last built package. This means that if you have `pkg/pkg.ml
  build -n PKG && pkg/pkg test` invocations you need to turn them into
  `pkg/pkg.ml build -n PKG && pkg/pkg test -n PKG`.
- Fix `topkg run`, do not run `.so` and `.cmxs` files.
- Fix changelog parsing. Subsections of an entry were not being properly
  parsed (#103).
- Fix `topkg opam pkg`'s `url` file generation for github users which
  have `dev-repo:` with opam "version control bound" uris (#106).
- Depends at least on `cmdliner.1.0.0` and `opam-format` (`opam-lib`
  is out).
Pull-request generated by opam-publish v0.3.4