### PR TITLE
New release for ocaml4.04.0+copatterns (V0.3).

### DIFF
--- a/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
+++ b/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.04.0"
-src: "https://github.com/yurug/ocaml4.04.0-copatterns/archive/V0.2.tar.gz"
+src: "https://github.com/yurug/ocaml4.04.0-copatterns/archive/V0.3.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]


### PR DESCRIPTION
OCaml 4.04.0+copatterns 0.3 :
-----------------------------

### Transformation:

- New syntax for nested copatterns.
- Verify that a child copattern is an instance of its parent.
  (Parser.check_instance)

### Syntactic assertions:
- Delegate verification for indexed colabel declaration to the OCaml type checker.
  (delete Parser.check_indexed_cotype)