### PR TITLE
reason.1.13.0 - via opam-publish

### DIFF
--- a/packages/reason/reason.1.13.0/descr
+++ b/packages/reason/reason.1.13.0/descr
@@ -1,0 +1,5 @@
+Reason: Meta Language Toolchain
+
+reason allows development of Meta Language syntax trees in non-text format. It
+allows a development model that is equivalent to collaborating on syntax trees
+that have been committed to a source code repository.

--- a/packages/reason/reason.1.13.0/opam
+++ b/packages/reason/reason.1.13.0/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: "Jordan Walke <jordojw@gmail.com>"
+homepage: "https://github.com/facebook/reason"
+bug-reports: "https://github.com/facebook/reason/issues"
+license: "BSD"
+doc: "http://facebook.github.io/reason"
+tags: "syntax"
+dev-repo: "git://github.com/facebook/reason.git"
+substs: "pkg/META"
+build: [
+  [make "compile_error"]
+  ["ocamlbuild" "-package" "topkg" "pkg/build.native"]
+  [
+    "./build.native"
+    "build"
+    "--native"
+    "%{ocaml-native}%"
+    "--native-dynlink"
+    "%{ocaml-native-dynlink}%"
+    "--utop"
+    "%{utop:installed}%"
+  ]
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_reason.byte"
+  "--"
+]
+depends: [
+  "ocamlfind" {build}
+  "utop" {>= "1.17"}
+  "menhir" {>= "20160303"}
+  "merlin-extend" {>= "0.3"}
+  "result" {= "1.2"}
+  "topkg" {= "0.8.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {= "5.0alpha"}
+]
+conflicts: [
+  "utop" {< "1.17"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]

--- a/packages/reason/reason.1.13.0/opam
+++ b/packages/reason/reason.1.13.0/opam
@@ -1,45 +1,37 @@
 opam-version: "1.2"
+name: "reason"
+version: "1.13.0"
 maintainer: "Jordan Walke <jordojw@gmail.com>"
-authors: "Jordan Walke <jordojw@gmail.com>"
-homepage: "https://github.com/facebook/reason"
-bug-reports: "https://github.com/facebook/reason/issues"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
 license: "BSD"
+homepage: "https://github.com/facebook/reason"
 doc: "http://facebook.github.io/reason"
-tags: "syntax"
+bug-reports: "https://github.com/facebook/reason/issues"
 dev-repo: "git://github.com/facebook/reason.git"
-substs: "pkg/META"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
 build: [
-  [make "compile_error"]
   ["ocamlbuild" "-package" "topkg" "pkg/build.native"]
-  [
-    "./build.native"
-    "build"
-    "--native"
-    "%{ocaml-native}%"
-    "--native-dynlink"
-    "%{ocaml-native-dynlink}%"
-    "--utop"
-    "%{utop:installed}%"
-  ]
+  ["./build.native" "build"
+                    "--native" "%{ocaml-native}%"
+                    "--native-dynlink" "%{ocaml-native-dynlink}%"
+                    "--utop" "%{utop:installed}%"]
 ]
 build-test: [
-  "ocamlbuild"
-  "-classic-display"
-  "-use-ocamlfind"
-  "src_test/test_reason.byte"
-  "--"
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_reason.byte" "--"
 ]
 depends: [
-  "ocamlfind" {build}
-  "utop" {>= "1.17"}
-  "menhir" {>= "20160303"}
-  "merlin-extend" {>= "0.3"}
-  "result" {= "1.2"}
-  "topkg" {= "0.8.1"}
+  "ocamlfind"               {build}
+  "utop"                    {>= "1.17"}
+  "merlin-extend"           {>= "0.3"}
+  "result"                  {=  "1.2"}
+  "topkg"                   {=  "0.8.1"}
   "ocaml-migrate-parsetree"
-  "ppx_tools_versioned" {= "5.0alpha"}
+  "reason-parser"           {= "1.13.0"}
+]
+depopts: [
 ]
 conflicts: [
   "utop" {< "1.17"}
 ]
-available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]

--- a/packages/reason/reason.1.13.0/url
+++ b/packages/reason/reason.1.13.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/facebook/reason/archive/1.13.0.tar.gz"
+checksum: "e1536c89e9fc0b7c90898c8483eea085"


### PR DESCRIPTION
Reason: Meta Language Toolchain

reason allows development of Meta Language syntax trees in non-text format. It
allows a development model that is equivalent to collaborating on syntax trees
that have been committed to a source code repository.


---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

Pull-request generated by opam-publish v0.3.2