### PR TITLE
mm.0.3.0 cannot be built with 4.04.0+flambda due to Mantis PR7426.

### DIFF
--- a/packages/mm/mm.0.3.0/opam
+++ b/packages/mm/mm.0.3.0/opam
@@ -23,3 +23,4 @@ depopts: [
 ]
 bug-reports: "https://github.com/savonet/ocaml-mm/issues"
 dev-repo: "https://github.com/savonet/ocaml-mm.git"
+available: [compiler != "4.04.0+flambda"]


### PR DESCRIPTION
https://caml.inria.fr/mantis/view.php?id=7426