### PR TITLE
ipaddr: conflict with a particular rev of ppx_sexp_conv

### DIFF
--- a/packages/ipaddr/ipaddr.2.0.0/opam
+++ b/packages/ipaddr/ipaddr.2.0.0/opam
@@ -23,3 +23,4 @@ depends: [
 dev-repo: "git://github.com/mirage/ocaml-ipaddr"
 install: [make "install"]
 available: [ ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.1.0/opam
+++ b/packages/ipaddr/ipaddr.2.1.0/opam
@@ -23,3 +23,4 @@ depends: [
 dev-repo: "git://github.com/mirage/ocaml-ipaddr"
 install: [make "install"]
 available: [ ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.2.0/opam
+++ b/packages/ipaddr/ipaddr.2.2.0/opam
@@ -23,3 +23,4 @@ depends: [
 dev-repo: "git://github.com/mirage/ocaml-ipaddr"
 install: [make "install"]
 available: [ ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.3.0/opam
+++ b/packages/ipaddr/ipaddr.2.3.0/opam
@@ -23,3 +23,4 @@ depends: [
 dev-repo: "git://github.com/mirage/ocaml-ipaddr"
 install: [make "install"]
 available: [ ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.4.0/opam
+++ b/packages/ipaddr/ipaddr.2.4.0/opam
@@ -23,3 +23,4 @@ depends: [
 dev-repo: "git://github.com/mirage/ocaml-ipaddr"
 install: [make "install"]
 available: [ ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.5.0/opam
+++ b/packages/ipaddr/ipaddr.2.5.0/opam
@@ -25,3 +25,4 @@ depends: [
 dev-repo: "git://github.com/mirage/ocaml-ipaddr"
 install: [make "install"]
 available: [ ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.6.0/opam
+++ b/packages/ipaddr/ipaddr.2.6.0/opam
@@ -29,3 +29,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.6.1/opam
+++ b/packages/ipaddr/ipaddr.2.6.1/opam
@@ -29,3 +29,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.7.0/opam
+++ b/packages/ipaddr/ipaddr.2.7.0/opam
@@ -38,3 +38,4 @@ depends: [
   "ounit" {test}
 ]
 available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.7.1/opam
+++ b/packages/ipaddr/ipaddr.2.7.1/opam
@@ -36,3 +36,4 @@ depends: [
 ]
 depopts: [ "base-unix" ]
 available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.04.0" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.7.2/opam
+++ b/packages/ipaddr/ipaddr.2.7.2/opam
@@ -36,3 +36,4 @@ depends: [
 ]
 depopts: [ "base-unix" ]
 available: [ ocaml-version >= "4.02.2" ]
+conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]


### PR DESCRIPTION
this version seems to result in an ast variant violation, whereas
the point release 113.33.01+4.03 works, so conflict with this one