### PR TITLE
solo5-kernel-virtio.0.2.2 - via opam-publish

### DIFF
--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/descr
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/descr
@@ -1,0 +1,11 @@
+Solo5 unikernel base (virtio target)
+
+This package provides the Solo5 base layer to run MirageOS unikernels on the
+"virtio" target. Unikernels built for the "virtio" target run directly on
+existing hypervisors, such as KVM/QEMU and bhyve.
+
+Additionally, this package installs the "solo5-run-virtio" tool, a wrapper for
+launching unikernels on various hypervisors, and the "solo5-mkimage" tool for
+building MBR-partitioned disk images with a bootloader and unikernel installed.
+The latter includes support for building images suitable for upload to Google
+Compute Engine.

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "https://github.com/solo5/solo5.git"
+build: [make "virtio"]
+install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
+remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
+depends: "conf-pkg-config"
+conflicts: "solo5-kernel-ukvm"
+available: [
+  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64") &
+  os != "darwin"
+]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/url
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Solo5/solo5/archive/v0.2.2.tar.gz"
+checksum: "29e344999bd7476e6e83e9533b8a4dd9"


### PR DESCRIPTION
Solo5 unikernel base (virtio target)

This package provides the Solo5 base layer to run MirageOS unikernels on the
"virtio" target. Unikernels built for the "virtio" target run directly on
existing hypervisors, such as KVM/QEMU and bhyve.

Additionally, this package installs the "solo5-run-virtio" tool, a wrapper for
launching unikernels on various hypervisors, and the "solo5-mkimage" tool for
building MBR-partitioned disk images with a bootloader and unikernel installed.
The latter includes support for building images suitable for upload to Google
Compute Engine.


---
* Homepage: https://github.com/solo5/solo5
* Source repo: https://github.com/solo5/solo5.git
* Bug tracker: https://github.com/solo5/solo5/issues

---

Pull-request generated by opam-publish v0.3.4