### PR TITLE
tyre.0.3 - via opam-publish

### DIFF
--- a/packages/tyre/tyre.0.3/descr
+++ b/packages/tyre/tyre.0.3/descr
@@ -1,0 +1,4 @@
+Typed Regular Expressions
+
+Tyre is a set of combinators to build type-safe regular expressions, allowing automatic extraction and modification of matched groups.
+Tyre is bi-directional: a typed regular expressions can be used for parsing and unparsing. It also allows routing, by providing a list of regexs/routes and their handlers.

--- a/packages/tyre/tyre.0.3/opam
+++ b/packages/tyre/tyre.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+authors: "Gabriel Radanne <drupyog@zoho.com>"
+homepage: "https://github.com/Drup/tyre"
+bug-reports: "https://github.com/Drup/tyre/issues"
+license: "ISC"
+doc: "https://drup.github.io/tyre/0.3/Tyre.html"
+tags: "regex"
+dev-repo: "https://github.com/Drup/tyre.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "tyre"]
+depends: [
+  "ocamlfind" {build}
+  "re" {>= "1.7.0"}
+  "alcotest" {test & >= "0.6.0"}
+  "result"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/tyre/tyre.0.3/url
+++ b/packages/tyre/tyre.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Drup/tyre/archive/0.3.tar.gz"
+checksum: "3260227f51b22c64cd43cd4c88b796b6"


### PR DESCRIPTION
Typed Regular Expressions

Tyre is a set of combinators to build type-safe regular expressions, allowing automatic extraction and modification of matched groups.
Tyre is bi-directional: a typed regular expressions can be used for parsing and unparsing. It also allows routing, by providing a list of regexs/routes and their handlers.

---
* Homepage: https://github.com/Drup/tyre
* Source repo: https://github.com/Drup/tyre.git
* Bug tracker: https://github.com/Drup/tyre/issues

---

Changelog:


* Performance improvements.
* Fix the behavior of opt (Prefer eating input).
* Remove conv_fail and allow usual converters to fail with an exception.
* Add Tyre.all and Tyre.all_gen

---

Pull-request generated by opam-publish v0.3.3