### PR TITLE
(can be published) yices2.0.0.3 - via opam-publish

### DIFF
--- a/packages/yices2/yices2.0.0.3/descr
+++ b/packages/yices2/yices2.0.0.3/descr
@@ -1,0 +1,5 @@
+Yices2 SMT solver binding
+
+Yices is a Satisfiability Modulo Theories (SMT) solver from SRI.
+It is available freely for non-commercial purposes.
+License terms: http://yices.csl.sri.com/yices-newnewlicense.html

--- a/packages/yices2/yices2.0.0.3/opam
+++ b/packages/yices2/yices2.0.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Mickaël Delahaye <mickael.delahaye@gmail.com>"
+authors: "Mickaël Delahaye <mickael.delahaye@gmail.com>"
+homepage: "http://micdel.fr/ocamlyices2.html"
+bug-reports: "https://github.com/polazarus/ocamlyices2/issues"
+license: "ISC license and non-commercial use"
+dev-repo: "https://github.com/maelvalais/ocamlyices2.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+build-test: [
+  ["./configure"]
+  [make test]
+]
+remove: ["ocamlfind" "remove" "yices2"]
+depends: [
+  "ocamlfind" {build}
+  "conf-gmp" {build}
+  "zarith"
+  "ounit" {test}
+]
+post-messages: [
+  "
+OCamlYices2 is free (BSD-like) but Yices is not!
+**Yices is free [only] for non-commercial use**
+License terms: http://yices.csl.sri.com/yices-newnewlicense.html
+  "
+    {success}
+]

--- a/packages/yices2/yices2.0.0.3/url
+++ b/packages/yices2/yices2.0.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/maelvalais/ocamlyices2/archive/v0.0.3.tar.gz"
+checksum: "520065f7d81db571aacbc0e8ea3a63c7"


### PR DESCRIPTION
Yices2 SMT solver binding

Yices is a Satisfiability Modulo Theories (SMT) solver from SRI.
It is available freely for non-commercial purposes.
License terms: http://yices.csl.sri.com/yices-newnewlicense.html


---
* Homepage: http://micdel.fr/ocamlyices2.html
* Source repo: https://github.com/maelvalais/ocamlyices2.git
* Bug tracker: https://github.com/polazarus/ocamlyices2/issues

---

Pull-request generated by opam-publish v0.3.4