### PR TITLE
future: restrict to core <v0.9.0 due to api changes

### DIFF
--- a/packages/future/future.0.1.0/opam
+++ b/packages/future/future.0.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "solvuu_build" {build}
-  "core" {>= "111.17.00"}
+  "core" {>= "111.17.00" & <"v0.9.0"}
   "cfstream"
 ]
 

--- a/packages/future/future.0.2.0/opam
+++ b/packages/future/future.0.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "solvuu-build" {build & >= "0.1.0" & < "0.3.0"}
-  "core" {>= "111.17.00"}
+  "core" {>= "111.17.00" & < "v0.9.0"}
   "cfstream"
 ]
 depopts: ["async" "lwt"]


### PR DESCRIPTION
helps with revdeps in #9132