### PR TITLE
caravan: add upper bound to ocaml version due to Result warning

### DIFF
--- a/packages/caravan/caravan.0.0.2/opam
+++ b/packages/caravan/caravan.0.0.2/opam
@@ -5,10 +5,10 @@ remove: [
   ["ocamlfind" "remove" "caravan"]
 ]
 depends: [
-  "ocamlfind"
-  "oasis"
+  "ocamlfind" {build}
+  "oasis" {build}
   "core"
-  "async"
+  "async" {<"113.24.00"}
   "textutils"
   "ocamlbuild" {build}
 ]

--- a/packages/caravan/caravan.0.0.2/opam
+++ b/packages/caravan/caravan.0.0.2/opam
@@ -14,3 +14,4 @@ depends: [
 ]
 dev-repo: "git://github.com/ibnfirnas/caravan"
 install: [make "install"]
+available: [ocaml-version <"4.03.0"]


### PR DESCRIPTION
warnings-as-errors;
```
Warning 45: this open statement shadows the constructor Error (which is later used)
File "src/caravan/caravan.ml", line 1:
Error: Some fatal warnings were triggered (2 occurrences)
```