### PR TITLE
Package opam-bundle.0.1

### DIFF
--- a/packages/opam-bundle/opam-bundle.0.1/descr
+++ b/packages/opam-bundle/opam-bundle.0.1/descr
@@ -1,0 +1,1 @@
+A tool that creates stand-alone source bundles from opam packages

--- a/packages/opam-bundle/opam-bundle.0.1/opam
+++ b/packages/opam-bundle/opam-bundle.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/AltGr/opam-bundle"
+bug-reports: "https://github.com/AltGr/opam-bundle/issues"
+license: "GPL-3"
+tags: ["org:ocamlpro" "flags:plugin"]
+dev-repo: "https://github.com/AltGr/opam-bundle.git"
+build: [make]
+depends: [
+  "ocamlfind"
+  "cmdliner"
+  "opam-client" {>= "2.0.0~beta3.1"}
+]

--- a/packages/opam-bundle/opam-bundle.0.1/url
+++ b/packages/opam-bundle/opam-bundle.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/opam-bundle/archive/0.1.tar.gz"
+checksum: "618f6cdb0648f80fe98dc6ea1a4ae291"


### PR DESCRIPTION
### `opam-bundle.0.1`

A tool that creates stand-alone source bundles from opam packages



---
* Homepage: https://github.com/AltGr/opam-bundle
* Source repo: https://github.com/AltGr/opam-bundle.git
* Bug tracker: https://github.com/AltGr/opam-bundle/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.4