### PR TITLE
New release for mirage-flow-lwt and mirage-flow-unix

### DIFF
--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/descr
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/descr
@@ -1,0 +1,1 @@
+Flow implementations and combinators for MirageOS using Lwt

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-flow"
+bug-reports:   "https://github.com/mirage/mirage-flow/issues"
+dev-repo:      "https://github.com/mirage/mirage-flow.git"
+doc:           "https://mirage.github.io/mirage-flow/"
+authors:       ["Thomas Gazagnaire" "Dave Scott"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder"  {build & >="1.0+beta7"}
+  "fmt"
+  "lwt"
+  "logs"
+  "cstruct" {>= "2.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0"}
+]

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/url
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-flow/releases/download/v1.4.0/mirage-flow-1.4.0.tbz"
+checksum: "fdbd270044821d21afc883399eea45aa"

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/descr
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/descr
@@ -1,0 +1,1 @@
+Flow implementations and combinators for MirageOS using Unix

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-flow"
+bug-reports:   "https://github.com/mirage/mirage-flow/issues"
+dev-repo:      "https://github.com/mirage/mirage-flow.git"
+doc:           "https://mirage.github.io/mirage-flow/"
+authors:       ["Thomas Gazagnaire" "Dave Scott"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+build-test: [
+  [ "jbuilder" "runtest" ]
+]
+
+depends: [
+  "jbuilder"  {build & >="1.0+beta7"}
+  "fmt"
+  "logs"
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "lwt"
+  "cstruct" {>= "2.3.0"}
+  "alcotest"   {test}
+]

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/url
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-flow/releases/download/v1.4.0/mirage-flow-1.4.0.tbz"
+checksum: "fdbd270044821d21afc883399eea45aa"


### PR DESCRIPTION
CHANGES:

* mirage-flow-unix: add `Mirage_flow_unix.Fd` to wrap `Lwt_unix.file_descr` into
  a MirageOS flow (#34, #36, @samoht)
* mirage-flow-lwt: add first class flow values of type `Mirage_flow_lwt.t`
  (#35, @samoht)