### PR TITLE
osdp0.5.4

### DIFF
--- a/packages/conf-sdpa/conf-sdpa.1/descr
+++ b/packages/conf-sdpa/conf-sdpa.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on a SDPA binary system installation.
+This package can only install if the SDPA binary is installed on the system.

--- a/packages/conf-sdpa/conf-sdpa.1/opam
+++ b/packages/conf-sdpa/conf-sdpa.1/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "Pierre Roux"
+authors: "SDPA Project"
+homepage: "http://sdpa.sourceforge.net/"
+build: ["sh" "-exc" "command -v sdpa"]
+depexts: [
+  [["debian"] ["sdpa"]]
+  [["ubuntu"] ["sdpa"]]
+]

--- a/packages/conf-sdpa/conf-sdpa.1/url
+++ b/packages/conf-sdpa/conf-sdpa.1/url
@@ -1,0 +1,2 @@
+http: "https://cavale.enseeiht.fr/osdp/conf-sdpa.1.tgz"
+checksum: "7293dd3478f263dcc43348b1a870c57d"

--- a/packages/osdp/osdp.0.5.4/descr
+++ b/packages/osdp/osdp.0.5.4/descr
@@ -1,0 +1,6 @@
+OCaml Interface to SDP solvers.
+
+OSDP is an OCaml frontend library to semi-definite programming (SDP)
+numerical optimization solvers. This package will be installed with
+the solver SDPA. It will also be compiled with CSDP and Mosek support
+if they can be found in the PATH.

--- a/packages/osdp/osdp.0.5.4/opam
+++ b/packages/osdp/osdp.0.5.4/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Pierre Roux"
+authors: "Pierre Roux"
+homepage: "https://cavale.enseeiht.fr/osdp/"
+license: "LGPL"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild"
+  "zarith"
+  "ocplib-simplex" {>= "0.3"}
+  "conf-sdpa"
+]

--- a/packages/osdp/osdp.0.5.4/url
+++ b/packages/osdp/osdp.0.5.4/url
@@ -1,0 +1,2 @@
+http: "https://cavale.enseeiht.fr/osdp/osdp-0.5.4.tgz"
+checksum: "9484e84852b54205f37a41b702304c73"


### PR DESCRIPTION
OCaml Interface to SDP solvers.

OSDP is an OCaml frontend library to semi-definite programming (SDP)
numerical optimization solvers. This package will be installed with
the solver SDPA. It will also be compiled with CSDP and Mosek support
if they can be found in the PATH.
