### PR TITLE
prob-cache.1.1.0: upper bound on containers

### DIFF
--- a/packages/prob-cache/prob-cache.1.1.0/opam
+++ b/packages/prob-cache/prob-cache.1.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ppx_deriving" {>= "1.1"}
   "ppx_deriving_protobuf" {>= "2.0"}
   "riakc_ppx" {>= "3.1.2"}
-  "containers" {>= "0.16"}
+  "containers" {>= "0.16" & <"1.0"}
   "sequence"
   "oml" {>= "0.0.5"}
 ]


### PR DESCRIPTION
Containers.Advanced was removed in 1.0, which this package uses