### PR TITLE
mirage-xen-ocaml: does not compile on ocaml 4.05.+ due to bigarray

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
@@ -15,5 +15,5 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.01.0" & os = "linux"]
+available: [ocaml-version >= "4.01.0" & os = "linux" & ocaml-version < "4.05.0" ]
 conflicts: [ "sexplib" { = "v0.9.0" } ]


### PR DESCRIPTION
spotted in revdeps for #9725