### PR TITLE
gmp-freestanding: install (empty) META file

### DIFF
--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/mirage-install.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/files/mirage-install.sh
@@ -9,5 +9,6 @@ mkdir -p ${PKG_CONFIG_PATH}
 cp gmp-freestanding.pc ${PKG_CONFIG_PATH}
 mkdir -p ${LIBDIR}
 cp .libs/libgmp.a ${LIBDIR}/libgmp-freestanding.a
+touch ${LIBDIR}/META
 mkdir -p ${LIBDIR}/include
 cp gmp.h ${LIBDIR}/include


### PR DESCRIPTION
This allows locating the package via `ocamlfind query`.