### PR TITLE
immutable.0.0.15 - via opam-publish

### DIFF
--- a/packages/immutable/immutable.0.0.15/descr
+++ b/packages/immutable/immutable.0.0.15/descr
@@ -1,0 +1,11 @@
+Pure Reason implementation of persistent immutable data structures.
+
+Immutable-re provides a complete set of efficient persistent immutable data
+structures for Reason and OCaml, targeting both OCaml native and byte code
+compilation modes, as well JavaScript using BuckleScript.
+
+The api includes concrete implementations of vectors, sets, and maps. Many
+implementations support transient mutability for efficient batch mutations.
+Additionally Immutable-re provides lazy functional iterators and sequences,
+along with type definitions for basic operators such as equality, comparison,
+and hashing.

--- a/packages/immutable/immutable.0.0.15/opam
+++ b/packages/immutable/immutable.0.0.15/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Dave Bordoley <bordoley@gmail.com>"
+authors: "Dave Bordoley <bordoley@gmail.com>"
+homepage: "https://facebookincubator.github.io/immutable-re/"
+bug-reports: "https://github.com/facebookincubator/immutable-re/issues"
+license: "BSD-3-Clause"
+tags: ["reason" "reasonml" "ocaml" "immutable"]
+dev-repo: "https://github.com/facebookincubator/immutable-re.git"
+build: [make "build"]
+depends: [
+  "reason" {build & >= "1.13.3"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]

--- a/packages/immutable/immutable.0.0.15/url
+++ b/packages/immutable/immutable.0.0.15/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/facebookincubator/immutable-re/archive/0.0.15.tar.gz"
+checksum: "8c3a3d43d5d3c629dd38f52281b52e6f"


### PR DESCRIPTION
Pure Reason implementation of persistent immutable data structures.

Immutable-re provides a complete set of efficient persistent immutable data
structures for Reason and OCaml, targeting both OCaml native and byte code
compilation modes, as well JavaScript using BuckleScript.

The api includes concrete implementations of vectors, sets, and maps. Many
implementations support transient mutability for efficient batch mutations.
Additionally Immutable-re provides lazy functional iterators and sequences,
along with type definitions for basic operators such as equality, comparison,
and hashing.


---
* Homepage: https://facebookincubator.github.io/immutable-re/
* Source repo: https://github.com/facebookincubator/immutable-re.git
* Bug tracker: https://github.com/facebookincubator/immutable-re/issues

---

Pull-request generated by opam-publish v0.3.4