### PR TITLE
Fix logtk.0.8.1 constraints.

### DIFF
--- a/packages/logtk/logtk.0.8.1/opam
+++ b/packages/logtk/logtk.0.8.1/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlfind" {build}
   "base-unix"
   "zarith"
-  "containers" {>= "0.3" < "1.0"}
+  "containers" {>= "0.7" < "1.0"}
   "sequence" {>= "0.4"}
   "base-bytes"
 ]


### PR DESCRIPTION
/cc @c-cube 

Fixes this error 
```
#=== ERROR while compiling logtk.0.8.1 ========================================#
# command              ocaml setup.ml -configure --disable-meta --disable-qcheck --disable-docs --disable-parsers --disable-solving --disable-tests --disable-tools --enable-meta
# path                 /home/opam/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/logtk.0.8.1
# exit-code            1
# env-file             /home/opam/.opam/log/logtk-177-b1a82b.env
# output-file          /home/opam/.opam/log/logtk-177-b1a82b.out
### output ###
# ocamlfind: Package `containers.data' not found
# W: Field 'pkg_containers_data' is not set: Command ''/home/opam/.opam/ocaml-base-compiler.4.03.0/bin/ocamlfind' query -format %d containers.data > '/tmp/oasis-2cb67c.txt'' terminated with error code 2
# E: Cannot find findlib package containers.data
# E: Failure("1 configuration error")
```
spotted [here](https://ci.ocaml.io/log/saved/docker-run-38cf3655e689979a5bd26ba3b8d1999f/6ea8f29006feb84e39371e6f0f27a6979722f2e9)

`containers.data` was [introduced in 0.7](https://github.com/c-cube/ocaml-containers/blob/master/CHANGELOG.adoc#07)
