### PR TITLE
redis-lwt.0.3.4 - via opam-publish

### DIFF
--- a/packages/redis-lwt/redis-lwt.0.3.4/descr
+++ b/packages/redis-lwt/redis-lwt.0.3.4/descr
@@ -1,0 +1,1 @@
+Lwt-based client for Redis

--- a/packages/redis-lwt/redis-lwt.0.3.4/opam
+++ b/packages/redis-lwt/redis-lwt.0.3.4/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "aluuu@husa.su"
+authors: ["Mike Wells" "David Höppner" "Aleksandr Dinu"]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+dev-repo: "https://github.com/0xffea/ocaml-redis.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+  "redis"
+  "base-unix"
+  "lwt"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/redis-lwt/redis-lwt.0.3.4/url
+++ b/packages/redis-lwt/redis-lwt.0.3.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/0xffea/ocaml-redis/archive/0.3.4.tar.gz"
+checksum: "396ad524a76267bb0c34eb0aea968573"


### PR DESCRIPTION
Lwt-based client for Redis


---
* Homepage: https://github.com/0xffea/ocaml-redis
* Source repo: https://github.com/0xffea/ocaml-redis.git
* Bug tracker: https://github.com/0xffea/ocaml-redis/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.4