### PR TITLE
nullable-array.0.1 - via opam-publish

### DIFF
--- a/packages/nullable-array/nullable-array.0.1/descr
+++ b/packages/nullable-array/nullable-array.0.1/descr
@@ -1,0 +1,1 @@
+Small self-contained library providing an efficient implementation for a type equivalent to `'a option array`

--- a/packages/nullable-array/nullable-array.0.1/opam
+++ b/packages/nullable-array/nullable-array.0.1/opam
@@ -1,23 +1,26 @@
 opam-version: "1.2"
+name: "ocplib-nullable-array"
+version: "0.1"
 maintainer: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
 authors: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
-homepage: "https://github.com/OCamlPro/ocplib-nullable-array"
-bug-reports: "https://github.com/OCamlPro/ocplib-nullable-array/issues"
+homepage: "https://github.com/chambart/ocplib-nullable-array"
+bug-reports: "https://github.com/chambart/ocplib-nullable-array/issues"
 license: "MIT"
-dev-repo: "https://github.com/OCamlPro/ocplib-nullable-array.git"
+dev-repo: "https://github.com/chambart/ocplib-nullable-array.git"
+
 build: [
-  "jbuilder"
-  "build"
-  "--only-packages"
-  "nullable-array"
-  "--root"
-  "."
-  "-j"
-  jobs
-  "@install"
+  ["jbuilder" "build" "--only-packages" "nullable-array" "--root" "." "-j" jobs "@install"]
 ]
-build-test: ["jbuilder" "runtest"]
+
+build-test: [
+  ["jbuilder" "runtest"]
+]
+
+available: [
+  ocaml-version >= "4.03"   (* use Sys.opaque_identity *)
+  & ocaml-version <= "4.06" (* need to be tested before announcing that a version is correct *)
+]
+
 depends: [
   "jbuilder" {build & >= "1.0+beta8"}
 ]
-available: [ocaml-version >= "4.03" & ocaml-version <= "4.06"]

--- a/packages/nullable-array/nullable-array.0.1/opam
+++ b/packages/nullable-array/nullable-array.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+authors: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+homepage: "https://github.com/OCamlPro/ocplib-nullable-array"
+bug-reports: "https://github.com/OCamlPro/ocplib-nullable-array/issues"
+license: "MIT"
+dev-repo: "https://github.com/OCamlPro/ocplib-nullable-array.git"
+build: [
+  "jbuilder"
+  "build"
+  "--only-packages"
+  "nullable-array"
+  "--root"
+  "."
+  "-j"
+  jobs
+  "@install"
+]
+build-test: ["jbuilder" "runtest"]
+depends: [
+  "jbuilder" {build & >= "1.0+beta8"}
+]
+available: [ocaml-version >= "4.03" & ocaml-version <= "4.06"]

--- a/packages/nullable-array/nullable-array.0.1/opam
+++ b/packages/nullable-array/nullable-array.0.1/opam
@@ -1,12 +1,10 @@
 opam-version: "1.2"
-name: "ocplib-nullable-array"
-version: "0.1"
 maintainer: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
 authors: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
-homepage: "https://github.com/chambart/ocplib-nullable-array"
-bug-reports: "https://github.com/chambart/ocplib-nullable-array/issues"
+homepage: "https://github.com/chambart/nullable-array"
+bug-reports: "https://github.com/chambart/nullable-array/issues"
 license: "MIT"
-dev-repo: "https://github.com/chambart/ocplib-nullable-array.git"
+dev-repo: "https://github.com/chambart/nullable-array.git"
 
 build: [
   ["jbuilder" "build" "--only-packages" "nullable-array" "--root" "." "-j" jobs "@install"]

--- a/packages/nullable-array/nullable-array.0.1/url
+++ b/packages/nullable-array/nullable-array.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/chambart/ocaml-nullable-array/archive/0.1.tar.gz"
+checksum: "c9856d37b6418c387e9d8def8ca31d5e"


### PR DESCRIPTION
Small self-contained library providing an efficient implementation for a type equivalent to `'a option array`


---
* Homepage: https://github.com/OCamlPro/ocplib-nullable-array
* Source repo: https://github.com/OCamlPro/ocplib-nullable-array.git
* Bug tracker: https://github.com/OCamlPro/ocplib-nullable-array/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.4