### PR TITLE
ollvm-tapir.0.99.1 - via opam-publish

### DIFF
--- a/packages/ollvm-tapir/ollvm-tapir.0.99.1/descr
+++ b/packages/ollvm-tapir/ollvm-tapir.0.99.1/descr
@@ -1,0 +1,3 @@
+a fork of ollvm with added LLVM-Tapir support
+
+This fork of ollvm adds support for the extra instructions added by [LLVM-Tapir](https://github.com/wsmoses/Parallel-IR). It adds the `detach`, `reattach`, and `sync` instructions to ollvm.

--- a/packages/ollvm-tapir/ollvm-tapir.0.99.1/opam
+++ b/packages/ollvm-tapir/ollvm-tapir.0.99.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Nathan Holland <nholland94@gmail.com>"
+authors: [
+  "Julien Sagot <ju.sagot@gmail.com>"
+  "Nathan Holland <nholland94@gmail.com>"
+]
+homepage: "https://github.com/nholland94/ollvm-tapir"
+bug-reports: "https://github.com/nholland94/ollvm-tapir/issues"
+license: "LGPL"
+dev-repo: "https://github.com/nholland94/ollvm-tapir.git"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["./configure"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+]
+depopts: "llvm"
+conflicts: [
+  "llvm" {!= "3.5"}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/ollvm-tapir/ollvm-tapir.0.99.1/url
+++ b/packages/ollvm-tapir/ollvm-tapir.0.99.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nholland94/ollvm-tapir/archive/v0.99.1.tar.gz"
+checksum: "dec24aa84a436bdea3f9e517a6f97647"


### PR DESCRIPTION
a fork of ollvm with added LLVM-Tapir support

This fork of ollvm adds support for the extra instructions added by [LLVM-Tapir](https://github.com/wsmoses/Parallel-IR). It adds the `detach`, `reattach`, and `sync` instructions to ollvm.


---
* Homepage: https://github.com/nholland94/ollvm-tapir
* Source repo: https://github.com/nholland94/ollvm-tapir.git
* Bug tracker: https://github.com/nholland94/ollvm-tapir/issues

---

Pull-request generated by opam-publish v0.3.2