### PR TITLE
topkg-care: bos constraint should be 0.1.5, not 1.5.0

### DIFF
--- a/packages/topkg-care/topkg-care.0.7.5/opam
+++ b/packages/topkg-care/topkg-care.0.7.5/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner"
   "opam-lib" {= "1.2.2"}
 ]

--- a/packages/topkg-care/topkg-care.0.7.6/opam
+++ b/packages/topkg-care/topkg-care.0.7.6/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner"
   "opam-lib" {= "1.2.2"}
 ]

--- a/packages/topkg-care/topkg-care.0.7.7/opam
+++ b/packages/topkg-care/topkg-care.0.7.7/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner"
   "opam-lib" {= "1.2.2"}
 ]

--- a/packages/topkg-care/topkg-care.0.7.8/opam
+++ b/packages/topkg-care/topkg-care.0.7.8/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.7.9/opam
+++ b/packages/topkg-care/topkg-care.0.7.9/opam
@@ -16,7 +16,7 @@ depends: [
   "rresult" {>= "0.4.0"}
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.8.0/opam
+++ b/packages/topkg-care/topkg-care.0.8.0/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.8.1/opam
+++ b/packages/topkg-care/topkg-care.0.8.1/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner"
   "webbrowser"
   "opam-lib" {= "1.2.2"}

--- a/packages/topkg-care/topkg-care.0.9.0/opam
+++ b/packages/topkg-care/topkg-care.0.9.0/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "fmt"
   "logs"
-  "bos" {>= "1.5.0"}
+  "bos" {>= "0.1.5"}
   "cmdliner" {>= "1.0.0"}
   "webbrowser"
   "opam-format"


### PR DESCRIPTION
followup to fix 94a80a83a900fc4eabc0b9b3410df4af6ae7e30c

cc @dbuenzli 