### PR TITLE
opam-state.2.0.0~beta3 — via opam-publish

### DIFF
--- a/packages/opam-state/opam-state.2.0.0~beta3/descr
+++ b/packages/opam-state/opam-state.2.0.0~beta3/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Handling of the ~/.opam hierarchy, repository and switch states.

--- a/packages/opam-state/opam-state.2.0.0~beta3/opam
+++ b/packages/opam-state/opam-state.2.0.0~beta3/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0.0~beta3"}
+  "opam-format" {= "2.0.0~beta3"}
+  "opam-repository" {= "2.0.0~beta3"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opam-state/opam-state.2.0.0~beta3/url
+++ b/packages/opam-state/opam-state.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"


### PR DESCRIPTION
opam 2.0 development libraries

Handling of the ~/.opam hierarchy, repository and switch states.


---
* Homepage: https://opam.ocaml.org/
* Source repo: https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---

Pull-request generated by opam-publish v0.3.4