### PR TITLE
digestif: prepare for the next version of alcotest

### DIFF
--- a/packages/digestif/digestif.0.1/opam
+++ b/packages/digestif/digestif.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"      {build}
   "topkg"          {build}
   "base-bytes"
-  "alcotest"       {test}
+  "alcotest"       {test & < "0.8.0"}
 ]
 
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
```
+ ocamlfind ocamlc -c -g -bin-annot -safe-string -package alcotest -I test -I lib -o test/test.cmo test/test.ml
 File "test/test.ml", line 307, characters 73-91:
 Error: The type constructor Alcotest.test_case expects 1 argument(s),
        but is here applied to 0 argument(s)
```

/cc @dinosaure 