### PR TITLE
reason-parser.1.13.5 - via opam-publish

### DIFF
--- a/packages/reason-parser/reason-parser.1.13.5/descr
+++ b/packages/reason-parser/reason-parser.1.13.5/descr
@@ -1,0 +1,7 @@
+Reason Parser: Meta Language Toolchain
+
+reason allows development of Meta Language syntax trees in non-text format. It
+allows a development model that is equivalent to collaborating on syntax trees
+that have been committed to a source code repository.
+
+This is the parser sub-package.

--- a/packages/reason-parser/reason-parser.1.13.5/opam
+++ b/packages/reason-parser/reason-parser.1.13.5/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: "Jordan Walke <jordojw@gmail.com>"
+homepage: "https://github.com/facebook/reason"
+bug-reports: "https://github.com/facebook/reason/issues"
+license: "BSD"
+doc: "http://facebook.github.io/reason"
+tags: "syntax"
+dev-repo: "git://github.com/facebook/reason.git"
+substs: "pkg/META"
+build: [
+  [make "compile_error"]
+  ["ocamlbuild" "-package" "topkg" "pkg/build.native"]
+  [
+    "./build.native"
+    "build"
+    "--native"
+    "%{ocaml-native}%"
+    "--native-dynlink"
+    "%{ocaml-native-dynlink}%"
+  ]
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_reason.byte"
+  "--"
+]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {= "20170418"}
+  "merlin-extend" {>= "0.3"}
+  "result" {= "1.2"}
+  "topkg" {= "0.8.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0beta"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]

--- a/packages/reason-parser/reason-parser.1.13.5/url
+++ b/packages/reason-parser/reason-parser.1.13.5/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/facebook/reason/releases/download/1.13.5/reason-parser-1.13.5.tar.gz"
+checksum: "e19b0caf980a629cb97b38fd5922abd0"


### PR DESCRIPTION
Reason Parser: Meta Language Toolchain

reason allows development of Meta Language syntax trees in non-text format. It
allows a development model that is equivalent to collaborating on syntax trees
that have been committed to a source code repository.

This is the parser sub-package.


---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

Pull-request generated by opam-publish v0.3.4