### PR TITLE
Add ppx_regexp version 0.2.0 and 0.3.0.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.2.0/descr
+++ b/packages/ppx_regexp/ppx_regexp.0.2.0/descr
@@ -1,0 +1,16 @@
+Matching Regular Expressions with OCaml Patterns
+
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations to the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, except groups can be bound to
+variables using the syntax `(?<var>...)`.  The type of `var` will be
+`string` if a match is of the groups is guaranteed given a match of the
+whole pattern, and `string option` if the variable is bound to or nested
+below an optionally matched group.

--- a/packages/ppx_regexp/ppx_regexp.0.2.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.2.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "paurkedal@gmail.com"
+authors: ["Petter A. Urkedal <paurkedal@gmail.com>"]
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+dev-repo: "https://github.com/paurkedal/ppx_regexp.git"
+license: "LGPL-3 with OCaml linking exception"
+build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+depends: [
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree"
+  "re"
+  "ppx_tools" {build}
+  "topkg-jbuilder" {build}
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.03.0"]

--- a/packages/ppx_regexp/ppx_regexp.0.2.0/url
+++ b/packages/ppx_regexp/ppx_regexp.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ppx_regexp/releases/download/v0.2.0/ppx_regexp-0.2.0.tbz"
+checksum: "3df1f48407d5bd361e647817841eb99b"

--- a/packages/ppx_regexp/ppx_regexp.0.3.0/descr
+++ b/packages/ppx_regexp/ppx_regexp.0.3.0/descr
@@ -1,0 +1,16 @@
+Matching Regular Expressions with OCaml Patterns
+
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations to the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, except groups can be bound to
+variables using the syntax `(?<var>...)`.  The type of `var` will be
+`string` if a match is of the groups is guaranteed given a match of the
+whole pattern, and `string option` if the variable is bound to or nested
+below an optionally matched group.

--- a/packages/ppx_regexp/ppx_regexp.0.3.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "paurkedal@gmail.com"
+authors: ["Petter A. Urkedal <paurkedal@gmail.com>"]
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+dev-repo: "https://github.com/paurkedal/ppx_regexp.git"
+license: "LGPL-3 with OCaml linking exception"
+build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+depends: [
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree"
+  "re"
+  "ppx_metaquot" {build}
+  "topkg-jbuilder" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ppx_regexp/ppx_regexp.0.3.0/url
+++ b/packages/ppx_regexp/ppx_regexp.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ppx_regexp/releases/download/v0.3.0/ppx_regexp-0.3.0.tbz"
+checksum: "6d5b91fb26530d1e08fd3f160855b8a1"


### PR DESCRIPTION
Versions 0.2.* works for OCaml 4.02.3 and will only receive bug fixes.
Versions >= 0.3.0 works for OCaml 4.03.0 and later.