### PR TITLE
Patience_diff v0.9.0

### DIFF
--- a/packages/patience_diff/patience_diff.v0.9.0/descr
+++ b/packages/patience_diff/patience_diff.v0.9.0/descr
@@ -1,0 +1,1 @@
+Diff library using Bram Cohen's patience diff algorithm.

--- a/packages/patience_diff/patience_diff.v0.9.0/opam
+++ b/packages/patience_diff/patience_diff.v0.9.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/patience_diff"
+bug-reports: "https://github.com/janestreet/patience_diff/issues"
+dev-repo: "https://github.com/janestreet/patience_diff.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "core_kernel"             {>= "v0.9" & < "v0.10"}
+  "jbuilder"                {build & >= "1.0+beta7"}
+  "ppx_driver"              {>= "v0.9" & < "v0.10"}
+  "ppx_jane"                {>= "v0.9" & < "v0.10"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/patience_diff/patience_diff.v0.9.0/url
+++ b/packages/patience_diff/patience_diff.v0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.9/files/patience_diff-v0.9.0.tar.gz"
+checksum: "e52b588ddd9c2660f830e278a650e48a"


### PR DESCRIPTION
This is the last Jane Street package with revdeps in opam. This PR is independent from https://github.com/ocaml/opam-repository/pull/9187