### PR TITLE
pilat.1 - via opam-publish

### DIFF
--- a/packages/pilat/pilat.1/descr
+++ b/packages/pilat/pilat.1/descr
@@ -1,0 +1,6 @@
+Short description A Frama-C polynomial invariant generator 
+
+Long 
+description This tool generates invariants of linear and polynomial loops, with 
+deterministic and non deterministic assignments, as annotations in the initial 
+source code.

--- a/packages/pilat/pilat.1/opam
+++ b/packages/pilat/pilat.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Steven De Oliveira <de.oliveira.steven@gmail.com>"
+authors: "Steven De Oliveira <de.oliveira.steven@gmail.com>"
+homepage: "https://github.com/Stevendeo/Pilat/"
+license: "LGPLv2.1"
+dev-repo: "https://github.com/Stevendeo/Pilat.git"
+build: ["sh" "make.sh"]
+install: ["sh" "install.sh"]
+remove: ["ocamlfind" "remove" "pilat"]
+depends: ["ocamlfind" "lacaml" "zarith" "frama-c"]
+available: [ocaml-version > "4.02.3"]

--- a/packages/pilat/pilat.1/url
+++ b/packages/pilat/pilat.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Stevendeo/Pilat/archive/master.zip"
+checksum: "acc9034ea8c908dbe97c2fd5bfd30499"


### PR DESCRIPTION
A Frama-C polynomial invariant generator 

This tool generates invariants of linear and polynomial loops, with 
deterministic and non deterministic assignments, as annotations in the initial 
source code.

---
* Homepage: https://github.com/Stevendeo/Pilat/
* Source repo: https://github.com/Stevendeo/Pilat.git
* Bug tracker: 

---
### opam-lint failures
- **WARNING** 36 Missing field 'bug-reports'

---

Pull-request generated by opam-publish v0.3.4