### PR TITLE
secp256k1.0.2.5 - via opam-publish

### DIFF
--- a/packages/secp256k1/secp256k1.0.2.5/descr
+++ b/packages/secp256k1/secp256k1.0.2.5/descr
@@ -1,0 +1,14 @@
+Elliptic curve library secp256k1 wrapper for Ocaml
+
+This library wrap the secp256k1 EC(DSA) library into an OCaml library. At 
+the moment only a subset of functionalities are available:
+
+- Context: create, clone, destroy, randomize
+- Elliptic curve: public key creation
+- ECDSA: verify, sign
+
+
+All exchanged data (pubkey, signature, seckey) are represented as hex 
+strings.
+
+

--- a/packages/secp256k1/secp256k1.0.2.5/opam
+++ b/packages/secp256k1/secp256k1.0.2.5/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+]
+homepage: "https://github.com/dakk/secp256k1-ml"
+bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/secp256k1-ml"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta9"}
+  "base" {build & >= "v0.9.2"}
+  "stdio" {build & >= "v0.9.0"}
+  "configurator" {build & >= "v0.9.1"}
+  "hex" {test & >= "1.1.1"}
+  "ounit" {test & >= "2.2.2"}
+  "base-bigarray"
+]
+depexts: [
+  [["archlinux"] ["libsecp256k1-git"]]
+  [["debian"] ["libsecp256k1" "libsecp256k1-dev"]]
+  [["gentoo"] ["libsecp256k1"]]
+  [["ubuntu"] ["libsecp256k1" "libsecp256k1-dev"]]
+]

--- a/packages/secp256k1/secp256k1.0.2.5/url
+++ b/packages/secp256k1/secp256k1.0.2.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dakk/secp256k1-ml/archive/0.2.5.zip"
+checksum: "677f73a2012e4eca4a2e7ee757137f90"


### PR DESCRIPTION
Elliptic curve library secp256k1 wrapper for Ocaml

This library wrap the secp256k1 EC(DSA) library into an OCaml library. At 
the moment only a subset of functionalities are available:

- Context: create, clone, destroy, randomize
- Elliptic curve: public key creation
- ECDSA: verify, sign


All exchanged data (pubkey, signature, seckey) are represented as hex 
strings.




---
* Homepage: https://github.com/dakk/secp256k1-ml
* Source repo: https://github.com/dakk/secp256k1-ml
* Bug tracker: https://github.com/dakk/secp256k1-ml/issues

---

Pull-request generated by opam-publish v0.3.2