### PR TITLE
opam-query.1.3 - via opam-publish

### DIFF
--- a/packages/opam-query/opam-query.1.3/descr
+++ b/packages/opam-query/opam-query.1.3/descr
@@ -1,0 +1,4 @@
+A tool to query opam files from shell scripts
+
+opam-query is a tool that allows querying the OPAM package
+description files from shell scripts, similar to `oasis query`.

--- a/packages/opam-query/opam-query.1.3/opam
+++ b/packages/opam-query/opam-query.1.3/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: "whitequark <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/opam-query"
+bug-reports: "https://github.com/whitequark/opam-query/issues"
+license: "MIT"
+dev-repo: "git://github.com/whitequark/opam-query"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "cppo" {build}
+  "opam-lib" {>= "1.3"}
+  "cmdliner"
+  "containers" {>= "1.0" & < "2.0"}
+  "uri"
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/opam-query/opam-query.1.3/url
+++ b/packages/opam-query/opam-query.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/opam-query/archive/v1.3.tar.gz"
+checksum: "3b0ce3651024dd85a21cdf281c51f5ac"


### PR DESCRIPTION
A tool to query opam files from shell scripts

opam-query is a tool that allows querying the OPAM package
description files from shell scripts, similar to `oasis query`.


---
* Homepage: https://github.com/whitequark/opam-query
* Source repo: git://github.com/whitequark/opam-query
* Bug tracker: https://github.com/whitequark/opam-query/issues

---

Pull-request generated by opam-publish v0.3.4