### PR TITLE
vchan: add missing upper bounds on xen-gnt

### DIFF
--- a/packages/vchan/vchan.0.9.5/opam
+++ b/packages/vchan/vchan.0.9.5/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "vchan"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "mirage" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.0.9.5/opam
+++ b/packages/vchan/vchan.0.9.5/opam
@@ -15,6 +15,8 @@ install: [make "install"]
 remove: [["ocamlfind" "remove" "vchan"]]
 depends: [
   "ocamlfind" {build}
+  "cstruct" {<= "1.9.0"}
+  "camlp4" {build}
   "mirage" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.0.9.5/opam
+++ b/packages/vchan/vchan.0.9.5/opam
@@ -19,12 +19,9 @@ depends: [
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"
-  "xen-evtchn" {>= "1.0.3"}
-  "xen-gnt"
+  "xen-evtchn" {>= "1.0.3" & < "2.0.0"}
+  "xen-gnt" {< "2.0.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.00.1"]
-conflicts: [
-"xen-evtchn" {>= "2.0.0"}
-]

--- a/packages/vchan/vchan.0.9.6/opam
+++ b/packages/vchan/vchan.0.9.6/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "vchan"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "mirage-types" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.0.9.6/opam
+++ b/packages/vchan/vchan.0.9.6/opam
@@ -19,8 +19,8 @@ depends: [
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"
-  "xen-evtchn" {>= "1.0.3"}
-  "xen-gnt"
+  "xen-evtchn" {>= "1.0.3" & < "2.0.0"}
+  "xen-gnt" { < "2.0.0" }
   "cmdliner"
   "lwt" {>= "2.4.4"}
   "ipaddr" {>= "1.0.0"}
@@ -29,6 +29,3 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.00.1"]
-conflicts: [
-"xen-evtchn" {>= "2.0.0"}
-]

--- a/packages/vchan/vchan.0.9.6/opam
+++ b/packages/vchan/vchan.0.9.6/opam
@@ -25,6 +25,7 @@ depends: [
   "lwt" {>= "2.4.4"}
   "ipaddr" {>= "1.0.0"}
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
+  "camlp4" {build}
   "type_conv"
   "ocamlbuild" {build}
 ]

--- a/packages/vchan/vchan.0.9.7/opam
+++ b/packages/vchan/vchan.0.9.7/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "vchan"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "mirage-types" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.0.9.7/opam
+++ b/packages/vchan/vchan.0.9.7/opam
@@ -19,8 +19,8 @@ depends: [
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"
-  "xen-evtchn" {>= "1.0.3"}
-  "xen-gnt"
+  "xen-evtchn" {>= "1.0.3" & < "2.0.0"}
+  "xen-gnt" {< "2.0.0"}
   "cmdliner"
   "lwt" {>= "2.4.4"}
   "ipaddr" {>= "1.0.0"}
@@ -30,6 +30,3 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.00.1"]
-conflicts: [
-"xen-evtchn" {>= "2.0.0"}
-]

--- a/packages/vchan/vchan.1.0.0/opam
+++ b/packages/vchan/vchan.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "vchan"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "mirage-types" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.1.0.0/opam
+++ b/packages/vchan/vchan.1.0.0/opam
@@ -19,8 +19,8 @@ depends: [
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"
-  "xen-evtchn" {>= "1.0.3"}
-  "xen-gnt"
+  "xen-evtchn" {>= "1.0.3" & < "2.0.0"}
+  "xen-gnt" {< "2.0.0" }
   "cmdliner"
   "lwt" {>= "2.4.4"}
   "ipaddr" {>= "1.0.0"}
@@ -30,6 +30,3 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.00.1"]
-conflicts: [
-"xen-evtchn" {>= "2.0.0"}
-]

--- a/packages/vchan/vchan.2.0.0/opam
+++ b/packages/vchan/vchan.2.0.0/opam
@@ -32,4 +32,5 @@ available: [ocaml-version >= "4.00.1"]
 conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
+  "xen-gnt"    {>= "2.0.0"}
 ]

--- a/packages/vchan/vchan.2.0.0/opam
+++ b/packages/vchan/vchan.2.0.0/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "vchan"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.4" & < "2.5.0"}
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"

--- a/packages/vchan/vchan.2.0.1/opam
+++ b/packages/vchan/vchan.2.0.1/opam
@@ -32,4 +32,5 @@ available: [ocaml-version >= "4.00.1"]
 conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
+  "xen-gnt"    {>= "2.0.0"}
 ]

--- a/packages/vchan/vchan.2.0.1/opam
+++ b/packages/vchan/vchan.2.0.1/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "vchan"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.4" & < "2.5.0"}
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"

--- a/packages/vchan/vchan.2.0.2/opam
+++ b/packages/vchan/vchan.2.0.2/opam
@@ -32,4 +32,5 @@ available: [ocaml-version >= "4.00.1"]
 conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
+  "xen-gnt"    {>= "2.0.0"}
 ]

--- a/packages/vchan/vchan.2.0.2/opam
+++ b/packages/vchan/vchan.2.0.2/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "vchan"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.4.4" & < "2.5.0"}
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"

--- a/packages/vchan/vchan.2.0.3/opam
+++ b/packages/vchan/vchan.2.0.3/opam
@@ -35,6 +35,8 @@ depends: [
 depopts: ["xen-evtchn" "xen-gnt" "mirage-xen"]
 conflicts: [
   "xen-evtchn" {< "1.0.3"}
+  "xen-evtchn" {>= "2.0.0"}
+  "xen-gnt"    {>= "2.0.0"}
 ]
 available: [ocaml-version >= "4.00.1"]
 depexts: [

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -37,6 +37,7 @@ depopts: ["xen-evtchn" "xen-gnt" "mirage-xen"]
 conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
+  "xen-gnt"    {>= "2.0.0"}
 ]
 available: [ocaml-version >= "4.02.0"]
 depexts: [

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -42,6 +42,7 @@ depopts: ["xen-evtchn" "xen-gnt" "mirage-xen"]
 conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
+  "xen-gnt" {>= "2.0.0"}
 ]
 available: [ocaml-version >= "4.02.0"]
 depexts: [

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -47,6 +47,7 @@ depopts: [
 conflicts: [
  "xen-evtchn" {< "1.0.3"}
  "xen-evtchn" {>= "2.0.0"}
+ "xen-gnt"    {>= "2.0.0"}
  ]
 available: [ocaml-version >= "4.02.0"]
 depexts: [

--- a/packages/xen-evtchn/xen-evtchn.1.0.1/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.1/opam
@@ -20,8 +20,12 @@ depends: [
 ]
 depopts: ["xenctrl"]
 depexts: [
+  [["alpine"] ["xen-dev"]]
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
+  [["archlinux"] ["xenstore"]]
 ]
 
 available: [ocaml-version >= "4.00.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.3/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.3/opam
@@ -20,8 +20,12 @@ depends: [
 ]
 depopts: ["xenctrl"]
 depexts: [
+  [["alpine"] ["xen-dev"]]
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
+  [["archlinux"] ["xenstore"]]
 ]
 
 available: [ocaml-version >= "4.00.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.4/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.4/opam
@@ -20,8 +20,12 @@ depends: [
 ]
 depopts: ["xenctrl"]
 depexts: [
+  [["alpine"] ["xen-dev"]]
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
+  [["archlinux"] ["xenstore"]]
 ]
 
 available: [ocaml-version >= "4.00.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.5/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.5/opam
@@ -20,8 +20,11 @@ depends: [
 ]
 depopts: ["xenctrl"]
 depexts: [
+  [["alpine"] ["xen-dev"]]
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
+  [["archlinux"] ["xenstore"]]
 ]
-
 available: [ocaml-version >= "4.00.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.6/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.6/opam
@@ -20,8 +20,11 @@ depends: [
 ]
 depopts: ["xenctrl"]
 depexts: [
+  [["alpine"] ["xen-dev"]]
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
+  [["archlinux"] ["xenstore"]]
 ]
-
 available: [ocaml-version >= "4.00.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.7/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.7/opam
@@ -18,8 +18,11 @@ depends: [
   "ounit"
 ]
 depexts: [
+  [["alpine"] ["xen-dev"]]
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
+  [["archlinux"] ["xenstore"]]
 ]
-
 available: [ocaml-version >= "4.00.0"]


### PR DESCRIPTION
There were already bounds on xen-evtchn, but xen-gnt were missed.

Related to https://github.com/mirage/ocaml-vchan/issues/102

Signed-off-by: David Scott <dave@recoil.org>