### PR TITLE
opam-query: restrict containers to one with CCOpt.get available

### DIFF
--- a/packages/opam-query/opam-query.1.0/opam
+++ b/packages/opam-query/opam-query.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "cppo" {build}
   "opam-lib" {>= "1.2" & < "1.3"}
   "cmdliner"
-  "containers"
+  "containers" {<"1.0"}
   "uri"
   "ocamlbuild" {build}
 ]

--- a/packages/opam-query/opam-query.1.1/opam
+++ b/packages/opam-query/opam-query.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "cppo" {build}
   "opam-lib" {>= "1.2" & < "1.3"}
   "cmdliner"
-  "containers"
+  "containers" {<"1.0"}
   "uri"
   "ocamlbuild" {build}
 ]

--- a/packages/opam-query/opam-query.1.2/opam
+++ b/packages/opam-query/opam-query.1.2/opam
@@ -11,7 +11,7 @@ depends: [
   "cppo" {build}
   "opam-lib" {>= "1.2" & < "1.3"}
   "cmdliner"
-  "containers"
+  "containers" {<"1.0"}
   "uri"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
revdep failure found in https://github.com/ocaml/opam-repository/pull/9025
testing. fixed upstream in whitequark/opam-query@cbd08532b69ed2daea415416973d9ca50369d50d