### PR TITLE
Add missing ppx deriving deps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,27 @@
+## Ppx_deriving becomes an optional dependency of ppx_type_conv
+
+There are two ways of using the `ppx_sexp_conv` ppx rewriter:
+
+- the legacy way, with:
+  ```
+  $ ocamlfind ocamlc -package ppx_sexp_conv ...
+  ```
+
+- the new way, with a driver. Since the v0.9.0 version of
+  `ppx_sexp_conv` one can use either the `ocaml-migrate-parsetree`
+  driver or `ppx_driver`. Before v0.9.0 one could only use
+  `ppx_driver`
+
+Using the legacy way requires using `ppx_deriving`. `ppx_deriving`
+used to be a hard dependency of `ppx_sexp_conv` through
+`ppx_type_conv`. Since v0.9.0 it is an optional one. As a result
+pacakges building using the legacy way must declare an explicit
+dependency on `ppx_deriving`.
+
+Many packages didn't at the time `ppx_sexp_conv` v0.9.0 was
+released. To fix builds failure, a `ppx_deriving` dependency was added
+to all packages depending on `ppx_sexp_conv` but not `ppx_deriving`.
+
 ## Split build and install steps (2016-05-18)
 
 The opam tool has been separating the "build" and "install" steps of packages

--- a/packages/biocaml/biocaml.0.4.0/opam
+++ b/packages/biocaml/biocaml.0.4.0/opam
@@ -35,6 +35,7 @@ depends: [
   "cfstream"
   "future"
   "ppx_compare"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "re"
   "uri"

--- a/packages/biocaml/biocaml.0.5.0/opam
+++ b/packages/biocaml/biocaml.0.5.0/opam
@@ -33,6 +33,7 @@ depends: [
   "xmlm"
   "cfstream"
   "ppx_compare"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "re"
   "rresult"

--- a/packages/biocaml/biocaml.0.6.0/opam
+++ b/packages/biocaml/biocaml.0.6.0/opam
@@ -29,6 +29,7 @@ depends: [
   "xmlm"
   "cfstream"
   "ppx_compare"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "re"
   "rresult"

--- a/packages/bookaml/bookaml.3.1/opam
+++ b/packages/bookaml/bookaml.3.1/opam
@@ -21,6 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"
   "ocamlnet" {>= "4"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "sexplib"
   "tyxml" {>= "3.4" & < "3.6"}

--- a/packages/bookaml/bookaml.4.0/opam
+++ b/packages/bookaml/bookaml.4.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"
   "ocamlnet" {>= "4"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "sexplib"
   "tyxml"

--- a/packages/camlhighlight/camlhighlight.4.0/opam
+++ b/packages/camlhighlight/camlhighlight.4.0/opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"
   "batteries" {>= "2"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "sexplib"
   "tyxml" {>= "3.2" & < "3.6"}

--- a/packages/camlhighlight/camlhighlight.5.0/opam
+++ b/packages/camlhighlight/camlhighlight.5.0/opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "batteries" {>= "2"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "sexplib"
   "tyxml" {>= "3.6"}

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -14,6 +14,7 @@ build: [
 depends: [
   "ocamlfind"
   {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "ppx_type_conv"
   "cstruct" {>= "1.9"}

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -13,6 +13,7 @@ build: [
 depends: [
   "ocamlfind"
   {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "ppx_type_conv"
   "cstruct" {>= "1.9"}

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -23,6 +23,7 @@ depends: [
   "ocamlfind"     {build}
   "ocamlbuild"    {build}
   "topkg"         {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_tools"     {build}
   "menhir"        {build}

--- a/packages/cohttp/cohttp.0.20.1/opam
+++ b/packages/cohttp/cohttp.0.20.1/opam
@@ -33,6 +33,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.11.0"}
   "ppx_fields_conv"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.20.2/opam
+++ b/packages/cohttp/cohttp.0.20.2/opam
@@ -34,6 +34,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.11.0"}
   "ppx_fields_conv"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.21.0/opam
+++ b/packages/cohttp/cohttp.0.21.0/opam
@@ -33,6 +33,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.11.0"}
   "ppx_fields_conv"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.21.1/opam
+++ b/packages/cohttp/cohttp.0.21.1/opam
@@ -34,6 +34,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.14.0"}
   "ppx_fields_conv"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.22.0/opam
+++ b/packages/cohttp/cohttp.0.22.0/opam
@@ -34,6 +34,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.14.0"}
   "ppx_fields_conv"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/datakit-ci/datakit-ci.0.9.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.9.0/opam
@@ -40,6 +40,7 @@ depends: [
   "github" {>= "2.2.0"}
   "prometheus-app"
   "lwt" {>= "2.7.0"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "crunch" {build}
   "datakit" {test}

--- a/packages/dockerfile/dockerfile.1.3.0/opam
+++ b/packages/dockerfile/dockerfile.1.3.0/opam
@@ -16,6 +16,7 @@ remove: ["ocamlfind" "remove" "dockerfile"]
 depends: [
   "ocamlfind" {build} 
   "cmdliner"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.4.0/opam
+++ b/packages/dockerfile/dockerfile.1.4.0/opam
@@ -15,6 +15,7 @@ remove: ["ocamlfind" "remove" "dockerfile"]
 depends: [
   "ocamlfind" {build} 
   "cmdliner"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.7.0/opam
+++ b/packages/dockerfile/dockerfile.1.7.0/opam
@@ -15,6 +15,7 @@ remove: ["ocamlfind" "remove" "dockerfile"]
 depends: [
   "ocamlfind" {build} 
   "cmdliner"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.7.1/opam
+++ b/packages/dockerfile/dockerfile.1.7.1/opam
@@ -15,6 +15,7 @@ remove: ["ocamlfind" "remove" "dockerfile"]
 depends: [
   "ocamlfind" {build} 
   "cmdliner"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.7.2/opam
+++ b/packages/dockerfile/dockerfile.1.7.2/opam
@@ -11,6 +11,7 @@ available: [ ocaml-version >= "4.02.3"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "topkg" {build}
   "cmdliner"

--- a/packages/dockerfile/dockerfile.2.0.0/opam
+++ b/packages/dockerfile/dockerfile.2.0.0/opam
@@ -11,6 +11,7 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "topkg" {build}
   "cmdliner"

--- a/packages/dockerfile/dockerfile.2.2.0/opam
+++ b/packages/dockerfile/dockerfile.2.2.0/opam
@@ -11,6 +11,7 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "topkg" {build}
   "cmdliner"

--- a/packages/dockerfile/dockerfile.2.2.1/opam
+++ b/packages/dockerfile/dockerfile.2.2.1/opam
@@ -11,6 +11,7 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "topkg" {build}
   "cmdliner"

--- a/packages/ibx/ibx.0.8.1/opam
+++ b/packages/ibx/ibx.0.8.1/opam
@@ -26,6 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
   "ppx_fields_conv" {>= "113.33.00"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {>= "113.33.00"}
   "textutils" {>= "113.33.00"}
 ]

--- a/packages/ipaddr/ipaddr.2.7.0/opam
+++ b/packages/ipaddr/ipaddr.2.7.0/opam
@@ -33,6 +33,7 @@ depends: [
   "ocamlbuild" {build}
   "base-bytes"
   "sexplib"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "ounit" {test}
 ]

--- a/packages/ipaddr/ipaddr.2.7.1/opam
+++ b/packages/ipaddr/ipaddr.2.7.1/opam
@@ -30,6 +30,7 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "sexplib"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "ounit" {test}
 ]

--- a/packages/ipaddr/ipaddr.2.7.2/opam
+++ b/packages/ipaddr/ipaddr.2.7.2/opam
@@ -30,6 +30,7 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "sexplib"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "ounit" {test}
 ]

--- a/packages/libsvm/libsvm.0.9.3/opam
+++ b/packages/libsvm/libsvm.0.9.3/opam
@@ -27,6 +27,7 @@ depopts: [
   "archimedes"
   "core"
   "gsl"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
 ]
 available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.03" & os != "darwin" ]

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocamlfind" {build}
   "cstruct" {>= "2.1.0"}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}

--- a/packages/msgpck/msgpck.1.0/opam
+++ b/packages/msgpck/msgpck.1.0/opam
@@ -11,6 +11,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "sexplib"
   "ocplib-endian"

--- a/packages/nbd/nbd.2.1.0/opam
+++ b/packages/nbd/nbd.2.1.0/opam
@@ -35,6 +35,7 @@ depends: [
   "io-page"
   "mirage" {>= "1.1.0" & < "3.0.0"}
   "uri"
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: ["org:mirage" "org:xapi-project"]

--- a/packages/nbd/nbd.2.1.1/opam
+++ b/packages/nbd/nbd.2.1.1/opam
@@ -34,6 +34,7 @@ depends: [
   "io-page"
   "mirage" {>= "1.1.0" & < "3.0.0"}
   "uri"
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: ["org:mirage" "org:xapi-project"]

--- a/packages/nbd/nbd.3.0.0/opam
+++ b/packages/nbd/nbd.3.0.0/opam
@@ -39,6 +39,7 @@ depends: [
   "io-page"
   "mirage" {>= "1.1.0"}
   "uri"
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: [ "org:mirage" "org:xapi-project" ]

--- a/packages/nocrypto/nocrypto.0.5.3/opam
+++ b/packages/nocrypto/nocrypto.0.5.3/opam
@@ -22,6 +22,7 @@ depends: [
   "cstruct" {>= "1.6.0"}
   "zarith"
   "sexplib"
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy-xen" & "zarith-xen"))
   "ounit" {test}

--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -20,6 +20,7 @@ depends: [
   "topkg" {build}
   "cpuid" {build}
   "ocb-stubblr" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ounit" {test}
   "cstruct"

--- a/packages/oci/oci.0.3/opam
+++ b/packages/oci/oci.0.3/opam
@@ -28,6 +28,7 @@ depends: [
    "core_extended"
    "extunix" {>= "0.1.3"}
    "fileutils" "textutils" "ocamlbuild"
+  "ppx_deriving" {build}
    "ppx_sexp_conv" "ppx_bin_prot" "ppx_here" "ppx_fields_conv" "ppx_compare"
 ]
 

--- a/packages/opass/opass.1.0.6/opam
+++ b/packages/opass/opass.1.0.6/opam
@@ -17,6 +17,7 @@ depends: [
 	"csv"
 	"ocamlfind"
 	"pds"
+  "ppx_deriving" {build}
 	"ppx_sexp_conv"
 	"sexplib"
 ]

--- a/packages/opium/opium.0.15.0/opam
+++ b/packages/opium/opium.0.15.0/opam
@@ -30,6 +30,7 @@ depends: [
   "fieldslib"
   "sexplib"
   "ppx_fields_conv"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "re" {>= "1.3.0"}
   "magic-mime"

--- a/packages/opium/opium.0.15.1/opam
+++ b/packages/opium/opium.0.15.1/opam
@@ -30,6 +30,7 @@ depends: [
   "fieldslib"
   "sexplib"
   "ppx_fields_conv"
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "re" {>= "1.3.0"}
   "magic-mime"

--- a/packages/otr/otr.0.3.1/opam
+++ b/packages/otr/otr.0.3.1/opam
@@ -22,6 +22,7 @@ depends: [
   "ppx_tools" {build}
   "cstruct" {>= "1.9.0"}
   "sexplib"
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "nocrypto" {>= "0.5.3"}
   "astring"

--- a/packages/otr/otr.0.3.2/opam
+++ b/packages/otr/otr.0.3.2/opam
@@ -23,6 +23,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "sexplib"
   "result"
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "nocrypto" {>= "0.5.3"}
   "astring"

--- a/packages/otr/otr.0.3.3/opam
+++ b/packages/otr/otr.0.3.3/opam
@@ -21,6 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "cstruct" {>= "1.9.0"}
   "sexplib"

--- a/packages/planck/planck.2.2.0/opam
+++ b/packages/planck/planck.2.2.0/opam
@@ -22,6 +22,7 @@ depends: [
   "spotlib" { >= "3.0.0" }
   "ocamlgraph" { >= "1.8.2" }
   "omake" { build }
+  "ppx_deriving" {build}
   "ppx_sexp_conv"
   "camlp4"
   "ppx_monadic"

--- a/packages/qcow-format/qcow-format.0.3/opam
+++ b/packages/qcow-format/qcow-format.0.3/opam
@@ -26,6 +26,7 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "oasis" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}

--- a/packages/qcow-format/qcow-format.0.4.1/opam
+++ b/packages/qcow-format/qcow-format.0.4.1/opam
@@ -30,6 +30,7 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow-format/qcow-format.0.4.2/opam
+++ b/packages/qcow-format/qcow-format.0.4.2/opam
@@ -30,6 +30,7 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow-format/qcow-format.0.4/opam
+++ b/packages/qcow-format/qcow-format.0.4/opam
@@ -30,6 +30,7 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow-format/qcow-format.0.5.0/opam
+++ b/packages/qcow-format/qcow-format.0.5.0/opam
@@ -30,6 +30,7 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow/qcow.0.6.0/opam
+++ b/packages/qcow/qcow.0.6.0/opam
@@ -27,6 +27,7 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow/qcow.0.7.0/opam
+++ b/packages/qcow/qcow.0.7.0/opam
@@ -27,6 +27,7 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow/qcow.0.8.1/opam
+++ b/packages/qcow/qcow.0.8.1/opam
@@ -30,6 +30,7 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow/qcow.0.9.0/opam
+++ b/packages/qcow/qcow.0.9.0/opam
@@ -31,6 +31,7 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/qcow/qcow.0.9.4/opam
+++ b/packages/qcow/qcow.0.9.4/opam
@@ -31,6 +31,7 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}

--- a/packages/tls/tls.0.7.1/opam
+++ b/packages/tls/tls.0.7.1/opam
@@ -23,6 +23,7 @@ depends: [
   "result"
   "ppx_tools" {build}
   "cstruct" {>= "1.9.0"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "sexplib"
   "nocrypto" {>= "0.5.3"}

--- a/packages/tls/tls.0.8.0/opam
+++ b/packages/tls/tls.0.8.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "result"
   "cstruct" {>= "1.9.0"}

--- a/packages/uri/uri.1.9.2/opam
+++ b/packages/uri/uri.1.9.2/opam
@@ -35,6 +35,7 @@ depends: [
   "ocamlfind" {build}
   "re"
   "sexplib" {>= "109.53.00"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {>= "113.33.01"}
   "base-bytes"
   "stringext" {>= "1.4.0"}

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -23,6 +23,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "io-page"
   "mirage-types-lwt" {< "3.0.0"}

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -27,6 +27,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "io-page"
   "mirage-types-lwt" {< "3.0.0"}

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -28,6 +28,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}

--- a/packages/vmnet/vmnet.1.1.0/opam
+++ b/packages/vmnet/vmnet.1.1.0/opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_tools" {build}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "sexplib" {>= "113.24.00"}
   "ipaddr" {>="1.4.0"}

--- a/packages/x509/x509.0.5.1/opam
+++ b/packages/x509/x509.0.5.1/opam
@@ -19,6 +19,7 @@ depends: [
   "oasis" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.6.0"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "sexplib"
   "asn1-combinators" {>= "0.1.1"}

--- a/packages/x509/x509.0.5.2/opam
+++ b/packages/x509/x509.0.5.2/opam
@@ -19,6 +19,7 @@ depends: [
   "oasis" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.6.0"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "sexplib"
   "asn1-combinators" {>= "0.1.1"}

--- a/packages/x509/x509.0.5.3/opam
+++ b/packages/x509/x509.0.5.3/opam
@@ -19,6 +19,7 @@ depends: [
   "oasis" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.6.0"}
+  "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "sexplib"
   "asn1-combinators" {>= "0.1.1"}


### PR DESCRIPTION
This PR adds a `ppx_deriving` dependency to all packages using `ppx_sexp_conv`. This is in preparation of the v0.9 release of `ppx_type_conv` where the `ppx_deriving` dependency is made optional