### PR TITLE
New release for ocaml4.04.0+copatterns (V0.2).

### DIFF
--- a/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
+++ b/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/yurug/ocaml4.04.0-copatterns/archive/V0.1.tar.gz"
+src: "https://github.com/yurug/ocaml4.04.0-copatterns/archive/V0.2.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
@@ -15,4 +15,3 @@ packages: [
 env: [
  [ CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs" ]
 ]
-


### PR DESCRIPTION
OCaml 4.04.0+copatterns 0.2 :
-----------------------------

### Transformation:

- Refactoring.

### Improve syntactic assertions:

- In a colabel declaration, the index type constructor's name
  corresponds to the one which is bound in the current type declaration.
  (Parser.check_indexed_cotype)
- The type annotation in a comatch expression is a cotype.
  (Parser.check_ty_in_comatch)
- The hole identifiers for a copattern matching are the same in the full
  set of copatterns and correspond to the one bound by the comatch.
  (Parser.check_id_in_cocases)
- At least a type annotation is declared in nested copatterns.
  (MNTSA.Error.Missing_type_annotation)

### Playground:

- Add a playground folder for examples.
- A complete example for streams.
  (testsuite/trans/playground/qstream.ml)