### PR TITLE
ocaml-top: fails to link against Thread on newer ocaml

### DIFF
--- a/packages/ocaml-top/ocaml-top.1.1.0/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.0/opam
@@ -30,3 +30,5 @@ depends: [
 ]
 dev-repo: "git://github.com/OCamlPro/ocaml-top"
 install: [make "install"]
+available: [ocaml-version <= "4.02.3"]
+

--- a/packages/ocaml-top/ocaml-top.1.1.1/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.1/opam
@@ -30,3 +30,5 @@ depends: [
 ]
 dev-repo: "git://github.com/OCamlPro/ocaml-top"
 install: [make "install"]
+available: [ocaml-version <= "4.02.3"]
+

--- a/packages/ocaml-top/ocaml-top.1.1.2/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.2/opam
@@ -19,3 +19,4 @@ depends: [
   "ocp-index" {>= "1.0.1" & < "1.1.5"}
 ]
 dev-repo: "git://github.com/OCamlPro/ocaml-top"
+available: [ocaml-version <= "4.02.3"]

--- a/packages/ocaml-top/ocaml-top.1.1.3/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.3/opam
@@ -15,3 +15,4 @@ depends: [
   "ocp-indent" {>= "1.4.0"}
   "ocp-index" {>= "1.0.0"}
 ]
+available: [ocaml-version <= "4.02.3"]


### PR DESCRIPTION
cc @altgr 

e.g. https://ci.ocaml.io/log/saved/docker-run-41304521e481f263087c2b45aaca7647/063b86cc6aab49e319d4be80c18f6b7aeaab0b8c

```
# [57.1] Command failed: '/home/opam/.opam/ocaml-base-compiler.4.03.0/bin/ocamlc.opt' '-thread' '-o' './_obuild/ocaml-top/ocaml-top.byte' './_obuild/ocaml-top/sigint_unix.o' '-I' './_obuild/ocaml-top' '-I' './src' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-index/lib' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lib' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/utils' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lexer' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/lablgtk2' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/compiler-libs' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/unix.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/compiler-libs/ocamlcommon.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/lablgtk2/lablgtk.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/lablgtk2/lablgtksourceview2.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lexer/ocp-indent.lexer.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/utils/ocp-indent.utils.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lib/ocp-indent.lib.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-index/lib/ocp-index-lib.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/str.cma' '-custom' './_obuild/ocaml-top/tools.cmo' './_obuild/ocaml-top/cfg.cmo' './_obuild/ocaml-top/ocamlBuffer.cmo' './_obuild/ocaml-top/completion.cmo' './_obuild/ocaml-top/top.cmo' './_obuild/ocaml-top/topUi.cmo' './_obuild/ocaml-top/gui.cmo' './_obuild/ocaml-top/main.cmo'
# -- stderr for ./_obuild/ocaml-top/ocaml-top.byte --
# File "_none_", line 1:
# Error: Error while linking ./_obuild/ocaml-top/top.cmo:
# Reference to undefined global `Thread'
# 0.16s _obuild/ocaml-top/main.cmx                                       [ done ]
# 2 errors in 1.05s. 38 jobs (parallelism 3.1x), 50 files generated.
# Error log:
# Error:
# [57.1] '/home/opam/.opam/ocaml-base-compiler.4.03.0/bin/ocamlc.opt' '-thread' '-o' './_obuild/ocaml-top/ocaml-top.byte' './_obuild/ocaml-top/sigint_unix.o' '-I' './_obuild/ocaml-top' '-I' './src' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-index/lib' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lib' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/utils' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lexer' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/lablgtk2' '-I' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/compiler-libs' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/unix.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/compiler-libs/ocamlcommon.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/lablgtk2/lablgtk.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/lablgtk2/lablgtksourceview2.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lexer/ocp-indent.lexer.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/utils/ocp-indent.utils.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-indent/lib/ocp-indent.lib.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocp-index/lib/ocp-index-lib.cma' '/home/opam/.opam/ocaml-base-compiler.4.03.0/lib/ocaml/str.cma' '-custom' './_obuild/ocaml-top/tools.cmo' './_obuild/ocaml-top/cfg.cmo' './_obuild/ocaml-top/ocamlBuffer.cmo' './_obuild/ocaml-top/completion.cmo' './_obuild/ocaml-top/top.cmo' './_obuild/ocaml-top/topUi.cmo' './_obuild/ocaml-top/gui.cmo' './_obuild/ocaml-top/main.cmo'
# 
# File "_none_", line 1:
# Error: Error while linking ./_obuild/ocaml-top/top.cmo:
# Reference to undefined global `Thread'
# 
# Error:
```