### PR TITLE
containers: add conflicts on sequence

### DIFF
--- a/packages/containers/containers.0.15/opam
+++ b/packages/containers/containers.0.15/opam
@@ -30,6 +30,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "sequence" "base-bigarray" "base-unix" "base-threads" ]
+conflicts: [ "sequence" >= "0.6" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"

--- a/packages/containers/containers.0.15/opam
+++ b/packages/containers/containers.0.15/opam
@@ -30,7 +30,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "sequence" "base-bigarray" "base-unix" "base-threads" ]
-conflicts: [ "sequence" >= "0.6" ]
+conflicts: [ "sequence" {>= "0.6"} ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"

--- a/packages/containers/containers.0.16.1/opam
+++ b/packages/containers/containers.0.16.1/opam
@@ -33,6 +33,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["sequence" "base-bigarray" "base-unix" "base-threads"]
+conflicts: [ "sequence" >= "0.6" ]
 available: [ocaml-version >= "4.00.0"]
 post-messages:
   "

--- a/packages/containers/containers.0.16.1/opam
+++ b/packages/containers/containers.0.16.1/opam
@@ -33,7 +33,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["sequence" "base-bigarray" "base-unix" "base-threads"]
-conflicts: [ "sequence" >= "0.6" ]
+conflicts: [ "sequence" {>="0.6"} ]
 available: [ocaml-version >= "4.00.0"]
 post-messages:
   "

--- a/packages/containers/containers.0.16/opam
+++ b/packages/containers/containers.0.16/opam
@@ -34,4 +34,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["sequence" "base-bigarray" "base-unix" "base-threads"]
+conflicts: [ "sequence" >= "0.6" ]
 available: [ocaml-version >= "4.00.0"]

--- a/packages/containers/containers.0.16/opam
+++ b/packages/containers/containers.0.16/opam
@@ -34,5 +34,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["sequence" "base-bigarray" "base-unix" "base-threads"]
-conflicts: [ "sequence" >= "0.6" ]
+conflicts: [ "sequence" {>="0.6"} ]
 available: [ocaml-version >= "4.00.0"]


### PR DESCRIPTION
This does not cover all versions of containers yet. The root issue
was fixed in 0.22.1 in https://github.com/c-cube/ocaml-containers/issues/90
but older versions are failing to compile (e.g. prob-cache in https://github.com/ocaml/opam-repository/pull/8932)

cc @c-cube