### PR TITLE
transmission-rpc: upper bound on ppx_deriving_yojson

### DIFF
--- a/packages/transmission-rpc/transmission-rpc.1.0/opam
+++ b/packages/transmission-rpc/transmission-rpc.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt"
   "ocamlfind" {build}
   "ppx_deriving"
-  "ppx_deriving_yojson" {>= "2.0"}
+  "ppx_deriving_yojson" {>= "2.0" & <"3.0"}
   "rresult"
   "yojson"
 ]


### PR DESCRIPTION
due to Result type change in generated code. Upstream issue
filed: https://github.com/bataille/ocaml-transmission-rpc/issues/1