### PR TITLE
opam-ed.0.1 - via opam-publish

### DIFF
--- a/packages/opam-ed/opam-ed.0.1/url
+++ b/packages/opam-ed/opam-ed.0.1/url
@@ -1,2 +1,2 @@
-http: "https://github.com/AltGr/opam-ed/archive/0.1b.tar.gz"
-checksum: "e1bb1645adbe1feb82e9eba26ea5f6b6"
+http: "https://github.com/AltGr/opam-ed/archive/0.1c.tar.gz"
+checksum: "972b909f563f223bce534ef2a8b1dd60"


### PR DESCRIPTION
Command-line edition tool for handling the opam file syntax

opam-ed can read and write files in the general opam syntax. It provides a small
CLI with some useful commands for mechanically extracting or modifying the file
contents.

The specification for the syntax itself is available at:
    http://opam.ocaml.org/doc/2.0/Manual.html#Commonfileformat


---
* Homepage: https://github.com/AltGr/opam-ed
* Source repo: git+https://github.com/AltGr/opam-ed.git
* Bug tracker: https://github.com/AltGr/opam-ed/issues

---

Pull-request generated by opam-publish v0.3.4