### PR TITLE
mirage-xen: add upper bound on shared-memory-ring

### DIFF
--- a/packages/mirage-xen/mirage-xen.0.9.1/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.1/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
-  "shared-memory-ring" {>= "0.4.0"}
+  "shared-memory-ring" {>= "0.4.0" & < "2.0.0"}
   "xenstore" {<= "1.2.1"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-xen/mirage-xen.0.9.2/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.2/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
-  "shared-memory-ring" {>= "0.4.0"}
+  "shared-memory-ring" {>= "0.4.0" & < "2.0.0"}
   "xenstore" {<= "1.2.1"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-xen/mirage-xen.0.9.3/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.3/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
-  "shared-memory-ring" {>= "0.4.0"}
+  "shared-memory-ring" {>= "0.4.0" & < "2.0.0"}
   "xenstore" {<= "1.2.1"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-xen/mirage-xen.0.9.4/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.4/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
-  "shared-memory-ring" {>= "0.4.1"}
+  "shared-memory-ring" {>= "0.4.1" & < "2.0.0"}
   "xenstore" {= "1.2.2"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-xen/mirage-xen.0.9.5/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.5/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
-  "shared-memory-ring" {>= "0.4.1"}
+  "shared-memory-ring" {>= "0.4.1" & < "2.0.0"}
   "xenstore" {= "1.2.2"}
   "ipaddr" {>= "0.2.2"}
   "ocamlbuild" {build}

--- a/packages/mirage-xen/mirage-xen.0.9.6/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.6/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0"}
-  "shared-memory-ring" {>= "0.4.1"}
+  "shared-memory-ring" {>= "0.4.1" & < "2.0.0"}
   "xenstore" {>= "1.2.3"}
   "ipaddr" {>= "0.2.2"}
   "ocamlbuild" {build}

--- a/packages/mirage-xen/mirage-xen.0.9.7/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.7/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "0.4.3"}
+  "shared-memory-ring" {>= "0.4.3" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "ipaddr" {>= "0.2.2"}
   "ocamlbuild" {build}

--- a/packages/mirage-xen/mirage-xen.0.9.8/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.8/opam
@@ -6,7 +6,7 @@ depends: [
   "cstruct" {>= "0.8.1"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "0.4.3"}
+  "shared-memory-ring" {>= "0.4.3" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "ipaddr" {>= "0.2.3"}
   "ocamlbuild" {build}

--- a/packages/mirage-xen/mirage-xen.0.9.9/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.9/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page-xen" {>= "0.9.9"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "0.4.3"}
+  "shared-memory-ring" {>= "0.4.3" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-xen/mirage-xen.1.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.1.0.0/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page-xen" {>= "0.9.9"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "0.4.3"}
+  "shared-memory-ring" {>= "0.4.3" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-xen/mirage-xen.1.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.1.1.0/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "0.9.9"}

--- a/packages/mirage-xen/mirage-xen.1.1.1/opam
+++ b/packages/mirage-xen/mirage-xen.1.1.1/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "0.9.9"}

--- a/packages/mirage-xen/mirage-xen.2.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.0.0/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.0.1/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.0/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.1/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.2/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.1.3/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.3/opam
@@ -8,7 +8,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.2.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.2.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.2/opam
@@ -15,7 +15,7 @@ depends: [
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.3.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.3.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.1/opam
@@ -13,7 +13,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.3.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.2/opam
@@ -13,7 +13,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.3.3/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.3/opam
@@ -13,7 +13,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.4.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.4.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.4.1/opam
@@ -16,7 +16,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.2.6.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-xen" {>= "1.0.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.3.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "mirage-clock-freestanding" {>= "1.2.0"}
   "lwt" {>= "2.4.3"}
-  "shared-memory-ring" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
   "xen-gnt" {>= "2.0.0"}


### PR DESCRIPTION
In shared-memory-ring.2.0.0 the findlib subpackage has become a top-level
package.

Signed-off-by: David Scott <dave@recoil.org>