### PR TITLE
Coclobas.0.0.0: Add constraint on solvuu-build

### DIFF
--- a/packages/coclobas/coclobas.0.0.0/opam
+++ b/packages/coclobas/coclobas.0.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "nonstd"
   "sosa"
   "pvem_lwt_unix"
-  "cohttp"
+  "cohttp" {>= "0.21.1"}
   "lwt"
   "trakeva"
   "cmdliner"

--- a/packages/coclobas/coclobas.0.0.0/opam
+++ b/packages/coclobas/coclobas.0.0.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "solvuu-build" {build}
+  "solvuu-build" {build & = "0.2.0"}
   "nonstd"
   "sosa"
   "pvem_lwt_unix"


### PR DESCRIPTION
Coclobas 0.0.1 is only available on ocaml ≥ 4.03.0, so the 0.0.0 is stll in use around.