### PR TITLE
zed.1.5 — via opam-publish

### DIFF
--- a/packages/zed/zed.1.5/descr
+++ b/packages/zed/zed.1.5/descr
@@ -1,0 +1,11 @@
+Abstract engine for text edition in OCaml
+Zed is an abstract engine for text edition. It can be used to write
+text editors, edition widgets, readlines, ...
+
+Zed uses Camomile to fully support the Unicode specification, and
+implements an UTF-8 encoded string type with validation, and a rope
+datastructure to achieve efficient operations on large Unicode
+buffers. Zed also features a regular expression search on ropes.
+
+To support efficient text edition capabilities, Zed provides macro
+recording and cursor management facilities.

--- a/packages/zed/zed.1.5/opam
+++ b/packages/zed/zed.1.5/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/zed"
+bug-reports: "https://github.com/diml/zed/issues"
+dev-repo: "git://github.com/diml/zed.git"
+license: "BSD3"
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "base-bytes"
+  "camomile" {>= "0.8"}
+  "react"
+]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git://github.com/diml/zed.git"
+available: ocaml-version >= "4.02.3"

--- a/packages/zed/zed.1.5/opam
+++ b/packages/zed/zed.1.5/opam
@@ -14,5 +14,4 @@ depends: [
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-dev-repo: "git://github.com/diml/zed.git"
 available: ocaml-version >= "4.02.3"

--- a/packages/zed/zed.1.5/url
+++ b/packages/zed/zed.1.5/url
@@ -1,0 +1,2 @@
+src: "https://github.com/diml/zed/archive/1.5.tar.gz"
+checksum: "a68d8a3fca3331b87e93ceb35483f09d"


### PR DESCRIPTION
Abstract engine for text edition in OCaml

Zed is an abstract engine for text edition. It can be used to write
text editors, edition widgets, readlines, ...

Zed uses Camomile to fully support the Unicode specification, and
implements an UTF-8 encoded string type with validation, and a rope
datastructure to achieve efficient operations on large Unicode
buffers. Zed also features a regular expression search on ropes.

To support efficient text edition capabilities, Zed provides macro
recording and cursor management facilities.


---
* Homepage: https://github.com/diml/zed
* Source repo: git://github.com/diml/zed.git
* Bug tracker: https://github.com/diml/zed/issues

---
### opam-lint failures
- **ERROR** 32 Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"
- **ERROR**  3 File format error in 'dev-repo' at line 17, column 0: Duplicate field dev-repo

---

Pull-request generated by opam-publish v0.3.4