### PR TITLE
lambda-term.1.11 — via opam-publish

### DIFF
--- a/packages/lambda-term/lambda-term.1.11/descr
+++ b/packages/lambda-term/lambda-term.1.11/descr
@@ -1,0 +1,12 @@
+Terminal manipulation library for OCaml
+Lambda-term is a cross-platform library for manipulating the terminal.
+It provides an abstraction for keys, mouse events, colors, as well as
+a set of widgets to write curses-like applications.
+
+The main objective of lambda-term is to provide a higher level
+functional interface to terminal manipulation than, for example,
+ncurses, by providing a native OCaml interface instead of bindings to
+a C library.
+
+Lambda-term integrates with zed to provide text edition facilities in
+console applications.

--- a/packages/lambda-term/lambda-term.1.11/opam
+++ b/packages/lambda-term/lambda-term.1.11/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+version: "1.11"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/lambda-term"
+bug-reports: "https://github.com/diml/lambda-term/issues"
+dev-repo: "git://github.com/diml/lambda-term.git"
+license: "BSD3"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "lwt"   {>= "2.7.0"}
+  "zed"   {>= "1.2"}
+  "lwt_react"
+  "jbuilder" {build & >= "1.0+beta7"}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/lambda-term/lambda-term.1.11/url
+++ b/packages/lambda-term/lambda-term.1.11/url
@@ -1,0 +1,2 @@
+src: "https://github.com/diml/lambda-term/archive/1.11.tar.gz"
+checksum: "51ae50136ad0989c941ad35ae4d89c72"


### PR DESCRIPTION
Terminal manipulation library for OCaml

Lambda-term is a cross-platform library for manipulating the terminal.
It provides an abstraction for keys, mouse events, colors, as well as
a set of widgets to write curses-like applications.

The main objective of lambda-term is to provide a higher level
functional interface to terminal manipulation than, for example,
ncurses, by providing a native OCaml interface instead of bindings to
a C library.

Lambda-term integrates with zed to provide text edition facilities in
console applications.


---
* Homepage: https://github.com/diml/lambda-term
* Source repo: git://github.com/diml/lambda-term.git
* Bug tracker: https://github.com/diml/lambda-term/issues

---
### opam-lint failures
- **ERROR** 32 Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4