### PR TITLE
Ketrew.3.0.0: Constrain sexplib to < "v.0.9.0"

### DIFF
--- a/packages/ketrew/ketrew.3.0.0/opam
+++ b/packages/ketrew/ketrew.3.0.0/opam
@@ -31,6 +31,7 @@ depends: [
   "cohttp" {>= "0.21.0" } "lwt"
   "conduit"
   "js_of_ocaml" {>= "2.6" } "tyxml" {>= "4.0.0"} "reactiveData" {>= "0.2"}
+  "sexplib" {<= "113.33.03"}
   ]
 depopts: [
   "sqlite3" "postgresql"


### PR DESCRIPTION
Cf. issue https://github.com/ocaml/opam-repository/issues/8787

(the constraint on `tls` (https://github.com/ocaml/opam-repository/pull/8793) fixed the issue for most use-cases but since it is an optional dep of `conduit` it's cleaner to put the constraint here also)