### PR TITLE
libsvm: add upper bound on version of sexplib

### DIFF
--- a/packages/libsvm/libsvm.0.8.3/opam
+++ b/packages/libsvm/libsvm.0.8.3/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "odietric@gmail.com"
+authors: [ "Oliver Gu <gu.oliver@yahoo.com>"
+           "Dominik Brugger <dominikbrugger@fastmail.fm>" ]
+homepage: "https://bitbucket.org/ogu/libsvm-ocaml"
 build: [
   ["ocaml" "setup.ml" "-configure"]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/libsvm/libsvm.0.8.3/opam
+++ b/packages/libsvm/libsvm.0.8.3/opam
@@ -11,7 +11,7 @@ remove: [["ocamlfind" "remove" "libsvm"]]
 depends: [
   "ocamlfind"
   "core" {>= "108.08.00"}
-  "lacaml"
+  "lacaml" {< "8.0"}
   "ocamlbuild" {build}
 ]
 conflicts: [

--- a/packages/libsvm/libsvm.0.8.3/opam
+++ b/packages/libsvm/libsvm.0.8.3/opam
@@ -11,6 +11,9 @@ depends: [
   "lacaml"
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "sexplib" {>= "113.24.00"}
+]
 patches: [
   "svm_cli_fix.patch"
   "calc_scc_fix.patch"

--- a/packages/libsvm/libsvm.0.8.3/opam
+++ b/packages/libsvm/libsvm.0.8.3/opam
@@ -22,3 +22,7 @@ patches: [
   "calc_scc_fix.patch"
 ]
 install: ["ocaml" "setup.ml" "-install"]
+depexts: [
+  [["ubuntu"]["libsvm-dev"]]
+  [["debian"]["libsvm-dev"]]
+]

--- a/packages/libsvm/libsvm.0.9.0/opam
+++ b/packages/libsvm/libsvm.0.9.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "gu.oliver@yahoo.com"
+authors: [ "Oliver Gu <gu.oliver@yahoo.com>"
+           "Dominik Brugger <dominikbrugger@fastmail.fm>" ]
+homepage: "https://bitbucket.org/ogu/libsvm-ocaml"
 build: [
   ["ocaml" "setup.ml" "-configure"]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/libsvm/libsvm.0.9.0/opam
+++ b/packages/libsvm/libsvm.0.9.0/opam
@@ -13,4 +13,7 @@ depends: [
   "archimedes"
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "sexplib" {>= "113.24.00"}
+]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/libsvm/libsvm.0.9.0/opam
+++ b/packages/libsvm/libsvm.0.9.0/opam
@@ -20,3 +20,7 @@ conflicts: [
   "sexplib" {>= "113.24.00"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+depexts: [
+  [["ubuntu"]["libsvm-dev"]]
+  [["debian"]["libsvm-dev"]]
+]

--- a/packages/libsvm/libsvm.0.9.0/opam
+++ b/packages/libsvm/libsvm.0.9.0/opam
@@ -11,7 +11,7 @@ remove: [["ocamlfind" "remove" "libsvm"]]
 depends: [
   "ocamlfind"
   "core" {>= "108.08.00"}
-  "lacaml"
+  "lacaml" {< "8.0"}
   "gsl"
   "archimedes"
   "ocamlbuild" {build}

--- a/packages/libsvm/libsvm.0.9.1/opam
+++ b/packages/libsvm/libsvm.0.9.1/opam
@@ -19,4 +19,8 @@ depends: [
 conflicts: [
   "sexplib" {>= "113.24.00"}
 ]
+depexts: [
+  [["ubuntu"]["libsvm-dev"]]
+  [["debian"]["libsvm-dev"]]
+]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/libsvm/libsvm.0.9.1/opam
+++ b/packages/libsvm/libsvm.0.9.1/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
 maintainer: "gu.oliver@yahoo.com"
+authors: [
+  "Oliver Gu <gu.oliver@yahoo.com>"
+  "Dominik Brugger <dominikbrugger@fastmail.fm>"
+]
+homepage: "https://bitbucket.org/ogu/libsvm-ocaml"
 build: [
   ["ocaml" "setup.ml" "-configure"]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/libsvm/libsvm.0.9.1/opam
+++ b/packages/libsvm/libsvm.0.9.1/opam
@@ -11,4 +11,7 @@ depends: [
   "lacaml"
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "sexplib" {>= "113.24.00"}
+]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/libsvm/libsvm.0.9.1/opam
+++ b/packages/libsvm/libsvm.0.9.1/opam
@@ -13,7 +13,7 @@ remove: [["ocamlfind" "remove" "libsvm"]]
 depends: [
   "ocamlfind"
   "core" {>= "108.08.00"}
-  "lacaml"
+  "lacaml" {< "8.0"}
   "ocamlbuild" {build}
 ]
 conflicts: [

--- a/packages/libsvm/libsvm.0.9.2/opam
+++ b/packages/libsvm/libsvm.0.9.2/opam
@@ -14,7 +14,7 @@ build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "libsvm"]]
 depends: [
   "core"
-  "lacaml"
+  "lacaml" {< "8.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/libsvm/libsvm.0.9.2/opam
+++ b/packages/libsvm/libsvm.0.9.2/opam
@@ -11,7 +11,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 build-doc: [["ocaml" "setup.ml" "-doc"]]
-remove: [["ocamlfind" "remove" "svm"]]
+remove: [["ocamlfind" "remove" "libsvm"]]
 depends: [
   "core"
   "lacaml"

--- a/packages/libsvm/libsvm.0.9.2/opam
+++ b/packages/libsvm/libsvm.0.9.2/opam
@@ -19,6 +19,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["sexplib"]
+conflicts: [
+  "sexplib" {>= "113.24.00"}
+]
 depexts: [
   [["ubuntu"]["libsvm-dev"]]
   [["debian"]["libsvm-dev"]]


### PR DESCRIPTION
Package `sexplib.syntax` was removed from newer versions of `sexplib` and `libsvm` needs it.
