### PR TITLE
jingoo: remove upper bounds on uutf

### DIFF
--- a/packages/jingoo/jingoo.1.2.13/opam
+++ b/packages/jingoo/jingoo.1.2.13/opam
@@ -11,4 +11,4 @@ build: [
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "jingoo"]
-depends: ["ocamlfind" "pcre" "uutf" {<= "0.9.4"} "ounit"]
+depends: ["ocamlfind" "pcre" "uutf" "ounit"]

--- a/packages/jingoo/jingoo.1.2.14/opam
+++ b/packages/jingoo/jingoo.1.2.14/opam
@@ -11,4 +11,4 @@ build: [
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "jingoo"]
-depends: ["ocamlfind" "pcre" "uutf" {<= "0.9.4"} "ounit"]
+depends: ["ocamlfind" "pcre" "uutf" "ounit"]


### PR DESCRIPTION
They were added in #6812 because of a breaking change in Uutf but in practice jingoo does not use this interface. So it can compile with both versions `< 1.0.0` and `>= 1.0.0`.

cc @dbuenzli @tategakibunko

Thanks!