### PR TITLE
Add base-num and num packages

### DIFF
--- a/packages/base-num/base-num.base/descr
+++ b/packages/base-num/base-num.base/descr
@@ -1,0 +1,1 @@
+Num library distributed with the OCaml compiler

--- a/packages/base-num/base-num.base/opam
+++ b/packages/base-num/base-num.base/opam
@@ -1,0 +1,3 @@
+opam-version: "1"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+available: [ ocaml-version <= "4.0.5" ]

--- a/packages/base-num/base-num.base/opam
+++ b/packages/base-num/base-num.base/opam
@@ -1,3 +1,4 @@
 opam-version: "1"
 maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
-available: [ ocaml-version < "4.06.0" ]
+# Once Num is removed from the OCaml core distribution, reflect this below
+# available: [ ocaml-version < "4.06.0" ]

--- a/packages/base-num/base-num.base/opam
+++ b/packages/base-num/base-num.base/opam
@@ -1,3 +1,3 @@
 opam-version: "1"
 maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
-available: [ ocaml-version <= "4.0.5" ]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/num/num.0/descr
+++ b/packages/num/num.0/descr
@@ -1,0 +1,1 @@
+The Num library for arbitrary-precision integer and rational arithmetic

--- a/packages/num/num.0/opam
+++ b/packages/num/num.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "num"
+version: "0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Valérie Ménissier-Morain"
+  "Pierre Weis"
+  "Xavier Leroy"
+]
+license: "LGPL-2 with OCaml linking exception"
+
+homepage: "https://github.com/ocaml/ocaml"
+dev-repo: "https://github.com/ocaml/ocaml.git"
+bug-reports: "http://caml.inria.fr/mantis/"
+
+depends: [ "base-num" ]


### PR DESCRIPTION
The Num library for arbitrary-precision integer and rational arithmetic is currently part of the OCaml core distribution and automatically installed.  In the future, it will be removed from the core distribution and distributed separately, https://github.com/ocaml/num/ 

This pull request introduces two new packages:
* `base-num`, which is currently always available, but eventually will be made available only if `ocaml-version < N` where `N` is the OCaml release number where Num will be removed.
* `num`, which currently has only one version number 0 that just depends on `base-num`, but eventually will have versions 1.0 and up corresponding to the separately-distributed Num library and conflicting with `base-num`.

Once this PR is merged, we can proceed in two directions independently:
* Identify packages that use the Num library and add a dependency on package `num`.  (I identified about 50 of them so far.)
* Package the separately-distributed Num library as version 1.0 of package `num`.  Some minor issues with ocamlfind must be fixed first.