### PR TITLE
Remove unnecessary `remove` instructions.

### DIFF
--- a/packages/camlp5/camlp5.6.15/opam
+++ b/packages/camlp5/camlp5.6.15/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Justus Matthiesen <justus.matthiesen@cl.cam.ac.uk>"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Daniel de Rauglaudre"]
 homepage: "http://pauillac.inria.fr/~ddr/camlp5"
 license: "BSD-3-Clause"

--- a/packages/camlp5/camlp5.6.16/opam
+++ b/packages/camlp5/camlp5.6.16/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Justus Matthiesen <justus.matthiesen@cl.cam.ac.uk>"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Daniel de Rauglaudre"]
 homepage: "http://pauillac.inria.fr/~ddr/camlp5"
 license: "BSD-3-Clause"

--- a/packages/camlp5/camlp5.6.17/opam
+++ b/packages/camlp5/camlp5.6.17/opam
@@ -12,4 +12,3 @@ bug-reports: "https://github.com/camlp5/camlp5/issues"
 dev-repo: "https://github.com/camlp5/camlp5.git"
 doc: "https://camlp5.github.io/doc/html"
 install: [make "install"]
-remove: [make "uninstall"]

--- a/packages/camlp5/camlp5.6.17/opam
+++ b/packages/camlp5/camlp5.6.17/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Justus Matthiesen <justus.matthiesen@cl.cam.ac.uk>"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Daniel de Rauglaudre"]
 homepage: "https://camlp5.github.io"
 license: "BSD-3-Clause"

--- a/packages/camlp5/camlp5.7.00/opam
+++ b/packages/camlp5/camlp5.7.00/opam
@@ -12,4 +12,3 @@ bug-reports: "https://github.com/camlp5/camlp5/issues"
 dev-repo: "https://github.com/camlp5/camlp5.git"
 doc: "https://camlp5.github.io/doc/html"
 install: [make "install"]
-remove: [make "uninstall"]

--- a/packages/camlp5/camlp5.7.00/opam
+++ b/packages/camlp5/camlp5.7.00/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Justus Matthiesen <justus.matthiesen@cl.cam.ac.uk>"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Daniel de Rauglaudre"]
 homepage: "https://camlp5.github.io"
 license: "BSD-3-Clause"


### PR DESCRIPTION
camlp5 currently does not uninstall cleanly (see #8262) because its `uninstall` Makefile target requires the `configure` script to run first. However, it merely removes installed files which opam 2.0 already takes care of so there is no need to make it part of the opam file.