### PR TITLE
mirage-xen-console-cli: <cstruct.3.0

### DIFF
--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/opam
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-console" {>= "2.2.0"}
   "mirage-console-lwt" {>= "2.2.0"}
   "lwt"
-  "cstruct"
+  "cstruct" {<"3.0.0"}
   "cstruct-lwt"
   "ipaddr"
   "io-page"


### PR DESCRIPTION
requires a new release to link to cstruct.lwt explictly

revdeps for #9154