### PR TITLE
testrunner.0.1.0 - via opam-publish

### DIFF
--- a/packages/testrunner/testrunner.0.1.0/descr
+++ b/packages/testrunner/testrunner.0.1.0/descr
@@ -1,0 +1,4 @@
+Simple framework to run tests and create test reports for OCaml libraries.
+
+Tests are described in JSON files, with nested JSON values.
+Generates report in text and XML formats.

--- a/packages/testrunner/testrunner.0.1.0/opam
+++ b/packages/testrunner/testrunner.0.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "http://zoggy.github.io/ocaml-testrunner/"
+bug-reports: "https://github.com/zoggy/ocaml-testrunner/issues"
+license: "GNU General Public License version 3"
+doc: "http://github.com/zoggy/ocaml-testrunner"
+tags: ["test" "continuous integration"]
+dev-repo: "https://github.com/zoggy/ocaml-testrunner.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install-lib"]
+remove: ["ocamlfind" "remove" "testrunner"]
+depends: [
+  "ocamlfind"
+  "xtmpl" {>= "0.16.0"}
+  "yojson" {>= "1.1.18"}
+  "re" {>= "1.4.1"}
+  "lwt" {>= "2.5"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/testrunner/testrunner.0.1.0/url
+++ b/packages/testrunner/testrunner.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/ocaml-testrunner/archive/v0.1.0.tar.gz"
+checksum: "31424f1282db7412d3f6669749c758a0"


### PR DESCRIPTION
Simple framework to run tests and create test reports for OCaml libraries.

Tests are described in JSON files, with nested JSON values.
Generates report in text and XML formats.


---
* Homepage: http://zoggy.github.io/ocaml-testrunner/
* Source repo: https://github.com/zoggy/ocaml-testrunner.git
* Bug tracker: https://github.com/zoggy/ocaml-testrunner/issues

---

Pull-request generated by opam-publish v0.3.3