### PR TITLE
fix dose3 5.0.1 compilation on FreeBSD

### DIFF
--- a/packages/dose3/dose3.5.0.1/files/0002-dont-make-printconf.patch
+++ b/packages/dose3/dose3.5.0.1/files/0002-dont-make-printconf.patch
@@ -1,0 +1,9 @@
+--- a/configure
++++ b/configure
+@@ -6552,6 +6552,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
+ $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
+ fi
+-
+-
+-make printconf

--- a/packages/dose3/dose3.5.0.1/opam
+++ b/packages/dose3/dose3.5.0.1/opam
@@ -16,6 +16,7 @@ license: "LGPL-v3+ with OCaml linking exception"
 dev-repo: "https://gforge.inria.fr/git/dose/dose.git"
 build: [
   ["./configure"]
+  [make "printconf"]
   [make]
 ]
 install: [make "installlib"]
@@ -33,4 +34,4 @@ depends: [
   "cppo" {build & >= "1.1.2"}
 ]
 conflicts: "dose"
-patches: "0001-Install-mli-cmx-etc.patch"
+patches: [ "0001-Install-mli-cmx-etc.patch" "0002-dont-make-printconf.patch" ]


### PR DESCRIPTION
please see https://gforge.inria.fr/tracker/index.php?func=detail&aid=21184&group_id=4395&atid=13808 for an issue report, the fix is trivial (revert the build system of dose3 to not execute `make printconf`, but instead do the `make printconf` in opam). tested on FreeBSD