### PR TITLE
touist.3.2.1 - via opam-publish

### DIFF
--- a/packages/touist/touist.3.2.1/descr
+++ b/packages/touist/touist.3.2.1/descr
@@ -1,0 +1,15 @@
+The solver for the Touist language
+
+The Touist language is a friendly language for writing propositional
+logic (SAT), logic on real and integers (SMT) and quantified boolean
+formulas (QBF). This language aims to formalize real-life problems
+(e.g., the sudoku can be solved in a few lines). Touist embeds a SAT
+solver (minisat) and can be built with optionnal SMT and QBF solvers.
+Touist is also able to generate the latex, DIMACS, SMT-LIB and QDIMACS
+formats from a touist file.
+
+Optionnal solvers:
+- for using the embeded SMT solver, run `opam install yices2` and then do
+  `opam reinstall touist`
+- for using the embeded QBF solver, run `opam install qbf` and then do
+  `opam reinstall touist`

--- a/packages/touist/touist.3.2.1/opam
+++ b/packages/touist/touist.3.2.1/opam
@@ -1,0 +1,76 @@
+opam-version: "1.2"
+maintainer: "Maël Valais <mael.valais@gmail.com>"
+authors: ["Maël Valais <mael.valais@gmail.com>" "Olivier Lezaud"]
+homepage: "https://www.irit.fr/touist"
+bug-reports: "https://github.com/touist/touist/issues"
+license: "MIT"
+dev-repo: "https://github.com/touist/touist.git"
+build: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--prefix"
+    prefix
+    "--%{yices2:enable}%-yices2"
+    "--%{qbf:enable}%-qbf"
+  ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--enable-tests"
+    "--%{yices2:enable}%-yices2"
+    "--%{qbf:enable}%-qbf"
+  ]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: [
+  "ocaml" "%{etc}%/touist/setup.ml" "-C" "%{etc}%/touist" "-uninstall"
+]
+depends: [
+  "cppo" {build & >= "0.9.4"}
+  "fileutils" {build & >= "0.4.0"}
+  "menhir" {build & >= "20151023"}
+  "minisat" {build}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {test}
+]
+depopts: ["qbf" "yices2"]
+conflicts: [
+  "qbf" {< "0.1"}
+  "yices2" {< "0.0.2"}
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages: [
+  "
+Touist built without yices2. If you also wanted to use the SMT solver, do:
+    opam install yices2
+    opam reinstall touist
+  "
+    {success & !yices2:installed}
+  "
+Touist built without quantor. If you also wanted to use the QBF solver, do
+    opam install qbf
+    opam reinstall touist
+  "
+    {success & !qbf:installed}
+  "
+Touist has been built with the yices2 solver. Yices2 is free [only] for
+non-commercial use. License terms:
+    http://yices.csl.sri.com/yices-newnewlicense.html
+  "
+    {success & yices2:installed}
+  "
+Touist has been built with the solver 'quantor'. Quantor is under BSD
+license.
+  "
+    {success & qbf:installed}
+]

--- a/packages/touist/touist.3.2.1/url
+++ b/packages/touist/touist.3.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/touist/touist/archive/v3.2.1.tar.gz"
+checksum: "b37b3aaefba542930f0e2b94cd0d79c1"


### PR DESCRIPTION
The solver for the Touist language

The Touist language is a friendly language for writing propositional
logic (SAT), logic on real and integers (SMT) and quantified boolean
formulas (QBF). This language aims to formalize real-life problems
(e.g., the sudoku can be solved in a few lines). Touist embeds a SAT
solver (minisat) and can be built with optionnal SMT and QBF solvers.
Touist is also able to generate the latex, DIMACS, SMT-LIB and QDIMACS
formats from a touist file.

Optionnal solvers:
- for using the embeded SMT solver, run `opam install yices2` and then do
  `opam reinstall touist`
- for using the embeded QBF solver, run `opam install qbf` and then do
  `opam reinstall touist`


---
* Homepage: https://www.irit.fr/touist
* Source repo: https://github.com/touist/touist.git
* Bug tracker: https://github.com/touist/touist/issues

---

Pull-request generated by opam-publish v0.3.4