### PR TITLE
elf2json: minimum bound on base64 due to B64->Base64 module change

### DIFF
--- a/packages/elf2json/elf2json.1.0.0/opam
+++ b/packages/elf2json/elf2json.1.0.0/opam
@@ -17,7 +17,7 @@ build-test: [
 ]
 remove: ["ocaml" "%{etc}%/elf2json/_oasis_remove_.ml" "%{etc}%/elf2json"]
 depends: [
-  "base64" {build}
+  "base64" {build & >="2.0.0"}
   "jsonm" {build}
   "ocamlfind" {build}
   "rdr" {>= "2.0.0"}


### PR DESCRIPTION
noted in revdeps for #9423