### PR TITLE
dsfo.0.0.1 - via opam-publish

### DIFF
--- a/packages/dsfo/dsfo.0.0.1/descr
+++ b/packages/dsfo/dsfo.0.0.1/descr
@@ -1,0 +1,5 @@
+Download (anyhow) and interact (ocaml, utop) with common machine learning datasets.
+
+A small library to simplify processing and interacting with a few common machine
+learning data sets. The code will call out to utilities such as `curl` to do the
+work.

--- a/packages/dsfo/dsfo.0.0.1/opam
+++ b/packages/dsfo/dsfo.0.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
+authors: "Leonid Rozenberg <leonidr@gmail.com>"
+homepage: "https://github.com/rleonid/dsfo/"
+bug-reports: "https://github.com/rleonid/dsfo/issues"
+license: "Apache2"
+dev-repo: "https://github.com/rleonid/dsfo.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "dsfo"]
+depends: [
+  "ocamlfind" {build}
+  "bau" {>= "0.0.3"}
+]
+available: [ocaml-version >= "4.01"]

--- a/packages/dsfo/dsfo.0.0.1/url
+++ b/packages/dsfo/dsfo.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rleonid/dsfo/archive/0.0.1.tar.gz"
+checksum: "d61e945b3c3c124a47e04ef39ebc7253"


### PR DESCRIPTION
Download (anyhow) and interact (ocaml, utop) with common machine learning datasets.

A small library to simplify processing and interacting with a few common machine
learning data sets. The code will call out to utilities such as `curl` to do the
work.


---
* Homepage: https://github.com/rleonid/dsfo/
* Source repo: https://github.com/rleonid/dsfo.git
* Bug tracker: https://github.com/rleonid/dsfo/issues

---

Pull-request generated by opam-publish v0.3.4