### PR TITLE
charrua-core.0.6 - via opam-publish

### DIFF
--- a/packages/charrua-core/charrua-core.0.6/descr
+++ b/packages/charrua-core/charrua-core.0.6/descr
@@ -1,0 +1,20 @@
+DHCP core library - a DHCP server and wire frame encoder and decoder
+
+[charrua-core](http://www.github.com/mirage/charrua-core) is an
+_ISC-licensed_ DHCP library implementation in OCaml.
+
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](http://mirage.github.io/charrua-core/api)
+[![Build Status](https://travis-ci.org/mirage/charrua-core.svg)](https://travis-ci.org/mirage/charrua-core)
+
+It provides basically two modules, a `Dhcp` responsible for parsing and
+constructing DHCP messages and a `Dhcp_server` module used for constructing DHCP
+servers.
+
+[charrua-unix](http://www.github.com/haesbaert/charrua-unix) is a Unix DHCP
+server based on charrua-core.
+
+[mirage](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua-core.
+
+You can browse the API for [charrua-core](http://www.github.com/mirage/charrua-core) at
+http://mirage.github.io/charrua-core/api

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+name: "charrua-core"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua-core"
+bug-reports: "https://github.com/mirage/charrua-core/issues"
+dev-repo: "https://github.com/mirage/charrua-core.git"
+doc: "https://mirage.github.io/charrua-core/api"
+
+available: [ocaml-version >= "4.03" & opam-version >= "1.2"]
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+]
+
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+
+depends: [
+  "ocamlfind"     {build}
+  "ocamlbuild"    {build}
+  "topkg"         {build}
+  "ppx_sexp_conv" {build}
+  "ppx_tools"     {build}
+  "menhir"        {build}
+  "cstruct"       {>= "1.9.0"}
+  "sexplib"
+  "ipaddr"        {>= "2.5.0"}
+  "tcpip"         {>= "3.1.0"}
+  "rresult"
+  "io-page"       {test}
+]

--- a/packages/charrua-core/charrua-core.0.6/url
+++ b/packages/charrua-core/charrua-core.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/charrua-core/releases/download/v0.6/charrua-core-0.6.tbz"
+checksum: "9d3dce29ca4f01060d8c6d4a8a66a457"


### PR DESCRIPTION
DHCP core library - a DHCP server and wire frame encoder and decoder

[charrua-core](http://www.github.com/mirage/charrua-core) is an
_ISC-licensed_ DHCP library implementation in OCaml.

[![docs](https://img.shields.io/badge/doc-online-blue.svg)](http://mirage.github.io/charrua-core/api)
[![Build Status](https://travis-ci.org/mirage/charrua-core.svg)](https://travis-ci.org/mirage/charrua-core)

It provides basically two modules, a `Dhcp` responsible for parsing and
constructing DHCP messages and a `Dhcp_server` module used for constructing DHCP
servers.

[charrua-unix](http://www.github.com/haesbaert/charrua-unix) is a Unix DHCP
server based on charrua-core.

[mirage](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
is a Mirage DHCP unikernel server based on charrua-core.

You can browse the API for [charrua-core](http://www.github.com/mirage/charrua-core) at
http://mirage.github.io/charrua-core/api

---
* Homepage: https://github.com/mirage/charrua-core
* Source repo: https://github.com/mirage/charrua-core.git
* Bug tracker: https://github.com/mirage/charrua-core/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
## 0.6 (2017-04-01)

* Dhcp_wire.buf_of_pkt now correctly rejects empty options.
* Dhcp_wire.options_of_buf now enforces minimun length on all cases.
* Fixed option code for Bcmcs_controller_ipv4_addr.
* **CRITICAL** Fixed a bug where dhcp_flags was read from the wrong offset.
Pull-request generated by opam-publish v0.3.3