### PR TITLE
ocamltter: constraint to <ppx_meta_conv.2.6.0

### DIFF
--- a/packages/ocamltter/ocamltter.4.1.0/opam
+++ b/packages/ocamltter/ocamltter.4.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ocurl" { >= "0.5.3" }
   "spotlib" { >= "3.0.0" }
   "ppx_orakuda" { >= "3.0.0" }
-  "ppx_meta_conv" { >= "2.4.0" }
+  "ppx_meta_conv" { >= "2.4.0" & <"2.6.0"}
   "tiny_json"
   "ppx_monadic"
 ]

--- a/packages/ocamltter/ocamltter.4.1.1/opam
+++ b/packages/ocamltter/ocamltter.4.1.1/opam
@@ -26,7 +26,7 @@ depends: [
   "ocurl" { >= "0.5.3" }
   "spotlib" { >= "3.0.0" }
   "ppx_orakuda" { >= "3.0.0" }
-  "ppx_meta_conv" { >= "2.4.0" }
+  "ppx_meta_conv" { >= "2.4.0" & < "2.6.0"}
   "tiny_json"
   "ppx_monadic"
 ]


### PR DESCRIPTION
otherwise fails with "Package `ppx_meta_conv_ocaml' not found"

cc @camlspotter