### PR TITLE
jsoo_broadcastchannel.1.0 - via opam-publish

### DIFF
--- a/packages/jsoo_broadcastchannel/jsoo_broadcastchannel.1.0/descr
+++ b/packages/jsoo_broadcastchannel/jsoo_broadcastchannel.1.0/descr
@@ -1,0 +1,7 @@
+Jsoo_broadcastchannel is a binding for the BroadcastChannel API for Js_of_OCaml.
+
+Jsoo_broadcastchannel is a binding for the BroadcastChannel API. 
+The BroadcastChannel interface represents a named channel that any browsing context of a given origin can subscribe to. 
+It allows communication between different documents (in different windows, tabs, frames or iframes) of the same origin. 
+Messages are broadcasted via a message event fired at all BroadcastChannel objects listening to the channel.
+

--- a/packages/jsoo_broadcastchannel/jsoo_broadcastchannel.1.0/opam
+++ b/packages/jsoo_broadcastchannel/jsoo_broadcastchannel.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "xvw <xavier.vdw@gmail.com>"
+authors: "xvw <xavier.vdw@gmail.com>"
+homepage: "https://github.com/xvw/jsoo_broadcastchannel"
+bug-reports: "https://github.com/xvw/jsoo_broadcastchannel/issues"
+license: "GPL3"
+dev-repo: "https://github.com/xvw/jsoo_broadcastchannel.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "jsoo_broadcastchannel"]
+depends: [
+  "js_of_ocaml" {>= "2.8.4"}
+  "lwt" {>= "2.5.2"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/jsoo_broadcastchannel/jsoo_broadcastchannel.1.0/url
+++ b/packages/jsoo_broadcastchannel/jsoo_broadcastchannel.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/xvw/jsoo_broadcastchannel/releases/download/v1.0/jsoo_broadcastchannel.tar.gz"
+checksum: "d59a76e59cc9f96a53c111e09b9f1778"


### PR DESCRIPTION
Jsoo_broadcastchannel is a binding for the BroadcastChannel API for Js_of_OCaml.

Jsoo_broadcastchannel is a binding for the BroadcastChannel API. 
The BroadcastChannel interface represents a named channel that any browsing context of a given origin can subscribe to. 
It allows communication between different documents (in different windows, tabs, frames or iframes) of the same origin. 
Messages are broadcasted via a message event fired at all BroadcastChannel objects listening to the channel.



---
* Homepage: https://github.com/xvw/jsoo_broadcastchannel
* Source repo: https://github.com/xvw/jsoo_broadcastchannel.git
* Bug tracker: https://github.com/xvw/jsoo_broadcastchannel/issues

---

Pull-request generated by opam-publish v0.3.3