### PR TITLE
mechaml.0.1 - via opam-publish

### DIFF
--- a/packages/mechaml/mechaml.0.1/descr
+++ b/packages/mechaml/mechaml.0.1/descr
@@ -1,0 +1,12 @@
+A Mechanize-like web scraping library
+Mechaml is a simple web scraping library that allows to :
+* Fetch web content
+* Analyze, fill and submit HTML forms
+* Handle cookies, headers and redirections
+* Use a web proxy **(soon to be implemented)**
+
+Mechaml is built on top of existing libraries that alreay provide most of the
+interesting features : Cohttp and Lwt for asynchronous I/O and HTTP handling,
+and Lambdasoup to parse HTML. It provides an interface that handles the
+interactions between these and add useful features.
+

--- a/packages/mechaml/mechaml.0.1/opam
+++ b/packages/mechaml/mechaml.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Yann Hamdaoui <yann.hamdaoui@gmail.com>"
+authors: "Yann Hamdaoui <yann.hamdaoui@gmail.com>"
+homepage: "https://github.com/yannham/mechaml"
+bug-reports: "https://github.com/yannham/mechaml/issues"
+license: "LGPL v3"
+dev-repo: "git://github.com/yannham/mechaml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+build-doc: ["make doc"]
+remove: ["ocamlfind" "remove" "mechaml"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "cohttp"
+  "lwt"
+  "uri"
+  "lambdasoup" {< "0.7.0"}
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/mechaml/mechaml.0.1/url
+++ b/packages/mechaml/mechaml.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/yannham/mechaml/archive/opam-release-0.1.tar.gz"
+checksum: "9294b88d7fe4ce3b42b9de4363827681"


### PR DESCRIPTION
A Mechanize-like web scraping library
Mechaml is a simple web scraping library that allows to :
* Fetch web content
* Analyze, fill and submit HTML forms
* Handle cookies, headers and redirections
* Use a web proxy **(soon to be implemented)**

Mechaml is built on top of existing libraries that alreay provide most of the
interesting features : Cohttp and Lwt for asynchronous I/O and HTTP handling,
and Lambdasoup to parse HTML. It provides an interface that handles the
interactions between these and add useful features.



---
* Homepage: https://github.com/yannham/mechaml
* Source repo: git://github.com/yannham/mechaml.git
* Bug tracker: https://github.com/yannham/mechaml/issues

---

Pull-request generated by opam-publish v0.3.4