### PR TITLE
ketrew.3.x.x: add constraint on Lwt ≥ 3.0.0

### DIFF
--- a/packages/ketrew/ketrew.3.0.0/opam
+++ b/packages/ketrew/ketrew.3.0.0/opam
@@ -28,7 +28,8 @@ depends: [
   "cmdliner" "yojson" "uri"
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.0"}
-  "cohttp" {>= "0.21.0" } "lwt"
+  "cohttp" {>= "0.21.0" }
+  "lwt" {< "3.0.0" }
   "conduit"
   "js_of_ocaml" {>= "2.6" } "tyxml" {>= "4.0.0"} "reactiveData" {>= "0.2"}
   "sexplib"


### PR DESCRIPTION

Cf. https://github.com/ocaml/opam-repository/pull/9085 (Thanks @samoht !)