### PR TITLE
irmin.1.0.2 - via opam-publish

### DIFF
--- a/packages/irmin/irmin.1.0.2/descr
+++ b/packages/irmin/irmin.1.0.2/descr
@@ -1,0 +1,7 @@
+Irmin, a distributed database that follows the same design principles as Git
+
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.

--- a/packages/irmin/irmin.1.0.2/opam
+++ b/packages/irmin/irmin.1.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build:
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"]
+
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test" "-n" name]
+]
+
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.9.0"}
+  "fmt"
+  "ocamlgraph"
+  "lwt" {>= "2.4.7"}
+  "logs" {>= "0.5.0"}
+  "cstruct" {>= "1.6.0"}
+  "jsonm" {>= "1.0.0"}
+  "uri" {>= "1.3.12"}
+  "astring"
+  "hex"
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.0.2/url
+++ b/packages/irmin/irmin.1.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.0.2/irmin-1.0.2.tbz"
+checksum: "fb8a6dab7c4dcbfadd8530c6351a7add"


### PR DESCRIPTION
Irmin, a distributed database that follows the same design principles as Git

Irmin is a library for persistent stores with built-in snapshot,
branching and reverting mechanisms. It is designed to use a large
variety of backends. Irmin is written in pure OCaml and does not
depend on external C stubs; it aims to run everywhere, from Linux,
to browsers and Xen unikernels.


---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 1.0.2 (2017-03-27)

**irmin**

- Add a cstruct type combinator (#429, @samoht)
- Fix regression introduced in 1.0.1 on merge of base buffers (strings,
  cstruct). For these types, updates are idempotent, e.g. it is fine
  if two concurrent branches make the same update. (#429, @samoht)

**irmin-unix**

- Add irminconfig man page (#427, @dudelson)
Pull-request generated by opam-publish v0.3.2