### PR TITLE
mtime.1.0.0 - via opam-publish

### DIFF
--- a/packages/mtime/mtime.1.0.0/descr
+++ b/packages/mtime/mtime.1.0.0/descr
@@ -1,0 +1,15 @@
+Monotonic wall-clock time for OCaml
+
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library.
+The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
+and its libraries are distributed under the ISC license.
+
+[jsoo]: http://ocsigen.org/js_of_ocaml/

--- a/packages/mtime/mtime.1.0.0/opam
+++ b/packages/mtime/mtime.1.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Daniel Bünzli <daniel.buenzl i@erratique.ch>" ]
+homepage: "http://erratique.ch/software/mtime"
+doc: "http://erratique.ch/software/mtime"
+dev-repo: "http://erratique.ch/repos/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+tags: [ "time" "monotonic" "system" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.03.0"]
+depends:
+[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+depopts: [ "js_of_ocaml" ]
+build: [[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]

--- a/packages/mtime/mtime.1.0.0/url
+++ b/packages/mtime/mtime.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/mtime/releases/mtime-1.0.0.tbz"
+checksum: "3e3f2fad1a3c4d8bd6d5006b1a6a6d99"


### PR DESCRIPTION
Monotonic wall-clock time for OCaml

Mtime has platform independent support for monotonic wall-clock time
in pure OCaml. This time increases monotonically and is not subject to
operating system calendar time adjustments. The library has types to
represent nanosecond precision timestamps and time spans.

The additional Mtime_clock library provide access to a system
monotonic clock.

Mtime has a no dependency. Mtime_clock depends on your system library.
The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
and its libraries are distributed under the ISC license.

[jsoo]: http://ocsigen.org/js_of_ocaml/


---
* Homepage: http://erratique.ch/software/mtime
* Source repo: http://erratique.ch/repos/mtime.git
* Bug tracker: https://github.com/dbuenzli/mtime/issues

---


---
v1.0.0 2017-05-09 La Forclaz (VS)
---------------------------------

This is a major breaking release with a new API. Thanks to David
Sheets for contributions and discussions. The API was changed to
mirror and follow the conventions and design of `Ptime`. The `Mtime`
module now only provides platform independent datatypes for supporting
monotonic clock readings. Platform dependent access to monotonic
clocks is provided by the `Mtime_clock` modules. The `Mtime.t` type
was added for monotonic timestamps.

* Rename packages `mtime.{jsoo,os}` to `mtime.{clock.jsoo,clock.os}`
  which implement the new `Mtime_clock` interface. The `mtime` package
  has the platform independent support.
* Remove `Mtime.available`, `Mtime_clock` functions now raise `Sys_error`
  on unsupported platforms or errors.
* Add a raw interface to `Mtime_clock` which statisfies MirageOS's monotonic
  clock signature.
* Move `Mtime.{elapsed,counter,count}` to
  `Mtime_clock.{elapsed,counter,count}`.
* Add `Mtime.t` a type to represent system-relative monotonic
  timestamps and related functions. Thanks to David Sheets for the
  patch and his patience.
* Add the `Mtime.Span` module for functions on monotonic time
  spans. Most of the previous platform independent support is now
  provided by this module. See below.
* Move `Mtime.to_ns_uint64` to `Mtime.Span.to_uint64_ns`.
* Move other `Mtime.to_*` to `Mtime.Span.to_*`.
* Move `Mtime.pp_span[_s]` to `Mtime.Span.pp[_float__s]`.
* Add `Mtime.Span.{compare,equal}`. Thanks to David Sheets for the patch.
* Add `Mtime.Span.of_uint64_ns`. Thanks to David Sheets for the patch.
Pull-request generated by opam-publish v0.3.4