### PR TITLE
+zarith-freestanding.1.4.1

### DIFF
--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/descr
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/descr
@@ -1,0 +1,5 @@
+Implements arithmetic and logical operations over arbitrary-precision integers
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy.

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/config.diff
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/config.diff
@@ -1,0 +1,17 @@
+--- a/configure	2016-07-22 21:53:10.872919000 +0200
++++ b/configure	2016-07-22 21:55:23.788871000 +0200
+@@ -340,12 +340,8 @@
+ if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
+     checkinc gmp.h
+     if test $? -eq 1; then
+-        checklib gmp
+-        if test $? -eq 1; then 
+-            gmp='OK'
+-            cclib="$cclib -lgmp"
+-            ccdef="-DHAS_GMP $ccdef"
+-        fi
++        gmp='OK'
++        ccdef="-DHAS_GMP $ccdef"
+     fi
+ fi
+ if test "$gmp" = 'mpir' -o "$gmp" = 'auto'; then

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/mirage-build.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/mirage-build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+# WARNING: if you pass invalid cflags here, zarith will silently
+# fall back to compiling with the default flags instead!
+CFLAGS="$(pkg-config --cflags gmp-freestanding ocaml-freestanding)" \
+LDFLAGS="$(pkg-config --libs gmp-freestanding)" \
+./configure -gmp
+
+if [ `uname -s` = "FreeBSD" ]; then
+    gmake
+else
+    make
+fi

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/mirage-install.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/mirage-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+cp libzarith.a "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+# This is a hack to get freestanding_linkopts into the host 'zarith' package.
+cat >>"$PREFIX/lib/zarith/META" <<EOM
+freestanding_linkopts = "-lzarith-freestanding -L@gmp-freestanding -lgmp-freestanding"
+EOM

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/mirage-uninstall.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/files/mirage-uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+
+rm -f "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+mv "$PREFIX/lib/zarith/META" "$PREFIX/lib/zarith/META.tmp"
+cat "$PREFIX/lib/zarith/META.tmp" | grep -v freestanding_linkopts > "$PREFIX/lib/zarith/META"
+rm -f "$PREFIX/lib/zarith/META.tmp"

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+authors: "Xavier Leroy"
+maintainer: "mirageos-devel"
+homepage: "https://forge.ocamlcore.org/projects/zarith"
+build: ["sh" "-eux" "./mirage-build.sh"]
+install: ["sh" "-eux" "./mirage-install.sh"]
+remove: ["sh" "-eux" "./mirage-uninstall.sh"]
+depends: [
+  "ocaml-freestanding"
+  "gmp-freestanding"
+  "zarith" {= "1.4.1"}
+  "ocamlfind"
+]
+patches: [ "config.diff" ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/url
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1574/zarith-1.4.1.tgz"
+checksum: "9ab2482d57f632c9cb3d10149138bc6e"


### PR DESCRIPTION
(due to version constraints); from zarith changelog:
Release 1.4.1 (2015-11-09):
- Fixed ml_z_of_substring_base and Z.of_substring [Thomas Braibant]
- Integrated Opam fix for Perl scripts [Thomas Braibant]

--> the z_pp.pl.patch was upstreamed and thus removed here