### PR TITLE
ppx_jsobject_conv 0.4.3

### DIFF
--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/descr
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/descr
@@ -1,0 +1,8 @@
+Ppx plugin for Typeconv to derive conversion from ocaml types to js objects to use with js_of_ocaml.
+
+For types annotated with [@@deriving jsobject], plugin will generate pair of functions: *_of_jsobject/jsobject_of_*
+to convert from/to JavaScript objects. This allows one to use clean OCaml types to describe their logic, while having ability
+to easy go down to js types. Easy conversion from js objects to OCaml types means also, one can use fast native JSON.parse to
+convert JSON to OCaml types.
+
+Plugin supports number of customizations.

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Roma Sokolov <sokolov.r.v@gmail.com>"
+authors: [ "Roma Sokolov <sokolov.r.v@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/little-arhat/ppx_jsobject_conv"
+bug-reports: "https://github.com/little-arhat/ppx_jsobject_conv/issues"
+dev-repo: "git://github.com/little-arhat/ppx_jsobject_conv.git"
+tags: [ "syntax" "jsoo" "javascript"]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "js_of_ocaml" {>= "2.8"}
+  "result"
+  "ppx_type_conv" {>= "v0.9.0"}
+  "ppx_driver"
+  "ppx_core"
+  "ppx_deriving"
+  "ocamlfind"    {build}
+  "ocamlbuild"   {build}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/url
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/little-arhat/ppx_jsobject_conv/archive/v0.4.3.tar.gz"
+checksum: "d7dab76cbf87495132c0b2f429cc73f4"


### PR DESCRIPTION
Fixes runtime dependency on `ppx_core.for_ppx_deriving` and
`ppx_type_conv.for_ppx_deriving` which are no longer exist.

Thanks for @disteph for pointing this out.