### PR TITLE
qcow.0.9.5 - via opam-publish

### DIFF
--- a/packages/qcow/qcow.0.9.5/descr
+++ b/packages/qcow/qcow.0.9.5/descr
@@ -1,0 +1,19 @@
+Support for Qcow2 images
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-qcow.png?branch=master)](https://travis-ci.org/mirage/ocaml-qcow) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-qcow/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-qcow?branch=master)
+
+Please read [the API documentation](https://mirage.github.io/ocaml-qcow/).
+
+Features
+--------
+
+- supports `resize`
+- exposes sparseness information
+- produces files which can be understood by qemu (although not in
+  reverse since we don't support many features)
+
+Example
+-------
+
+In a top-level like utop:
+```ocaml

--- a/packages/qcow/qcow.0.9.5/opam
+++ b/packages/qcow/qcow.0.9.5/opam
@@ -1,0 +1,50 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: ["David Scott"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-qcow"
+dev-repo: "https://github.com/mirage/ocaml-qcow.git"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+tags: [
+  "org:mirage"
+]
+
+depends: [
+  "astring"
+  "cmdliner"
+  "cstruct"
+  "result"
+  "mirage-types-lwt" {>= "3.0.0"}
+  "lwt"
+  "mirage-block" {>= "0.2"}
+  "mirage-block-lwt"
+  "mirage-block-unix" {>= "2.1.0"}
+  "mirage-time"
+  "mirage-time-lwt"
+  "cmdliner"
+  "sha"
+  "sexplib"
+  "logs"
+  "fmt"
+  "astring"
+  "io-page"
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_type_conv" {build}
+  "ounit" {test}
+  "mirage-block-ramdisk" {test}
+  "ezjsonm" {test}
+  "nbd" {test & >= "2.0.1"}
+]
+
+build: [
+  [ "ocaml" "detect_word_size.ml" ]
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/qcow/qcow.0.9.5/url
+++ b/packages/qcow/qcow.0.9.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-qcow/releases/download/0.9.5/qcow-0.9.5.tbz"
+checksum: "d6a656883006023730749a8b4744cfa0"


### PR DESCRIPTION
Support for Qcow2 images

[![Build Status](https://travis-ci.org/mirage/ocaml-qcow.png?branch=master)](https://travis-ci.org/mirage/ocaml-qcow) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-qcow/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-qcow?branch=master)

Please read [the API documentation](https://mirage.github.io/ocaml-qcow/).

Features
--------

- supports `resize`
- exposes sparseness information
- produces files which can be understood by qemu (although not in
  reverse since we don't support many features)

Example
-------

In a top-level like utop:
```ocaml

---
* Homepage: https://github.com/mirage/ocaml-qcow
* Source repo: https://github.com/mirage/ocaml-qcow.git
* Bug tracker: https://github.com/mirage/ocaml-qcow/issues

---


---
## 0.9.5 (2017-03-12)
- CLI: `check` and `sha` will nolonger resize the file as a side-effect
  (#84)
- Allow the number of `cluster_bits` to be set in `create`
Pull-request generated by opam-publish v0.3.2