### PR TITLE
js_of_ocaml: older versions do not work with newest ppx_driver

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
@@ -28,5 +28,6 @@ conflicts: [
   "ppx_deriving" {< "3.0"}
   "reactiveData" {< "0.2"}
   "async_kernel" {< "113.33.00"}
+  "ppx_driver"   {>="v0.9.0"}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.04.0" ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
@@ -34,5 +34,6 @@ conflicts: [
   "ppx_deriving" {< "3.0"}
   "reactiveData" {< "0.2"}
   "async_kernel" {< "113.33.00"}
+  "ppx_driver" {>="v0.9.0"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
@@ -34,5 +34,6 @@ conflicts: [
   "ppx_deriving" {< "3.0"}
   "reactiveData" {< "0.2"}
   "async_kernel" {< "113.33.00"}
+  "ppx_driver" {>="v0.9.0"}
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
This only affects OCaml 4.04.0 in practise