### PR TITLE
ppx_import.1.2 - via opam-publish

### DIFF
--- a/packages/ppx_import/ppx_import.1.2/descr
+++ b/packages/ppx_import/ppx_import.1.2/descr
@@ -1,0 +1,1 @@
+A syntax extension for importing declarations from interface files

--- a/packages/ppx_import/ppx_import.1.2/opam
+++ b/packages/ppx_import/ppx_import.1.2/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: "whitequark <whitequark@whitequark.org>"
+homepage: "https://github.com/whitequark/ppx_import"
+bug-reports: "https://github.com/whitequark/ppx_import/issues"
+license: "MIT"
+tags: "syntax"
+dev-repo: "git://github.com/whitequark/ppx_import.git"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_ppx_import.byte"
+  "--"
+]
+depends: [
+  "ppx_tools" {>= "0.99.1"}
+  "ocamlfind" {build}
+  "cppo" {build}
+  "ounit" {test}
+  "ppx_deriving" {test & >= "2.0"}
+]
+available: [ocaml-version >= "4.02.0" & opam-version >= "1.2.2"]

--- a/packages/ppx_import/ppx_import.1.2/url
+++ b/packages/ppx_import/ppx_import.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_import/archive/v1.2.tar.gz"
+checksum: "7091ab31a453d4aff37d3fdb413aa5c4"


### PR DESCRIPTION
A syntax extension for importing declarations from interface files


---
* Homepage: https://github.com/whitequark/ppx_import
* Source repo: git://github.com/whitequark/ppx_import.git
* Bug tracker: https://github.com/whitequark/ppx_import/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.2