### PR TITLE
charrua-unix.0.6 - via opam-publish

### DIFF
--- a/packages/charrua-unix/charrua-unix.0.6/descr
+++ b/packages/charrua-unix/charrua-unix.0.6/descr
@@ -1,0 +1,7 @@
+DHCP Unix Server
+
+[charrua-unix](http://www.github.com/haesbaert/charrua-unix) is an _ISC-licensed_
+Unix DHCP daemon based on
+[charrua-core](http://www.github.com/haesbaert/charrua-core).
+
+[![Build Status](https://travis-ci.org/haesbaert/charrua-unix.svg)](https://travis-ci.org/haesbaert/charrua-unix)

--- a/packages/charrua-unix/charrua-unix.0.6/opam
+++ b/packages/charrua-unix/charrua-unix.0.6/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "charrua-unix"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/haesbaert/charrua-unix"
+bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
+license: "ISC"
+dev-repo: "https://github.com/haesbaert/charrua-unix.git"
+available: [ocaml-version >= "4.03" & opam-version >= "1.2"]
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+
+depends: [
+  "ocamlfind"
+  {build}
+  "cstruct"
+  "ipaddr"
+  "lwt"
+  "charrua-core" {>= "0.5"}
+  "cmdliner"
+  "rawlink"
+  "tuntap"
+  "mtime"
+]

--- a/packages/charrua-unix/charrua-unix.0.6/url
+++ b/packages/charrua-unix/charrua-unix.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/haesbaert/charrua-unix/releases/download/v0.6/charrua-unix-0.6.tbz"
+checksum: "dddd026edb4026bb7b45816b1c0102d0"


### PR DESCRIPTION
DHCP Unix Server

[charrua-unix](http://www.github.com/haesbaert/charrua-unix) is an _ISC-licensed_
Unix DHCP daemon based on
[charrua-core](http://www.github.com/haesbaert/charrua-core).

[![Build Status](https://travis-ci.org/haesbaert/charrua-unix.svg)](https://travis-ci.org/haesbaert/charrua-unix)

---
* Homepage: https://github.com/haesbaert/charrua-unix
* Source repo: https://github.com/haesbaert/charrua-unix.git
* Bug tracker: https://github.com/haesbaert/charrua-unix/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
## 0.6 (2017-04-14)

* topkg support
Pull-request generated by opam-publish v0.3.3