### PR TITLE
Fix installation of llvm.3.9 on Centos

### DIFF
--- a/packages/llvm/llvm.3.9/files/build.sh
+++ b/packages/llvm/llvm.3.9/files/build.sh
@@ -10,6 +10,12 @@ fi
 
 shopt -s nullglob
 
+if command -v cmake3 > /dev/null; then
+    cmake=cmake3
+else
+    cmake=cmake
+fi
+
 version_sans_dot=$(echo $version | tr -d .)
 for llvm_config in llvm-config-$version llvm-config$version_sans_dot llvm-config-mp-$version $brew_llvm_config llvm-config; do
     case `$llvm_config --version` in
@@ -25,7 +31,7 @@ for llvm_config in llvm-config-$version llvm-config$version_sans_dot llvm-config
             esac
             mkdir build
             cd build
-            cmake -DLLVM_OCAML_OUT_OF_TREE=TRUE -DLLVM_OCAML_INSTALL_PATH="$libdir" ..
+            $cmake -DLLVM_OCAML_OUT_OF_TREE=TRUE -DLLVM_OCAML_INSTALL_PATH="$libdir" ..
             exit 0;;
         *)
             continue;;

--- a/packages/llvm/llvm.3.9/opam
+++ b/packages/llvm/llvm.3.9/opam
@@ -31,6 +31,7 @@ depends: [
 ]
 depexts: [
   [["debian"] ["llvm-3.9-dev" "cmake"]]
+  [["centos"] ["llvm-3.9-devel" "cmake3"]]
   [["source" "linux"] ["https://gist.githubusercontent.com/jpdeplaix/53a7f91155e9d98dcfb18afcd1d6c529/raw"]]
 ]
 available: [ocaml-version >= "4.00.0"]


### PR DESCRIPTION
The first patch adds the external dependencies to the opam file. The second one changes the build script to use `cmake3` rather than `cmake` when available. The default `cmake` command on Centos 7 is cmake 2.* and llvm 3.9 requires version 3.4 at least.

/cc @jpdeplaix @whitequark 