### PR TITLE
ocaml-protoc-yojson.0.2.0 - via opam-publish

### DIFF
--- a/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/descr
+++ b/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/descr
@@ -1,0 +1,3 @@
+JSON Runtime based on Yojson library for `ocaml-protoc` generated code
+
+JSON Runtime based on Yojson library for `ocaml-protoc` generated code

--- a/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/opam
+++ b/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors: "Maxime Ransan <maxime.ransan@gmail.com>"
+homepage: "https://github.com/mransan/ocaml-protoc-yojson"
+bug-reports: "https://github.com/mransan/ocaml-protoc-yojson/issues"
+license: "MIT"
+dev-repo: "https://github.com/mransan/ocaml-protoc-yojson.git"
+build: [
+  [make "lib.byte"]
+  [make "lib.native"] {ocaml-native}
+]
+install: [make "lib.install"]
+remove: [make "lib.uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "yojson"
+]
+available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]

--- a/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/url
+++ b/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mransan/ocaml-protoc-yojson/archive/0.2.1.tar.gz"
+checksum: "e9a6d639022cd201bdcf2bc6a6ede835"


### PR DESCRIPTION
JSON Runtime based on Yojson library for `ocaml-protoc` generated code

JSON Runtime based on Yojson library for `ocaml-protoc` generated code


---
* Homepage: https://github.com/mransan/ocaml-protoc-yojson
* Source repo: https://github.com/mransan/ocaml-protoc-yojson.git
* Bug tracker: https://github.com/mransan/ocaml-protoc-yojson/issues

---

Pull-request generated by opam-publish v0.3.2