### PR TITLE
mustache.3.0.0 - via opam-publish

### DIFF
--- a/packages/mustache/mustache.3.0.0/descr
+++ b/packages/mustache/mustache.3.0.0/descr
@@ -1,0 +1,3 @@
+Mustache logic-less templates in OCaml
+
+Read and write mustache templates and render them by providing a json object

--- a/packages/mustache/mustache.3.0.0/opam
+++ b/packages/mustache/mustache.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg" "Armaël Guéneau"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/ocaml-mustache"
+bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
+dev-repo: "https://github.com/rgrinberg/ocaml-mustache.git"
+doc: "http://mustache.github.io/mustache.5.html"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--disable-cli"]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: ["ocaml" "setup.ml" "-install"]
+
+remove: [
+  ["ocamlfind" "remove" "mustache"]
+]
+
+build-doc: ["ocaml" "setup.ml" "-doc"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "menhir" {build}
+  "ounit" {test}
+  "ezjsonm" {test}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/mustache/mustache.3.0.0/url
+++ b/packages/mustache/mustache.3.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/ocaml-mustache/archive/v3.0.0.tar.gz"
+checksum: "f201cbdf16994bb6f8316fb1c743b589"


### PR DESCRIPTION
Mustache logic-less templates in OCaml

Read and write mustache templates and render them by providing a json object


---
* Homepage: https://github.com/rgrinberg/ocaml-mustache
* Source repo: https://github.com/rgrinberg/ocaml-mustache.git
* Bug tracker: https://github.com/rgrinberg/ocaml-mustache/issues

---

Pull-request generated by opam-publish v0.3.3