### PR TITLE
opam_of_packagejson.0.0.8 - via opam-publish

### DIFF
--- a/packages/opam_of_packagejson/opam_of_packagejson.0.0.8/descr
+++ b/packages/opam_of_packagejson/opam_of_packagejson.0.0.8/descr
@@ -1,0 +1,3 @@
+Simple tool to generate META, opam and .install files.
+
+This works as a replacement for topkg.

--- a/packages/opam_of_packagejson/opam_of_packagejson.0.0.8/opam
+++ b/packages/opam_of_packagejson/opam_of_packagejson.0.0.8/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+dev-repo: "https://github.com/bsansouci/opam_of_packagejson.git"
+homepage: "https://github.com/bsansouci/opam_of_packagejson"
+bug-reports: "https://github.com/bsansouci/opam_of_packagejson/issues"
+maintainer: "Benjamin San Souci <benjamin.sansouci@gmail.com>"
+authors: [ "Benjamin San Souci <benjamin.sansouci@gmail.com>" ]
+build: [
+  [ make "build" ]
+]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]

--- a/packages/opam_of_packagejson/opam_of_packagejson.0.0.8/url
+++ b/packages/opam_of_packagejson/opam_of_packagejson.0.0.8/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/bsansouci/opam_of_packagejson/archive/v0.0.8.tar.gz"
+checksum: "eb42d6ae210f32fe40c0f4a2ececa79d"


### PR DESCRIPTION
Simple tool to generate META, opam and .install files.

This works as a replacement for topkg.


---
* Homepage: https://github.com/bsansouci/opam_of_packagejson
* Source repo: https://github.com/bsansouci/opam_of_packagejson.git
* Bug tracker: https://github.com/bsansouci/opam_of_packagejson/issues

---

Pull-request generated by opam-publish v0.3.4