### PR TITLE
mirage-kv.1.1.1 - via opam-publish

### DIFF
--- a/packages/mirage-kv/mirage-kv.1.1.1/descr
+++ b/packages/mirage-kv/mirage-kv.1.1.1/descr
@@ -1,0 +1,9 @@
+MirageOS signatures for key/value devices
+
+mirage-kv provides the [Mirage_kv.RO][ro] and [Mirage_kv_lwt.RO][ro-lwt]
+signatures the MirageOS key/value devices should implement.
+
+mirage-kv is distributed under the ISC license.
+
+[ro]: https://mirage.github.io/mirage-kv/Mirage_kv.html
+[ro-lwt]: https://mirage.github.io/mirage-kv/Mirage_kv_lwt.html

--- a/packages/mirage-kv/mirage-kv.1.1.1/opam
+++ b/packages/mirage-kv/mirage-kv.1.1.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "mirage-device" {>= "1.0.0"}
+  "fmt"
+]
+
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/mirage-kv/mirage-kv.1.1.1/url
+++ b/packages/mirage-kv/mirage-kv.1.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-kv/releases/download/v1.1.1/mirage-kv-1.1.1.tbz"
+checksum: "8c1ac2888c17e1e1586d3b3de595bd28"


### PR DESCRIPTION
MirageOS signatures for key/value devices

mirage-kv provides the [Mirage_kv.RO][ro] and [Mirage_kv_lwt.RO][ro-lwt]
signatures the MirageOS key/value devices should implement.

mirage-kv is distributed under the ISC license.

[ro]: https://mirage.github.io/mirage-kv/Mirage_kv.html
[ro-lwt]: https://mirage.github.io/mirage-kv/Mirage_kv_lwt.html

---
* Homepage: https://github.com/mirage/mirage-kv
* Source repo: https://github.com/mirage/mirage-kv.git
* Bug tracker: https://github.com/mirage/mirage-kv/issues

---


---
### v1.1.1 (2017-06-29)

* Remove `open Result` statements (and drop support to 4.02)
Pull-request generated by opam-publish v0.3.4