### PR TITLE
hlarp: upper bound nonstd due to api change

### DIFF
--- a/packages/hlarp/hlarp.0.0.3/opam
+++ b/packages/hlarp/hlarp.0.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cmdliner"
-  "nonstd"
+  "nonstd" {<"0.0.2"}
   "re" {>= "1.5.0"}
   "oml" {>= "0.0.7"}
 ]


### PR DESCRIPTION
noted in revdeps for #9423