### PR TITLE
mirage-net-unix: uses cstruct-lwt package, so bound is >3.0.0

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.2.4.1/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.4.1/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
-  "cstruct" {>= "1.7.1"}
+  "cstruct" {>= "3.0.2"}
   "cstruct-lwt"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
@@ -28,4 +28,4 @@ depends: [
   "result"
   "alcotest" {test}
 ]
-available: [ ocaml-version >= "4.02.3"]
+available: [ ocaml-version >= "4.03.0"]


### PR DESCRIPTION
cc @djs55