### PR TITLE
tls.0.8.0: build subpackages even when building with tests

### DIFF
--- a/packages/tls/tls.0.8.0/opam
+++ b/packages/tls/tls.0.8.0/opam
@@ -15,7 +15,10 @@ build: [
     "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock:installed}%" ]
 ]
 build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+    "--tests" "true"
+    "--with-lwt" "%{lwt:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock:installed}%" ]
   ["ocaml" "pkg/pkg.ml" "test"]
 ]
 


### PR DESCRIPTION
When `opam install tls` runs with `OPAMBUILDTEST=1` then `opam`:

- executes the `build` block: this correctly builds sub-packages
- executes the `build-test` block: this removes the sub-packages from the .install file
- installs the library, without subpackages

This patch duplicates the build runes from the `build` block into the `build-test` block as a workaround.

See [mirleft/ocaml-tls#366] although I think this is a more general problem.

Signed-off-by: David Scott <dave@recoil.org>