### PR TITLE
irmin-watcher.0.3.0 - via opam-publish

### DIFF
--- a/packages/irmin-watcher/irmin-watcher.0.3.0/descr
+++ b/packages/irmin-watcher/irmin-watcher.0.3.0/descr
@@ -1,0 +1,9 @@
+Portable Irmin watch backends using FSevents or Inotify
+
+
+irmin-watcher implements [Irmin's watch hooks][watch] for various OS,
+using FSevents in OSX and Inotify on Linux.
+
+irmin-watcher is distributed under the ISC license.
+
+[watch]: http://mirage.github.io/irmin/Irmin.Private.Watch.html

--- a/packages/irmin-watcher/irmin-watcher.0.3.0/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "https://github.com/mirage/irmin-watcher"
+doc:          "https://mirage.github.io/irmin-watcher/"
+dev-repo:     "https://github.com/mirage/irmin-watcher.git"
+bug-reports:  "https://github.com/mirage/irmin-watcher/issues"
+license:      "ISC"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {>= "1.0+beta10"}
+  "alcotest" {test}
+  "mtime"    {test & >= "1.0.0"}
+  "lwt"
+  "logs"
+  "fmt"
+  "astring"
+]
+depopts: ["inotify" "osx-fsevents"]
+conflicts: [ "osx-fsevents" {< "0.2.0"} ]
+
+available: [ocaml-version >= "4.02.0"]

--- a/packages/irmin-watcher/irmin-watcher.0.3.0/url
+++ b/packages/irmin-watcher/irmin-watcher.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin-watcher/releases/download/0.3.0/irmin-watcher-0.3.0.tbz"
+checksum: "1060efb3507315f5056f4db65a8d978d"


### PR DESCRIPTION
Portable Irmin watch backends using FSevents or Inotify


irmin-watcher implements [Irmin's watch hooks][watch] for various OS,
using FSevents in OSX and Inotify on Linux.

irmin-watcher is distributed under the ISC license.

[watch]: http://mirage.github.io/irmin/Irmin.Private.Watch.html

---
* Homepage: https://github.com/mirage/irmin-watcher
* Source repo: https://github.com/mirage/irmin-watcher.git
* Bug tracker: https://github.com/mirage/irmin-watcher/issues

---


---
### 0.3.0 (2017-06-21)

- Use jbuilder (#11, @samoht)
Pull-request generated by opam-publish v0.3.4