### PR TITLE
camlhighlight: restrict to tyxml<4 due to Html5_sigs usage

### DIFF
--- a/packages/camlhighlight/camlhighlight.5.0/opam
+++ b/packages/camlhighlight/camlhighlight.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "batteries" {>= "2"}
   "ppx_sexp_conv"
   "sexplib"
-  "tyxml" {>= "3.6"}
+  "tyxml" {>= "3.6" & <"4.0"}
 ]
 depexts: [
   [["debian"] ["libsource-highlight-dev"]]


### PR DESCRIPTION
without this bound we fail compilation with

```
 Error: Unbound module Html5_sigs
```