### PR TITLE
irmin-unix.1.1.0 - via opam-publish

### DIFF
--- a/packages/irmin-unix/irmin-unix.1.1.0/descr
+++ b/packages/irmin-unix/irmin-unix.1.1.0/descr
@@ -1,0 +1,5 @@
+Unix backends for Irmin
+
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.

--- a/packages/irmin-unix/irmin-unix.1.1.0/opam
+++ b/packages/irmin-unix/irmin-unix.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test" "-n" name]
+]
+
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.9.0"}
+  "irmin"      {>= "1.1.0"}
+  "irmin-git"  {>= "1.1.0"}
+  "irmin-http" {>= "1.0.0"}
+  "git-unix"   {>= "1.10.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "irmin-mirage" {test & >= "1.0.0"}
+  "alcotest"     {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-unix/irmin-unix.1.1.0/url
+++ b/packages/irmin-unix/irmin-unix.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.1.0/irmin-1.1.0.tbz"
+checksum: "6e59e9288faf0033592ab842539caad4"


### PR DESCRIPTION
Unix backends for Irmin

`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
stores.

---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 1.1.0 (2017-04-24)

**irmin**

- Change the type of `S.Tree.find_tree` to return a `tree option` instead of
  `tree`. This is a breaking API change but it let distinguish between
  the empty and non-existent cases (#431, @samoht)
- Allow to specify branches in urls for fetch using the `url#branch` syntax
  (#432, @samoht)
- Expose `Irmin.Merge.idempotent` for values with idempotent operations
  (#433, @samoht)
- Add a `S.repo` type as an alias to the `S.Repo.t` (#436, @samoht)
- Fix regression in `S.Tree.diff` intoduced in the 1.0 release: nested
  differences where reported with the wrong path (#438, @samoht)

**irmin-unix**

- Update to irmin.1.1.0 API changes (@samoht)

**irmin-git**

- Update to irmin.1.1.0 API changes (@samoht)
Pull-request generated by opam-publish v0.3.2