### PR TITLE
nonstd.0.0.2 - via opam-publish

### DIFF
--- a/packages/nonstd/nonstd.0.0.2/descr
+++ b/packages/nonstd/nonstd.0.0.2/descr
@@ -1,0 +1,4 @@
+Non-standard mini-library
+
+Core-style (labels, exceptionless) pure-OCaml super-light library
+providing basic modules: List, Option, Int. and Float.

--- a/packages/nonstd/nonstd.0.0.2/opam
+++ b/packages/nonstd/nonstd.0.0.2/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "seb@mondet.org"
+authors: [
+  "Sebastien Mondet <seb@modnet.org>" "Leonid Rozenberg <leonidr@gmail.com>"
+]
+homepage: "https://bitbucket.org/smondet/nonstd"
+bug-reports: "https://bitbucket.org/smondet/nonstd"
+dev-repo: "https://bitbucket.org/smondet/nonstd.git"
+build: ["ocaml" "please.ml" "build"]
+install: ["ocaml" "please.ml" "install"]
+remove: ["ocaml" "please.ml" "uninstall"]
+depends: "ocamlfind"
+available: [ocaml-version >= "4.00.0"]

--- a/packages/nonstd/nonstd.0.0.2/url
+++ b/packages/nonstd/nonstd.0.0.2/url
@@ -1,0 +1,2 @@
+http: "https://bitbucket.org/smondet/nonstd/get/nonstd.0.0.2.tar.gz"
+checksum: "e954fc45d9e2522fd3db81351ba44da8"


### PR DESCRIPTION
Non-standard mini-library

Core-style (labels, exceptionless) pure-OCaml super-light library
providing basic modules: List, Option, Int. and Float.


---
* Homepage: https://bitbucket.org/smondet/nonstd
* Source repo: https://bitbucket.org/smondet/nonstd.git
* Bug tracker: https://bitbucket.org/smondet/nonstd

---

Pull-request generated by opam-publish v0.3.4