### PR TITLE
anycache use a pre-0.8.0 alcotest

### DIFF
--- a/packages/anycache/anycache.0.6.0/opam
+++ b/packages/anycache/anycache.0.6.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "alcotest" { test & >= "0.7.2" }
+  "alcotest" { test & >= "0.7.2" & < "0.8.0"}
   "base-bytes"
   "result"
 ]


### PR DESCRIPTION
Alcotest.float now takes a mandatory epsilon argument

/cc @edwintorok 