### PR TITLE
macaroons.0.1.1 - via opam-publish

### DIFF
--- a/packages/macaroons/macaroons.0.1.1/descr
+++ b/packages/macaroons/macaroons.0.1.1/descr
@@ -1,0 +1,12 @@
+Macaroons for OCaml
+
+This is a minimal reimplementation of libmacaroons
+(https://github.com/rescrv/libmacaroons) in OCaml.
+
+It consists of two findlib libraries: `macaroons` and `macaroons.sodium`.  The
+first provides a functor over the required cryptographic operations, while the
+second uses libsodium for crypto, and is only installed if the OPAM package
+`sodium` is installed.
+
+See the paper http://research.google.com/pubs/pub41892.html to learn about
+Macaroons.

--- a/packages/macaroons/macaroons.0.1.1/opam
+++ b/packages/macaroons/macaroons.0.1.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+authors: "Nicolas Ojeda Bar <n.oje.bar@gmail.com>"
+homepage: "https://www.github.com/nojb/ocaml-macaroons"
+dev-repo: "https://www.github.com/nojb/ocaml-macaroons.git"
+bug-reports: "https://www.github.com/nojb/ocaml-macaroons/issues"
+license: "MIT"
+build: [
+  [make]
+]
+build-doc: [make "doc"]
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "macaroons"]
+depends: [
+  "base64" {>= "2.0.0"}
+  "ocamlfind" {build}
+]
+depopts: "sodium"
+available: [ocaml-version >= "4.01.0"]

--- a/packages/macaroons/macaroons.0.1.1/url
+++ b/packages/macaroons/macaroons.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nojb/ocaml-macaroons/archive/v0.1.1.tar.gz"
+checksum: "e3118571a4d219d78a03db9ac4761a2c"


### PR DESCRIPTION
Macaroons for OCaml

This is a minimal reimplementation of libmacaroons
(https://github.com/rescrv/libmacaroons) in OCaml.

It consists of two findlib libraries: `macaroons` and `macaroons.sodium`.  The
first provides a functor over the required cryptographic operations, while the
second uses libsodium for crypto, and is only installed if the OPAM package
`sodium` is installed.

See the paper http://research.google.com/pubs/pub41892.html to learn about
Macaroons.


---
* Homepage: https://www.github.com/nojb/ocaml-macaroons
* Source repo: https://www.github.com/nojb/ocaml-macaroons.git
* Bug tracker: https://www.github.com/nojb/ocaml-macaroons/issues

---

Pull-request generated by opam-publish v0.3.4