### PR TITLE
future.0.2.0: add upper bound on version of solvuu-build

### DIFF
--- a/packages/future/future.0.2.0/opam
+++ b/packages/future/future.0.2.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "solvuu-build" {build & >= "0.1.0"}
+  "solvuu-build" {build & >= "0.1.0" & < "0.3.0"}
   "core" {>= "111.17.00"}
   "cfstream"
 ]


### PR DESCRIPTION
`future` doesn't compile with `solvuu-build` 0.3.0 (API change).

cc @agarwal 
