### PR TITLE
mirage-net-fd.0.2.0 - via opam-publish

### DIFF
--- a/packages/mirage-net-fd/mirage-net-fd.0.2.0/descr
+++ b/packages/mirage-net-fd/mirage-net-fd.0.2.0/descr
@@ -1,0 +1,5 @@
+MirageOS network interfaces using raw sockets
+
+Implementation of MirageOS network interfaces using raw sockets. The
+caller is in charge of opening the file-descriptor with that are passed
+to the `connect` function.

--- a/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      [
+  "Anil Madhavapeddy"
+  "David Scott"
+  "Thomas Gazagnaire"
+  "Hannes Mehnert"
+]
+homepage:    "https://github.com/mirage/mirage-net-fd"
+bug-reports: "https://github.com/mirage/mirage-net-fd/issues"
+dev-repo:    "https://github.com/mirage/mirage-net-fd.git"
+license:     "ISC"
+doc:         "https://mirage.github.io/mirage-net-fd/"
+
+build:   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "cstruct" {>= "1.7.1"}
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "lwt"            {>= "2.4.3"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "io-page" {>= "1.0.1"}
+  "result"
+  "ipaddr"
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.3"]

--- a/packages/mirage-net-fd/mirage-net-fd.0.2.0/url
+++ b/packages/mirage-net-fd/mirage-net-fd.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net-fd/releases/download/0.2.0/mirage-net-fd-0.2.0.tbz"
+checksum: "2fa2d4660799f5dfec72e62a8941f0dc"


### PR DESCRIPTION
MirageOS network interfaces using raw sockets

Implementation of MirageOS network interfaces using raw sockets. The
caller is in charge of opening the file-descriptor with that are passed
to the `connect` function.

---
* Homepage: https://github.com/mirage/mirage-net-fd
* Source repo: https://github.com/mirage/mirage-net-fd.git
* Bug tracker: https://github.com/mirage/mirage-net-fd/issues

---


---
### 0.2.0 (2017/04/07)

* Allow to specify the mac address of the network interface (@samoht)
Pull-request generated by opam-publish v0.3.2