### PR TITLE
dtoa.0.1 - via opam-publish

### DIFF
--- a/packages/dtoa/dtoa.0.1/descr
+++ b/packages/dtoa/dtoa.0.1/descr
@@ -1,0 +1,5 @@
+converts OCaml floats into strings, using the efficient Grisu3 algorithm
+
+A library for converting floats to strings (doubles to ascii, "d to a").
+
+This is a (partial) port of Google's double-conversion library from C++ to C.

--- a/packages/dtoa/dtoa.0.1/opam
+++ b/packages/dtoa/dtoa.0.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Marshall Roch <mroch@fb.com>"
+authors: "Marshall Roch <mroch@fb.com>"
+homepage: "https://github.com/flowtype/ocaml-dtoa"
+bug-reports: "https://github.com/flowtype/ocaml-dtoa/issues"
+license: "BSD"
+doc: "https://github.com/flowtype/ocaml-dtoa"
+dev-repo: "https://github.com/flowtype/ocaml-dtoa.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ocb-stubblr" {build}
+  "topkg" {build & >= "0.9.0"}
+  "ounit" {test & >= "2.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/dtoa/dtoa.0.1/url
+++ b/packages/dtoa/dtoa.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/flowtype/ocaml-dtoa/archive/v0.1.tar.gz"
+checksum: "40cb786876812a7e70ab5a7cf4094829"


### PR DESCRIPTION
converts OCaml floats into strings, using the efficient Grisu3 algorithm

A library for converting floats to strings (doubles to ascii, "d to a").

This is a (partial) port of Google's double-conversion library from C++ to C.


---
* Homepage: https://github.com/flowtype/ocaml-dtoa
* Source repo: https://github.com/flowtype/ocaml-dtoa.git
* Bug tracker: https://github.com/flowtype/ocaml-dtoa/issues

---

Pull-request generated by opam-publish v0.3.4