### PR TITLE
add missing lwt constraints to packages using Lwt.Infix

### DIFF
--- a/packages/irmin-watcher/irmin-watcher.0.3.0/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "alcotest" {test}
   "mtime"    {test & >= "1.0.0"}
-  "lwt"
+  "lwt"      {>= "2.4.7"}
   "logs"
   "fmt"
   "astring"

--- a/packages/tar-format/tar-format.0.4.0/opam
+++ b/packages/tar-format/tar-format.0.4.0/opam
@@ -29,4 +29,8 @@ depopts: [
   "lwt"
   "mirage-types"
 ]
+conflicts: [
+  "lwt" {< "2.4.7"}
+]
+
 available: [ ocaml-version >= "4.01.0" ]


### PR DESCRIPTION
There are probably many more, but I've just hit those