### PR TITLE
mirage-net-fd: do not run tests on stable opam-repo

### DIFF
--- a/packages/mirage-net-fd/mirage-net-fd.0.1.0/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.1.0/opam
@@ -13,10 +13,13 @@ license:     "ISC"
 doc:         "https://mirage.github.io/mirage-net-fd/"
 
 build:   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
-build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
-]
+
+# tests block on automated CI, so commented out here
+#build-test: [
+#  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
+#  [ "ocaml" "pkg/pkg.ml" "test" ]
+#]
+
 depends: [
   "cstruct" {>= "1.7.1"}
   "cstruct-lwt"

--- a/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
+++ b/packages/mirage-net-fd/mirage-net-fd.0.2.0/opam
@@ -13,10 +13,13 @@ license:     "ISC"
 doc:         "https://mirage.github.io/mirage-net-fd/"
 
 build:   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
-build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
-]
+
+# tests block on automated CI, so commented out here
+#build-test: [
+#  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
+#  [ "ocaml" "pkg/pkg.ml" "test" ]
+#]
+
 depends: [
   "cstruct" {>= "1.7.1"}
   "cstruct-lwt"


### PR DESCRIPTION
The tests in these packages appear to block indefinitely and are
tying up CI until the timeout (3 hours).  Since the tests run
upstream in the relevant Travis setup, I am disabling them in
the central repository.

cc @samoht maintainer