### PR TITLE
+tcpip-3.1.3

### DIFF
--- a/packages/tcpip/tcpip.3.1.3/descr
+++ b/packages/tcpip/tcpip.3.1.3/descr
@@ -1,0 +1,1 @@
+Userlevel TCP/IP stack

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -1,0 +1,75 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+authors: [
+  "Anil Madhavapeddy"
+  "Balraj Singh"
+  "Richard Mortier"
+  "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire"
+  "Vincent Bernardoff"
+  "Magnus Skjegstad"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "David Scott"
+  "Gabor Pali"
+  "Hannes Mehnert"
+  "Haris Rotsos"
+  "Kia"
+  "Luke Dunstan"
+  "Pablo Polvorin"
+  "Tim Cuthbertson"
+  "lnmx"
+  "pqwy"
+]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["./configure" "--prefix" prefix
+    "--%{mirage-xen:enable}%-xen" ]
+  [make]
+]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test" "TESTFLAGS=-v"]
+]
+
+install: [make "install"]
+remove: ["ocamlfind" "remove" "tcpip"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "result"
+  "rresult"
+  "cstruct" {>= "2.2.0"}
+  "ppx_tools" {build}
+  "mirage-net" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.1.0"}
+  "mirage-protocols-lwt" {>= "1.1.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "2.2.0"}
+  "mirage-profile" {>= "0.5"}
+  "mirage-flow" {test & >= "1.2.0"}
+  "mirage-vnetif" {test & >= "0.2.0"}
+  "alcotest" {test}
+  "pcap-format" {test}
+  "mirage-clock-unix" {test & >= "1.2.0"}
+  "fmt"
+  "lwt" {>= "2.7.0"}
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "cstruct-lwt"
+]
+depopts: [
+  "mirage-xen"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/tcpip/tcpip.3.1.3/url
+++ b/packages/tcpip/tcpip.3.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-tcpip/archive/v3.1.3.tar.gz"
+checksum: "c628d9545b45283876f430b4b7ac9171"


### PR DESCRIPTION
Bugfix release with more correct handling of the interaction between
IP-module expressed maximum transmission unit (MTU) and the TCP maximum
segment size (MSS).  This release is preferred over 3.1.0 and 3.1.1
(which would crash on some backends under some circumstances) and 3.1.2
(which artificially pinned the maximum segment size at a common, but not
universal, value).

tcpip versions prior to 3.1.0 did not support TCP decision-making based
on the MTU and had behavior similar to 3.1.2.