### PR TITLE
duration needs a pre-0.8 alcotest

### DIFF
--- a/packages/duration/duration.0.1.0/opam
+++ b/packages/duration/duration.0.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "alcotest" {test & >= "0.6.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
 ]
 
 build: [


### PR DESCRIPTION
`Alcotest.float` now takes a mandatory epsilon.

/cc @hannesm 