### PR TITLE
depext-1.0.3 does not compile on FreeBSD (since https://github.com/oc…

### DIFF
--- a/packages/depext/depext.1.0.3/opam
+++ b/packages/depext/depext.1.0.3/opam
@@ -13,4 +13,4 @@ license: "LGPL-3.0 with OCaml linking exception"
 tags: "flags:plugin"
 dev-repo: "https://github.com/ocaml/opam-depext.git"
 build: [make]
-available: [opam-version >= "1.1.0"]
+available: [opam-version >= "1.1.0" & os != "freebsd"]


### PR DESCRIPTION
…aml/opam-depext/pull/59, fixed (unreleased patch https://github.com/ocaml/opam-depext/pull/61))

1.0.2 and master work fine..