### PR TITLE
stop testing opam 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
   - os: linux
     env: OCAML_VERSION=4.02 OPAM_VERSION=1.2.2
   - os: linux
-    env: OCAML_VERSION=4.02 OPAM_VERSION=1.2.0
-  - os: linux
     env: OCAML_VERSION=4.01 OPAM_VERSION=1.2.2
   - os: linux
     env: OCAML_VERSION=4.00 OPAM_VERSION=1.2.2


### PR DESCRIPTION
See https://discuss.ocaml.org/t/rfc-deprecating-opam-1-2-0/332
for the justification and discussion.