### PR TITLE
mirage-flow-rawlink.1.0.0 - via opam-publish

### DIFF
--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/descr
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/descr
@@ -1,0 +1,3 @@
+Expose rawlink devices as MirageOS flows
+
+Allow to use rawlink devices as MirageOS flows.

--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-flow-rawlink"
+dev-repo: "https://github.com/mirage/mirage-flow-rawlink.git"
+bug-reports: "https://github.com/mirage/mirage-flow-rawlink/issues"
+doc: "https://mirage.github.io/mirage-flow-rawlink/"
+
+build: [ "jbuilder" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "rawlink" {>= "0.5"}
+  "cstruct"
+  "lwt"
+]
+
+available: [ocaml-version >= "4.02.0"]
+tags: "org:mirage"

--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/url
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-flow-rawlink/releases/download/1.0.0/mirage-flow-rawlink-1.0.0.tbz"
+checksum: "dfe2029e153133588aaff67896bba8e2"


### PR DESCRIPTION
Expose rawlink devices as MirageOS flows

Allow to use rawlink devices as MirageOS flows.

---
* Homepage: https://github.com/mirage/mirage-flow-rawlink
* Source repo: https://github.com/mirage/mirage-flow-rawlink.git
* Bug tracker: https://github.com/mirage/mirage-flow-rawlink/issues

---


---
### 1.0.0 (2017/06/19)

- Initial release
Pull-request generated by opam-publish v0.3.4