### PR TITLE
lablgtk-extras.1.6 - via opam-publish

### DIFF
--- a/packages/lablgtk-extras/lablgtk-extras.1.6/descr
+++ b/packages/lablgtk-extras/lablgtk-extras.1.6/descr
@@ -1,0 +1,4 @@
+A collection of additional tools and libraries to develop ocaml applications based on Lablgtk2.
+
+Convenient modules to create configuration boxes, handle keyboard
+shortcuts, share syntax highlighting between applications, ...

--- a/packages/lablgtk-extras/lablgtk-extras.1.6/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.6/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "https://github.com/zoggy/lablgtk-extras"
+bug-reports: "https://github.com/zoggy/lablgtk-extras.git/issues"
+license: "GNU Lesser General Public License version 2 or later"
+doc: "https://github.com/zoggy/lablgtk-extras"
+tags: ["gtk" "utils" "configuration"]
+dev-repo: "https://github.com/zoggy/lablgtk-extras.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "lablgtk2-extras"]
+depends: [
+  "ocamlfind"
+  "config-file" {>= "1.1"}
+  "xmlm" {>= "1.1.1"}
+  "lablgtk" {>= "2.16.0"}
+  "conf-gtksourceview" {= "2"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/lablgtk-extras/lablgtk-extras.1.6/url
+++ b/packages/lablgtk-extras/lablgtk-extras.1.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/zoggy/lablgtk-extras/archive/release-1.6.tar.gz"
+checksum: "58cebe0e28944cd1269249a1e9522604"


### PR DESCRIPTION
A collection of additional tools and libraries to develop ocaml applications based on Lablgtk2.

Convenient modules to create configuration boxes, handle keyboard
shortcuts, share syntax highlighting between applications, ...


---
* Homepage: https://github.com/zoggy/lablgtk-extras
* Source repo: https://github.com/zoggy/lablgtk-extras.git
* Bug tracker: https://github.com/zoggy/lablgtk-extras.git/issues

---

Pull-request generated by opam-publish v0.3.3