### PR TITLE
biocaml: upper bound on solvuu-build due to api change

### DIFF
--- a/packages/biocaml/biocaml.0.5.0/opam
+++ b/packages/biocaml/biocaml.0.5.0/opam
@@ -42,4 +42,4 @@ depopts: ["async" "core" "lwt" "ounit"]
 conflicts: [
   "core" {< "111.13.00"}
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.04.0" ]

--- a/packages/biocaml/biocaml.0.5.0/opam
+++ b/packages/biocaml/biocaml.0.5.0/opam
@@ -26,7 +26,7 @@ build-doc: [
 ]
 depends: [
   "ocamlfind" {build}
-  "solvuu-build" {build & <"0.3.0"}
+  "solvuu-build" {build & <="0.1"}
   "core_kernel" {>= "111.13.00"}
   "sexplib"
   "camlzip" {>= "1.05"}

--- a/packages/biocaml/biocaml.0.5.0/opam
+++ b/packages/biocaml/biocaml.0.5.0/opam
@@ -26,7 +26,7 @@ build-doc: [
 ]
 depends: [
   "ocamlfind" {build}
-  "solvuu-build" {build & <="0.1"}
+  "solvuu-build" {build & <="0.1.0"}
   "core_kernel" {>= "111.13.00"}
   "sexplib"
   "camlzip" {>= "1.05"}

--- a/packages/biocaml/biocaml.0.5.0/opam
+++ b/packages/biocaml/biocaml.0.5.0/opam
@@ -26,7 +26,7 @@ build-doc: [
 ]
 depends: [
   "ocamlfind" {build}
-  "solvuu-build" {build}
+  "solvuu-build" {build & <"0.3.0"}
   "core_kernel" {>= "111.13.00"}
   "sexplib"
   "camlzip" {>= "1.05"}

--- a/packages/biocaml/biocaml.0.6.0/opam
+++ b/packages/biocaml/biocaml.0.6.0/opam
@@ -22,7 +22,7 @@ build: [
 ]
 depends: [
   "ocamlfind" {build}
-  "solvuu-build" {build & >= "0.2.0"}
+  "solvuu-build" {build & >= "0.2.0" & <"0.3.0"}
   "core_kernel" {>= "111.13.00" }
   "sexplib"
   "camlzip" {>= "1.05"}


### PR DESCRIPTION
otherwise build fails with

```
 Error: The function applied to this argument has type
 [...]
          ?linkall:unit ->
          ?mli_files:[ `Add of string list | `Replace of string list ] ->
          ?c_files:[ `Add of string list | `Replace of string list ] ->
          ?h_files:[ `Add of string list | `Replace of string list ] ->
          ?install:[ `Findlib of Solvuu_build.Std.Project.findlib_pkg | `No ] ->
          Solvuu_build.Project.item
 This argument cannot be applied with label ~pkg
```