### PR TITLE
immutable.0.0.5 - via opam-publish

### DIFF
--- a/packages/immutable/immutable.0.0.5/descr
+++ b/packages/immutable/immutable.0.0.5/descr
@@ -1,0 +1,11 @@
+Pure Reason implementation of persistent immutable data structures.
+
+Immutable-re provides a complete set of efficient persistent immutable data
+structures for Reason and OCaml, targeting both OCaml native and byte code
+compilation modes, as well JavaScript using BuckleScript.
+
+The api includes concrete implementations of vectors, sets, and maps. Many
+implementations support transient mutability for efficient batch mutations.
+Additionally Immutable-re provides lazy functional iterators and sequences,
+along with type definitions for basic operators such as equality, comparison,
+and hashing.

--- a/packages/immutable/immutable.0.0.5/opam
+++ b/packages/immutable/immutable.0.0.5/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+maintainer: "Dave Bordoley <bordoley>"
+authors: "Dave Bordoley <bordoley>"
+homepage: "https://github.com/facebookincubator/immutable-re.git"
+bug-reports: "https://github.com/facebookincubator/immutable-re/issues"
+license: "BSD"
+tags: ["reason" "immutable"]
+dev-repo: "git://github.com/facebookincubator/immutable-re.git"
+build: [make "build"]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]

--- a/packages/immutable/immutable.0.0.5/url
+++ b/packages/immutable/immutable.0.0.5/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/facebookincubator/immutable-re/archive/0.0.5.tar.gz"
+checksum: "a735fe90b6a036988560092d699d71a0"


### PR DESCRIPTION
Pure Reason implementation of persistent immutable data structures.

Immutable-re provides a complete set of efficient persistent immutable data
structures for Reason and OCaml, targeting both OCaml native and byte code
compilation modes, as well JavaScript using BuckleScript.

The api includes concrete implementations of vectors, sets, and maps. Many
implementations support transient mutability for efficient batch mutations.
Additionally Immutable-re provides lazy functional iterators and sequences,
along with type definitions for basic operators such as equality, comparison,
and hashing.


---
* Homepage: https://github.com/facebookincubator/immutable-re.git
* Source repo: git://github.com/facebookincubator/immutable-re.git
* Bug tracker: https://github.com/facebookincubator/immutable-re/issues

---

Pull-request generated by opam-publish v0.3.4