### PR TITLE
New Irmin release

### DIFF
--- a/packages/datakit/datakit.0.10.0/opam
+++ b/packages/datakit/datakit.0.10.0/opam
@@ -17,7 +17,7 @@ depends: [
   "rresult" "astring" "fmt" "asetmap"
   "git"         {>= "1.9.3"}
   "uri"
-  "irmin"       {>= "1.1.0"}
+  "irmin"       {>= "1.1.0" & < "1.2.0"}
   "irmin-git"   {>= "1.0.0"}
   "camlzip"     {>= "1.06"}
   "cstruct"     {>= "2.2"}

--- a/packages/datakit/datakit.0.10.1/opam
+++ b/packages/datakit/datakit.0.10.1/opam
@@ -17,7 +17,7 @@ depends: [
   "rresult" "astring" "fmt" "asetmap"
   "git"         {>= "1.9.3"}
   "uri"
-  "irmin"       {>= "1.1.0"}
+  "irmin"       {>= "1.1.0" & < "1.2.0"}
   "irmin-git"   {>= "1.0.0"}
   "camlzip"     {>= "1.06"}
   "cstruct"     {>= "2.2"}

--- a/packages/irmin-fs/irmin-fs.1.2.0/descr
+++ b/packages/irmin-fs/irmin-fs.1.2.0/descr
@@ -1,0 +1,1 @@
+Generic file-system backend for Irmin

--- a/packages/irmin-fs/irmin-fs.1.2.0/opam
+++ b/packages/irmin-fs/irmin-fs.1.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "test/irmin-fs"]
+
+depends: [
+  "jbuilder" {build}
+  "irmin"    {>= "1.2.0"}
+  "alcotest" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin-fs/irmin-fs.1.2.0/url
+++ b/packages/irmin-fs/irmin-fs.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.2.0/irmin-1.2.0.tbz"
+checksum: "0c75e0e73ea4ceda7e35e9379f21fe81"

--- a/packages/irmin-git/irmin-git.1.2.0/descr
+++ b/packages/irmin-git/irmin-git.1.2.0/descr
@@ -1,0 +1,4 @@
+Git backend for Irmin
+
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.

--- a/packages/irmin-git/irmin-git.1.2.0/opam
+++ b/packages/irmin-git/irmin-git.1.2.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "test/irmin-git"]
+
+depends: [
+  "jbuilder" {build}
+  "irmin"    {>= "1.2.0"}
+  "git"      {>= "1.11.0"}
+  "alcotest" {test}
+  "git-unix" {test & >= "1.11.0"}
+  "mtime"    {test & >= "1.0.0"}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-git/irmin-git.1.2.0/url
+++ b/packages/irmin-git/irmin-git.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.2.0/irmin-1.2.0.tbz"
+checksum: "0c75e0e73ea4ceda7e35e9379f21fe81"

--- a/packages/irmin-http/irmin-http.1.2.0/descr
+++ b/packages/irmin-http/irmin-http.1.2.0/descr
@@ -1,0 +1,1 @@
+HTTP client and server for Irmin

--- a/packages/irmin-http/irmin-http.1.2.0/opam
+++ b/packages/irmin-http/irmin-http.1.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "test/irmin-mem"]
+
+depends: [
+  "jbuilder" {build}
+  "crunch"
+  "webmachine" {>= "0.3.2"}
+  "irmin"  {>= "1.2.0"}
+  "cohttp" {>= "0.18.3"}
+  "irmin-git" {test & >= "1.2.0"}
+  "alcotest"  {test}
+  "mtime"     {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-http/irmin-http.1.2.0/url
+++ b/packages/irmin-http/irmin-http.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.2.0/irmin-1.2.0.tbz"
+checksum: "0c75e0e73ea4ceda7e35e9379f21fe81"

--- a/packages/irmin-mem/irmin-mem.1.2.0/descr
+++ b/packages/irmin-mem/irmin-mem.1.2.0/descr
@@ -1,0 +1,1 @@
+In-memory backend for Irmin

--- a/packages/irmin-mem/irmin-mem.1.2.0/opam
+++ b/packages/irmin-mem/irmin-mem.1.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "test/irmin-mem"]
+
+depends: [
+  "jbuilder" {build}
+  "irmin"    {>= "1.2.0"}
+  "alcotest" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin-mem/irmin-mem.1.2.0/url
+++ b/packages/irmin-mem/irmin-mem.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.2.0/irmin-1.2.0.tbz"
+checksum: "0c75e0e73ea4ceda7e35e9379f21fe81"

--- a/packages/irmin-mirage/irmin-mirage.1.2.0/descr
+++ b/packages/irmin-mirage/irmin-mirage.1.2.0/descr
@@ -1,0 +1,1 @@
+MirageOS-compatible Irmin stores

--- a/packages/irmin-mirage/irmin-mirage.1.2.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.2.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder"   {build}
+  "irmin"      {>= "1.2.0"}
+  "irmin-git"  {>= "1.2.0"}
+  "irmin-mem"  {>= "1.2.0"}
+  "git-mirage" {>= "1.11.0"}
+  "ptime"
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "result"
+]

--- a/packages/irmin-mirage/irmin-mirage.1.2.0/url
+++ b/packages/irmin-mirage/irmin-mirage.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.2.0/irmin-1.2.0.tbz"
+checksum: "0c75e0e73ea4ceda7e35e9379f21fe81"

--- a/packages/irmin-unix/irmin-unix.1.2.0/descr
+++ b/packages/irmin-unix/irmin-unix.1.2.0/descr
@@ -1,0 +1,5 @@
+Unix backends for Irmin
+
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.

--- a/packages/irmin-unix/irmin-unix.1.2.0/opam
+++ b/packages/irmin-unix/irmin-unix.1.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "test/irmin-unix"]
+
+depends: [
+  "jbuilder"   {build}
+  "irmin"      {>= "1.2.0"}
+  "irmin-git"  {>= "1.2.0"}
+  "irmin-http" {>= "1.2.0"}
+  "irmin-fs"   {>= "1.2.0"}
+  "git-unix"   {>= "1.11.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "irmin-mirage" {test & >= "1.2.0"}
+  "alcotest"     {test}
+  "mtime"        {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-unix/irmin-unix.1.2.0/url
+++ b/packages/irmin-unix/irmin-unix.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.2.0/irmin-1.2.0.tbz"
+checksum: "0c75e0e73ea4ceda7e35e9379f21fe81"

--- a/packages/irmin/irmin.0.10.0/opam
+++ b/packages/irmin/irmin.0.10.0/opam
@@ -50,8 +50,9 @@ depopts: [
   "mirage-git"
 ]
 conflicts: [
-  "cohttp" {< "0.18.3"}
-  "git"    {< "1.7.1" & >= "1.8.0"}
+  "cohttp"   {< "0.18.3"}
+  "git"      {< "1.7.1"}
+  "git"      {>= "1.8.0"}
   "git-unix" {>= "1.10.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin/irmin.0.10.1/opam
+++ b/packages/irmin/irmin.0.10.1/opam
@@ -50,9 +50,10 @@ depopts: [
   "mirage-git"
 ]
 conflicts: [
-  "cohttp" {< "0.18.3"}
-  "git"    {< "1.7.1" & > "1.7.2"}
+  "cohttp"   {< "0.18.3"}
+  "git"      {< "1.7.1"}
+  "git"      {> "1.7.2"}
   "git-unix" {>= "1.10.0"}
-  "conduit" {< "0.9.0"}
+  "conduit"  {< "0.9.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin/irmin.0.9.9/opam
+++ b/packages/irmin/irmin.0.9.9/opam
@@ -49,8 +49,9 @@ depopts: [
   "mirage-git"
 ]
 conflicts: [
-  "cohttp" {< "0.18.3"}
-  "git"    {< "1.7.1" & >= "1.8.0"}
+  "cohttp"   {< "0.18.3"}
+  "git"      {< "1.7.1"}
+  "git"      {>= "1.8.0"}
   "git-unix" {>= "1.10.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin/irmin.1.2.0/descr
+++ b/packages/irmin/irmin.1.2.0/descr
@@ -1,0 +1,7 @@
+Irmin, a distributed database that follows the same design principles as Git
+
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.

--- a/packages/irmin/irmin.1.2.0/opam
+++ b/packages/irmin/irmin.1.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "result"
+  "fmt"
+  "uri" {>= "1.3.12"}
+  "cstruct" {>= "1.6.0"}
+  "jsonm" {>= "1.0.0"}
+  "lwt" {>= "2.4.7"}
+  "ocamlgraph"
+  "hex"
+  "logs" {>= "0.5.0"}
+  "astring"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.2.0/url
+++ b/packages/irmin/irmin.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.2.0/irmin-1.2.0.tbz"
+checksum: "0c75e0e73ea4ceda7e35e9379f21fe81"


### PR DESCRIPTION
This release changes the build system to use
[jbuilder](https://github.com/janestreet/jbuilder). By doing so, it introduces
two new packages: `irmin-mem` and `irmin-fs` -- containing `Irmin_mem` and
`Irmin_fs` respectively. That release also fixes a bunch of regressions
introduced in the big 1.0 rewrite.

**all**

- Use `jbuilder` (mirage/irmin#444, @samoht)
- Use mtime 1.0 (mirage/irmin#445, @samoht)

**irmin**

- Fix `Irmin.Contents.Cstruct`: pretty-print the raw contents, not the hexdump
  (mirage/irmin#442, @samoht)
- `Irmin.Hash.X.of_string` should not raise an exception on invalid hash
  (mirage/irmin#443, @samoht)

**irmin-mem**

- New package! Use it if you want to use the `Irmin_mem` module.

**irmin-fs**

- New package! Use it if you want to use the `Irmin_fs` module.

**irmin-git**

- Fix watches (mirage/irmin#446, @samoht)