### PR TITLE
immutable.0.0.1 - via opam-publish

### DIFF
--- a/packages/immutable/immutable.0.0.1/descr
+++ b/packages/immutable/immutable.0.0.1/descr
@@ -1,0 +1,11 @@
+Pure Reason implementation of persistent immutable data structures.
+
+Immutable-re provides a complete set of efficient persistent immutable data
+structures for Reason and OCaml, targeting both OCaml native and byte code
+compilation modes, as well JavaScript using BuckleScript.
+
+The api includes concrete implementations of vectors, sets, and maps. Many
+implementations support transient mutability for efficient batch mutations.
+Additionally Immutable-re provides lazy functional iterators and sequences,
+along with type definitions for basic operators such as equality, comparison,
+and hashing.

--- a/packages/immutable/immutable.0.0.1/opam
+++ b/packages/immutable/immutable.0.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Dave Bordoley <bordoley>"
+authors: "Dave Bordoley <bordoley>"
+homepage: "https://github.com/facebookincubator/immutable-re.git"
+license: "BSD"
+tags: ["reason" "immutable"]
+dev-repo: "git://github.com/facebookincubator/immutable-re.git"
+bug-reports: "https://github.com/facebookincubator/immutable-re/issues"
+substs: "pkg/META"
+build: [make "build"]
+depends: [
+  "topkg" {= "0.8.1"}
+  "reason" {= "1.13.0"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.03"]

--- a/packages/immutable/immutable.0.0.1/url
+++ b/packages/immutable/immutable.0.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/facebookincubator/immutable-re/archive/0.0.1.tar.gz"
+checksum: "b8728f45b2fad69aee1099031e849e87"


### PR DESCRIPTION
Pure Reason implementation of persistent immutable data structures.

Immutable-re provides a complete set of efficient persistent immutable data
structures for Reason and OCaml, targeting both OCaml native and byte code
compilation modes, as well JavaScript using BuckleScript.

The api includes concrete implementations of vectors, sets, and maps. Many
implementations support transient mutability for efficient batch mutations.
Additionally Immutable-re provides lazy functional iterators and sequences,
along with type definitions for basic operators such as equality, comparison,
and hashing.


---
* Homepage: https://github.com/facebookincubator/immutable-re.git
* Source repo: git://github.com/facebookincubator/immutable-re.git
* Bug tracker: https://github.com/facebookincubator/immutable-re/issues

---

Pull-request generated by opam-publish v0.3.2