### PR TITLE
xe: upper bound on lwt due to use of Lwt_ssl

### DIFF
--- a/packages/xe/xe.0.6.0/opam
+++ b/packages/xe/xe.0.6.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "0.6.0"}
   "camlp4"
-  "lwt"
+  "lwt" {<"3.0.0"}
   "ocamlfind"
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "ssl"

--- a/packages/xe/xe.0.6.2/opam
+++ b/packages/xe/xe.0.6.2/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "0.6.0"}
   "camlp4"
-  "lwt"
+  "lwt" {<"3.0.0"}
   "ocamlfind"
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "ssl"

--- a/packages/xe/xe.0.6.3/opam
+++ b/packages/xe/xe.0.6.3/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "cstruct" {>= "0.6.0"}
   "camlp4"
-  "lwt"
+  "lwt" {<"3.0.0"}
   "ocamlfind"
   "cohttp" {>= "0.14.0"}
   "ssl"


### PR DESCRIPTION
Lwt_ssl is in a separate package as of Lwt 3.0

cc @jonludlam 

revdep failure spotted in #9080