### PR TITLE
graphql.0.2.0 - via opam-publish

### DIFF
--- a/packages/graphql/graphql.0.2.0/descr
+++ b/packages/graphql/graphql.0.2.0/descr
@@ -1,0 +1,12 @@
+Build GraphQL schemas and execute queries against them
+
+`graphql` is a package for creating GraphQL servers. Current feature set includes:
+
+- Type-safe schema design
+- GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- Query execution
+- Introspection of schemas
+- Arguments for fields
+- Allows variables in queries
+
+Use `graphql-lwt` for Lwt support, or `graphql-async` for Async support.

--- a/packages/graphql/graphql.0.2.0/opam
+++ b/packages/graphql/graphql.0.2.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "angstrom" {>= "0.4.0"}
+  "sexplib"
+  "ppx_sexp_conv" {>= "0.9.0"}
+  "yojson"
+  "rresult"
+  "alcotest" {test}
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql/graphql.0.2.0/url
+++ b/packages/graphql/graphql.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.2.0/graphql-0.2.0.tbz"
+checksum: "1228c9a47292052b84cc6dd67a899091"


### PR DESCRIPTION
Build GraphQL schemas and execute queries against them

`graphql` is a package for creating GraphQL servers. Current feature set includes:

- Type-safe schema design
- GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
- Query execution
- Introspection of schemas
- Arguments for fields
- Allows variables in queries

Use `graphql-lwt` for Lwt support, or `graphql-async` for Async support.


---
* Homepage: https://github.com/andreas/ocaml-graphql-server
* Source repo: https://github.com/andreas/ocaml-graphql-server.git
* Bug tracker: https://github.com/andreas/ocaml-graphql-server/issues

---


---
0.2.0 2017-07-02
---------------------------------

- Support deprecation of fields (#53)
- Support documentation and deprecation of enum values (#54)
Pull-request generated by opam-publish v0.3.4