### PR TITLE
Add version 1.19.0 of OCaml EFL

### DIFF
--- a/packages/efl/efl.1.19.0/descr
+++ b/packages/efl/efl.1.19.0/descr
@@ -1,0 +1,12 @@
+An OCaml interface to the Enlightenment Foundation Libraries (EFL) and Elementary.
+The Enlightenment Fondation Libraires provide both a semi-traditional toolkit
+set in Elementary as well as the object canvas (Evas) and powerful abstracted
+objects (Edje) that you can combine, mix and match, even layer on top of each
+other with alpha channels and events in-tact. It has 3D transformations for all
+objects and more.
+https://www.enlightenment.org/
+Currently, only the interfacing of Elementary is more or less complete.
+This project is still in alpha stage.
+Ocamlforge page and github page:
+https://forge.ocamlcore.org/projects/ocaml-efl/
+https://github.com/axiles/ocaml-efl

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Alexis Bernadet <alexis.bernadet at noos.fr>"
+authors: "Alexis Bernadet <alexis.bernadet at noos.fr>"
+available: [ ocaml-version >= "3.12"]
+homepage: "https://forge.ocamlcore.org/projects/ocaml-efl/"
+license: "LGPL with linking exception"
+dev-repo: "https://github.com/axiles/ocaml-efl.git"
+bug-reports: "https://github.com/axiles/ocaml-efl/issues"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "OCAMLFIND_DESTDIR=%{lib}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "efl"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
+depexts: [
+  [["osx" "homebrew"] ["efl"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/20bdb96e21a42315587851ee9b76cad3d7c096c4/install_efl_1_19_on_ubuntu"]]
+]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/72a1e2b757b768fcba7f183f4ee8256b54752fb4/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/b1f8aeab7a8528c406861d5d33621f793474f9c6/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/20bdb96e21a42315587851ee9b76cad3d7c096c4/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/6672f3506c36af02a7590ec2480fe48236c9006a/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/a1a8af774ba602f6c84b89979de48052e1d13e9c/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/d65c33e76ccc0dde9a3cda96b2e7c548ebe3e836/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/6672f3506c36af02a7590ec2480fe48236c9006a/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/72a1e2b757b768fcba7f183f4ee8256b54752fb4/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/b1012989afeaf6214792b3e290bbedbfca371967/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/c564b4d11a1da8593dbab7ee1cda42f4852b163a/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/73ef5b4c8b14d65c7b323c01149c2c0b02015e37/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/d2c25922f476ddf753a6210a6589631d1c69dead/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/b1f8aeab7a8528c406861d5d33621f793474f9c6/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/b1012989afeaf6214792b3e290bbedbfca371967/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/5f900f78362c554d4154d1d9f07dcbca91f63f50/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/a1a8af774ba602f6c84b89979de48052e1d13e9c/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/f9a06ee1968c32ff80bcc1890d604d4f115a317f/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/5f900f78362c554d4154d1d9f07dcbca91f63f50/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/c564b4d11a1da8593dbab7ee1cda42f4852b163a/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/f9a06ee1968c32ff80bcc1890d604d4f115a317f/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/d2c25922f476ddf753a6210a6589631d1c69dead/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/52685ac061c36c15ba48f8c9d3fb876fb2bc7c15/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -18,5 +18,5 @@ depends: [
 ]
 depexts: [
   [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/d65c33e76ccc0dde9a3cda96b2e7c548ebe3e836/install_efl_1_19_on_ubuntu"]]
+  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/9f586339249397c08a3c3b8b66793a51/raw/73ef5b4c8b14d65c7b323c01149c2c0b02015e37/install_efl_1_19_on_ubuntu"]]
 ]

--- a/packages/efl/efl.1.19.0/url
+++ b/packages/efl/efl.1.19.0/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1700/ocaml-efl-1.19.0.tar.gz"
+checksum: "dc3f9af24e449a6001f726de143f96a9"


### PR DESCRIPTION
Before merging, we have to check that the new script can install the EFL 1.19 on Ubuntu during the Travis build.

I cannot test it directly. 