### PR TITLE
pomap.3.0.6 is incompatible with OCaml 4.05

### DIFF
--- a/packages/pomap/pomap.3.0.6/opam
+++ b/packages/pomap/pomap.3.0.6/opam
@@ -23,4 +23,4 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
 ]
-available: [ ocaml-version >= "3.12" ]
+available: [ ocaml-version >= "3.12" & ocaml-version < "4.05.0" ]


### PR DESCRIPTION
opam-builder report:
  http://opam.ocamlpro.com/builder/html/pomap/pomap.3.0.6/78caa380c32b85e11b9e8e9dd93e569e

upstream issue report:
  https://github.com/mmottl/pomap/issues/2