### PR TITLE
Fix gmp/zarith configuration on macOS.

### DIFF
--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -6,7 +6,8 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "darwin"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/opt/local/include -I/usr/local/include test.c"] {os = "darwin"}
 ]
 depexts: [
   [["debian"] ["libgmp-dev"]]

--- a/packages/zarith/zarith.1.5/opam
+++ b/packages/zarith/zarith.1.5/opam
@@ -2,9 +2,12 @@ opam-version: "1.2"
 maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
 authors: "Xavier Leroy"
 homepage: "https://github.com/ocaml/Zarith"
+bug-reports: "https://github.com/ocaml/Zarith/issues"
+dev-repo: "https://github.com/ocaml/Zarith.git"
 build: [
   ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
-  ["env" "LDFLAGS=-L/usr/local/lib" "CFLAGS=-I/usr/local/include" "./configure"] { os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/usr/local/include\" ./configure"] { os = "openbsd" | os = "freebsd" }
+  ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"] { os = "darwin" }
   [make]
 ]
 install: [


### PR DESCRIPTION
In particular this allows to use again LDFLAGS and CFLAGS
environment variables to choose your location and and automatically
checks for the two locations where gmp will be found in 99% of
the cases.

Closes #3000 and #9389.

See [this comment](https://github.com/ocaml/opam-repository/issues/3000#issuecomment-312752454) for details.