### PR TITLE
subtype-refinement.0.1 - via opam-publish

### DIFF
--- a/packages/subtype-refinement/subtype-refinement.0.1/descr
+++ b/packages/subtype-refinement/subtype-refinement.0.1/descr
@@ -1,0 +1,3 @@
+Refinement types encoded with private types in OCaml.
+
+Generating refinement constraints through OCaml's Applicative Functors and private types.

--- a/packages/subtype-refinement/subtype-refinement.0.1/opam
+++ b/packages/subtype-refinement/subtype-refinement.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Marco Aurélio <marcoonroad@gmail.com>"
+authors: "Marco Aurélio <marcoonroad@gmail.com>"
+homepage: "http://github.com/marcoonroad/subtype-refinement"
+bug-reports: "http://github.com/marcoonroad/subtype-refinement/issues"
+license: "MIT"
+dev-repo: "http://github.com/marcoonroad/subtype-refinement.git"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%" "--%{ounit:enable}%-tests"]
+  [make]
+]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "subtype-refinement"]
+depends: [
+  "ounit" {test}
+  "oasis" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "3.12"]

--- a/packages/subtype-refinement/subtype-refinement.0.1/url
+++ b/packages/subtype-refinement/subtype-refinement.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/marcoonroad/subtype-refinement/archive/v0.1.tar.gz"
+checksum: "84c3ab089fc771450917f0bd2613ed9c"


### PR DESCRIPTION
Refinement types encoded with private types in OCaml.

Generating refinement constraints through OCaml's Applicative Functors and private types.


---
* Homepage: http://github.com/marcoonroad/subtype-refinement
* Source repo: http://github.com/marcoonroad/subtype-refinement.git
* Bug tracker: http://github.com/marcoonroad/subtype-refinement/issues

---

Pull-request generated by opam-publish v0.3.1