### PR TITLE
nocrypto: make lwt a firm opam dependency of nocrypto

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -23,18 +23,18 @@ depends: [
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ounit" {test}
-  "cstruct" {<"3.0.0"}
+  "cstruct" {>="2.4.0"}
+  "cstruct-lwt"
   "zarith"
+  "lwt"
   "sexplib"
   ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy" & "zarith-xen"))
   ("mirage-no-solo5" | ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding"))
 ]
 
-depopts: [ "lwt" ]
 conflicts: [
   "topkg" {<"0.8.0"}
   "ocb-stubblr" {<"0.1.0"}
-  "cstruct" {<"2.3.0"}
   "mirage-xen" {<"2.2.0"}
   "sexplib" {="v0.9.0"}
 ]


### PR DESCRIPTION
this removes the depopt from opam, but lwt remains optional from
a findlib perspective. The reason this is necessary is to allow
cstruct-lwt to work (>=cstruct.3.0) which is difficult to do if
lwt remains a depopt.

An upstream release will be necessary to fully support cstruct3+
while lwt remains a depopt, but this unblocks the conflict in the
stable opam repository for now when using any version of cstruct