### PR TITLE
pfff: only compiles < 4.03.0 due to warnings-as-errors

### DIFF
--- a/packages/pfff/pfff.0.29/opam
+++ b/packages/pfff/pfff.0.29/opam
@@ -20,6 +20,6 @@ remove: [
   [make "uninstall-findlib"]
 ]
 depends: ["ocamlfind" "camlp4"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.03.0"]
 bug-reports: "https://github.com/facebook/pfff/issues"
 dev-repo: "https://github.com/facebook/pfff.git"


### PR DESCRIPTION
part of revdeps for #9341