### PR TITLE
type-beat.0.1 - via opam-publish

### DIFF
--- a/packages/type-beat/type-beat.0.1/descr
+++ b/packages/type-beat/type-beat.0.1/descr
@@ -1,0 +1,3 @@
+A parser for the Content-Type value
+
+A agnostic parser for the Content-Type value (from the RFC822 and the RFC2045).

--- a/packages/type-beat/type-beat.0.1/opam
+++ b/packages/type-beat/type-beat.0.1/opam
@@ -8,4 +8,12 @@ doc: "https://oklm-wsh.github.io/TypeBeat/"
 dev-repo: "https://github.com/oklm-wsh/TypeBeat.git"
 build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%"]
 build-test: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%"]
-depends: "angstrom"
+depends:
+[
+  "topkg" {build}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "angstrom"
+]
+
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/type-beat/type-beat.0.1/opam
+++ b/packages/type-beat/type-beat.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/oklm-wsh/TypeBeat"
+bug-reports: "https://github.com/oklm-wsh/TypeBeat/issues"
+license: "MIT"
+doc: "https://oklm-wsh.github.io/TypeBeat/"
+dev-repo: "https://github.com/oklm-wsh/TypeBeat.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%"]
+build-test: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%"]
+depends: "angstrom"

--- a/packages/type-beat/type-beat.0.1/opam
+++ b/packages/type-beat/type-beat.0.1/opam
@@ -16,4 +16,4 @@ depends:
   "angstrom"
 ]
 
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/type-beat/type-beat.0.1/url
+++ b/packages/type-beat/type-beat.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/oklm-wsh/TypeBeat/archive/0.1.tar.gz"
+checksum: "558891c835ce07666ac5fc2eac7471ea"


### PR DESCRIPTION
A parser for the Content-Type value

A agnostic parser for the Content-Type value (from the RFC822 and the RFC2045).


---
* Homepage: https://github.com/oklm-wsh/TypeBeat
* Source repo: https://github.com/oklm-wsh/TypeBeat.git
* Bug tracker: https://github.com/oklm-wsh/TypeBeat/issues

---

Pull-request generated by opam-publish v0.3.4