### PR TITLE
cohttp: add missing js_of_ocaml constraints

### DIFF
--- a/packages/cohttp/cohttp.0.21.0/opam
+++ b/packages/cohttp/cohttp.0.21.0/opam
@@ -46,5 +46,6 @@ conflicts: [
   "async" {< "113.24.00"}
   "lwt" {< "2.5.0"}
   "js_of_ocaml" {< "2.6"}
+  "js_of_ocaml" {>= "3.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/cohttp/cohttp.0.21.1/opam
+++ b/packages/cohttp/cohttp.0.21.1/opam
@@ -47,5 +47,6 @@ conflicts: [
   "async" {< "113.24.00"}
   "lwt" {< "2.5.0"}
   "js_of_ocaml" {< "2.8"}
+  "js_of_ocaml" {>= "3.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/cohttp/cohttp.0.22.0/opam
+++ b/packages/cohttp/cohttp.0.22.0/opam
@@ -49,5 +49,6 @@ conflicts: [
   "async" {< "113.24.00"}
   "lwt" {< "2.5.0"}
   "js_of_ocaml" {< "2.8"}
+  "js_of_ocaml" {>= "3.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
We missed these because we don't test depopts :-/

/cc @hhugo 