### PR TITLE
mirage-protocols: enforce lower bounds on mirage-flow

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.1.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "topkg" {build & >= "0.8.0"}
   "mirage-device" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
-  "fmt"
+  "fmt" {>="0.8.2"}
 ]
 
 available: [ ocaml-version >= "4.03.0"]

--- a/packages/mirage-protocols/mirage-protocols.1.1.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.1.0/opam
@@ -14,9 +14,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device"
-  "mirage-flow"
-  "fmt"
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>="1.2.0"}
+  "fmt" {>="0.8.2"}
 ]
 
 available: [ ocaml-version >= "4.03.0"]


### PR DESCRIPTION
Sync up the versions so that they consistently use mirage3 libraries