### PR TITLE
mark ppx_cstruct and ppx_tools as build dependencies for some packages

### DIFF
--- a/packages/arp/arp.0.1.1/opam
+++ b/packages/arp/arp.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_tools" {build}
   "result"
   "cstruct" {>= "2.2.0"}
-  "ppx_cstruct"
+  "ppx_cstruct" {build}
   "ipaddr" {>= "2.2.0"}
   "logs"
   "alcotest" {test}

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -28,7 +28,7 @@ depends: [
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>="1.9.0" & <"3.0.0"}
-  "ppx_cstruct"
+  "ppx_cstruct"   {build}
   "sexplib"
   "ipaddr"        {>= "2.5.0"}
   "tcpip"         {>= "3.1.0"}

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>= "1.9.0" & <"3.0.0"}
-  "ppx_cstruct"
+  "ppx_cstruct"   {build}
   "sexplib"
   "ipaddr"        {>= "2.5.0"}
   "tcpip"         {>= "3.1.0"}

--- a/packages/dns/dns.0.18.0/opam
+++ b/packages/dns/dns.0.18.0/opam
@@ -41,7 +41,7 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct" {>= "1.9.0" & <"3.0.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0" & <"2.8.0"}

--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -34,7 +34,7 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct" {>= "1.9.0" & <"3.0.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0" & <"2.8.0"}

--- a/packages/dns/dns.0.19.0/opam
+++ b/packages/dns/dns.0.19.0/opam
@@ -41,8 +41,8 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct" {>= "2.0.0" & <"3.0.0"}
-  "ppx_cstruct"
-  "ppx_tools"
+  "ppx_cstruct" {build}
+  "ppx_tools" {build}
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0" & <"2.8.0"}

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ppx_tools"        {build}
   "base-bytes"
   "cstruct"          {>= "2.0.0"}
-  "ppx_cstruct"
+  "ppx_cstruct"      {build}
   "re"
   "ipaddr"           {>= "2.6.0" & <"2.8.0"}
   "uri"              {>= "1.7.0" & <"1.9.4"}

--- a/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "shared-memory-ring" {>= "0.4.1"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
@@ -29,7 +29,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
@@ -29,7 +29,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"

--- a/packages/mirage-profile/mirage-profile.0.7.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.7.0/opam
@@ -19,8 +19,8 @@ remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct"
-  "ppx_tools"
+  "ppx_cstruct" {build}
+  "ppx_tools" {build}
   "ocplib-endian"
   "io-page"
   "lwt"


### PR DESCRIPTION
this includes mirage-block-xen, which may be the issue https://github.com/mirage/mirage-www/pull/558

/cc @djs55 @haesbaert @talex5 @avsm @samoht 

there are more results for `git grep ppx_ | grep -v {build}` instances in case some is motivated to fix them all