### PR TITLE
ipv6-multicast: upper bound on ipaddr

### DIFF
--- a/packages/ipv6-multicast/ipv6-multicast.0.1/opam
+++ b/packages/ipv6-multicast/ipv6-multicast.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "lwt"
-  "ipaddr"
+  "ipaddr" {<"2.8.0"}
 ]
 depopts: []
 build:


### PR DESCRIPTION
fixed upstream with https://github.com/vbmithr/ocaml-ipv6-multicast/pull/1

revdeps for #9382