### PR TITLE
Release xapi-rrd 1.0.1, using the ppx derivers for rpc

### DIFF
--- a/packages/message-switch/message-switch.1.4.0/files/fix-mktemp-for-busybox.patch
+++ b/packages/message-switch/message-switch.1.4.0/files/fix-mktemp-for-busybox.patch
@@ -1,0 +1,25 @@
+From 653eac9553482c6a57c1e55068fe86a0f5c1201d Mon Sep 17 00:00:00 2001
+From: Marcello Seri <marcello.seri@citrix.com>
+Date: Tue, 20 Jun 2017 11:02:23 +0100
+Subject: [PATCH] Update mktemp template in configure to support busybox
+
+Signed-off-by: Marcello Seri <marcello.seri@citrix.com>
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 5ad76e3..d9d2e21 100755
+--- a/configure
++++ b/configure
+@@ -1,6 +1,6 @@
+ #!/bin/bash
+ 
+-D=$(mktemp -d /tmp/configure.XXXXX)
++D=$(mktemp -d /tmp/configure.XXXXXX)
+ function cleanup {
+   cd /
+   rm -rf $D
+-- 
+2.11.0
+

--- a/packages/message-switch/message-switch.1.4.0/opam
+++ b/packages/message-switch/message-switch.1.4.0/opam
@@ -15,7 +15,10 @@ install: [
 remove: [
   ["ocamlfind" "remove" "message_switch"]
 ]
-patches: [ "disable-error-on-warn.patch" ]
+patches: [
+  "disable-error-on-warn.patch"
+  "fix-mktemp-for-busybox.patch"
+]
 depends: [
   "oasis" {build}
   "ocamlfind" {build}

--- a/packages/xapi-idl/xapi-idl.1.14.0/opam
+++ b/packages/xapi-idl/xapi-idl.1.14.0/opam
@@ -37,6 +37,6 @@ depends: [
   "lwt" {< "3.0.0"}
   "ounit" {>= "2.0.0"}
   "ppx_sexp_conv"
-  "sexplib"
+  "sexplib" {> "113.00.00" & < "v0.9.0" }
 ]
 

--- a/packages/xapi-idl/xapi-idl.1.14.0/opam
+++ b/packages/xapi-idl/xapi-idl.1.14.0/opam
@@ -30,7 +30,7 @@ depends: [
   "rpc" {>= "1.9.51"}
   "message-switch" {= "1.4.0"}
   "xapi-stdext" {= "2.1.0"}
-  "xapi-rrd" {= "1.0.0"}
+  "xapi-rrd" {>= "1.0.0"}
   "xapi-inventory" {= "1.0.2"}
   "xapi-backtrace" {= "0.4"}
   "fd-send-recv"

--- a/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/files/use-xen-gnt-unix.patch
+++ b/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/files/use-xen-gnt-unix.patch
@@ -1,0 +1,26 @@
+From 50343916acec27b13c3e9101ca8bd84ecce98665 Mon Sep 17 00:00:00 2001
+From: Marcello Seri <marcello.seri@citrix.com>
+Date: Wed, 21 Jun 2017 15:21:08 +0100
+Subject: [PATCH] Fix _oasis to use xen-gnt-unix
+
+Signed-off-by: Marcello Seri <marcello.seri@citrix.com>
+---
+ _oasis | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/_oasis b/_oasis
+index 0aa7f86..f8b96b1 100644
+--- a/_oasis
++++ b/_oasis
+@@ -12,7 +12,7 @@ Library rrd_transport
+   Path:                 lib
+   Findlibname:          rrd-transport
+   Modules:              Rrd_json, Rrd_protocol, Rrd_rpc, Rrd_protocol_v1, Rrd_protocol_v2, Rrd_io, Rrd_reader, Rrd_writer
+-  BuildDepends:         bigarray, bytes, cstruct, stringext, xcp.rrd, rrd, xen-gnt, xen-gnt.unix, crc, threads
++  BuildDepends:         bigarray, bytes, cstruct, stringext, xcp.rrd, rrd, xen-gnt, xen-gnt-unix, crc, threads
+ 
+ Executable rrdreader
+   CompiledObject:       best
+-- 
+2.11.0
+

--- a/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/opam
+++ b/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/opam
@@ -23,5 +23,6 @@ depends: [
   "crc"
   "xapi-idl" {= "1.14.0"}
   "xapi-rrd" {>= "1.0.0"}
-  "xen-gnt" {< "3.0.0"}
+  "xen-gnt-unix"
 ]
+patches: [ "use-xen-gnt-unix.patch" ]

--- a/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/opam
+++ b/packages/xapi-rrd-transport/xapi-rrd-transport.1.2.0/opam
@@ -22,6 +22,6 @@ depends: [
   "cstruct" {< "3.0.0"}
   "crc"
   "xapi-idl" {= "1.14.0"}
-  "xapi-rrd" {= "1.0.0"}
+  "xapi-rrd" {>= "1.0.0"}
   "xen-gnt" {< "3.0.0"}
 ]

--- a/packages/xapi-rrd/xapi-rrd.1.0.1/descr
+++ b/packages/xapi-rrd/xapi-rrd.1.0.1/descr
@@ -1,0 +1,5 @@
+RRD library for use with xapi
+
+Round-Robin Databases (RRDs) are constant-space datastructures
+used for archiving historical data where the older data is stored
+at a lower resolution.

--- a/packages/xapi-rrd/xapi-rrd.1.0.1/opam
+++ b/packages/xapi-rrd/xapi-rrd.1.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: ["Dave Scott" "Jon Ludlam" "John Else"]
+homepage: "https://github.com/xapi-project/xcp-rrd"
+bug-reports: "https://github.com/xapi-project/xcp-rrd/issues"
+dev-repo: "https://github.com/xapi-project/xcp-rrd.git"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  [make]
+]
+build-test: [
+  [make "test"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "oasis"     {build}
+  "base-bigarray"
+  "base-unix"
+  "rpc" {>= "1.9.51"}
+  "uuidm"
+  "ounit" {test}
+]

--- a/packages/xapi-rrd/xapi-rrd.1.0.1/url
+++ b/packages/xapi-rrd/xapi-rrd.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/xcp-rrd/archive/v1.0.1.tar.gz"
+checksum: "2615707aeccb48a35f65c43f0d06754a"

--- a/packages/xapi-rrdd/xapi-rrdd.1.2.1/files/use-xen-gnt-unix.patch
+++ b/packages/xapi-rrdd/xapi-rrdd.1.2.1/files/use-xen-gnt-unix.patch
@@ -1,0 +1,35 @@
+From f87e2e4641faea4ba8d1d96e5ed914cb02b69254 Mon Sep 17 00:00:00 2001
+From: Marcello Seri <marcello.seri@citrix.com>
+Date: Wed, 21 Jun 2017 15:24:14 +0100
+Subject: [PATCH] Fix _oasis to use xen-gnt-unix
+
+Signed-off-by: Marcello Seri <marcello.seri@citrix.com>
+---
+ _oasis | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/_oasis b/_oasis
+index 12ba1263..d8683bce 100644
+--- a/_oasis
++++ b/_oasis
+@@ -59,7 +59,7 @@ Executable "xcp-rrdd"
+     threads,
+     ppx_deriving_rpc,
+     io-page.unix,
+-    xen-gnt.unix,
++    xen-gnt-unix,
+     oclock,
+     systemd,
+     inotify
+@@ -96,7 +96,7 @@ Executable "test_rrdd_monitor"
+     threads,
+     ppx_deriving_rpc,
+     io-page.unix,
+-    xen-gnt.unix,
++    xen-gnt-unix,
+     oclock
+ 
+ Test "test_rrdd_monitor"
+-- 
+2.11.0
+

--- a/packages/xapi-rrdd/xapi-rrdd.1.2.1/opam
+++ b/packages/xapi-rrdd/xapi-rrdd.1.2.1/opam
@@ -34,10 +34,10 @@ depends: [
   "xapi-xenops" {= "1.0.1"}
   "io-page"
   "inotify"
-  "xen-gnt" {< "3.0.0"}
+  "xen-gnt-unix"
   "xapi-rrd-transport" {= "1.2.0"}
   "oclock"
   "ounit"
   "ocaml-systemd" {>= "1.2"}
 ]
-
+patches: [ "use-xen-gnt-unix.patch" ]

--- a/packages/xen-api-client/xen-api-client.0.9.14/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.14/opam
@@ -35,6 +35,6 @@ depends: [
 ]
 depopts: ["async"]
 conflicts: [
-  "async" {< "111.13.00"}
+  "async" {< "113.24.00"}
   "async" {>= "v0.9.0"}
 ]

--- a/packages/xen-api-client/xen-api-client.0.9.14/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.14/opam
@@ -30,7 +30,7 @@ depends: [
   "re"
   "xmlm"
   "rpc" {>= "1.9.51"}
-  "xapi-rrd" {= "1.0.0"}
+  "xapi-rrd" {>= "1.0.0"}
   "uuidm"
 ]
 depopts: ["async"]

--- a/packages/xen-api-client/xen-api-client.0.9.6/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.6/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
+license: "LGPL"
+homepage: "https://github.com/xapi-project/xen-api-client"
+dev-repo: "git://github.com/xen-org/xen-api-client"
+bug-reports: "https://github.com/xapi-project/xen-api-client/issues"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -21,5 +26,4 @@ depends: [
 ]
 depopts: ["async"]
 conflicts: ["async" {< "109.15.00"} "async" {>= "111.13.00"}]
-dev-repo: "git://github.com/xen-org/xen-api-client"
 install: [make "install"]

--- a/packages/xen-api-client/xen-api-client.0.9.7/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.7/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
+license: "LGPL"
+homepage: "https://github.com/xapi-project/xen-api-client"
+bug-reports: "https://github.com/xapi-project/xen-api-client/issues"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -20,6 +24,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["async"]
-conflicts: ["async" {< "111.13.00"}]
+conflicts: [
+  "async" {< "111.13.00"}
+  "async" {>= "v0.9.0"}
+]
 dev-repo: "git://github.com/xen-org/xen-api-client"
 install: [make "install"]

--- a/packages/xen-api-client/xen-api-client.0.9.8/opam
+++ b/packages/xen-api-client/xen-api-client.0.9.8/opam
@@ -1,5 +1,9 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
+license: "LGPL"
+homepage: "https://github.com/xapi-project/xen-api-client"
+bug-reports: "https://github.com/xapi-project/xen-api-client/issues"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -20,6 +24,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["async"]
-conflicts: ["async" {< "111.13.00"}]
+conflicts: [
+  "async" {< "111.13.00"}
+  "async" {>= "v0.9.0"}
+]
 dev-repo: "git://github.com/xen-org/xen-api-client"
 install: [make "install"]


### PR DESCRIPTION
This should fix some random issues with the `xapi-rrd` package failing to find the `Jsonrpc` implementation.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>