### PR TITLE
shared-secret.0.3 - via opam-publish

### DIFF
--- a/packages/shared-secret/shared-secret.0.3/descr
+++ b/packages/shared-secret/shared-secret.0.3/descr
@@ -1,0 +1,2 @@
+Exceptions are shared secrets.
+Abstract (encapsulated) messages or hidden (semi-deterministic) exceptions using OCaml's module system.

--- a/packages/shared-secret/shared-secret.0.3/opam
+++ b/packages/shared-secret/shared-secret.0.3/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Marco Aurélio <marcoonroad@gmail.com>"
+authors: "Marco Aurélio <marcoonroad@gmail.com>"
+homepage: "http://github.com/marcoonroad/shared-secret"
+bug-reports: "http://github.com/marcoonroad/shared-secret/issues"
+license: "MIT"
+dev-repo: "http://github.com/marcoonroad/shared-secret.git"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%" "--%{ounit:enable}%-tests"]
+  [make]
+]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "shared-secret"]
+depends: [
+  "ounit" {test}
+  "oasis" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/shared-secret/shared-secret.0.3/url
+++ b/packages/shared-secret/shared-secret.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/marcoonroad/shared-secret/archive/v0.3.zip"
+checksum: "1fcdc9408e844c46e3a510c162836944"


### PR DESCRIPTION
Exceptions are shared secrets.
Abstract (encapsulated) messages or hidden (semi-deterministic) exceptions using OCaml's module system.


---
* Homepage: http://github.com/marcoonroad/shared-secret
* Source repo: http://github.com/marcoonroad/shared-secret.git
* Bug tracker: http://github.com/marcoonroad/shared-secret/issues

---

Pull-request generated by opam-publish v0.3.4