### PR TITLE
mirage-console-unix: depend on cstruct-lwt

### DIFF
--- a/packages/mirage-console-unix/mirage-console-unix.2.2.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.2.0/opam
@@ -11,13 +11,13 @@ license:       "ISC"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.8.0"}
+  "topkg" {build & >= "0.8.0"}
   "lwt"
   "cstruct"
   "cstruct-lwt"
   "mirage-console-lwt" {>= "2.2.0"}
-  "mirage-unix" {>="1.1.0"}
+  "mirage-unix" {>= "1.1.0"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
part of revdeps for https://github.com/ocaml/opam-repository/pull/9154