### PR TITLE
systemverilog.0.0.1 - via opam-publish

### DIFF
--- a/packages/systemverilog/systemverilog.0.0.1/descr
+++ b/packages/systemverilog/systemverilog.0.0.1/descr
@@ -1,0 +1,5 @@
+SystemVerilog for OCaml
+
+This package provides a lexer and a parser for SystemVerilog IEEE 1800-2012 .
+It is not supposed to be fully featured from the get go. Capabilities are added
+depending on the needs or on-demand.

--- a/packages/systemverilog/systemverilog.0.0.1/opam
+++ b/packages/systemverilog/systemverilog.0.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Xavier Guérin <ghub@applepine.org>"
+authors: ["Xavier Guérin <ghub@applepine.org>"]
+homepage: "https://github.com/xguerin/systemverilog"
+doc: "https://xguerin.github.io/systemverilog/wiki"
+license: "ISC"
+dev-repo: "https://github.com/xguerin/systemverilog.git"
+bug-reports: "https://github.com/xguerin/systemverilog/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+substs: [ "pkg/META" ]
+depends:
+[
+  "ocamlfind"  { build                 }
+  "ocamlbuild" { build                 }
+  "topkg"      { build & >= "0.9.0"    }
+  "astring"    { build & >= "0.8.3"    }
+  "ppx_import" { build & >= "1.2"      }
+  "menhir"     { build & >= "20170418" }
+]
+depopts: []
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%"
+]]

--- a/packages/systemverilog/systemverilog.0.0.1/url
+++ b/packages/systemverilog/systemverilog.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/xguerin/systemverilog/archive/0.0.1.tar.gz"
+checksum: "4a9837096f2e208a6be6541f378e57e7"


### PR DESCRIPTION
SystemVerilog for OCaml

This package provides a lexer and a parser for SystemVerilog IEEE 1800-2012 .
It is not supposed to be fully featured from the get go. Capabilities are added
depending on the needs or on-demand.


---
* Homepage: https://github.com/xguerin/systemverilog
* Source repo: https://github.com/xguerin/systemverilog.git
* Bug tracker: https://github.com/xguerin/systemverilog/issues

---

Pull-request generated by opam-publish v0.3.4