### PR TITLE
ocaml-topexpect.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-topexpect/ocaml-topexpect.0.1/descr
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.1/descr
@@ -1,0 +1,3 @@
+Simulate and post-process ocaml toplevel sessions
+
+A variant of ocaml-expect from toplevel_expect_test that mimics ocaml toplevel more closely

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.1/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/topexpect"
+bug-reports: "https://github.com/let-def/topexpect"
+license: "MIT"
+dev-repo: "https://github.com/let-def/topexpect.git"
+build: [make]
+depends: [
+  "ocamlfind" {build}
+  "ppx_sexp_conv"
+  "ppx_deriving"
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.1/url
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/topexpect/archive/v0.1.tar.gz"
+checksum: "74d48a6387b38b4c5dfd23be14167b8a"


### PR DESCRIPTION
Simulate and post-process ocaml toplevel sessions

A variant of ocaml-expect from toplevel_expect_test that mimics ocaml toplevel more closely


---
* Homepage: https://github.com/let-def/topexpect
* Source repo: https://github.com/let-def/topexpect.git
* Bug tracker: https://github.com/let-def/topexpect

---

Pull-request generated by opam-publish v0.3.4