### PR TITLE
Disable tests for oasis 0.4.10

### DIFF
--- a/packages/oasis/oasis.0.4.10/opam
+++ b/packages/oasis/oasis.0.4.10/opam
@@ -13,24 +13,13 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocaml" "%{etc}%/oasis/setup.ml" "-C" "%{etc}%/oasis" "-uninstall"]
 ]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-unix"
-  "camlp4" {test}
-  "expect" {test & >= "0.0.4"}
-  "fileutils" {test & >= "0.4.2"}
   "ocamlbuild"
   "ocamlfind" {>= "1.3.1"}
   "ocamlify" {build}
   "ocamlmod" {build}
-  "omake" {test}
-  "ounit" {test & >= "2.0.0"}
-  "pcre" {test}
 ]
 depopts: [
   "benchmark"

--- a/packages/oasis/oasis.0.4.8/opam
+++ b/packages/oasis/oasis.0.4.8/opam
@@ -13,24 +13,13 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocaml" "%{etc}%/oasis/setup.ml" "-C" "%{etc}%/oasis" "-uninstall"]
 ]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-unix"
-  "camlp4" {test}
-  "expect" {test & >= "0.0.4"}
-  "fileutils" {test & >= "0.4.2"}
   "ocamlbuild"
   "ocamlfind" {build & >= "1.3.1"}
   "ocamlify" {build}
   "ocamlmod" {build}
-  "omake" {test}
-  "ounit" {test & >= "2.0.0"}
-  "pcre" {test}
 ]
 depopts: [
   "benchmark"


### PR DESCRIPTION
They are failing on OSX with:

```
=== ERROR while installing oasis.0.4.10 ======================================#
 opam-version 1.2.2
 os           darwin
 command      ocaml setup.ml -test
 path         /Users/thomas/.opam/alcotest/build/oasis.0.4.10
 compiler     system (4.04.1)
 exit-code    1
 env-file     /Users/thomas/.opam/alcotest/build/oasis.0.4.10/oasis-3402-57f057.env
 stdout-file  /Users/thomas/.opam/alcotest/build/oasis.0.4.10/oasis-3402-57f057.out
 stderr-file  /Users/thomas/.opam/alcotest/build/oasis.0.4.10/oasis-3402-57f057.err
--- stdout ---
 Error: OASIS:6:TestFull:1:best=native:12:bugClib (in the code).
 [...]
 Exit status of command '/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/ounit-195216-roccapina.local#02.dir/precompilesetup
 -info -debug -all -- --override is_native true'
 expected: Exited with code 0 but got: Exited with code 1
 ------------------------------------------------------------------------------
 Ran: 268 tests in: 158.86 seconds.
 FAILED: Cases: 268 Tried: 268 Errors: 0 Failures: 4 Skip:  3 Todo: 0 Timeouts: 0.
 ..
 Ran: 2 tests in: 0.25 seconds.
 OK
--- stderr ---
 W: Test 'main' fails: Command '/Users/thomas/.opam/alcotest/build/oasis.0.4.10/_build/test/test-main/Test.native -oasis/Users/thomas/.opam/alcotest/build/oasis.0.4.10/_build/src/cli/Main.native -is-native true \
 -native-dynlink true -ocamlmod /Users/thomas/.opam/alcotest/bin/ocamlmod \
 -fake-ocamlfind /Users/thomas/.opam/alcotest/build/oasis.0.4.10/_build/test/fake-ocamlfind/FakeOCamlfind.native' terminted with error code 1
 E: Failure("Tests had a 33.33% failure rate")
```