### PR TITLE
+dockerfile.3.0.0

### DIFF
--- a/packages/dockerfile-opam/dockerfile-opam.3.0.0/descr
+++ b/packages/dockerfile-opam/dockerfile-opam.3.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: http://docs.mirage.io/dockerfile
+- **Source:**: https://github.com/avsm/ocaml-dockerfile
+- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile-opam/dockerfile-opam.3.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.3.0.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "dockerfile" {>="3.0.0"}
+  "cmdliner"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile-opam/dockerfile-opam.3.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.3.0.0/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 tags: ["org:mirage" "org:ocamllabs"]
-available: [ ocaml-version >= "4.02.3"]
+available: [ ocaml-version >= "4.03.0"]
 depends: [
   "jbuilder" {build & >="1.0+beta10"}
   "dockerfile" {>="3.0.0"}

--- a/packages/dockerfile-opam/dockerfile-opam.3.0.0/url
+++ b/packages/dockerfile-opam/dockerfile-opam.3.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v3.0.0/dockerfile-3.0.0.tbz"
+checksum: "849ae08c8e6639df0569aa647baf35dd"

--- a/packages/dockerfile/dockerfile.2.2.3/descr
+++ b/packages/dockerfile/dockerfile.2.2.3/descr
@@ -1,0 +1,18 @@
+Typed interface for constructing Docker container descriptions
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+- **HTML Documentation**: https://avsm.github.io/ocaml-dockerfile
+- **Source:**: https://github.com/avsm/ocaml-dockerfile
+- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
+- **Email**: <mirageos-devel@lists.xenproject.org>
+

--- a/packages/dockerfile/dockerfile.2.2.3/opam
+++ b/packages/dockerfile/dockerfile.2.2.3/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+license: "ISC"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+tags: ["org:mirage" "org:ocamllabs"]
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_deriving" {build}
+  "topkg" {build}
+  "cmdliner"
+  "sexplib"
+  "base-bytes"
+  "fmt"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/dockerfile/dockerfile.2.2.3/url
+++ b/packages/dockerfile/dockerfile.2.2.3/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/avsm/ocaml-dockerfile/releases/download/v2.2.2/dockerfile-2.2.2.tbz"
+checksum: "964595e28259b85cd1201bba77d8eb4c"

--- a/packages/dockerfile/dockerfile.3.0.0/descr
+++ b/packages/dockerfile/dockerfile.3.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: http://docs.mirage.io/dockerfile
+- **Source:**: https://github.com/avsm/ocaml-dockerfile
+- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile/dockerfile.3.0.0/opam
+++ b/packages/dockerfile/dockerfile.3.0.0/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 tags: ["org:mirage" "org:ocamllabs"]
-available: [ ocaml-version >= "4.02.3"]
+available: [ ocaml-version >= "4.03.0"]
 depends: [
   "jbuilder" {build & >="1.0+beta10"}
   "ppx_sexp_conv" {build}

--- a/packages/dockerfile/dockerfile.3.0.0/opam
+++ b/packages/dockerfile/dockerfile.3.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "ppx_sexp_conv" {build}
+  "sexplib"
+  "base-bytes"
+  "fmt"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile/dockerfile.3.0.0/url
+++ b/packages/dockerfile/dockerfile.3.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v3.0.0/dockerfile-3.0.0.tbz"
+checksum: "849ae08c8e6639df0569aa647baf35dd"


### PR DESCRIPTION
--
Add support for [multistage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/)
to the `from`, `add`, and `copy` commands.

There are also backwards incompatible changes to the package layout:

Split up OPAM packages into `dockerfile` and `dockerfile-opam`.
The latter contains the OPAM- and Linux-specific modules, with
the core DSL in `dockerfile`.

Port to [jbuilder](https://github.com/janestreet/jbuilder).