### PR TITLE
Package opam-publish.0.3.5

### DIFF
--- a/packages/opam-publish/opam-publish.0.3.5/descr
+++ b/packages/opam-publish/opam-publish.0.3.5/descr
@@ -1,0 +1,3 @@
+A tool to ease contributions to opam repositories.
+
+Opam-publish helps gather metadata to form an OPAM package and submit it to a remote repository.

--- a/packages/opam-publish/opam-publish.0.3.5/opam
+++ b/packages/opam-publish/opam-publish.0.3.5/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+homepage: "http://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+license: "GPL-3"
+tags: "flags:plugin"
+dev-repo: "https://github.com/ocaml/opam-publish.git#1.3"
+build: [make]
+depends: [
+  "opam-lib" {build & > "1.2.2"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  ("github" {build & >= "2.0.0" & < "3.0.0"} |
+   "github-unix" {build & >= "3.0.0"})
+]

--- a/packages/opam-publish/opam-publish.0.3.5/url
+++ b/packages/opam-publish/opam-publish.0.3.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam-publish/archive/0.3.5.tar.gz"
+checksum: "1e34c167dd789dff55630fbf47099044"

--- a/packages/publish/publish.0.3.4+transition/descr
+++ b/packages/publish/publish.0.3.4+transition/descr
@@ -1,0 +1,4 @@
+opam-publish transition package
+
+The package has been renamed back to 'opam-publish'. You can safely remove this
+package.

--- a/packages/publish/publish.0.3.4+transition/opam
+++ b/packages/publish/publish.0.3.4+transition/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+]
+homepage: "http://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml/opam-publish.git#1.3"
+depends: "opam-publish" { > "0.3.4" }


### PR DESCRIPTION
### `opam-publish.0.3.5`

A tool to ease contributions to opam repositories.

Opam-publish helps gather metadata to form an OPAM package and submit it to a remote repository.



---
* Homepage: http://opam.ocaml.org
* Source repo: https://github.com/ocaml/opam-publish.git#1.3
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---

:camel: Pull-request generated by opam-publish v0.3.5