### PR TITLE
vpnkit: upper bounds on tar-format

### DIFF
--- a/packages/vpnkit/vpnkit.0.0.0/opam
+++ b/packages/vpnkit/vpnkit.0.0.0/opam
@@ -32,7 +32,7 @@ depends: [
   "oasis"      {build}
   "alcotest"   {test}
   "result"
-  "tar-format"
+  "tar-format" {>="0.6.0" & <"0.7.0"}
   "ipaddr"
   "lwt" { < "2.7.0" }
   "uwt" { = "0.0.3" }


### PR DESCRIPTION
part of #9338 revdeps on tar-format, and #9154 more broadly

cc @djs55