### PR TITLE
terminal_size.0.1.3 - via opam-publish

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.3/descr
+++ b/packages/terminal_size/terminal_size.0.1.3/descr
@@ -1,0 +1,4 @@
+Get the dimensions of the terminal
+
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.

--- a/packages/terminal_size/terminal_size.0.1.3/opam
+++ b/packages/terminal_size/terminal_size.0.1.3/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "alcotest" {test}
+  "topkg" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/terminal_size/terminal_size.0.1.3/url
+++ b/packages/terminal_size/terminal_size.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/terminal_size/releases/download/v0.1.3/terminal_size-0.1.3.tbz"
+checksum: "b99f6a769e503dae7c04568100e29214"


### PR DESCRIPTION
Get the dimensions of the terminal

You can use this small library to detect the dimensions of the terminal window
attached to a process.


---
* Homepage: https://github.com/cryptosense/terminal_size
* Source repo: https://github.com/cryptosense/terminal_size.git
* Bug tracker: https://github.com/cryptosense/terminal_size/issues

---


---
v0.1.3
------

*2017-05-02*

Tests:

- Use the correct signature for `ioctl`.
  This fixes tests on OSX (#8, #9).
Pull-request generated by opam-publish v0.3.4