### PR TITLE
ADD Add opass 2.15

### DIFF
--- a/packages/lua_pattern/lua_pattern.1.7/descr
+++ b/packages/lua_pattern/lua_pattern.1.7/descr
@@ -1,0 +1,2 @@
+Implementation of Lua patterns
+

--- a/packages/lua_pattern/lua_pattern.1.7/opam
+++ b/packages/lua_pattern/lua_pattern.1.7/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "orbitz@gmail.com"
+build: [
+	[make "-j%{jobs}%"]
+]
+
+build-test: [
+	[make "-j%{jobs}%" "test"]
+]
+
+install: [
+	[make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+	[make "PREFIX=%{prefix}%" "remove"]
+]
+
+depends: [
+	"containers" { test }
+	"merlin-of-pds"
+	"ocamlfind"
+	"oth" { test }
+	"pds" { build & (>= "5" & < "6") }
+	"qcheck" { test }
+]
+
+authors: [
+	"orbitz@gmail.com"
+]
+
+homepage: "https://bitbucket.org/mimirops/lua_pattern"
+bug-reports: "https://bitbucket.org/mimirops/lua_pattern/issues"
+dev-repo: "git@bitbucket.org:mimirops/lua_pattern.git"
+available: [ocaml-version >= "4.03"]
+

--- a/packages/lua_pattern/lua_pattern.1.7/url
+++ b/packages/lua_pattern/lua_pattern.1.7/url
@@ -1,0 +1,3 @@
+archive: "https://bitbucket.org/mimirops/lua_pattern/get/1.7.tar.gz"
+checksum: "7ec7e0cd487600eb073b5bf6d8470683"
+

--- a/packages/merlin-of-pds/merlin-of-pds.1.4/descr
+++ b/packages/merlin-of-pds/merlin-of-pds.1.4/descr
@@ -1,0 +1,2 @@
+Simple script that turns a pds.conf into a .merlin file
+

--- a/packages/merlin-of-pds/merlin-of-pds.1.4/opam
+++ b/packages/merlin-of-pds/merlin-of-pds.1.4/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "orbitz@gmail.com"
+build: [
+	[make "-j%{jobs}%"]
+]
+
+build-test: [
+	[make "-j%{jobs}%" "test"]
+]
+
+install: [
+	[make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+	[make "PREFIX=%{prefix}%" "remove"]
+]
+
+depends: [
+	"ocamlfind"
+	"pds" { build & (>= "5" & < "6") }
+]
+
+authors: [
+	"orbitz@gmail.com"
+]
+
+homepage: "https://bitbucket.org/acslab/merlin-of-pds"
+bug-reports: "https://bitbucket.org/acslab/merlin-of-pds/issues"
+dev-repo: "https://bitbucket.org/acslab/merlin-of-pds.git"
+

--- a/packages/merlin-of-pds/merlin-of-pds.1.4/url
+++ b/packages/merlin-of-pds/merlin-of-pds.1.4/url
@@ -1,0 +1,3 @@
+archive: "https://bitbucket.org/acslab/merlin-of-pds/get/1.4.tar.gz"
+checksum: "7392d566419232c46424fab4706570ff"
+

--- a/packages/opass/opass.2.15/descr
+++ b/packages/opass/opass.2.15/descr
@@ -1,0 +1,3 @@
+A simple command line tool for storing, retreiving,
+and generating password and secret notes, using PGP for encryption.
+

--- a/packages/opass/opass.2.15/opam
+++ b/packages/opass/opass.2.15/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "mmatalka@gmail.com"
+build: [
+	[make "-j%{jobs}%"]
+]
+
+build-test: [
+	[make "-j%{jobs}%" "test"]
+]
+
+install: [
+	[make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+	[make "PREFIX=%{prefix}%" "remove"]
+]
+
+depends: [
+	"cmdliner"
+	"containers"
+	"csv"
+	"lua_pattern"
+	"merlin-of-pds"
+	"ocamlfind"
+	"pds" { build & (>= "5" & < "6") }
+	"ppx_deriving"
+	"ppx_sexp_conv"
+	"sexplib"
+]
+
+authors: [
+	"mmatalka@gmail.com"
+]
+
+homepage: "https://github.com/orbitz/opass"
+bug-reports: "https://github.com/orbitz/opass/issues"
+dev-repo: "git@github.com:orbitz/opass.git"
+

--- a/packages/opass/opass.2.15/url
+++ b/packages/opass/opass.2.15/url
@@ -1,0 +1,3 @@
+archive: "https://github.com/orbitz/opass/archive/2.15.tar.gz"
+checksum: "0e662ebe04efc311bc5f975745f48d60"
+

--- a/packages/pds/pds.5.24/descr
+++ b/packages/pds/pds.5.24/descr
@@ -1,0 +1,2 @@
+A tool to build Makefiles for Ocaml projects
+

--- a/packages/pds/pds.5.24/opam
+++ b/packages/pds/pds.5.24/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "orbitz@gmail.com"
+build: [
+	[make "-j%{jobs}%"]
+]
+
+build-test: [
+	[make "-j%{jobs}%" "test"]
+]
+
+install: [
+	[make "PREFIX=%{prefix}%" "install"]
+]
+
+remove: [
+	[make "PREFIX=%{prefix}%" "remove"]
+]
+
+depends: [
+	"cmdliner"
+	"crunch"
+	"ocamlfind"
+	"toml"
+]
+
+authors: [
+	"dklee@dklee.org"
+	"orbitz@gmail.com"
+]
+
+homepage: "https://bitbucket.org/mimirops/pds"
+bug-reports: "https://bitbucket.org/mimirops/pds/issues"
+dev-repo: "git@bitbucket.org:mimirops/pds.git"
+available: [ocaml-version >= "4.02"]
+

--- a/packages/pds/pds.5.24/url
+++ b/packages/pds/pds.5.24/url
@@ -1,0 +1,3 @@
+archive: "https://bitbucket.org/mimirops/pds/get/5.24.tar.gz"
+checksum: "63d503f85d640ddc5bb7fe7d2dc48dec"
+


### PR DESCRIPTION
This is a backwards breaking update of opass.  The CLI has been changed from
Core's parser to Cmdliner.  Cmdliner does not support single-dash parameters
that are more than a character long.  With that, all of the parameters such as
"-copy" and "-show" are now "--copy" and "--show".  However, many parameters
have a single character option as well, such as "-c" and "-s".

The database format is unchanged.

A new search parameter, "-p" or "--pattern", has been added where the search
terms can be a Lua pattern.