### PR TITLE
Add gen_js_api 1.0.4 (for OCaml 4.05)

### DIFF
--- a/packages/gen_js_api/gen_js_api.1.0.4/descr
+++ b/packages/gen_js_api/gen_js_api.1.0.4/descr
@@ -1,0 +1,8 @@
+Easy OCaml bindings for Javascript libraries
+
+gen_js_api aims at simplifying the creation of OCaml bindings for
+Javascript libraries.  Authors of bindings write OCaml signatures for
+Javascript libraries and the tool generates the actual binding code
+with a combination of implicit conventions and explicit annotations.
+
+gen_js_api is to be used with the js_of_ocaml compiler.

--- a/packages/gen_js_api/gen_js_api.1.0.4/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.4/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlfind" {build}
   "js_of_ocaml"
 ]
-available: [ocaml-version >= "4.03.0" & ocaml-version <= "4.05"]
+available: [ocaml-version >= "4.05.0"]

--- a/packages/gen_js_api/gen_js_api.1.0.4/url
+++ b/packages/gen_js_api/gen_js_api.1.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/LexiFi/gen_js_api/archive/v1.0.4.tar.gz"
+checksum: "b996938e315fbcc37b7586ca6830eed5"


### PR DESCRIPTION
Also mark the previous version as incompatible with 4.05.