### PR TITLE
dns.0.20.1 - via opam-publish

### DIFF
--- a/packages/dns/dns.0.20.1/descr
+++ b/packages/dns/dns.0.20.1/descr
@@ -1,0 +1,29 @@
+DNS client and server implementation in pure OCaml
+
+This is a pure OCaml implementation of the DNS protocol.  It is intended to be
+a reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-dns.svg?branch=master)](https://travis-ci.org/mirage/ocaml-dns)
+
+To build it, please use the [OPAM](https://opam.ocaml.org) package manager (1.2+):
+
+    opam pin add dns .
+
+This will install the dependencies needed and give you a working development
+version of the library.
+
+Packages:
+
+* `lib/` contains the core DNS protocol, which is packed into the `Dns` module.
+* `lib_test/` contains unit tests and sample uses of the library.
+  In particular, `time_server` is a simple dynamic responder.
+
+Areas that need work:
+
+* We need an Lwt-based client iterative resolver
+  Patches for this are highly welcome!
+* EDNS0 extensions
+* DNSSEC extensions (using [nocrypto](https://github.com/mirleft/ocaml-nocrypto/))
+* TC bit and TCP fallback
+* mDNS resolver

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -1,0 +1,76 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-dns"
+dev-repo:     "https://github.com/mirage/ocaml-dns.git"
+bug-reports:  "https://github.com/mirage/ocaml-dns/issues"
+doc:          "https://mirage.github.io/ocaml-dns/"
+
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+    "--with-lwt" "%{lwt+mirage-profile+cmdliner:installed}%"
+    "--with-mirage" "%{mirage-time-lwt+mirage-stack-lwt+mirage-kv-lwt+lwt+duration+mirage-profile:installed}%"
+    "--with-async" "%{async:installed}%" ]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  ["ocaml" "pkg/pkg.ml" "test" ]
+]
+
+depends: [
+  "ocamlfind"        {build}
+  "ocamlbuild"       {build}
+  "topkg"            {build & >= "0.8.0"}
+  "ppx_tools"        {build}
+  "base-bytes"
+  "cstruct"          {>= "2.0.0"}
+  "re"
+  "ipaddr"           {>= "2.6.0"}
+  "uri"              {>= "1.7.0"}
+  "base64"           {>= "2.0.0"}
+  "hashcons"
+  "result"
+  "lwt"              {test}
+  "ounit"            {test}
+  "pcap-format"      {test}
+  "mirage-protocols" {test & >="1.1.0"}
+  "mirage-stack-lwt" {test}
+  "mirage-time-lwt"  {test}
+  "mirage-kv"        {test}
+  "mirage-kv-lwt"    {test}
+  "mirage-profile"   {test}
+  "duration"         {test}
+]
+depopts: [
+  "async"
+
+  "lwt"
+  "mirage-profile"
+  "cmdliner"
+
+  "mirage-stack-lwt"
+  "mirage-kv-lwt"
+  "mirage-time-lwt"
+  "duration"
+]
+conflicts: [
+  "mirage-types-lwt" {< "3.0.0"}
+  "async" {<"112.24.00"}
+  "lwt" {< "3.0.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/dns/dns.0.20.1/url
+++ b/packages/dns/dns.0.20.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-dns/releases/download/0.20.1/dns-0.20.1.tbz"
+checksum: "16f38546fb454480cb063ef83c4eb37c"


### PR DESCRIPTION
DNS client and server implementation in pure OCaml

This is a pure OCaml implementation of the DNS protocol.  It is intended to be
a reasonably high-performance implementation, but clarity is preferred rather
than low-level performance hacks.

[![Build Status](https://travis-ci.org/mirage/ocaml-dns.svg?branch=master)](https://travis-ci.org/mirage/ocaml-dns)

To build it, please use the [OPAM](https://opam.ocaml.org) package manager (1.2+):

    opam pin add dns .

This will install the dependencies needed and give you a working development
version of the library.

Packages:

* `lib/` contains the core DNS protocol, which is packed into the `Dns` module.
* `lib_test/` contains unit tests and sample uses of the library.
  In particular, `time_server` is a simple dynamic responder.

Areas that need work:

* We need an Lwt-based client iterative resolver
  Patches for this are highly welcome!
* EDNS0 extensions
* DNSSEC extensions (using [nocrypto](https://github.com/mirleft/ocaml-nocrypto/))
* TC bit and TCP fallback
* mDNS resolver

---
* Homepage: https://github.com/mirage/ocaml-dns
* Source repo: https://github.com/mirage/ocaml-dns.git
* Bug tracker: https://github.com/mirage/ocaml-dns/issues

---


---
## 0.20.1 (2017-05-16)

* Port to lwt >= 3.0 (#136, @djs55)
Pull-request generated by opam-publish v0.3.2