### PR TITLE
tar-format: upper bound on cstruct

### DIFF
--- a/packages/tar-format/tar-format.0.5.0/opam
+++ b/packages/tar-format/tar-format.0.5.0/opam
@@ -23,7 +23,7 @@ remove:  ["ocamlfind" "remove" "tar"]
 
 depends: [
   "ocamlfind"
-  "cstruct"           {>= "1.9.0"}
+  "cstruct"           {>= "1.9.0" & <"3.0.0"}
   "ppx_cstruct"       {build}
   "cstruct-lwt"
   "re"

--- a/packages/tar-format/tar-format.0.5.1/opam
+++ b/packages/tar-format/tar-format.0.5.1/opam
@@ -23,7 +23,7 @@ remove:  ["ocamlfind" "remove" "tar"]
 
 depends: [
   "ocamlfind"
-  "cstruct"           {>= "1.9.0"}
+  "cstruct"           {>= "1.9.0" & <"3.0.0"}
   "ppx_cstruct"       {build}
   "cstruct-lwt"
   "re"

--- a/packages/tar-format/tar-format.0.6.1/opam
+++ b/packages/tar-format/tar-format.0.6.1/opam
@@ -23,7 +23,7 @@ remove:  ["ocamlfind" "remove" "tar"]
 
 depends: [
   "ocamlfind"
-  "cstruct"           {>= "1.9.0"}
+  "cstruct"           {>= "1.9.0" & <"3.0.0"}
   "ppx_cstruct"       {build}
   "cstruct-lwt"
   "re"

--- a/packages/tar-format/tar-format.0.7.1/opam
+++ b/packages/tar-format/tar-format.0.7.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlbuild"        {build}
   "ocamlfind"         {build}
   "topkg"             {build & >= "0.8.0"}
-  "cstruct"           {>= "1.9.0"}
+  "cstruct"           {>= "1.9.0" & <"3.0.0"}
   "ppx_cstruct"       {build}
   "cstruct-lwt"       {build}
   "re"


### PR DESCRIPTION
looks like it is missing an explicit linkage to `cstruct.lwt`
so the build fails with jbuilder cstruct. just upper bounding
it as this is an older package that is superseded by `tar`

cc @djs55, noted in revdeps for #9423