### PR TITLE
Heptagon version 1.03.04

### DIFF
--- a/packages/heptagon/heptagon.1.03.04/descr
+++ b/packages/heptagon/heptagon.1.03.04/descr
@@ -1,0 +1,10 @@
+Compiler for the Heptagon/BZR synchronous programming language
+Heptagon/BZR is a synchronous dataflow language whose syntax and
+semantics is inspired from Lustre, with a syntax allowing the
+expression of control structures (e.g., switch or mode automata).
+Heptagon/BZR is a research compiler, whose aim is to facilitate
+experimentation. The current version of the compiler includes the
+following features:
+- Inclusion of discrete controller synthesis within the compilation
+- Expression and compilation of array values with modular memory optimization
+See http://heptagon.gforge.inria.fr for further informations.

--- a/packages/heptagon/heptagon.1.03.04/files/heptagon.install
+++ b/packages/heptagon/heptagon.1.03.04/files/heptagon.install
@@ -1,0 +1,19 @@
+bin: [
+  "compiler/_build/main/heptc.byte" {"heptc"}
+  "?compiler/_build/main/hepts.byte" {"hepts"}
+  "?compiler/_build/main/ctrl2ept.byte" {"ctrl2ept"}
+  "?compiler/_build/main/heptc.native" {"heptc.opt"}
+  "?compiler/_build/main/hepts.native" {"hepts.opt"}
+  "?compiler/_build/main/ctrl2ept.native" {"ctrl2ept.opt"}
+]
+lib: [
+  "lib/c/math.c" {"c/math.c"}
+  "lib/c/math.h" {"c/math.h"}
+  "lib/c/pervasives.h" {"c/pervasives.h"}
+  "lib/iostream.epci" {"iostream.epci"}
+  "lib/iostream.epi" {"iostream.epi"}
+  "lib/math.epci" {"math.epci"}
+  "lib/math.epi" {"math.epi"}
+  "lib/pervasives.epci" {"pervasives.epci"}
+  "lib/pervasives.epi" {"pervasives.epi"}
+]

--- a/packages/heptagon/heptagon.1.03.04/opam
+++ b/packages/heptagon/heptagon.1.03.04/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "gwenael.delaval@inria.fr"
+authors: "Gwenaël Delaval"
+homepage: "http://heptagon.gforge.inria.fr"
+bug-reports: "https://gforge.inria.fr/tracker/?group_id=2773"
+build: [
+   ["./configure" "--prefix" prefix]
+   [make]
+]
+tags: [ "flags:light-uninstall" ]
+depends: [
+  "ocamlfind"  {build}
+  "menhir"     {build & >= "20141215"}
+  "ocamlgraph" {build}
+  "camlp4"     {build}
+  "ocamlbuild" {build}
+]
+depopts: [
+  "lablgtk"
+  "reatk"
+]
+conflicts: [
+  "reatk" { <= "0.10.1" }
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/heptagon/heptagon.1.03.04/url
+++ b/packages/heptagon/heptagon.1.03.04/url
@@ -1,0 +1,2 @@
+archive: "https://gforge.inria.fr/frs/download.php/file/36835/heptagon-1.03.04.tar.gz"
+checksum: "8165c9eb39e6869dd0d376c0343a1e50"


### PR DESCRIPTION
 - Bug correction in init analysis (bug #14076)
 - Bug correction in causality analysis: contradictory dependencies
   in states of automata were accepted, non schedulable equations generated
 - optimization on several passes
 - added -simple-scheduler option, triggering very simple, time-efficient
   scheduling