### PR TITLE
Update xapi-project packages

### DIFF
--- a/packages/message-switch/message-switch.1.4.0/descr
+++ b/packages/message-switch/message-switch.1.4.0/descr
@@ -1,0 +1,4 @@
+A simple store-and-forward message switch.
+
+The switch stores messages in queues with well-known names. Clients use
+a simple HTTP protocol to enqueue and dequeue messages.

--- a/packages/message-switch/message-switch.1.4.0/files/disable-error-on-warn.patch
+++ b/packages/message-switch/message-switch.1.4.0/files/disable-error-on-warn.patch
@@ -1,0 +1,151 @@
+From b5dfcb6eda440c70776bc2af059576de288c05a6 Mon Sep 17 00:00:00 2001
+From: Marcello Seri <marcello.seri@citrix.com>
+Date: Mon, 5 Jun 2017 16:13:39 +0100
+Subject: [PATCH] Disable warn-on-error when compiling message switch
+
+Signed-off-by: Marcello Seri <marcello.seri@citrix.com>
+---
+ _oasis | 30 +-----------------------------
+ 1 file changed, 1 insertion(+), 29 deletions(-)
+
+diff --git a/_oasis b/_oasis
+index 31ee872..516c5a0 100644
+--- a/_oasis
++++ b/_oasis
+@@ -1,6 +1,6 @@
+ OASISFormat: 0.3
+ Name:        message_switch
+-Version:     1.0.0
++Version:     1.4.0
+ Synopsis:    A simple store-and-forward message switch
+ Authors:     Dave Scott
+ License:     ISC
+@@ -18,8 +18,6 @@ Flag lwt
+ Library message_switch
+   CompiledObject:     best
+   Pack:               true
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   Path:               core
+   Findlibname:        message_switch
+   Modules:            Protocol, Make, Monad, Mresult, S
+@@ -28,8 +26,6 @@ Library message_switch
+ Library message_switch_lwt
+   Build$:             flag(lwt)
+   CompiledObject:     best
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   Path:               lwt
+   Findlibparent:      message_switch
+   Findlibname:        lwt
+@@ -39,8 +35,6 @@ Library message_switch_lwt
+ Library message_switch_async
+   Build$:             flag(async)
+   CompiledObject:     best
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   Path:               async
+   Findlibparent:      message_switch
+   Findlibname:        async
+@@ -49,8 +43,6 @@ Library message_switch_async
+ 
+ Library message_switch_unix
+   CompiledObject:     best
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   Path:               unix
+   Findlibparent:      message_switch
+   Findlibname:        unix
+@@ -59,8 +51,6 @@ Library message_switch_unix
+ 
+ Library message_switch_server
+   Build$:             flag(lwt)
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   CompiledObject:     best
+   Pack:               true
+   Install:            false
+@@ -72,8 +62,6 @@ Library message_switch_server
+ 
+ Executable m_cli
+   CompiledObject:     best
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   Path:               cli
+   MainIs:             main.ml
+   Custom:             true
+@@ -82,8 +70,6 @@ Executable m_cli
+ 
+ Executable link_test
+   Build$:             flag(lwt)&&flag(tests)
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   CompiledObject:     best
+   Path:               core_test
+   MainIs:             link_test_main.ml
+@@ -93,8 +79,6 @@ Executable link_test
+ 
+ Executable client
+   Build$:             flag(lwt)&&flag(tests)
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   CompiledObject:     best
+   Path:               core_test
+   MainIs:             client_main.ml
+@@ -104,8 +88,6 @@ Executable client
+ 
+ Executable client_async
+   Build$:             flag(async)&&flag(tests)
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   CompiledObject:     best
+   Path:               core_test
+   MainIs:             client_async_main.ml
+@@ -115,8 +97,6 @@ Executable client_async
+ 
+ Executable client_unix
+   CompiledObject:     best
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   Path:               core_test
+   MainIs:             client_unix_main.ml
+   Build$:             flag(tests)
+@@ -126,8 +106,6 @@ Executable client_unix
+ 
+ Executable server
+   Build$:             flag(lwt)&&flag(tests)
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   CompiledObject:     best
+   Path:               core_test
+   MainIs:             server_main.ml
+@@ -137,8 +115,6 @@ Executable server
+ 
+ Executable server_async
+   Build$:             flag(async)&&flag(tests)
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   CompiledObject:     best
+   Path:               core_test
+   MainIs:             server_async_main.ml
+@@ -148,8 +124,6 @@ Executable server_async
+ 
+ Executable server_unix
+   CompiledObject:     best
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   Path:               core_test
+   MainIs:             server_unix_main.ml
+   Build$:             flag(tests)
+@@ -159,8 +133,6 @@ Executable server_unix
+ 
+ Executable switch
+   Build$:             flag(lwt)
+-  ByteOpt:            -warn-error +a
+-  NativeOpt:          -warn-error +a
+   CompiledObject:     best
+   Path:               switch
+   MainIs:             switch_main.ml
+-- 
+2.11.0
+

--- a/packages/message-switch/message-switch.1.4.0/opam
+++ b/packages/message-switch/message-switch.1.4.0/opam
@@ -29,5 +29,5 @@ depends: [
   "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring" {>= "2.3.0"}
   "cmdliner"
-  "async"
+  "async" {< "v0.9.0"}
 ]

--- a/packages/message-switch/message-switch.1.4.0/opam
+++ b/packages/message-switch/message-switch.1.4.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_sexp_conv"
   "uri"
   "re"
-  "mtime"
+  "mtime" {< "1.0.0"}
   "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring" {>= "2.3.0"}
   "cmdliner"

--- a/packages/message-switch/message-switch.1.4.0/opam
+++ b/packages/message-switch/message-switch.1.4.0/opam
@@ -15,6 +15,7 @@ install: [
 remove: [
   ["ocamlfind" "remove" "message_switch"]
 ]
+patches: [ "disable-error-on-warn.patch" ]
 depends: [
   "oasis" {build}
   "ocamlfind" {build}

--- a/packages/message-switch/message-switch.1.4.0/opam
+++ b/packages/message-switch/message-switch.1.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/message-switch"
+bug-reports: "https://github.com/xapi-project/message-switch/issues"
+dev-repo: "git://github.com/xapi-project/message-switch"
+tags: [ "org:xapi-project" ]
+build: [
+  ["./configure" "--bindir" "%{bin}%"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "message_switch"]
+]
+depends: [
+  "oasis" {build}
+  "ocamlfind" {build}
+  "base-unix"
+  "cohttp" {>= "0.15.0" & < "0.22.0"}
+  "rpc" {>= "1.9.51"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "uri"
+  "re"
+  "mtime"
+  "mirage-block-unix" {>= "2.4.0"}
+  "shared-block-ring" {>= "2.3.0"}
+  "cmdliner"
+  "async"
+]

--- a/packages/message-switch/message-switch.1.4.0/url
+++ b/packages/message-switch/message-switch.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/message-switch/archive/v1.4.0.tar.gz"
+checksum: "151c572b5b3669ef85eb7afaedf62bb2"

--- a/packages/ocaml-systemd/ocaml-systemd.1.2/descr
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/descr
@@ -1,0 +1,6 @@
+OCaml module for native access to the systemd facilities
+
+* Logging to the Journal
+* Socket activation
+* Watchdog
+* Notifications

--- a/packages/ocaml-systemd/ocaml-systemd.1.2/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "systemd"
+version: "1.1"
+maintainer: "Juergen Hoetzel <juergen@archlinux.org>"
+authors: "Juergen Hoetzel <juergen@archlinux.org>"
+homepage: "https://github.com/juergenhoetzel/ocaml-systemd/"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/juergenhoetzel/ocaml-systemd.git"
+license: "LGPL-3 with OCaml linking exception"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "systemd"]
+depends: "ocamlfind"
+depexts: [
+  [["debian"] ["libsystemd-dev"]]
+  [["ubuntu"] ["libsystemd-dev"]]
+  [["centos"] ["systemd-devel"]]
+]

--- a/packages/ocaml-systemd/ocaml-systemd.1.2/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/opam
@@ -1,6 +1,5 @@
 opam-version: "1.2"
 name: "systemd"
-version: "1.1"
 maintainer: "Juergen Hoetzel <juergen@archlinux.org>"
 authors: "Juergen Hoetzel <juergen@archlinux.org>"
 homepage: "https://github.com/juergenhoetzel/ocaml-systemd/"

--- a/packages/ocaml-systemd/ocaml-systemd.1.2/url
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/juergenhoetzel/ocaml-systemd/archive/1.2.tar.gz"
+checksum: "f9206f1284addca555934100b1e68928"

--- a/packages/rpc/rpc.1.9.51/descr
+++ b/packages/rpc/rpc.1.9.51/descr
@@ -1,0 +1,6 @@
+A library to deal with RPCs in OCaml
+
+This library provides a PPX and a camlp4 syntax extension to generate functions
+to convert values of a given type to and from their RPC representations. In
+order to do so, it is sufficient to add `[@@deriving rpc]` (or `with rpc` in
+case of camlp4) to the corresponding type definition.

--- a/packages/rpc/rpc.1.9.51/opam
+++ b/packages/rpc/rpc.1.9.51/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+homepage: "https://github.com/mirage/ocaml-rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [configure]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "rpclib"]
+  ["ocamlfind" "remove" "ppx_deriving_rpc"]
+]
+build-test: [
+    [make]
+    [make "test"]
+]
+depends: [
+  "oasis" {build}
+  "cppo"  {build}
+  "ocamlfind"
+  "type_conv" {>= "108.07.01"}
+  "ppx_deriving"
+  "cow"
+  "xmlm"
+  "lwt"
+  "cmdliner"
+  "rresult"
+  "async"
+]
+depopts: [ "js_of_ocaml" ]

--- a/packages/rpc/rpc.1.9.51/url
+++ b/packages/rpc/rpc.1.9.51/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-rpc/archive/v1.9.51.tar.gz"
+checksum: "6a4b6a56c426124f947ede40ffa9b0ba"

--- a/packages/shared-block-ring/shared-block-ring.1.0.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"
   "ounit"
   "mirage-types" {< "3.0.0"}
-  "mirage-block-unix"
+  "mirage-block-unix" {<= "2.4.0"}
   "sexplib" {< "113.01.00"}
   "io-page"
   "io-page-unix"

--- a/packages/shared-block-ring/shared-block-ring.2.3.0/descr
+++ b/packages/shared-block-ring/shared-block-ring.2.3.0/descr
@@ -1,0 +1,4 @@
+A single-consumer single-producer queue on a block device
+
+This is a simple queue containing variable-length items stored on a disk,
+in the style of Xen shared-memory-ring.

--- a/packages/shared-block-ring/shared-block-ring.2.3.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: [ "David Scott" "Jon Ludlam" "Si Beaumont" ]
+homepage: "https://github.com/mirage/shared-block-ring"
+bug-reports: "https://github.com/mirage/shared-block-ring/issues/"
+dev-repo: "https://github.com/mirage/shared-block-ring.git"
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [make "all"]
+]
+install: [make "install"]
+remove: [["ocamlfind" "remove" "shared-block-ring"]]
+depends: [
+  "cstruct" {>= "0.7.1"}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "lwt"
+  "ocamlfind"
+  "ounit"
+  "mirage-types-lwt"
+  "mirage-block-unix" {<= "2.4.0"}
+  "mirage-clock-unix" {<= "1.0.0"}
+  "sexplib"
+  "io-page"
+  "io-page-unix"
+  "cmdliner"
+  "bisect_ppx"
+  "oasis"
+  "result"
+]

--- a/packages/shared-block-ring/shared-block-ring.2.3.0/url
+++ b/packages/shared-block-ring/shared-block-ring.2.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/shared-block-ring/archive/v2.3.0.tar.gz"
+checksum: "98049c44ff170227d8b04fdb58d96286"

--- a/packages/vhd-tool/vhd-tool.0.12.0/descr
+++ b/packages/vhd-tool/vhd-tool.0.12.0/descr
@@ -1,0 +1,6 @@
+A command-line tool to manipulate, transcode and stream .vhd format data.
+
+This tool currently allows you to:
+* extract data from a vhd tree
+* upload vhd-formatted data to a XenServer host
+

--- a/packages/vhd-tool/vhd-tool.0.12.0/opam
+++ b/packages/vhd-tool/vhd-tool.0.12.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/vhd-tool"
+bug-reports: "https://github.com/xapi-project/vhd-tool/issues"
+dev-repo: "https://github.com/xapi-project/vhd-tool.git"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--bindir=%{bin}%" "--etcdir=%{etc}%" "--libexecdir=%{bin}%"]
+  [make]
+]
+depends: [
+  "oasis" {build}
+  "ocamlfind" {build}
+  "base-threads"
+  "cmdliner"
+  "cohttp" {>="0.12.0" & < "0.22.0"}
+  "cstruct" {>= "1.0.1" & < "3.0.0"}
+  "io-page-unix"
+  "lwt" {>= "2.4.3" & < "3.0.0"}
+  "nbd" {>= "1.0.1" & < "3.0.0"}
+  "re"
+  "sha"
+  "ssl"
+  "tar-format" {>"0.5.0"}
+  "uri"
+  "vhd-format" {>= "0.7.0"}
+  "xapi-idl" {= "1.14.0"}
+  "xapi-tapctl" {= "1.0.1"}
+  "xenstore"
+  "xenstore_transport"
+]

--- a/packages/vhd-tool/vhd-tool.0.12.0/url
+++ b/packages/vhd-tool/vhd-tool.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/vhd-tool/archive/v0.12.0.tar.gz"
+checksum: "c2e165e4baf36d5c0c2b20e169941990"

--- a/packages/xapi-backtrace/xapi-backtrace.0.4/descr
+++ b/packages/xapi-backtrace/xapi-backtrace.0.4/descr
@@ -1,0 +1,4 @@
+A simple library for recording and managing backtraces
+
+This allows backtraces from multiple processes to be combined together
+and pretty-printed.

--- a/packages/xapi-backtrace/xapi-backtrace.0.4/opam
+++ b/packages/xapi-backtrace/xapi-backtrace.0.4/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/backtrace"
+bug-reports: "https://github.com/xapi-project/backtrace/issues"
+dev-repo: "git://github.com/xapi-project/backtrace.git"
+tags: [ "org:xapi-project" ]
+build: [
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  [make "uninstall"]
+  ["ocamlfind" "remove" "xapi-backtrace"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-threads"
+  "sexplib"
+  "ppx_sexp_conv"
+  "rpc" {>= "1.9.51"}
+]

--- a/packages/xapi-backtrace/xapi-backtrace.0.4/url
+++ b/packages/xapi-backtrace/xapi-backtrace.0.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/backtrace/archive/v0.4.tar.gz"
+checksum: "f2aa19665712d1acd96258a7cbdf4616"

--- a/packages/xapi-forkexecd/xapi-forkexecd.1.4.0/descr
+++ b/packages/xapi-forkexecd/xapi-forkexecd.1.4.0/descr
@@ -1,0 +1,3 @@
+Sub-process control service for xapi
+
+This daemon creates and manages sub-processes on behalf of xapi.

--- a/packages/xapi-forkexecd/xapi-forkexecd.1.4.0/opam
+++ b/packages/xapi-forkexecd/xapi-forkexecd.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/"
+bug-reports: "https://github.com/xapi-project/forkexecd/issues"
+dev-repo: "git://github.com/xapi-project/forkexecd"
+tags: [ "org:xapi-project" ]
+build: [
+  ["oasis" "setup"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+    ["oasis" "setup"]
+    [make "uninstall"]
+    ["ocamlfind" "remove" "forkexec"]
+]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "base-threads"
+  "ocaml-systemd" {>= "1.2"}
+  "syslog"
+  "rpc" {>= "1.9.51"}
+  "fd-send-recv"
+  "uuidm"
+  "xapi-stdext" {= "2.1.0"}
+  "xapi-idl" {= "1.14.0"}
+]

--- a/packages/xapi-forkexecd/xapi-forkexecd.1.4.0/url
+++ b/packages/xapi-forkexecd/xapi-forkexecd.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/forkexecd/archive/v1.4.0.tar.gz"
+checksum: "2e24d66dbc7c6d2fe4572feaea7701ae"

--- a/packages/xapi-idl/xapi-idl.1.14.0/descr
+++ b/packages/xapi-idl/xapi-idl.1.14.0/descr
@@ -1,0 +1,9 @@
+Interface descriptions and common boilerplate for xapi services.
+
+The xapi toolstack is a set of communicating services including
+  - xenopsd: low-level Xen domain management
+  - networkd: host network configuration
+  - squeezed: balances memory between domains
+  - rrdd: manages datasources and records history
+plus storage 'plugins'
+

--- a/packages/xapi-idl/xapi-idl.1.14.0/opam
+++ b/packages/xapi-idl/xapi-idl.1.14.0/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+authors: "Dave Scott"
+homepage: "https://github.com/xapi-project/xcp-idl"
+bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
+dev-repo: "git://github.com/xapi-project/xcp-idl"
+maintainer: "xen-api@lists.xen.org"
+tags: [ "org:xapi-project" ]
+build: [
+  [make "all"]
+]
+build-test: [
+  [make "test"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "xcp"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-threads"
+  "base-unix"
+  "uri"
+  "re"
+  "cmdliner"
+  "cohttp" {< "0.22.0"}
+  "xmlm"
+  "rpc" {>= "1.9.51"}
+  "message-switch" {= "1.4.0"}
+  "xapi-stdext" {= "2.1.0"}
+  "xapi-rrd" {= "1.0.0"}
+  "xapi-inventory" {= "1.0.2"}
+  "xapi-backtrace" {= "0.4"}
+  "fd-send-recv"
+  "lwt" {< "3.0.0"}
+  "ounit" {>= "2.0.0"}
+  "ppx_sexp_conv"
+  "sexplib"
+]
+

--- a/packages/xapi-idl/xapi-idl.1.14.0/url
+++ b/packages/xapi-idl/xapi-idl.1.14.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xcp-idl/archive/v1.14.0.tar.gz"
+checksum: "587a14daed37b581593acd7f66632141"

--- a/packages/xapi-inventory/xapi-inventory.1.0.2/descr
+++ b/packages/xapi-inventory/xapi-inventory.1.0.2/descr
@@ -1,0 +1,4 @@
+Library for accessing the xapi toolstack inventory file
+
+The inventory file provides global host identify information
+needed by multiple services.

--- a/packages/xapi-inventory/xapi-inventory.1.0.2/opam
+++ b/packages/xapi-inventory/xapi-inventory.1.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/xcp-inventory"
+bug-reports: "https://github.com/xapi-project/xcp-inventory/issues"
+dev-repo: "git://github.com/xapi-project/xcp-inventory.git"
+tags: [ "org:xapi-project" ]
+build: [
+  ["./configure" "--default_inventory=%{prefix}%/etc"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "ocamlbuild" {build}
+  "base-threads"
+  "xapi-stdext" {= "2.1.0"}
+  "cmdliner"
+  "uuidm"
+]

--- a/packages/xapi-inventory/xapi-inventory.1.0.2/url
+++ b/packages/xapi-inventory/xapi-inventory.1.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xcp-inventory/archive/v1.0.2.tar.gz"
+checksum: "14a2a654e04028f226dc891e52e6cff9"

--- a/packages/xapi-rrd/xapi-rrd.1.0.0/descr
+++ b/packages/xapi-rrd/xapi-rrd.1.0.0/descr
@@ -1,0 +1,5 @@
+RRD library for use with xapi
+
+Round-Robin Databases (RRDs) are constant-space datastructures
+used for archiving historical data where the older data is stored
+at a lower resolution.

--- a/packages/xapi-rrd/xapi-rrd.1.0.0/opam
+++ b/packages/xapi-rrd/xapi-rrd.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: ["Dave Scott" "Jon Ludlam" "John Else"]
+homepage: "https://github.com/xapi-project/xcp-rrd"
+bug-reports: "https://github.com/xapi-project/xcp-rrd/issues"
+dev-repo: "https://github.com/xapi-project/xcp-rrd.git"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  [make]
+]
+build-test: [
+  [make "test"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "oasis"     {build}
+  "base-bigarray"
+  "base-unix"
+  "rpc" {>= "1.9.51"}
+  "uuidm"
+  "ounit" {test}
+]

--- a/packages/xapi-rrd/xapi-rrd.1.0.0/url
+++ b/packages/xapi-rrd/xapi-rrd.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xcp-rrd/archive/v1.0.0.tar.gz"
+checksum: "b40f140063c4758ff3d587760881201c"

--- a/packages/xapi-stdext/xapi-stdext.2.1.0/descr
+++ b/packages/xapi-stdext/xapi-stdext.2.1.0/descr
@@ -1,0 +1,4 @@
+A deprecated collection of utility functions
+
+This library is provided for a transitionary period only.
+No new code should use this library.

--- a/packages/xapi-stdext/xapi-stdext.2.1.0/opam
+++ b/packages/xapi-stdext/xapi-stdext.2.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: "xen-api@list.xen.org"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+dev-repo: "git://github.com/xapi-project/stdext.git"
+homepage: "https://xapi-project.github.io/"
+tags: [ "org:xapi-project" ]
+build: [
+  ["oasis" "setup"]
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["oasis" "setup"]
+  [make "uninstall" "BINDIR=%{bin}%"]
+  ["ocamlfind" "remove" "stdext"]
+]
+depends: [
+  "oasis" {build}
+  "ocamlfind" {build}
+  "base-bigarray"
+  "base-threads"
+  "base-unix"
+  "uuidm"
+  "fd-send-recv"
+  "xapi-backtrace" {= "0.4"}
+]

--- a/packages/xapi-stdext/xapi-stdext.2.1.0/url
+++ b/packages/xapi-stdext/xapi-stdext.2.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/stdext/archive/v2.1.0.tar.gz"
+checksum: "dbc33a1b84fa2e3ed9b41a12511b9d21"

--- a/packages/xapi-tapctl/xapi-tapctl.1.0.1/descr
+++ b/packages/xapi-tapctl/xapi-tapctl.1.0.1/descr
@@ -1,0 +1,5 @@
+A library to control tapdisk on a Xen host
+
+Tapdisk is used to create block devices for VMs. This library allows
+tapdisks to be manipulated: created, destroyed, paused, unpaused and
+the storage media inserted and ejected.

--- a/packages/xapi-tapctl/xapi-tapctl.1.0.1/opam
+++ b/packages/xapi-tapctl/xapi-tapctl.1.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: "xen-api@lists.xen.org"
+homepage: "https://xapi-project.github.io/"
+bug-reports: "https://github.com/xapi-project/tapctl/issues"
+dev-repo: "git://github.com/xapi-project/tapctl.git"
+tags: [ "org:xapi-project" ]
+build: [
+  ["oasis" "setup"]
+  [make]
+]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "tapctl"]
+]
+depends: [
+  "ocamlfind" {build}
+  "oasis" {build}
+  "xapi-stdext" {= "2.1.0"}
+  "xapi-forkexecd" {= "1.4.0"}
+  "rpc"
+  "base-threads"
+]
+

--- a/packages/xapi-tapctl/xapi-tapctl.1.0.1/url
+++ b/packages/xapi-tapctl/xapi-tapctl.1.0.1/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/tapctl/archive/v1.0.1.tar.gz"

--- a/packages/xen-api-client/xen-api-client.0.9.10/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.10/opam
@@ -36,4 +36,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["async"]
-conflicts: ["async" {< "111.13.00"}]
+conflicts: [
+  "async" {< "111.13.00"}
+  "async" {>= "v0.9.0"}
+]

--- a/packages/xen-api-client/xen-api-client.0.9.14/descr
+++ b/packages/xen-api-client/xen-api-client.0.9.14/descr
@@ -1,0 +1,1 @@
+Xen-API client library for remotely-controlling an XCP or XenServer host.

--- a/packages/xen-api-client/xen-api-client.0.9.14/findlib
+++ b/packages/xen-api-client/xen-api-client.0.9.14/findlib
@@ -1,0 +1,1 @@
+xen-api-client

--- a/packages/xen-api-client/xen-api-client.0.9.14/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.14/opam
@@ -34,4 +34,7 @@ depends: [
   "uuidm"
 ]
 depopts: ["async"]
-conflicts: ["async" {< "111.13.00"}]
+conflicts: [
+  "async" {< "111.13.00"}
+  "async" {>= "v0.9.0"}
+]

--- a/packages/xen-api-client/xen-api-client.0.9.14/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.14/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+name: "xen-api-client"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
+license: "LGPL"
+homepage: "https://github.com/xapi-project/xen-api-client"
+dev-repo: "https://github.com/xapi-project/xen-api-client.git"
+bug-reports: "https://github.com/xapi-project/xen-api-client/issues"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "xen-api-client"]]
+depends: [
+  "ocamlfind" {build}
+  "oasis"     {build}
+  "lwt" {>= "2.4.3" & < "3.0.0"}
+  "cstruct" {>= "1.0.1" & < "3.0.0"}
+  "ssl"
+  "ounit"
+  "cohttp" {>= "0.12.0" & < "0.22.0"}
+  "uri"
+  "re"
+  "xmlm"
+  "rpc" {>= "1.9.51"}
+  "xapi-rrd" {= "1.0.0"}
+  "uuidm"
+]
+depopts: ["async"]
+conflicts: ["async" {< "111.13.00"}]

--- a/packages/xen-api-client/xen-api-client.0.9.14/url
+++ b/packages/xen-api-client/xen-api-client.0.9.14/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xen-api-client/archive/v0.9.14.tar.gz"
+checksum: "e8a31f7c0cd4a781fd57bc5d48b18047"


### PR DESCRIPTION
This is the "constructive" PR after https://github.com/ocaml/opam-repository/pull/9206 to update our packages required by others to their newest version.

We pinned our own packages from [xs-opam](https://github.com/xapi-project/xs-opam) to exact versions, to ensure that we always have a consistent set of packages, this way we can update all of them together at the same time. Our plan is to update these libraries to their newest versions after each XenServer release.