### PR TITLE
+lwt.2.7.1 - concurrency library

### DIFF
--- a/packages/lwt/lwt.2.7.1/descr
+++ b/packages/lwt/lwt.2.7.1/descr
@@ -1,0 +1,10 @@
+Monadic promises and concurrent I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.2.7.1/files/lwt.install
+++ b/packages/lwt/lwt.2.7.1/files/lwt.install
@@ -1,0 +1,6 @@
+lib: "lwt.opam" { "opam" }
+doc: [
+  "README.md"
+  "CHANGES"
+  "doc/COPYING" { "LICENSE" }
+]

--- a/packages/lwt/lwt.2.7.1/opam
+++ b/packages/lwt/lwt.2.7.1/opam
@@ -1,0 +1,68 @@
+opam-version: "1.2"
+name: "lwt"
+version: "2.7.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+build: [
+  [make "setup"]
+  ["ocaml" "setup.ml" "-configure"
+    "--prefix" prefix
+    "--%{conf-libev:enable}%-libev"
+    "--%{camlp4:enable}%-camlp4"
+    "--%{react:enable}%-react"
+    "--%{ssl:enable}%-ssl"
+    "--%{base-unix:enable}%-unix"
+    "--%{base-threads:enable}%-preemptive"
+    "--%{lablgtk:enable}%-glib"
+    "--%{ppx_tools:enable}%-ppx"]
+  [make "build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  [make "test"]
+]
+install: [[make "install"]]
+remove: [[ "ocamlfind" "remove" "lwt" ]]
+depends: [
+  "ocamlfind" {build & >= "1.5.0"}
+  "ocamlbuild" {build}
+  "result"
+  "cppo" {build}
+  # See https://github.com/ocsigen/lwt/issues/266
+  ( "base-no-ppx" | "ppx_tools" {build} )
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+  "camlp4"
+  "ssl"
+  "lablgtk"
+  "react"
+]
+conflicts: [
+  "react" {< "1.0.0"}
+  "ssl" {< "0.5.0"}
+  "ppx_tools" {< "1.0.0" }
+]
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+messages: [
+  "For module Lwt_ssl, please install package lwt_ssl"
+  {ssl:installed & !lwt_ssl:installed}
+  "For module Lwt_glib, please install package lwt_glib"
+  {lablgtk:installed & !lwt_glib:installed}
+  "For module Lwt_react, please install package lwt_react"
+  {react:installed & !lwt_react:installed}
+]

--- a/packages/lwt/lwt.2.7.1/url
+++ b/packages/lwt/lwt.2.7.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/2.7.1.tar.gz"
+checksum: "fb478fbdb6fda0d1fa64a8a2f9ac1bbb"


### PR DESCRIPTION
```
Fixes

- OCaml 4.05 compatibility (Mauricio Fernandez, #322).
- Give Lwt_unix.file_exists the same semantics as Sys.file_exists, with
  respect to not raising Unix.Unix_error (Mauricio Fernandez, #316).
- Improve diagnostics from build scripts (Tim Cuthbertson, #313, #314).

Additions

- Announce Lwt_result, which was originally released as an experimental
  module in release 2.6.0 (Simon Cruanes, #320, #247).
```

From [the repo's own changelog](https://github.com/ocsigen/lwt/releases/tag/2.7.1).

This will be followed shortly by 3.0.0, perhaps tomorrow. I don't expect 2.7.1 to conflict with any reverse dependencies. For 3.0.0, I'll try to estimate the conflicts on my machine, and add the right constraints on the first pass, but that PR will probably still require one or more amendments before everything is right.

cc @mfp @c-cube