### PR TITLE
Cstruct without 3.0

### DIFF
--- a/packages/arp/arp.0.1.1/opam
+++ b/packages/arp/arp.0.1.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ppx_tools" {build}
   "result"
   "cstruct" {>= "2.2.0"}
+  "ppx_cstruct"
   "ipaddr" {>= "2.2.0"}
   "logs"
   "alcotest" {test}

--- a/packages/arp/arp.0.2.0/opam
+++ b/packages/arp/arp.0.2.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ppx_tools" {build}
   "result"
   "cstruct" {>= "2.2.0"}
+  "ppx_cstruct" {build}
   "ipaddr" {>= "2.2.0"}
   "logs"
   "alcotest" {test}

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -18,6 +18,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_type_conv"
   "cstruct" {>= "1.9"}
+  "ppx_cstruct"
   "sexplib"
   "menhir"
   "ipaddr" {>= "2.5.0"}

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_type_conv"
   "cstruct" {>= "1.9"}
+  "ppx_cstruct"
   "sexplib"
   "menhir"
   "ipaddr" {>= "2.5.0"}

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -28,6 +28,7 @@ depends: [
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>= "1.9.0"}
+  "ppx_cstruct"
   "sexplib"
   "ipaddr"        {>= "2.5.0"}
   "tcpip"         {>= "3.1.0"}

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -27,6 +27,7 @@ depends: [
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>= "1.9.0"}
+  "ppx_cstruct"
   "sexplib"
   "ipaddr"        {>= "2.5.0"}
   "tcpip"         {>= "3.1.0"}

--- a/packages/charrua-core/charrua-core.0.7/opam
+++ b/packages/charrua-core/charrua-core.0.7/opam
@@ -27,6 +27,7 @@ depends: [
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>= "1.9.0"}
+  "ppx_cstruct"
   "sexplib"
   "ipaddr"        {>= "2.5.0"}
   "tcpip"         {>= "3.1.0"}

--- a/packages/cstruct-lwt/cstruct-lwt.0/descr
+++ b/packages/cstruct-lwt/cstruct-lwt.0/descr
@@ -1,0 +1,4 @@
+Access C-like structures directly from OCaml
+
+This is a dummy package to facilitate the migration to cstruct 3.0.0,
+where several package were split out of the main Cstruct package.

--- a/packages/cstruct-lwt/cstruct-lwt.0/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: []
+depends: [
+  "cstruct" {<"3.0.0"}
+  "lwt"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/dns/dns.0.18.0/opam
+++ b/packages/dns/dns.0.18.0/opam
@@ -40,7 +40,7 @@ depends: [
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
-  "cstruct" {>= "1.9.0" & <"3.0.0"}}
+  "cstruct" {>= "1.9.0" & <"3.0.0"}
   "ppx_tools"
   "re"
   "cmdliner"

--- a/packages/dns/dns.0.18.0/opam
+++ b/packages/dns/dns.0.18.0/opam
@@ -40,7 +40,7 @@ depends: [
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & <"3.0.0"}}
   "ppx_tools"
   "re"
   "cmdliner"

--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -47,7 +47,7 @@ depends: [
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"3.0.0"}
   "ppx_tools"
   "re"
   "cmdliner"

--- a/packages/dns/dns.0.19.0/opam
+++ b/packages/dns/dns.0.19.0/opam
@@ -41,6 +41,7 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct" {>= "2.0.0"}
+  "ppx_cstruct"
   "ppx_tools"
   "re"
   "cmdliner"

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -34,7 +34,8 @@ depends: [
   "ocamlfind"        {build}
   "ocamlbuild"       {build}
   "topkg"            {build & >= "0.8.0"}
-  "ppx_tools"        {build}
+  "ppx_cstruct"      {build}
+  "ppx_deriving"     {build}
   "base-bytes"
   "cstruct"          {>= "2.0.0"}
   "re"

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -37,6 +37,7 @@ depends: [
   "ppx_tools"        {build}
   "base-bytes"
   "cstruct"          {>= "2.0.0"}
+  "ppx_cstruct"
   "re"
   "ipaddr"           {>= "2.6.0"}
   "uri"              {>= "1.7.0"}

--- a/packages/mirage-block-ccm/mirage-block-ccm.1.0.0/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.1.0.0/opam
@@ -15,6 +15,7 @@ remove: ["ocamlfind" "remove" "mirage-block-ccm"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
+  "cstruct-lwt"
   "lwt" {>= "2.4.3"}
   "mirage-types-lwt" {< "3.0.0"}
   "nocrypto" {>= "0.5.1"}

--- a/packages/mirage-block-ccm/mirage-block-ccm.1.0.1/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.1.0.1/opam
@@ -15,6 +15,7 @@ remove: ["ocamlfind" "remove" "mirage-block-ccm"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
+  "cstruct-lwt"
   "lwt" {>= "2.4.3"}
   "mirage-types-lwt" {< "3.0.0"}
   "nocrypto" {>= "0.5.1"}

--- a/packages/mirage-block-unix/mirage-block-unix.0.2.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.0.2.1/opam
@@ -3,7 +3,7 @@ maintainer: "dave@recoil.org"
 build: make
 remove: [[make "uninstall"]]
 depends: [
-  "cstruct" {>= "0.8.1"}
+  "cstruct" {>= "0.8.1" & <"3.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {= "0.3.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.1.0.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.0.0/opam
@@ -3,7 +3,7 @@ maintainer: "dave@recoil.org"
 build: make
 remove: [[make "uninstall"]]
 depends: [
-  "cstruct" {>= "0.8.1"}
+  "cstruct" {>= "0.8.1" & <"3.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "0.4.0" & < "1.1.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.1.1.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.1.0/opam
@@ -3,7 +3,7 @@ maintainer: "dave@recoil.org"
 build: make
 remove: [[make "uninstall"]]
 depends: [
-  "cstruct" {>= "0.8.1"}
+  "cstruct" {>= "0.8.1" & <"3.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "0.5.0" & < "1.1.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.1.2.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.0/opam
@@ -3,7 +3,7 @@ maintainer: "dave@recoil.org"
 build: make
 remove: [[make "uninstall"]]
 depends: [
-  "cstruct" {>= "0.8.1"}
+  "cstruct" {>= "0.8.1" & <"3.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "0.5.0" & < "1.1.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
@@ -3,7 +3,7 @@ maintainer: "dave@recoil.org"
 build: make
 remove: [[make "uninstall"]]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"3.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "2.3.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.1.2.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.2/opam
@@ -14,7 +14,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"3.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.0.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.0.0/opam
@@ -18,6 +18,7 @@ remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
@@ -18,6 +18,7 @@ remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
@@ -18,6 +18,7 @@ remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
@@ -18,6 +18,7 @@ remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
@@ -18,6 +18,7 @@ remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "2.3.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.6.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "rresult"

--- a/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.6.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "rresult"

--- a/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0"}
+  "ppx_cstruct" {build}
   "lwt" {>= "2.6.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "rresult"

--- a/packages/mirage-console-unix/mirage-console-unix.0.9.9/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.0.9.9/opam
@@ -8,6 +8,7 @@ build: [make "unix-build"]
 remove: ["ocamlfind" "remove" "mirage-console-unix"]
 depends: [
   "ocamlfind"
+  "cstruct-lwt"
   "mirage-types" {="0.3.0"}
   "mirage-unix" {>="0.9.9"}
 ]

--- a/packages/mirage-console-unix/mirage-console-unix.1.0.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.1.0.0/opam
@@ -8,6 +8,7 @@ build: [make "unix-build"]
 remove: ["ocamlfind" "remove" "mirage-console-unix"]
 depends: [
   "ocamlfind"
+  "cstruct-lwt"
   "mirage-types" {>="0.4.0" & <"2.0.0"}
   "mirage-unix" {>="0.9.9"}
 ]

--- a/packages/mirage-console-unix/mirage-console-unix.2.2.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.2.0/opam
@@ -16,6 +16,7 @@ depends: [
   "topkg"      {build & >= "0.8.0"}
   "lwt"
   "cstruct"
+  "cstruct-lwt"
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-unix" {>="1.1.0"}
 ]

--- a/packages/mirage-console/mirage-console.2.0.0/opam
+++ b/packages/mirage-console/mirage-console.2.0.0/opam
@@ -9,6 +9,7 @@ depends: [
   "ocamlfind"
   "mirage-types-lwt" {< "2.3.0" & >= "2.0.0"}
   "mirage-unix" {>= "1.1.0"}
+  "cstruct-lwt"
   "ocamlbuild" {build}
 ]
 depopts: ["mirage-xen"]

--- a/packages/mirage-console/mirage-console.2.1.0/opam
+++ b/packages/mirage-console/mirage-console.2.1.0/opam
@@ -9,6 +9,7 @@ depends: [
   "ocamlfind"
   "mirage-types-lwt" {< "2.3.0"}
   "mirage-unix" {>= "1.1.0"}
+  "cstruct-lwt"
   "ocamlbuild" {build}
 ]
 depopts: ["mirage-xen"]

--- a/packages/mirage-console/mirage-console.2.1.1/opam
+++ b/packages/mirage-console/mirage-console.2.1.1/opam
@@ -9,6 +9,7 @@ depends: [
   "ocamlfind"
   "mirage-types-lwt" {< "3.0.0"}
   "mirage-unix" {>= "1.1.0"}
+  "cstruct-lwt"
   "ocamlbuild" {build}
 ]
 depopts: ["mirage-xen"]

--- a/packages/mirage-console/mirage-console.2.1.2/opam
+++ b/packages/mirage-console/mirage-console.2.1.2/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind" {build}
   "mirage-types-lwt" {< "3.0.0"}
   "cmdliner"
+  "cstruct-lwt"
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-console/mirage-console.2.1.3/opam
+++ b/packages/mirage-console/mirage-console.2.1.3/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind" {build}
   "mirage-types-lwt" {< "3.0.0"}
   "cmdliner"
+  "cstruct-lwt"
   "mirage-unix" {>= "1.1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-profile/mirage-profile.0.7.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.7.0/opam
@@ -19,6 +19,7 @@ remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.9.0"}
+  "ppx_cstruct"
   "ppx_tools"
   "ocplib-endian"
   "io-page"

--- a/packages/ppx_cstruct/ppx_cstruct.0/descr
+++ b/packages/ppx_cstruct/ppx_cstruct.0/descr
@@ -1,0 +1,4 @@
+Access C-like structures directly from OCaml
+
+This is a dummy package to facilitate the migration to cstruct 3.0.0,
+where several package were split out of the main Cstruct package.

--- a/packages/ppx_cstruct/ppx_cstruct.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: []
+depends: [
+  "cstruct" {<"3.0.0"}
+  "ppx_deriving"
+  "ppx_tools"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/protocol-9p/protocol-9p.0.10.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.10.0/opam
@@ -18,6 +18,7 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
   "sexplib" {> "113.00.00" }
   "result"
   "rresult"

--- a/packages/protocol-9p/protocol-9p.0.11.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.0/opam
@@ -18,6 +18,7 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
   "sexplib" {> "113.00.00" }
   "result"
   "rresult"

--- a/packages/protocol-9p/protocol-9p.0.7.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.2/opam
@@ -30,6 +30,7 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
   "sexplib" {> "113.00.00"}
   "result"
   "mirage-types-lwt" {< "3.0.0"}

--- a/packages/protocol-9p/protocol-9p.0.7.3/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.3/opam
@@ -30,6 +30,7 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
   "sexplib" {> "113.00.00"}
   "result"
   "mirage-types-lwt" {< "3.0.0"}

--- a/packages/protocol-9p/protocol-9p.0.7.4/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.4/opam
@@ -30,6 +30,7 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
   "sexplib" {> "113.00.00"}
   "result"
   "mirage-types-lwt" {< "3.0.0"}

--- a/packages/protocol-9p/protocol-9p.0.8.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.8.0/opam
@@ -19,6 +19,7 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
   "sexplib" {> "113.00.00" }
   "result"
   "mirage-types-lwt"

--- a/packages/protocol-9p/protocol-9p.0.9.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.9.0/opam
@@ -20,6 +20,7 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
   "sexplib" {> "113.00.00" }
   "result"
   "rresult"


### PR DESCRIPTION
This is #9154 without the 3.0, to help migrate dependencies without actually merging the new version