### PR TITLE
Constrain topkg to bos 1.5.0.

### DIFF
--- a/packages/topkg-care/topkg-care.0.7.5/opam
+++ b/packages/topkg-care/topkg-care.0.7.5/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner"
   "opam-lib" {= "1.2.2"}
 ]

--- a/packages/topkg-care/topkg-care.0.7.6/opam
+++ b/packages/topkg-care/topkg-care.0.7.6/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner"
   "opam-lib" {= "1.2.2"}
 ]

--- a/packages/topkg-care/topkg-care.0.7.7/opam
+++ b/packages/topkg-care/topkg-care.0.7.7/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner"
   "opam-lib" {= "1.2.2"}
 ]

--- a/packages/topkg-care/topkg-care.0.7.8/opam
+++ b/packages/topkg-care/topkg-care.0.7.8/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.7.9/opam
+++ b/packages/topkg-care/topkg-care.0.7.9/opam
@@ -16,7 +16,7 @@ depends: [
   "rresult" {>= "0.4.0"}
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.8.0/opam
+++ b/packages/topkg-care/topkg-care.0.8.0/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.8.1/opam
+++ b/packages/topkg-care/topkg-care.0.8.1/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.9.0/opam
+++ b/packages/topkg-care/topkg-care.0.9.0/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos"
+  "bos" {>= "1.5.0"}
   "cmdliner" {>= "1.0.0"}
   "webbrowser"
   "opam-format"


### PR DESCRIPTION
The reason for this can be found in this commit message.

https://github.com/dbuenzli/topkg/commit/faed66fb86cfa3536051f16d08004d4431591eb9

To be merged after https://github.com/ocaml/opam-repository/pull/8740