### PR TITLE
mirage-console-unix: cstruct<3 since it doesnt link to cstruct.lwt correctly

### DIFF
--- a/packages/mirage-console-unix/mirage-console-unix.0.9.9/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.0.9.9/opam
@@ -8,6 +8,7 @@ build: [make "unix-build"]
 remove: ["ocamlfind" "remove" "mirage-console-unix"]
 depends: [
   "ocamlfind"
+  "cstruct" {<"3.0.0"}
   "cstruct-lwt"
   "mirage-types" {="0.3.0"}
   "mirage-unix" {>="0.9.9"}

--- a/packages/mirage-console-unix/mirage-console-unix.1.0.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.1.0.0/opam
@@ -8,6 +8,7 @@ build: [make "unix-build"]
 remove: ["ocamlfind" "remove" "mirage-console-unix"]
 depends: [
   "ocamlfind"
+  "cstruct" {<"3.0.0"}
   "cstruct-lwt"
   "mirage-types" {>="0.4.0" & <"2.0.0"}
   "mirage-unix" {>="0.9.9"}

--- a/packages/mirage-console-unix/mirage-console-unix.2.2.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
   "lwt"
-  "cstruct"
+  "cstruct" {<"3.0.0"}
   "cstruct-lwt"
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-unix" {>= "1.1.0"}


### PR DESCRIPTION

cstruct>3 will be in a point release