### PR TITLE
Remove broken tests for dns.0.18.1

### DIFF
--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -33,7 +33,7 @@ depends: [
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
-  "cstruct" {>= "1.0.1" & <"3.0.0"}
+  "cstruct" {>= "1.9.0" & <"3.0.0"}
   "ppx_tools"
   "re"
   "cmdliner"

--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -28,20 +28,6 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  [
-    "ocaml"
-    "setup.ml"
-    "-configure"
-    "--prefix"
-    prefix
-    "--enable-lwt"
-    "--%{mirage-types:enable}%-mirage"
-    "--enable-tests"
-  ]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test" "-runner" "sequential"]
-]
 remove: ["ocamlfind" "remove" "dns"]
 depends: [
   "ocamlfind" {build}


### PR DESCRIPTION
```
#=== ERROR while installing dns.0.18.1 ========================================#
# opam-version         1.2.2
# os                   darwin
# command              ocaml setup.ml -test -runner sequential
# path                 /Users/thomas/.opam/alcotest/build/dns.0.18.1
# compiler             system (4.04.1)
# exit-code            1
# env-file             /Users/thomas/.opam/alcotest/build/dns.0.18.1/dns-73013-e72aaf.env
# stdout-file          /Users/thomas/.opam/alcotest/build/dns.0.18.1/dns-73013-e72aaf.out
# stderr-file          /Users/thomas/.opam/alcotest/build/dns.0.18.1/dns-73013-e72aaf.err
### stdout ###
# [...]
# Error: dns:3:Dns_resolver_unix:0:fd-leak-test (in the log).
#
# Raised at file "src/core/lwt.ml", line 805, characters 16-23
# Called from file "src/unix/lwt_main.ml", line 34, characters 8-18
# Called from file "src/oUnitRunner.ml", line 46, characters 13-26
#
# Dns.Protocol.Dns_resolve_error(_)
# ------------------------------------------------------------------------------
# Ran: 39 tests in: 41.08 seconds.
# FAILED: Cases: 39 Tried: 39 Errors: 1 Failures: 0 Skip:  0 Todo: 0 Timeouts: 0.
### stderr ###
# [...]
# Warning 3: deprecated: String.uncapitalize
# Use String.uncapitalize_ascii instead.
# File "setup.ml", line 5847, characters 11-28:
# Warning 3: deprecated: String.capitalize
# Use String.capitalize_ascii instead.
# File "setup.ml", line 5848, characters 11-30:
# Warning 3: deprecated: String.uncapitalize
# Use String.uncapitalize_ascii instead.
# W: Test 'test' fails: Command '/Users/thomas/.opam/alcotest/build/dns.0.18.1/_build/lib_test/ounit/test.native -runner sequential' terminated with error code 1
# E: Failure("Tests had a 100.00% failure rate")
```

/cc @avsm 

Seems to happen only on OSX