### PR TITLE
tensorflow.0.0.10 - via opam-publish

### DIFF
--- a/packages/tensorflow/tensorflow.0.0.10/descr
+++ b/packages/tensorflow/tensorflow.0.0.10/descr
@@ -1,0 +1,4 @@
+TensorFlow bindings for OCaml
+
+The tensorflow-ocaml project provides some OCaml bindings for TensorFlow, a machine learning framework.
+These bindings are in an early stage of their development. Some operators are not supported and the API is likely to change in the future. You may also encounter some segfaults. That being said they already contain the necessary to train a convolution network using various optimizers.

--- a/packages/tensorflow/tensorflow.0.0.10/opam
+++ b/packages/tensorflow/tensorflow.0.0.10/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Laurent Mazare <lmazare@gmail.com>"
+authors: ["Laurent Mazare" "Nicolas Oury"]
+homepage: "https://github.com/LaurentMazare/tensorflow-ocaml"
+bug-reports: "https://github.com/LaurentMazare/tensorflow-ocaml/issues"
+dev-repo: "git+https://github.com/LaurentMazare/tensorflow-ocaml.git"
+build: [
+  "jbuilder"
+  "build"
+  "--only-packages"
+  "tensorflow"
+  "--root"
+  "."
+  "-j"
+  jobs
+  "@install"
+]
+depends: [
+  "cmdliner"
+  "base"
+  "stdio"
+  "ctypes" {>= "0.5"}
+  "ctypes-foreign"
+  "ocamlfind" {build}
+  "jbuilder" {build}
+]
+depopts: "gnuplot"
+available: [ocaml-version >= "4.03"]

--- a/packages/tensorflow/tensorflow.0.0.10/url
+++ b/packages/tensorflow/tensorflow.0.0.10/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/LaurentMazare/tensorflow-ocaml/archive/0.0.10.tar.gz"
+checksum: "af6f276e287f18abfe01c53a89022e5e"


### PR DESCRIPTION
TensorFlow bindings for OCaml

The tensorflow-ocaml project provides some OCaml bindings for TensorFlow, a machine learning framework.
These bindings are in an early stage of their development. Some operators are not supported and the API is likely to change in the future. You may also encounter some segfaults. That being said they already contain the necessary to train a convolution network using various optimizers.


---
* Homepage: https://github.com/LaurentMazare/tensorflow-ocaml
* Source repo: git+https://github.com/LaurentMazare/tensorflow-ocaml.git
* Bug tracker: https://github.com/LaurentMazare/tensorflow-ocaml/issues

---

Pull-request generated by opam-publish v0.3.4