### PR TITLE
ppx_netblob.1.2.1 - via opam-publish

### DIFF
--- a/packages/ppx_netblob/ppx_netblob.1.2.1/descr
+++ b/packages/ppx_netblob/ppx_netblob.1.2.1/descr
@@ -1,0 +1,3 @@
+type-driven generation of HTTP calling code
+
+ppx_netblob (may be renamed as "schildpad" in the future) is a library for generating RESTful API bindings from types.

--- a/packages/ppx_netblob/ppx_netblob.1.2.1/opam
+++ b/packages/ppx_netblob/ppx_netblob.1.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "christophermcalpine@gmail.com"
+authors: ["John Whitington" "John Christopher McAlpine"]
+homepage: "https://github.com/chrismamo1/ppx_netblob"
+bug-reports: "https://github.com/chrismamo1/ppx_netblob/issues/"
+dev-repo: "https://github.com/chrismamo1/ppx_netblob.git"
+build: [
+  [make "native-code"] {ocaml-native}
+  [make "byte-code"] {!ocaml-native}
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "ppx_netblob"]
+depends: [
+  "ocamlfind" {build & >= "1.5.2"}
+  "ppx_tools" {build}
+  "cohttp" {build}
+  "lwt" {build}
+  "ppx_deriving" {build}
+  "ppx_deriving_yojson" {build}
+  "extlib" {build}
+]
+available: [ocaml-version > "4.03.0"]

--- a/packages/ppx_netblob/ppx_netblob.1.2.1/url
+++ b/packages/ppx_netblob/ppx_netblob.1.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/chrismamo1/ppx_netblob/archive/v1.2.1.tar.gz"
+checksum: "322693a0a634e8077e0a3befe4313f43"


### PR DESCRIPTION
type-driven generation of HTTP calling code

ppx_netblob (may be renamed as "schildpad" in the future) is a library for generating RESTful API bindings from types.


---
* Homepage: https://github.com/chrismamo1/ppx_netblob
* Source repo: https://github.com/chrismamo1/ppx_netblob.git
* Bug tracker: https://github.com/chrismamo1/ppx_netblob/issues/

---

Pull-request generated by opam-publish v0.3.3