### PR TITLE
Constrain xmldiff to xmlm < 1.3.0 due to configure failure.

### DIFF
--- a/packages/xmldiff/xmldiff.0.1/opam
+++ b/packages/xmldiff/xmldiff.0.1/opam
@@ -8,6 +8,6 @@ build: [make "all"]
 remove: [["ocamlfind" "remove" "xmldiff"]]
 depends: [
   "ocamlfind"
-  "xmlm"
+  "xmlm" { < "1.3.0" }
 ]
 install: [make "install"]

--- a/packages/xmldiff/xmldiff.0.2/opam
+++ b/packages/xmldiff/xmldiff.0.2/opam
@@ -8,7 +8,7 @@ build: [make "all"]
 remove: [["ocamlfind" "remove" "xmldiff"]]
 depends: [
   "ocamlfind"
-  "xmlm"
+  "xmlm" { < "1.3.0" }
 ]
 available: ocaml-version >= "4.00.0"
 install: [make "install"]

--- a/packages/xmldiff/xmldiff.0.3.0/opam
+++ b/packages/xmldiff/xmldiff.0.3.0/opam
@@ -13,7 +13,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "xmlm" {>= "1.1.0" }
+  "xmlm" {>= "1.1.0" & < "1.3.0" }
   "camlp4"
 ]
 depopts: ["js_of_ocaml"]

--- a/packages/xmldiff/xmldiff.0.4.0/opam
+++ b/packages/xmldiff/xmldiff.0.4.0/opam
@@ -13,7 +13,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "xmlm" {>= "1.1.0" }
+  "xmlm" {>= "1.1.0" & < "1.3.0" }
   "camlp4"
 ]
 depopts: ["js_of_ocaml"]

--- a/packages/xmldiff/xmldiff.0.5.0/opam
+++ b/packages/xmldiff/xmldiff.0.5.0/opam
@@ -13,7 +13,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "xmlm" {>= "1.1.0" }
+  "xmlm" {>= "1.1.0" & < "1.3.0" }
 ]
 depopts: ["js_of_ocaml"]
 conflicts: [


### PR DESCRIPTION
/cc @zoggy

Cf. https://github.com/ocaml/opam-repository/pull/8721