### PR TITLE
Improve conf-gtksourceview-2.0.

### DIFF
--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -1,8 +1,11 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "The gtksourceview programmers"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
 homepage: "https://projects.gnome.org/gtksourceview/"
 license: "LGPL 2.1"
-build: [["pkg-config" "gtksourceview-2.0"]]
+build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-2.0"]]
 depexts: [
   [["debian"] ["libgtksourceview2.0-dev"]]
   [["ubuntu"] ["libgtksourceview2.0-dev"]]


### PR DESCRIPTION
It seems that in certain circumstances the package fails in an obscure
fashion, see #8449 for details. This PR changes the `pkg-config`
invocation so as to print more errors to allow end users to possibly
spot the problem.

(The commit also makes sure that package lints).