### PR TITLE
irmin: since 1.0.2, it needs hex>=0.2.0

### DIFF
--- a/packages/irmin/irmin.1.0.0/opam
+++ b/packages/irmin/irmin.1.0.0/opam
@@ -29,5 +29,7 @@ depends: [
   "astring"
   "hex"
   "alcotest" {test}
+  "git-unix" {test & >= "1.10.0"}
+  "mtime"    {test & < "1.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.0.1/opam
+++ b/packages/irmin/irmin.1.0.1/opam
@@ -29,5 +29,7 @@ depends: [
   "astring"
   "hex"
   "alcotest" {test}
+  "git-unix" {test & >= "1.10.0"}
+  "mtime"    {test & < "1.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.0.2/opam
+++ b/packages/irmin/irmin.1.0.2/opam
@@ -27,7 +27,7 @@ depends: [
   "jsonm" {>= "1.0.0"}
   "uri" {>= "1.3.12"}
   "astring"
-  "hex"
+  "hex" {>= "0.2.0"}
   "alcotest" {test}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.0.2/opam
+++ b/packages/irmin/irmin.1.0.2/opam
@@ -29,5 +29,7 @@ depends: [
   "astring"
   "hex" {>= "0.2.0"}
   "alcotest" {test}
+  "git-unix" {test & >= "1.10.0"}
+  "mtime"    {test & < "1.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.1.0/opam
+++ b/packages/irmin/irmin.1.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "jsonm" {>= "1.0.0"}
   "uri" {>= "1.3.12"}
   "astring"
-  "hex"
+  "hex" {>= "0.2.0"}
   "alcotest" {test}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.1.0/opam
+++ b/packages/irmin/irmin.1.1.0/opam
@@ -29,5 +29,7 @@ depends: [
   "astring"
   "hex" {>= "0.2.0"}
   "alcotest" {test}
+  "git-unix" {test & >= "1.10.0"}
+  "mtime"    {test & < "1.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.2.0/opam
+++ b/packages/irmin/irmin.1.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jsonm" {>= "1.0.0"}
   "lwt" {>= "2.4.7"}
   "ocamlgraph"
-  "hex"
+  "hex" {>= "0.2.0"}
   "logs" {>= "0.5.0"}
   "astring"
 ]


### PR DESCRIPTION
Because it uses Hex.of_cstruct