### PR TITLE
rpc: add missing quotes

### DIFF
--- a/packages/rpc/rpc.1.5.1/opam
+++ b/packages/rpc/rpc.1.5.1/opam
@@ -14,6 +14,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "js_of_ocaml" ]
-conflicts: [ js_of_ocaml { >= "3.0" } ]
+conflicts: [ "js_of_ocaml" { >= "3.0" } ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 install: [make "install"]

--- a/packages/rpc/rpc.1.5.3/opam
+++ b/packages/rpc/rpc.1.5.3/opam
@@ -14,6 +14,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "js_of_ocaml" ]
-conflicts: [ js_of_ocaml { >= "3.0" } ]
+conflicts: [ "js_of_ocaml" { >= "3.0" } ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 install: [make "install"]

--- a/packages/rpc/rpc.1.5.4/opam
+++ b/packages/rpc/rpc.1.5.4/opam
@@ -14,6 +14,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "js_of_ocaml" ]
-conflicts: [ js_of_ocaml { >= "3.0" } ]
+conflicts: [ "js_of_ocaml" { >= "3.0" } ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 install: [make "install"]


### PR DESCRIPTION
`opam` doesn't seem to care, but `opam-lint` doesn't like this syntax, and there is no other occurrence of it anywhere in `opam-repository`.

cc @samoht 
