### PR TITLE
npy.0.0.5 - via opam-publish

### DIFF
--- a/packages/npy/npy.0.0.5/descr
+++ b/packages/npy/npy.0.0.5/descr
@@ -1,0 +1,3 @@
+Numpy npy file format reading/writing.
+
+Provide simple read/write function using the numpy npy/npz file formats. These can be used to save a bigarray to disk and then load it from python using numpy.

--- a/packages/npy/npy.0.0.5/opam
+++ b/packages/npy/npy.0.0.5/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Laurent Mazare <lmazare@gmail.com>"
+authors: "Laurent Mazare"
+homepage: "https://github.com/LaurentMazare/npy-ocaml"
+bug-reports: "https://github.com/LaurentMazare/npy-ocaml/issues"
+dev-repo: "git+https://github.com/LaurentMazare/npy-ocaml.git"
+build: [
+  "jbuilder"
+  "build"
+  "--only-packages"
+  "npy"
+  "--root"
+  "."
+  "-j"
+  jobs
+  "@install"
+]
+depends: [
+  "camlzip"
+  "ocamlfind" {build}
+  "jbuilder" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/npy/npy.0.0.5/url
+++ b/packages/npy/npy.0.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/LaurentMazare/npy-ocaml/archive/0.0.6.tar.gz"
+checksum: "1176541495878867a78a7e5efc3ac9bc"


### PR DESCRIPTION
Numpy npy file format reading/writing.

Provide simple read/write function using the numpy npy/npz file formats. These can be used to save a bigarray to disk and then load it from python using numpy.


---
* Homepage: https://github.com/LaurentMazare/npy-ocaml
* Source repo: git+https://github.com/LaurentMazare/npy-ocaml.git
* Bug tracker: https://github.com/LaurentMazare/npy-ocaml/issues

---

Pull-request generated by opam-publish v0.3.4