### PR TITLE
Backported 4.04.0+afl compiler and afl-persistent package.

### DIFF
--- a/compilers/4.04.0/4.04.0+afl/4.04.0+afl.comp
+++ b/compilers/4.04.0/4.04.0+afl/4.04.0+afl.comp
@@ -1,0 +1,17 @@
+opam-version: "1"
+version: "4.04.0+afl"
+src: "https://github.com/stedolan/ocaml/archive/afl-backport.tar.gz"
+build: [
+  ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
+  ["./configure" "-prefix" prefix]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.04.0/4.04.0+afl/4.04.0+afl.descr
+++ b/compilers/4.04.0/4.04.0+afl/4.04.0+afl.descr
@@ -1,0 +1,1 @@
+OCaml 4.04.0, with afl-fuzz instrumentation backported from 4.05

--- a/packages/afl-persistent/afl-persistent.1.2/descr
+++ b/packages/afl-persistent/afl-persistent.1.2/descr
@@ -1,0 +1,5 @@
+use afl-fuzz in persistent mode
+
+afl-fuzz normally works by repeatedly fork()ing the program being
+tested. using this package, you can run afl-fuzz in 'persistent mode',
+which avoids repeated forking and is much faster.

--- a/packages/afl-persistent/afl-persistent.1.2/opam
+++ b/packages/afl-persistent/afl-persistent.1.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "stephen.dolan@cl.cam.ac.uk"
+authors: ["Stephen Dolan"]
+homepage: "https://github.com/stedolan/ocaml-afl-persistent"
+bug-reports: "https://github.com/stedolan/ocaml-afl-persistent/issues"
+dev-repo: "https://github.com/stedolan/ocaml-afl-persistent.git"
+license: "MIT"
+build: [[ "./build.sh" ]]
+depends: [
+  "ocamlfind"
+  "base-unix"
+]
+available: [ ocaml-version >= "4.00" ]
+post-messages: [
+"afl-persistent is installed, but since AFL instrumentation is not available
+with this OCaml compiler, instrumented fuzzing with afl-fuzz won't work.
+
+To use instrumented fuzzing, switch to an OCaml version supporting AFL, such
+as 4.04.0+afl." {success & !afl-available}
+
+"afl-persistent is installed, but since the current OCaml compiler does
+not enable AFL instrumentation by default, most packages will not be
+instrumented and fuzzing with afl-fuzz may not be effective.
+
+To globally enable AFL instrumentation, use an OCaml switch such as
+4.04.0+afl." {success & afl-available & !afl-always}
+]

--- a/packages/afl-persistent/afl-persistent.1.2/url
+++ b/packages/afl-persistent/afl-persistent.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/stedolan/ocaml-afl-persistent/archive/v1.2.tar.gz"
+checksum: "1c26b72e0646402f6f5daac91a70c4cf"


### PR DESCRIPTION
The new compiler `4.04.0+afl` is `4.04.0` with afl instrumentation backported and globally enabled, which also requires a new version of the `afl-persistent` package.

`afl-persistent` now installs on versions of OCaml that do not support afl instrumentation, but displays a message and does nothing interesting when run under `afl-fuzz`.