### PR TITLE
mirari: constrain cmdliner upper version

### DIFF
--- a/packages/mirari/mirari.0.9.0/opam
+++ b/packages/mirari/mirari.0.9.0/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "obuild"
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/mirari/mirari.0.9.1/opam
+++ b/packages/mirari/mirari.0.9.1/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "obuild"
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/mirari/mirari.0.9.2/opam
+++ b/packages/mirari/mirari.0.9.2/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "obuild"
 ]
 ocaml-version: [>= "4.00.0"]

--- a/packages/mirari/mirari.0.9.3/opam
+++ b/packages/mirari/mirari.0.9.3/opam
@@ -8,6 +8,7 @@ depends: [
   "obuild" {>= "0.0.2"}
   "tuntap" {>= "0.5" & < "1.0"}
   "fd-send-recv"
+  "sexplib" {<="113.24.00"}
 ]
 ocaml-version: [>= "4.00.0"]
 dev-repo: "git://github.com/mirage/mirari"

--- a/packages/mirari/mirari.0.9.3/opam
+++ b/packages/mirari/mirari.0.9.3/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "obuild" {>= "0.0.2"}
   "tuntap" {>= "0.5" & < "1.0"}
   "fd-send-recv"

--- a/packages/mirari/mirari.0.9.4/opam
+++ b/packages/mirari/mirari.0.9.4/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "obuild" {>= "0.0.2"}
   "tuntap" {>= "0.5" & < "1.0"}
   "fd-send-recv"

--- a/packages/mirari/mirari.0.9.5/opam
+++ b/packages/mirari/mirari.0.9.5/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "fd-send-recv"
   "tuntap" {>= "0.5" & < "1.0"}
 ]

--- a/packages/mirari/mirari.0.9.6/opam
+++ b/packages/mirari/mirari.0.9.6/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "tuntap" {>= "0.5" & < "1.0"}
   "fd-send-recv"
   "ipaddr"

--- a/packages/mirari/mirari.0.9.7/opam
+++ b/packages/mirari/mirari.0.9.7/opam
@@ -4,7 +4,7 @@ tags: ["org:mirage"]
 build: [[make]]
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {<"1.0"}
   "tuntap" {>= "0.5" & < "1.0"}
   "fd-send-recv"
   "ipaddr"


### PR DESCRIPTION
source is a revdep failure from #9062