### PR TITLE
unix-unistd.0.4.0 - via opam-publish

### DIFF
--- a/packages/unix-unistd/unix-unistd.0.4.0/descr
+++ b/packages/unix-unistd/unix-unistd.0.4.0/descr
@@ -1,0 +1,7 @@
+Host-independent unistd.h bindings
+
+ocaml-unix-unistd provides access to the features exposed in unistd.h in a way that is not tied to the implementation on the host system.
+
+The Unistd module provides functions for translating between the constants accessible through unistd.h and their values on particular systems.
+
+The Unistd_unix module provides bindings to functions that use the constants and types in Unistd along with a representation of the host system. The bindings support a more comprehensive range of seek commands than the corresponding functions in the standard OCaml Unix module. The Unistd_unix_lwt module exports non-blocking versions of the functions in Unistd_unix based on the Lwt cooperative threading library.

--- a/packages/unix-unistd/unix-unistd.0.4.0/opam
+++ b/packages/unix-unistd/unix-unistd.0.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "David Sheets <sheets@alum.mit.edu>"
+authors: [
+  "David Sheets <sheets@alum.mit.edu>" "Jeremy Yallop <yallop@gmail.com>"
+]
+homepage: "https://github.com/dsheets/ocaml-unix-unistd"
+bug-reports: "https://github.com/dsheets/ocaml-unix-unistd/issues"
+license: "ISC"
+dev-repo: "https://github.com/dsheets/ocaml-unix-unistd.git"
+build: [make "build"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "unix-unistd"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes-build" {build}
+]
+depopts: [
+  "ctypes"
+  "lwt"
+  "unix-type-representations"
+  "posix-types"
+  "unix-errno"
+  "base-unix"
+]
+conflicts: [
+  "lwt" {< "2.5.0"}
+  "ctypes" {< "0.9.0"}
+  "unix-errno" {< "0.4.0"}
+]

--- a/packages/unix-unistd/unix-unistd.0.4.0/url
+++ b/packages/unix-unistd/unix-unistd.0.4.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/ocaml-unix-unistd/archive/0.4.0.tar.gz"
+checksum: "9791a4a23c7e8f9fc6f3a3d85e3f1473"


### PR DESCRIPTION
Host-independent unistd.h bindings

ocaml-unix-unistd provides access to the features exposed in unistd.h in a way that is not tied to the implementation on the host system.

The Unistd module provides functions for translating between the constants accessible through unistd.h and their values on particular systems.

The Unistd_unix module provides bindings to functions that use the constants and types in Unistd along with a representation of the host system. The bindings support a more comprehensive range of seek commands than the corresponding functions in the standard OCaml Unix module. The Unistd_unix_lwt module exports non-blocking versions of the functions in Unistd_unix based on the Lwt cooperative threading library.


---
* Homepage: https://github.com/dsheets/ocaml-unix-unistd
* Source repo: https://github.com/dsheets/ocaml-unix-unistd.git
* Bug tracker: https://github.com/dsheets/ocaml-unix-unistd/issues

---

Pull-request generated by opam-publish v0.3.4