### PR TITLE
dns.0.19.[0|1]: upper bound cstruct due to cstruct-lwt depopts

### DIFF
--- a/packages/dns/dns.0.19.0/opam
+++ b/packages/dns/dns.0.19.0/opam
@@ -40,7 +40,7 @@ depends: [
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & <"3.0.0"}
   "ppx_cstruct"
   "ppx_tools"
   "re"

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -37,7 +37,7 @@ depends: [
   "ppx_cstruct"      {build}
   "ppx_deriving"     {build}
   "base-bytes"
-  "cstruct"          {>= "2.0.0"}
+  "cstruct"          {>= "2.0.0" & < "3.0.0"}
   "re"
   "ipaddr"           {>= "2.6.0" & <"2.8.0"}
   "uri"              {>= "1.7.0" & <"1.9.4"}


### PR DESCRIPTION
follow up to https://github.com/ocaml/opam-repository/pull/9380