### PR TITLE
irmin-unix.1.0.2 - via opam-publish

### DIFF
--- a/packages/irmin-unix/irmin-unix.1.0.2/descr
+++ b/packages/irmin-unix/irmin-unix.1.0.2/descr
@@ -1,0 +1,5 @@
+Unix backends for Irmin
+
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.

--- a/packages/irmin-unix/irmin-unix.1.0.2/opam
+++ b/packages/irmin-unix/irmin-unix.1.0.2/opam
@@ -23,6 +23,7 @@ depends: [
   "irmin-git"  {>= "1.0.0"}
   "irmin-http" {>= "1.0.0"}
   "git-unix"   {>= "1.10.0"}
+  "cmdliner"   {>= "1.0.0"}
   "irmin-watcher" {>= "0.2.0"}
   "irmin-mirage" {test & >= "1.0.0"}
   "alcotest"     {test}

--- a/packages/irmin-unix/irmin-unix.1.0.2/opam
+++ b/packages/irmin-unix/irmin-unix.1.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test" "-n" name]
+]
+
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.9.0"}
+  "irmin"      {>= "1.0.0"}
+  "irmin-git"  {>= "1.0.0"}
+  "irmin-http" {>= "1.0.0"}
+  "git-unix"   {>= "1.10.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "irmin-mirage" {test & >= "1.0.0"}
+  "alcotest"     {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-unix/irmin-unix.1.0.2/url
+++ b/packages/irmin-unix/irmin-unix.1.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.0.2/irmin-1.0.2.tbz"
+checksum: "fb8a6dab7c4dcbfadd8530c6351a7add"


### PR DESCRIPTION
Unix backends for Irmin

`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
stores.

---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 1.0.2 (2017-03-27)

**irmin**

- Add a cstruct type combinator (#429, @samoht)
- Fix regression introduced in 1.0.1 on merge of base buffers (strings,
  cstruct). For these types, updates are idempotent, e.g. it is fine
  if two concurrent branches make the same update. (#429, @samoht)

**irmin-unix**

- Add irminconfig man page (#427, @dudelson)
Pull-request generated by opam-publish v0.3.2