### PR TITLE
obandit.0.2.3.1-5-g40e1b6c - via opam-publish

### DIFF
--- a/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/descr
+++ b/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/descr
@@ -1,0 +1,8 @@
+Ocaml Multi-Armed Bandits
+
+[![DOI](https://zenodo.org/badge/81206527.svg)](https://zenodo.org/badge/latestdoi/81206527)
+
+Obandit is an OCaml module for basic multi-armed bandits. It supports the
+EXP3, UCB1 and Epsilon-greedy algorithms.
+
+Obandit is distributed under the ISC license.

--- a/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/opam
+++ b/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Valentin Reis <fre@freux.fr>"
+authors: ["Valentin Reis <fre@freux.fr>"]
+homepage: "https://freuk.github.io/obandit/"
+doc: "https://freuk.github.io/obandit/api.docdir"
+license: "ISC"
+dev-repo: "https://github.com/freuk/obandit.git"
+bug-reports: "https://github.com/freuk/obandit/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "batteries" ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%" ]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]]

--- a/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/url
+++ b/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/freuk/obandit/releases/download/v0.2.3.1-5-g40e1b6c/obandit-0.2.3.1-5-g40e1b6c.tbz"
+checksum: "d82685c6eee4b958f480a10f86c78d13"


### PR DESCRIPTION
Ocaml Multi-Armed Bandits

[![DOI](https://zenodo.org/badge/81206527.svg)](https://zenodo.org/badge/latestdoi/81206527)

Obandit is an OCaml module for basic multi-armed bandits. It supports the
EXP3, UCB1 and Epsilon-greedy algorithms.

Obandit is distributed under the ISC license.


---
* Homepage: https://freuk.github.io/obandit/
* Source repo: https://github.com/freuk/obandit.git
* Bug tracker: https://github.com/freuk/obandit/issues

---


---
v0.2.3.2 2017-04-13 Grenoble
--------------------------

* fix delegate to use github based documentation.
Pull-request generated by opam-publish v0.3.4