### PR TITLE
mirage-net-flow.1.0.0 - via opam-publish

### DIFF
--- a/packages/mirage-net-flow/mirage-net-flow.1.0.0/descr
+++ b/packages/mirage-net-flow/mirage-net-flow.1.0.0/descr
@@ -1,0 +1,6 @@
+Build MirageOS network interfaces on top of MirageOS flows
+
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/mirage-net-flow/mirage-net=flow)
+
+Allow to create a MirageOS network interface on top of an existing MirageOS
+flow.

--- a/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
+++ b/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+homepage:    "https://github.com/mirage/mirage-net-flow"
+bug-reports: "https://github.com/mirage/mirage-net-flow/issues"
+dev-repo:    "https://github.com/mirage/mirage-net-flow.git"
+license:     "ISC"
+doc:         "https://mirage.github.io/mirage-net-flow/"
+
+build:   ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "cstruct-lwt"
+  "logs"
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.3"]

--- a/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
+++ b/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {build}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "cstruct-lwt"
+  "cstruct-lwt" {>= "3.0.0"}
   "logs"
   "alcotest" {test}
 ]

--- a/packages/mirage-net-flow/mirage-net-flow.1.0.0/url
+++ b/packages/mirage-net-flow/mirage-net-flow.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net-flow/releases/download/1.0.0/mirage-net-flow-1.0.0.tbz"
+checksum: "8504c8bfec68f2837d7b136cfeb3997e"


### PR DESCRIPTION
Build MirageOS network interfaces on top of MirageOS flows

[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/mirage-net-flow/mirage-net=flow)

Allow to create a MirageOS network interface on top of an existing MirageOS
flow.

---
* Homepage: https://github.com/mirage/mirage-net-flow
* Source repo: https://github.com/mirage/mirage-net-flow.git
* Bug tracker: https://github.com/mirage/mirage-net-flow/issues

---


---
### 1.0.0 (2017/06/19)

* Initial release
Pull-request generated by opam-publish v0.3.4