### PR TITLE
Add modular implicits conflicts.

### DIFF
--- a/compilers/4.02.0/4.02.0+modular-implicits/4.02.0+modular-implicits.comp
+++ b/compilers/4.02.0/4.02.0+modular-implicits/4.02.0+modular-implicits.comp
@@ -7,7 +7,7 @@ build: [
   ["%{make}%" "world.opt"]
   ["%{make}%" "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" "base-implicits"]
 env: [
   [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
 ]

--- a/compilers/4.02.1/4.02.1+modular-implicits-ber/4.02.1+modular-implicits-ber.comp
+++ b/compilers/4.02.1/4.02.1+modular-implicits-ber/4.02.1+modular-implicits-ber.comp
@@ -7,7 +7,7 @@ build: [
   ["%{make}%" "install"]
   ["%{make}%" "-C" "metalib" "all" "install"]
 ]
-packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" "base-metaocaml-ocamlfind"]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-ocamlbuild" "base-metaocaml-ocamlfind" "base-implicits"]
 env: [
   [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
 ]

--- a/packages/asn1-combinators/asn1-combinators.0.1.0/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.0/opam
@@ -14,6 +14,10 @@ depends: [
 ]
 conflicts: [ "base-implicits" ]
 tags: [ "org:mirage" ]
+homepage:     "https://github.com/mirleft/ocaml-asn1-combinators"
 dev-repo: "git://github.com/mirleft/ocaml-asn1-combinators"
+bug-reports:  "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+authors:      "David Kaloper <david@numm.org>"
+maintainer:   "David Kaloper <david@numm.org>"
 available: ocaml-version >= "4.01.0"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/asn1-combinators/asn1-combinators.0.1.0/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.0/opam
@@ -12,6 +12,7 @@ depends: [
   "zarith"
   "ocamlbuild" {build}
 ]
+conflicts: [ "base-implicits" ]
 tags: [ "org:mirage" ]
 dev-repo: "git://github.com/mirleft/ocaml-asn1-combinators"
 available: ocaml-version >= "4.01.0"

--- a/packages/asn1-combinators/asn1-combinators.0.1.1/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.1/opam
@@ -22,4 +22,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "org:mirage" ]
+conflicts: [ "base-implicits" ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/asn1-combinators/asn1-combinators.0.1.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.2/opam
@@ -20,4 +20,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "org:mirage" ]
+conflicts: [ "base-implicits" ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/asn1-combinators/asn1-combinators.0.1.3/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.3/opam
@@ -23,4 +23,5 @@ depends: [
   "ounit" {test}
 ]
 depopts: []
-conflicts: [ "cstruct" {< "1.2.0"} ]
+conflicts: [ "cstruct" {< "1.2.0"} 
+             "base-implicits" ]

--- a/packages/base-implicits/base-implicits.base/descr
+++ b/packages/base-implicits/base-implicits.base/descr
@@ -1,0 +1,5 @@
+Dummy base package for compilers with modular implicits support.
+
+Packages which cannot be compiled with a compiler that supports
+modular implicits, typically because 'implicit' is used as an
+identifier, should mark this package as a conflict.

--- a/packages/base-implicits/base-implicits.base/opam
+++ b/packages/base-implicits/base-implicits.base/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop"]
+depopts: ["ocamlfind"]
+homepage: "https://github.com/ocaml/opam-repository/tree/master/packages/base-implicits/base-implicits.base"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+install: []
+remove: []
+available: [ compiler = "4.02.0+modular-implicits" 
+           | compiler = "4.02.1+modular-implicits-ber" ]


### PR DESCRIPTION
A few packages are incompatible with compilers that support modular implicits, typically because they use `implicit` as an identifier.

This PR adds a new base package, `base-implicits` to the implicit-supporting compilers.  A conflict with `base-implicits` indicates that the package cannot be built with those compilers.

This PR also adds a conflict with `base-implicits` to `asn1-combinators` (/cc @pqwy), which exposes a function [`Asn.implicit`](https://github.com/mirleft/ocaml-asn1-combinators/blob/c95304fc87bea8b0d9c1882aef97019bb75a5da7/src/asn.mli#L122-L128) in the public interface.