### PR TITLE
mirage-fs.1.1.1 - via opam-publish

### DIFF
--- a/packages/mirage-fs/mirage-fs.1.1.1/descr
+++ b/packages/mirage-fs/mirage-fs.1.1.1/descr
@@ -1,0 +1,9 @@
+MirageOS signatures for filesystem devices
+
+[![Build Status](https://travis-ci.org/mirage/mirage-fs.svg?branch=master)](https://travis-ci.org/mirage/mirage-fs)
+
+mirage-fs provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures
+the MirageOS filesystem devices should implement.
+
+[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
+[fslwt]: http://mirage.github.io/mirage-fs/Mirage_fs_lwt.html

--- a/packages/mirage-fs/mirage-fs.1.1.1/opam
+++ b/packages/mirage-fs/mirage-fs.1.1.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/mirage/mirage-fs"
+doc:          "https://mirage.github.io/mirage-fs/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-fs.git"
+bug-reports:  "https://github.com/mirage/mirage-fs/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "fmt"
+  "mirage-device" {>= "1.0.0"}
+]
+
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/mirage-fs/mirage-fs.1.1.1/url
+++ b/packages/mirage-fs/mirage-fs.1.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-fs/releases/download/v1.1.1/mirage-fs-1.1.1.tbz"
+checksum: "8e8f51347c4fec027025c76eda4ff6b5"


### PR DESCRIPTION
MirageOS signatures for filesystem devices

[![Build Status](https://travis-ci.org/mirage/mirage-fs.svg?branch=master)](https://travis-ci.org/mirage/mirage-fs)

mirage-fs provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures
the MirageOS filesystem devices should implement.

[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
[fslwt]: http://mirage.github.io/mirage-fs/Mirage_fs_lwt.html

---
* Homepage: https://github.com/mirage/mirage-fs
* Source repo: https://github.com/mirage/mirage-fs.git
* Bug tracker: https://github.com/mirage/mirage-fs/issues

---


---
### v1.1.1 (2016-06-29)

* Remove `open Result` statements
Pull-request generated by opam-publish v0.3.4