### PR TITLE
Add -use-lto configure option to the +lto compiler

### DIFF
--- a/compilers/4.05.0/4.05.0+trunk+lto/4.05.0+trunk+lto.comp
+++ b/compilers/4.05.0/4.05.0+trunk+lto/4.05.0+trunk+lto.comp
@@ -2,7 +2,7 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/chambart/ocaml-1/archive/lto.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto" "-use-lto"]
   [make "world"]
   [make "world.opt"]
   [make "install"]


### PR DESCRIPTION
It was missing some configure option option, see https://github.com/ocaml/opam-repository/pull/9274