### PR TITLE
pumping.0.1.0 - via opam-publish

### DIFF
--- a/packages/pumping/pumping.0.1.0/descr
+++ b/packages/pumping/pumping.0.1.0/descr
@@ -1,0 +1,3 @@
+Regular languages in types
+
+Pumping is a library leverage the OCaml type system to recognize regular languages.

--- a/packages/pumping/pumping.0.1.0/opam
+++ b/packages/pumping/pumping.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer:   "Gabriel Radanne <drupyog@zoho.com>"
+authors:      [ "Gabriel Radanne" ]
+homepage:     "https://github.com/Drup/pumping"
+bug-reports:  "https://github.com/Drup/pumping/issues"
+dev-repo:     "https://github.com/Drup/pumping.git"
+license: "LGPL with OCaml linking exception"
+tags: [ "regex" "types" ]
+build: [
+  ["jbuilder" "build" "--only-packages" "pumping" "--root" "." "-j" jobs "@install"]
+]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree"
+  "fmt"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/pumping/pumping.0.1.0/url
+++ b/packages/pumping/pumping.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Drup/pumping/archive/0.1.0.tar.gz"
+checksum: "4b3f058aa0dc4842927b3b7e29064ce2"


### PR DESCRIPTION
Regular languages in types

Pumping is a library leverage the OCaml type system to recognize regular languages.

---
* Homepage: https://github.com/Drup/pumping
* Source repo: https://github.com/Drup/pumping.git
* Bug tracker: https://github.com/Drup/pumping/issues

---

Pull-request generated by opam-publish v0.3.3