### PR TITLE
pkcs11.0.8.0 - via opam-publish

### DIFF
--- a/packages/pkcs11/pkcs11.0.8.0/descr
+++ b/packages/pkcs11/pkcs11.0.8.0/descr
@@ -1,0 +1,6 @@
+Bindings to the PKCS#11 cryptographic API
+
+This library contains ctypes bindings to the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.

--- a/packages/pkcs11/pkcs11.0.8.0/opam
+++ b/packages/pkcs11/pkcs11.0.8.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--with-cmdliner" "%{cmdliner:installed}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" "--with-cmdliner" "%{cmdliner:installed}%" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ctypes" { >= "0.11.0" }
+  "ctypes-foreign" { >= "0.4.0" }
+  "hex" { >= "1.0.0" }
+  "key-parsers" { >= "0.5.0" & != "0.6.0" }
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+depopts: [
+  "cmdliner"
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.02.0" & os != "darwin"]

--- a/packages/pkcs11/pkcs11.0.8.0/url
+++ b/packages/pkcs11/pkcs11.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/pkcs11/releases/download/v0.8.0/pkcs11-0.8.0.tbz"
+checksum: "f79b591ad280af2729fb1c85caf462b2"


### PR DESCRIPTION
Bindings to the PKCS#11 cryptographic API

This library contains ctypes bindings to the PKCS#11 API.

This API is used by smartcards and Hardware Security Modules to perform
cryptographic operations such as signature or encryption.


---
* Homepage: https://github.com/cryptosense/pkcs11
* Source repo: https://github.com/cryptosense/pkcs11.git
* Bug tracker: https://github.com/cryptosense/pkcs11/issues

---


---
v0.8.0 2017-05-22
=================

Breaking changes:

- Related to `Ctypes_helpers` (#48):
  + remove `is_null` (now in ctypes)
  + remove `safe_deref` and `Null_pointer` (unused)
- Make `Pkcs11` depend on `P11`, and not the other way around (#45).
  + Thanks to Bertrand Bonnefoy-Claudet.
  + This is a first step in splitting out the `ctypes` dependency.
  + Remove `P11_sigs`
  + Types named `u` are removed (use `t` types from `P11`).
  + Constructor reexports are removed.
  + `of_raw` aliases are removed.
  + functions acting on `u` are moved to `P11_x`
  + rename `compare_t` / `equal_t` to `compare` / `equal`
- Split the `P11` module into several smaller modules.
  + This is only breaking because it uses more global `P11_` names.

Deprecated functions:

- `P11_attribute_type.(==)` (#43, #50)

New functions:

- Add `eq` and `ord` instances for inner modules (#49).

Cleanup:

- Remove dead code here and there (#49).

Packaging:

- Always install fake DLL (#46, #47)
Pull-request generated by opam-publish v0.3.4