### PR TITLE
mirage-xen-console-cli: depend on cstruct-lwt

### DIFF
--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/opam
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/opam
@@ -16,6 +16,7 @@ depends: [
   "mirage-console-lwt" {>= "2.2.0"}
   "lwt"
   "cstruct"
+  "cstruct-lwt"
   "ipaddr"
   "io-page"
   "cmdliner"


### PR DESCRIPTION
part of #1954