### PR TITLE
arakoon.1.9.0: upper bound on core

### DIFF
--- a/packages/arakoon/arakoon.1.9.0/opam
+++ b/packages/arakoon/arakoon.1.9.0/opam
@@ -27,7 +27,7 @@ depends: [
   "snappy" {>= "0.1.0"}
   "quickcheck" {>= "1.0.2"}
   "sexplib" {>= "113.00.00"}
-  "core" {>="113.00.00"}
+  "core" {>="113.00.00" & <"113.33.00"}
   "ocamlbuild" {build}
   "redis" {>= "0.2.3"}
   "uri" {>= "1.9.1"}


### PR DESCRIPTION
upstream is already fixed; see
https://github.com/openvstorage/arakoon/commit/c9ff60275308de0e2f3e160984e7de41985a03db