### PR TITLE
ocaml-basics.0.1.0 - via opam-publish

### DIFF
--- a/packages/ocaml-basics/ocaml-basics.0.1.0/descr
+++ b/packages/ocaml-basics/ocaml-basics.0.1.0/descr
@@ -1,0 +1,1 @@
+Implements common functionnal patterns / abstractions

--- a/packages/ocaml-basics/ocaml-basics.0.1.0/opam
+++ b/packages/ocaml-basics/ocaml-basics.0.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Antoine Luciani <aluciani@advanced-schema.com>"
+authors: "Advanced Schema"
+homepage: "http://github.com/advanced-schema/ocaml-basics"
+bug-reports: "http://github.com/advanced-schema/ocaml-basics/issues"
+license: "MIT"
+dev-repo: "https://github.com/advanced-schema/ocaml-basics.git"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ocaml-basics"]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {>= "0.4"}
+  "result" {>= "1.2"}
+  "ppx_sexp_conv" {>= "v0.9"}
+  "sexplib" {>= "v0.9"}
+  "ppx_deriving" {>= "4.0"}
+]
+available: [ ocaml-version >= "4.04" ]

--- a/packages/ocaml-basics/ocaml-basics.0.1.0/url
+++ b/packages/ocaml-basics/ocaml-basics.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/advanced-schema/ocaml-basics/archive/v0.1.0.tar.gz"
+checksum: "01e2ecb3c650d8a3ecf5b7feb182aaf2"


### PR DESCRIPTION
Implements common functionnal patterns / abstractions


---
* Homepage: http://github.com/advanced-schema/ocaml-basics
* Source repo: https://github.com/advanced-schema/ocaml-basics.git
* Bug tracker: http://github.com/advanced-schema/ocaml-basics/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.4