### PR TITLE
tube.2.1 - via opam-publish

### DIFF
--- a/packages/tube/tube.2.1/descr
+++ b/packages/tube/tube.2.1/descr
@@ -1,0 +1,3 @@
+Typesafe abstraction on top of Lwt_io channels
+
+A typesafe abstraction on top of Lwt_io channels in order to avoid things like unsafe operations (i.e. https://github.com/ocsigen/lwt/issues/345 ) when running in practice.

--- a/packages/tube/tube.2.1/opam
+++ b/packages/tube/tube.2.1/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "alin.popa@gmail.com"
+authors: "Alin Popa"
+homepage: "https://github.com/alinpopa/tube"
+bug-reports: "https://github.com/alinpopa/tube/issues"
+license: "LGPL-3 with OCaml linking exception"
+dev-repo: "https://github.com/alinpopa/tube.git"
+build: ["jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs "@install"]
+depends: ["core" "lwt"]

--- a/packages/tube/tube.2.1/url
+++ b/packages/tube/tube.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/alinpopa/tube/archive/2.1.tar.gz"
+checksum: "e0b7296129622c03851c92da57969014"


### PR DESCRIPTION
Typesafe abstraction on top of Lwt_io channels

A typesafe abstraction on top of Lwt_io channels in order to avoid things like unsafe operations (i.e. https://github.com/ocsigen/lwt/issues/345 ) when running in practice.


---
* Homepage: https://github.com/alinpopa/tube
* Source repo: https://github.com/alinpopa/tube.git
* Bug tracker: https://github.com/alinpopa/tube/issues

---

Pull-request generated by opam-publish v0.3.4