### PR TITLE
hdf5.0.1.2 - via opam-publish

### DIFF
--- a/packages/hdf5/hdf5.0.1.2/descr
+++ b/packages/hdf5/hdf5.0.1.2/descr
@@ -1,0 +1,3 @@
+Manages HDF5 files used for storing large amounts of data
+
+The library manages reading and writing to HDF5 files. HDF5 file format is used for storing and organizing large amounts of data. Also provided is a fast way of working with large arrays of records, much faster than OCaml arrays of records.

--- a/packages/hdf5/hdf5.0.1.2/opam
+++ b/packages/hdf5/hdf5.0.1.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Vladimir Brankov <vbrankov@janestreet.com>"
+authors: "Vladimir Brankov <vbrankov@janestreet.com>"
+homepage: "https://github.com/vbrankov/hdf5-ocaml"
+bug-reports: "https://github.com/vbrankov/hdf5-ocaml/issues"
+license: "MIT"
+dev-repo: "git@github.com:vbrankov/hdf5-ocaml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "hdf5_caml"]
+  ["ocamlfind" "remove" "hdf5_raw"]
+]
+depends: [
+  "ocamlfind" {build}
+]
+depexts: [
+  [["homebrew" "osx"] ["homebrew/science/hdf5"]]
+  [["ubuntu"] ["libhdf5-serial-dev"]]
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/hdf5/hdf5.0.1.2/url
+++ b/packages/hdf5/hdf5.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vbrankov/hdf5-ocaml/archive/v0.1.2-alpha.tar.gz"
+checksum: "808d1cfa1ef41d20e463e05b9f3284a5"


### PR DESCRIPTION
Manages HDF5 files used for storing large amounts of data

The library manages reading and writing to HDF5 files. HDF5 file format is used for storing and organizing large amounts of data. Also provided is a fast way of working with large arrays of records, much faster than OCaml arrays of records.


---
* Homepage: https://github.com/vbrankov/hdf5-ocaml
* Source repo: git@github.com:vbrankov/hdf5-ocaml.git
* Bug tracker: https://github.com/vbrankov/hdf5-ocaml/issues

---

Pull-request generated by opam-publish v0.3.4