### PR TITLE
mirage-net-unix.2.4.0 - via opam-publish

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.2.4.0/descr
+++ b/packages/mirage-net-unix/mirage-net-unix.2.4.0/descr
@@ -1,0 +1,5 @@
+Unix implementation of the Mirage NETWORK interface.
+
+This interface exposes raw Ethernet frames using `ocaml-tuntap`,
+suitable for use with an OCaml network stack such as the one
+found at <https://github.com/mirage/mirage-tcpip>.

--- a/packages/mirage-net-unix/mirage-net-unix.2.4.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      [
+  "Anil Madhavapeddy"
+  "David Scott"
+  "Thomas Gazagnaire"
+  "Hannes Mehnert"
+]
+homepage:    "https://github.com/mirage/mirage-net-unix"
+bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
+dev-repo:    "https://github.com/mirage/mirage-net-unix.git"
+license:     "ISC"
+doc:         "https://mirage.github.io/mirage-net-unix/"
+
+build:   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "cstruct" {>= "1.7.1"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "io-page" {>= "1.0.1"}
+  "tuntap" {>= "1.3.0"}
+  "result"
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.3"]

--- a/packages/mirage-net-unix/mirage-net-unix.2.4.0/url
+++ b/packages/mirage-net-unix/mirage-net-unix.2.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net-unix/releases/download/2.4.0/mirage-net-unix-2.4.0.tbz"
+checksum: "815587d8cf618f897958bf9141ad69a4"


### PR DESCRIPTION
Unix implementation of the Mirage NETWORK interface.

This interface exposes raw Ethernet frames using `ocaml-tuntap`,
suitable for use with an OCaml network stack such as the one
found at <https://github.com/mirage/mirage-tcpip>.

---
* Homepage: https://github.com/mirage/mirage-net-unix
* Source repo: https://github.com/mirage/mirage-net-unix.git
* Bug tracker: https://github.com/mirage/mirage-net-unix/issues

---


---
### 2.4.0 (02-Apr-2017)

* Expose the underlying fd (#40, from @samoht)
Pull-request generated by opam-publish v0.3.2