### PR TITLE
protocol-9p.0.9.0: restrict cstruct upper bound

### DIFF
--- a/packages/protocol-9p/protocol-9p.0.9.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.9.0/opam
@@ -19,7 +19,7 @@ build-test: [
 
 depends: [
   "base-bytes"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "3.0.0"}
   "cstruct-lwt"
   "sexplib" {> "113.00.00"}
   "result"


### PR DESCRIPTION
does not link explicitly to cstruct.lwt

revdeps for #9433