### PR TITLE
Building utop 2.0 still requires lambda-term >= 1.9

### DIFF
--- a/packages/nebula/nebula.0.2.1/opam
+++ b/packages/nebula/nebula.0.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ounit" {test & >= "2.0.0"}
   "ppx_deriving" {>= "2.2"}
   "tsdl" {>= "0.8.1" & < "0.9.0"}
-  "utop" {>= "1.18"}
+  "utop" {>= "1.18" & < "2.0"}
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/reason/reason.1.11.0/opam
+++ b/packages/reason/reason.1.11.0/opam
@@ -32,7 +32,7 @@ build-test: [
 depends: [
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & <= "20170101"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}

--- a/packages/reason/reason.1.11.0/opam
+++ b/packages/reason/reason.1.11.0/opam
@@ -31,7 +31,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "menhir" {>= "20160303"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}

--- a/packages/reason/reason.1.13.2/opam
+++ b/packages/reason/reason.1.13.2/opam
@@ -30,7 +30,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}

--- a/packages/reason/reason.1.13.3/opam
+++ b/packages/reason/reason.1.13.3/opam
@@ -30,7 +30,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}

--- a/packages/reason/reason.1.13.4/opam
+++ b/packages/reason/reason.1.13.4/opam
@@ -30,7 +30,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {>= "0.8.1" & < "0.9"}

--- a/packages/reason/reason.1.13.5/opam
+++ b/packages/reason/reason.1.13.5/opam
@@ -30,7 +30,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3"}
   "result" {= "1.2"}
   "topkg" {>= "0.8.1" & < "0.9"}

--- a/packages/reason/reason.1.3.0/opam
+++ b/packages/reason/reason.1.3.0/opam
@@ -28,7 +28,7 @@ build-test: [
 depends: [
   "easy-format" {>= "1.2.0"}
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "BetterErrors" {>= "0.0.1"}
   "menhir" {>= "20160303"}
   "merlin" {>= "2.5.0"}

--- a/packages/reason/reason.1.4.0/opam
+++ b/packages/reason/reason.1.4.0/opam
@@ -28,7 +28,7 @@ build-test: [
 depends: [
   "easy-format" {>= "1.2.0"}
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "BetterErrors" {>= "0.0.1"}
   "menhir" {>= "20160303"}
   "merlin" {>= "2.5.0"}

--- a/packages/reason/reason.1.7.4/opam
+++ b/packages/reason/reason.1.7.4/opam
@@ -27,7 +27,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "utop" {>= "1.17"}
+  "utop" {>= "1.17" & < "2.0"}
   "menhir" {>= "20160303"}
   "merlin-extend" {>= "0.3"}
 ]

--- a/packages/utop/utop.2.0.0/opam
+++ b/packages/utop/utop.2.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind"    {>= "1.7.2"}
-  "lambda-term"  {>= "1.2"}
+  "lambda-term"  {>= "1.9"}
   "lwt"
   "react"        {>= "1.0.0"}
   "cppo"         {build & >= "1.1.2"}

--- a/packages/utop/utop.2.0.1/opam
+++ b/packages/utop/utop.2.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind"    {>= "1.7.2"}
-  "lambda-term"  {>= "1.2"}
+  "lambda-term"  {>= "1.9"}
   "lwt"
   "react"        {>= "1.0.0"}
   "cppo"         {build & >= "1.1.2"}


### PR DESCRIPTION
Won't build with earlier versions of lambda-term. Surprisingly, earlier versions of utop already had a dependency on lambda-term >= 1.9.

cc @diml 