### PR TITLE
Remove debug hack from compiler definitions

### DIFF
--- a/compilers/4.03.0/4.03.0+32bit/4.03.0+32bit.comp
+++ b/compilers/4.03.0/4.03.0+32bit/4.03.0+32bit.comp
@@ -2,9 +2,36 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -m32" "-as" "as --32" "-aspp" "gcc -m32 -c" "-host" "i386-linux" "-partialld" "ld -r -melf_i386"] {os = "linux"}
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" "-as" "as -arch i386" "-aspp" "gcc -arch i386 -m32 -c" "-host" "i386-apple-darwin13.2.0"] {os = "darwin"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-cc"
+    "gcc -m32"
+    "-as"
+    "as --32"
+    "-aspp"
+    "gcc -m32 -c"
+    "-host"
+    "i386-linux"
+    "-partialld"
+    "ld -r -melf_i386"
+  ] {os = "linux"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-cc"
+    "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+    "-as"
+    "as -arch i386"
+    "-aspp"
+    "gcc -arch i386 -m32 -c"
+    "-host"
+    "i386-apple-darwin13.2.0"
+  ] {os = "darwin"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+beta1+flambda/4.03.0+beta1+flambda.comp
+++ b/compilers/4.03.0/4.03.0+beta1+flambda/4.03.0+beta1+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+beta1/4.03.0+beta1.comp
+++ b/compilers/4.03.0/4.03.0+beta1/4.03.0+beta1.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+beta2+flambda/4.03.0+beta2+flambda.comp
+++ b/compilers/4.03.0/4.03.0+beta2+flambda/4.03.0+beta2+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0+beta2+flambda"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta2"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+beta2/4.03.0+beta2.comp
+++ b/compilers/4.03.0/4.03.0+beta2/4.03.0+beta2.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://codeload.github.com/ocaml/ocaml/legacy.tar.gz/4.03.0+beta2"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+fPIC/4.03.0+fPIC.comp
+++ b/compilers/4.03.0/4.03.0+fPIC/4.03.0+fPIC.comp
@@ -2,9 +2,16 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
+  [
+    "./configure"
+    "-cc"
+    "cc -fPIC"
+    "-aspp"
+    "cc -c -fPIC"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
+++ b/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
+++ b/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
@@ -2,9 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
+++ b/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
@@ -2,9 +2,13 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+termux/4.03.0+termux.comp
+++ b/compilers/4.03.0/4.03.0+termux/4.03.0+termux.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["sh" "./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+trunk+flambda/4.03.0+trunk+flambda.comp
+++ b/compilers/4.03.0/4.03.0+trunk+flambda/4.03.0+trunk+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0+trunk+fp+flambda/4.03.0+trunk+fp+flambda.comp
+++ b/compilers/4.03.0/4.03.0+trunk+fp+flambda/4.03.0+trunk+fp+flambda.comp
@@ -2,9 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+trunk+fp/4.03.0+trunk+fp.comp
+++ b/compilers/4.03.0/4.03.0+trunk+fp/4.03.0+trunk+fp.comp
@@ -2,9 +2,13 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
+++ b/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.03.0/4.03.0/4.03.0.comp
+++ b/compilers/4.03.0/4.03.0/4.03.0.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.0/4.04.0+32bit/4.04.0+32bit.comp
+++ b/compilers/4.04.0/4.04.0+32bit/4.04.0+32bit.comp
@@ -2,10 +2,36 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -m32" "-as" "as --32" "-aspp" "gcc -m32 -c" "-host" "i386-linux" "-partialld" "ld -r -melf_i386"] {os = "linux"}
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" "-as" "as -arch i386" "-aspp" "gcc -arch i386 -m32 -c" "-host" "i386-apple-darwin13.2.0"] {os = "darwin"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-cc"
+    "gcc -m32"
+    "-as"
+    "as --32"
+    "-aspp"
+    "gcc -m32 -c"
+    "-host"
+    "i386-linux"
+    "-partialld"
+    "ld -r -melf_i386"
+  ] {os = "linux"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-cc"
+    "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+    "-as"
+    "as -arch i386"
+    "-aspp"
+    "gcc -arch i386 -m32 -c"
+    "-host"
+    "i386-apple-darwin13.2.0"
+  ] {os = "darwin"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.comp
+++ b/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.comp
@@ -2,9 +2,9 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+  [
+    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ]
   [make "world"]
   [make "install"]
 ]

--- a/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
+++ b/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/yurug/ocaml4.04.0-copatterns/archive/V0.3.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.0/4.04.0+fPIC/4.04.0+fPIC.comp
+++ b/compilers/4.04.0/4.04.0+fPIC/4.04.0+fPIC.comp
@@ -2,9 +2,16 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
+  [
+    "./configure"
+    "-cc"
+    "cc -fPIC"
+    "-aspp"
+    "cc -c -fPIC"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.comp
+++ b/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.comp
+++ b/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.comp
@@ -2,9 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+fp/4.04.0+fp.comp
+++ b/compilers/4.04.0/4.04.0+fp/4.04.0+fp.comp
@@ -2,9 +2,13 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+spacetime/4.04.0+spacetime.comp
+++ b/compilers/4.04.0/4.04.0+spacetime/4.04.0+spacetime.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.0/4.04.0+termux/4.04.0+termux.comp
+++ b/compilers/4.04.0/4.04.0+termux/4.04.0+termux.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["sh" "./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.0/4.04.0+trunk+forced_lto/4.04.0+trunk+forced_lto.comp
+++ b/compilers/4.04.0/4.04.0+trunk+forced_lto/4.04.0+trunk+forced_lto.comp
@@ -2,8 +2,11 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/chambart/ocaml-1/archive/lto.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : lto = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
+  [
+    "sh"
+    "-exc"
+    "echo \"* : lto = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"
+  ]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.0/4.04.0/4.04.0.comp
+++ b/compilers/4.04.0/4.04.0/4.04.0.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.1/4.04.1+32bit/4.04.1+32bit.comp
+++ b/compilers/4.04.1/4.04.1+32bit/4.04.1+32bit.comp
@@ -2,10 +2,36 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -m32" "-as" "as --32" "-aspp" "gcc -m32 -c" "-host" "i386-linux" "-partialld" "ld -r -melf_i386"] {os = "linux"}
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" "-as" "as -arch i386" "-aspp" "gcc -arch i386 -m32 -c" "-host" "i386-apple-darwin13.2.0"] {os = "darwin"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-cc"
+    "gcc -m32"
+    "-as"
+    "as --32"
+    "-aspp"
+    "gcc -m32 -c"
+    "-host"
+    "i386-linux"
+    "-partialld"
+    "ld -r -melf_i386"
+  ] {os = "linux"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-cc"
+    "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+    "-as"
+    "as -arch i386"
+    "-aspp"
+    "gcc -arch i386 -m32 -c"
+    "-host"
+    "i386-apple-darwin13.2.0"
+  ] {os = "darwin"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+bytecode-only/4.04.1+bytecode-only.comp
+++ b/compilers/4.04.1/4.04.1+bytecode-only/4.04.1+bytecode-only.comp
@@ -2,9 +2,9 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+  [
+    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ]
   [make "world"]
   [make "install"]
 ]

--- a/compilers/4.04.1/4.04.1+fPIC/4.04.1+fPIC.comp
+++ b/compilers/4.04.1/4.04.1+fPIC/4.04.1+fPIC.comp
@@ -2,9 +2,16 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
+  [
+    "./configure"
+    "-cc"
+    "cc -fPIC"
+    "-aspp"
+    "cc -c -fPIC"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+flambda/4.04.1+flambda.comp
+++ b/compilers/4.04.1/4.04.1+flambda/4.04.1+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.1/4.04.1+fp+flambda/4.04.1+fp+flambda.comp
+++ b/compilers/4.04.1/4.04.1+fp+flambda/4.04.1+fp+flambda.comp
@@ -2,9 +2,14 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+fp/4.04.1+fp.comp
+++ b/compilers/4.04.1/4.04.1+fp/4.04.1+fp.comp
@@ -2,9 +2,13 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+spacetime/4.04.1+spacetime.comp
+++ b/compilers/4.04.1/4.04.1+spacetime/4.04.1+spacetime.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.04.1/4.04.1/4.04.1.comp
+++ b/compilers/4.04.1/4.04.1/4.04.1.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.05.0/4.05.0+beta1+flambda/4.05.0+beta1+flambda.comp
+++ b/compilers/4.05.0/4.05.0+beta1+flambda/4.05.0+beta1+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+beta1.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.05.0/4.05.0+beta2+flambda/4.05.0+beta2+flambda.comp
+++ b/compilers/4.05.0/4.05.0+beta2+flambda/4.05.0+beta2+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+beta2.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.05.0/4.05.0+trunk+flambda/4.05.0+trunk+flambda.comp
+++ b/compilers/4.05.0/4.05.0+trunk+flambda/4.05.0+trunk+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.05.0/4.05.0+trunk+fp+flambda/4.05.0+trunk+fp+flambda.comp
+++ b/compilers/4.05.0/4.05.0+trunk+fp+flambda/4.05.0+trunk+fp+flambda.comp
@@ -2,9 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+trunk+fp/4.05.0+trunk+fp.comp
+++ b/compilers/4.05.0/4.05.0+trunk+fp/4.05.0+trunk+fp.comp
@@ -2,9 +2,13 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+trunk+flambda/4.06.0+trunk+flambda.comp
+++ b/compilers/4.06.0/4.06.0+trunk+flambda/4.06.0+trunk+flambda.comp
@@ -2,8 +2,6 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
   [make "world"]
   [make "world.opt"]

--- a/compilers/4.06.0/4.06.0+trunk+fp+flambda/4.06.0+trunk+fp+flambda.comp
+++ b/compilers/4.06.0/4.06.0+trunk+fp+flambda/4.06.0+trunk+fp+flambda.comp
@@ -2,9 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers" "-flambda"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+trunk+fp/4.06.0+trunk+fp.comp
+++ b/compilers/4.06.0/4.06.0+trunk+fp/4.06.0+trunk+fp.comp
@@ -2,9 +2,13 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 build: [
-  ["mkdir" "-p" "%{lib}%/ocaml/"]
-  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ]
   [make "world"]
   [make "world.opt"]
   [make "install"]


### PR DESCRIPTION
Completely removing this is probably not desired. But in its current
form, it breaks the packaging rules of opam2 (no writes allowed
outside of srcdir and tmp in the build phase)

@chambart, do you have a solution ?