### PR TITLE
shcaml.0.2.0 - via opam-publish

### DIFF
--- a/packages/shcaml/shcaml.0.2.0/descr
+++ b/packages/shcaml/shcaml.0.2.0/descr
@@ -1,0 +1,1 @@
+Library for Unix shell programming

--- a/packages/shcaml/shcaml.0.2.0/opam
+++ b/packages/shcaml/shcaml.0.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+authors: "Jesse A. Tov <jesse.tov@gmail.com>"
+maintainer: "Armael <armael@isomorphis.me>"
+homepage: "https://github.com/tov/shcaml"
+dev-repo: "git+https://github.com/tov/shcaml.git"
+bug-reports: "https://github.com/tov/shcaml/issues"
+doc: "https://tov.github.io/shcaml/doc"
+license: "MIT"
+available: [ ocaml-version >= "4.02.0" ]
+depends: [ "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build & >= "0.9.0"}
+           "cppo" {build}
+           "pcre"
+           "hmap"
+         ]
+depopts: [ "lwt" "base-unix" ]
+build:
+[
+  [ "ocaml" "pkg/pkg.ml" "build"
+      "--dev-pkg" "%{pinned}%"
+      "--with-lwt" "%{lwt+base-unix:installed}%"
+  ]
+]

--- a/packages/shcaml/shcaml.0.2.0/url
+++ b/packages/shcaml/shcaml.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/tov/shcaml/releases/download/0.2.0/shcaml-0.2.0.tbz"
+checksum: "b725f56686069a780adde0e39ce82f0c"


### PR DESCRIPTION
Library for Unix shell programming


---
* Homepage: https://github.com/tov/shcaml
* Source repo: git+https://github.com/tov/shcaml.git
* Bug tracker: https://github.com/tov/shcaml/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
Caml-Shcaml 0.2.0
-----------------

- Drop the dependency on camlp4, mainly by replacing the static typing of
  structured fields by a lighter, dynamically-checked discipline. This trades
  static guarantees for maintenability.

- Build system changes, switch to ocamlbuild+topkg

- Some API refactoring; improve API browsing at the price of some signature
  duplication in the source.

- Documentation improvements
Pull-request generated by opam-publish v0.3.4