### PR TITLE
mechaml: prepare the release of the upcoming alcotest 0.8.0

### DIFF
--- a/packages/mechaml/mechaml.0.1/opam
+++ b/packages/mechaml/mechaml.0.1/opam
@@ -19,7 +19,7 @@ remove: ["ocamlfind" "remove" "mechaml"]
 depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "cohttp"
+  "cohttp" {>= "0.21.0"}
   "lwt"
   "uri"
   "lambdasoup" {< "0.7.0"}

--- a/packages/mechaml/mechaml.0.1/opam
+++ b/packages/mechaml/mechaml.0.1/opam
@@ -23,6 +23,6 @@ depends: [
   "lwt"
   "uri"
   "lambdasoup" {< "0.7.0"}
-  "alcotest" {test}
+  "alcotest" {test & < "0.8.0"}
 ]
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
`Alcotest.test_case` now takes a parameter (by default it's `unit`):

```
 File "test/test.ml", line 151, characters 22-40:
 Error: The type constructor Alcotest.test_case expects 1 argument(s),
        but is here applied to 0 argument(s)
```

/cc @yannham