### PR TITLE
Constrain unix-fcntl to OCaml versions below 4.05.0

### DIFF
--- a/packages/unix-fcntl/unix-fcntl.0.2.0/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.2.0/opam
@@ -14,3 +14,4 @@ depends: [
   "unix-errno" {>= "0.2.0" & < "0.3.0"}
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.05.0" ]

--- a/packages/unix-fcntl/unix-fcntl.0.3.0/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.0/opam
@@ -17,4 +17,4 @@ depends: [
   "unix-type-representations"
 ]
 depopts: ["lwt" "base-threads"]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.05.0" ]

--- a/packages/unix-fcntl/unix-fcntl.0.3.1/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.1/opam
@@ -26,4 +26,5 @@ depopts: [
   "base-threads"
 ]
 conflicts: ["lwt" {< "2.4.7"}]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.05.0" ]
+

--- a/packages/unix-fcntl/unix-fcntl.0.3.2/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.2/opam
@@ -19,4 +19,5 @@ depends: [
 ]
 depopts: ["lwt" "base-threads"]
 conflicts: ["lwt" {< "2.4.7"}]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.05.0" ]
+

--- a/packages/unix-fcntl/unix-fcntl.0.3.3/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.3/opam
@@ -19,4 +19,4 @@ depends: [
 ]
 depopts: ["lwt" "base-threads"]
 conflicts: ["lwt" {< "2.4.7"}]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.05.0" ]

--- a/packages/unix-fcntl/unix-fcntl.0.3.4/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.4/opam
@@ -19,4 +19,4 @@ depends: [
 ]
 depopts: ["lwt" "base-threads"]
 conflicts: ["lwt" {< "2.4.7"}]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.05.0" ]

--- a/packages/unix-fcntl/unix-fcntl.0.3.5/opam
+++ b/packages/unix-fcntl/unix-fcntl.0.3.5/opam
@@ -19,4 +19,4 @@ depends: [
 ]
 depopts: ["lwt" "base-threads"]
 conflicts: ["lwt" {< "2.4.7"}]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.05.0" ]


### PR DESCRIPTION
unix-fcntl doesn't build with 4.05.0, which introduces O_KEEPEXEC:

```
    File "unix/fcntl_unix.ml", line 58, characters 28-516:
    Warning 8: this pattern-matching is not exhaustive.
    Here is an example of a case that is not matched:
    O_KEEPEXEC
    File "unix/fcntl_unix.ml", line 1:
    Error: Some fatal warnings were triggered (1 occurrences)
    Command exited with code 2.
    Makefile:77: recipe for target 'build' failed
```

/cc @dsheets