### PR TITLE
Constrain mtime dependents to < 1.0.0 which is a breaking release.

### DIFF
--- a/packages/charrua-unix/charrua-unix.0.1/opam
+++ b/packages/charrua-unix/charrua-unix.0.1/opam
@@ -22,4 +22,5 @@ depends: [
   "ocamlbuild" {build}
   "tuntap"
   "cstruct" {<"2.0"}
+  "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.2/opam
+++ b/packages/charrua-unix/charrua-unix.0.2/opam
@@ -18,4 +18,5 @@ depends: [
   "cmdliner"
   "rawlink"
   "ocamlbuild" {build}
+  "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.5/opam
+++ b/packages/charrua-unix/charrua-unix.0.5/opam
@@ -19,5 +19,5 @@ depends: [
   "cmdliner"
   "rawlink"
   "tuntap"
-  "mtime"
+  "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.6/opam
+++ b/packages/charrua-unix/charrua-unix.0.6/opam
@@ -21,5 +21,5 @@ depends: [
   "cmdliner"
   "rawlink"
   "tuntap"
-  "mtime"
+  "mtime" {< "1.0.0"}
 ]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
@@ -17,7 +17,9 @@ depends: [
   "lwt" {>= "2.7.1"}
   "datakit-github" {>= "0.10.0"}
   "datakit-server" {>= "0.10.0"}
-  "logs" "fmt" "mtime" "asl" "win-eventlog"
+  "logs" "fmt"
+  "mtime" {< "1.0.0"}
+  "asl" "win-eventlog"
   "uri" {>= "1.8.0"}
   "hvsock" {>= "0.8.1"}
   "hex" "nocrypto" "conduit"

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.9.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.9.0/opam
@@ -23,7 +23,9 @@ depends: [
   "topkg"      {build}
   "cmdliner"   {<"1.0.0"}
   "lwt" {>= "2.7.0"}
-  "logs" "fmt" "mtime" "asl" "win-eventlog"
+  "logs" "fmt"
+  "mtime" {< "1.0.0"}
+  "asl" "win-eventlog"
   "hvsock" {>= "0.8.1" & < "0.14.0"}
   "hex" "nocrypto" "conduit"
   "prometheus-app"

--- a/packages/datakit-github/datakit-github.0.8.1/opam
+++ b/packages/datakit-github/datakit-github.0.8.1/opam
@@ -18,7 +18,9 @@ depends: [
   "topkg"      {build}
   "cmdliner"   {< "1.0.0"}
   "lwt" "asetmap"
-  "logs" "fmt" "mtime" "asl" "win-eventlog"
+  "logs" "fmt"
+  "mtime" {< "1.0.0"}
+  "asl" "win-eventlog"
   "uri" {>= "1.8.0"}
   "hvsock" {>= "0.8.1" < "0.14.0"}
   "named-pipe" {>= "0.4.0"}

--- a/packages/datakit/datakit.0.10.0/opam
+++ b/packages/datakit/datakit.0.10.0/opam
@@ -29,7 +29,7 @@ depends: [
   "logs"        {>= "0.5.0"}
   "win-eventlog"
   "asl"         {>= "0.10"}
-  "mtime"
+  "mtime"       {< "1.0.0"}
   "irmin-watcher" {>= "0.2.0"}
   "prometheus-app"
   "datakit-server" {>= "0.10.0"}

--- a/packages/datakit/datakit.0.8.0/opam
+++ b/packages/datakit/datakit.0.8.0/opam
@@ -30,7 +30,7 @@ depends: [
   "logs"        {>= "0.5.0"}
   "win-eventlog"
   "asl"         {>= "0.10"}
-  "mtime"
+  "mtime"       {< "1.0.0"}
   "irmin-watcher" {>= "0.2.0"}
   "datakit-server" {>= "0.8.0" & < "0.9.0"}
 ]

--- a/packages/datakit/datakit.0.9.0/opam
+++ b/packages/datakit/datakit.0.9.0/opam
@@ -35,7 +35,7 @@ depends: [
   "logs"        {>= "0.5.0"}
   "win-eventlog"
   "asl"         {>= "0.10"}
-  "mtime"
+  "mtime"       {< "1.0.0"}
   "irmin-watcher" {>= "0.2.0"}
   "prometheus-app"
   "datakit-server" {>= "0.9.0" & < "0.10.0"}

--- a/packages/dns-forward/dns-forward.0.7.2/opam
+++ b/packages/dns-forward/dns-forward.0.7.2/opam
@@ -27,7 +27,7 @@ depends: [
   "result"
   "lwt"         {>= "2.6.0"}
   "logs"        {>= "0.5.0"}
-  "mtime"
+  "mtime"       {< "1.0.0"}
   "sexplib"
   "ipaddr"
   "alcotest"   {test}

--- a/packages/git-unix/git-unix.1.10.0/opam
+++ b/packages/git-unix/git-unix.1.10.0/opam
@@ -21,7 +21,7 @@ depends: [
   "conduit"  {>= "0.8.4"}
   "camlzip"  {>= "1.06"}
   "nocrypto" {>= "0.2.0"}
-  "mtime"
+  "mtime"    {< "1.0.0"}
   "base-unix"
   "alcotest"       {test}
 ]

--- a/packages/git-unix/git-unix.1.10.1/opam
+++ b/packages/git-unix/git-unix.1.10.1/opam
@@ -21,7 +21,7 @@ depends: [
   "conduit"  {>= "0.8.4"}
   "camlzip"  {>= "1.06"}
   "nocrypto" {>= "0.2.0"}
-  "mtime"
+  "mtime"    {< "1.0.0"}
   "base-unix"
   "alcotest"       {test}
 ]

--- a/packages/git/git.1.8.0/opam
+++ b/packages/git/git.1.8.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ocamlgraph"
   "uri"        {>= "1.3.12"}
   "lwt"        {>= "2.4.7"}
-  "mtime"
+  "mtime"      {< "1.0.0"}
   "logs"
   "fmt"
   "hex"

--- a/packages/git/git.1.9.0/opam
+++ b/packages/git/git.1.9.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlgraph"
   "uri"        {>= "1.3.12"}
   "lwt"        {>= "2.4.7"}
-  "mtime"
+  "mtime"      {< "1.0.0"}
   "logs"
   "fmt"
   "hex"

--- a/packages/git/git.1.9.1/opam
+++ b/packages/git/git.1.9.1/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlgraph"
   "uri"        {>= "1.3.12"}
   "lwt"        {>= "2.4.7"}
-  "mtime"
+  "mtime"      {< "1.0.0"}
   "logs"
   "fmt"
   "hex"

--- a/packages/git/git.1.9.2/opam
+++ b/packages/git/git.1.9.2/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlgraph"
   "uri"        {>= "1.3.12"}
   "lwt"        {>= "2.4.7"}
-  "mtime"
+  "mtime"      {< "1.0.0"}
   "logs"
   "fmt"
   "hex"

--- a/packages/git/git.1.9.3/opam
+++ b/packages/git/git.1.9.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlgraph"
   "uri"        {>= "1.3.12"}
   "lwt"        {>= "2.4.7"}
-  "mtime"
+  "mtime"      {< "1.0.0"}
   "logs"
   "fmt"
   "hex"

--- a/packages/odig/odig.0.0.1/opam
+++ b/packages/odig/odig.0.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "logs"
   "bos"
   "cmdliner"
-  "mtime"
+  "mtime" {< "1.0.0"}
   "webbrowser"
   "opam-lib" {< "1.3"}
 ]


### PR DESCRIPTION
See [here](https://github.com/dbuenzli/mtime/issues/20) for what's upcoming. 

/cc @haesbaert @samoht @djs55 