### PR TITLE
coclobas.0.0.2 - via opam-publish

### DIFF
--- a/packages/coclobas/coclobas.0.0.2/descr
+++ b/packages/coclobas/coclobas.0.0.2/descr
@@ -1,0 +1,14 @@
+Coclobas is a scheduler for HPC-like jobs accessible through HTTP
+
+It can be setup with three configurations:
+
+- Using Kubernetes and the *Google Container Engine*,
+  i.e. using a Kubernetes “eleastic” cluster setup with `gcloud` and submitting
+  jobs as Kubernetes “pods”.
+- Using the server's machine as a one-node cluster and submitting jobs as docker
+  containers given a maximal number of jobs.
+- Using AWS-Batch, submitting jobs with aws-cli and optionally using
+  S3 bucket to share data (new in 0.0.2, and a bit experimental).
+
+Coclobas is mostly used as a Ketrew plugin, but can be driven separately.
+

--- a/packages/coclobas/coclobas.0.0.2/opam
+++ b/packages/coclobas/coclobas.0.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: "Seb Mondet <seb@mondet.org>"
+homepage: "https://github.com/hammerlab/coclobas"
+bug-reports: "https://github.com/hammerlab/coclobas/issues"
+dev-repo: "https://github.com/hammerlab/coclobas.git"
+license: "Apache 2.0"
+
+build: [
+  [make "byte"]
+  [make "native"]
+  [make "META"]
+  [make "coclobas.install"]
+]
+
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "solvuu-build" {build & >= "0.3.0"}
+  "nonstd"
+  "sosa"
+  "pvem_lwt_unix"
+  "cohttp" "lwt"
+  "trakeva"
+  "cmdliner"
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.0"}
+  "uuidm"
+  "base64"
+  "odate"
+]
+depopts: [
+  "ketrew"
+]
+
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/coclobas/coclobas.0.0.2/url
+++ b/packages/coclobas/coclobas.0.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/coclobas/archive/coclobas.0.0.2.tar.gz"
+checksum: "46ce8c59a482eb4cdf7b3325ce9840a3"


### PR DESCRIPTION
Coclobas is a scheduler for HPC-like jobs accessible through HTTP

It can be setup with three configurations:

- Using Kubernetes and the *Google Container Engine*,
  i.e. using a Kubernetes “eleastic” cluster setup with `gcloud` and submitting
  jobs as Kubernetes “pods”.
- Using the server's machine as a one-node cluster and submitting jobs as docker
  containers given a maximal number of jobs.
- Using AWS-Batch, submitting jobs with aws-cli and optionally using
  S3 bucket to share data (new in 0.0.2, and a bit experimental).

Coclobas is mostly used as a Ketrew plugin, but can be driven separately.



---
* Homepage: https://github.com/hammerlab/coclobas
* Source repo: https://github.com/hammerlab/coclobas.git
* Bug tracker: https://github.com/hammerlab/coclobas/issues

---

Pull-request generated by opam-publish v0.3.4