### PR TITLE
Package base.v0.9.3

### DIFF
--- a/packages/base/base.v0.9.3/descr
+++ b/packages/base/base.v0.9.3/descr
@@ -1,0 +1,12 @@
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio

--- a/packages/base/base.v0.9.3/opam
+++ b/packages/base/base.v0.9.3/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+license: "Apache-2.0"
+dev-repo: "https://github.com/janestreet/base.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "sexplib" {>= "v0.9.1" & < "v0.10"}
+]
+depopts: "base-native-int63"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/base/base.v0.9.3/url
+++ b/packages/base/base.v0.9.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/base/archive/v0.9.3.tar.gz"
+checksum: "3edb19585be84ea308323ccd41213e57"


### PR DESCRIPTION
### `base.v0.9.3`

Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---

:camel: Pull-request generated by opam-publish v0.3.4