### PR TITLE
utop.2.0.0 - via opam-publish

### DIFF
--- a/packages/utop/utop.2.0.0/descr
+++ b/packages/utop/utop.2.0.0/descr
@@ -1,0 +1,6 @@
+Universal toplevel for OCaml
+utop is an improved toplevel for OCaml. It can run in a terminal or in
+Emacs. It supports line edition, history, real-time and context
+sensitive completion, colors, and more.
+
+It integrates with the tuareg mode in Emacs.

--- a/packages/utop/utop.2.0.0/opam
+++ b/packages/utop/utop.2.0.0/opam
@@ -12,12 +12,11 @@ build: [
 depends: [
   "base-unix"
   "base-threads"
-  "ocamlfind"    {>= "1.4.0"}
+  "ocamlfind"    {>= "1.7.2"}
   "lambda-term"  {>= "1.2"}
   "lwt"
   "react"        {>= "1.0.0"}
   "cppo"         {build & >= "1.1.2"}
-  "findlib"      {>= "1.7.2"}
   "jbuilder"     {build & >= "1.0+beta9"}
 ]
 available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/utop/utop.2.0.0/opam
+++ b/packages/utop/utop.2.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/utop"
+bug-reports: "https://github.com/diml/utop/issues"
+dev-repo: "git://github.com/diml/utop.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base-unix"
+  "base-threads"
+  "ocamlfind"    {>= "1.4.0"}
+  "lambda-term"  {>= "1.2"}
+  "lwt"
+  "react"        {>= "1.0.0"}
+  "cppo"         {build & >= "1.1.2"}
+  "findlib"      {>= "1.7.2"}
+  "jbuilder"     {build & >= "1.0+beta9"}
+]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/utop/utop.2.0.0/url
+++ b/packages/utop/utop.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/utop/releases/download/2.0.0/utop-2.0.0.tbz"
+checksum: "3b7c56ac3aaea9f79947f98d43487707"


### PR DESCRIPTION
Universal toplevel for OCaml
utop is an improved toplevel for OCaml. It can run in a terminal or in
Emacs. It supports line edition, history, real-time and context
sensitive completion, colors, and more.

It integrates with the tuareg mode in Emacs.


---
* Homepage: https://github.com/diml/utop
* Source repo: git://github.com/diml/utop.git
* Bug tracker: https://github.com/diml/utop/issues

---


---
2.0.0 (2016-05-26)
------------------

* Add `-implicit-bindings` option to automatically bind expressions to names
  `_0`, `_1` and so on. For example, `3 + 4;;` becomes `let _0 = 3 + 4;;`
  (#161, #193, Fabian Hemmer)
* Add tab completion for `#mod_use` (#181, Leonid Rozenberg)
* Mention `#help` in `#utop_help` (#190, Fabian Hemmer)
* Add `#utop_stash` and `#utop_save` to save the session to a file
  (#169, #199, Christopher Mcalpine and Fabian Hemmer)
* Fix a bug where utop wouldn't apply ppx rewriters when running in
  emacs (Bug report: #192, fix: #202, Deokhwan Kim)
* Drop support for camlp4/camlp5
* Drop support for OCaml <= 4.01
* Switch the build system to jbuilder
* Resurect `UTop_main.interact`
Pull-request generated by opam-publish v0.3.4