### PR TITLE
Remove terminal_size 0.1.1 tests which are broken on OSX

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.1/opam
+++ b/packages/terminal_size/terminal_size.0.1.1/opam
@@ -10,8 +10,8 @@ build: [
   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 ]
 build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ] { os != "darwin" }
+  [ "ocaml" "pkg/pkg.ml" "test" ] { os != "darwin" }
 ]
 depends: [
   "ocamlbuild" {build}

--- a/packages/terminal_size/terminal_size.0.1.2/opam
+++ b/packages/terminal_size/terminal_size.0.1.2/opam
@@ -10,8 +10,8 @@ build: [
   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 ]
 build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ] { os != "darwin" }
+  [ "ocaml" "pkg/pkg.ml" "test" ] { os != "darwin" }
 ]
 depends: [
   "ocamlbuild" {build}


### PR DESCRIPTION
See https://github.com/cryptosense/terminal_size/issues/8

/cc @emillon 