### PR TITLE
add 4.05+trunk+lto compiler

### DIFF
--- a/compilers/4.05.0/4.05.0+trunk+lto/4.05.0+trunk+lto.comp
+++ b/compilers/4.05.0/4.05.0+trunk+lto/4.05.0+trunk+lto.comp
@@ -1,0 +1,15 @@
+opam-version: "1"
+version: "4.05.0"
+src: "https://github.com/chambart/ocaml-1/archive/lto.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.05.0/4.05.0+trunk+lto/4.05.0+trunk+lto.descr
+++ b/compilers/4.05.0/4.05.0+trunk+lto/4.05.0+trunk+lto.descr
@@ -1,0 +1,1 @@
+latest 4.05 snapshot with flambda and lto activated


### PR DESCRIPTION
This follows the PR https://github.com/ocaml/ocaml/pull/608, but some additional configure option `-lto` is needed for to be any useful.