### PR TITLE
pumping: constrain to a jbuilder version that has `executable`

### DIFF
--- a/packages/pumping/pumping.0.1.0/opam
+++ b/packages/pumping/pumping.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocamlfind" {build}
-  "jbuilder" {build}
+  "jbuilder" {build & >="1.0+beta6"}
   "ocaml-migrate-parsetree"
   "fmt"
 ]


### PR DESCRIPTION
spotted in #9004 cc @drup @diml