### PR TITLE
jbuilder.1.0+beta5 — via opam-publish

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta5/descr
+++ b/packages/jbuilder/jbuilder.1.0+beta5/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+jbuilder is a build system that was designed to simplify the release
+of Jane Street packages. It reads metadata from "jbuild" files
+following a very simple s-expression syntax.
+
+jbuilder is fast, it has very low-overhead and support parallel builds
+on all platforms. It has no system dependencies, all you need to build
+jbuilder and packages using jbuilder is OCaml. You don't need or make
+or bash as long as the packages themselves don't use bash explicitely.
+
+jbuilder supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/jbuilder/jbuilder.1.0+beta5/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta5/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/jbuilder"
+bug-reports: "https://github.com/janestreet/jbuilder/issues"
+dev-repo: "https://github.com/janestreet/jbuilder.git"
+license: "Apache-2.0"
+build: [
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "-j" jobs]
+]
+depopts: [
+  # This dependency is here just to prevent a race condition
+  # as jbuilder calls `ocamlfind printconf path`
+  # when ocamlfind is present in the PATH
+  "ocamlfind" {build}
+]
+available: [ ocaml-version >= "4.02.3" ]
+
+# CR-soon jdimino: uncomment this when opam 2 is the norm:
+#
+# descr: "
+# Fast, portable and opinionated build system
+#
+# jbuilder is a build system that was designed to simplify the release
+# of Jane Street packages. It reads metadata from \"jbuild\" files
+# following a very simple s-expression syntax.
+#
+# jbuilder is fast, it has very low-overhead and support parallel builds
+# on all platforms. It has no system dependencies, all you need to build
+# jbuilder and packages using jbuilder is OCaml. You don't need or make
+# or bash as long as the packages themselves don't use bash explicitely.
+#
+# jbuilder supports multi-package development by simply dropping multiple
+# repositories into the same directory.
+#
+# It also supports multi-context builds, such as building against
+# several opam roots/switches simultaneously. This helps maintaining
+# packages across several versions of OCaml and gives cross-compilation
+# for free.
+# "

--- a/packages/jbuilder/jbuilder.1.0+beta5/url
+++ b/packages/jbuilder/jbuilder.1.0+beta5/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/jbuilder/archive/1.0+beta5.tar.gz"
+checksum: "md5=609a647290e42d1f7af7fcad24b6ce08"

--- a/packages/jbuilder/jbuilder.1.0+beta5/url
+++ b/packages/jbuilder/jbuilder.1.0+beta5/url
@@ -1,2 +1,2 @@
 src: "https://github.com/janestreet/jbuilder/archive/1.0+beta5.tar.gz"
-checksum: "md5=609a647290e42d1f7af7fcad24b6ce08"
+checksum: "609a647290e42d1f7af7fcad24b6ce08"


### PR DESCRIPTION
Fast, portable and opinionated build system

jbuilder is a build system that was designed to simplify the release
of Jane Street packages. It reads metadata from "jbuild" files
following a very simple s-expression syntax.

jbuilder is fast, it has very low-overhead and support parallel builds
on all platforms. It has no system dependencies, all you need to build
jbuilder and packages using jbuilder is OCaml. You don't need or make
or bash as long as the packages themselves don't use bash explicitely.

jbuilder supports multi-package development by simply dropping multiple
repositories into the same directory.

It also supports multi-context builds, such as building against
several opam roots/switches simultaneously. This helps maintaining
packages across several versions of OCaml and gives cross-compilation
for free.


---
* Homepage: https://github.com/janestreet/jbuilder
* Source repo: git+https://github.com/janestreet/jbuilder.git
* Bug tracker: https://github.com/janestreet/jbuilder/issues

---
### opam-lint failures
- **ERROR** 32 Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4