### PR TITLE
datakit-bridge-github.0.10.0: upper bound on mtime < 1.0.0

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
@@ -17,7 +17,9 @@ depends: [
   "lwt" {>= "3.0.0"}
   "datakit-github" {>= "0.10.0"}
   "datakit-server" {>= "0.10.0"}
-  "logs" "fmt" "mtime" "asl" "win-eventlog"
+  "logs" "fmt"
+  "mtime" {< "1.0.0" }
+  "asl" "win-eventlog"
   "uri" {>= "1.8.0"}
   "hvsock" {>= "0.8.1"}
   "hex" "nocrypto" "conduit"


### PR DESCRIPTION
mtime.1.0.0 does not include the mtime.os package.

This should fix the revdep failure seen here:

https://ci.ocaml.io/log/saved/docker-run-240ec374808c47fcaa32ac6a9393a552/3047f051fcaebe1e2d2eac6db1cc79c2a919b68e

Related to #9220

Signed-off-by: David Scott <dave@recoil.org>