### PR TITLE
fpath.0.7.2 - via opam-publish

### DIFF
--- a/packages/fpath/fpath.0.7.2/descr
+++ b/packages/fpath/fpath.0.7.2/descr
@@ -1,0 +1,10 @@
+File system paths for OCaml
+
+Fpath is an OCaml module for handling file system paths with POSIX or
+Windows conventions. Fpath processes paths without accessing the file
+system and is independent from any system library.
+
+Fpath depends on [Astring][astring] and is distributed under the ISC
+license.
+
+[astring]: http://erratique.ch/software/astring

--- a/packages/fpath/fpath.0.7.2/opam
+++ b/packages/fpath/fpath.0.7.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/fpath"
+doc: "http://erratique.ch/software/fpath/doc"
+dev-repo: "http://erratique.ch/repos/fpath.git"
+bug-reports: "https://github.com/dbuenzli/fpath/issues"
+tags: [ "file" "system" "path" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build & >= "0.9.0"}
+   "result"
+   "astring"
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%" ]]

--- a/packages/fpath/fpath.0.7.2/url
+++ b/packages/fpath/fpath.0.7.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/fpath/releases/fpath-0.7.2.tbz"
+checksum: "52c7ecb0bf180088336f3c645875fa41"


### PR DESCRIPTION
File system paths for OCaml

Fpath is an OCaml module for handling file system paths with POSIX or
Windows conventions. Fpath processes paths without accessing the file
system and is independent from any system library.

Fpath depends on [Astring][astring] and is distributed under the ISC
license.

[astring]: http://erratique.ch/software/astring


---
* Homepage: http://erratique.ch/software/fpath
* Source repo: http://erratique.ch/repos/fpath.git
* Bug tracker: https://github.com/dbuenzli/fpath/issues

---


---
v0.7.2 2017-05-04 La Forclaz (VS)
---------------------------------

- Fix `odoc` documentation generation.
- Document the error message of `Fpath.of_string` so that
  client can rely and build on it.
Pull-request generated by opam-publish v0.3.4