### PR TITLE
ocaml-migrate-parsetree.1.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
+license: "LGPL-2.1"
+tags: ["syntax" "org:ocamllabs"]
+dev-repo: "git://github.com/let-def/ocaml-migrate-parsetree.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "result"
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/let-def/ocaml-migrate-parsetree/archive/1.0.1.tar.gz"
+checksum: "b2abce65e3e9057af3fe96fa8e9d088b"


### PR DESCRIPTION
Convert OCaml parsetrees between different versions 

This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
High-level functions help making PPX rewriters independent of a compiler version.


---
* Homepage: https://github.com/let-def/ocaml-migrate-parsetree
* Source repo: git://github.com/let-def/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/let-def/ocaml-migrate-parsetree/issues

---

Pull-request generated by opam-publish v0.3.4