### PR TITLE
shared-memory-ring: the minimum cstruct dependency is >=2.4.0

### DIFF
--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.2.0.0/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.2.0.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "2.4.1"}	
   "shared-memory-ring" {= "2.0.0"}
   "lwt"
   "mirage-profile"

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
@@ -15,8 +15,8 @@ build: [
 depends: [
   "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
-  "cstruct" {>= "1.9.0"}
-  "ppx_tools"
+  "cstruct" {>= "2.4.1"}
+  "ppx_cstruct" {build}
   "mirage-profile"
   "ounit" {test}
 ]


### PR DESCRIPTION
This is the one that added jbuilder support via ppx_deriving
cc @djs55

