### PR TITLE
qbf.0.2 - via opam-publish

### DIFF
--- a/packages/qbf/qbf.0.2/descr
+++ b/packages/qbf/qbf.0.2/descr
@@ -1,0 +1,9 @@
+QBF solving in OCaml, including bindings to solvers
+
+Ocaml-qbf provides a unified API to several QBF solvers, along with
+common types for formulas, QCNF and literals and operations such as
+simplifications and reduction to CNF.
+
+It packs:
+- a binding to quantor, which is shipped with the library
+- a binding to Depqbf

--- a/packages/qbf/qbf.0.2/opam
+++ b/packages/qbf/qbf.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Simon Cruanes <simon.cruanes@inria.fr>"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/ocaml-qbf"
+bug-reports: "https://github.com/c-cube/ocaml-qbf/issues"
+license: "BSD-3-clause"
+tags: ["clib:quantor" "clib:qdpll" "clib:picosat"]
+dev-repo: "https://github.com/c-cube/ocaml-qbf.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "qbf"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {test}
+]
+depopts: ["ctypes" "random-generator"]

--- a/packages/qbf/qbf.0.2/url
+++ b/packages/qbf/qbf.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-qbf/archive/0.2.tar.gz"
+checksum: "4213a4a6138e2056ec5db3871d0dd17a"


### PR DESCRIPTION
QBF solving in OCaml, including bindings to solvers

Ocaml-qbf provides a unified API to several QBF solvers, along with
common types for formulas, QCNF and literals and operations such as
simplifications and reduction to CNF.

It packs:
- a binding to quantor, which is shipped with the library
- a binding to Depqbf


---
* Homepage: https://github.com/c-cube/ocaml-qbf
* Source repo: https://github.com/c-cube/ocaml-qbf.git
* Bug tracker: https://github.com/c-cube/ocaml-qbf/issues

---

Pull-request generated by opam-publish v0.3.4