### PR TITLE
modelica_ml.0.1.1: add upper bound on OCaml version

### DIFF
--- a/packages/modelica_ml/modelica_ml.0.1.1/opam
+++ b/packages/modelica_ml/modelica_ml.0.1.1/opam
@@ -22,4 +22,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: "ounit"
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.03"]


### PR DESCRIPTION
Note that the latest version of `modelica_ml` (0.2.0) has dependencies that are not available on OCaml 4.03 and 4.04.

cc @choeger 
