### PR TITLE
+cstruct.3.1.0

### DIFF
--- a/packages/cstruct-async/cstruct-async.3.1.0/descr
+++ b/packages/cstruct-async/cstruct-async.3.1.0/descr
@@ -1,0 +1,5 @@
+Access C-like structures directly from OCaml
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.

--- a/packages/cstruct-async/cstruct-async.3.1.0/opam
+++ b/packages/cstruct-async/cstruct-async.3.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >="1.0+beta7"}
+  "async_kernel" {>="v0.9.0"}
+  "async_unix" {>="v0.9.0"}
+  "core_kernel" {>="v0.9.0"}
+  "cstruct" {>="3.1.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cstruct-async/cstruct-async.3.1.0/url
+++ b/packages/cstruct-async/cstruct-async.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cstruct/releases/download/v3.1.0/cstruct-3.1.0.tbz"
+checksum: "236ec33a9ff9f6a41bb27c3343a06f70"

--- a/packages/cstruct-lwt/cstruct-lwt.3.1.0/descr
+++ b/packages/cstruct-lwt/cstruct-lwt.3.1.0/descr
@@ -1,0 +1,5 @@
+Access C-like structures directly from OCaml
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.

--- a/packages/cstruct-lwt/cstruct-lwt.3.1.0/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.3.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base-unix"
+  "lwt"
+  "cstruct" {>="3.1.0"}
+  "jbuilder" {build & >="1.0+beta7"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cstruct-lwt/cstruct-lwt.3.1.0/url
+++ b/packages/cstruct-lwt/cstruct-lwt.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cstruct/releases/download/v3.1.0/cstruct-3.1.0.tbz"
+checksum: "236ec33a9ff9f6a41bb27c3343a06f70"

--- a/packages/cstruct-unix/cstruct-unix.3.1.0/descr
+++ b/packages/cstruct-unix/cstruct-unix.3.1.0/descr
@@ -1,0 +1,5 @@
+Access C-like structures directly from OCaml
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.

--- a/packages/cstruct-unix/cstruct-unix.3.1.0/opam
+++ b/packages/cstruct-unix/cstruct-unix.3.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >="1.0+beta7"}
+  "base-unix"
+  "cstruct" {>="3.1.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cstruct-unix/cstruct-unix.3.1.0/url
+++ b/packages/cstruct-unix/cstruct-unix.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cstruct/releases/download/v3.1.0/cstruct-3.1.0.tbz"
+checksum: "236ec33a9ff9f6a41bb27c3343a06f70"

--- a/packages/cstruct/cstruct.3.1.0/descr
+++ b/packages/cstruct/cstruct.3.1.0/descr
@@ -1,0 +1,5 @@
+Access C-like structures directly from OCaml
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.

--- a/packages/cstruct/cstruct.3.1.0/opam
+++ b/packages/cstruct/cstruct.3.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "ocplib-endian"
+  "sexplib"
+  "base-bytes"
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cstruct/cstruct.3.1.0/url
+++ b/packages/cstruct/cstruct.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cstruct/releases/download/v3.1.0/cstruct-3.1.0.tbz"
+checksum: "236ec33a9ff9f6a41bb27c3343a06f70"

--- a/packages/ppx_cstruct/ppx_cstruct.3.1.0/descr
+++ b/packages/ppx_cstruct/ppx_cstruct.3.1.0/descr
@@ -1,0 +1,5 @@
+Access C-like structures directly from OCaml
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.

--- a/packages/ppx_cstruct/ppx_cstruct.3.1.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >="1.0+beta7"}
+  "cstruct" {>="3.1.0"}
+  "ounit" {test}
+  "ppx_tools_versioned" {>="5.0.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_driver"    {test & >= "v0.9.0"}
+  "ppx_sexp_conv" {test}
+  "cstruct-unix"  {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ppx_cstruct/ppx_cstruct.3.1.0/url
+++ b/packages/ppx_cstruct/ppx_cstruct.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cstruct/releases/download/v3.1.0/cstruct-3.1.0.tbz"
+checksum: "236ec33a9ff9f6a41bb27c3343a06f70"


### PR DESCRIPTION
--

- Fix arithmetic overflow in `Cstruct.lenv` and `copyv` (mirage/ocaml-cstruct#159 by @yallop)
- Reject negative destination offsets in `blit` (mirage/ocaml-cstruct#160 by @yallop)
- Add AFL fuzz tests using Crowbar, which independently discovered
  mirage/ocaml-cstruct#160 and also an overflow in `of_bigarray` and `sub`, now bith
  fixed (mirage/ocaml-cstruct#164 by @talex5)
- Improve performance of several allocation functions by eliminating an
  unnecessary buffer zero step (mirage/ocaml-cstruct#158 by @hannesm)
- Compile the source tree with stricter flags, including dead variable
  detection and deprecation warnings (mirage/ocaml-cstruct#157 by @samoht)
- Bump the required minimum OCaml version up to 4.03.0 (due to mirage/ocaml-cstruct#157).