### PR TITLE
ppx_ast.v0.9.1 — via opam-publish

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.9.1/descr
+++ b/packages/ppx_ast/ppx_ast.v0.9.1/descr
@@ -1,0 +1,9 @@
+OCaml AST used by Jane Street ppx rewriters
+
+Ppx_ast selects a specific version of the OCaml Abstract Syntax Tree
+from the migrate-parsetree project that is not necessarily the same
+one as the one being used by the compiler.
+
+It also snapshots the corresponding parser and pretty-printer from the
+OCaml compiler, to create a full frontend independent of the version
+of OCaml.

--- a/packages/ppx_ast/ppx_ast.v0.9.1/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_ast"
+bug-reports: "https://github.com/janestreet/ppx_ast/issues"
+dev-repo: "https://github.com/janestreet/ppx_ast.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs "@install"]
+]
+depends: [
+  "jbuilder"                {build & >= "1.0+beta2"}
+  "ocaml-compiler-libs"     {>= "v0.9" & < "v0.10"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_ast/ppx_ast.v0.9.1/url
+++ b/packages/ppx_ast/ppx_ast.v0.9.1/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/ppx_ast/archive/v0.9.1.tar.gz"
+checksum: "aaf009fd50a6342c95bf3c1422da0273"


### PR DESCRIPTION
OCaml AST used by Jane Street ppx rewriters

Ppx_ast selects a specific version of the OCaml Abstract Syntax Tree
from the migrate-parsetree project that is not necessarily the same
one as the one being used by the compiler.

It also snapshots the corresponding parser and pretty-printer from the
OCaml compiler, to create a full frontend independent of the version
of OCaml.


---
* Homepage: https://github.com/janestreet/ppx_ast
* Source repo: git+https://github.com/janestreet/ppx_ast.git
* Bug tracker: https://github.com/janestreet/ppx_ast/issues

---
### opam-lint failures
- **ERROR** 32 Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4