### PR TITLE
opam-ed.0.1 - via opam-publish

### DIFF
--- a/packages/opam-ed/opam-ed.0.1/descr
+++ b/packages/opam-ed/opam-ed.0.1/descr
@@ -1,0 +1,8 @@
+Command-line edition tool for handling the opam file syntax
+
+opam-ed can read and write files in the general opam syntax. It provides a small
+CLI with some useful commands for mechanically extracting or modifying the file
+contents.
+
+The specification for the syntax itself is available at:
+    http://opam.ocaml.org/doc/2.0/Manual.html#Commonfileformat

--- a/packages/opam-ed/opam-ed.0.1/opam
+++ b/packages/opam-ed/opam-ed.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/AltGr/opam-ed"
+bug-reports: "https://github.com/AltGr/opam-ed/issues"
+license: "GPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/AltGr/opam-ed.git"
+build: [ make "COMP=ocamlc" {!ocaml-native} ]
+depends: [
+  "ocamlfind"
+  "cmdliner"
+  "opam-file-format" {>= "2.0.0~beta3"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/opam-ed/opam-ed.0.1/url
+++ b/packages/opam-ed/opam-ed.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/opam-ed/archive/0.1.tar.gz"
+checksum: "7434878602abdd52e3c04e18fd250e0c"


### PR DESCRIPTION
Command-line edition tool for handling the opam file syntax

opam-ed can read and write files in the general opam syntax. It provides a small
CLI with some useful commands for mechanically extracting or modifying the file
contents.

The specification for the syntax itself is available at:
    http://opam.ocaml.org/doc/2.0/Manual.html#Commonfileformat


---
* Homepage: https://github.com/AltGr/opam-ed
* Source repo: git+https://github.com/AltGr/opam-ed.git
* Bug tracker: https://github.com/AltGr/opam-ed/issues

---

Pull-request generated by opam-publish v0.3.4