### PR TITLE
+magic-mime.1.1.0

### DIFF
--- a/packages/magic-mime/magic-mime.1.1.0/descr
+++ b/packages/magic-mime/magic-mime.1.1.0/descr
@@ -1,0 +1,26 @@
+Map filenames to common MIME types
+
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+
+### Internals
+
+The following files need to be edited to add MIME types:
+
+- mime.types: this is obtained by synching from the Apache Foundation's
+  [mime.types](https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types)
+  in the Apache Subversion repository.
+- x-mime.types: these are the extension types, so non-standard `x-` prefixes are used here.
+- file.types: full filenames of common occurrences that are useful to map onto a MIME type.
+  OCaml-specific things like `opam` files show up here.

--- a/packages/magic-mime/magic-mime.1.1.0/opam
+++ b/packages/magic-mime/magic-mime.1.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+name: "magic-mime"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "https://github.com/mirage/ocaml-magic-mime.git"
+doc: "https://mirage.github.io/ocaml-magic-mime"
+license: "ISC"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+]

--- a/packages/magic-mime/magic-mime.1.1.0/opam
+++ b/packages/magic-mime/magic-mime.1.1.0/opam
@@ -16,3 +16,4 @@ build: [
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
 ]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/magic-mime/magic-mime.1.1.0/url
+++ b/packages/magic-mime/magic-mime.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.0/magic-mime-1.1.0.tbz"
+checksum: "341ab5133c2e17ca645f23a0149025d1"


### PR DESCRIPTION
--

* Support a `map_file` which maps filenames onto MIME types, using
  a database based on GTKSourceView lang files.  This adds support
  for several `x-*` MIME type extensions as well which are unofficial
  but useful, including ones for common programming languages.
  (mirage/ocaml-magic-mime#4 by @zoggy)

* Sync mime.types with Apache SVN and note its source in the README.