### PR TITLE
Added new cloudi.1.7.1-rc1

### DIFF
--- a/packages/cloudi/cloudi.1.7.1-rc1/descr
+++ b/packages/cloudi/cloudi.1.7.1-rc1/descr
@@ -1,0 +1,1 @@
+OCaml CloudI API

--- a/packages/cloudi/cloudi.1.7.1-rc1/opam
+++ b/packages/cloudi/cloudi.1.7.1-rc1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "cloudi"
+version: "1.7.1-rc1"
+maintainer: "Michael Truog <mjtruog@gmail.com>"
+authors: "Michael Truog <mjtruog@gmail.com>"
+homepage: "http://cloudi.org/"
+bug-reports: "https://github.com/CloudI/CloudI/issues"
+license: "BSD"
+dev-repo: "https://github.com/CloudI/cloudi_api_ocaml.git"
+build: [
+  [make]
+]
+remove: ["ocamlfind" "remove" "cloudi"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/cloudi/cloudi.1.7.1-rc1/url
+++ b/packages/cloudi/cloudi.1.7.1-rc1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/CloudI/cloudi_api_ocaml/archive/v1.7.1-rc1.tar.gz"
+checksum: "64c6f06b373813d89af3ec258413f1ed"


### PR DESCRIPTION
This is the first version added of the OCaml CloudI API to make OCaml development a bit easier with CloudI (http://cloudi.org)