### PR TITLE
ppx_jsobject_conv: add an explicit dependency on ppx_deriving

### DIFF
--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.1/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.1/opam
@@ -24,3 +24,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.1/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.1/opam
@@ -20,6 +20,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.2/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.2/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.2/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.2/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.3/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.3/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.3/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.3/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.5/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.5/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.5/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.5/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.6/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.6/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.6/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.0.6/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.0/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.1/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.1/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.1/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.1/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.3/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.3/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.3/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.3/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.4/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.4/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.4/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.1.4/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]
+available: [ocaml-version >= "4.02.3" & ocaml-version<"4.03.0"]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.1/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.1/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.4/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.4/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.5/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.5/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.6/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.6/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.7/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.7/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.8/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.2.8/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.5/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.5/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.6/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.6/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.7/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.3.7/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_type_conv" {>= "113.24.00"}
   "ppx_driver"
   "ppx_core"
+  "ppx_deriving"
   "ocamlfind"    {build}
   "ocamlbuild"   {build}
 ]


### PR DESCRIPTION
This is due to https://github.com/janestreet/ppx_type_conv/issues/7