### PR TITLE
faraday.0.2.0 - via opam-publish

### DIFF
--- a/packages/faraday/faraday.0.2.0/descr
+++ b/packages/faraday/faraday.0.2.0/descr
@@ -1,0 +1,8 @@
+A library for writing fast and memory-efficient serializers.
+
+Faraday is a library for writing fast and memory-efficient serializers. Its
+core type and related operation gives the user fine-grained control over
+copying and allocation behavior while serializing user-defined types, and
+presents the output in a form that makes it possible to use vectorized write
+operations, such as the writev system call, or any other platform or
+application-specific output APIs.

--- a/packages/faraday/faraday.0.2.0/opam
+++ b/packages/faraday/faraday.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+homepage: "https://github.com/inhabitedtype/faraday"
+bug-reports: "https://github.com/inhabitedtype/faraday/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/inhabitedtype/faraday.git"
+build: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--prefix"
+    prefix
+    "--%{base-unix:enable}%-unix"
+    "--%{lwt:enable}%-lwt"
+    "--%{async:enable}%-async"
+  ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "faraday"]
+depends: [
+  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
+  "ocamlfind" {build}
+  "ocplib-endian" {>= "0.8"}
+]
+depopts: ["async" "base-unix" "lwt"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/faraday/faraday.0.2.0/url
+++ b/packages/faraday/faraday.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/inhabitedtype/faraday/archive/0.2.0.tar.gz"
+checksum: "f5493327d8a491ba3b9a6fbed9d1b561"


### PR DESCRIPTION
A library for writing fast and memory-efficient serializers.

Faraday is a library for writing fast and memory-efficient serializers. Its
core type and related operation gives the user fine-grained control over
copying and allocation behavior while serializing user-defined types, and
presents the output in a form that makes it possible to use vectorized write
operations, such as the writev system call, or any other platform or
application-specific output APIs.


---
* Homepage: https://github.com/inhabitedtype/faraday
* Source repo: https://github.com/inhabitedtype/faraday.git
* Bug tracker: https://github.com/inhabitedtype/faraday/issues

---

Pull-request generated by opam-publish v0.3.4