### PR TITLE
extunix.0.1.5 - via opam-publish

### DIFF
--- a/packages/extunix/extunix.0.1.5/descr
+++ b/packages/extunix/extunix.0.1.5/descr
@@ -1,0 +1,7 @@
+Collection of thin bindings to various low-level system API
+
+Motto: "Be to Unix, what extlib is to stdlib"
+
+ * Implement thin C bindings that directly map to underlying system API.
+ * Provide common consistent ocaml interface: naming convention, exceptions.
+ * Simple to build - no extra dependencies.

--- a/packages/extunix/extunix.0.1.5/opam
+++ b/packages/extunix/extunix.0.1.5/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+homepage: "http://ygrek.org.ua/p/extunix"
+dev-repo: "git://github.com/ygrek/extunix.git"
+bug-reports: "https://github.com/ygrek/extunix/issues"
+doc: "http://ygrek.org.ua/p/ocaml-extunix/api/index.html"
+license: "LGPL-2.1 with OCaml linking exception"
+authors: [ "ygrek"
+           "Sylvain Le Gall"
+           "Stéphane Glondu"
+           "Kaustuv Chaudhuri"
+           "Joshua Smith"
+           "Niki Yoshiuchi"
+           "Gerd Stolpmann"
+           "Goswin von Brederlow"
+           "Andre Nathan"
+           "Zhenya Lykhovyd"
+           "Mehdi Dogguy"
+           "Roman Vorobets"
+           "Pierre Chambart"
+           "Dmitry Grebeniuk"
+           "François Bobot" ]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--%{ounit:enable}%-tests" "--prefix" prefix] {ocaml-version >= "4.02.0"}
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix] {ocaml-version < "4.02.0"}
+  ["ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+build-doc: [
+  ["ocaml" "setup.ml" "-doc"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: [
+  ["ocamlfind" "remove" "extunix"]
+]
+depends: [
+  "ocamlfind" {build}
+  "camlp4" {build}
+  "ounit" {test & >= "1.0.3"}
+  "base-bytes"
+  "base-bigarray"
+  "base-unix"
+  "ocamlbuild" {build}
+]

--- a/packages/extunix/extunix.0.1.5/url
+++ b/packages/extunix/extunix.0.1.5/url
@@ -1,0 +1,3 @@
+http: "http://ygrek.org.ua/p/release/ocaml-extunix/ocaml-extunix-0.1.5.tar.gz"
+mirrors: ["https://github.com/ygrek/extunix/releases/download/v0.1.5/ocaml-extunix-0.1.5.tar.gz"]
+checksum: "5412a0b392ad5ac90cee6e951aea2076"


### PR DESCRIPTION
Collection of thin bindings to various low-level system API

Motto: "Be to Unix, what extlib is to stdlib"

 * Implement thin C bindings that directly map to underlying system API.
 * Provide common consistent ocaml interface: naming convention, exceptions.
 * Simple to build - no extra dependencies.


---
* Homepage: http://ygrek.org.ua/p/extunix
* Source repo: git://github.com/ygrek/extunix.git
* Bug tracker: https://github.com/ygrek/extunix/issues

---

Pull-request generated by opam-publish v0.3.4