### PR TITLE
Constrain Oml 0.0.6 and 0.0.7 dependencies

### DIFF
--- a/packages/oml/oml.0.0.6/opam
+++ b/packages/oml/oml.0.0.6/opam
@@ -12,7 +12,7 @@ remove: ["ocamlfind" "remove" "oml"]
 depends: [
   "ocamlfind" {build}
   "cppo" { build & >= "1.4.0" }
-  "lacaml" { >= "8.0.6" }
+  "lacaml" { >= "8.0.6" & < "9.2.3"}
   "lbfgs" { >= "0.8.7" }
   "ocephes" { >= "0.8" }
 ]

--- a/packages/oml/oml.0.0.6/opam
+++ b/packages/oml/oml.0.0.6/opam
@@ -12,7 +12,13 @@ remove: ["ocamlfind" "remove" "oml"]
 depends: [
   "ocamlfind" {build}
   "cppo" { build & >= "1.4.0" }
-  "lacaml" { >= "8.0.6" & < "9.2.3"}
-  "lbfgs" { >= "0.8.7" }
-  "ocephes" { >= "0.8" }
+  "lacaml"
+  "lbfgs"
+  "ocephes"
+]
+conflicts : [
+  "lacaml" { <= "8.0.6" }
+  "lacaml" { >= "9.2.3" }
+  "lbfgs" { < "0.8.7" }
+  "ocephes" { < "0.8" }
 ]

--- a/packages/oml/oml.0.0.6/opam
+++ b/packages/oml/oml.0.0.6/opam
@@ -17,7 +17,7 @@ depends: [
   "ocephes"
 ]
 conflicts : [
-  "lacaml" { <= "8.0.6" }
+  "lacaml" { < "8.0.6" }
   "lacaml" { >= "9.2.3" }
   "lbfgs" { < "0.8.7" }
   "ocephes" { < "0.8" }

--- a/packages/oml/oml.0.0.7/opam
+++ b/packages/oml/oml.0.0.7/opam
@@ -16,9 +16,15 @@ depends: [
   "dsfo" {test}
 ]
 depopts: [
-  "lacaml" { >= "8.06" & < "9.2.3" }
-  "lbfgs" { >= "0.8.7" }
-  "ocephes" { >= "0.8" }
+  "lacaml"
+  "lbfgs"
+  "ocephes"
+]
+conflicts: [
+  "lacaml" { <= "8.0.6" }
+  "lacaml" { >= "9.2.3" }
+  "lbfgs" { < "0.8.7" }
+  "ocephes" { < "0.8" }
 ]
 
 build: [[

--- a/packages/oml/oml.0.0.7/opam
+++ b/packages/oml/oml.0.0.7/opam
@@ -21,7 +21,7 @@ depopts: [
   "ocephes"
 ]
 conflicts: [
-  "lacaml" { <= "8.0.6" }
+  "lacaml" { < "8.0.6" }
   "lacaml" { >= "9.2.3" }
   "lbfgs" { < "0.8.7" }
   "ocephes" { < "0.8" }

--- a/packages/oml/oml.0.0.7/opam
+++ b/packages/oml/oml.0.0.7/opam
@@ -16,9 +16,9 @@ depends: [
   "dsfo" {test}
 ]
 depopts: [
-  "lacaml"
-  "lbfgs"
-  "ocephes"
+  "lacaml" { >= "8.06" & < "9.2.3" }
+  "lbfgs" { >= "0.8.7" }
+  "ocephes" { >= "0.8" }
 ]
 
 build: [[


### PR DESCRIPTION
The impetus for this PR was to constrain the version of `lacaml` due to recent changes. I also took the opportunity to constrain the dependencies in 0.0.7 that were left off on the other packages (lbfgs, ocephes).