### PR TITLE
xe-unikernel-upload: add upper and lower bounds

### DIFF
--- a/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
+++ b/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
@@ -8,7 +8,7 @@ depends: [
   "ocamlfind" {build}
   "cmdliner"
   "lwt"
-  "xen-api-client" {<"0.9.9"}
+  "xen-api-client" {>="0.9.4" & <"0.9.9"}
   "cstruct" {>="1.3.0" & <"2.0.0"}
   "mbr-format" {>="0.3"}
   "fat-filesystem"

--- a/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
+++ b/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
@@ -5,15 +5,15 @@ remove: [
   ["make" "uninstall" "BINDIR=%{bin}%" "MANDIR=%{man}%/man1"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "cmdliner"
   "lwt"
   "xen-api-client"
-  "cstruct"
-  "mbr-format"
+  "cstruct" {>="1.3.0" & <"2.0.0"}
+  "mbr-format" {>="0.3"}
   "fat-filesystem"
   "io-page"
-  "mirage-types" {< "2.3.0"}
+  "mirage-types" {< "2.3.0" & <"3.0.0"}
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/djs55/xe-unikernel-upload"

--- a/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
+++ b/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
@@ -8,12 +8,12 @@ depends: [
   "ocamlfind" {build}
   "cmdliner"
   "lwt"
-  "xen-api-client"
+  "xen-api-client" {<"0.9.9"}
   "cstruct" {>="1.3.0" & <"2.0.0"}
   "mbr-format" {>="0.3"}
   "fat-filesystem"
   "io-page"
-  "mirage-types" {< "2.3.0" & <"3.0.0"}
+  "mirage-types" {< "2.3.0" & >"2.1.0"}
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/djs55/xe-unikernel-upload"

--- a/packages/xe-unikernel-upload/xe-unikernel-upload.0.5/opam
+++ b/packages/xe-unikernel-upload/xe-unikernel-upload.0.5/opam
@@ -5,11 +5,11 @@ remove: [
   ["make" "uninstall" "BINDIR=%{bin}%" "MANDIR=%{man}%/man1"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "cmdliner"
   "lwt"
   "xen-api-client"
-  "cstruct"
+  "cstruct" {>="1.3.0" & <"2.0.0"}
   "mbr-format" {>= "0.3"}
   "fat-filesystem"
   "io-page"

--- a/packages/xe-unikernel-upload/xe-unikernel-upload.0.5/opam
+++ b/packages/xe-unikernel-upload/xe-unikernel-upload.0.5/opam
@@ -8,7 +8,7 @@ depends: [
   "ocamlfind" {build}
   "cmdliner"
   "lwt"
-  "xen-api-client"
+  "xen-api-client" {<"0.9.9"}
   "cstruct" {>="1.3.0" & <"2.0.0"}
   "mbr-format" {>= "0.3"}
   "fat-filesystem"

--- a/packages/xe-unikernel-upload/xe-unikernel-upload.0.5/opam
+++ b/packages/xe-unikernel-upload/xe-unikernel-upload.0.5/opam
@@ -8,7 +8,7 @@ depends: [
   "ocamlfind" {build}
   "cmdliner"
   "lwt"
-  "xen-api-client" {<"0.9.9"}
+  "xen-api-client" {>="0.9.5" & <"0.9.9"}
   "cstruct" {>="1.3.0" & <"2.0.0"}
   "mbr-format" {>= "0.3"}
   "fat-filesystem"


### PR DESCRIPTION
upper bounds on mirage3, and lower bounds on cstruct for the
Lwt_cstruct.complete function