### PR TITLE
terminal_size.0.1.2 - via opam-publish

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.2/descr
+++ b/packages/terminal_size/terminal_size.0.1.2/descr
@@ -1,0 +1,4 @@
+Get the dimensions of the terminal
+
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.

--- a/packages/terminal_size/terminal_size.0.1.2/opam
+++ b/packages/terminal_size/terminal_size.0.1.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "alcotest" {test}
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/terminal_size/terminal_size.0.1.2/url
+++ b/packages/terminal_size/terminal_size.0.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/terminal_size/releases/download/v0.1.2/terminal_size-0.1.2.tbz"
+checksum: "e658053d12ac9e837597e2c34f842ed2"


### PR DESCRIPTION
Get the dimensions of the terminal

You can use this small library to detect the dimensions of the terminal window
attached to a process.


---
* Homepage: https://github.com/cryptosense/terminal_size
* Source repo: https://github.com/cryptosense/terminal_size.git
* Bug tracker: https://github.com/cryptosense/terminal_size/issues

---


---
v0.1.2
------

*2017-05-02*

Build system:

- Fix profiling information in META (#6)
- Support OCaml 4.05 (#7)
- Use travis-docker
Pull-request generated by opam-publish v0.3.4