### PR TITLE
git: tighten conflict on cmdliner.1.0

### DIFF
--- a/packages/git/git.1.7.0/opam
+++ b/packages/git/git.1.7.0/opam
@@ -63,6 +63,6 @@ conflicts: [
   "alcotest" {< "0.4.0"}
   "camlzip" {< "1.05"}
   "nocrypto" {< "0.2.0"}
-  "cmdliner" {>= "1.0"}
+  "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.7.1/opam
+++ b/packages/git/git.1.7.1/opam
@@ -62,6 +62,6 @@ conflicts: [
  "alcotest" {< "0.4.0"}
  "camlzip"  {< "1.05"}
  "nocrypto" {< "0.2.0"}
- "cmdliner" {>= "1.0"}
+ "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.7.2/opam
+++ b/packages/git/git.1.7.2/opam
@@ -61,6 +61,6 @@ conflicts: [
  "alcotest" {< "0.4.0"}
  "camlzip"  {< "1.05"}
  "nocrypto" {< "0.2.0"}
- "cmdliner" {>= "1.0"}
+ "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0"]

--- a/packages/git/git.1.8.0/opam
+++ b/packages/git/git.1.8.0/opam
@@ -63,6 +63,6 @@ conflicts: [
  "alcotest" {< "0.4.0"}
  "camlzip"  {< "1.05"}
  "nocrypto" {< "0.2.0"}
- "cmdliner" {>= "1.0"}
+ "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.9.0/opam
+++ b/packages/git/git.1.9.0/opam
@@ -66,6 +66,6 @@ conflicts: [
  "nocrypto" {< "0.2.0"}
  "camlzip"  {< "1.06"}
  "mirage-fs-unix" {<"1.1.4"}
- "cmdliner" {>= "1.0"}
+ "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.9.1/opam
+++ b/packages/git/git.1.9.1/opam
@@ -64,6 +64,6 @@ conflicts: [
  "alcotest" {< "0.4.0"}
  "camlzip"  {< "1.06"}
  "nocrypto" {< "0.2.0"}
- "cmdliner" {>= "1.0"}
+ "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.9.2/opam
+++ b/packages/git/git.1.9.2/opam
@@ -63,6 +63,6 @@ conflicts: [
  "alcotest" {< "0.4.0"}
  "camlzip"  {< "1.06"}
  "nocrypto" {< "0.2.0"}
- "cmdliner" {>= "1.0"}
+ "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.9.3/opam
+++ b/packages/git/git.1.9.3/opam
@@ -63,6 +63,6 @@ conflicts: [
  "alcotest" {< "0.4.0"}
  "camlzip"  {< "1.06"}
  "nocrypto" {< "0.2.0"}
- "cmdliner" {>= "1.0"}
+ "cmdliner" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
without this, `opam install git.1.7.2 git-unix.1.7.1 cmdliner.1.0.0`
fails to conflict for some reason...

addresses #8272 