### PR TITLE
IOCaml 0.4.{6,7,8,9} is incompatible with Lwt >= 3.0.0.

### DIFF
--- a/packages/iocaml/iocaml.0.4.6/opam
+++ b/packages/iocaml/iocaml.0.4.6/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
+authors: "Andrew Ray <andy.ray@ujamjar.com>"
 maintainer: "andy.ray@ujamjar.com"
+dev-repo: "https://github.com/andrewray/iocamlserver.git"
+bug-reports: "https://github.com/andrewray/iocamlserver/issues"
 homepage: "https://github.com/andrewray/iocamlserver"
 build: [
   [ "cp" "config.darwin.ml" "config.ml" ] {os = "darwin"}
@@ -21,5 +24,5 @@ depends: [
   "iocamljs-kernel" {= "0.4.6"}
   "ocamlbuild" {build}
 ]
-ocaml-version: [ >= "4.00.1" ]
-dev-repo: "git://github.com/andrewray/iocamlserver"
+available: [ ocaml-version >= "4.00.1" ]
+

--- a/packages/iocaml/iocaml.0.4.6/opam
+++ b/packages/iocaml/iocaml.0.4.6/opam
@@ -11,7 +11,7 @@ depends: [
   "uuidm"
   "yojson"
   "cow" {< "2.0.0"}
-  "lwt" {>= "2.4"}
+  "lwt" {>= "2.4" & < "3.0.0"}
   "websocket" {= "0.8.1"}
   "cohttp" {>= "0.10.0"}
   "crunch"

--- a/packages/iocaml/iocaml.0.4.7/opam
+++ b/packages/iocaml/iocaml.0.4.7/opam
@@ -14,7 +14,7 @@ depends: [
   "uuidm"
   "yojson"
   "cow" {< "2.0.0"}
-  "lwt" {>= "2.4"}
+  "lwt" {>= "2.4" & < "3.0.0"}
   "websocket" {>= "0.9" & < "1.0"}
   "cohttp" {>= "0.15.0"}
   "crunch"

--- a/packages/iocaml/iocaml.0.4.8/opam
+++ b/packages/iocaml/iocaml.0.4.8/opam
@@ -13,7 +13,7 @@ depends: [
   "uuidm"
   "yojson"
   "cow" {< "2.0.0"}
-  "lwt" {>= "2.4"}
+  "lwt" {>= "2.4" & < "3.0.0"}
   "websocket" {>= "2.0" & <="2.6"}
   "cohttp" {>= "0.15.0" & < "0.21.0"}
   "crunch"

--- a/packages/iocaml/iocaml.0.4.9/opam
+++ b/packages/iocaml/iocaml.0.4.9/opam
@@ -13,7 +13,7 @@ depends: [
   "uuidm"
   "yojson"
   "cow" {< "2.0.0"}
-  "lwt" {>= "2.4"}
+  "lwt" {>= "2.4" & < "3.0.0"}
   "websocket" {>= "2.0" & <="2.6"}
   "cohttp" {>= "0.21.0"}
   "crunch"


### PR DESCRIPTION
IOCaml uses `-strict-sequence`, and the type of Lwt.bind has changed so that it no longer returns unit (https://github.com/ocsigen/lwt/issues/308).

```
#=== ERROR while installing iocaml.0.4.8 ======================================#
# opam-version 1.2.2
# os           linux
# command      make all
# path         /home/jeremy/.opam/4.04.0/build/iocaml.0.4.8
# compiler     4.04.0
# exit-code    2
# env-file     /home/jeremy/.opam/4.04.0/build/iocaml.0.4.8/iocaml-31170-a7c577.env
# stdout-file  /home/jeremy/.opam/4.04.0/build/iocaml.0.4.8/iocaml-31170-a7c577.out
# stderr-file  /home/jeremy/.opam/4.04.0/build/iocaml.0.4.8/iocaml-31170-a7c577.err
### stdout ###
# [...]
# ocamlfind ocamldep -package lwt,re -modules uri_paths.ml > uri_paths.ml.depends
# ocamlfind ocamlc -c -g -annot -bin-annot -principal -strict-sequence -syntax camlp4o -package lwt.syntax,uri,websocket.lwt,iocaml-kernel,yojson -o bridge.cmo bridge.ml
# ocamlfind ocamlc -c -g -annot -bin-annot -principal -strict-sequence -syntax camlp4o -package lwt.syntax,yojson,unix -o files.cmo files.ml
# ocamlfind ocamlc -c -g -annot -bin-annot -principal -strict-sequence -syntax camlp4o -package lwt.syntax,iocaml-kernel,uuidm,yojson -o kernel.cmo kernel.ml
# + ocamlfind ocamlc -c -g -annot -bin-annot -principal -strict-sequence -syntax camlp4o -package lwt.syntax,iocaml-kernel,uuidm,yojson -o kernel.cmo kernel.ml
# File "kernel.ml", line 156, characters 22-53:
# Error: This expression has type unit Lwt.t
#        but an expression was expected of type unit
# Command exited with code 2.
# makefile:13: recipe for target 'iocamlserver.byte' failed
```

/cc @andrewray