### PR TITLE
farfadet.0.1 - via opam-publish

### DIFF
--- a/packages/farfadet/farfadet.0.1/descr
+++ b/packages/farfadet/farfadet.0.1/descr
@@ -1,0 +1,3 @@
+Printf-like for Faraday library
+
+Printf-like for Faraday library, a type-safe way to serialize what you want.

--- a/packages/farfadet/farfadet.0.1/opam
+++ b/packages/farfadet/farfadet.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/oklm-wsh/Farfadet"
+bug-reports: "https://github.com/oklm-wsh/Farfadet/issues"
+license: "MIT"
+dev-repo: "https://github.com/oklm-wsh/Farfadet.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "faraday"
+  "alcotest" {test}
+  "ezjsonm" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/farfadet/farfadet.0.1/url
+++ b/packages/farfadet/farfadet.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/oklm-wsh/Farfadet/archive/0.1.tar.gz"
+checksum: "c5b20e8880324b4c7c62b4830ff3261f"


### PR DESCRIPTION
Printf-like for Faraday library

Printf-like for Faraday library, a type-safe way to serialize what you want.

---
* Homepage: https://github.com/oklm-wsh/Farfadet
* Source repo: https://github.com/oklm-wsh/Farfadet.git
* Bug tracker: https://github.com/oklm-wsh/Farfadet/issues

---

Pull-request generated by opam-publish v0.3.4