### PR TITLE
ketrew: upper bound on cohttp in anticipation of 1.0 release

### DIFF
--- a/packages/ketrew/ketrew.1.0.0/opam
+++ b/packages/ketrew/ketrew.1.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "trakeva" "sqlite3" "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"
   "ppx_deriving" "ppx_deriving_yojson" {>= "2.3" & <= "2.4"} "ppx_include" "ppx_blob"
-  "cohttp" {= "0.17.2"} "lwt" {< "2.5.0"} "ssl"
+  "cohttp" {= "0.17.2" & <"0.99"} "lwt" {< "2.5.0"} "ssl"
   "conduit"
   ]
 

--- a/packages/ketrew/ketrew.1.1.0/opam
+++ b/packages/ketrew/ketrew.1.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "trakeva" "sqlite3" "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"
   "ppx_deriving" "ppx_deriving_yojson" {>= "2.3" & <= "2.4"} "ppx_include" "ppx_blob"
-  "cohttp" "lwt" {< "2.5.0" } "ssl"
+  "cohttp" {>="0.17.2" & <"0.99"} "lwt" {< "2.5.0" } "ssl"
   "conduit"
   ]
 post-messages: [

--- a/packages/ketrew/ketrew.1.1.1/opam
+++ b/packages/ketrew/ketrew.1.1.1/opam
@@ -28,7 +28,7 @@ depends: [
   "trakeva" "sqlite3" "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"
   "ppx_deriving" "ppx_deriving_yojson" {>= "2.3" & <= "2.4"} "ppx_include" "ppx_blob"
-  "cohttp" {>= "0.17.0"}
+  "cohttp" {>= "0.17.0" & <"0.99"}
   "lwt" {< "2.5.0" }
   "ssl" "conduit"
   ]

--- a/packages/ketrew/ketrew.2.0.0/opam
+++ b/packages/ketrew/ketrew.2.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "trakeva" "sqlite3" "sosa" "nonstd" "docout" "pvem" "pvem_lwt_unix"
   "cmdliner" "yojson" "uri"
   "ppx_deriving" {>= "3.0"} "ppx_deriving_yojson" {>= "2.3" & <= "2.4"}
-  "cohttp" {>= "0.17.0" } "lwt" {< "2.5.0" } "ssl"
+  "cohttp" {>= "0.17.0" & <"0.99" } "lwt" {< "2.5.0" } "ssl"
   "conduit"
   "js_of_ocaml" {>= "2.6" & <"3.0"}
   "tyxml" {<= "3.5.0"} "reactiveData"

--- a/packages/ketrew/ketrew.3.0.0/opam
+++ b/packages/ketrew/ketrew.3.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "cmdliner" "yojson" "uri"
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.0"}
-  "cohttp" {>= "0.21.0" }
+  "cohttp" {>= "0.21.0" & <"0.99"}
   "lwt" {< "3.0.0" }
   "conduit"
   "js_of_ocaml" {>= "2.6" & <"3.0"}

--- a/packages/ketrew/ketrew.3.1.0/opam
+++ b/packages/ketrew/ketrew.3.1.0/opam
@@ -38,7 +38,7 @@ depends: [
   "uri"
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.0"}
-  "cohttp" {>= "0.21.0"}
+  "cohttp" {>= "0.21.0" & <"0.99"}
   "lwt" {< "3.0.0"}
   "conduit"
   "js_of_ocaml" {>= "2.6" & <"3.0"}


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/9685