### PR TITLE
irmin.1.1.0 - via opam-publish

### DIFF
--- a/packages/irmin/irmin.1.1.0/descr
+++ b/packages/irmin/irmin.1.1.0/descr
@@ -1,0 +1,7 @@
+Irmin, a distributed database that follows the same design principles as Git
+
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.

--- a/packages/irmin/irmin.1.1.0/opam
+++ b/packages/irmin/irmin.1.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build:
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"]
+
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test" "-n" name]
+]
+
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.9.0"}
+  "fmt"
+  "ocamlgraph"
+  "lwt" {>= "2.4.7"}
+  "logs" {>= "0.5.0"}
+  "cstruct" {>= "1.6.0"}
+  "jsonm" {>= "1.0.0"}
+  "uri" {>= "1.3.12"}
+  "astring"
+  "hex"
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.1.0/url
+++ b/packages/irmin/irmin.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.1.0/irmin-1.1.0.tbz"
+checksum: "6e59e9288faf0033592ab842539caad4"


### PR DESCRIPTION
Irmin, a distributed database that follows the same design principles as Git

Irmin is a library for persistent stores with built-in snapshot,
branching and reverting mechanisms. It is designed to use a large
variety of backends. Irmin is written in pure OCaml and does not
depend on external C stubs; it aims to run everywhere, from Linux,
to browsers and Xen unikernels.


---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 1.1.0 (2017-04-24)

**irmin**

- Change the type of `S.Tree.find_tree` to return a `tree option` instead of
  `tree`. This is a breaking API change but it let distinguish between
  the empty and non-existent cases (#431, @samoht)
- Allow to specify branches in urls for fetch using the `url#branch` syntax
  (#432, @samoht)
- Expose `Irmin.Merge.idempotent` for values with idempotent operations
  (#433, @samoht)
- Add a `S.repo` type as an alias to the `S.Repo.t` (#436, @samoht)
- Fix regression in `S.Tree.diff` intoduced in the 1.0 release: nested
  differences where reported with the wrong path (#438, @samoht)

**irmin-unix**

- Update to irmin.1.1.0 API changes (@samoht)

**irmin-git**

- Update to irmin.1.1.0 API changes (@samoht)
Pull-request generated by opam-publish v0.3.2