### PR TITLE
rawlink.0.5 - via opam-publish

### DIFF
--- a/packages/rawlink/rawlink.0.5/descr
+++ b/packages/rawlink/rawlink.0.5/descr
@@ -1,0 +1,30 @@
+Portable library to read and write raw packets.
+
+[![Build Status](https://travis-ci.org/haesbaert/rawlink.svg)](https://travis-ci.org/haesbaert/rawlink)
+
+Rawlink is an ocaml library for sending and receiving raw packets at the link
+layer level. Sometimes you need to have full control of the packet, including
+building the full ethernet frame.
+
+The API is platform independent, it uses BPF on real UNIXes and AF_SOCKET on
+linux. Some functionality is sacrificed so that the API is portable enough.
+
+Currently BPF and AF_PACKET are implemented, including filtering capabilities.
+Writing a BPF program is a pain in the ass, so no facilities are provided for
+it. If you need a BPF filter, I suggest you write a small .c file with a
+function that returns the BPF program as a string, check `rawlink_stubs.c` for
+an example.
+
+Both normal blocking functions as well as `Lwt` monadic variants are provided.
+
+A typical code for receiving all packets and just sending them back on an
+specified interface are detailed below:
+
+```
+let link = Rawlink.open_link "eth0" in
+let buf = Rawlink.read_packet link in
+Printf.printf "got a packet with %d bytes.\n%!" (Cstruct.len buf);
+Rawlink.send_packet link buf
+```
+
+Check the mli interface for more options.

--- a/packages/rawlink/rawlink.0.5/opam
+++ b/packages/rawlink/rawlink.0.5/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "rawlink"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/haesbaert/rawlink"
+bug-reports: "https://github.com/haesbaert/rawlink/issues"
+dev-repo: "https://github.com/haesbaert/rawlink.git"
+doc: "https://haesbaert.github.io/rawlink/api"
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+depends: [
+  "ocamlfind" {build}
+  "topkg" {build}
+  "lwt" {>= "2.4.7"}
+  "cstruct" {>= "1.9"}
+  "ocamlbuild" {build}
+]
+depexts: [[ ["alpine"] ["linux-headers"] ]]
+available: [ocaml-version >= "4.03.0"]
+

--- a/packages/rawlink/rawlink.0.5/url
+++ b/packages/rawlink/rawlink.0.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/haesbaert/rawlink/releases/download/v0.5/rawlink-0.5.tbz"
+checksum: "145158526778fa7110a73c39e738e93e"


### PR DESCRIPTION
Portable library to read and write raw packets.

[![Build Status](https://travis-ci.org/haesbaert/rawlink.svg)](https://travis-ci.org/haesbaert/rawlink)

Rawlink is an ocaml library for sending and receiving raw packets at the link
layer level. Sometimes you need to have full control of the packet, including
building the full ethernet frame.

The API is platform independent, it uses BPF on real UNIXes and AF_SOCKET on
linux. Some functionality is sacrificed so that the API is portable enough.

Currently BPF and AF_PACKET are implemented, including filtering capabilities.
Writing a BPF program is a pain in the ass, so no facilities are provided for
it. If you need a BPF filter, I suggest you write a small .c file with a
function that returns the BPF program as a string, check `rawlink_stubs.c` for
an example.

Both normal blocking functions as well as `Lwt` monadic variants are provided.

A typical code for receiving all packets and just sending them back on an
specified interface are detailed below:

```
let link = Rawlink.open_link "eth0" in
let buf = Rawlink.read_packet link in
Printf.printf "got a packet with %d bytes.\n%!" (Cstruct.len buf);
Rawlink.send_packet link buf
```

Check the mli interface for more options.

---
* Homepage: https://github.com/haesbaert/rawlink
* Source repo: https://github.com/haesbaert/rawlink.git
* Bug tracker: https://github.com/haesbaert/rawlink/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
## 0.5 (2017-04-16)

* Convert to topkg
Pull-request generated by opam-publish v0.3.4