### PR TITLE
mtime.1.1.0 - via opam-publish

### DIFF
--- a/packages/mtime/mtime.1.1.0/descr
+++ b/packages/mtime/mtime.1.1.0/descr
@@ -1,0 +1,15 @@
+Monotonic wall-clock time for OCaml
+
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library.
+The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
+and its libraries are distributed under the ISC license.
+
+[jsoo]: http://ocsigen.org/js_of_ocaml/

--- a/packages/mtime/mtime.1.1.0/opam
+++ b/packages/mtime/mtime.1.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Daniel Bünzli <daniel.buenzl i@erratique.ch>" ]
+homepage: "http://erratique.ch/software/mtime"
+doc: "http://erratique.ch/software/mtime"
+dev-repo: "http://erratique.ch/repos/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+tags: [ "time" "monotonic" "system" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.03.0"]
+depends:
+[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+depopts: [ "js_of_ocaml" ]
+build: [[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]

--- a/packages/mtime/mtime.1.1.0/url
+++ b/packages/mtime/mtime.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/mtime/releases/mtime-1.1.0.tbz"
+checksum: "2935fe4a36b721735f60c9c65ad63a26"


### PR DESCRIPTION
Monotonic wall-clock time for OCaml

Mtime has platform independent support for monotonic wall-clock time
in pure OCaml. This time increases monotonically and is not subject to
operating system calendar time adjustments. The library has types to
represent nanosecond precision timestamps and time spans.

The additional Mtime_clock library provide access to a system
monotonic clock.

Mtime has a no dependency. Mtime_clock depends on your system library.
The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
and its libraries are distributed under the ISC license.

[jsoo]: http://ocsigen.org/js_of_ocaml/


---
* Homepage: http://erratique.ch/software/mtime
* Source repo: http://erratique.ch/repos/mtime.git
* Bug tracker: https://github.com/dbuenzli/mtime/issues

---


---
v1.1.0 2017-06-24 London
------------------------

* Add `Mtime.Span.{add,zero,one,min_span,max_span}`.
Pull-request generated by opam-publish v0.3.4