### PR TITLE
DNS packaging fixes for ipaddr and uri releases

### DIFF
--- a/packages/dns/dns.0.10.0/opam
+++ b/packages/dns/dns.0.10.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.2.0"}
+  "ipaddr" {>= "2.2.0" & <"2.8.0"}
   "io-page"
   "base64" {< "2.0.0"}
   "ocamlbuild" {build}

--- a/packages/dns/dns.0.11.0/opam
+++ b/packages/dns/dns.0.11.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.2.0"}
+  "ipaddr" {>= "2.2.0" & <"2.8.0"}
   "base64" {< "2.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/dns/dns.0.12.0/opam
+++ b/packages/dns/dns.0.12.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.2.0"}
+  "ipaddr" {>= "2.2.0" & <"2.8.0"}
   "base64" {>= "2.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/dns/dns.0.13.0/opam
+++ b/packages/dns/dns.0.13.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.2.0"}
+  "ipaddr" {>= "2.2.0" & <"2.8.0"}
   "base64" {>= "2.0.0"}
   "ounit"
   "pcap-format" {test}

--- a/packages/dns/dns.0.14.0/opam
+++ b/packages/dns/dns.0.14.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.2.0"}
+  "ipaddr" {>= "2.2.0" & <"2.8.0"}
   "base64" {>= "2.0.0"}
   "ounit"
   "pcap-format" {test}

--- a/packages/dns/dns.0.14.1/opam
+++ b/packages/dns/dns.0.14.1/opam
@@ -32,7 +32,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.2.0"}
+  "ipaddr" {>= "2.2.0" & <"2.8.0"}
   "base64" {>= "2.0.0"}
   "ounit"
   "pcap-format" {test}

--- a/packages/dns/dns.0.15.0/opam
+++ b/packages/dns/dns.0.15.0/opam
@@ -35,7 +35,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "ounit"
   "pcap-format" {test}

--- a/packages/dns/dns.0.15.0/opam
+++ b/packages/dns/dns.0.15.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "ounit"

--- a/packages/dns/dns.0.15.1/opam
+++ b/packages/dns/dns.0.15.1/opam
@@ -40,7 +40,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "ounit"
   "pcap-format" {test}

--- a/packages/dns/dns.0.15.1/opam
+++ b/packages/dns/dns.0.15.1/opam
@@ -39,7 +39,7 @@ depends: [
   "ocamlfind"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "ounit"

--- a/packages/dns/dns.0.15.2/opam
+++ b/packages/dns/dns.0.15.2/opam
@@ -42,7 +42,7 @@ depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"

--- a/packages/dns/dns.0.15.2/opam
+++ b/packages/dns/dns.0.15.2/opam
@@ -43,7 +43,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"
   "ounit" {test}

--- a/packages/dns/dns.0.15.3/opam
+++ b/packages/dns/dns.0.15.3/opam
@@ -39,8 +39,8 @@ depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"
   "ounit" {test}

--- a/packages/dns/dns.0.16.0/opam
+++ b/packages/dns/dns.0.16.0/opam
@@ -42,7 +42,7 @@ depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"

--- a/packages/dns/dns.0.16.0/opam
+++ b/packages/dns/dns.0.16.0/opam
@@ -43,7 +43,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"
   "ounit" {test}

--- a/packages/dns/dns.0.17.0/opam
+++ b/packages/dns/dns.0.17.0/opam
@@ -44,7 +44,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"
   "hashcons"

--- a/packages/dns/dns.0.17.0/opam
+++ b/packages/dns/dns.0.17.0/opam
@@ -43,7 +43,7 @@ depends: [
   "cstruct" {>= "1.0.1" & <"2.0.0"}
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"

--- a/packages/dns/dns.0.18.0/opam
+++ b/packages/dns/dns.0.18.0/opam
@@ -45,7 +45,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"
   "hashcons"

--- a/packages/dns/dns.0.18.0/opam
+++ b/packages/dns/dns.0.18.0/opam
@@ -44,7 +44,7 @@ depends: [
   "ppx_tools"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"

--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -51,7 +51,7 @@ depends: [
   "ppx_tools"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"

--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -52,7 +52,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"
   "hashcons"

--- a/packages/dns/dns.0.19.0/opam
+++ b/packages/dns/dns.0.19.0/opam
@@ -46,7 +46,7 @@ depends: [
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0"}
-  "uri" {>= "1.7.0"}
+  "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"
   "hashcons"

--- a/packages/dns/dns.0.19.0/opam
+++ b/packages/dns/dns.0.19.0/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_tools"
   "re"
   "cmdliner"
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & <"2.8.0"}
   "uri" {>= "1.7.0" & <"1.9.4"}
   "base64" {>= "2.0.0"}
   "mirage-profile"

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -40,7 +40,7 @@ depends: [
   "cstruct"          {>= "2.0.0"}
   "re"
   "ipaddr"           {>= "2.6.0"}
-  "uri"              {>= "1.7.0"}
+  "uri"              {>= "1.7.0" & <"1.9.4"}
   "base64"           {>= "2.0.0"}
   "hashcons"
   "result"

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -39,7 +39,7 @@ depends: [
   "base-bytes"
   "cstruct"          {>= "2.0.0"}
   "re"
-  "ipaddr"           {>= "2.6.0"}
+  "ipaddr"           {>= "2.6.0" & <"2.8.0"}
   "uri"              {>= "1.7.0" & <"1.9.4"}
   "base64"           {>= "2.0.0"}
   "hashcons"

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -39,7 +39,7 @@ depends: [
   "cstruct"          {>= "2.0.0"}
   "ppx_cstruct"
   "re"
-  "ipaddr"           {>= "2.6.0"}
+  "ipaddr"           {>= "2.6.0" & <"2.8.0"}
   "uri"              {>= "1.7.0" & <"1.9.4"}
   "base64"           {>= "2.0.0"}
   "hashcons"

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -40,7 +40,7 @@ depends: [
   "ppx_cstruct"
   "re"
   "ipaddr"           {>= "2.6.0"}
-  "uri"              {>= "1.7.0"}
+  "uri"              {>= "1.7.0" & <"1.9.4"}
   "base64"           {>= "2.0.0"}
   "hashcons"
   "result"

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -41,7 +41,7 @@ depends: [
   "cstruct"          {>= "2.0.0"}
   "ppx_cstruct"      {build}
   "re"
-  "ipaddr"           {>= "2.6.0"}
+  "ipaddr"           {>= "2.6.0" & <"2.8.0"}
   "uri"              {>= "1.7.0" & <"1.9.4"}
   "base64"           {>= "2.0.0"}
   "hashcons"

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -42,7 +42,7 @@ depends: [
   "ppx_cstruct"      {build}
   "re"
   "ipaddr"           {>= "2.6.0"}
-  "uri"              {>= "1.7.0"}
+  "uri"              {>= "1.7.0" & <"1.9.4"}
   "base64"           {>= "2.0.0"}
   "hashcons"
   "result"


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/9378 for the URI revdep 