### PR TITLE
Rpc syntax error

### DIFF
--- a/packages/rpc/rpc.1.5.1/opam
+++ b/packages/rpc/rpc.1.5.1/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Jon Ludlam"
+]
+homepage: "https://github.com/mirage/ocaml-rpc"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/rpc/rpc.1.5.1/opam
+++ b/packages/rpc/rpc.1.5.1/opam
@@ -14,6 +14,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "js_of_ocaml" ]
-conflicts: [ js_of_ocaml { >= "3.0" } ]
+conflicts: [ "js_of_ocaml" { >= "3.0" } ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 install: [make "install"]

--- a/packages/rpc/rpc.1.5.3/opam
+++ b/packages/rpc/rpc.1.5.3/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Jon Ludlam"
+]
+homepage: "https://github.com/mirage/ocaml-rpc"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/rpc/rpc.1.5.3/opam
+++ b/packages/rpc/rpc.1.5.3/opam
@@ -14,6 +14,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "js_of_ocaml" ]
-conflicts: [ js_of_ocaml { >= "3.0" } ]
+conflicts: [ "js_of_ocaml" { >= "3.0" } ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 install: [make "install"]

--- a/packages/rpc/rpc.1.5.4/opam
+++ b/packages/rpc/rpc.1.5.4/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Jon Ludlam"
+]
+homepage: "https://github.com/mirage/ocaml-rpc"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/rpc/rpc.1.5.4/opam
+++ b/packages/rpc/rpc.1.5.4/opam
@@ -14,6 +14,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: [ "js_of_ocaml" ]
-conflicts: [ js_of_ocaml { >= "3.0" } ]
+conflicts: [ "js_of_ocaml" { >= "3.0" } ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 install: [make "install"]


### PR DESCRIPTION
Missing quotes around package name: opam doesn't seem to care, but opam-lint signals an error and this syntax is not used anywhere else in `opam-repository`.

cc @samoht 