### PR TITLE
qtest.2.6 - via opam-publish

### DIFF
--- a/packages/qtest/qtest.2.6/descr
+++ b/packages/qtest/qtest.2.6/descr
@@ -1,0 +1,6 @@
+iTeML / qtest : Inline (Unit) Tests for OCaml.
+
+qtest extracts inline unit tests written using a special
+syntax in comments. Those tests are then run using the oUnit framework
+and the qcheck library.  The possibilities range from trivial tests --
+extremely simple to use -- to sophisticated random generation of test cases.

--- a/packages/qtest/qtest.2.6/files/qtest.install
+++ b/packages/qtest/qtest.2.6/files/qtest.install
@@ -1,0 +1,4 @@
+bin: [
+  "?qtest/_build/qtest.byte" {"qtest"}
+  "?qtest/_build/qtest.native" {"qtest"}
+]

--- a/packages/qtest/qtest.2.6/opam
+++ b/packages/qtest/qtest.2.6/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Vincent Hugot <vincent.hugot@gmail.com>"
+authors: [
+  "Vincent Hugot <vincent.hugot@gmail.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+homepage: "https://github.com/vincent-hugot/iTeML"
+bug-reports: "https://github.com/vincent-hugot/iTeML/issues"
+doc:
+  "https://github.com/vincent-hugot/iTeML/blob/master/README.adoc#introduction"
+tags: ["test" "property" "quickcheck"]
+dev-repo: "git@github.com:vincent-hugot/iTeML.git"
+build: [make "build"]
+install: [make "BIN=%{bin}%" "install"]
+remove: ["rm" "%{bin}%/qtest"]
+depends: [
+  "ocamlfind"
+  "ounit" {>= "2.0.0"}
+  "ocamlbuild" {build}
+  "qcheck" {>= "0.5"}
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/qtest/qtest.2.6/url
+++ b/packages/qtest/qtest.2.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vincent-hugot/iteml/archive/v2.6.tar.gz"
+checksum: "bedf6e77d55f374071f2d9173de9768a"


### PR DESCRIPTION
iTeML / qtest : Inline (Unit) Tests for OCaml.

qtest extracts inline unit tests written using a special
syntax in comments. Those tests are then run using the oUnit framework
and the qcheck library.  The possibilities range from trivial tests --
extremely simple to use -- to sophisticated random generation of test cases.


---
* Homepage: https://github.com/vincent-hugot/iTeML
* Source repo: git@github.com:vincent-hugot/iTeML.git
* Bug tracker: https://github.com/vincent-hugot/iTeML/issues

---

Pull-request generated by opam-publish v0.3.3