### PR TITLE
ppx_type_conv.v0.9.0: conflict with ppx_deriving.4.0 as well

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
@@ -19,6 +19,6 @@ depopts: [
   "ppx_deriving"
 ]
 conflicts: [
-  "ppx_deriving" {< "4.0"}
+  "ppx_deriving" {< "4.1"}
 ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
type_conv depends on the API registration hooks added in
https://github.com/whitequark/ppx_deriving/pull/109 which are
only in ppx_deriving.4.1