### PR TITLE
github: restrict deps to < 3.0 for findlib package name changes

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
@@ -27,6 +27,6 @@ depends: [
   "protocol-9p" {= "0.9.0"}
   "datakit-client" {>= "0.10.0"}
   "github-hooks" {>= "0.1.1"}
-  "github" {>= "2.1.0"}
+  "github" {>= "2.1.0" & < "3.0.0"}
   "datakit" {test & >= "0.10.0"}
 ]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
@@ -25,6 +25,6 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "datakit-client" {>= "0.10.0"}
   "github-hooks" {>= "0.1.1"}
-  "github" {>= "2.1.0"}
+  "github" {>= "2.1.0" & < "3.0.0"}
   "datakit" {test & >= "0.10.0"}
 ]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.9.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.9.0/opam
@@ -35,6 +35,6 @@ depends: [
   "datakit-server" {>= "0.9.0" & < "0.10.0"}
   "datakit-client" {>= "0.9.0" & < "0.10.0"}
   "github-hooks" {>= "0.1.1"}
-  "github" {>= "2.1.0"}
+  "github" {>= "2.1.0" & < "3.0.0"}
   "datakit" {test & < "0.10.0"}
 ]

--- a/packages/github-hooks/github-hooks.0.1.1/opam
+++ b/packages/github-hooks/github-hooks.0.1.1/opam
@@ -23,7 +23,7 @@ depends: [
   "logs"
   "lwt"
   "cohttp"
-  "github" {>= "2.0.1"}
+  "github" {>= "2.0.1" & < "3.0.0"}
   "nocrypto"
   "hex"
 ]

--- a/packages/github-hooks/github-hooks.0.1.2/opam
+++ b/packages/github-hooks/github-hooks.0.1.2/opam
@@ -23,7 +23,7 @@ depends: [
   "logs"
   "lwt"
   "cohttp"
-  "github" {>= "2.0.1"}
+  "github" {>= "2.0.1" & < "3.0.0"}
   "nocrypto"
   "hex"
 ]

--- a/packages/opam-sync-github-prs/opam-sync-github-prs.1.1.0/opam
+++ b/packages/opam-sync-github-prs/opam-sync-github-prs.1.1.0/opam
@@ -18,7 +18,7 @@ remove: [["rm" "-f" "%{bin}%/opam-sync-github-prs"]]
 depends: [
   "ocamlfind" {build}
   "core" {build & >= "109.53.01"}
-  "github" {build & >= "1.0.0"}
+  "github" {build & >= "1.0.0" & < "3.0.0"}
   "lwt" {build & >= "2.4.2"}
   "ocamlbuild" {build}
 ]

--- a/packages/publish/publish.0.3.4/opam
+++ b/packages/publish/publish.0.3.4/opam
@@ -14,5 +14,5 @@ depends: [
   "opam-lib" {build & > "1.2.2"}
   "ocamlfind" {build}
   "cmdliner" {build}
-  "github" {build & >= "2.0.0"}
+  "github" {build & >= "2.0.0" & < "3.0.0"}
 ]


### PR DESCRIPTION
Due to mirage/ocaml-github#192, the findlib package names will be changing.

/cc @AltGr @avsm @samoht