### PR TITLE
mirage-net-flow: prepare the upcoming alcotest 0.8 release

### DIFF
--- a/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
+++ b/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
@@ -16,6 +16,6 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "cstruct-lwt" {>= "3.0.0"}
   "logs"
-  "alcotest" {test}
+  "alcotest" {test & < "0.8.0"}
 ]
 available: [ ocaml-version >= "4.02.3"]


### PR DESCRIPTION
The `Alcotet.test_case` type now takes a parameter:

```
 File "test/test.ml", line 46, characters 12-30:
 Error: The type constructor Alcotest.test_case expects 1 argument(s),
        but is here applied to 0 argument(s)
```