### PR TITLE
charrua-core: constraint cstruct to <3

### DIFF
--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -12,13 +12,13 @@ build: [
   ["sh" "build.sh"]
 ]
 depends: [
-  "ocamlfind"
-  {build}
+  "ocamlfind" {build}
   "ppx_deriving" {build}
+  "ppx_cstruct" {build}
   "ppx_sexp_conv"
   "ppx_type_conv"
-  "cstruct" {>= "1.9"}
-  "ppx_cstruct"
+  "cstruct" {>="1.9.0" & <"3.0.0"}
+  "cstruct-unix"
   "sexplib"
   "menhir"
   "ipaddr" {>= "2.5.0"}

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -11,13 +11,12 @@ build: [
   ["sh" "build.sh"]
 ]
 depends: [
-  "ocamlfind"
-  {build}
+  "ocamlfind" {build}
   "ppx_deriving" {build}
+  "ppx_cstruct" {build}
   "ppx_sexp_conv"
   "ppx_type_conv"
-  "cstruct" {>= "1.9"}
-  "ppx_cstruct"
+  "cstruct" {>="1.9.0" & <"3.0.0"}
   "sexplib"
   "menhir"
   "ipaddr" {>= "2.5.0"}

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "ppx_tools"     {build}
   "menhir"        {build}
-  "cstruct"       {>= "1.9.0"}
+  "cstruct"       {>="1.9.0" & <"3.0.0"}
   "ppx_cstruct"
   "sexplib"
   "ipaddr"        {>= "2.5.0"}

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "ppx_tools"     {build}
   "menhir"        {build}
-  "cstruct"       {>= "1.9.0"}
+  "cstruct"       {>= "1.9.0" & <"3.0.0"}
   "ppx_cstruct"
   "sexplib"
   "ipaddr"        {>= "2.5.0"}

--- a/packages/charrua-core/charrua-core.0.7/opam
+++ b/packages/charrua-core/charrua-core.0.7/opam
@@ -26,8 +26,8 @@ depends: [
   "ppx_sexp_conv" {build}
   "ppx_tools"     {build}
   "menhir"        {build}
-  "cstruct"       {>= "1.9.0"}
-  "ppx_cstruct"
+  "cstruct"       {>= "1.9.0" & < "3.0.0"}
+  "ppx_cstruct"   {build}
   "sexplib"
   "ipaddr"        {>= "2.5.0"}
   "tcpip"         {>= "3.1.0"}


### PR DESCRIPTION
this is because charrua uses both cstruct and sexp_conv which
has been problematic in cstruct3+. a new release of charrua-core
which addressses this is in https://github.com/mirage/charrua-core/pull/57