### PR TITLE
ocaml-migrate-parsetree-ocamlbuild.1.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.1/descr
+++ b/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.1/descr
@@ -1,0 +1,3 @@
+ocamlbuild plugin for ocaml-migrate-parsetree
+
+Configure ocamlbuild for building ppx drivers using ocaml-migrate-parsetree.

--- a/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.1/opam
+++ b/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: "Jérémie Dimino <jeremie@dimino.org>"
+homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
+license: "LGPL-2.1"
+tags: ["syntax" "org:ocamllabs"]
+dev-repo: "git://github.com/let-def/ocaml-migrate-parsetree.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ocaml-migrate-parsetree"
+  "ocamlbuild"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.1/url
+++ b/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/let-def/ocaml-migrate-parsetree/archive/1.0.1.tar.gz"
+checksum: "b2abce65e3e9057af3fe96fa8e9d088b"


### PR DESCRIPTION
ocamlbuild plugin for ocaml-migrate-parsetree

Configure ocamlbuild for building ppx drivers using ocaml-migrate-parsetree.


---
* Homepage: https://github.com/let-def/ocaml-migrate-parsetree
* Source repo: git://github.com/let-def/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/let-def/ocaml-migrate-parsetree/issues

---

Pull-request generated by opam-publish v0.3.4