### PR TITLE
Add patch to include `rpclib.json` dependency

### DIFF
--- a/packages/xapi-rrd/xapi-rrd.1.0.1/files/depend-on-rpclib.json.patch
+++ b/packages/xapi-rrd/xapi-rrd.1.0.1/files/depend-on-rpclib.json.patch
@@ -1,0 +1,32 @@
+From ec7c82d15945831cf0557c80cac7438e3cc54b59 Mon Sep 17 00:00:00 2001
+From: David Scott <dave@recoil.org>
+Date: Sat, 24 Jun 2017 10:57:03 +0100
+Subject: [PATCH] Add dependency on rpclib.json
+
+Since rpclib.1.9.51, the Jsonrpc module has moved to a subpackage.
+See the build breakage here:
+
+https://travis-ci.org/mirage/mirage-www/jobs/246491914
+
+Signed-off-by: David Scott <dave@recoil.org>
+Signed-off-by: Marcello Seri <marcello.seri@citrix.com>
+---
+ _oasis | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/_oasis b/_oasis
+index be3531d..a734360 100644
+--- a/_oasis
++++ b/_oasis
+@@ -14,7 +14,7 @@ Library rrd
+   Path:               lib
+   Findlibname:        rrd
+   Modules:            Rrd, Rrd_fring, Rrd_updates, Rrd_utils, Rrd_timescales
+-  BuildDepends:       rpclib, ppx_deriving_rpc
++  BuildDepends:       rpclib.json, ppx_deriving_rpc
+ 
+ Library rrd_unix
+   Pack:               false
+-- 
+2.11.0
+

--- a/packages/xapi-rrd/xapi-rrd.1.0.1/opam
+++ b/packages/xapi-rrd/xapi-rrd.1.0.1/opam
@@ -28,3 +28,6 @@ depends: [
   "uuidm"
   "ounit" {test}
 ]
+patches: [
+  "depend-on-rpclib.json.patch"
+]


### PR DESCRIPTION
This should fix some issues before a the release will be produced.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>