### PR TITLE
mirage-os-shim: depend on a modern version of mirage-unix/xen

### DIFF
--- a/packages/mirage-os-shim/mirage-os-shim.3.0.0/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.3.0.0/opam
@@ -24,4 +24,8 @@ depopts: [
   "mirage-xen"
   "mirage-unix"
 ]
+conflicts: [
+  "mirage-unix" {<"3.0.0"}
+  "mirage-xen" {<"3.0.0"}
+]
 available: [ ocaml-version >= "4.01.0"]


### PR DESCRIPTION
spotted in revdeps for #9798