### PR TITLE
base64.2.2.0 - via opam-publish

### DIFF
--- a/packages/base64/base64.2.2.0/descr
+++ b/packages/base64/base64.2.2.0/descr
@@ -1,0 +1,26 @@
+For OCaml
+
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in [RFC 4648][rfc4648].
+
+See also [documentation][docs].
+
+[rfc4648]: https://tools.ietf.org/html/rfc4648
+[docs]: http://mirage.github.io/ocaml-base64/base64/
+
+## Example
+
+Simple encoding and decoding.
+
+```shell
+utop # #require "base64";;
+utop # let enc = B64.encode "OCaml rocks!";;
+val enc : string = "T0NhbWwgcm9ja3Mh"
+utop # let plain = B64.decode enc;;
+val plain : string = "OCaml rocks!"
+```
+
+## License
+
+[ISC](https://www.isc.org/downloads/software-support-policy/isc-license/)

--- a/packages/base64/base64.2.2.0/descr
+++ b/packages/base64/base64.2.2.0/descr
@@ -1,4 +1,4 @@
-For OCaml
+Base64 encoding for OCaml
 
 Base64 is a group of similar binary-to-text encoding schemes that represent
 binary data in an ASCII string format by translating it into a radix-64

--- a/packages/base64/base64.2.2.0/opam
+++ b/packages/base64/base64.2.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "https://github.com/mirage/ocaml-base64.git"
+depends: [
+  "base-bytes"
+  "jbuilder" {build & >= "1.0+beta10"}
+  "bos" {test}
+  "rresult" {test}
+  "alcotest" {test}
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]

--- a/packages/base64/base64.2.2.0/url
+++ b/packages/base64/base64.2.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-base64/releases/download/v2.2.0/base64-2.2.0.tbz"
+checksum: "49f2bc4ae37b832c652277c0b701a02a"


### PR DESCRIPTION
For OCaml

Base64 is a group of similar binary-to-text encoding schemes that represent
binary data in an ASCII string format by translating it into a radix-64
representation.  It is specified in [RFC 4648][rfc4648].

See also [documentation][docs].

[rfc4648]: https://tools.ietf.org/html/rfc4648
[docs]: http://mirage.github.io/ocaml-base64/base64/

## Example

Simple encoding and decoding.

```shell
utop # #require "base64";;
utop # let enc = B64.encode "OCaml rocks!";;
val enc : string = "T0NhbWwgcm9ja3Mh"
utop # let plain = B64.decode enc;;
val plain : string = "OCaml rocks!"
```

## License

[ISC](https://www.isc.org/downloads/software-support-policy/isc-license/)

---
* Homepage: https://github.com/mirage/ocaml-base64
* Source repo: https://github.com/mirage/ocaml-base64.git
* Bug tracker: https://github.com/mirage/ocaml-base64/issues

---


---
### v2.2.0 (2017-06-20)

* Switch to jbuilder (#13, @rgrinberg)
Pull-request generated by opam-publish v0.3.4