### PR TITLE
add sexplib conflicts in mirage-xen and ocaml-freestanding

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
@@ -14,3 +14,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & os = "linux" & ocaml-version < "4.02.2"]
+conflicts: [ "sexplib" { > "113.33.03" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
@@ -15,3 +15,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & os = "linux" & ocaml-version < "4.02.2"]
+conflicts: [ "sexplib" { > "113.33.03" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
@@ -15,3 +15,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0" & os = "linux"]
+conflicts: [ "sexplib" { > "113.33.03" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
@@ -15,3 +15,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.04.0" & os = "linux"]
+conflicts: [ "sexplib" { > "113.33.03" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
@@ -16,3 +16,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & os = "linux"]
+conflicts: [ "sexplib" { > "113.33.03" } ]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
@@ -14,6 +14,9 @@ depends: [
   "ocaml-src"
   ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
 ]
+conflicts: [
+  "sexplib" { > "113.33.03" }
+]
 available: [
  ocaml-version >= "4.02.3" & ocaml-version <= "4.03.0" & arch = "x86_64"
 ]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
@@ -15,6 +15,9 @@ depends: [
   "ocaml-src"
   ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
 ]
+conflicts: [
+  "sexplib" { > "113.33.03" }
+]
 available: [
   ocaml-version >= "4.02.3" & ocaml-version <= "4.05.0" &
   (arch = "x86_64" | arch = "amd64")


### PR DESCRIPTION
See https://lists.xenproject.org/archives/html/mirageos-devel/2017-03/msg00036.html , https://github.com/mirage/mirage-www/issues/547 , and https://github.com/ocaml/opam-repository/pull/8793 for more information.  tl;dr: sexplib > 113.33.03 requires base which unikernels built against mirage-xen and ocaml-freestanding can't use.