### PR TITLE
sociaml-vcard: add upper bounds on core and core_kernel

### DIFF
--- a/packages/sociaml-vcard/sociaml-vcard.0.1.0/opam
+++ b/packages/sociaml-vcard/sociaml-vcard.0.1.0/opam
@@ -16,7 +16,7 @@ remove: [
 ]
 depends: [
   "oasis"
-  "core"
+  "core" {< "113.24.00"}
   "menhir"
   "ulex"
   "re2"

--- a/packages/sociaml-vcard/sociaml-vcard.0.2.1/opam
+++ b/packages/sociaml-vcard/sociaml-vcard.0.2.1/opam
@@ -16,7 +16,7 @@ remove: [
 ]
 depends: [
   "oasis"
-  "core_kernel"
+  "core_kernel" {< "113.33.00"}
   "menhir"
   "ulex"
   "re2"


### PR DESCRIPTION
`sociaml-vcard` uses `Core.Result` or `Core_kernel.Result`, which was removed from core when type `result` was introduced in the stdlib.

cc @dominicjprice 
