### PR TITLE
mirage-xen-ocaml: fails to compile on ocaml 4.04.2

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
@@ -15,5 +15,5 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.01.0" & os = "linux" & ocaml-version < "4.05.0" ]
+available: [ocaml-version >= "4.01.0" & os = "linux" & ocaml-version < "4.04.1" ]
 conflicts: [ "sexplib" { = "v0.9.0" } ]


### PR DESCRIPTION
this sets a bound to the version that compiles, since we silently
always used the 4.04.0 sources before (until 0da1dcad1490a1780bd09169de983bc5d427e10a)

New version with fix for 4.04.2 support (and 4.05.0 support) coming
shortly