### PR TITLE
Disable GCC optimization

### DIFF
--- a/packages/delimcc/delimcc.0/files/ocaml.4.04.patch
+++ b/packages/delimcc/delimcc.0/files/ocaml.4.04.patch
@@ -1,38 +1,6 @@
-diff --git a/caml-shift/Makefile b/caml-shift/Makefile
-index 098390f..886fb36 100644
---- a/caml-shift/Makefile
-+++ b/caml-shift/Makefile
-@@ -44,7 +44,7 @@
- #OCAMLINCLUDES=../../byterun
- #OCAMLINCLUDES=./ocaml-byterun-3.09
- #OCAMLINCLUDES=./ocaml-byterun-3.10
--OCAMLINCLUDES=./ocaml-byterun-3.11
-+#OCAMLINCLUDES=./ocaml-byterun-3.11
- 
- LIBDIR := $(shell ocamlc -where)
- 
-@@ -70,7 +70,7 @@ STDINCLUDES=$(LIBDIR)/caml
- STUBLIBDIR=$(LIBDIR)/stublibs
- # CC=$(NATIVECC)
- CC=gcc
--CFLAGS=-fPIC -Wall -I$(OCAMLINCLUDES) -I$(STDINCLUDES) -O2
-+CFLAGS=-fPIC -Wall -I$(STDINCLUDES) -O2
- NATIVEFLAGS=-DCAML_NAME_SPACE -DNATIVE_CODE \
-        -DTARGET_$(ARCH) -DSYS_$(SYSTEM)
- RANLIB=ranlib
-@@ -124,7 +124,7 @@ delimcc.cmo: delimcc.cmi
- # When using GCC 4.7, add the flag -fno-ipa-sra
- stacks-native.o: stacks-native.c
- 	$(CC) -c $(NATIVEFLAGS) -O2 -fPIC -Wall \
--	-I$(OCAMLINCLUDES) -I$(STDINCLUDES) stacks-native.c
-+	-I$(STDINCLUDES) stacks-native.c
- 
- top:	libdelimcc.a delimcc.cma
- 	$(OCAMLMKTOP) -o ocamltopcc delimcc.cma
-diff --git a/caml-shift/delim_serialize.c b/caml-shift/delim_serialize.c
-index 7ac2ef2..97c5574 100644
---- a/caml-shift/delim_serialize.c
-+++ b/caml-shift/delim_serialize.c
+diff -Naur a/caml-shift/delim_serialize.c b/caml-shift/delim_serialize.c
+--- a/caml-shift/delim_serialize.c	2010-07-29 09:55:49.000000000 +0400
++++ b/caml-shift/delim_serialize.c	2017-06-03 15:17:58.028864281 +0300
 @@ -12,7 +12,9 @@
  
   *------------------------------------------------------------------------
@@ -43,7 +11,7 @@ index 7ac2ef2..97c5574 100644
  #include <string.h>
  #include "misc.h"
  #include <alloc.h>
-@@ -355,7 +357,7 @@ static value abs_rec(value global_data_arr, value v)
+@@ -355,7 +357,7 @@
    if(Tag_val(v) == Custom_tag && Wosize_val(v) == 2 &&
       strcmp(Custom_ops_val(v)->identifier,"delimcc_gdix") == 0)
    {
@@ -52,7 +20,7 @@ index 7ac2ef2..97c5574 100644
      value f;
  #if defined(DEBUG_SER) && DEBUG_SER
      fprintf(stderr, "absolutizing %d\n",i);
-@@ -366,7 +368,7 @@ static value abs_rec(value global_data_arr, value v)
+@@ -366,7 +368,7 @@
      {
        const value f1 = Field(f,1);
        myassert( Is_block(f1) && Wosize_val(f1) == 2 &&
@@ -61,7 +29,7 @@ index 7ac2ef2..97c5574 100644
      }
      v = Field(f,0);
      myassert( Is_block(v) && Is_in_heap(v) && Tag_val(v) == Closure_tag );
-@@ -483,20 +485,20 @@ value output_delim_value(value global_data_arr,
+@@ -483,20 +485,20 @@
  
  
  /* Implementing the custom data type global_data_ix
@@ -85,7 +53,7 @@ index 7ac2ef2..97c5574 100644
    return 4;
  }
  
-@@ -519,7 +521,7 @@ CAMLexport value global_data_ix_make(value i) /* int->global_data_idx */
+@@ -519,7 +521,7 @@
  {
    value res = caml_alloc_custom(&global_data_ix_ops, 4, 0, 1);
    myassert( Is_long(i) );
@@ -94,22 +62,40 @@ index 7ac2ef2..97c5574 100644
    return res;
  }
  
-diff --git a/caml-shift/stacks-native.c b/caml-shift/stacks-native.c
-index 23f197f..47c0c8b 100644
---- a/caml-shift/stacks-native.c
-+++ b/caml-shift/stacks-native.c
-@@ -127,6 +127,7 @@ Thanks to Anthony Tavener for investigation.
+diff -Naur a/caml-shift/Makefile b/caml-shift/Makefile
+--- a/caml-shift/Makefile	2017-06-03 15:17:23.187816388 +0300
++++ b/caml-shift/Makefile	2017-06-03 15:19:25.091482812 +0300
+@@ -44,7 +44,7 @@
+ #OCAMLINCLUDES=../../byterun
+ #OCAMLINCLUDES=./ocaml-byterun-3.09
+ #OCAMLINCLUDES=./ocaml-byterun-3.10
+-OCAMLINCLUDES=./ocaml-byterun-3.11
++#OCAMLINCLUDES=./ocaml-byterun-3.11
  
- */
+ LIBDIR := $(shell ocamlc -where)
  
-+#define CAML_INTERNALS
+@@ -70,7 +70,7 @@
+ STUBLIBDIR=$(LIBDIR)/stublibs
+ # CC=$(NATIVECC)
+ CC=gcc
+-CFLAGS=-fPIC -Wall -I$(OCAMLINCLUDES) -I$(STDINCLUDES) -O2
++CFLAGS+=-fPIC -Wall -I$(STDINCLUDES)
+ NATIVEFLAGS=-DCAML_NAME_SPACE -DNATIVE_CODE \
+        -DTARGET_$(ARCH) -DSYS_$(SYSTEM)
+ RANLIB=ranlib
+@@ -123,8 +123,7 @@
  
- #include "misc.h"
- #include "memory.h"
-diff --git a/caml-shift/stacks.c b/caml-shift/stacks.c
-index 3d498ff..cb3b76f 100644
---- a/caml-shift/stacks.c
-+++ b/caml-shift/stacks.c
+ # When using GCC 4.7, add the flag -fno-ipa-sra
+ stacks-native.o: stacks-native.c
+-	$(CC) -c $(NATIVEFLAGS) -O2 -fPIC -Wall \
+-	-I$(OCAMLINCLUDES) -I$(STDINCLUDES) stacks-native.c
++	$(CC) -c $(NATIVEFLAGS) $(CFLAGS) stacks-native.c
+ 
+ top:	libdelimcc.a delimcc.cma
+ 	$(OCAMLMKTOP) -o ocamltopcc delimcc.cma
+diff -Naur a/caml-shift/stacks.c b/caml-shift/stacks.c
+--- a/caml-shift/stacks.c	2010-08-21 06:40:57.000000000 +0400
++++ b/caml-shift/stacks.c	2017-06-03 15:17:58.028864281 +0300
 @@ -60,6 +60,8 @@
   *------------------------------------------------------------------------
   */
@@ -119,3 +105,14 @@ index 3d498ff..cb3b76f 100644
  #include <string.h>
  #include "misc.h"
  #include <alloc.h>
+diff -Naur a/caml-shift/stacks-native.c b/caml-shift/stacks-native.c
+--- a/caml-shift/stacks-native.c	2013-08-21 07:57:51.000000000 +0400
++++ b/caml-shift/stacks-native.c	2017-06-03 15:17:58.028864281 +0300
+@@ -127,6 +127,7 @@
+ 
+ */
+ 
++#define CAML_INTERNALS
+ 
+ #include "misc.h"
+ #include "memory.h"


### PR DESCRIPTION
When delimcc is compiled natively with a recent version of GCC,
a segfault may occur during take_subcont calls. The reason is that
recent GCC optimizes too much, see related discussion at
https://sympa.inria.fr/sympa/arc/caml-list/2017-06/msg00007.html

This PR removes -O2 flag from `Makefile`. Also the PR propogates
CFLAGS system variable in the case if someone wants to enable
optimization during delimcc installation from opam

Note that this PR affects `ocaml` >= 4.04 only, because it modifies
`ocaml.4.04.patch`. Also, seems like `delimcc.0` tarball from the archives
should also be updated (by an admin?)