### PR TITLE
base-flambda

### DIFF
--- a/packages/base-flambda/base-flambda.base/descr
+++ b/packages/base-flambda/base-flambda.base/descr
@@ -1,0 +1,2 @@
+Virtual package relying on Flambda.
+This package can only install if the OCaml compiler supports Flambda.

--- a/packages/base-flambda/base-flambda.base/files/check_flambda.ml
+++ b/packages/base-flambda/base-flambda.base/files/check_flambda.ml
@@ -1,0 +1,11 @@
+#use "topfind";;
+#require "compiler-libs.bytecomp";;
+if Config.flambda then
+  exit 0
+else begin
+  output_string stderr
+    ("The current OCaml switch does not support Flambda, so this package cannot be installed.\n" ^
+     "Try switching to a configuration with Flambda support, e.g.\n" ^
+     "   opam switch 4.04.0+flambda\n");
+  exit 1
+end

--- a/packages/base-flambda/base-flambda.base/opam
+++ b/packages/base-flambda/base-flambda.base/opam
@@ -1,5 +1,29 @@
 opam-version: "1.2"
 maintainer: "stephen.dolan@cl.cam.ac.uk"
 build: [["ocaml" "check_flambda.ml"]]
-available: [ ocaml-version >= "4.03" ]
 depends: ["ocamlfind" {build}]
+available: [
+#
+# The lines below were generated using the following travesty:
+#  grep -l '[-]flambda' `find compilers/ -name *.comp` | \
+#    sed 's/.*\/\([^/]*\)\.comp/| compiler = "\1"/; 1s/^| /  /'
+#
+#
+  compiler = "4.03.0+beta2+flambda"
+| compiler = "4.03.0+fp+flambda"
+| compiler = "4.03.0+trunk+flambda"
+| compiler = "4.03.0+flambda"
+| compiler = "4.03.0+trunk+fp+flambda"
+| compiler = "4.03.0+beta1+flambda"
+| compiler = "4.06.0+trunk+flambda"
+| compiler = "4.06.0+trunk+fp+flambda"
+| compiler = "4.05.0+beta2+flambda"
+| compiler = "4.05.0+beta1+flambda"
+| compiler = "4.05.0+trunk+flambda"
+| compiler = "4.05.0+trunk+fp+flambda"
+| compiler = "4.04.0+trunk+forced_lto"
+| compiler = "4.04.0+flambda"
+| compiler = "4.04.0+beta1+flambda"
+| compiler = "4.04.0+beta2+flambda"
+| compiler = "4.04.0+fp+flambda"
+]

--- a/packages/base-flambda/base-flambda.base/opam
+++ b/packages/base-flambda/base-flambda.base/opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+maintainer: "stephen.dolan@cl.cam.ac.uk"
+build: [["ocaml" "check_flambda.ml"]]
+available: [ ocaml-version >= "4.03" ]
+depends: ["ocamlfind" {build}]


### PR DESCRIPTION
Malfunction currently has a hard dependency on Flambda, but I don't know how to express that in an opam file. This patch adds a package `base-flambda`, which is installable only on switches where Flambda is available, so that Malfunction (and any other packages with Flambda deps) can depend on it.