### PR TITLE
[do not merge] alcotest.0.8.0 - via opam-publish

### DIFF
--- a/packages/alcotest/alcotest.0.8.0/descr
+++ b/packages/alcotest/alcotest.0.8.0/descr
@@ -1,0 +1,61 @@
+Logo](https://raw.githubusercontent.com/mirage/alcotest/master/alcotest-logo.png)
+
+Alcotest is a lightweight and colourful test framework.
+
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple `TESTABLE` module type, a `check` function to assert test
+predicates and a `run` function to perform a list of `unit -> unit`
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+
+[![Build Status](https://travis-ci.org/mirage/alcotest.svg)](https://travis-ci.org/mirage/alcotest)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/alcotest/Alcotest.html)
+
+### Examples
+
+A simple example:
+
+```ocaml
+(* Build with `ocamlbuild -pkg alcotest simple.byte` *)
+
+(* A module with functions to test *)
+module To_test = struct
+  let capit letter = Char.uppercase letter
+  let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
+end
+
+(* The tests *)
+let capit () =
+  Alcotest.(check char) "same chars"  'A' (To_test.capit 'a')
+
+let plus () =
+  Alcotest.(check int) "same ints" 7 (To_test.plus [1;1;2;3])
+
+let test_set = [
+  "Capitalize" , `Quick, capit;
+  "Add entries", `Slow , plus ;
+]
+
+(* Run it *)
+let () =
+  Alcotest.run "My first test" [
+    "test_set", test_set;
+  ]
+```
+
+The result is a self-contained binary which displays the test results. Use
+`./simple.byte --help` to see the runtime options.
+
+```shell
+$ ./simple.native
+[OK]        test_set  0   Capitalize.
+[OK]        test_set  1   Add entries.
+Test Successful in 0.001s. 2 tests run.
+```
+
+See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
+folder for more examples.

--- a/packages/alcotest/alcotest.0.8.0/opam
+++ b/packages/alcotest/alcotest.0.8.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder"  {build & >= "1.0+beta10"}
+  "fmt"
+  "astring"
+  "result"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/alcotest/alcotest.0.8.0/url
+++ b/packages/alcotest/alcotest.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/alcotest/releases/download/0.8.0/alcotest-0.8.0.tbz"
+checksum: "771277ef1fe21b17920b5b44acf441b3"


### PR DESCRIPTION
Logo](https://raw.githubusercontent.com/mirage/alcotest/master/alcotest-logo.png)

Alcotest is a lightweight and colourful test framework.

Alcotest exposes simple interface to perform unit tests. It exposes
a simple `TESTABLE` module type, a `check` function to assert test
predicates and a `run` function to perform a list of `unit -> unit`
test callbacks.

Alcotest provides a quiet and colorful output where only faulty runs
are fully displayed at the end of the run (with the full logs ready to
inspect), with a simple (yet expressive) query language to select the
tests to run.

[![Build Status](https://travis-ci.org/mirage/alcotest.svg)](https://travis-ci.org/mirage/alcotest)
[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/alcotest/Alcotest.html)

### Examples

A simple example:

```ocaml
(* Build with `ocamlbuild -pkg alcotest simple.byte` *)

(* A module with functions to test *)
module To_test = struct
  let capit letter = Char.uppercase letter
  let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
end

(* The tests *)
let capit () =
  Alcotest.(check char) "same chars"  'A' (To_test.capit 'a')

let plus () =
  Alcotest.(check int) "same ints" 7 (To_test.plus [1;1;2;3])

let test_set = [
  "Capitalize" , `Quick, capit;
  "Add entries", `Slow , plus ;
]

(* Run it *)
let () =
  Alcotest.run "My first test" [
    "test_set", test_set;
  ]
```

The result is a self-contained binary which displays the test results. Use
`./simple.byte --help` to see the runtime options.

```shell
$ ./simple.native
[OK]        test_set  0   Capitalize.
[OK]        test_set  1   Add entries.
Test Successful in 0.001s. 2 tests run.
```

See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
folder for more examples.

---
* Homepage: https://github.com/mirage/alcotest/
* Source repo: https://github.com/mirage/alcotest.git
* Bug tracker: https://github.com/mirage/alcotest/issues/

---


---
### 0.8.0 (2016-06-22)

- Format "got" and "expected" values in the same way (#86, @talex5)
- Change the `float` combinator to take a mandatory 'epsilon' parameter
  (#89, @superbobry)
- Switch to jbuilder (#92, @rgrinberg)
- Add a `test_case` function (#94, @samoht)
- Add an `alcotest-lwt` package, containing an `Alcotet_lwt` module with
  an `Alcotest_lwt.test_case` function to better deal with lwt tests
  (#94, @talex5, @samoht)
- Add `Alcotest.neg` to negate test results (#95, @samoht)
- Change the `test_case` type from `unit -> unit` to `'a -> unit`. The `'a`
  parameter can be built using as a `Cmdliner` term using the new
  `run_with_args` function. This is useful to configure the tests using the CLI
  (#96, @samoht)
Pull-request generated by opam-publish v0.3.4