### PR TITLE
datakit-bridge-github: depends on github >2.2.0 for get_ref

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
@@ -27,6 +27,6 @@ depends: [
   "protocol-9p" {= "0.9.0"}
   "datakit-client" {>= "0.10.0" & < "0.11.0"}
   "github-hooks" {>= "0.1.1"}
-  "github" {>= "2.1.0" & < "3.0.0"}
+  "github" {>= "2.2.0" & < "3.0.0"}
   "datakit" {test & >= "0.10.0" & < "0.11.0"}
 ]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
@@ -27,6 +27,6 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "datakit-client" {>= "0.10.0" & < "0.11.0"}
   "github-hooks" {>= "0.1.1"}
-  "github" {>= "2.1.0" & < "3.0.0"}
+  "github" {>= "2.2.0" & < "3.0.0"}
   "datakit" {test & >= "0.10.0" & < "0.11.0"}
 ]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
@@ -28,7 +28,7 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "datakit-client" {>= "0.11.0"}
   "github-hooks" {>= "0.1.1"}
-  "github" {>= "2.1.0"}
+  "github" {>= "2.2.0"}
   "alcotest" {test & < "0.8.0"}
   "datakit"  {test & >= "0.11.0"}
 ]

--- a/packages/protocol-9p/protocol-9p.0.9.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.9.0/opam
@@ -43,6 +43,7 @@ depends: [
   "topkg" {build & >= "0.7.3"}
   "alcotest" {test & >= "0.4.0"}
   "ppx_cstruct"
+  "io-page-unix"
 ]
 depopts: ["lambda-term"]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
cc @samoht 
noticed in revdeps for #9701