### PR TITLE
mirage-net-fd: add upper bounds on alcotest to prepare the 0.8 release

### DIFF
--- a/packages/mirage-net-fd/mirage-net-fd.0.1.0/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.1.0/opam
@@ -28,6 +28,6 @@ depends: [
   "io-page" {>= "1.0.1"}
   "result"
   "ipaddr"
-  "alcotest" {test}
+  "alcotest" {test & < "0.8.0"}
 ]
 available: [ ocaml-version >= "4.02.3"]

--- a/packages/mirage-net-fd/mirage-net-fd.0.1.0/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "topkg"      {build}
   "lwt"            {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
-  "io-page" {>= "1.0.1"}
+  "io-page" {>= "1.0.1" & < "2.0.0"}
   "result"
   "ipaddr"
   "alcotest" {test & < "0.8.0"}

--- a/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
@@ -28,6 +28,6 @@ depends: [
   "io-page" {>= "1.0.1"}
   "result"
   "ipaddr"
-  "alcotest" {test}
+  "alcotest" {test & < "0.8.0"}
 ]
 available: [ ocaml-version >= "4.02.3"]

--- a/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "topkg"      {build}
   "lwt"            {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
-  "io-page" {>= "1.0.1"}
+  "io-page" {>= "1.0.1" & < "2.0.0"}
   "result"
   "ipaddr"
   "alcotest" {test & < "0.8.0"}

--- a/packages/mirage-net-fd/mirage-net-fd.0.2.1/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.2.1/opam
@@ -25,6 +25,6 @@ depends: [
   "io-page-unix"   {>= "2.0.0"}
   "result"
   "ipaddr"
-  "alcotest" {test}
+  "alcotest" {test & < "0.8.0"}
 ]
 available: [ ocaml-version >= "4.02.3"]


### PR DESCRIPTION
otherwise it fails with:

```
 File "test/test.ml", line 45, characters 12-30:
 Error: The type constructor Alcotest.test_case expects 1 argument(s),
        but is here applied to 0 argument(s)
```