### PR TITLE
Fix the split of the world created by sexplib v0.9.0

### DIFF
--- a/packages/base/base.v0.9.0/opam
+++ b/packages/base/base.v0.9.0/opam
@@ -11,4 +11,7 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta4"}
 ]
+conflicts: [
+  "sexplib" {>= "v0.9.1"}
+]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/base/base.v0.9.1/descr
+++ b/packages/base/base.v0.9.1/descr
@@ -1,0 +1,12 @@
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio

--- a/packages/base/base.v0.9.1/opam
+++ b/packages/base/base.v0.9.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "https://github.com/janestreet/base.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "--only-packages" "base" "--root" "." "-j" jobs "@install"]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta2"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/base/base.v0.9.1/opam
+++ b/packages/base/base.v0.9.1/opam
@@ -10,5 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta2"}
+  "sexplib"  {>= "v0.9.1" & < "v0.10"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/base/base.v0.9.1/url
+++ b/packages/base/base.v0.9.1/url
@@ -1,2 +1,2 @@
 src: "https://github.com/janestreet/base/archive/v0.9.1.tar.gz"
-checksum: "195935958af319853577635b871aa803"
+checksum: "a0ce2861bcbb756614f0de375576caa6"

--- a/packages/base/base.v0.9.1/url
+++ b/packages/base/base.v0.9.1/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/base/archive/v0.9.1.tar.gz"
+checksum: "195935958af319853577635b871aa803"

--- a/packages/ketrew/ketrew.3.0.0/opam
+++ b/packages/ketrew/ketrew.3.0.0/opam
@@ -31,8 +31,11 @@ depends: [
   "cohttp" {>= "0.21.0" } "lwt"
   "conduit"
   "js_of_ocaml" {>= "2.6" } "tyxml" {>= "4.0.0"} "reactiveData" {>= "0.2"}
-  "sexplib" {<= "113.33.03"}
-  ]
+  "sexplib"
+]
 depopts: [
   "sqlite3" "postgresql"
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
 ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
@@ -14,4 +14,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & os = "linux" & ocaml-version < "4.02.2"]
-conflicts: [ "sexplib" { > "113.33.03" } ]
+conflicts: [ "sexplib" { = "v0.9.0" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & os = "linux" & ocaml-version < "4.02.2"]
-conflicts: [ "sexplib" { > "113.33.03" } ]
+conflicts: [ "sexplib" { = "v0.9.0" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0" & os = "linux"]
-conflicts: [ "sexplib" { > "113.33.03" } ]
+conflicts: [ "sexplib" { = "v0.9.0" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.04.0" & os = "linux"]
-conflicts: [ "sexplib" { > "113.33.03" } ]
+conflicts: [ "sexplib" { = "v0.9.0" } ]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
@@ -16,4 +16,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.01.0" & os = "linux"]
-conflicts: [ "sexplib" { > "113.33.03" } ]
+conflicts: [ "sexplib" { = "v0.9.0" } ]

--- a/packages/nocrypto/nocrypto.0.5.3/opam
+++ b/packages/nocrypto/nocrypto.0.5.3/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "1.6.0"}
   "zarith"
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy-xen" & "zarith-xen"))
@@ -35,6 +35,7 @@ depopts: [
 conflicts: [
   "mirage-xen" {<"2.2.0"}
   "mirage-entropy-xen" {<"0.3.0"}
+  "sexplib" {="v0.9.0"}
 ]
 
 build-test: [

--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -25,7 +25,7 @@ depends: [
   "ounit" {test}
   "cstruct"
   "zarith"
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy" & "zarith-xen"))
   ("mirage-no-solo5" | ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding"))
 ]
@@ -36,5 +36,6 @@ conflicts: [
   "ocb-stubblr" {<"0.1.0"}
   "cstruct" {<"2.3.0"}
   "mirage-xen" {<"2.2.0"}
+  "sexplib" {="v0.9.0"}
 ]
 

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
 ]
 conflicts: [
-  "sexplib" { > "113.33.03" }
+  "sexplib" {= "v0.9.0"}
 ]
 available: [
  ocaml-version >= "4.02.3" & ocaml-version <= "4.03.0" & arch = "x86_64"

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
 ]
 conflicts: [
-  "sexplib" { > "113.33.03" }
+  "sexplib" {= "v0.9.0"}
 ]
 available: [
   ocaml-version >= "4.02.3" & ocaml-version <= "4.05.0" &

--- a/packages/otr/otr.0.3.1/opam
+++ b/packages/otr/otr.0.3.1/opam
@@ -21,11 +21,14 @@ depends: [
   "ocamlfind" {build}
   "ppx_tools" {build}
   "cstruct" {>= "1.9.0"}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "nocrypto" {>= "0.5.3"}
   "astring"
   "ocamlbuild" {build}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
 ]
 available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03" ]

--- a/packages/otr/otr.0.3.2/opam
+++ b/packages/otr/otr.0.3.2/opam
@@ -21,12 +21,15 @@ depends: [
   "ocamlfind" {build}
   "ppx_tools" {build}
   "cstruct" {>= "1.9.0"}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "result"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "nocrypto" {>= "0.5.3"}
   "astring"
   "ocamlbuild" {build}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
 ]
 available: [ ocaml-version >= "4.02.2" ]

--- a/packages/otr/otr.0.3.3/opam
+++ b/packages/otr/otr.0.3.3/opam
@@ -24,9 +24,12 @@ depends: [
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "cstruct" {>= "1.9.0"}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "result"
   "nocrypto" {>= "0.5.3"}
   "astring"
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
 ]
 available: [ ocaml-version >= "4.02.2" ]

--- a/packages/sexplib/sexplib.v0.9.0/opam
+++ b/packages/sexplib/sexplib.v0.9.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "--only-packages" "sexplib" "--root" "." "-j" jobs "@install"]
 ]
 depends: [
-  "base"     {>= "v0.9" & < "v0.10"}
+  "base"     {= "v0.9.0"}
   "jbuilder" {build & >= "1.0+beta4"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/sexplib/sexplib.v0.9.1/descr
+++ b/packages/sexplib/sexplib.v0.9.1/descr
@@ -1,0 +1,6 @@
+Library for serializing OCaml values to and from S-expressions
+
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib/sexplib.v0.9.1/opam
+++ b/packages/sexplib/sexplib.v0.9.1/opam
@@ -9,7 +9,6 @@ build: [
   ["jbuilder" "build" "--only-packages" "sexplib" "--root" "." "-j" jobs "@install"]
 ]
 depends: [
-  "base"     {>= "v0.9.1" & < "v0.10"}
   "jbuilder" {build & >= "1.0+beta2"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/sexplib/sexplib.v0.9.1/opam
+++ b/packages/sexplib/sexplib.v0.9.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/sexplib"
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "https://github.com/janestreet/sexplib.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "--only-packages" "sexplib" "--root" "." "-j" jobs "@install"]
+]
+depends: [
+  "base"     {>= "v0.9.1" & < "v0.10"}
+  "jbuilder" {build & >= "1.0+beta2"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/sexplib/sexplib.v0.9.1/url
+++ b/packages/sexplib/sexplib.v0.9.1/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/sexplib/archive/v0.9.1.tar.gz"
+checksum: "ce2b00a2ba52012c691d243dfbae193c"

--- a/packages/sexplib/sexplib.v0.9.1/url
+++ b/packages/sexplib/sexplib.v0.9.1/url
@@ -1,2 +1,2 @@
 src: "https://github.com/janestreet/sexplib/archive/v0.9.1.tar.gz"
-checksum: "ce2b00a2ba52012c691d243dfbae193c"
+checksum: "2e820b5de70ba33883c936cd7af317fb"

--- a/packages/tls/tls.0.7.1/opam
+++ b/packages/tls/tls.0.7.1/opam
@@ -25,7 +25,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "nocrypto" {>= "0.5.3"}
   "x509" {>= "0.5.0"}
   "ounit" {test}
@@ -39,6 +39,7 @@ conflicts: [
   "mirage-types-lwt" {<"2.3.0"}
   "mirage-types-lwt" {>="3.0.0"}
   "mirage-net-xen" {<"1.3.0"}
+  "sexplib" {= "v0.9.0"}
 ]
 
 build-test: [

--- a/packages/tls/tls.0.8.0/opam
+++ b/packages/tls/tls.0.8.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "result"
   "cstruct" {>= "1.9.0"}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.5.0"}
   "ounit" {test}
@@ -44,6 +44,7 @@ conflicts: [
   "lwt" {<"2.4.8"}
   "mirage-net-xen" {<"1.3.0"}
   "mirage-types" {<"3.0.0"}
+  "sexplib" {= "v0.9.0"}
 ]
 
 tags: [ "org:mirage"]

--- a/packages/x509/x509.0.5.1/opam
+++ b/packages/x509/x509.0.5.1/opam
@@ -21,11 +21,14 @@ depends: [
   "cstruct" {>= "1.6.0"}
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "asn1-combinators" {>= "0.1.1"}
   "nocrypto" {>= "0.5.3"}
   "base-bytes"
   "ounit" {test}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
 ]
 build-test: [
   [ "./configure" "--%{ounit:enable}%-tests" ]

--- a/packages/x509/x509.0.5.2/opam
+++ b/packages/x509/x509.0.5.2/opam
@@ -21,11 +21,14 @@ depends: [
   "cstruct" {>= "1.6.0"}
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "asn1-combinators" {>= "0.1.1"}
   "nocrypto" {>= "0.5.3"}
   "base-bytes"
   "ounit" {test}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
 ]
 build-test: [
   [ "./configure" "--%{ounit:enable}%-tests" ]

--- a/packages/x509/x509.0.5.3/opam
+++ b/packages/x509/x509.0.5.3/opam
@@ -21,11 +21,14 @@ depends: [
   "cstruct" {>= "1.6.0"}
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
-  "sexplib" {<= "113.33.03"}
+  "sexplib"
   "asn1-combinators" {>= "0.1.1"}
   "nocrypto" {>= "0.5.3"}
   "base-bytes"
   "ounit" {test}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
 ]
 build-test: [
   [ "./configure" "--%{ounit:enable}%-tests" ]


### PR DESCRIPTION
This PR contain minor releases of Base and Sexplib, with some code refactoring so that linking against Sexplib doesn't require linking against Base.

After this PR, the only problematic version of sexplib is v0.9.0, so I updated the constraint/conflicts added by the following PR: #8793, #8794, #8798. /cc @avsm @hannesm @yomimono @smondet.

Note that the `base` opam package is still a dependency of the `sexplib` opam package. Let me know if this is an issue. I can try to push things a bit further to avoid this.