### PR TITLE
tsdl.0.9.3 - via opam-publish

### DIFF
--- a/packages/tsdl/tsdl.0.9.3/descr
+++ b/packages/tsdl/tsdl.0.9.3/descr
@@ -1,0 +1,11 @@
+Thin bindings to SDL for OCaml
+
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.5][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the ISC license.
+
+[sdl]: http://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes

--- a/packages/tsdl/tsdl.0.9.3/opam
+++ b/packages/tsdl/tsdl.0.9.3/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/tsdl"
+doc: "http://erratique.ch/software/tsdl/doc/Tsdl"
+dev-repo: "http://erratique.ch/repos/tsdl.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
+        "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.02.0" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "result"
+  "ctypes" {>= "0.9.0"}
+  "ctypes-foreign" ]
+depexts: [
+ [["debian"] ["libsdl2-dev"]]
+ [["ubuntu"] ["libsdl2-dev"]]
+ [["mageia"] ["libsdl2.0-devel"]]
+ [["osx" "homebrew"] ["sdl2"]]
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/tsdl/tsdl.0.9.3/url
+++ b/packages/tsdl/tsdl.0.9.3/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/tsdl/releases/tsdl-0.9.3.tbz"
+checksum: "95ac94745afad8f0c154ee1b0fdd11b8"


### PR DESCRIPTION
Thin bindings to SDL for OCaml

Tsdl is an OCaml library providing thin bindings to the cross-platform
SDL C library.

Tsdl depends on the [SDL 2.0.5][sdl] C library (or later),
[ocaml-ctypes][ctypes] and the `result` compatibility package.
Tsdl is distributed under the ISC license.

[sdl]: http://www.libsdl.org/
[ctypes]: https://github.com/ocamllabs/ocaml-ctypes


---
* Homepage: http://erratique.ch/software/tsdl
* Source repo: http://erratique.ch/repos/tsdl.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---


---
v0.9.3 2017-05-03 La Forclaz (VS)
---------------------------------

- Fix segfaulting `Sdl.load_raw_rw`. Thanks to @sanette for the
  report and the patch.
- Fix audio callback support. The client could not get a handle on the
  actual callback closure which would lead to
  `Ctypes_ffi_stubs.CallToExpiredClosure.` exceptions. The callback
  wrapping is now done via the `Sdl.audio_callback` function. The
  client must keep a reference on the returned value until no longer
  needed.  As a side effect this changes the signature of
  `Sdl.load_raw_rw`. Thanks to @sanette for the report.
- Fix signature of `Sdl.blit_scaled`. Thanks to Léo Andrès for the report
  and the patch.
Pull-request generated by opam-publish v0.3.4