### PR TITLE
New release: rpc 1.9.52

### DIFF
--- a/packages/rpc/rpc.1.9.52/descr
+++ b/packages/rpc/rpc.1.9.52/descr
@@ -1,0 +1,6 @@
+A library to deal with RPCs in OCaml
+
+This library provides a PPX and a camlp4 syntax extension to generate functions
+to convert values of a given type to and from their RPC representations. In
+order to do so, it is sufficient to add `[@@deriving rpc]` (or `with rpc` in
+case of camlp4) to the corresponding type definition.

--- a/packages/rpc/rpc.1.9.52/opam
+++ b/packages/rpc/rpc.1.9.52/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+homepage: "https://github.com/mirage/ocaml-rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [configure]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "rpclib"]
+  ["ocamlfind" "remove" "ppx_deriving_rpc"]
+]
+build-test: [
+    [make]
+    [make "test"]
+]
+depends: [
+  "oasis" {build}
+  "cppo"  {build}
+  "ocamlfind"
+  "type_conv" {>= "108.07.01"}
+  "ppx_deriving"
+  "cow"
+  "xmlm"
+  "lwt"
+  "cmdliner"
+  "rresult"
+  "async"
+]
+depopts: [ "js_of_ocaml" ]

--- a/packages/rpc/rpc.1.9.52/url
+++ b/packages/rpc/rpc.1.9.52/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-rpc/archive/v1.9.52.tar.gz"
+checksum: "a6208b59fe0c53be5c6ddb279b5f1296"


### PR DESCRIPTION
This includes the following fixes and additions

* Fix compilation on MacOS X
* Add a ClientExnRpc functor that takes an RPC impl as argument
* ppx_deriving_rpc: Fix marshalling of dictionaries in the rpcty code too
* ppx_deriving_rpc: Allow unnamed parameters in functions to introduce compatibility with the old camlp4 idl

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>