### PR TITLE
fmt.0.8.1 - via opam-publish

### DIFF
--- a/packages/fmt/fmt.0.8.1/descr
+++ b/packages/fmt/fmt.0.8.1/descr
@@ -1,0 +1,12 @@
+OCaml Format pretty-printer combinators
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner

--- a/packages/fmt/fmt.0.8.1/opam
+++ b/packages/fmt/fmt.0.8.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [
+  "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  "Gabriel Radanne"
+]
+homepage: "http://erratique.ch/software/fmt"
+doc: "http://erratique.ch/software/fmt"
+dev-repo: "http://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "result"
+  "uchar"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]

--- a/packages/fmt/fmt.0.8.1/url
+++ b/packages/fmt/fmt.0.8.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/fmt/releases/fmt-0.8.1.tbz"
+checksum: "516ee813a08f1f5ea122b51a2d1bdb06"


### PR DESCRIPTION
OCaml Format pretty-printer combinators

Fmt exposes combinators to devise `Format` pretty-printing functions.

Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
library that allows to setup formatters for terminal color output
depends on the Unix library. The optional `Fmt_cli` library that
provides command line support for Fmt depends on [`Cmdliner`][cmdliner].

Fmt is distributed under the ISC license.

[cmdliner]: http://erratique.ch/software/cmdliner


---
* Homepage: http://erratique.ch/software/fmt
* Source repo: http://erratique.ch/repos/fmt.git
* Bug tracker: https://github.com/dbuenzli/fmt/issues

---


---
v0.8.1 2017-03-15 La Forclaz (VS)
---------------------------------

* `Fmt_tty.setup`, treat empty `TERM` env var as dumb.
* Add `Fmt.Dump.uchar` formatter for inspecting `Uchar.t` values.
Pull-request generated by opam-publish v0.3.4