### PR TITLE
redis.0.3.4 - via opam-publish

### DIFF
--- a/packages/redis/redis.0.3.4/descr
+++ b/packages/redis/redis.0.3.4/descr
@@ -1,0 +1,1 @@
+Bindings for the key-value cache and store redis.

--- a/packages/redis/redis.0.3.4/opam
+++ b/packages/redis/redis.0.3.4/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "aluuu@husa.su"
+authors: ["Mike Wells" "David Höppner" "Alexander Dinu"]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+dev-repo: "https://github.com/0xffea/ocaml-redis.git"
+build: [
+  ["./configure" "--prefix" prefix "--%{lwt:enable}%-lwt"]
+  [make]
+]
+install: [make "PREFIX=%{prefix}%" "install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "redis"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-bytes"
+  "uuidm"
+  "re"
+]
+depopts: "lwt"
+available: [ocaml-version >= "4.01.0"]

--- a/packages/redis/redis.0.3.4/url
+++ b/packages/redis/redis.0.3.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/0xffea/ocaml-redis/archive/0.3.4.tar.gz"
+checksum: "920babeb6baaf22c3c184196e470e1eb"


### PR DESCRIPTION
Bindings for the key-value cache and store redis.


---
* Homepage: https://github.com/0xffea/ocaml-redis
* Source repo: https://github.com/0xffea/ocaml-redis.git
* Bug tracker: https://github.com/0xffea/ocaml-redis/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.4