### PR TITLE
datakit-server: upper bounds on 9p which are <mirage3 APIs

### DIFF
--- a/packages/datakit-server/datakit-server.0.6.0/opam
+++ b/packages/datakit-server/datakit-server.0.6.0/opam
@@ -21,8 +21,8 @@ depends: [
   "uri"
   "rresult"
   "cstruct"
-  "fmt"
-  "protocol-9p" {>= "0.7.0"}
+  "fmt" {>="0.8.2"}
+  "protocol-9p" {>= "0.7.0" & <"0.9.0"}
   "sexplib"
-  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types-lwt" {>="2.6.0" & < "3.0.0"}
 ]

--- a/packages/datakit-server/datakit-server.0.7.0/opam
+++ b/packages/datakit-server/datakit-server.0.7.0/opam
@@ -21,8 +21,8 @@ depends: [
   "uri"
   "rresult"
   "cstruct"
-  "fmt"
-  "protocol-9p" {>= "0.7.4"}
+  "fmt" {>="0.8.2"}
+  "protocol-9p" {>= "0.7.4" & <"0.9.0"}
   "sexplib"
-  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types-lwt" {>="2.6.0" & < "3.0.0"}
 ]

--- a/packages/datakit-server/datakit-server.0.8.0/opam
+++ b/packages/datakit-server/datakit-server.0.8.0/opam
@@ -17,8 +17,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg"      {build}
   "base-bytes"
-  "astring" "logs" "uri" "rresult" "cstruct" "fmt"
-  "protocol-9p" {>= "0.7.4"}
+  "astring" "logs" "uri" "rresult" "cstruct"
+  "fmt" {>="0.8.2"}
+  "protocol-9p" {>= "0.7.4" & <"0.9.0"}
   "sexplib"
-  "mirage-types-lwt" {< "3.0.0" }
+  "mirage-types-lwt" {>="2.6.0" & < "3.0.0" }
 ]

--- a/packages/datakit-server/datakit-server.0.9.0/opam
+++ b/packages/datakit-server/datakit-server.0.9.0/opam
@@ -19,7 +19,7 @@ depends: [
   "base-bytes"
   "astring" "logs" "uri" "rresult" "fmt"
   "cstruct" {>= "2.2.0"}
-  "protocol-9p" {>= "0.7.4"}
+  "protocol-9p" {>= "0.7.4" & <"0.9.0"}
   "sexplib"
-  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types-lwt" {>="2.6.0" & < "3.0.0"}
 ]


### PR DESCRIPTION
also constraint fmt and mirage-types-lwt with lower bounds
