### PR TITLE
kaputt.1.1: warning-failure on String.copy deprecation

### DIFF
--- a/packages/kaputt/kaputt.1.1/opam
+++ b/packages/kaputt/kaputt.1.1/opam
@@ -4,9 +4,10 @@ build: [
   ["sh" "configure"]
   [make]
 ]
+install: [make "install"]
 remove: [["ocamlfind" "remove" "kaputt"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build]
   "ocamlbuild" {build}
 ]
-install: [make "install"]
+available: [ocaml-version <"4.02.0"]


### PR DESCRIPTION
found as part of #9341 revdeps