### PR TITLE
Make capnp.2.1.1 installable again

### DIFF
--- a/packages/capnp/capnp.2.1.1/opam
+++ b/packages/capnp/capnp.2.1.1/opam
@@ -20,4 +20,4 @@ depends: [
   "uint"
   "camlp4"
 ]
-available: [ ocaml-version >= "4.01.0" & ocaml-version != "4.03.0" & ocaml_version != "4.04.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version != "4.03.0" & ocaml-version != "4.04.0" ]


### PR DESCRIPTION
Before:

```
$ ocaml -version
The OCaml toplevel, version 4.04.1
```

```
$ opam install capnp.2.1.1
[ERROR] capnp.2.1.1 is not available because your system doesn't comply with ocaml-version >= "4.01.0" &
 ocaml-version != "4.03.0" & ocaml_version != "4.04.0".
```

/cc @avsm 