### PR TITLE
depyt.0.2.0 - via opam-publish

### DIFF
--- a/packages/depyt/depyt.0.2.0/descr
+++ b/packages/depyt/depyt.0.2.0/descr
@@ -1,0 +1,25 @@
+Yet-an-other type combinator library
+
+Depyt provides type combinators to define runtime representation for
+OCaml types and generic operations to manipulate values with a runtime
+type representation.
+
+The type combinators supports all the usual type primitives but also
+compact definitions of records and variants. It also allows to define
+the runtime representation of recursive types.
+
+Depyt is a modern reboot of
+[Dyntype](https://github.com/mirage/dyntype) but using
+[GADT](https://en.wikipedia.org/wiki/Generalized_algebraic_data_type)s-based
+combinators instead of syntax-extensions. When we originally wrote
+Dyntype (in 2012) GADTs were not available in OCaml and
+[camlp4](https://github.com/ocaml/camlp4) was everywhere -- this is
+not the case anymore. Finally, Depyt avoids some of the performance
+caveats present in Dyntype by avoiding allocating and converting
+between intermediate formats.
+
+#### Variants
+
+For instance, to define variants:
+
+```ocaml

--- a/packages/depyt/depyt.0.2.0/opam
+++ b/packages/depyt/depyt.0.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/samoht/depyt"
+dev-repo:     "https://github.com/samoht/depyt.git"
+bug-reports:  "https://github.com/samoht/depyt/issues"
+doc:          "https://samoht.github.io/depyt/doc"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  ["jbuilder" "subst"]
+  ["jbuilder" "build" "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cstruct" "fmt" "result" "jsonm"
+  "ocplib-endian" {>="0.7"}
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/depyt/depyt.0.2.0/url
+++ b/packages/depyt/depyt.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/depyt/releases/download/0.2.0/depyt-0.2.0.tbz"
+checksum: "b5e53bea6298f6b255fda6b906496938"


### PR DESCRIPTION
Yet-an-other type combinator library

Depyt provides type combinators to define runtime representation for
OCaml types and generic operations to manipulate values with a runtime
type representation.

The type combinators supports all the usual type primitives but also
compact definitions of records and variants. It also allows to define
the runtime representation of recursive types.

Depyt is a modern reboot of
[Dyntype](https://github.com/mirage/dyntype) but using
[GADT](https://en.wikipedia.org/wiki/Generalized_algebraic_data_type)s-based
combinators instead of syntax-extensions. When we originally wrote
Dyntype (in 2012) GADTs were not available in OCaml and
[camlp4](https://github.com/ocaml/camlp4) was everywhere -- this is
not the case anymore. Finally, Depyt avoids some of the performance
caveats present in Dyntype by avoiding allocating and converting
between intermediate formats.

#### Variants

For instance, to define variants:

```ocaml

---
* Homepage: https://github.com/samoht/depyt
* Source repo: https://github.com/samoht/depyt.git
* Bug tracker: https://github.com/samoht/depyt/issues

---


---
### 0.2.0 (2016-07-12)

- add `like` to describe similar/bijective types (@samoht)
- rename `pp` to dump (@samoht)
- use jbuilder (@samoht)
- add `decode_json_lexemes` (@samoht)
Pull-request generated by opam-publish v0.3.4