### PR TITLE
utop.2.0.1 - via opam-publish

### DIFF
--- a/packages/utop/utop.2.0.1/descr
+++ b/packages/utop/utop.2.0.1/descr
@@ -1,0 +1,6 @@
+Universal toplevel for OCaml
+utop is an improved toplevel for OCaml. It can run in a terminal or in
+Emacs. It supports line edition, history, real-time and context
+sensitive completion, colors, and more.
+
+It integrates with the tuareg mode in Emacs.

--- a/packages/utop/utop.2.0.1/opam
+++ b/packages/utop/utop.2.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/utop"
+bug-reports: "https://github.com/diml/utop/issues"
+dev-repo: "git://github.com/diml/utop.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base-unix"
+  "base-threads"
+  "ocamlfind"    {>= "1.7.2"}
+  "lambda-term"  {>= "1.2"}
+  "lwt"
+  "react"        {>= "1.0.0"}
+  "cppo"         {build & >= "1.1.2"}
+  "jbuilder"     {build & >= "1.0+beta9"}
+]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/utop/utop.2.0.1/url
+++ b/packages/utop/utop.2.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/utop/releases/download/2.0.1/utop-2.0.1.tbz"
+checksum: "ae165a2a41e3bdfce545698225caed1e"


### PR DESCRIPTION
Universal toplevel for OCaml
utop is an improved toplevel for OCaml. It can run in a terminal or in
Emacs. It supports line edition, history, real-time and context
sensitive completion, colors, and more.

It integrates with the tuareg mode in Emacs.


---
* Homepage: https://github.com/diml/utop
* Source repo: git://github.com/diml/utop.git
* Bug tracker: https://github.com/diml/utop/issues

---


---
2.0.1 (2016-05-30)
------------------

* Fix: restore the installation of `utop.el` (#210, Louis Gesbert)
Pull-request generated by opam-publish v0.3.4