### PR TITLE
bos.0.1.6 - via opam-publish

### DIFF
--- a/packages/bos/bos.0.1.6/descr
+++ b/packages/bos/bos.0.1.6/descr
@@ -1,0 +1,18 @@
+Basic OS interaction for OCaml
+
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs

--- a/packages/bos/bos.0.1.6/opam
+++ b/packages/bos/bos.0.1.6/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/bos"
+doc: "http://erratique.ch/software/bos/doc"
+dev-repo: "http://erratique.ch/repos/bos.git"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "conf-which"
+  "base-unix"
+  "rresult" {>= "0.4.0"}
+  "astring"
+  "fpath"
+  "fmt"
+  "logs"
+  "mtime" {test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%" ]]

--- a/packages/bos/bos.0.1.6/url
+++ b/packages/bos/bos.0.1.6/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/bos/releases/bos-0.1.6.tbz"
+checksum: "fa371d545d8490fab87245e329e9bb15"


### PR DESCRIPTION
Basic OS interaction for OCaml

Bos provides support for basic and robust interaction with the
operating system in OCaml. It has functions to access the process
environment, parse command line arguments, interact with the file
system and run command line programs.

Bos works equally well on POSIX and Windows operating systems.

Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
distributed under the ISC license.

[rresult]: http://erratique.ch/software/rresult
[astring]: http://erratique.ch/software/astring
[fmt]: http://erratique.ch/software/fmt
[fpath]: http://erratique.ch/software/fpath
[logs]: http://erratique.ch/software/logs


---
* Homepage: http://erratique.ch/software/bos
* Source repo: http://erratique.ch/repos/bos.git
* Bug tracker: https://github.com/dbuenzli/bos/issues

---


---
v0.1.6 2017-05-04 La Forclaz (VS)
---------------------------------

- Fix `OS.Dir.create`. The documentation says it returns `true` if the
  directory was created and `false` otherwise. The implementation did
  the converse, the latter was adjusted to match the doc
  specification.
Pull-request generated by opam-publish v0.3.4