### PR TITLE
Make Alpine use libressl for openssl depext

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -14,7 +14,7 @@ depexts: [
   [["oraclelinux"] ["openssl-devel"]]
   [["fedora"] ["openssl-devel"]]
   [["osx" "homebrew"] ["openssl"]]
-  [["alpine"] ["openssl-dev"]]
+  [["alpine"] ["libressl-dev"]]
   [["nixpkgs"] ["openssl"]]
   [["archlinux"] ["openssl"]]
   [["opensuse"] ["libopenssl-devel"]]


### PR DESCRIPTION
This avoids a conflict with the mariadb development package in Alpine.
Fixes #9640