### PR TITLE
toplevel_expect_test.v0.9.1 — via opam-publish

### DIFF
--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/descr
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/descr
@@ -1,0 +1,6 @@
+Expectation tests for the OCaml toplevel
+
+Allows one to write both toplevel phrases and the expected output from
+the toplevel in the same file. This provides an easy way to test
+compilations errors as well as provide a nice alternative to using
+the toplevel in a terminal.

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "core_kernel"             {>= "v0.9" & < "v0.10"}
   "ocamlfind"               {>= "1.7.2"}
-  "jbuilder"                {build & >= "1.0+beta2"}
+  "jbuilder"                {build & >= "1.0+beta8"}
   "ocaml-compiler-libs"     {>= "v0.9" & < "v0.10"}
   "ppx_core"                {>= "v0.9" & < "v0.10"}
   "ppx_driver"              {>= "v0.9.1" & < "v0.10"}

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "core_kernel"             {>= "v0.9" & < "v0.10"}

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/toplevel_expect_test"
+bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
+dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "p" name "-j" jobs]
+]
+depends: [
+  "core_kernel"             {>= "v0.9" & < "v0.10"}
+  "ocamlfind"               {>= "1.7.2"}
+  "jbuilder"                {build & >= "1.0+beta2"}
+  "ocaml-compiler-libs"     {>= "v0.9" & < "v0.10"}
+  "ppx_core"                {>= "v0.9" & < "v0.10"}
+  "ppx_driver"              {>= "v0.9.1" & < "v0.10"}
+  "ppx_expect"              {>= "v0.9" & < "v0.10"}
+  "ppx_here"                {>= "v0.9" & < "v0.10"}
+  "ppx_jane"                {>= "v0.9" & < "v0.10"}
+  "base-threads"
+  "ocaml-migrate-parsetree" {>= "1.0"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/url
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/toplevel_expect_test/archive/v0.9.1.tar.gz"
+checksum: "49dfb01e795d55fb2f71226c429cf4d0"


### PR DESCRIPTION
Expectation tests for the OCaml toplevel

Allows one to write both toplevel phrases and the expected output from
the toplevel in the same file. This provides an easy way to test
compilations errors as well as provide a nice alternative to using
the toplevel in a terminal.


---
* Homepage: https://github.com/janestreet/toplevel_expect_test
* Source repo: git+https://github.com/janestreet/toplevel_expect_test.git
* Bug tracker: https://github.com/janestreet/toplevel_expect_test/issues

---
### opam-lint failures
- **ERROR** 32 Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4