### PR TITLE
avoid incompatible menhir change in reason-parser

### DIFF
--- a/packages/reason-parser/reason-parser.1.12.0/opam
+++ b/packages/reason-parser/reason-parser.1.12.0/opam
@@ -23,7 +23,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind"               {build}
-  "menhir"                  {>= "20160303"}
+  "menhir"                  {>= "20160303" & < "20170418"}
   "merlin-extend"           {>= "0.3"}
   "result"                  {=  "1.2"}
   "topkg"                   {=  "0.8.1"}

--- a/packages/reason-parser/reason-parser.1.13.0/opam
+++ b/packages/reason-parser/reason-parser.1.13.0/opam
@@ -29,7 +29,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & < "20170418"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}

--- a/packages/reason-parser/reason-parser.1.13.2/opam
+++ b/packages/reason-parser/reason-parser.1.13.2/opam
@@ -29,7 +29,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & < "20170418"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}

--- a/packages/reason-parser/reason-parser.1.13.3/opam
+++ b/packages/reason-parser/reason-parser.1.13.3/opam
@@ -29,7 +29,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & < "20170418"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}


### PR DESCRIPTION
reason-parser versions 1.12.0-1.13.3 are not compatible with merlin version >= 20170418.

Tested with:
```
$ opam repository add local .
$ opam install reason-parser.1.13.2
[... succeeds instead of crashing ...]
```