### PR TITLE
release datakit 0.11.0

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/descr
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/descr
@@ -1,0 +1,8 @@
+A bi-directional bridge between the GitHub API and Datakit
+
+The package provides a bi-directional bridge between the GitHub API
+and Datakit, so you can talk to the GitHub API using filesystem and
+Git-like commands only. The `datakit-github` programs can start a
+webhook server to listen for GitHub events in real time, and project
+it into a Git repository. It also monitors that Git repository for
+user-provided changes, and translate them into GitHub API calls.

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "tests/%{name}%"]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "lwt" {>= "3.0.0"}
+  "datakit-github"    {>= "0.11.0"}
+  "datakit-client-9p" {>= "0.11.0"}
+  "datakit-client-git"
+  "logs" "fmt"
+  "mtime" {>= "1.0.0"}
+  "asl" "win-eventlog"
+  "uri" {>= "1.8.0"}
+  "hvsock" {>= "0.8.1"}
+  "hex" "nocrypto" "conduit"
+  "prometheus-app"
+  "protocol-9p-unix" {>= "0.11.0"}
+  "datakit-client" {>= "0.10.0"}
+  "github-hooks" {>= "0.1.1"}
+  "github" {>= "2.1.0"}
+  "alcotest" {test}
+  "datakit"  {test & >= "0.11.0"}
+]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/url
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/descr
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/descr
@@ -1,0 +1,21 @@
+DataKit Local-Git bridge
+
+This service is a drop-in replacement for the DataKit-GitHub bridge
+that instead just monitors a local Git repository. It is useful for
+testing a new DataKitCI configuration without having to configure
+GitHub integration first.
+
+The local bridge monitors the state of one or more local Git
+repositories, writing the current head of each branch to
+DataKit. DataKitCI can be configured to run the CI tests against the
+project each time a commit is made.
+
+Once you are happy with the way the CI is working, you can replace
+this service with the GitHub bridge service to have the CI test a
+project hosted on GitHub instead.
+
+Unlike the GitHub bridge, this service:
+
+- only reports on branches, not tags or pull requests;
+- does not report build statuses from other CI systems; and
+- does not push the statuses set by the CI anywhere.

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
@@ -19,5 +19,6 @@ depends: [
   "logs" "fmt"
   "protocol-9p-unix" {>= "0.11.0"}
   "datakit-client" {>= "0.11.0"}
+  "datakit-client-9p" {>= "0.11.0"}
   "datakit-github" {>= "0.11.0"}
 ]

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas.leonard@docker.com"
+authors:      ["Thomas Leonard"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "irmin-watcher"
+  "irmin"      {>= "1.2.0"}
+  "irmin-unix" {>= "1.2.0"}
+  "lwt" {>= "3.0.0"}
+  "logs" "fmt"
+  "protocol-9p-unix" {>= "0.11.0"}
+  "datakit-client" {>= "0.11.0"}
+  "datakit-github" {>= "0.11.0"}
+]

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/url
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-ci/datakit-ci.0.11.0/descr
+++ b/packages/datakit-ci/datakit-ci.0.11.0/descr
@@ -1,0 +1,7 @@
+Continuous Integration service using DataKit
+
+DataKitCI is a continuous integration service that monitors your
+GitHub project and tests each branch, tag and pull request. It
+displays the test results as status indicators in the GitHub UI. It
+keeps all of its state and logs in DataKit, rather than a traditional
+relational database, allowing review with the usual Git tools.

--- a/packages/datakit-ci/datakit-ci.0.11.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.11.0/opam
@@ -15,6 +15,7 @@ depends: [
   "jbuilder" {build}
   "multipart-form-data"
   "datakit-client" {>= "0.11.0"}
+  "datakit-client-9p" {>= "0.11.0"}
   "datakit-github" {>= "0.11.0"}
   "protocol-9p-unix" {>= "0.11.0"}
   "astring"

--- a/packages/datakit-ci/datakit-ci.0.11.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.11.0/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+maintainer:   "datakit@docker.com"
+authors:      ["Thomas© Leonard" "Anil Madhavapeddy"
+               "Dave Tucker" "Thomas Gazagnaire" ]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "ci/tests"]
+
+depends: [
+  "jbuilder" {build}
+  "multipart-form-data"
+  "datakit-client" {>= "0.11.0"}
+  "datakit-github" {>= "0.11.0"}
+  "protocol-9p-unix" {>= "0.11.0"}
+  "astring"
+  "cmdliner"
+  "fmt"
+  "logs"
+  "tyxml" {>= "4.0.0"}
+  "tls"
+  "conduit"
+  "io-page"
+  "pbkdf"
+  "webmachine" {>= "0.4.0"}
+  "session" {>= "0.3.0"}
+  "redis-lwt"
+  "asetmap"
+  "github" {>= "2.2.0"}
+  "prometheus-app"
+  "lwt" {>= "3.0.0"}
+  "ppx_sexp_conv" {build}
+  "crunch" {build}
+  "datakit" {test & >= "0.11.0"}
+  "irmin-unix" {test & >= "1.2.0"}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/datakit-ci/datakit-ci.0.11.0/url
+++ b/packages/datakit-ci/datakit-ci.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-client-9p/datakit-client-9p.0.11.0/descr
+++ b/packages/datakit-client-9p/datakit-client-9p.0.11.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit-client-9p/datakit-client-9p.0.11.0/opam
+++ b/packages/datakit-client-9p/datakit-client-9p.0.11.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "astring"
+  "logs"
+  "fmt"
+  "cstruct"          {> "2.2.0"}
+  "datakit-client"   {>= "0.11.0"}
+  "protocol-9p-unix" {>= "0.11.0"}
+  "cmdliner"
+]

--- a/packages/datakit-client-9p/datakit-client-9p.0.11.0/url
+++ b/packages/datakit-client-9p/datakit-client-9p.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-client-git/datakit-client-git.0.11.0/descr
+++ b/packages/datakit-client-git/datakit-client-git.0.11.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit-client-git/datakit-client-git.0.11.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.11.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "tests/datakit-git"]
+
+depends: [
+  "jbuilder" {build}
+  "datakit-client" {>= "0.10.0"}
+  "irmin-git" {>= "1.2.0"}
+  "irmin-watcher"
+  "git-unix"
+  "alcotest"  {test}
+  "irmin-mem" {test}
+  "irmin-git" {test}
+]

--- a/packages/datakit-client-git/datakit-client-git.0.11.0/url
+++ b/packages/datakit-client-git/datakit-client-git.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-client/datakit-client.0.11.0/descr
+++ b/packages/datakit-client/datakit-client.0.11.0/descr
@@ -1,0 +1,5 @@
+A library to connect to DataKit servers
+
+The library currently only provides only a 9p client to talk to
+Datakit, but other filesystem protocols will be available in the
+future.

--- a/packages/datakit-client/datakit-client.0.11.0/opam
+++ b/packages/datakit-client/datakit-client.0.11.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "astring"
+  "result"
+  "fmt"
+  "lwt"
+  "cstruct" {> "2.2.0"}
+]

--- a/packages/datakit-client/datakit-client.0.11.0/url
+++ b/packages/datakit-client/datakit-client.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-github/datakit-github.0.11.0/descr
+++ b/packages/datakit-github/datakit-github.0.11.0/descr
@@ -1,0 +1,1 @@
+Abstraction of the GitHub API, suitable for DataKit clients

--- a/packages/datakit-github/datakit-github.0.11.0/opam
+++ b/packages/datakit-github/datakit-github.0.11.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.8.0"}
+  "asetmap"
+  "logs"
+  "fmt"
+  "result"
+  "datakit-client" {>= "0.11.0"}
+]

--- a/packages/datakit-github/datakit-github.0.11.0/url
+++ b/packages/datakit-github/datakit-github.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-server-9p/datakit-server-9p.0.11.0/descr
+++ b/packages/datakit-server-9p/datakit-server-9p.0.11.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit-server-9p/datakit-server-9p.0.11.0/opam
+++ b/packages/datakit-server-9p/datakit-server-9p.0.11.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "datakit-server"  {>= "0.11.0"}
+  "mirage-flow-lwt"
+  "protocol-9p" {>= "0.11.0"}
+  "sexplib"
+]

--- a/packages/datakit-server-9p/datakit-server-9p.0.11.0/url
+++ b/packages/datakit-server-9p/datakit-server-9p.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit-server/datakit-server.0.11.0/descr
+++ b/packages/datakit-server/datakit-server.0.11.0/descr
@@ -1,0 +1,6 @@
+A library to write Datakit servers
+
+The library exposes a VFS interface, that servers can use to write
+introspection libraries -- for instance to expose runtime parameters
+over 9p. The library does not depend on Irmin so is relatively
+lightweight to embed in any application.

--- a/packages/datakit-server/datakit-server.0.11.0/opam
+++ b/packages/datakit-server/datakit-server.0.11.0/opam
@@ -16,5 +16,6 @@ depends: [
   "logs"
   "rresult"
   "fmt"
+  "lwt"     {>= "3.0.0"}
   "cstruct" {>= "2.2.0"}
 ]

--- a/packages/datakit-server/datakit-server.0.11.0/opam
+++ b/packages/datakit-server/datakit-server.0.11.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "astring"
+  "logs"
+  "rresult"
+  "fmt"
+  "cstruct" {>= "2.2.0"}
+]

--- a/packages/datakit-server/datakit-server.0.11.0/url
+++ b/packages/datakit-server/datakit-server.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"

--- a/packages/datakit/datakit.0.11.0/descr
+++ b/packages/datakit/datakit.0.11.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit/datakit.0.11.0/opam
+++ b/packages/datakit/datakit.0.11.0/opam
@@ -1,0 +1,43 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: [
+  ["jbuilder" "runtest" "tests/datakit"]
+  ["jbuilder" "runtest" "tests/datakit-9p"]
+]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "rresult" "astring" "fmt" "asetmap"
+  "git"         {>= "1.11.0"}
+  "uri"
+  "irmin"       {>= "1.2.0"}
+  "irmin-mem"   {>= "1.2.0"}
+  "irmin-git"   {>= "1.2.0"}
+  "cstruct"     {>= "2.2"}
+  "result"
+  "lwt"         {>= "3.0.0"}
+  "conduit" "mirage-flow"
+  "named-pipe"  {>= "0.4.0"}
+  "hvsock"      {>= "0.8.1"}
+  "logs"        {>= "0.5.0"}
+  "win-eventlog"
+  "asl"         {>= "0.10"}
+  "mtime"       {>= "1.0.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "prometheus-app"
+  "protocol-9p-unix"  {>= "0.11.0"}
+  "datakit-server-9p" {>= "0.11.0"}
+  "datakit-client-9p" {test & >= "0.11.0"}
+  "alcotest"          {test & >= "0.7.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/datakit/datakit.0.11.0/url
+++ b/packages/datakit/datakit.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.11.0/datakit-0.11.0.tbz"
+checksum: "b1b7bb4d727d5c7e61f34045be96f178"


### PR DESCRIPTION
The main change in this release is the addition of `datakit-client-git`
which implements the DataKit API on top of a normal Git repository. This
means that the deployment of DataKit tools is now much simpler as they do
not need a running DataKit server anymore. The client and server packages
have been renamed to make the use of 9p more explicit. Support for more
transport is planned, including gRPC and Cap-n-proto.

**Go bindings**

- Go: Separate user config from defaults in the database (moby/datakit#523, @djs55)
- Go: add `List` to list files in snapshots (moby/datakit#578, @ebriney)

**datakit-server, datakit-client**

- client/server: split the libraires between core API and 9p transport.

  There is now:
  - `datakit-client`: signature for client API + Path library
  - `datakit-server`: implementation of the VFS on top of Irmin
  - `datakit-client-9p`: implementation of the API using 9p as transport
  - `datakit-server-9p`: expose the Irmin VFS as the Datakit API; server-side
     implementation of the API using 9p as transport

  The tests are split as well, so all the client/server tests can be re-used
  with a different transport mechanism. (moby/datakit#551, @samoht)

- client: add a top-level `Datakit_client` module namespace: `Datakit_S.CLIENT`
  becomes `Datakit_client.S` and `Datakit_path` becomes `Datakit_client.Path`
  (moby/datakit#558, @samoht)

- client: remove `rename` API calls (moby/datakit#563, @samoht)

**datakit-client-9p**

`datakit-client-9p` is now the new name for the previously named
`datakit-client`. That package contains the 9p client bindings to the DataKit
API. More clients to come.

- 9p client: `DK.commit` now fails if the commit does not exists (instead of
  failing later when the commit is used) (moby/datakit#565, @samoht)

**datakit-client-git**

- git client: add client bindings using Git directly, without the need for a
  DataKit server (moby/datakit#559, @samoht)

**datakit**

- datakit: move all modules under the `Datakit` namespace. Expose
  `Datakit.Blob`, `Datakit.Branch`, `Datakit.Hash,` `Datakit.Metadata`,
  `Datakit.Path` forming the base types for DataKit stores. Also expose
  `Datakit.Make` (and `Datakit.Make_git`) to build a DataKit store from an
  `Irmin` store (or from a `Irmin_git` store). Finally, rename the functor
  to expose a DataKit store into a virtual file-system into `Datakit.VFS`
  (moby/datakit#583, @samoht)
- datakit: use irmin 1.2.0 and git 1.11.0 (moby/datakit#556, @samoht)
- datakit: use mtime 1.0 (moby/datakit#560, @samoht)
- datakit: stop using camlzip, switch to decompress (moby/datakit#570, @samoht)

**datakit-github**

- github: expose PR's owner (moby/datakit#587, @samoht)

**datakit-github-bridge**

- github bridge: look at the GH token in various places (moby/datakit#577, @samoht)
- github bridge: add the ability to monitor default repositories using the CLI
  (moby/datakit#577, @samoht)
- github bridge: allow to use `git://<path>` urls to "connect" to a local Git
  repo instead of a 9p DataKit server (moby/datakit#577, @samoht). For instance:

      $ datakit-bridge-github -r samoht/test -d git:///tmp/foo --resync 60

  will download all the issues and PR into a Git repository `/tmp/foo` and will
  keep it up-to-date when changes occur either on GitHub (with a full resync
  every 60s) or locally by commiting updates in the `/tmp/foo` Git repository.

**datakit-ci**

- use redis 0.3.5 (moby/datakit#562, moby/datakit#567, @samoht)
