### PR TITLE
Markup.ml 0.7.5: error-correcting HTML5, XML parser

### DIFF
--- a/packages/markup/markup.0.7.5/descr
+++ b/packages/markup/markup.0.7.5/descr
@@ -1,0 +1,20 @@
+Error-recovering functional HTML5 and XML parsers and writers
+
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8.

--- a/packages/markup/markup.0.7.5/opam
+++ b/packages/markup/markup.0.7.5/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "markup"
+version: "0.7.5"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "https://github.com/aantron/markup.ml.git"
+license: "BSD"
+depends: [
+  "uutf" {>= "1.0.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ounit" {test}
+]
+depopts: ["lwt"]
+build: [
+  [make "build"]
+]
+build-test: [
+  [make "test"]
+]
+build-doc: [
+  [make "docs"]
+]
+install: [make "ocamlfind-install"]
+remove: ["ocamlfind" "remove" "markup"]

--- a/packages/markup/markup.0.7.5/url
+++ b/packages/markup/markup.0.7.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/aantron/markup.ml/archive/0.7.5.tar.gz"
+checksum: "968e485574a5b7d15e61376c937a368d"


### PR DESCRIPTION
Markup.ml is a pair of streaming, error-correcting, and standards-compliant parsers and writers, for HTML5 and XML. Markup.ml underlies the web scraper [Lambda Soup](https://github.com/aantron/lambda-soup). See the [Markup.ml repository](https://github.com/aantron/markup.ml) for more information.

The release [changelog](https://github.com/aantron/markup.ml/releases/tag/0.7.5):

> - When writing HTML, do not perform entity escaping inside `<script>` and similar tags (aantron/markup.ml#17, Johannes Kloos @johanneskloos).
> - Fix handling of unpaired `</form>` tags (aantron/markup.ml@0bf4f1b, reported Yann Hamdaoui @yannham).
> - Fix stream combinators to be tail-recursive (aantron/markup.ml@4a20cae).
> - Fix dependency on Findlib package `lwt.unix` (aantron/markup.ml#18, diagnosed Andrew Ray @andrewray).
> - Speed up reading from files by about 30% (aantron/markup.ml@7d84cb9).
