### PR TITLE
mirage-flow-lwt needs cstruct-lwt if cstruct >= 3.0

### DIFF
--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
@@ -18,6 +18,7 @@ depends: [
   "fmt"
   "lwt"
   "cstruct" {>= "2.0.0"}
+  "cstruct-lwt"
   "mirage-clock" {>= "1.2.0"}
   "mirage-flow" {>= "1.2.0"}
 ]


### PR DESCRIPTION
/cc @djs55 

Would probably be simpler to just require `"cstruct" {>= "3.0.0"}`