### PR TITLE
webidl.1.2 - via opam-publish

### DIFF
--- a/packages/webidl/webidl.1.2/descr
+++ b/packages/webidl/webidl.1.2/descr
@@ -1,0 +1,4 @@
+Web IDL parser
+- parse Web IDL(https://heycam.github.io/webidl/) 
+- convert them to OCaml data
+- print them by deriving.show

--- a/packages/webidl/webidl.1.2/opam
+++ b/packages/webidl/webidl.1.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "0zat <0.zat.zer0@gmail.com>"
+authors: ["0zat"]
+homepage: "https://github.com/0zat/webidl"
+bug-reports: "https://github.com/0zat/webidl"
+dev-repo: "git+https://github.com/0zat/webidl.git"
+build: ["ocaml" "setup.ml" "build"]
+install: ["ocaml" "setup.ml" "install"]
+remove: ["ocaml" "setup.ml" "remove"]
+depends: [
+  "ocamlfind" {build & >= "1.7.1"}
+  "ocamlbuild" {build & >= "0.9.3"}
+  "ppx_deriving" { >= "4.1" }
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/webidl/webidl.1.2/url
+++ b/packages/webidl/webidl.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/0zat/webidl/archive/v1.2.zip"
+checksum: "bfb54b6b7e3fb6ee6b78a1451cf06616"


### PR DESCRIPTION
Web IDL parser
- parse Web IDL(https://heycam.github.io/webidl/) 
- convert them to OCaml data
- print them by deriving.show


---
* Homepage: https://github.com/0zat/webidl
* Source repo: git+https://github.com/0zat/webidl.git
* Bug tracker: https://github.com/0zat/webidl

---

Pull-request generated by opam-publish v0.3.4