### PR TITLE
ppx_deriving: update bounds on OCaml version

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.3.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.3/opam
@@ -26,5 +26,5 @@ depends: [
   "ppx_tools"  {>= "4.02.3"}
   "ounit"      {test}
 ]
-available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.05" & opam-version >= "1.2" ]
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]

--- a/packages/ppx_deriving/ppx_deriving.4.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.0/opam
@@ -27,5 +27,5 @@ depends: [
   "result"
   "ounit"      {test}
 ]
-available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.05" & opam-version >= "1.2" ]
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]

--- a/packages/ppx_deriving/ppx_deriving.4.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1/opam
@@ -27,5 +27,5 @@ depends: [
   "result"
   "ounit"      {test}
 ]
-available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+available: [ ocaml-version >= "4.02.1" & ocaml-version < "4.05" & opam-version >= "1.2" ]
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]


### PR DESCRIPTION
`ppx_deriving` does not work with 4.05.0+beta3 because the AST changed. IIUC `ppx_deriving` will have to be adapted, possibly with the help of `ocaml-migrate-parsetree`.

cc @whitequark 