### PR TITLE
ppx_tools_versioned.5.0.1 - via opam-publish

### DIFF
--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/descr
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/descr
@@ -1,0 +1,1 @@
+A variant of ppx_tools based on ocaml-migrate-parsetree

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+]
+homepage: "https://github.com/let-def/ppx_tools_versioned"
+bug-reports: "https://github.com/let-def/ppx_tools_versioned/issues"
+license: "MIT"
+tags: "syntax"
+dev-repo: "git://github.com/let-def/ppx_tools_versioned.git"
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ppx_tools_versioned"]
+depends: [
+  "ocamlfind" {>= "1.5.0"}
+  "ocaml-migrate-parsetree" {>= "0.7"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/url
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/ppx_tools_versioned/archive/5.0.1.tar.gz"
+checksum: "fa26fd27ac77aaf5058c86158b6b2267"


### PR DESCRIPTION
A variant of ppx_tools based on ocaml-migrate-parsetree


---
* Homepage: https://github.com/let-def/ppx_tools_versioned
* Source repo: git://github.com/let-def/ppx_tools_versioned.git
* Bug tracker: https://github.com/let-def/ppx_tools_versioned/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.4