### PR TITLE
tcpip: upper bound on mirage-profile

### DIFF
--- a/packages/tcpip/tcpip.2.2.0/opam
+++ b/packages/tcpip/tcpip.2.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "uint"
   "io-page" {< "1.3.0"}
   "ocamlbuild" {build}

--- a/packages/tcpip/tcpip.2.2.1/opam
+++ b/packages/tcpip/tcpip.2.2.1/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "io-page" {< "1.3.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/tcpip/tcpip.2.2.2/opam
+++ b/packages/tcpip/tcpip.2.2.2/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile"  {<"0.8.0"}
   "io-page" {< "1.3.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/tcpip/tcpip.2.2.3/opam
+++ b/packages/tcpip/tcpip.2.2.3/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile"  {<"0.8.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/tcpip/tcpip.2.3.0/opam
+++ b/packages/tcpip/tcpip.2.3.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/tcpip/tcpip.2.3.1/opam
+++ b/packages/tcpip/tcpip.2.3.1/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/tcpip/tcpip.2.4.0/opam
+++ b/packages/tcpip/tcpip.2.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "ocamlbuild" {build}
 ]
 depopts: "mirage-xen"

--- a/packages/tcpip/tcpip.2.4.1/opam
+++ b/packages/tcpip/tcpip.2.4.1/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/tcpip/tcpip.2.4.2/opam
+++ b/packages/tcpip/tcpip.2.4.2/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "mirage-flow" {test}
   "alcotest" {test}
   "ocamlbuild" {build}

--- a/packages/tcpip/tcpip.2.4.3/opam
+++ b/packages/tcpip/tcpip.2.4.3/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.2.5.0/opam
+++ b/packages/tcpip/tcpip.2.5.0/opam
@@ -33,7 +33,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile"
+  "mirage-profile" {<"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.2.5.1/opam
+++ b/packages/tcpip/tcpip.2.5.1/opam
@@ -36,7 +36,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.2.6.0/opam
+++ b/packages/tcpip/tcpip.2.6.0/opam
@@ -38,7 +38,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.2.6.1/opam
+++ b/packages/tcpip/tcpip.2.6.1/opam
@@ -38,7 +38,7 @@ depends: [
   "mirage-clock-unix" {>= "1.0.0" & <"1.2.0"}
   "mirage-net-unix" {>= "1.1.0" & <"2.3.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.2.7.0/opam
+++ b/packages/tcpip/tcpip.2.7.0/opam
@@ -51,7 +51,7 @@ depends: [
   "mirage-console" {< "2.2.0"}
   "mirage-clock-unix" {test & >= "1.0.0" & < "1.2.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.2.8.0/opam
+++ b/packages/tcpip/tcpip.2.8.0/opam
@@ -52,7 +52,7 @@ depends: [
   "mirage-console" {< "2.2.0"}
   "mirage-clock-unix" {test & >= "1.0.0" & < "1.2.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.2.8.1/opam
+++ b/packages/tcpip/tcpip.2.8.1/opam
@@ -52,7 +52,7 @@ depends: [
   "mirage-console" {< "2.2.0"}
   "mirage-clock-unix" {test & >= "1.0.0" & < "1.2.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test}
   "mirage-vnetif" {test}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -56,7 +56,7 @@ depends: [
   "mirage-protocols-lwt" {= "1.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test & >= "1.2.0"}
   "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.3.1.0/opam
+++ b/packages/tcpip/tcpip.3.1.0/opam
@@ -56,7 +56,7 @@ depends: [
   "mirage-protocols-lwt" {>= "1.1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test & >= "1.2.0"}
   "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.3.1.1/opam
+++ b/packages/tcpip/tcpip.3.1.1/opam
@@ -56,7 +56,7 @@ depends: [
   "mirage-protocols-lwt" {>= "1.1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test & >= "1.2.0"}
   "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.3.1.2/opam
+++ b/packages/tcpip/tcpip.3.1.2/opam
@@ -56,7 +56,7 @@ depends: [
   "mirage-protocols-lwt" {>= "1.1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test & >= "1.2.0"}
   "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -56,7 +56,7 @@ depends: [
   "mirage-protocols-lwt" {>= "1.1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
-  "mirage-profile" {>= "0.5"}
+  "mirage-profile" {>= "0.5" & <"0.8.0"}
   "mirage-flow" {test & >= "1.2.0"}
   "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}


### PR DESCRIPTION
this is due to the removal of an accidental cstruct.ppx linkage
in mirage-profile, which means that downstream packages that
depended on that now fail to build.  there is an associated release
of tcpip coming that fixes this issue in that package as well.

see #9543 revdeps and https://github.com/mirage/mirage-tcpip/pull/318