### PR TITLE
mirage-entropy-unix: depend on cstruct-lwt

### DIFF
--- a/packages/mirage-entropy-unix/mirage-entropy-unix.0.2.0/opam
+++ b/packages/mirage-entropy-unix/mirage-entropy-unix.0.2.0/opam
@@ -9,6 +9,7 @@ remove: [
 depends: [
   "ocamlfind"
   "cstruct" {>= "1.3.0"}
+  "cstruct-lwt"
   "mirage-types-lwt" {< "2.5.0"}
   "mirage-unix"
   "camlp4"


### PR DESCRIPTION
revdeps for    https://github.com/ocaml/opam-repository/pull/9154
