### PR TITLE
extlib.1.7.2 - via opam-publish

### DIFF
--- a/packages/extlib/extlib.1.7.2/descr
+++ b/packages/extlib/extlib.1.7.2/descr
@@ -1,0 +1,5 @@
+A complete yet small extension for OCaml standard library (reduced, recommended)
+The purpose of this library is to add new functions to OCaml standard library
+modules, to modify some functions in order to get better performances or
+safety (tail-recursive) and also to provide new modules which should be useful
+for day to day programming.

--- a/packages/extlib/extlib.1.7.2/opam
+++ b/packages/extlib/extlib.1.7.2/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/ygrek/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+doc: ["http://ygrek.org.ua/p/extlib/doc/"]
+license: "LGPL-2.1 with OCaml linking exception"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+  "Markus Mottl"
+  "Jesse Guardiani"
+  "John Skaller"
+  "Bardur Arantsson"
+  "Janne Hellsten"
+  "Richard W.M. Jones"
+  "ygrek"
+  "Gabriel Scherer"
+  "Pietro Abate"
+]
+build: [
+  [make "minimal=1" "build"]
+]
+install: [ [make "minimal=1" "install"] ]
+build-doc: [ [make "doc"] ]
+build-test: [ [make "test"] ]
+remove: [
+  ["ocamlfind" "remove" "extlib"]
+]
+depends: [
+  "ocamlfind" {build}
+  "cppo" {build}
+  "base-bytes" {build}
+]

--- a/packages/extlib/extlib.1.7.2/url
+++ b/packages/extlib/extlib.1.7.2/url
@@ -1,0 +1,3 @@
+http: "http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.2.tar.gz"
+mirrors: ["https://github.com/ygrek/ocaml-extlib/releases/download/1.7.2/extlib-1.7.2.tar.gz"]
+checksum: "0f550dd06242828399a73387c49e0eed"


### PR DESCRIPTION
A complete yet small extension for OCaml standard library (reduced, recommended)
The purpose of this library is to add new functions to OCaml standard library
modules, to modify some functions in order to get better performances or
safety (tail-recursive) and also to provide new modules which should be useful
for day to day programming.


---
* Homepage: https://github.com/ygrek/ocaml-extlib
* Source repo: git://github.com/ygrek/ocaml-extlib.git
* Bug tracker: https://github.com/ygrek/ocaml-extlib/issues

---

Pull-request generated by opam-publish v0.3.2