### PR TITLE
bau: does not work with 4.05

### DIFF
--- a/packages/bau/bau.0.0.2/opam
+++ b/packages/bau/bau.0.0.2/opam
@@ -12,4 +12,4 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.05"]

--- a/packages/bau/bau.0.0.3/opam
+++ b/packages/bau/bau.0.0.3/opam
@@ -12,4 +12,4 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.05"]


### PR DESCRIPTION
Both bau 0.0.2 and 0.0.3 don't work in 4.05 because the parsetree was changed.
bau 0.0.3 also doesn't work because we added `Bigarray.Array0`.

cc @rleonid 
