### PR TITLE
opam_of_packagejson.0.1.0 - via opam-publish

### DIFF
--- a/packages/opam_of_packagejson/opam_of_packagejson.0.1.0/descr
+++ b/packages/opam_of_packagejson/opam_of_packagejson.0.1.0/descr
@@ -1,0 +1,1 @@
+Simple tool to generate META, opam and .install files.

--- a/packages/opam_of_packagejson/opam_of_packagejson.0.1.0/opam
+++ b/packages/opam_of_packagejson/opam_of_packagejson.0.1.0/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Benjamin San Souci <benjamin.sansouci@gmail.com>"
+authors: "Benjamin San Souci <benjamin.sansouci@gmail.com>"
+homepage: "https://github.com/bsansouci/opam_of_packagejson"
+bug-reports: "https://github.com/bsansouci/opam_of_packagejson/issues"
+dev-repo: "https://github.com/bsansouci/opam_of_packagejson.git"
+build: [make "build"]
+depends: [
+  "reason" {build & >= "1.13.3"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]

--- a/packages/opam_of_packagejson/opam_of_packagejson.0.1.0/url
+++ b/packages/opam_of_packagejson/opam_of_packagejson.0.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/bsansouci/opam_of_packagejson/archive/v0.1.0.tar.gz"
+checksum: "557134e538146b9e98e31b20fd7f36f0"


### PR DESCRIPTION
Simple tool to generate META, opam and .install files.


---
* Homepage: https://github.com/bsansouci/opam_of_packagejson
* Source repo: https://github.com/bsansouci/opam_of_packagejson.git
* Bug tracker: https://github.com/bsansouci/opam_of_packagejson/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.4