### PR TITLE
mirage-entropy-xen.0.2.0 needs mirage-types-lwt < 2.5.0

### DIFF
--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.2.0/opam
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.2.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "cstruct" {>= "1.3.0"}
-  "mirage-types-lwt" {< "3.0.0"}
+  "mirage-types-lwt" {< "2.5.0"}
   "mirage-console" {>= "2.1.3"}
   "mirage-xen" {>= "2.2.0"}
   "xen-gnt"


### PR DESCRIPTION
The signature V1_LWT.ENTROPY was removed in 2.5.0.

Seen in this build log:

https://ci.ocaml.io/log/saved/docker-build-a8b7a87aa35fb62edfd5154a4e14ed0b/2ed4a7a1346abc8c9268c37555e3b775511a8ea2

Signed-off-by: David Scott <dave@recoil.org>