### PR TITLE
Add depopts to ssl for duppy.

### DIFF
--- a/packages/duppy/duppy.0.6.0/opam
+++ b/packages/duppy/duppy.0.6.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind"
   "pcre"
 ]
+depopts: ["ssl"]
 conflicts: ["liquidsoap" {<= "1.2.1"}]
 bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
 dev-repo: "https://github.com/savonet/ocaml-duppy.git"


### PR DESCRIPTION
I forgot this in the last update.