### PR TITLE
containers.1.2 - via opam-publish

### DIFF
--- a/packages/containers/containers.1.2/descr
+++ b/packages/containers/containers.1.2/descr
@@ -1,0 +1,12 @@
+A modular, clean and powerful extension of the OCaml standard library.
+
+Containers is an extension of OCaml's standard library (under BSD license)
+focused on data structures, combinators and iterators, without dependencies on
+unix, str or num. Every module is independent and is prefixed with 'CC' in the
+global namespace. Some modules extend the stdlib (e.g. CCList provides safe
+map/fold_right/append, and additional functions on lists).
+Alternatively, `open Containers` will bring enhanced versions of the standard
+modules into scope.
+
+It also features sub-libraries for dealing with threads, S-expressions,
+and the intricacies of unix.

--- a/packages/containers/containers.1.2/opam
+++ b/packages/containers/containers.1.2/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+doc: "http://cedeela.fr/~simon/software/containers/"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+dev-repo: "https://github.com/c-cube/ocaml-containers.git"
+build: [
+  [
+    "./configure"
+    "--prefix"
+    prefix
+    "--disable-bench"
+    "--disable-tests"
+    "--%{base-unix:enable}%-unix"
+    "--enable-docs"
+  ]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "containers"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "result"
+  "cppo" {build}
+  "ocamlbuild" {build}
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+  "qtest" {test}
+]
+conflicts: [
+  "sequence" {< "0.5"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/containers/containers.1.2/url
+++ b/packages/containers/containers.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-containers/archive/1.2.tar.gz"
+checksum: "5755b0fdc75fb9bc01f56e2c8dc31695"

--- a/packages/zipperposition/zipperposition.1.0/opam
+++ b/packages/zipperposition/zipperposition.1.0/opam
@@ -41,4 +41,8 @@ depopts: [
   "menhir" {build}
   "qcheck" {test}
 ]
+conflicts: [
+  "containers" { >= "1.2" }
+  "sequence" { >= "0.9" }
+]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/zipperposition/zipperposition.1.1/opam
+++ b/packages/zipperposition/zipperposition.1.1/opam
@@ -43,4 +43,7 @@ depends: [
 depopts: [
   "qcheck" {test}
 ]
+conflicts: [
+  "containers" { >= "1.2" }
+]
 available: [ocaml-version >= "4.02.1"]


### PR DESCRIPTION
A modular, clean and powerful extension of the OCaml standard library.

Containers is an extension of OCaml's standard library (under BSD license)
focused on data structures, combinators and iterators, without dependencies on
unix, str or num. Every module is independent and is prefixed with 'CC' in the
global namespace. Some modules extend the stdlib (e.g. CCList provides safe
map/fold_right/append, and additional functions on lists).
Alternatively, `open Containers` will bring enhanced versions of the standard
modules into scope.

It also features sub-libraries for dealing with threads, S-expressions,
and the intricacies of unix.


---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---

Pull-request generated by opam-publish v0.3.3