### PR TITLE
jsoo_storage.1.0 - via opam-publish

### DIFF
--- a/packages/jsoo_storage/jsoo_storage.1.0/descr
+++ b/packages/jsoo_storage/jsoo_storage.1.0/descr
@@ -1,0 +1,3 @@
+A wrapper in Js_of_ocaml for the WebStorage API 
+
+The Web Storage API provides mechanisms by which browsers can store key/value pairs, in a much more intuitive fashion than using cookies.

--- a/packages/jsoo_storage/jsoo_storage.1.0/opam
+++ b/packages/jsoo_storage/jsoo_storage.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Xavier Van de Woestyne <xaviervdw@gmail.com>"
+authors: "Xavier Van de Woestyne <xaviervdw@gmail.com>"
+homepage: "http://github.com/xvw/jsoo_storage"
+bug-reports: "https://github.com/xvw/jsoo_storage/issues"
+license: "MIT"
+dev-repo: "https://github.com/xvw/jsoo_storage.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "jsoo_storage"]
+depends: [
+  "js_of_ocaml" {>= "2.8.4"}
+  "lwt"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02.0" & ocaml-version <= "4.04.0"]

--- a/packages/jsoo_storage/jsoo_storage.1.0/url
+++ b/packages/jsoo_storage/jsoo_storage.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/xvw/jsoo_storage/releases/download/1.0/jsoo_storage.tar.gz"
+checksum: "5082d3f5716a2547380d468cd4fda7cc"


### PR DESCRIPTION
A wrapper in Js_of_ocaml for the WebStorage API 

The Web Storage API provides mechanisms by which browsers can store key/value pairs, in a much more intuitive fashion than using cookies.


---
* Homepage: http://github.com/xvw/jsoo_storage
* Source repo: https://github.com/xvw/jsoo_storage.git
* Bug tracker: https://github.com/xvw/jsoo_storage/issues

---

Pull-request generated by opam-publish v0.3.3