### PR TITLE
coq-.8.4.6~camlp4: restrict ocaml version

### DIFF
--- a/packages/coq/coq.8.4.6~camlp4/opam
+++ b/packages/coq/coq.8.4.6~camlp4/opam
@@ -31,5 +31,5 @@ depends: [
 conflicts: [
   "camlp5"
 ]
-available: [ ocaml-version >= "3.11.2" ] # According to INSTALL file
+available: [ ocaml-version >= "3.11.2" & ocaml-version < "4.03.0" ] # fatal warning-as-error after this version
 install: ["%{make}%" "install"]


### PR DESCRIPTION
otherwise it triggers a fatal warning `Warning 3: deprecated: Pervasives.&`

part of #9341 revdeps