### PR TITLE
pilat.1 - via opam-publish

### DIFF
--- a/packages/pilat/pilat.1/descr
+++ b/packages/pilat/pilat.1/descr
@@ -1,6 +1,5 @@
-Short description A Frama-C polynomial invariant generator 
+A Frama-C polynomial invariant generator 
 
-Long 
-description This tool generates invariants of linear and polynomial loops, with 
+This tool generates invariants of linear and polynomial loops, with 
 deterministic and non deterministic assignments, as annotations in the initial 
 source code.


### PR DESCRIPTION
A Frama-C polynomial invariant generator 

This tool generates invariants of linear and polynomial loops, with 
deterministic and non deterministic assignments, as annotations in the initial 
source code.

---
* Homepage: https://github.com/Stevendeo/Pilat/
* Source repo: https://github.com/Stevendeo/Pilat.git
* Bug tracker: 

---
### opam-lint failures
- **WARNING** 36 Missing field 'bug-reports'

---

Pull-request generated by opam-publish v0.3.4