### PR TITLE
expect.0.0.2: upper bound on oasis

### DIFF
--- a/packages/expect/expect.0.0.2/opam
+++ b/packages/expect/expect.0.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "extlib" {= "1.5.3"}
   "ounit"
   "pcre"
-  "oasis" {>= "0.3.0"}
+  "oasis" {>= "0.3.0" & <"0.4.2"}
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]


### PR DESCRIPTION
otherwise: `# E: OASIS format version '0.1' is not supported.`

spotted in revdeps for #9683