### PR TITLE
solo5-kernel-ukvm.0.2.2 - via opam-publish

### DIFF
--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/descr
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/descr
@@ -1,0 +1,5 @@
+Solo5 unikernel base (ukvm target)
+
+This package provides the Solo5 base layer to run MirageOS unikernels on the
+"ukvm" target. ukvm, a specialized unikernel monitor, runs as a Linux process
+and uses KVM.

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "https://github.com/solo5/solo5.git"
+build: [make "ukvm"]
+install: [make "opam-ukvm-install" "PREFIX=%{prefix}%"]
+remove: [make "opam-ukvm-uninstall" "PREFIX=%{prefix}%"]
+depends: "conf-pkg-config"
+depexts: [
+  [["alpine"] ["linux-headers"]]
+  [["debian"] ["linux-libc-dev"]]
+  [["fedora"] ["kernel-headers"]]
+  [["rhel"] ["kernel-headers"]]
+  [["ubuntu"] ["linux-libc-dev"]]
+]
+conflicts: "solo5-kernel-virtio"
+available: [ocaml-version >= "4.02.3" & arch = "x86_64" & os = "linux"]

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/url
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Solo5/solo5/archive/v0.2.2.tar.gz"
+checksum: "29e344999bd7476e6e83e9533b8a4dd9"


### PR DESCRIPTION
Solo5 unikernel base (ukvm target)

This package provides the Solo5 base layer to run MirageOS unikernels on the
"ukvm" target. ukvm, a specialized unikernel monitor, runs as a Linux process
and uses KVM.


---
* Homepage: https://github.com/solo5/solo5
* Source repo: https://github.com/solo5/solo5.git
* Bug tracker: https://github.com/solo5/solo5/issues

---

Pull-request generated by opam-publish v0.3.4