### PR TITLE
git 1.11.0 release

### DIFF
--- a/packages/git-http/git-http.1.11.0/descr
+++ b/packages/git-http/git-http.1.11.0/descr
@@ -1,0 +1,1 @@
+Client implementation of the "Smart" HTTP Git protocol in pure OCaml

--- a/packages/git-http/git-http.1.11.0/opam
+++ b/packages/git-http/git-http.1.11.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "git"      {>= "1.11.0"}
+  "cohttp"   {>= "0.19.1"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-http/git-http.1.11.0/url
+++ b/packages/git-http/git-http.1.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.0/git-1.11.0.tbz"
+checksum: "3058529840aed0053fec7899069d3974"

--- a/packages/git-mirage/git-mirage.1.11.0/descr
+++ b/packages/git-mirage/git-mirage.1.11.0/descr
@@ -1,0 +1,1 @@
+MirageOS backend for the Git protocol(s)

--- a/packages/git-mirage/git-mirage.1.11.0/opam
+++ b/packages/git-mirage/git-mirage.1.11.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "test/git-mirage"]
+
+depends: [
+  "jbuilder" {build}
+  "mirage-http"
+  "mirage-flow-lwt"
+  "mirage-channel-lwt"
+  "mirage-fs-lwt"
+  "mirage-conduit" {>= "2.3.0"}
+  "result"
+  "git-http" {>= "1.11.0"}
+  "git"      {>= "1.11.0"}
+  "alcotest"       {test}
+  "mtime"          {test & >= "1.0.0"}
+  "mirage-fs-unix" {test & >= "1.3.0"}
+  "nocrypto"       {test & >= "0.5.4"}
+  "io-page"        {test & >= "1.6.1"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-mirage/git-mirage.1.11.0/url
+++ b/packages/git-mirage/git-mirage.1.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.0/git-1.11.0.tbz"
+checksum: "3058529840aed0053fec7899069d3974"

--- a/packages/git-unix/git-unix.1.11.0/descr
+++ b/packages/git-unix/git-unix.1.11.0/descr
@@ -1,0 +1,5 @@
+Unix backend for the Git protocol(s)
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git-unix/git-unix.1.11.0/opam
+++ b/packages/git-unix/git-unix.1.11.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "test/git-unix"]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "logs"
+  "git-http" {>= "1.11.0"}
+  "conduit"  {>= "0.8.4"}
+  "nocrypto" {>= "0.2.0"}
+  "mtime"    {>= "1.0.0"}
+  "base-unix"
+  "alcotest" {test}
+  "io-page"  {test & >= "1.6.1"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-unix/git-unix.1.11.0/url
+++ b/packages/git-unix/git-unix.1.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.0/git-1.11.0.tbz"
+checksum: "3058529840aed0053fec7899069d3974"

--- a/packages/git/git.1.11.0/descr
+++ b/packages/git/git.1.11.0/descr
@@ -1,0 +1,13 @@
+Git format and protocol in pure OCaml
+
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects. For instance, it is
+possible to make a pack file position independent (as the Zlib
+compression might change the relative offsets between the packed
+objects), to generate pack indexes from pack files, or to expand
+the filesystem of a given commit.

--- a/packages/git/git.1.11.0/opam
+++ b/packages/git/git.1.11.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "build" "test/git"]
+
+depends: [
+  "jbuilder"   {build}
+  "mstruct"    {>= "1.3.1"}
+  "ocamlgraph"
+  "uri"        {>= "1.3.12"}
+  "lwt"        {>= "2.4.7"}
+  "logs"
+  "fmt"
+  "hex"
+  "astring"
+  "decompress" {>= "0.6"}
+  "alcotest" {test}
+  "nocrypto" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.11.0/url
+++ b/packages/git/git.1.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.0/git-1.11.0.tbz"
+checksum: "3058529840aed0053fec7899069d3974"


### PR DESCRIPTION
Changes:

* Add `ogit add-commit-parent` to add a new parent to a given commit
  (mirage/ocaml-git#208, @samoht)
* port to jbuilder (mirage/ocaml-git#209, @samoht)
* port to mtime 1.0 (mirage/ocaml-git#212, @dinosaure and @samoht)
* use Decompress instead of camlzip (mirage/ocaml-git#211, @dinosaure and @samoht)