### PR TITLE
regular: upper bound on core_kernel

### DIFF
--- a/packages/regular/regular.1.0.0/opam
+++ b/packages/regular/regular.1.0.0/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-    "core_kernel"       {>= "113.24.00"}
+    "core_kernel"       {>= "113.24.00" & <"v0.9.0"}
     "oasis"             {build & = "0.4.7"}
     "ppx_jane"          {>= "113.24.01"}
 ]

--- a/packages/regular/regular.1.1.0/opam
+++ b/packages/regular/regular.1.1.0/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-    "core_kernel"       {>= "113.24.00"}
+    "core_kernel"       {>= "113.24.00" & <"v0.9.0"}
     "oasis"             {build & = "0.4.7"}
     "ppx_jane"          {>= "113.24.01"}
 ]

--- a/packages/regular/regular.1.2.0/opam
+++ b/packages/regular/regular.1.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-    "core_kernel"       {>= "113.24.00"}
+    "core_kernel"       {>= "113.24.00" & <"v0.9.0"}
     "oasis"             {build & = "0.4.7"}
     "ppx_jane"          {>= "113.24.01"}
 ]


### PR DESCRIPTION
due to interface change:

```
 File "lib/regular/regular_bytes.ml", line 64, characters 18-21:
 Error: Signature mismatch:
       ...
       The value `unsafe_blit' is required but not provided
       The value `length' is required but not provided
       The value `create' is required but not provided
```

cc @ivg 