### PR TITLE
mlgmp: Add patch to update extern declarations for [de]serialize functions...

### DIFF
--- a/packages/mlgmp/mlgmp.20120224/files/fix-extern-declarations.diff
+++ b/packages/mlgmp/mlgmp.20120224/files/fix-extern-declarations.diff
@@ -1,0 +1,20 @@
+Description: Update extern declarations for [de]serialize functions to match ocaml 4.04 definitions.
+Author: Dimitri John Ledkov <xnox@ubuntu.com>
+
+--- mlgmp-20021123.orig/config.h
++++ mlgmp-20021123/config.h
+@@ -58,11 +58,11 @@
+ #define MPFR_SIZE_ARCH32 16
+ #define MPFR_SIZE_ARCH64 24
+ 
+-extern void serialize_int_4(int32 i);
++extern void serialize_int_4(int32_t i);
+ extern void serialize_block_1(void * data, long len);
+ 
+-extern uint32 deserialize_uint_4(void);
+-extern int32 deserialize_sint_4(void);
++extern uint32_t deserialize_uint_4(void);
++extern int32_t deserialize_sint_4(void);
+ extern void deserialize_block_1(void * data, long len);
+ 
+ #endif /* SERIALIZE */

--- a/packages/mlgmp/mlgmp.20120224/opam
+++ b/packages/mlgmp/mlgmp.20120224/opam
@@ -26,6 +26,6 @@ conflicts: [
   "apron" {= "20140725"}
   "apron" {= "20150518"}
 ]
-available: [
-  ocaml-version < "4.03"
+patches: [
+  "fix-extern-declarations.diff" { ocaml-version >= "4.03" }
 ]


### PR DESCRIPTION
... to match ocaml 4.04 definitions

This is to fix #9634 

(Contributed by Dimitri John Ledkov)