### PR TITLE
mirage-console-xen-backend: add upper bound on shared-memory-ring

### DIFF
--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.2.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.2.0/opam
@@ -17,5 +17,5 @@ depends: [
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-console-xen-proto" {>= "2.2.0"}
   "lwt"
-  "xenstore" "xen-evtchn" "xen-gnt" "shared-memory-ring"
+  "xenstore" "xen-evtchn" "xen-gnt" "shared-memory-ring" {< "2.0.0"}
 ]


### PR DESCRIPTION
Signed-off-by: David Scott <dave@recoil.org>