### PR TITLE
graphql.0.1.0, graphql-lwt.0.1.0 and graphql-async.0.1.0 - via opam-publish

### DIFF
--- a/packages/graphql-async/graphql-async.0.1.0/descr
+++ b/packages/graphql-async/graphql-async.0.1.0/descr
@@ -1,0 +1,18 @@
+Execution of GraphQL queries in OCaml
+
+`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.
+
+**NB** Requires OCaml 4.03 or greater.
+
+Current feature set:
+
+- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- [x] Execution
+- [x] Introspection
+- [x] Arguments
+- [x] Variables
+- [x] Lwt support
+- [x] Async support
+- [x] Example with HTTP server and GraphiQL
+
+![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)

--- a/packages/graphql-async/graphql-async.0.1.0/descr
+++ b/packages/graphql-async/graphql-async.0.1.0/descr
@@ -1,18 +1,3 @@
-Execution of GraphQL queries in OCaml
+Build GraphQL schemas with Async support
 
-`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.
-
-**NB** Requires OCaml 4.03 or greater.
-
-Current feature set:
-
-- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
-- [x] Execution
-- [x] Introspection
-- [x] Arguments
-- [x] Variables
-- [x] Lwt support
-- [x] Async support
-- [x] Example with HTTP server and GraphiQL
-
-![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)
+`graphql-async` adds support for Async to `graphql`, so you can use Async in your GraphQL schema resolver functions.

--- a/packages/graphql-async/graphql-async.0.1.0/opam
+++ b/packages/graphql-async/graphql-async.0.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "graphql"
+  "async_kernel" {>= "v0.9.0"}
+  "alcotest" {test}
+  "async_unix" {test & >= "v0.9.0"}
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql-async/graphql-async.0.1.0/url
+++ b/packages/graphql-async/graphql-async.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.1.0/graphql-0.1.0.tbz"
+checksum: "07da45cbc0ade2a2d0182b66a8029239"

--- a/packages/graphql-lwt/graphql-lwt.0.1.0/descr
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/descr
@@ -1,0 +1,18 @@
+Execution of GraphQL queries in OCaml
+
+`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.
+
+**NB** Requires OCaml 4.03 or greater.
+
+Current feature set:
+
+- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- [x] Execution
+- [x] Introspection
+- [x] Arguments
+- [x] Variables
+- [x] Lwt support
+- [x] Async support
+- [x] Example with HTTP server and GraphiQL
+
+![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)

--- a/packages/graphql-lwt/graphql-lwt.0.1.0/descr
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/descr
@@ -1,18 +1,3 @@
-Execution of GraphQL queries in OCaml
+Build GraphQL schemas with Lwt support
 
-`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.
-
-**NB** Requires OCaml 4.03 or greater.
-
-Current feature set:
-
-- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
-- [x] Execution
-- [x] Introspection
-- [x] Arguments
-- [x] Variables
-- [x] Lwt support
-- [x] Async support
-- [x] Example with HTTP server and GraphiQL
-
-![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)
+`graphql-lwt` adds support for Lwt to `graphql`, so you can use Lwt in your GraphQL schema resolver functions.

--- a/packages/graphql-lwt/graphql-lwt.0.1.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "graphql"
+  "alcotest" {test}
+  "lwt"
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql-lwt/graphql-lwt.0.1.0/url
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.1.0/graphql-0.1.0.tbz"
+checksum: "07da45cbc0ade2a2d0182b66a8029239"

--- a/packages/graphql/graphql.0.1.0/descr
+++ b/packages/graphql/graphql.0.1.0/descr
@@ -1,0 +1,18 @@
+Execution of GraphQL queries in OCaml
+
+`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.
+
+**NB** Requires OCaml 4.03 or greater.
+
+Current feature set:
+
+- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- [x] Execution
+- [x] Introspection
+- [x] Arguments
+- [x] Variables
+- [x] Lwt support
+- [x] Async support
+- [x] Example with HTTP server and GraphiQL
+
+![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)

--- a/packages/graphql/graphql.0.1.0/descr
+++ b/packages/graphql/graphql.0.1.0/descr
@@ -1,18 +1,12 @@
-Execution of GraphQL queries in OCaml
+Build GraphQL schemas and execute queries against them
 
-`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.
+`graphql` is a package for creating GraphQL servers. Current feature set includes:
 
-**NB** Requires OCaml 4.03 or greater.
+- Type-safe schema design
+- GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- Query execution
+- Introspection of schemas
+- Arguments for fields
+- Allows variables in queries
 
-Current feature set:
-
-- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
-- [x] Execution
-- [x] Introspection
-- [x] Arguments
-- [x] Variables
-- [x] Lwt support
-- [x] Async support
-- [x] Example with HTTP server and GraphiQL
-
-![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)
+Use `graphql-lwt` for Lwt support, or `graphql-async` for Async support.

--- a/packages/graphql/graphql.0.1.0/opam
+++ b/packages/graphql/graphql.0.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "angstrom" {>= "0.4.0"}
+  "sexplib"
+  "ppx_sexp_conv" {>= "0.9.0"}
+  "yojson"
+  "rresult"
+  "alcotest" {test}
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql/graphql.0.1.0/url
+++ b/packages/graphql/graphql.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.1.0/graphql-0.1.0.tbz"
+checksum: "07da45cbc0ade2a2d0182b66a8029239"


### PR DESCRIPTION
Execution of GraphQL queries in OCaml

`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.

**NB** Requires OCaml 4.03 or greater.

Current feature set:

- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
- [x] Execution
- [x] Introspection
- [x] Arguments
- [x] Variables
- [x] Lwt support
- [x] Async support
- [x] Example with HTTP server and GraphiQL

![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)

---
* Homepage: https://github.com/andreas/ocaml-graphql-server
* Source repo: https://github.com/andreas/ocaml-graphql-server.git
* Bug tracker: https://github.com/andreas/ocaml-graphql-server/issues

---


---
0.1.0 2017-05-25
---------------------------------

Initial public release.
Pull-request generated by opam-publish v0.3.4