### PR TITLE
jitsu: install the array of packages required for dns.lwt

### DIFF
--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -14,6 +14,8 @@ build-test: [
 ]
 depends: [  "lwt"
             "dns"  { >= "0.15.3" }
+            "mirage-time" "mirage-stack-lwt" "mirage-kv-lwt" "duration" "mirage-profile"
+            # above are needed for dns.lwt
             "xenstore"
             "xenstore_transport"
             "cmdliner"

--- a/packages/jitsu/jitsu.0.3.0/opam
+++ b/packages/jitsu/jitsu.0.3.0/opam
@@ -18,6 +18,8 @@ build-test: [
 depends: [  "ocamlfind"
             "lwt"
             "dns"  { >= "0.15.3" }
+            "mirage-time" "mirage-stack-lwt" "mirage-kv-lwt" "duration" "mirage-profile"
+            # above are needed for dns.lwt
             "xenstore"
             "xenstore_transport"
             "cmdliner"


### PR DESCRIPTION
And yes, I am fixing the rather crazy set of depopts that dns.lwt
seems to be pulling in these days; see
https://github.com/mirage/ocaml-dns/issues/135