### PR TITLE
cfstream.1.2.2 - via opam-publish

### DIFF
--- a/packages/cfstream/cfstream.1.2.2/descr
+++ b/packages/cfstream/cfstream.1.2.2/descr
@@ -1,0 +1,1 @@
+Stream operations in the style of Core's API.

--- a/packages/cfstream/cfstream.1.2.2/opam
+++ b/packages/cfstream/cfstream.1.2.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Ashish Agarwal <agarwal1975@gmail.com>"
+authors: [
+  "Philippe Veber <philippe.veber@gmail.com>"
+  "Ashish Agarwal <agarwal1975@gmail.com>"
+  "Drup <drupyog@zoho.com>"
+]
+homepage: "https://github.com/biocaml/cfstream"
+bug-reports: "https://github.com/biocaml/cfstream/issues"
+license: "LGPL + linking exception"
+dev-repo: "https://github.com/biocaml/cfstream.git"
+build: [
+  [make "byte"]
+  [make "native"]
+  [make "_build/META"]
+  [make "%{name}%.install"]
+]
+depends: [
+  "ocamlfind" {build}
+  "solvuu-build" {build & >= "0.3.0"}
+  "core_kernel"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/cfstream/cfstream.1.2.2/url
+++ b/packages/cfstream/cfstream.1.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/biocaml/cfstream/archive/1.2.2.tar.gz"
+checksum: "cfbd9a0cfa53f94cebcd98387586bc7e"


### PR DESCRIPTION
Stream operations in the style of Core's API.


---
* Homepage: https://github.com/biocaml/cfstream
* Source repo: https://github.com/biocaml/cfstream.git
* Bug tracker: https://github.com/biocaml/cfstream/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3