### PR TITLE
nocrypto: match the depopt to the package flag to activate mirage

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -12,7 +12,7 @@ available:     [ ocaml-version >= "4.02.0" ]
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
                 "--with-lwt" "%{lwt:installed}%"
                 "--xen" "%{mirage-xen:installed}%"
-                "--freestanding" "%{ocaml-freestanding:installed}%"]
+                "--freestanding" "%{mirage-solo5:installed}%"]
 
 depends: [
   "ocamlfind" {build}


### PR DESCRIPTION
fix pointed out by @hannesm in #9413, confirmed by @paurkedal