### PR TITLE
graphql-lwt.0.1.0 - via opam-publish

### DIFF
--- a/packages/graphql-lwt/graphql-lwt.0.1.0/descr
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/descr
@@ -1,0 +1,18 @@
+Execution of GraphQL queries in OCaml
+
+`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.
+
+**NB** Requires OCaml 4.03 or greater.
+
+Current feature set:
+
+- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- [x] Execution
+- [x] Introspection
+- [x] Arguments
+- [x] Variables
+- [x] Lwt support
+- [x] Async support
+- [x] Example with HTTP server and GraphiQL
+
+![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)

--- a/packages/graphql-lwt/graphql-lwt.0.1.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "graphql"
+  "alcotest" {test}
+  "lwt"
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql-lwt/graphql-lwt.0.1.0/url
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.1.0/graphql-0.1.0.tbz"
+checksum: "07da45cbc0ade2a2d0182b66a8029239"


### PR DESCRIPTION
Execution of GraphQL queries in OCaml

`ocaml-graphql-server` is a library for creating GraphQL servers. It's currently in an early, experimental stage.

**NB** Requires OCaml 4.03 or greater.

Current feature set:

- [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
- [x] Execution
- [x] Introspection
- [x] Arguments
- [x] Variables
- [x] Lwt support
- [x] Async support
- [x] Example with HTTP server and GraphiQL

![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)

---
* Homepage: https://github.com/andreas/ocaml-graphql-server
* Source repo: https://github.com/andreas/ocaml-graphql-server.git
* Bug tracker: https://github.com/andreas/ocaml-graphql-server/issues

---


---
0.1.0 2017-05-25
---------------------------------

Initial public release.
Pull-request generated by opam-publish v0.3.4