### PR TITLE
mirage-flow-rawlink.1.0.0 - via opam-publish

### DIFF
--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/descr
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/descr
@@ -1,0 +1,14 @@
+Expose rawlink interfaces as MirageOS flows
+
+Allow to use rawlink interfaces as MirageOS flows.
+
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/mirage-flow-rawlink/mirage-flow-rawlink)
+
+An example:
+
+```ocaml
+  Lwt_rawlink.open_link "eth0" >>= fun rawlink ->
+  Mirage_flow_lwt.read rawlink >>= function
+  | Ok (`Data buf) ->
+  ...
+```

--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-flow-rawlink"
+dev-repo: "https://github.com/mirage/mirage-flow-rawlink.git"
+bug-reports: "https://github.com/mirage/mirage-flow-rawlink/issues"
+doc: "https://mirage.github.io/mirage-flow-rawlink/"
+
+build: [ "jbuilder" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "rawlink" {>= "0.5"}
+  "cstruct"
+  "lwt"
+]
+
+available: [ocaml-version >= "4.02.0"]
+tags: "org:mirage"

--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "jbuilder" {build & >="1.0+beta10"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "rawlink" {>= "0.5"}
-  "cstruct"
+  "cstruct" {>= "3.0.2"}
   "lwt"
 ]
 

--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
@@ -7,7 +7,10 @@ dev-repo: "https://github.com/mirage/mirage-flow-rawlink.git"
 bug-reports: "https://github.com/mirage/mirage-flow-rawlink/issues"
 doc: "https://mirage.github.io/mirage-flow-rawlink/"
 
-build: [ "jbuilder" "build" "-p" name "-j" jobs ]
+build: [
+  ["jbuilder" "subst"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
 
 depends: [
   "jbuilder" {build & >="1.0+beta10"}

--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/url
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-flow-rawlink/releases/download/1.0.0/mirage-flow-rawlink-1.0.0.tbz"
+checksum: "f3744a62ae1dcaead17b9442ec269f78"


### PR DESCRIPTION
Expose rawlink interfaces as MirageOS flows

Allow to use rawlink interfaces as MirageOS flows.

[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/mirage-flow-rawlink/mirage-flow-rawlink)

An example:

```ocaml
  Lwt_rawlink.open_link "eth0" >>= fun rawlink ->
  Mirage_flow_lwt.read rawlink >>= function
  | Ok (`Data buf) ->
  ...
```

---
* Homepage: https://github.com/mirage/mirage-flow-rawlink
* Source repo: https://github.com/mirage/mirage-flow-rawlink.git
* Bug tracker: https://github.com/mirage/mirage-flow-rawlink/issues

---


---
### 1.0.0 (2017/06/19)

- Initial release
Pull-request generated by opam-publish v0.3.4