### PR TITLE
angstrom: prepare the 0.8.0 release of alcotest

### DIFF
--- a/packages/angstrom/angstrom.0.1.0/opam
+++ b/packages/angstrom/angstrom.0.1.0/opam
@@ -22,7 +22,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1"}
+  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocamlfind" {build}
   "result"

--- a/packages/angstrom/angstrom.0.1.1/opam
+++ b/packages/angstrom/angstrom.0.1.1/opam
@@ -22,7 +22,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1"}
+  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocamlfind" {build}
   "result"

--- a/packages/angstrom/angstrom.0.2.0/opam
+++ b/packages/angstrom/angstrom.0.2.0/opam
@@ -22,7 +22,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1"}
+  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}

--- a/packages/angstrom/angstrom.0.3.0/opam
+++ b/packages/angstrom/angstrom.0.3.0/opam
@@ -23,7 +23,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1"}
+  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}

--- a/packages/angstrom/angstrom.0.4.0/opam
+++ b/packages/angstrom/angstrom.0.4.0/opam
@@ -23,7 +23,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1"}
+  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}


### PR DESCRIPTION
Alcotest.float now takes a mandatory parameter to specify the epsilon