### PR TITLE
Remove broken test for ppx_cstruct

### DIFF
--- a/packages/ppx_cstruct/ppx_cstruct.3.0.1/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.0.1/opam
@@ -12,9 +12,6 @@ build: [
   ["jbuilder" "subst" "-p" name "--name" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-build-test: [
-  ["jbuilder" "runtest" "-j" jobs]
-]
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
   "cstruct" {>="3.0.1"}

--- a/packages/ppx_cstruct/ppx_cstruct.3.0.2/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.0.2/opam
@@ -12,9 +12,6 @@ build: [
   ["jbuilder" "subst" "-p" name "--name" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-build-test: [
-  ["jbuilder" "runtest" "-j" jobs]
-]
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
   "cstruct" {>="3.0.2"}


### PR DESCRIPTION
```
=== ERROR while installing ppx_cstruct.3.0.2 =================================#
 opam-version 1.2.2
 os           darwin
 command      jbuilder runtest -j 4
 path         /Users/thomas/.opam/alcotest/build/ppx_cstruct.3.0.2
 compiler     system (4.04.1)
 exit-code    1
 env-file     /Users/thomas/.opam/alcotest/build/ppx_cstruct.3.0.2/ppx_cstruct-52536-d2c37b.env
 stdout-file  /Users/thomas/.opam/alcotest/build/ppx_cstruct.3.0.2/ppx_cstruct-52536-d2c37b.out
 stderr-file  /Users/thomas/.opam/alcotest/build/ppx_cstruct.3.0.2/ppx_cstruct-52536-d2c37b.err
--- stderr ---
 Error: External library "cstruct.ppx" is unavailable.
 -> required by "ppx_test/with-sexp/jbuild (context default)"
 External library "cstruct.ppx" is not available because it depends on the following libraries that are not available:
 - ppx_cstruct -> not found
 Hint: try: jbuilder external-lib-deps --missing @runtest
```