### PR TITLE
i3ipc.0.1.1 - via opam-publish

### DIFF
--- a/packages/i3ipc/i3ipc.0.1.1/descr
+++ b/packages/i3ipc/i3ipc.0.1.1/descr
@@ -1,0 +1,4 @@
+A pure OCaml implementation of the i3 IPC protocol
+
+This library allows you to communicate with a running instance of i3, run
+commands, query information about the state of the WM, and subscribe to events.

--- a/packages/i3ipc/i3ipc.0.1.1/opam
+++ b/packages/i3ipc/i3ipc.0.1.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "armael@isomorphis.me"
+authors: "Armaël Guéneau"
+homepage: "https://github.com/Armael/ocaml-i3ipc"
+bug-reports: "https://github.com/Armael/ocaml-i3ipc/issues"
+license: "MIT"
+tags: ["i3" "ipc" "window-manager"]
+dev-repo: "git+https://github.com/Armael/ocaml-i3ipc"
+doc: "https://armael.github.io/ocaml-i3ipc/0.1/"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "i3ipc"]
+depends: [
+  "lwt"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ppx_deriving_yojson"
+  "result"
+  "stdint"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/i3ipc/i3ipc.0.1.1/url
+++ b/packages/i3ipc/i3ipc.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Armael/ocaml-i3ipc/archive/v0.1.1.tar.gz"
+checksum: "aed20b4c521e557a12abf52bf142689d"


### PR DESCRIPTION
A pure OCaml implementation of the i3 IPC protocol

This library allows you to communicate with a running instance of i3, run
commands, query information about the state of the WM, and subscribe to events.

---
* Homepage: https://github.com/Armael/ocaml-i3ipc
* Source repo: https://github.com/Armael/ocaml-i3ipc
* Bug tracker: https://github.com/Armael/ocaml-i3ipc/issues

---

Pull-request generated by opam-publish v0.3.4