### PR TITLE
Introduce xapi packages for xapi-rrdd

### DIFF
--- a/packages/ezxenstore/ezxenstore.0.1.1/descr
+++ b/packages/ezxenstore/ezxenstore.0.1.1/descr
@@ -1,0 +1,4 @@
+An easy-to-use xenstore library with a simplified interface geared
+towards use within a daemon that maintains a single connection to
+xenstored.
+

--- a/packages/ezxenstore/ezxenstore.0.1.1/opam
+++ b/packages/ezxenstore/ezxenstore.0.1.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: ["xen-api@lists.xensource.com"]
+license: "ISC"
+homepage: "https://github.com/xapi-project/ezxenstore"
+bug-reports: "https://github.com/xapi-project/ezxenstore/issues"
+dev-repo: "https://github.com/xapi-project/ezxenstore.git"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  make
+]
+install: [
+  make "install"
+]
+remove: [
+  "ocamlfind" "remove" "ezxenstore"
+]
+depends: [
+  "xenstore"
+  "xenstore_transport"
+  "logs"
+  "cmdliner"
+  "oasis" {build}
+]

--- a/packages/ezxenstore/ezxenstore.0.1.1/url
+++ b/packages/ezxenstore/ezxenstore.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/ezxenstore/archive/v0.1.1/ezxenstore-0.1.1.tar.gz"
+checksum: "fca162554d8496a877ac1d353109c8a8"

--- a/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/descr
+++ b/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/descr
@@ -1,0 +1,4 @@
+Further transitional libraries required by xapi
+
+These libraries are provided for backwards compatibility only.
+No new code should use these libraries.

--- a/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/opam
+++ b/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "Jon Ludlam" ]
+homepage: "https://github.com/xapi-project/xen-api-libs-transitional"
+bug-reports: "https://github.com/xapi-project/xen-api-libs-transitional/issues"
+dev-repo: "https://github.com/xapi-project/xen-api-libs-transitional.git"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  [make]
+]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "cpuid"]
+  ["ocamlfind" "remove" "gzip"]
+  ["ocamlfind" "remove" "http-svr"]
+  ["ocamlfind" "remove" "log"]
+  ["ocamlfind" "remove" "pciutil"]
+  ["ocamlfind" "remove" "sexpr"]
+  ["ocamlfind" "remove" "sha1"]
+  ["ocamlfind" "remove" "stunnel"]
+  ["ocamlfind" "remove" "uuid"]
+  ["ocamlfind" "remove" "xenctrlext"]
+  ["ocamlfind" "remove" "xenstore-compat"]
+  ["ocamlfind" "remove" "xen-utils"]
+  ["ocamlfind" "remove" "xml-light2"]
+]
+available: [ os = "linux" ]
+depends: [
+  "ocamlfind"
+  "xapi-stdext" {= "2.1.0"}
+  "xmlm"
+  "xapi-forkexecd" {= "1.4.0"}
+  "rpc" {>= "1.9.51"}
+  "xenctrl"
+  "xenstore"
+  "xenstore_transport"
+  "ezxenstore" {= "0.1.1"}
+]
+depexts: [
+  [["debian"] ["libxen-dev"]]
+  [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
+]

--- a/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/url
+++ b/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xen-api-libs-transitional/archive/v1.0.1.tar.gz"
+checksum: "0a2d2badca8dca9881ead80ff5237878"

--- a/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/descr
+++ b/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/descr
@@ -1,0 +1,4 @@
+Shared-memory protocols for exposing performance counters
+
+VMs running on a Xen host can use this library to expose performance
+counters which can be sampled by the xapi performance monitoring daemon.

--- a/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/opam
+++ b/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "Jon Ludlam" ]
+homepage: "https://github.com/xapi-project/rrd-transport"
+bug-reports: "https://github.com/xapi-project/rrd-transport/issues"
+dev-repo: "https://github.com/xapi-project/rrd-transport.git"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  [make]
+]
+build-test: [
+  [make "test"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [make "PREFIX=%{prefix}%" "uninstall"]
+depends: [
+  "cmdliner"
+  "cstruct" {< "3.0.0"}
+  "crc"
+  "xapi-idl" {= "1.14.0"}
+  "xapi-rrd" {= "1.0.0"}
+  "xen-gnt" {< "3.0.0"}
+]

--- a/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/url
+++ b/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/rrd-transport/archive/v1.2.0.tar.gz"
+checksum: "11baeb615cbe93b8449ae5889b32e1a6"

--- a/packages/xapi-rrdd/xapi-rrdd.1.2.1/descr
+++ b/packages/xapi-rrdd/xapi-rrdd.1.2.1/descr
@@ -1,0 +1,5 @@
+Performance monitoring daemon for xapi
+
+This daemon monitors "datasources" i.e. time-varying values such as
+performance counters and records the samples in RRD archives. These
+archives can be used to examine historical performance trends.

--- a/packages/xapi-rrdd/xapi-rrdd.1.2.1/opam
+++ b/packages/xapi-rrdd/xapi-rrdd.1.2.1/opam
@@ -1,0 +1,43 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "Jon Ludlam" ]
+homepage: "https://github.com/xapi-project/xcp-rrdd"
+bug-reports: "https://github.com/xapi-project/xcp-rrdd/issues"
+dev-repo: "https://github.com/xapi-project/xcp-rrdd.git"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  ["oasis" "setup"]
+  [make]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+build-test: [
+  [make "test"]
+]
+remove: [
+    [make "uninstall"]
+    ["ocamlfind" "remove" "rrdd-libs"]
+]
+depends: [
+  "ocamlfind" {build}
+  "xapi-backtrace" {= "0.4"}
+  "xapi-idl" {= "1.14.0"}
+  "xapi-libs-transitional" {= "1.0.1"}
+  "xapi-inventory" {= "1.0.2"}
+  "xapi-stdext" {= "2.1.0"}
+  "xapi-forkexecd" {= "1.4.0"}
+  "xenctrl"
+  "xenstore_transport"
+  "xapi-xenops" {= "1.0.1"}
+  "io-page"
+  "inotify"
+  "xen-gnt" {< "3.0.0"}
+  "xapi-rrd-transport" {= "1.2.0"}
+  "oclock"
+  "ounit"
+  "ocaml-systemd" {>= "1.2"}
+]
+

--- a/packages/xapi-rrdd/xapi-rrdd.1.2.1/url
+++ b/packages/xapi-rrdd/xapi-rrdd.1.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xcp-rrdd/archive/v1.2.1.tar.gz"
+checksum: "79d195a853fa6b3a45190d7d8d710f9b"

--- a/packages/xapi-xenops/xapi-xenops.1.0.1/descr
+++ b/packages/xapi-xenops/xapi-xenops.1.0.1/descr
@@ -1,0 +1,7 @@
+Create/destroy/manipulate Xen domains
+
+This library provides a set of building-blocks for constructing a Xen
+domain manager (aka a "toolstack"). There are functions for
+  - creating and building a domain
+  - attaching virtual disk and network devices
+  - spawning hardware emulators

--- a/packages/xapi-xenops/xapi-xenops.1.0.1/opam
+++ b/packages/xapi-xenops/xapi-xenops.1.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: "xen-api@lists.xen.org"
+homepage: "https://xapi-project.github.io/"
+bug-reports: "https://github.com/xapi-project/xenops/issues"
+dev-repo: "git://github.com/xapi-project/xenops.git"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  [make]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "BINDIR=%{bin}%" "install"]
+]
+remove: [
+  [make "PREFIX=%{prefix}%" "BINDIR=%{bin}%" "uninstall"]
+]
+depends: [
+  "oasis" {build}
+  "xapi-stdext" {= "2.1.0"}
+  "xapi-libs-transitional" {= "1.0.1"}
+  "xenctrl"
+  "xenstore"
+  "xenstore_transport"
+]

--- a/packages/xapi-xenops/xapi-xenops.1.0.1/url
+++ b/packages/xapi-xenops/xapi-xenops.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xenops/archive/v1.0.1.tar.gz"
+checksum: "3730f99b9e1713f3c5d60461b1b20944"


### PR DESCRIPTION
This is a follow-up of the last PR from @gaborigloi to re-introduce the latest `vhd-tool`.

It introduces:
- `ezxenstore`: a simplified interface to `xenstore`
- `xapi-rrdd` and `xapi-rrd-transport`: a preformance monitoring daemon that uses the `rrdd` protocol for `xen` hosts and a library to write your own `rrdd` plugins