### PR TITLE
lru.0.2.0 - via opam-publish

### DIFF
--- a/packages/lru/lru.0.2.0/descr
+++ b/packages/lru/lru.0.2.0/descr
@@ -1,0 +1,16 @@
+Scalable LRU caches
+
+
+lru provides LRU caches for OCaml. These are size-bounded finite maps that
+remove the least-recently-used (LRU) bindings to maintain their size constraint.
+
+The library has two implementations: one is functional, the other imperative.
+
+lru is distributed under the ISC license.
+
+
+## Documentation
+
+Interface, [online][doc].
+
+[doc]: https://pqwy.github.io/lru/doc

--- a/packages/lru/lru.0.2.0/opam
+++ b/packages/lru/lru.0.2.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/lru"
+doc: "https://pqwy.github.io/lru/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/lru.git"
+bug-reports: "https://github.com/pqwy/lru/issues"
+tags: ["data-structure"]
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "psq"
+  "alcotest" {test} ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]

--- a/packages/lru/lru.0.2.0/url
+++ b/packages/lru/lru.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/lru/releases/download/v0.2.0/lru-0.2.0.tbz"
+checksum: "0de0ccda69b0b07a1c8169395782617f"


### PR DESCRIPTION
Scalable LRU caches


lru provides LRU caches for OCaml. These are size-bounded finite maps that
remove the least-recently-used (LRU) bindings to maintain their size constraint.

The library has two implementations: one is functional, the other imperative.

lru is distributed under the ISC license.


## Documentation

Interface, [online][doc].

[doc]: https://pqwy.github.io/lru/doc

---
* Homepage: https://github.com/pqwy/lru
* Source repo: https://github.com/pqwy/lru.git
* Bug tracker: https://github.com/pqwy/lru/issues

---


---
## v0.2.0 2017-03-31

Breaking changes:

* `resize` no longer drops bindings if the new size pushes the queue over capacity.

* `of_list` has simpler semantics; dropped the `cap` parameter.

Other changes:

* Replace `Lru.M.cache` with more general `Lru.memo`.

* Queues with 0 initial capacity are legal.

* Add `trim` to shrink a queue to its capacity, as queues are no longer guaranteed to
  have size smaller than capacity.

* `find` gets the `promote` parameter, allowing queries that do not change the order.

* `add` gets the `trim` parameter, allowing insertions that do not drop old entries.
Pull-request generated by opam-publish v0.3.4