### PR TITLE
cstruct.2.4.0 - via opam-publish

### DIFF
--- a/packages/cstruct/cstruct.2.4.0/descr
+++ b/packages/cstruct/cstruct.2.4.0/descr
@@ -1,0 +1,22 @@
+access C structures via a camlp4 extension
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the Bigarray module.
+
+An example pcap description using PPX extension points is:
+
+```
+[%%cstruct
+type pcap_header = {
+  magic_number: uint32_t;   (* magic number *)
+  version_major: uint16_t;  (* major version number *)
+  version_minor: uint16_t;  (* minor version number *)
+  thiszone: uint32_t;       (* GMT to local correction *)
+  sigfigs: uint32_t;        (* accuracy of timestamps *)
+  snaplen: uint32_t;        (* max length of captured packets, in octets *)
+  network: uint32_t;        (* data link type *)
+} [@@little_endian]]
+```
+
+For Camlp4 support, please use a version of Cstruct that is `<=1.9.0`

--- a/packages/cstruct/cstruct.2.4.0/opam
+++ b/packages/cstruct/cstruct.2.4.0/opam
@@ -1,0 +1,66 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Richard Mortier"
+  "Thomas Gazagnaire"
+  "Pierre Chambart"
+  "David Kaloper"
+  "Jeremy Yallop"
+  "David Scott"
+  "Mindy Preston"
+]
+homepage: "https://github.com/mirage/ocaml-cstruct"
+bug-reports: "https://github.com/mirage/ocaml-cstruct/issues"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/ocaml-cstruct.git"
+build: [
+  [
+    "./configure"
+    "--prefix"
+    prefix
+    "--%{lwt+base-unix:enable}%-lwt"
+    "--enable-ppx"
+    "--%{async:enable}%-async"
+    "--%{base-unix:enable}%-unix"
+  ]
+  [make]
+]
+install: [
+  [make "install"]
+  [make "js-install"]
+]
+build-test: [
+  [
+    "./configure"
+    "--prefix"
+    prefix
+    "--%{lwt:enable}%-lwt"
+    "--enable-ppx"
+    "--%{async:enable}%-async"
+    "--%{base-unix:enable}%-unix"
+    "--enable-tests"
+  ]
+  [make]
+  [make "test"]
+]
+remove: [
+  [make "js-uninstall"]
+  ["ocamlfind" "remove" "cstruct"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ounit" {test}
+  "ocplib-endian"
+  "sexplib"
+  "base-bytes"
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+]
+depopts: ["async" "lwt" "base-unix"]
+depexts: [
+  [["debian"] ["time"]]
+  [["ubuntu"] ["time"]]
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/cstruct/cstruct.2.4.0/url
+++ b/packages/cstruct/cstruct.2.4.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cstruct/archive/v2.4.0.tar.gz"
+checksum: "cabfb205187391373f746a4e7d109d45"


### PR DESCRIPTION
access C structures via a camlp4 extension

Cstruct is a library and syntax extension to make it easier to access C-like
structures directly from OCaml. It supports both reading and writing to these
structures, and they are accessed via the Bigarray module.

An example pcap description using PPX extension points is:

```
[%%cstruct
type pcap_header = {
  magic_number: uint32_t;   (* magic number *)
  version_major: uint16_t;  (* major version number *)
  version_minor: uint16_t;  (* minor version number *)
  thiszone: uint32_t;       (* GMT to local correction *)
  sigfigs: uint32_t;        (* accuracy of timestamps *)
  snaplen: uint32_t;        (* max length of captured packets, in octets *)
  network: uint32_t;        (* data link type *)
} [@@little_endian]]
```

For Camlp4 support, please use a version of Cstruct that is `<=1.9.0`


---
* Homepage: https://github.com/mirage/ocaml-cstruct
* Source repo: https://github.com/mirage/ocaml-cstruct.git
* Bug tracker: https://github.com/mirage/ocaml-cstruct/issues

---

Pull-request generated by opam-publish v0.3.4