### PR TITLE
coclobas.0.0.1 - via opam-publish

### DIFF
--- a/packages/coclobas/coclobas.0.0.1/descr
+++ b/packages/coclobas/coclobas.0.0.1/descr
@@ -1,0 +1,11 @@
+Coclobas is a scheduler for HPC-like jobs accessible through HTTP
+
+It can be setup with two kinds of configurations:
+
+- Using Kubernetes and the *Google Container Engine*,
+  i.e. using a Kubernetes “eleastic” cluster setup with `gcloud` and submitting
+  jobs as Kubernetes “pods”.
+- Using the server's machine as a one-node cluster and submitting jobs as docker
+  containers given a maximal number of jobs.
+
+Coclobas is mostly used as a Ketrew plugin, but can be driven separately.

--- a/packages/coclobas/coclobas.0.0.1/opam
+++ b/packages/coclobas/coclobas.0.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: "Seb Mondet <seb@mondet.org>"
+homepage: "https://github.com/hammerlab/coclobas"
+bug-reports: "https://github.com/hammerlab/coclobas/issues"
+license: "Apache 2.0"
+dev-repo: "https://github.com/hammerlab/coclobas.git"
+build: [
+  [make "byte"]
+  [make "native"]
+  [make "META"]
+  [make "coclobas.install"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "solvuu-build" {build & >= "0.3.0"}
+  "nonstd"
+  "sosa"
+  "pvem_lwt_unix"
+  "cohttp" {>= "0.21.1" }
+  "lwt" {>= "2.6.0"}
+  "trakeva"
+  "cmdliner"
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.0"}
+  "uuidm"
+  "base64"
+  "odate"
+]
+depopts: "ketrew"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/coclobas/coclobas.0.0.1/url
+++ b/packages/coclobas/coclobas.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/coclobas/archive/coclobas.0.0.1.tar.gz"
+checksum: "76ca13fabd99fb05b8b2792ac303d7d5"


### PR DESCRIPTION
Coclobas is a scheduler for HPC-like jobs accessible through HTTP

It can be setup with two kinds of configurations:

- Using Kubernetes and the *Google Container Engine*,
  i.e. using a Kubernetes “eleastic” cluster setup with `gcloud` and submitting
  jobs as Kubernetes “pods”.
- Using the server's machine as a one-node cluster and submitting jobs as docker
  containers given a maximal number of jobs.

Coclobas is mostly used as a Ketrew plugin, but can be driven separately.


---
* Homepage: https://github.com/hammerlab/coclobas
* Source repo: https://github.com/hammerlab/coclobas.git
* Bug tracker: https://github.com/hammerlab/coclobas/issues

---

Pull-request generated by opam-publish v0.3.3