### PR TITLE
immutable.0.0.6 - via opam-publish

### DIFF
--- a/packages/immutable/immutable.0.0.6/descr
+++ b/packages/immutable/immutable.0.0.6/descr
@@ -1,0 +1,11 @@
+Pure Reason implementation of persistent immutable data structures.
+
+Immutable-re provides a complete set of efficient persistent immutable data
+structures for Reason and OCaml, targeting both OCaml native and byte code
+compilation modes, as well JavaScript using BuckleScript.
+
+The api includes concrete implementations of vectors, sets, and maps. Many
+implementations support transient mutability for efficient batch mutations.
+Additionally Immutable-re provides lazy functional iterators and sequences,
+along with type definitions for basic operators such as equality, comparison,
+and hashing.

--- a/packages/immutable/immutable.0.0.6/opam
+++ b/packages/immutable/immutable.0.0.6/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Dave Bordoley <bordoley>"
+authors: "Dave Bordoley <bordoley>"
+homepage: "https://github.com/facebookincubator/immutable-re.git"
+bug-reports: "https://github.com/facebookincubator/immutable-re/issues"
+license: "BSD"
+tags: ["reason" "immutable"]
+dev-repo: "git://github.com/facebookincubator/immutable-re.git"
+build: [make "build"]
+depends: [
+  "topkg" {>= "0.8.1" & < "0.9"}
+  "reason" {>= "1.13.3"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]

--- a/packages/immutable/immutable.0.0.6/url
+++ b/packages/immutable/immutable.0.0.6/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/facebookincubator/immutable-re/archive/0.0.6.tar.gz"
+checksum: "4f338793ab6acdd6bd846573c45b9adc"


### PR DESCRIPTION
Pure Reason implementation of persistent immutable data structures.

Immutable-re provides a complete set of efficient persistent immutable data
structures for Reason and OCaml, targeting both OCaml native and byte code
compilation modes, as well JavaScript using BuckleScript.

The api includes concrete implementations of vectors, sets, and maps. Many
implementations support transient mutability for efficient batch mutations.
Additionally Immutable-re provides lazy functional iterators and sequences,
along with type definitions for basic operators such as equality, comparison,
and hashing.


---
* Homepage: https://github.com/facebookincubator/immutable-re.git
* Source repo: git://github.com/facebookincubator/immutable-re.git
* Bug tracker: https://github.com/facebookincubator/immutable-re/issues

---

Pull-request generated by opam-publish v0.3.4