### PR TITLE
capnp: exclude ocaml 4.04.0 and 4.03.0

### DIFF
--- a/packages/capnp/capnp.2.1.0/opam
+++ b/packages/capnp/capnp.2.1.0/opam
@@ -20,4 +20,4 @@ depends: [
   "uint"
   "camlp4"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version != "4.03.0" & ocaml_version != "4.04.0" ]

--- a/packages/capnp/capnp.2.1.1/opam
+++ b/packages/capnp/capnp.2.1.1/opam
@@ -20,4 +20,4 @@ depends: [
   "uint"
   "camlp4"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version != "4.03.0" & ocaml_version != "4.04.0" ]


### PR DESCRIPTION
ocaml 4.03/4.04.0 forgot to include Ephemeron in the stdlib list,
this has been fixed in 4.04.1