### PR TITLE
Fix wrong uunf depopt constraint.

### DIFF
--- a/packages/uunf/uunf.10.0.0/opam
+++ b/packages/uunf/uunf.10.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "uchar"
 ]
 depopts: [ "uutf" "cmdliner" ]
-conflicts: [ "uutf" {< "0.9.4"} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
   "--pinned" "%{pinned}%"


### PR DESCRIPTION
Discovered while testing 4.05.0+rc1 (#9650).