### PR TITLE
+flowtype.0.42.0

### DIFF
--- a/packages/flowtype/flowtype.0.42.0/descr
+++ b/packages/flowtype/flowtype.0.42.0/descr
@@ -1,0 +1,15 @@
+Flow is a static typechecker for JavaScript.
+
+To find out more about Flow, check out <http://flowtype.org>.
+
+Flow adds static typing to JavaScript to improve developer productivity and
+code quality. In particular, static typing offers benefits like early error
+checking, which helps you avoid certain kinds of runtime failures, and code
+intelligence, which aids code maintenance, navigation, transformation, and
+optimization.
+
+We have designed Flow so developers can reap its benefits without losing the
+"feel" of coding in JavaScript. Flow adds minimal compile-time overhead, as it
+does all its work proactively in the background. And Flow does not force you to
+change how you code — it performs sophisticated program analysis to work with
+the idioms you already know and love.

--- a/packages/flowtype/flowtype.0.42.0/files/flowtype.install
+++ b/packages/flowtype/flowtype.0.42.0/files/flowtype.install
@@ -1,0 +1,1 @@
+bin: ["bin/flow" {"flow"}]

--- a/packages/flowtype/flowtype.0.42.0/opam
+++ b/packages/flowtype/flowtype.0.42.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "gabe@fb.com"
+homepage: "http://flowtype.org"
+dev-repo: "https://github.com/facebook/flow.git"
+bug-reports: "https://github.com/facebook/flow/issues"
+authors: [
+  "Avik Chaudhuri"
+  "Basil Hosmer"
+  "Gabe Levi"
+  "Jeff Morrison"
+  "Marshall Roch"
+  "Sam Goldman"
+  "James Kyle"
+]
+doc: "http://flowtype.org/docs/getting-started.html"
+license: "BSD3"
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.04.0"]
+build: [ [ make ] ]
+depexts: [
+ [ ["debian"] ["libelf-dev"] ]
+ [ ["ubuntu"] ["libelf-dev"] ]
+ [ ["centos"] ["elfutils-libelf-devel"] ]
+]

--- a/packages/flowtype/flowtype.0.42.0/url
+++ b/packages/flowtype/flowtype.0.42.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/facebook/flow/archive/v0.42.0.tar.gz"
+checksum: "e75b34445e18ad54b72326973f4f85be"


### PR DESCRIPTION
Like 0.40.0, it still won't build on musl-libc, but 0.43.0 hopefully will.