### PR TITLE
river.0.1.3 - via opam-publish

### DIFF
--- a/packages/river/river.0.1.3/descr
+++ b/packages/river/river.0.1.3/descr
@@ -1,0 +1,11 @@
+A planet (feed aggregator) in OCaml.
+
+A library for aggregating RSS2 and Atom feeds in OCaml.
+
+Features:
+
+* Performs deduplication.
+* Supports pagination and generating well-formed html prefix snippets.
+* Support for generating aggregate feeds.
+* Sorts the posts from most recent to oldest.
+* Depends on ocamlnet for html parsing.

--- a/packages/river/river.0.1.3/opam
+++ b/packages/river/river.0.1.3/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "sk826@cl.cam.ac.uk"
+authors: "KC Sivaramakrishnan"
+homepage: "https://github.com/kayceesrk/river"
+bug-reports: "https://github.com/kayceesrk/river/issues"
+license: "ISC"
+dev-repo: "https://github.com/kayceesrk/river.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "river"]
+depends: [
+  "ocamlnet" {>= "4.0.2"}
+  "lwt" {>= "2.4.7"}
+  "cohttp" {>= "0.15.1"}
+  "syndic" {>= "1.5"}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/river/river.0.1.3/url
+++ b/packages/river/river.0.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/kayceesrk/river/archive/v0.1.3.tar.gz"
+checksum: "a3b686e8e517208e8f436114679847b5"


### PR DESCRIPTION
A planet (feed aggregator) in OCaml.

A library for aggregating RSS2 and Atom feeds in OCaml.

Features:

* Performs deduplication.
* Supports pagination and generating well-formed html prefix snippets.
* Support for generating aggregate feeds.
* Sorts the posts from most recent to oldest.
* Depends on ocamlnet for html parsing.


---
* Homepage: https://github.com/kayceesrk/river
* Source repo: https://github.com/kayceesrk/river.git
* Bug tracker: https://github.com/kayceesrk/river/issues

---

Pull-request generated by opam-publish v0.3.4