### PR TITLE
ocaml-monadic.0.3.3 - via opam-publish

### DIFF
--- a/packages/ocaml-monadic/ocaml-monadic.0.3.3/descr
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.3/descr
@@ -1,0 +1,3 @@
+PPX monadic
+
+A simple PPX language extension to include monadic binds.

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.3/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.3/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+homepage: "http://github.com/zepalmer/ocaml-monadic"
+bug-reports: "https://github.com/zepalmer/ocaml-monadic/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/zepalmer/ocaml-monadic.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: [
+  "ocaml"
+  "%{etc}%/ocaml-monadic/setup.ml"
+  "-C"
+  "%{etc}%/ocaml-monadic"
+  "-uninstall"
+]
+depends: [
+  "oasis" {build & >= "0.4.7"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ppx_tools"
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.3/url
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.3/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/zepalmer/ocaml-monadic/archive/307ea8f294ae075714958cbc546b96a5fc8adfe0.zip"
+checksum: "ed11eaba07eed7c2c293fee82d2d8ae1"


### PR DESCRIPTION
PPX monadic

A simple PPX language extension to include monadic binds.


---
* Homepage: http://github.com/zepalmer/ocaml-monadic
* Source repo: https://github.com/zepalmer/ocaml-monadic.git
* Bug tracker: https://github.com/zepalmer/ocaml-monadic/issues

---

Pull-request generated by opam-publish v0.3.4