### PR TITLE
react.1.2.1 - via opam-publish

### DIFF
--- a/packages/react/react.1.2.1/descr
+++ b/packages/react/react.1.2.1/descr
@@ -1,0 +1,10 @@
+Declarative events and signals for OCaml
+Release %%VERSION%%
+
+React is an OCaml module for functional reactive programming (FRP). It
+provides support to program with time varying values : declarative
+events and signals. React doesn't define any primitive event or
+signal, it lets the client chooses the concrete timeline.
+
+React is made of a single, independent, module and distributed under
+the ISC license.

--- a/packages/react/react.1.2.1/opam
+++ b/packages/react/react.1.2.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/react"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/react/doc/React"
+dev-repo: "http://erratique.ch/repos/react.git"
+bug-reports: "https://github.com/dbuenzli/react/issues"
+tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+]
+available: [ ocaml-version >= "4.01.0" ]
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--dev-pkg" "%{pinned}%" ]]

--- a/packages/react/react.1.2.1/url
+++ b/packages/react/react.1.2.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/react/releases/react-1.2.1.tbz"
+checksum: "ce1454438ce4e9d2931248d3abba1fcc"


### PR DESCRIPTION
Declarative events and signals for OCaml
Release %%VERSION%%

React is an OCaml module for functional reactive programming (FRP). It
provides support to program with time varying values : declarative
events and signals. React doesn't define any primitive event or
signal, it lets the client chooses the concrete timeline.

React is made of a single, independent, module and distributed under
the ISC license.


---
* Homepage: http://erratique.ch/software/react
* Source repo: http://erratique.ch/repos/react.git
* Bug tracker: https://github.com/dbuenzli/react/issues

---


---
v1.2.1 2017-03-16 La Forclaz (VS)
---------------------------------

- Allow signals to be created and `S.stop`ped instantaneously (#18)
  Previously this could lead to failed assertions in updates (e.g.
  `S.bind` trying to switch to an uninitialized signal). Thanks
  to Arthur Wendling for the report.
- Fix implementation of `S.Bool.flip`, its initial value on creation
  could be wrong in dynamic creation (#17). Thanks to Arthur Wendling
  for the report.
- Fix bug in `S.Option.value` with `` `Always`` on `S.const None` (#19).
  Thanks to Arthur Wendling for the report.
- Safe-string support.
- Build depend on topkg.
- Relicense from BSD3 to ISC
Pull-request generated by opam-publish v0.3.4