### PR TITLE
topkg-jbuilder.0.1.0 - via opam-publish

### DIFF
--- a/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/descr
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/descr
@@ -1,0 +1,4 @@
+Helpers for using topkg with jbuilder
+
+Topkg-jbuilder exposes helpers for using topkg-care in projects using
+Jbuilder.

--- a/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/opam
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/opam
@@ -11,4 +11,5 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta7"}
+  "topkg"
 ]

--- a/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/opam
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/topkg-jbuilder"
+bug-reports: "https://github.com/diml/utop/topkg-jbuilder"
+dev-repo: "git://github.com/diml/topkg-jbuilder.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+]

--- a/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/url
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/topkg-jbuilder/releases/download/0.1.0/topkg-jbuilder-0.1.0.tbz"
+checksum: "cb6f69448e9a88b0497532843f1db9f2"


### PR DESCRIPTION
Helpers for using topkg with jbuilder

Topkg-jbuilder exposes helpers for using topkg-care in projects using
Jbuilder.


---
* Homepage: https://github.com/diml/topkg-jbuilder
* Source repo: git://github.com/diml/topkg-jbuilder.git
* Bug tracker: https://github.com/diml/utop/topkg-jbuilder

---


---
0.1.0 (05/19/2017)
------------------

Initial release
Pull-request generated by opam-publish v0.3.4