### PR TITLE
vpnkit: turn off tests

### DIFF
--- a/packages/vpnkit/vpnkit.0.0.0/opam
+++ b/packages/vpnkit/vpnkit.0.0.0/opam
@@ -20,9 +20,6 @@ doc:          "https://docker.github.io/vpnkit/"
 build: [
   [make]
 ]
-build-test: [
-  [make "test"]
-]
 install: [make "install" "BINDIR=%{bin}%"]
 remove: [make "uninstall" "BINDIR=%{bin}%"]
 


### PR DESCRIPTION
these take hours to run, so tie up opam CI resources.
discussed with maintainer @djs55 and he agrees that they already
run in the upstream repo, so no need to also have them here.