### PR TITLE
bistro.0.3.0 - via opam-publish

### DIFF
--- a/packages/bistro/bistro.0.3.0/descr
+++ b/packages/bistro/bistro.0.3.0/descr
@@ -1,0 +1,21 @@
+A library to build and run distributed workflows
+
+bistro is an OCaml library to build and run computations represented
+by a collection of interdependent scripts, as is often found in
+data analysis (especially computational biology).
+
+Features:
+- build complex and composable workflows declaratively
+- simple and lightweight wrapping of new components
+- resume-on-failure: if something fails, fix it and the workflow will
+  restart from where it stopped
+- parallel workflow execution (locally or over a PBS cluster)
+- development-friendly: when a script is modified, bistro
+  automatically finds out what needs to be recomputed
+- automatic naming of generated files
+- static typing: detect file format errors at compile time!
+
+The library provides a datatype to represent scripts (including
+metadata and dependencies), an engine to run workflows and a standard
+library providing components for popular tools (although mostly
+related to computational biology and unix for now).

--- a/packages/bistro/bistro.0.3.0/opam
+++ b/packages/bistro/bistro.0.3.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Philippe Veber <philippe.veber@gmail.com>"
+authors: "Philippe Veber <philippe.veber@gmail.com>"
+homepage: "https://github.com/pveber/bistro/"
+bug-reports: "https://github.com/pveber/bistro/issues"
+license: "GPL"
+dev-repo: "https://github.com/pveber/bistro.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta8"}
+  "core" {>= "0.9.0"}
+  "lwt"
+  "ocamlgraph" {>= "1.8.7"}
+  "rresult"
+  "sexplib" {>= "113.24.00"}
+  "tyxml" {>= "4.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/bistro/bistro.0.3.0/url
+++ b/packages/bistro/bistro.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/pveber/bistro/archive/v0.3.0.tar.gz"
+checksum: "670877e55d851a83cf8a833b6df1e955"


### PR DESCRIPTION
A library to build and run distributed workflows

bistro is an OCaml library to build and run computations represented
by a collection of interdependent scripts, as is often found in
data analysis (especially computational biology).

Features:
- build complex and composable workflows declaratively
- simple and lightweight wrapping of new components
- resume-on-failure: if something fails, fix it and the workflow will
  restart from where it stopped
- parallel workflow execution (locally or over a PBS cluster)
- development-friendly: when a script is modified, bistro
  automatically finds out what needs to be recomputed
- automatic naming of generated files
- static typing: detect file format errors at compile time!

The library provides a datatype to represent scripts (including
metadata and dependencies), an engine to run workflows and a standard
library providing components for popular tools (although mostly
related to computational biology and unix for now).


---
* Homepage: https://github.com/pveber/bistro/
* Source repo: https://github.com/pveber/bistro.git
* Bug tracker: https://github.com/pveber/bistro/issues

---

Pull-request generated by opam-publish v0.3.4