### PR TITLE
xmlm.1.3.0 - via opam-publish

### DIFF
--- a/packages/xmlm/xmlm.1.3.0/descr
+++ b/packages/xmlm/xmlm.1.3.0/descr
@@ -1,0 +1,8 @@
+Streaming XML codec for OCaml
+
+Xmlm is a streaming codec to decode and encode the XML data format. It
+can process XML documents without a complete in-memory representation of the
+data.
+
+Xmlm is made of a single independent module and distributed
+under the ISC license.

--- a/packages/xmlm/xmlm.1.3.0/opam
+++ b/packages/xmlm/xmlm.1.3.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/xmlm"
+dev-repo: "http://erratique.ch/repos/xmlm.git"
+bug-reports: "https://github.com/dbuenzli/xmlm/issues"
+doc: "http://erratique.ch/software/xmlm/doc/Xmlm"
+tags: [ "xml" "codec" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.02.0" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0" }
+]
+build:
+[[
+   "ocaml" "pkg/pkg.ml" "build"
+           "--dev-pkg" "%{pinned}%"
+]]

--- a/packages/xmlm/xmlm.1.3.0/url
+++ b/packages/xmlm/xmlm.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/xmlm/releases/xmlm-1.3.0.tbz"
+checksum: "d63ce15d913975211196b5079e86a797"


### PR DESCRIPTION
Streaming XML codec for OCaml

Xmlm is a streaming codec to decode and encode the XML data format. It
can process XML documents without a complete in-memory representation of the
data.

Xmlm is made of a single independent module and distributed
under the ISC license.


---
* Homepage: http://erratique.ch/software/xmlm
* Source repo: http://erratique.ch/repos/xmlm.git
* Bug tracker: https://github.com/dbuenzli/xmlm/issues

---


---
v1.3.0 2017-03-15 La Forclaz (VS)
---------------------------------

- Add `Xmlm.pp_{dtd,name,attribute,tag,signal}`
- Safe-string support.
- Build depend on topkg.
- Relicense from BSD3 to ISC.
Pull-request generated by opam-publish v0.3.4