### PR TITLE
mikmatch: does not work with pcre >= 7.2

### DIFF
--- a/packages/mikmatch/mikmatch.1.0.8/opam
+++ b/packages/mikmatch/mikmatch.1.0.8/opam
@@ -25,4 +25,7 @@ depends: [
 depopts: [
   "pcre"
 ]
+conflicts: [
+  "pcre" {>= "7.2"}
+]
 available: [ ocaml-version >= "4.01" ]


### PR DESCRIPTION
Note that part of `mikmatch` is be installed when `pcre` is absent, and could also be installed when `pcre` is incompatible, but I don't know how to express that in opam.

A solution might be to split `mikmatch` into two packages: `mikmatch` and `mikmatch-pcre`.

cc @ujamjar
