### PR TITLE
Add upper bounds on cohttp

### DIFF
--- a/packages/aws-s3/aws-s3.0.9.0/opam
+++ b/packages/aws-s3/aws-s3.0.9.0/opam
@@ -19,7 +19,7 @@ depends: [
   "core"
   "async" {<"v0.9"}
   "ounit"
-  "cohttp"
+  "cohttp" {<"0.99"}
   "ocaml-inifiles"
   "cryptokit"
   "nocrypto"

--- a/packages/aws/aws.1.0.0/opam
+++ b/packages/aws/aws.1.0.0/opam
@@ -42,4 +42,5 @@ depopts: [
 ]
 conflicts: [
   "cohttp" {< "0.17.0"}
+  "cohttp" {>="0.99"}
 ]

--- a/packages/aws/aws.1.0.1/opam
+++ b/packages/aws/aws.1.0.1/opam
@@ -42,5 +42,6 @@ depopts: [
 ]
 conflicts: [
   "cohttp" {< "0.17.0"}
+  "cohttp" {>="0.99"}
 ]
 available: [ ocaml-version >= "4.01" ]

--- a/packages/aws/aws.1.0.2/opam
+++ b/packages/aws/aws.1.0.2/opam
@@ -42,5 +42,6 @@ depopts: [
 ]
 conflicts: [
   "cohttp" {< "0.17.0"}
+  "cohttp" {>="0.99"}
 ]
 available: [ ocaml-version >= "4.01" ]

--- a/packages/bap/bap.0.9.4/opam
+++ b/packages/bap/bap.0.9.4/opam
@@ -44,7 +44,7 @@ depends: [
   "bitstring"
   "camlzip"
   "cmdliner"
-  "cohttp"
+  "cohttp" {="0.15.0"}
   "core_kernel" {= "111.28.0"}
   "ezjsonm" {= "0.4.0"}
   "faillib"

--- a/packages/bap/bap.0.9.9/opam
+++ b/packages/bap/bap.0.9.9/opam
@@ -40,7 +40,7 @@ depends: [
   "bitstring"
   "camlzip"
   "cmdliner" {>= "0.9.6"}
-  "cohttp" {>= "0.15.0"}
+  "cohttp" {>= "0.15.0" & <"0.99"}
   "core_kernel" {>= "111.28.0" & <= "112.35.0"}
   "ezjsonm" {>= "0.4.0"}
   "faillib"

--- a/packages/prometheus-app/prometheus-app.0.1/opam
+++ b/packages/prometheus-app/prometheus-app.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "prometheus"
   "fmt"
-  "cohttp" {>="0.20.0"}
+  "cohttp" {>="0.20.0" & <"0.99"}
   "lwt" {>="2.5.0"}
   "alcotest" {test}
 ]

--- a/packages/prometheus-app/prometheus-app.0.2/opam
+++ b/packages/prometheus-app/prometheus-app.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "prometheus" {= "0.2" }
   "fmt"
   "re"
-  "cohttp" {>="0.20.0"}
+  "cohttp" {>="0.20.0" & <"0.99"}
   "lwt" {>="2.5.0"}
   "alcotest" {test}
 ]


### PR DESCRIPTION
Start adding upper bounds on cohttp, in preparation for the release of cohttp 1.0 which breaks up packages into different subpackages without depopts and uses jbuilder.

See mirage/ocaml-cohttp#558 