### PR TITLE
ppx_derivers.1.0 — via opam-publish

### DIFF
--- a/packages/ppx_derivers/ppx_derivers.1.0/descr
+++ b/packages/ppx_derivers/ppx_derivers.1.0/descr
@@ -1,0 +1,5 @@
+Shared [@@deriving] plugin registry
+
+Ppx_derivers is a tiny package whose sole purpose is to allow
+ppx_deriving and ppx_type_conv to inter-operate gracefully when linked
+as part of the same ocaml-migrate-parsetree driver.

--- a/packages/ppx_derivers/ppx_derivers.1.0/opam
+++ b/packages/ppx_derivers/ppx_derivers.1.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/ppx_derivers"
+bug-reports: "https://github.com/diml/ppx_derivers/issues"
+dev-repo: "git://github.com/diml/ppx_derivers.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {>= "1.0+beta7"}
+]

--- a/packages/ppx_derivers/ppx_derivers.1.0/url
+++ b/packages/ppx_derivers/ppx_derivers.1.0/url
@@ -1,0 +1,2 @@
+src: "https://github.com/diml/ppx_derivers/archive/1.0.tar.gz"
+checksum: "4ddce8f43fdb9b0ef0ab6a7cbfebc3e3"


### PR DESCRIPTION
Shared [@@deriving] plugin registry

Ppx_derivers is a tiny package whose sole purpose is to allow
ppx_deriving and ppx_type_conv to inter-operate gracefully when linked
as part of the same ocaml-migrate-parsetree driver.


---
* Homepage: https://github.com/diml/ppx_derivers
* Source repo: git://github.com/diml/ppx_derivers.git
* Bug tracker: https://github.com/diml/ppx_derivers/issues

---
### opam-lint failures
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4