### PR TITLE
charrua-client.0.1 works only with charrua-core < 0.8

### DIFF
--- a/packages/charrua-client/charrua-client.0.1.0/opam
+++ b/packages/charrua-client/charrua-client.0.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind" {build}
   "topkg"     {build}
   "alcotest"     {test}
-  "charrua-core" {>= "0.4"}
+  "charrua-core" {>= "0.4" & < "0.8"}
   "cstruct"
   "ipaddr"
   "rresult"


### PR DESCRIPTION
/cc @yomimono 

otherwise, we get:

```
#=== ERROR while installing charrua-client.0.1.0 ==============================#
# opam-version 1.2.2
# os           linux
# command      ocaml pkg/pkg.ml build --pinned false --tests false --with-mirage true
# path         /home/samoht/.opam/mirage/build/charrua-client.0.1.0
# compiler     4.04.1
# exit-code    1
# env-file     /home/samoht/.opam/mirage/build/charrua-client.0.1.0/charrua-client-13309-604a5f.env
# stdout-file  /home/samoht/.opam/mirage/build/charrua-client.0.1.0/charrua-client-13309-604a5f.out
# stderr-file  /home/samoht/.opam/mirage/build/charrua-client.0.1.0/charrua-client-13309-604a5f.err
### stdout ###
# [...]
# ocamlfind ocamlc -a -package 'charrua-core.wire mirage-random' -package 'ipaddr charrua-core cstruct rresult' -I src src/dhcp_client.cmo -o src/charrua-client.cma
# + ocamlfind ocamlc -a -package 'charrua-core.wire mirage-random' -package 'ipaddr charrua-core cstruct rresult' -I src src/dhcp_client.cmo -o src/charrua-client.cma
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/samoht/.opam/mirage/lib/ocaml/compiler-libs, /home/samoht/.opam/mirage/lib/ocaml
# ocamlfind ocamldep -package 'mirage-types-lwt duration lwt logs tcpip.ipv4 fmt' -package 'ipaddr charrua-core cstruct rresult' -modules src/mirage/dhcp_client_mirage.ml > src/mirage/dhcp_client_mirage.ml.depends
# ocamlfind ocamldep -package 'mirage-types-lwt duration lwt logs tcpip.ipv4 fmt' -package 'ipaddr charrua-core cstruct rresult' -modules src/mirage/dhcp_client_mirage.mli > src/mirage/dhcp_client_mirage.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -keep-locs -package 'mirage-types-lwt duration lwt logs tcpip.ipv4 fmt' -package 'ipaddr charrua-core cstruct rresult' -w A-44-45 -I src/mirage -I src -I test -o src/mirage/dhcp_client_mirage.cmi src/mirage/dhcp_client_mirage.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -keep-locs -package 'mirage-types-lwt duration lwt logs tcpip.ipv4 fmt' -package 'ipaddr charrua-core cstruct rresult' -w A-44-45 -I src/mirage -I src -I test -o src/mirage/dhcp_client_mirage.cmi src/mirage/dhcp_client_mirage.mli
# File "src/mirage/dhcp_client_mirage.mli", line 2, characters 2-15:
# Error: Unbound module Dhcp_wire
# Command exited with code 2.
```
