### PR TITLE
irmin.0.10.x: depend on lwt<2.7.0

### DIFF
--- a/packages/irmin-unix/irmin-unix.1.1.0/opam
+++ b/packages/irmin-unix/irmin-unix.1.1.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.9.0"}
+  "cmdliner"   {>= "1.0.0"}
   "irmin"      {>= "1.1.0"}
   "irmin-git"  {>= "1.1.0"}
   "irmin-http" {>= "1.0.0"}

--- a/packages/irmin/irmin.0.10.0/opam
+++ b/packages/irmin/irmin.0.10.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {>= "0.4.2" & <"0.5.0"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.4.7" & <"3.0.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.6.0"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/irmin/irmin.0.10.0/opam
+++ b/packages/irmin/irmin.0.10.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {>= "0.4.2" & <"0.5.0"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7" & <"3.0.0"}
+  "lwt" {>= "2.4.7" & <"2.7.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.6.0"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/irmin/irmin.0.10.1/opam
+++ b/packages/irmin/irmin.0.10.1/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {>= "0.4.2" & <"0.5.0"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.4.7" & <"3.0.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.6.0"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/irmin/irmin.0.10.1/opam
+++ b/packages/irmin/irmin.0.10.1/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {>= "0.4.2" & <"0.5.0"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7" & <"3.0.0"}
+  "lwt" {>= "2.4.7" & <"2.7.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.6.0"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/irmin/irmin.0.9.6/opam
+++ b/packages/irmin/irmin.0.9.6/opam
@@ -24,7 +24,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {>= "0.4.0" & < "0.4.2"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.4.7" & < "2.7.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.0.1"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/irmin/irmin.0.9.7/opam
+++ b/packages/irmin/irmin.0.9.7/opam
@@ -24,7 +24,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {>= "0.4.0" & < "0.4.2"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.4.7" & <"2.7.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.0.1"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/irmin/irmin.0.9.8/opam
+++ b/packages/irmin/irmin.0.9.8/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {>= "0.4.0" & < "0.4.2"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.4.7" & <"2.7.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.0.1"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/irmin/irmin.0.9.9/opam
+++ b/packages/irmin/irmin.0.9.9/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "ezjsonm" {= "0.4.1" & < "0.5.0"}
   "ocamlgraph"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.4.7" & <"2.7.0"}
   "dolog" {>= "0.4"}
   "cstruct" {>= "1.0.1"}
   "mirage-tc" {>= "0.3.0"}

--- a/packages/jitsu/jitsu.0.3.0/opam
+++ b/packages/jitsu/jitsu.0.3.0/opam
@@ -15,7 +15,7 @@ build-test: [
   [make "test"]
 ]
 
-depends: [  "ocamlfind"
+depends: [  "ocamlfind" {build}
             "lwt"
             "dns"  { >= "0.15.3" }
             "mirage-time" "mirage-stack-lwt" "mirage-kv-lwt" "duration" "mirage-profile"


### PR DESCRIPTION
otherwise fatal warning is triggered about lwt.run deprecation

revdeps for #9382