### PR TITLE
core.v0.9.1 — via opam-publish

### DIFF
--- a/packages/core/core.v0.9.1/descr
+++ b/packages/core/core.v0.9.1/descr
@@ -1,0 +1,5 @@
+Industrial strength alternative to OCaml's standard library
+
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/core/core.v0.9.1/opam
+++ b/packages/core/core.v0.9.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "https://github.com/janestreet/core.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.9" & < "v0.10"}
+  "configurator"            {>= "v0.9" & < "v0.10"}
+  "core_kernel"             {>= "v0.9" & < "v0.10"}
+  "jbuilder"                {build & >= "1.0+beta2"}
+  "ppx_assert"              {>= "v0.9" & < "v0.10"}
+  "ppx_driver"              {>= "v0.9" & < "v0.10"}
+  "ppx_jane"                {>= "v0.9" & < "v0.10"}
+  "sexplib"                 {>= "v0.9" & < "v0.10"}
+  "spawn"                   {>= "v0.9" & < "v0.10"}
+  "stdio"                   {>= "v0.9" & < "v0.10"}
+  "base-threads"
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/core/core.v0.9.1/url
+++ b/packages/core/core.v0.9.1/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/core/archive/v0.9.1.tar.gz"
+checksum: "ce86cbba19a9ced6502540ec887d7f99"


### PR DESCRIPTION
Industrial strength alternative to OCaml's standard library

The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.


---
* Homepage: https://github.com/janestreet/core
* Source repo: git+https://github.com/janestreet/core.git
* Bug tracker: https://github.com/janestreet/core/issues

---
### opam-lint failures
- **ERROR** 32 Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4