### PR TITLE
tyre: prepare for the upcoming release of alcotest 0.8

### DIFF
--- a/packages/tyre/tyre.0.1.1/opam
+++ b/packages/tyre/tyre.0.1.1/opam
@@ -22,7 +22,7 @@ remove: ["ocamlfind" "remove" "tyre"]
 depends: [
   "ocamlfind" {build}
   "re" {>= "1.6.0"}
-  "alcotest" {test & >= "0.6.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/tyre/tyre.0.1/opam
+++ b/packages/tyre/tyre.0.1/opam
@@ -22,7 +22,7 @@ remove: ["ocamlfind" "remove" "tyre"]
 depends: [
   "ocamlfind" {build}
   "re" {>= "1.6.0"}
-  "alcotest" {test & >= "0.6.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/tyre/tyre.0.2/opam
+++ b/packages/tyre/tyre.0.2/opam
@@ -22,7 +22,7 @@ remove: ["ocamlfind" "remove" "tyre"]
 depends: [
   "ocamlfind" {build}
   "re" {>= "1.7.0"}
-  "alcotest" {test & >= "0.6.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/tyre/tyre.0.3/opam
+++ b/packages/tyre/tyre.0.3/opam
@@ -22,7 +22,7 @@ remove: ["ocamlfind" "remove" "tyre"]
 depends: [
   "ocamlfind" {build}
   "re" {>= "1.7.0"}
-  "alcotest" {test & >= "0.6.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
Alcotest.float now takes a mandatory epsilon parameter:

```
File "test/test.ml", line 92, characters 16-23:
 Error: This expression has type float -> float A.testable
        but an expression was expected of type
          'a A.testable = (module A.TESTABLE with type t = 'a)
```

/cc @Drup 