### PR TITLE
rml: constrain old rml to !linux since they do not work with gnu patch

### DIFF
--- a/packages/rml/rml.1.09.00/opam
+++ b/packages/rml/rml.1.09.00/opam
@@ -8,3 +8,4 @@ build: [
 remove: [[make "uninstall"]]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install"]
+available: [ os != "linux" ]

--- a/packages/rml/rml.1.09.01/opam
+++ b/packages/rml/rml.1.09.01/opam
@@ -8,3 +8,4 @@ build: [
 remove: [[make "uninstall"]]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install"]
+available: [ os != "linux" ]

--- a/packages/rml/rml.1.09.02/opam
+++ b/packages/rml/rml.1.09.02/opam
@@ -10,3 +10,4 @@ remove: [
 ]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install"]
+available: [ os != "linux" ]

--- a/packages/rml/rml.1.09.03/opam
+++ b/packages/rml/rml.1.09.03/opam
@@ -11,3 +11,4 @@ remove: [
 ]
 depends: ["ocamlbuild"]
 install: [make "install"]
+available: [ os != "linux" ]


### PR DESCRIPTION
the issue with patching has been fixed in rml.1.09.04, so this
constraint helps the CI skip trying to build older versions, but
lets them remain on option on other operating systems that may have
a compliant patch binary for it.

found as part of revdeps for #9341