### PR TITLE
Remove the js_of_ocaml-->ppx_driver|async_kernel depopts

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
@@ -4,7 +4,7 @@ authors: "Ocsigen team"
 homepage: "http://ocsigen.org/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 dev-repo: "https://github.com/ocsigen/js_of_ocaml.git"
-build: [make "build"]
+build: [make "build" "WITH_ASYNC=NO" "WITH_PPX_DRIVER=NO"]
 install: [make "install-lib" "BINDIR=%{bin}%" "WITH_ASYNC=NO" "WITH_PPX_DRIVER=NO"]
 remove: ["ocamlfind" "remove" "js_of_ocaml"]
 depends: [

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
@@ -5,7 +5,7 @@ homepage: "http://ocsigen.org/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 dev-repo: "https://github.com/ocsigen/js_of_ocaml.git"
 build: [make "build"]
-install: [make "install-lib" "BINDIR=%{bin}%"]
+install: [make "install-lib" "BINDIR=%{bin}%" "WITH_ASYNC=NO" "WITH_PPX_DRIVER=NO"]
 remove: ["ocamlfind" "remove" "js_of_ocaml"]
 depends: [
   "cmdliner"
@@ -26,14 +26,11 @@ depopts: [
   "ppx_deriving"
   "tyxml"
   "reactiveData"
-  "async_kernel"
-  "ppx_driver"
 ]
 conflicts: [
   "deriving" {< "0.6"}
   "tyxml" {< "4.0.0"}
   "ppx_deriving" {< "3.0"}
   "reactiveData" {< "0.2"}
-  "async_kernel" {< "113.33.00"}
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
`js_of_ocaml.{ppx_driver,async}` doesn't seem to be used at the moment. In the v0.9 release of JS packages, these are superseded by `async_js`. Moreover async.v0.9.0 and ppx_driver.v0.9.0 break the build of `js_of_ocaml.{ppx_driver,async}` so it's better to just remove them

/cc @hhugo 