### PR TITLE
Added new package mld.0.1

### DIFF
--- a/packages/mld/mld.0.1/descr
+++ b/packages/mld/mld.0.1/descr
@@ -1,0 +1,30 @@
+The MLD package makes directory foo.mld turn into module Foo
+
+The contents of module `Foo` are the modules that can be "found" in directory `foo.mld` and recursively in its subdirectories,
+down to other directories of the form `bar.mld`:
+`Bar` will be a submodule of `Foo`, and the recursive search for `Foo`'s modules stops there.
+The contents of `bar.mld` will then be used to determine the submodules of `Foo.Bar`.
+Hence, the following source tree
+
+-src/
+ |-foo.mld/
+   |-a/
+   | |-bar.mld/
+   | | |-b.ml
+   | |
+   | |-c/
+   |   |-d.ml
+   |
+   |-e.ml
+
+will turn into the following module structure
+
+-Foo
+ |-Bar
+ | |-B
+ |
+ |-D
+ |-E
+
+In the background:
+an mlpack is automatically generated for each directory *.mld, and the `-for-pack` options are automatically generated.

--- a/packages/mld/mld.0.1/opam
+++ b/packages/mld/mld.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "mld"
+version: "0.1"
+maintainer: "Stephane Graham-Lengrand <graham-lengrand@lix.polytechnique.fr>"
+authors: [ "Stephane Graham-Lengrand <graham-lengrand@lix.polytechnique.fr>" ]
+homepage: "https://github.com/disteph/mld"
+bug-reports: "https://github.com/disteph/mld/issues"
+dev-repo: "https://github.com/disteph/mld.git"
+license: "CeCILL-C"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "mld"]
+]
+depends: [
+  ((("ocamlbuild" {>= "0.9.0"}) & ("ocamlbuild" {<= "0.11.0"})) | "ocamlbuild" {= "0"})
+  "ocamlfind" {build}
+]

--- a/packages/mld/mld.0.1/url
+++ b/packages/mld/mld.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/disteph/mld/archive/master.tar.gz"
+checksum: "c2fa18b3f1649858e516edd753c777e0"

--- a/packages/mld/mld.0.1/url
+++ b/packages/mld/mld.0.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/disteph/mld/archive/master.tar.gz"
-checksum: "c2fa18b3f1649858e516edd753c777e0"
+archive: "https://github.com/disteph/mld/archive/0.1.tar.gz"
+checksum: "35b4dfb32e273e33c8a9067191ce6fb5"


### PR DESCRIPTION
The MLD package makes directory foo.mld turn into module Foo

The contents of module Foo are the modules that can be "found" in directory foo.mld and recursively in its subdirectories, down to other directories of the form bar.mld:
Bar will be a submodule of Foo, and the recursive search for Foo's modules stops there.
The contents of bar.mld will then be used to determine the submodules of Foo.Bar.