### PR TITLE
genspio.0.0.0 - via opam-publish

### DIFF
--- a/packages/genspio/genspio.0.0.0/descr
+++ b/packages/genspio/genspio.0.0.0/descr
@@ -1,0 +1,5 @@
+Genspio is a typed EDSL to generate shell scripts and commands from OCaml.
+
+The idea is to build values of type `Genspio.EDSL.t` with the
+combinators in the `Genspio.EDSL` module, and compile them to POSIX
+shell scripts (or one-liners) with functions from `Genspio.Compile`.

--- a/packages/genspio/genspio.0.0.0/opam
+++ b/packages/genspio/genspio.0.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: "Seb Mondet <seb@mondet.org>"
+homepage: "http://www.hammerlab.org/docs/genspio/master/index.html"
+bug-reports: "https://github.com/hammerlab/genspio/issues"
+license: "Apache 2.0"
+dev-repo: "https://github.com/hammerlab/genspio.git"
+build: [
+  [make "byte"]
+  [make "native"]
+  [make "META"]
+  [make "genspio.install"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "solvuu-build" {build & >= "0.3.0"}
+  "nonstd"
+  "sosa"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/genspio/genspio.0.0.0/url
+++ b/packages/genspio/genspio.0.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/genspio/archive/genspio.0.0.0.tar.gz"
+checksum: "67a1a3fa6928b8baf9f6be169bcf5e1a"


### PR DESCRIPTION
Genspio is a typed EDSL to generate shell scripts and commands from OCaml.

The idea is to build values of type `Genspio.EDSL.t` with the
combinators in the `Genspio.EDSL` module, and compile them to POSIX
shell scripts (or one-liners) with functions from `Genspio.Compile`.


---
* Homepage: http://www.hammerlab.org/docs/genspio/master/index.html
* Source repo: https://github.com/hammerlab/genspio.git
* Bug tracker: https://github.com/hammerlab/genspio/issues

---

Pull-request generated by opam-publish v0.3.3