### PR TITLE
capnp: do not use latest Core until OCaml 4.04.1 comes out

### DIFF
--- a/packages/capnp/capnp.1.0.0/opam
+++ b/packages/capnp/capnp.1.0.0/opam
@@ -5,7 +5,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core"
+  "core" {<"v0.9.0"}
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/packages/capnp/capnp.1.0.0/opam
+++ b/packages/capnp/capnp.1.0.0/opam
@@ -5,7 +5,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core" {<"v0.9.0"}
+  "core" {<"111.25.00"}
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/packages/capnp/capnp.1.0.1/opam
+++ b/packages/capnp/capnp.1.0.1/opam
@@ -5,7 +5,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core"
+  "core" {<"v0.9.0"}
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/packages/capnp/capnp.1.0.1/opam
+++ b/packages/capnp/capnp.1.0.1/opam
@@ -5,7 +5,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core" {<"v0.9.0"}
+  "core" {<"111.25.00"}
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/packages/capnp/capnp.2.0.1/opam
+++ b/packages/capnp/capnp.2.0.1/opam
@@ -5,7 +5,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core"
+  "core" {<"v0.9.0"}
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/packages/capnp/capnp.2.0.1/opam
+++ b/packages/capnp/capnp.2.0.1/opam
@@ -5,7 +5,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core" {<"v0.9.0"}
+  "core" {<"111.25.00"}
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/packages/capnp/capnp.2.1.0/opam
+++ b/packages/capnp/capnp.2.1.0/opam
@@ -13,6 +13,7 @@ depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
   "core_kernel"
+  "sexplib" {<="v0.9.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"

--- a/packages/capnp/capnp.2.1.1/opam
+++ b/packages/capnp/capnp.2.1.1/opam
@@ -13,6 +13,7 @@ depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
   "core_kernel"
+  "sexplib" {<="v0.9.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"


### PR DESCRIPTION
There is a bug in OCaml 4.04.0 that causes anything that links with
Ephemeron to fail in the toplevel, since it was accidentally missed
in the release from the stdlib/StdlibModules file.

This causes capnp builds to fail with sexplib>=v0.9.0 which does
link to it. The constraint here is not quite right, since it should
all work when ocaml 4.04.1 is released, but we cannot express the
constraint easily.

So for now, removing the build failure and will figure out the
compiler constraint when the new version of ocaml is released.

thanks @diml for diagnosing the issue