### PR TITLE
salsa20-core.0.2.0 - via opam-publish

### DIFF
--- a/packages/salsa20-core/salsa20-core.0.2.0/descr
+++ b/packages/salsa20-core/salsa20-core.0.2.0/descr
@@ -1,0 +1,26 @@
+Salsa20 core functions, in OCaml
+
+An OCaml implementation of [Salsa20 Core](http://cr.yp.to/salsa20.html) functions, both Salsa20/20 Core and the reduced Salsa20/8 Core and Salsa20/12 Core functions.
+The hot loop is implemented in C for efficiency reasons.
+
+Salsa 20 Core are functions from 64-byte strings to 64-byte strings.
+
+## Installation
+
+```
+opam install salsa20-core
+```
+
+## Usage
+
+```ocaml
+utop[0]> #require "salsa20-core";;
+utop[1]> 0
+|> Char.chr
+|> String.make 64
+|> Cstruct.of_string
+|> Salsa20_core.salsa20_20_core (* or salsa20_12_core / salsa20_8_core *)
+|> Cstruct.to_string;;
+- : string =
+"\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+```

--- a/packages/salsa20-core/salsa20-core.0.2.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name:         "salsa20-core"
+homepage:     "https://github.com/abeaumont/ocaml-salsa20-core"
+dev-repo:     "https://github.com/abeaumont/ocaml-salsa20-core.git"
+bug-reports:  "https://github.com/abeaumont/ocaml-salsa20-core/issues"
+author:       "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+maintainer:   "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+license:      "BSD2"
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {test}
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/salsa20-core/salsa20-core.0.2.0/url
+++ b/packages/salsa20-core/salsa20-core.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/abeaumont/ocaml-salsa20-core/archive/0.2.0.tar.gz"
+checksum: "495ad44e06e44c85cc61f5b27a4fa6e0"


### PR DESCRIPTION
Salsa20 core functions, in OCaml

An OCaml implementation of [Salsa20 Core](http://cr.yp.to/salsa20.html) functions, both Salsa20/20 Core and the reduced Salsa20/8 Core and Salsa20/12 Core functions.
The hot loop is implemented in C for efficiency reasons.

Salsa 20 Core are functions from 64-byte strings to 64-byte strings.

## Installation

```
opam install salsa20-core
```

## Usage

```ocaml
utop[0]> #require "salsa20-core";;
utop[1]> 0
|> Char.chr
|> String.make 64
|> Cstruct.of_string
|> Salsa20_core.salsa20_20_core (* or salsa20_12_core / salsa20_8_core *)
|> Cstruct.to_string;;
- : string =
"\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
```

---
* Homepage: https://github.com/abeaumont/ocaml-salsa20-core
* Source repo: https://github.com/abeaumont/ocaml-salsa20-core.git
* Bug tracker: https://github.com/abeaumont/ocaml-salsa20-core/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
# 0.2.0 (2017-06-05)

* Rewrite salsa_core inner function in C.
* Add ocb-stubblr dependency and use it to link to C code
* Make nocrypto a dependency only for tests
Pull-request generated by opam-publish v0.3.4