### PR TITLE
pds-reachability.0.2.1 - via opam-publish

### DIFF
--- a/packages/pds-reachability/pds-reachability.0.2.1/descr
+++ b/packages/pds-reachability/pds-reachability.0.2.1/descr
@@ -1,0 +1,4 @@
+A PDS reachability query library.
+
+This library performs efficient reachability queries on abstractly
+specified push-down systems.

--- a/packages/pds-reachability/pds-reachability.0.2.1/opam
+++ b/packages/pds-reachability/pds-reachability.0.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+homepage: "https://github.com/JHU-PL-Lab/pds-reachability"
+bug-reports: "https://github.com/JHU-PL-Lab/pds-reachability/issues"
+license: "Apache"
+dev-repo: "https://github.com/JHU-PL-Lab/pds-reachability.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: [
+  "ocaml"
+  "%{etc}%/pds-reachability/setup.ml"
+  "-C"
+  "%{etc}%/pds-reachability"
+  "-uninstall"
+]
+depends: [
+  "base-threads"
+  "batteries"
+  "jhupllib"
+  "oasis" {build & >= "0.4.7"}
+  "ocaml-monadic"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+  "ppx_deriving" {>= "3.2"}
+  "ppx_deriving_yojson" {>= "2.1"}
+  "yojson"
+]

--- a/packages/pds-reachability/pds-reachability.0.2.1/url
+++ b/packages/pds-reachability/pds-reachability.0.2.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/JHU-PL-Lab/pds-reachability/archive/4c7b9abf5ff73e73b7b23455f1f626387311fb86.zip"
+checksum: "fd3acd007a7247833868a9d1f7470939"


### PR DESCRIPTION
A PDS reachability query library.

This library performs efficient reachability queries on abstractly
specified push-down systems.


---
* Homepage: https://github.com/JHU-PL-Lab/pds-reachability
* Source repo: https://github.com/JHU-PL-Lab/pds-reachability.git
* Bug tracker: https://github.com/JHU-PL-Lab/pds-reachability/issues

---

Pull-request generated by opam-publish v0.3.4