### PR TITLE
decompress.0.6 - via opam-publish

### DIFF
--- a/packages/decompress/decompress.0.6/descr
+++ b/packages/decompress/decompress.0.6/descr
@@ -1,0 +1,63 @@
+Pure OCaml implementation of Zlib
+
+[![Build Status](https://travis-ci.org/oklm-wsh/Decompress.svg?branch=master)](https://travis-ci.org/oklm-wsh/Decompress)
+
+Decompress is a pure implementation of `zlib`. The goal is to create an
+available package for Mirage OS for `zlib` in OCaml (instead a C code).
+
+We respect the interface of `zlib` and all flush mode is available
+(experimental):
+
+- `SYNC_FLUSH`
+- `PARTIAL_FLUSH`
+- `FULL_FLUSH`
+
+The interface proposed is a non-blocking interface.
+
+
+Documentation: https://oklm-wsh.github.io/Decompress/api.docdir/
+
+
+## Installation
+
+Decompress can be installed with `opam`:
+
+    opam install decompress
+
+## Sample programs
+
+Sample program are located in the `bin` directory of the distribution. It can be
+built with (dependancy with Unix module, the `cmdliner` package and a C code):
+
+    ocamlbuild -use-ocamlfind bin/dpipe.native
+
+Another good example is provided in `bin/easy.ml` with the signature:
+
+```ocaml
+val compress   : ?level:int -> string -> string
+val uncompress : string -> string
+```
+
+And you can compile this program with:
+
+    ocamlbuild -use-ocamlfind bin/easy.native
+
+But keep in your mind, it's an easy example and it's not optimized for a
+productive environment - so, don't copy/paste and think.
+
+The documentation is
+available [online](https://oklm-wsh.github.io/Decompress/api.docdir/) to
+understand how to use Decompress.
+
+## Build Requirements
+
+ * OCaml >= 4.02.0
+ * `base-bytes` meta-package
+ * Bigarray module (provided by the standard library of OCaml)
+ * `topkg`, `ocamlfind` and `ocamlbuild` to build the project
+
+If you want to compile the test program, you need:
+
+ * `camlzip` to compare `decompress` with `zlib`
+ * `re`
+ * `alcotest`

--- a/packages/decompress/decompress.0.6/opam
+++ b/packages/decompress/decompress.0.6/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+  "--with-cmdliner" "%{cmdliner:installed}%"
+]
+
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build}
+  "topkg"          {build}
+  "base-bytes"
+  "camlzip"        {test}
+  "re"             {test}
+  "alcotest"       {test}
+]
+
+depopts: [
+  "cmdliner"
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/decompress/decompress.0.6/url
+++ b/packages/decompress/decompress.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/decompress/releases/download/v0.6/decompress-0.6.tbz"
+checksum: "dac7f1514080334ed81f72eee9ebb45b"


### PR DESCRIPTION
Pure OCaml implementation of Zlib

[![Build Status](https://travis-ci.org/oklm-wsh/Decompress.svg?branch=master)](https://travis-ci.org/oklm-wsh/Decompress)

Decompress is a pure implementation of `zlib`. The goal is to create an
available package for Mirage OS for `zlib` in OCaml (instead a C code).

We respect the interface of `zlib` and all flush mode is available
(experimental):

- `SYNC_FLUSH`
- `PARTIAL_FLUSH`
- `FULL_FLUSH`

The interface proposed is a non-blocking interface.


Documentation: https://mirage.github.io/decompress/api.docdir/


## Installation

Decompress can be installed with `opam`:

    opam install decompress

## Sample programs

Sample program are located in the `bin` directory of the distribution. It can be
built with (dependancy with Unix module, the `cmdliner` package and a C code):

    ocamlbuild -use-ocamlfind bin/dpipe.native

Another good example is provided in `bin/easy.ml` with the signature:

```ocaml
val compress   : ?level:int -> string -> string
val uncompress : string -> string
```

And you can compile this program with:

    ocamlbuild -use-ocamlfind bin/easy.native

But keep in your mind, it's an easy example and it's not optimized for a
productive environment - so, don't copy/paste and think.

The documentation is
available [online](https://oklm-wsh.github.io/Decompress/api.docdir/) to
understand how to use Decompress.

## Build Requirements

 * OCaml >= 4.02.0
 * `base-bytes` meta-package
 * Bigarray module (provided by the standard library of OCaml)
 * `topkg`, `ocamlfind` and `ocamlbuild` to build the project

If you want to compile the test program, you need:

 * `camlzip` to compare `decompress` with `zlib`
 * `re`
 * `alcotest`

---
* Homepage: https://github.com/mirage/decompress
* Source repo: https://github.com/mirage/decompress.git
* Bug tracker: https://github.com/mirage/decompress/issues

---


---
v0.6 2017-05-11 Cao Lãnh (Vietnam)
------------------------------------

- Fixed bug #29
- Produce far pattern (Lz77 compression)
- Optimize memory consumption of the Inflate module
- Move repository from oklm-wsh to mirage
- Learn topkg release
Pull-request generated by opam-publish v0.3.4