### PR TITLE
Disable broken tests for fileutils

### DIFF
--- a/packages/fileutils/fileutils.0.5.2/opam
+++ b/packages/fileutils/fileutils.0.5.2/opam
@@ -13,11 +13,6 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocamlfind" "remove" "fileutils"]
 ]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-unix"


### PR DESCRIPTION
On OSX:

```
=== ERROR while installing fileutils.0.5.2 ===================================#
 opam-version 1.2.2
 os           darwin
 command      ocaml setup.ml -test
 path         /Users/thomas/.opam/alcotest/build/fileutils.0.5.2
 compiler     system (4.04.1)
 exit-code    1
 env-file     /Users/thomas/.opam/alcotest/build/fileutils.0.5.2/fileutils-76861-70a526.env
 stdout-file  /Users/thomas/.opam/alcotest/build/fileutils.0.5.2/fileutils-76861-70a526.out
 stderr-file  /Users/thomas/.opam/alcotest/build/fileutils.0.5.2/fileutils-76861-70a526.err
--- stdout ---
 [...]
 Error: ocaml-fileutils:1:FileUtil:18:Unix specific:11:Readlink (in the log).

 Raised at file "src/oUnitAssert.ml", line 45, characters 8-27
 Called from file "src/oUnitRunner.ml", line 46, characters 13-26

 expected: "/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/ounit-60edff-roccapina.local#01.dir"
 but got: "/private/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/ounit-60edff-roccapina.local#01.dir"
 ------------------------------------------------------------------------------
 Ran: 257 tests in: 0.25 seconds.
 FAILED: Cases: 257 Tried: 257 Errors: 0 Failures: 1 Skip:  0 Todo: 0 Timeouts: 0.
--- stderr ---
 W: Test 'main' fails: Command '/Users/thomas/.opam/alcotest/build/fileutils.0.5.2/_build/test/test.byte' terminated with error code 1
 E: Failure("Tests had a 100.00% failure rate")
```