### PR TITLE
Update capnp downloads to point to new repository

### DIFF
--- a/packages/capnp/capnp.1.0.0/url
+++ b/packages/capnp/capnp.1.0.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/pelzlpj/capnp-ocaml/archive/v1.0.0.tar.gz"
+archive: "https://github.com/capnproto/capnp-ocaml/archive/v1.0.0.tar.gz"
 checksum: "fadf2d058f266514e4a5227469d040f7"

--- a/packages/capnp/capnp.1.0.1/url
+++ b/packages/capnp/capnp.1.0.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/pelzlpj/capnp-ocaml/archive/v1.0.1.tar.gz"
+archive: "https://github.com/capnproto/capnp-ocaml/archive/v1.0.1.tar.gz"
 checksum: "7df6d317fb0f1e1bb3395f8b0d92743c"

--- a/packages/capnp/capnp.2.0.1/url
+++ b/packages/capnp/capnp.2.0.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/pelzlpj/capnp-ocaml/archive/v2.0.1.tar.gz"
+archive: "https://github.com/capnproto/capnp-ocaml/archive/v2.0.1.tar.gz"
 checksum: "65fe11901d4a9d9e963107927867fc00"

--- a/packages/capnp/capnp.2.1.0/url
+++ b/packages/capnp/capnp.2.1.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/pelzlpj/capnp-ocaml/archive/v2.1.0.tar.gz"
+archive: "https://github.com/capnproto/capnp-ocaml/archive/v2.1.0.tar.gz"
 checksum: "fc7a34b16faba3387b3b25ec9c1bfcd4"

--- a/packages/capnp/capnp.2.1.1/url
+++ b/packages/capnp/capnp.2.1.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/pelzlpj/capnp-ocaml/archive/v2.1.1.tar.gz"
+archive: "https://github.com/capnproto/capnp-ocaml/archive/v2.1.1.tar.gz"
 checksum: "88faa1670c4cce32cf986f14fe749eed"


### PR DESCRIPTION
The old links still work, but I guess they might break if the author forks the repository back into their personal account.