### PR TITLE
mirage-unix: establish upper bound on io-page

### DIFF
--- a/packages/mirage-unix/mirage-unix.2.2.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.3/opam
@@ -12,7 +12,7 @@ depends: [
   "type_conv"
   "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}

--- a/packages/mirage-unix/mirage-unix.2.3.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.3.1/opam
@@ -13,7 +13,7 @@ depends: [
   "conf-which" {build}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}

--- a/packages/mirage-unix/mirage-unix.2.4.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.0/opam
@@ -14,7 +14,7 @@ depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}

--- a/packages/mirage-unix/mirage-unix.2.4.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.1/opam
@@ -14,7 +14,7 @@ depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}

--- a/packages/mirage-unix/mirage-unix.2.5.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.5.0/opam
@@ -14,7 +14,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}

--- a/packages/mirage-unix/mirage-unix.2.6.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "ocamlfind" {build}
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}

--- a/packages/mirage-unix/mirage-unix.3.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.3.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}

--- a/packages/mirage-unix/mirage-unix.3.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.3.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & <"2.0.0"}
   "mirage-clock-unix" {>= "1.0.0"}
   "shared-memory-ring" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}


### PR DESCRIPTION
this is because of the shift to io-page-unix, so its safer to
have upper bounds on older releases to stop them pulling in the
new split package model. cc @djs55