### PR TITLE
Add upper bounds for ctypes dependency to memcpy packages.

### DIFF
--- a/packages/memcpy/memcpy.0.1.0/opam
+++ b/packages/memcpy/memcpy.0.1.0/opam
@@ -10,7 +10,7 @@ install: [[make "install"]]
 build-test: [[make "test"]]
 remove: [["ocamlfind" "remove" "memcpy"]]
 depends: [
-   "ctypes" {>= "0.4.0"}
+   "ctypes" {>= "0.4.0" & < "0.12.0"}
    "ounit" {test}
    "ocamlfind" {build}
    "ocamlbuild" {build}

--- a/packages/memcpy/memcpy.0.2.0/opam
+++ b/packages/memcpy/memcpy.0.2.0/opam
@@ -10,7 +10,7 @@ install: [[make "install"]]
 build-test: [[make "test"]]
 remove: [["ocamlfind" "remove" "memcpy"]]
 depends: [
-   "ctypes" {>= "0.4.0"}
+   "ctypes" {>= "0.4.0" & < "0.12.0"}
    "ounit" {test}
    "ocamlfind" {build}
    "ocamlbuild" {build}


### PR DESCRIPTION
See https://github.com/yallop/ocaml-memcpy/pull/10