### PR TITLE
ocurl 0.7.10 - via opam-publish

### DIFF
--- a/packages/0/0.7.10/descr
+++ b/packages/0/0.7.10/descr
@@ -1,0 +1,3 @@
+Bindings to libcurl
+Client-side URL transfer library, supporting HTTP and a multitude of
+other network protocols (FTP/SMTP/RTSP/etc).

--- a/packages/0/0.7.10/opam
+++ b/packages/0/0.7.10/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+homepage: "http://ygrek.org.ua/p/ocurl/"
+license: "MIT"
+authors: [ "Lars Nilsson" "ygrek" ]
+doc: ["http://ygrek.org.ua/p/ocurl/api/index.html"]
+dev-repo: "git://github.com/ygrek/ocurl.git"
+bug-reports: "https://github.com/ygrek/ocurl/issues"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+build-test: [
+  [make "test"]
+]
+build-doc: [[make "doc"]]
+remove: [["ocamlfind" "remove" "curl"]]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+  "conf-libcurl"
+]
+depopts: ["lwt"]

--- a/packages/0/0.7.10/url
+++ b/packages/0/0.7.10/url
@@ -1,0 +1,3 @@
+http: "http://ygrek.org.ua/p/release/ocurl/ocurl-0.7.10.tar.gz"
+mirrors: ["https://github.com/ygrek/ocurl/releases/download/0.7.10/ocurl-0.7.10.tar.gz"]
+checksum: "82dec986ab22a349606d6bc51321f947"


### PR DESCRIPTION
Bindings to libcurl
Client-side URL transfer library, supporting HTTP and a multitude of
other network protocols (FTP/SMTP/RTSP/etc).


---
* Homepage: http://ygrek.org.ua/p/ocurl/
* Source repo: git://github.com/ygrek/ocurl.git
* Bug tracker: https://github.com/ygrek/ocurl/issues

---

Pull-request generated by opam-publish v0.3.4