### PR TITLE
uuidm 0.9.6: correct contraints on cmdliner depopt.

### DIFF
--- a/packages/uuidm/uuidm.0.9.6/opam
+++ b/packages/uuidm/uuidm.0.9.6/opam
@@ -16,6 +16,7 @@ depends: [
 depopts: [
   "cmdliner"
 ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
 build:
 [  "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"


### PR DESCRIPTION
Fixes dbuenzli/uuidm#7