### PR TITLE
ipaddr.2.7.1: not compatible with ocaml 4.03.0 due to Toploop issue

### DIFF
--- a/packages/ipaddr/ipaddr.2.7.1/opam
+++ b/packages/ipaddr/ipaddr.2.7.1/opam
@@ -35,4 +35,4 @@ depends: [
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]
-available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.04.0" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.03.0" ]


### PR DESCRIPTION
tied to #9407 