### PR TITLE
opam-state, opam-solver, opam-repository, opam-format, opam-devel, opam-core, opam-client.2.0.0~beta3 — via opam-publish

### DIFF
--- a/packages/opam-client/opam-client.2.0.0~beta3/descr
+++ b/packages/opam-client/opam-client.2.0.0~beta3/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Actions on the opam root, switches, installations, and front-end.

--- a/packages/opam-client/opam-client.2.0.0~beta3/opam
+++ b/packages/opam-client/opam-client.2.0.0~beta3/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-state" {= "2.0.0~beta3"}
+  "opam-solver" {= "2.0.0~beta3"}
+  "cmdliner" {>= "0.9.8"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opam-client/opam-client.2.0.0~beta3/url
+++ b/packages/opam-client/opam-client.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"

--- a/packages/opam-core/opam-core.2.0.0~beta3/descr
+++ b/packages/opam-core/opam-core.2.0.0~beta3/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Small standard library extensions, and generic system interaction modules used
+by opam.

--- a/packages/opam-core/opam-core.2.0.0~beta3/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta3/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocp-build" {build & >= "1.99.7"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "jsonm"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opam-core/opam-core.2.0.0~beta3/url
+++ b/packages/opam-core/opam-core.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"

--- a/packages/opam-devel/opam-devel.2.0.0~beta3/descr
+++ b/packages/opam-devel/opam-devel.2.0.0~beta3/descr
@@ -1,0 +1,6 @@
+opam 2.0.0 beta version
+
+This package compiles (bootstraps) the beta version of opam 2.0.0. For
+consistency and safety of the installation, the binaries are not installed into
+the PATH, but into lib/opam-devel, from where the user can manually install them
+system-wide.

--- a/packages/opam-devel/opam-devel.2.0.0~beta3/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta3/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+build-test: [make "tests"]
+depends: [
+  "opam-client" {= "2.0.0~beta3"}
+  "cmdliner" {>= "0.9.8"}
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages: [
+  "
+The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/* /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\"
+  "
+    {success}
+]

--- a/packages/opam-devel/opam-devel.2.0.0~beta3/url
+++ b/packages/opam-devel/opam-devel.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"

--- a/packages/opam-format/opam-format.2.0.0~beta3/descr
+++ b/packages/opam-format/opam-format.2.0.0~beta3/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Definition of opam datastructures and its file interface.

--- a/packages/opam-format/opam-format.2.0.0~beta3/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0.0~beta3"}
+  "opam-file-format" {>= "2.0.0~beta3"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opam-format/opam-format.2.0.0~beta3/url
+++ b/packages/opam-format/opam-format.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"

--- a/packages/opam-repository/opam-repository.2.0.0~beta3/descr
+++ b/packages/opam-repository/opam-repository.2.0.0~beta3/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+This library includes repository and remote sources handling, including
+curl/wget, rsync, git, mercurial, darcs backends.

--- a/packages/opam-repository/opam-repository.2.0.0~beta3/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~beta3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0.0~beta3"}
+  "opam-format" {= "2.0.0~beta3"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opam-repository/opam-repository.2.0.0~beta3/url
+++ b/packages/opam-repository/opam-repository.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"

--- a/packages/opam-solver/opam-solver.2.0.0~beta3/descr
+++ b/packages/opam-solver/opam-solver.2.0.0~beta3/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Solver and Cudf interaction. This library is based on the Cudf and Dose
+libraries, and handles calls to the external solver from opam.

--- a/packages/opam-solver/opam-solver.2.0.0~beta3/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~beta3/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0.0~beta3"}
+  "opam-format" {= "2.0.0~beta3"}
+  "dose3" {>= "5"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opam-solver/opam-solver.2.0.0~beta3/url
+++ b/packages/opam-solver/opam-solver.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"

--- a/packages/opam-state/opam-state.2.0.0~beta3/descr
+++ b/packages/opam-state/opam-state.2.0.0~beta3/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Handling of the ~/.opam hierarchy, repository and switch states.

--- a/packages/opam-state/opam-state.2.0.0~beta3/opam
+++ b/packages/opam-state/opam-state.2.0.0~beta3/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make name]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0.0~beta3"}
+  "opam-format" {= "2.0.0~beta3"}
+  "opam-repository" {= "2.0.0~beta3"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/opam-state/opam-state.2.0.0~beta3/url
+++ b/packages/opam-state/opam-state.2.0.0~beta3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
+checksum: "19ce08c078494cf5640b65843ce650ab"


### PR DESCRIPTION

  opam-state.2.0.0~beta3: opam 2.0 development libraries

Handling of the ~/.opam hierarchy, repository and switch states.

  opam-solver.2.0.0~beta3: opam 2.0 development libraries

Solver and Cudf interaction. This library is based on the Cudf and Dose
libraries, and handles calls to the external solver from opam.

  opam-repository.2.0.0~beta3: opam 2.0 development libraries

This library includes repository and remote sources handling, including
curl/wget, rsync, git, mercurial, darcs backends.

  opam-format.2.0.0~beta3: opam 2.0 development libraries

Definition of opam datastructures and its file interface.

  opam-devel.2.0.0~beta3: opam 2.0.0 beta version

This package compiles (bootstraps) the beta version of opam 2.0.0. For
consistency and safety of the installation, the binaries are not installed into
the PATH, but into lib/opam-devel, from where the user can manually install them
system-wide.

  opam-core.2.0.0~beta3: opam 2.0 development libraries

Small standard library extensions, and generic system interaction modules used
by opam.

  opam-client.2.0.0~beta3: opam 2.0 development libraries

Actions on the opam root, switches, installations, and front-end.


---
* Homepage: 
  opam-state.2.0.0~beta3: https://opam.ocaml.org/
  opam-solver.2.0.0~beta3: https://opam.ocaml.org/
  opam-repository.2.0.0~beta3: https://opam.ocaml.org/
  opam-format.2.0.0~beta3: https://opam.ocaml.org/
  opam-devel.2.0.0~beta3: https://opam.ocaml.org
  opam-core.2.0.0~beta3: https://opam.ocaml.org/
  opam-client.2.0.0~beta3: https://opam.ocaml.org/
* Source repo: https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---

Pull-request generated by opam-publish v0.3.4