### PR TITLE
extlib 1.7.1: add bound on OCaml version

### DIFF
--- a/packages/extlib/extlib.1.7.1/opam
+++ b/packages/extlib/extlib.1.7.1/opam
@@ -32,3 +32,4 @@ depends: [
   "cppo" {build}
   "base-bytes"
 ]
+available: [ ocaml-version < "4.05.0" ]


### PR DESCRIPTION
extlib 1.7.1 does not compile with OCaml 4.05 because of the new function `Hashtbl.find_opt`.
Interestingly, extlib 1.7.0 does work.

cc @gasche 
