### PR TITLE
disable tests for polyglot as it is failing on OSX

### DIFF
--- a/packages/polyglot/polyglot.1.0.0/opam
+++ b/packages/polyglot/polyglot.1.0.0/opam
@@ -11,7 +11,6 @@ build: [
   [make "tool"] {cmdliner:installed & base-unix:installed}
 ]
 install: [make "install"]
-build-test: [make "test"]
 remove: ["ocamlfind" "remove" "polyglot"]
 depends: [
   "ocamlfind" {build}


### PR DESCRIPTION
```
$ ./test/test.native test Simple 0
Testing polyglot.
[ERROR]             Simple           0   no_dtd.
[SKIP]              Simple           1   keep_dtd.
[SKIP]              Simple           2   void.
[SKIP]              Simple           3   nonvoid.
[SKIP]              Simple           4   fragment.
[SKIP]              Simple           5   other_ns.
[SKIP]              Detect           0   detect_no_dtd.
[SKIP]              Detect           1   detect_fragment.
[SKIP]              Detect           2   detect_nonstandard_html.
[SKIP]              Detect           3   detect_no_dtd_xml.
[SKIP]              Detect           4   detect_dtd_xml.
[SKIP]              Error            0   empty.
[SKIP]              Error            1   bad_xml_no_close.
[SKIP]              Error            2   bad_xml_no_open.
-- Simple.000 Failed --
no_dtd.
_build/_tests/Simple.000.output:
[exception] Unix.Unix_error(Unix.ENOENT, "chdir", "no_dtd")
Raised by primitive operation at file "test.ml", line 45, characters 4-18
Re-raised at file "test.ml", line 51, characters 4-11
Called from file "test.ml", line 56, characters 17-93
Called from file "test.ml" (inlined), line 68, characters 17-55
Called from file "test.ml", line 70, characters 31-43
Called from file "src/alcotest.ml", line 268, characters 8-12
```

/cc @dsheets 