### PR TITLE
+lwt.3.0.0 - concurrency library

### DIFF
--- a/packages/lwt/lwt.3.0.0/descr
+++ b/packages/lwt/lwt.3.0.0/descr
@@ -1,0 +1,10 @@
+Monadic promises and concurrent I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.3.0.0/files/lwt.install
+++ b/packages/lwt/lwt.3.0.0/files/lwt.install
@@ -1,0 +1,6 @@
+lib: "opam/opam" { "opam" }
+doc: [
+  "README.md"
+  "CHANGES"
+  "doc/COPYING" { "LICENSE" }
+]

--- a/packages/lwt/lwt.3.0.0/opam
+++ b/packages/lwt/lwt.3.0.0/opam
@@ -1,0 +1,64 @@
+opam-version: "1.2"
+name: "lwt"
+version: "3.0.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+build: [
+  [make "setup"]
+  ["ocaml" "setup.ml" "-configure"
+    "--prefix" prefix
+    "--%{conf-libev:enable}%-libev"
+    "--%{camlp4:enable}%-camlp4"
+    "--%{base-unix:enable}%-unix"
+    "--%{base-threads:enable}%-preemptive"
+    "--%{ppx_tools:enable}%-ppx"]
+  [make "build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  [make "test"]
+]
+install: [[make "install"]]
+remove: [[ "ocamlfind" "remove" "lwt" ]]
+depends: [
+  "ocamlfind" {build & >= "1.5.0"}
+  "ocamlbuild" {build}
+  "result"
+  "cppo" {build}
+  # See https://github.com/ocsigen/lwt/issues/266
+  ( "base-no-ppx" | "ppx_tools" {build} )
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+  "camlp4"
+]
+conflicts: [
+  "ppx_tools" {< "1.0.0" }
+]
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+messages: [
+  "For module Lwt_ssl, please install package lwt_ssl"
+  {ssl:installed & !lwt_ssl:installed}
+  "For module Lwt_glib, please install package lwt_glib"
+  {lablgtk:installed & !lwt_glib:installed}
+  "For module Lwt_react, please install package lwt_react"
+  {react:installed & !lwt_react:installed}
+]
+post-messages: [
+  "Lwt 3.0.0 made some minor breaking changes, announced in 2.7.0. See
+  https://github.com/ocsigen/lwt/issues/308"
+]

--- a/packages/lwt/lwt.3.0.0/url
+++ b/packages/lwt/lwt.3.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.0.0.tar.gz"
+checksum: "6c45ce0035f627d0de0d3d185f2a1a7f"

--- a/packages/lwt_glib/lwt_glib.1.0.1/descr
+++ b/packages/lwt_glib/lwt_glib.1.0.1/descr
@@ -1,0 +1,1 @@
+GLib integration for Lwt

--- a/packages/lwt_glib/lwt_glib.1.0.1/opam
+++ b/packages/lwt_glib/lwt_glib.1.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "lwt_glib"
+version: "1.0.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+build: [
+    [make "configure"]
+    [make "build"]
+]
+install: [
+    [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "lwt_glib"]
+]
+depends: [
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "conf-pkg-config" {build}
+]

--- a/packages/lwt_glib/lwt_glib.1.0.1/url
+++ b/packages/lwt_glib/lwt_glib.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_glib-1.0.1.tar.gz"
+checksum: "5effd9d4bf2c951617a920cef5621deb"

--- a/packages/lwt_react/lwt_react.1.0.1/descr
+++ b/packages/lwt_react/lwt_react.1.0.1/descr
@@ -1,0 +1,1 @@
+Helpers for using React with Lwt

--- a/packages/lwt_react/lwt_react.1.0.1/opam
+++ b/packages/lwt_react/lwt_react.1.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "lwt_react"
+version: "1.0.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+build: [
+    [make "configure"]
+    [make "build"]
+]
+install: [
+    [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "lwt_react"]
+]
+depends: [
+  "lwt" {>= "3.0.0"}
+  "react" {>= "1.0.0"}
+]

--- a/packages/lwt_react/lwt_react.1.0.1/url
+++ b/packages/lwt_react/lwt_react.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_react-1.0.1.tar.gz"
+checksum: "775cc1bc0bbfa6dfebe8c6fa62c057b2"

--- a/packages/lwt_ssl/lwt_ssl.1.0.1/descr
+++ b/packages/lwt_ssl/lwt_ssl.1.0.1/descr
@@ -1,0 +1,1 @@
+Lwt-friendly OpenSSL bindings

--- a/packages/lwt_ssl/lwt_ssl.1.0.1/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "lwt_ssl"
+version: "1.0.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+build: [
+    [make "configure"]
+    [make "build"]
+]
+install: [
+    [make "install"]
+]
+remove: [
+    ["ocamlfind" "remove" "lwt_ssl"]
+]
+depends: [
+  "lwt" {>= "3.0.0"}
+  "ssl" {>= "0.5.0"}
+  "base-unix"
+]

--- a/packages/lwt_ssl/lwt_ssl.1.0.1/url
+++ b/packages/lwt_ssl/lwt_ssl.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_ssl-1.0.1.tar.gz"
+checksum: "67a4663fbffd0c2371f573912e387210"


### PR DESCRIPTION
Lwt 3.0.0 is finally here.

[Changelog](https://github.com/ocsigen/lwt/releases/tag/3.0.0):

> Breaking
>
> - These changes were originally announced in release 2.7.0 (#308).
> - [`Lwt_engine.libev`](https://ocsigen.org/lwt/api/Lwt_engine#2_Predefinedengines) now has an optional argument for selecting the libev back end (#269, #294, Jeremy Yallop).
> - [`Lwt_io.establish_server`](https://ocsigen.org/lwt/2.7.0/api/Lwt_io#VALestablish_server) has been changed to make it more difficult to leak file descriptors (#258, #260).
> - [`Lwt_io.shutdown_server`](https://ocsigen.org/lwt/2.7.0/api/Lwt_io#VALshutdown_server) now evaluates to a promise, which completes when the listening socket's `close(2)` operation completes (#259).
> - [`Lwt_unix.bind`](https://ocsigen.org/lwt/2.7.0/api/Lwt_unix#VALbind) now evaluates to a promise, because the `bind(2)` system call can block for Unix domain sockets (#296, requested David Sheets).
> - `ocamlfind` packages `lwt.react`, `lwt.ssl`, `lwt.glib` are replaced by `lwt_react`, `lwt_ssl`, `lwt_glib`. These have been separate OPAM packages, under those names, since 2.7.0 (#301).

I originally wanted to estimate the failed revdeps from this locally. However, since I expect this to still fail the revdeps build at least once, I think it makes more sense to just let it run, and try to add the right constraints afterwards.

cc @mfp @c-cube