### PR TITLE
odig.0.0.2 - via opam-publish

### DIFF
--- a/packages/odig/odig.0.0.2/descr
+++ b/packages/odig/odig.0.0.2/descr
@@ -1,0 +1,7 @@
+Mine installed OCaml packages
+
+odig is a library and command line tool to mine installed OCaml
+packages. It supports package distribution documentation and metadata
+lookups and generates cross-referenced API documentation.
+
+odig is distributed under the ISC license.

--- a/packages/odig/odig.0.0.2/opam
+++ b/packages/odig/odig.0.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/odig"
+doc: "http://erratique.ch/software/odig/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/odig.git"
+bug-reports: "https://github.com/dbuenzli/odig/issues"
+tags: [ "org:erratique" "build" "dev" "meta" "doc" "packaging" ]
+available: [ ocaml-version >= "4.03"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-unix"
+  "rresult" {>= "0.5.0"}
+  "asetmap"
+  "fpath"
+  "fmt"
+  "logs"
+  "bos"
+  "cmdliner" {>= "1.0.0"}
+  "mtime" {>= "1.0.0"}
+  "webbrowser"
+  "opam-format"
+]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+           "--etc-dir" "%{odig:etc}%"
+           "--lib-dir" "%{lib}%" ]

--- a/packages/odig/odig.0.0.2/url
+++ b/packages/odig/odig.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/odig/releases/odig-0.0.2.tbz"
+checksum: "c5e309797e91580a87922916d89835ea"


### PR DESCRIPTION
Mine installed OCaml packages

odig is a library and command line tool to mine installed OCaml
packages. It supports package distribution documentation and metadata
lookups and generates cross-referenced API documentation.

odig is distributed under the ISC license.


---
* Homepage: http://erratique.ch/software/odig
* Source repo: http://erratique.ch/repos/odig.git
* Bug tracker: https://github.com/dbuenzli/odig/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them: "odig"

---


---
v0.0.2 2017-05-31 Cambridge (UK)
--------------------------------

- Added experimental data-driven toplevel loaders.
- The `odoc` API documentation is shown by default on `odig doc`.
- The `mli`, `cmi`, `cmo`, `cmti`, `cmx` and `cmt` commands are grouped in
  the `cobjs` command.
- Track latest cmdliner and mtime.
Pull-request generated by opam-publish v0.3.4