### PR TITLE
Make codept available for ocaml >= 4.04.0

### DIFF
--- a/packages/codept/codept.0.9.0/opam
+++ b/packages/codept/codept.0.9.0/opam
@@ -9,4 +9,4 @@ build: [make "all"]
 build-test: [make "alt2-tests"]
 build-doc: [make "alt2-docs"]
 depopts: "ocamlbuild"
-available: [ocaml-version = "4.04.0"]
+available: [ocaml-version >= "4.04.0"]


### PR DESCRIPTION
Codept is not available for ocaml 4.04.1 because of the requirement of the exact version 4.04.0.

cc @Octachron 