### PR TITLE
osx-membership: remove broken tests

### DIFF
--- a/packages/osx-membership/osx-membership.0.1.0/opam
+++ b/packages/osx-membership/osx-membership.0.1.0/opam
@@ -8,7 +8,6 @@ tags: ["osx" "membership" "uid" "gid" "guid" "uuid" "opendirectoryd"]
 dev-repo: "https://github.com/dsheets/ocaml-osx-membership.git"
 build: [make "build"]
 install: [make "install"]
-build-test: [make "test"]
 remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}


### PR DESCRIPTION
```
+ ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -strict-sequence -package posix-types -package ctypes.stubs
 -package unix-errno.unix -package alcotest -w @5@8@10@11@12@14@23@24@26@29 -I lib_test -I lwt -I lib -o lib_test/test.cm
o lib_test/test.ml
 File "lib_test/test.ml", line 23, characters 27-33:
 Error: Unbound constructor Id.Uid
```

/cc @dsheets 