### PR TITLE
cryptohash.0.1.2 - via opam-publish

### DIFF
--- a/packages/cryptohash/cryptohash.0.1.2/descr
+++ b/packages/cryptohash/cryptohash.0.1.2/descr
@@ -1,0 +1,4 @@
+hash functions for OCaml
+Cryptohash provides OCaml bindings to various cryptographic hash
+functions written in C
+

--- a/packages/cryptohash/cryptohash.0.1.2/opam
+++ b/packages/cryptohash/cryptohash.0.1.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "andreashauptmann@t-online.de"
+authors: "andreashauptmann@t-online.de"
+homepage: "https://github.com/fdopen/cryptohash"
+bug-reports: "https://github.com/fdopen/cryptohash/issues"
+license: "MIT"
+dev-repo: "https://github.com/fdopen/cryptohash.git"
+build: ["omake" "lib"]
+install: ["omake" "install"]
+build-test: ["omake" "quick-test"]
+remove: ["ocamlfind" "remove" "cryptohash"]
+depends: [
+  "base-unix" {test}
+  "base-bigarray"
+  "base-bytes"
+  "ocamlfind" {build}
+  "omake" {build}
+  "ounit" {test & >= "2.0"}
+]

--- a/packages/cryptohash/cryptohash.0.1.2/url
+++ b/packages/cryptohash/cryptohash.0.1.2/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/fdopen/cryptohash/releases/download/0.1.2/cryptohash-0.1.2.tar.gz"
+checksum: "1a48d563fa1e125f24975f3456ad78aa"


### PR DESCRIPTION
hash functions for OCaml
Cryptohash provides OCaml bindings to various cryptographic hash
functions written in C



---
* Homepage: https://github.com/fdopen/cryptohash
* Source repo: https://github.com/fdopen/cryptohash.git
* Bug tracker: https://github.com/fdopen/cryptohash/issues

---

Pull-request generated by opam-publish v0.3.4