### PR TITLE
irmin-unix.1.0.1: add missing upper bound on irmin

### DIFF
--- a/packages/irmin-unix/irmin-unix.1.0.1/opam
+++ b/packages/irmin-unix/irmin-unix.1.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.7.8"}
-  "irmin"      {>= "1.0.0"}
+  "irmin"      {>= "1.0.0" & < "1.1.0" }
   "irmin-git"  {>= "1.0.0"}
   "irmin-http" {>= "1.0.0"}
   "git-unix"   {>= "1.10.0"}


### PR DESCRIPTION
this exists already for 1.0.0 and 1.0.2 but was missed for this
fixed revdep failure in #9408