### PR TITLE
configurator.v0.9.1 — via opam-publish

### DIFF
--- a/packages/configurator/configurator.v0.9.1/descr
+++ b/packages/configurator/configurator.v0.9.1/descr
@@ -1,0 +1,11 @@
+Helper library for gathering system configuration
+
+Configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+
+Configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file

--- a/packages/configurator/configurator.v0.9.1/opam
+++ b/packages/configurator/configurator.v0.9.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/configurator"
+bug-reports: "https://github.com/janestreet/configurator/issues"
+dev-repo: "https://github.com/janestreet/configurator.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.9" & < "v0.10"}
+  "jbuilder"                {build & >= "1.0+beta7"}
+  "ppx_base"                {>= "v0.9" & < "v0.10"}
+  "ppx_driver"              {>= "v0.9" & < "v0.10"}
+  "stdio"                   {>= "v0.9" & < "v0.10"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/configurator/configurator.v0.9.1/url
+++ b/packages/configurator/configurator.v0.9.1/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/configurator/archive/v0.9.1.tar.gz"
+checksum: "3152504ee8f08667e385fe36bd058cf5"


### PR DESCRIPTION
Helper library for gathering system configuration

Configurator is a small library that helps writing OCaml scripts that
test features available on the system, in order to generate config.h
files for instance.

Configurator allows one to:
- test if a C program compiles
- query pkg-config
- import #define from OCaml header files
- generate config.h file


---
* Homepage: https://github.com/janestreet/configurator
* Source repo: git+https://github.com/janestreet/configurator.git
* Bug tracker: https://github.com/janestreet/configurator/issues

---
### opam-lint failures
- **ERROR** 32 Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
- **ERROR** 21 Field 'opam-version' doesn't match the current version, validation may not be accurate: "1.2"

---

Pull-request generated by opam-publish v0.3.4