### PR TITLE
ocp-index-top.0.4.1 - via opam-publish

### DIFF
--- a/packages/ocp-index-top/ocp-index-top.0.4.1/descr
+++ b/packages/ocp-index-top/ocp-index-top.0.4.1/descr
@@ -1,0 +1,7 @@
+In the OCaml toplevel
+
+## NB: users of utop 2.0.1
+
+Please use `utop-full` if you have upgraded to utop 2.0.1. Due to a change in utop 2.0.1 this module will not work in `utop`. See [issue #9](https://github.com/reynir/ocp-index-top/issues/9) for more information.
+
+![Using #doc List.find](https://reyn.ir/ocp-index-top.png)

--- a/packages/ocp-index-top/ocp-index-top.0.4.1/opam
+++ b/packages/ocp-index-top/ocp-index-top.0.4.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+author: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "https://github.com/reynir/ocp-index-top.git"
+homepage: "https://github.com/reynir/ocp-index-top/"
+bug-reports:  "https://github.com/reynir/ocp-index-top/issues"
+doc: "https://reynir.github.io/ocp-index-top/"
+license: "BSD-2-clause"
+available: [ ocaml-version > "4.01.0" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cppo" {build}
+  "ocp-index"
+]

--- a/packages/ocp-index-top/ocp-index-top.0.4.1/url
+++ b/packages/ocp-index-top/ocp-index-top.0.4.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/reynir/ocp-index-top/releases/download/v0.4.1/ocp-index-top-0.4.1.tbz"
+checksum: "4163f84bbf6c77458bc74c3658ae37f7"


### PR DESCRIPTION
In the OCaml toplevel

## NB: users of utop 2.0.1

Please use `utop-full` if you have upgraded to utop 2.0.1. Due to a change in utop 2.0.1 this module will not work in `utop`. See [issue #9](https://github.com/reynir/ocp-index-top/issues/9) for more information.

![Using #doc List.find](https://reyn.ir/ocp-index-top.png)

---
* Homepage: https://github.com/reynir/ocp-index-top/
* Source repo: https://github.com/reynir/ocp-index-top.git
* Bug tracker: https://github.com/reynir/ocp-index-top/issues

---


---
v0.4.1 (14th May 2017)
-----------------------

First release on opam
Pull-request generated by opam-publish v0.3.4