### PR TITLE
text-tags: upper bound on core_kernel

### DIFF
--- a/packages/text-tags/text-tags.1.0.0/opam
+++ b/packages/text-tags/text-tags.1.0.0/opam
@@ -17,6 +17,6 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "text-tags"]]
 
 depends: [
-    "core_kernel"       {>= "113.24.00"}
+    "core_kernel"       {>= "113.24.00" & <"v0.9.0"}
     "oasis"             {build & = "0.4.7" }
 ]

--- a/packages/text-tags/text-tags.1.1.0/opam
+++ b/packages/text-tags/text-tags.1.1.0/opam
@@ -17,6 +17,6 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "text-tags"]]
 
 depends: [
-    "core_kernel"       {>= "113.24.00"}
+    "core_kernel"       {>= "113.24.00" & <"v0.9.0"}
     "oasis"             {build & = "0.4.7" }
 ]

--- a/packages/text-tags/text-tags.1.2.0/opam
+++ b/packages/text-tags/text-tags.1.2.0/opam
@@ -17,6 +17,6 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "text-tags"]]
 
 depends: [
-    "core_kernel"       {>= "113.24.00"}
+    "core_kernel"       {>= "113.24.00" & <"v0.9.0"}
     "oasis"             {build & = "0.4.7" }
 ]


### PR DESCRIPTION
due to interface changes in core_kernel

```
 File "lib/text_tags/text_tags.ml", line 176, characters 2-29:
 Error: This expression has type equal:(mode -> mode -> bool) -> 'a option
        but an expression was expected of type ('b -> 'c) option
```