### PR TITLE
Add extlib-compat 1.7.2

### DIFF
--- a/packages/extlib-compat/extlib-compat.1.7.2/descr
+++ b/packages/extlib-compat/extlib-compat.1.7.2/descr
@@ -1,0 +1,5 @@
+A complete yet small extension for OCaml standard library (full, compatibility)
+The purpose of this library is to add new functions to OCaml standard library
+modules, to modify some functions in order to get better performances or
+safety (tail-recursive) and also to provide new modules which should be useful
+for day to day programming.

--- a/packages/extlib-compat/extlib-compat.1.7.2/opam
+++ b/packages/extlib-compat/extlib-compat.1.7.2/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/ygrek/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+doc: ["http://ygrek.org.ua/p/extlib/doc/"]
+license: "LGPL-2.1 with OCaml linking exception"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+  "Markus Mottl"
+  "Jesse Guardiani"
+  "John Skaller"
+  "Bardur Arantsson"
+  "Janne Hellsten"
+  "Richard W.M. Jones"
+  "ygrek"
+  "Gabriel Scherer"
+  "Pietro Abate"
+]
+build: [
+  [make "build"]
+]
+install: [ [make "install"] ]
+build-doc: [ [make "doc"] ]
+build-test: [ [make "test"] ]
+remove: [
+  ["ocamlfind" "remove" "extlib"]
+]
+conflicts: ["extlib"]
+depends: [
+  "ocamlfind" {build}
+  "cppo" {build}
+  "base-bytes" {build}
+]

--- a/packages/extlib-compat/extlib-compat.1.7.2/url
+++ b/packages/extlib-compat/extlib-compat.1.7.2/url
@@ -1,0 +1,3 @@
+http: "http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.2.tar.gz"
+mirrors: ["https://github.com/ygrek/ocaml-extlib/releases/download/1.7.2/extlib-1.7.2.tar.gz"]
+checksum: "0f550dd06242828399a73387c49e0eed"


### PR DESCRIPTION
Tested with:
```shell
opam switch 4.05.0
opam install extlib-compat.1.7.2 # works
opam install javalib # also works
```

Difference with extlib.1.7.2:
```diff
diff -ru packages/extlib/extlib.1.7.2/descr packages/extlib-compat/extlib-compat.1.7.2/descr
--- packages/extlib/extlib.1.7.2/descr  2017-05-08 15:04:08.000000000 +0100
+++ packages/extlib-compat/extlib-compat.1.7.2/descr    2017-07-13 16:30:04.571224664 +0100
@@ -1,4 +1,4 @@
-A complete yet small extension for OCaml standard library (reduced, recommended)
+A complete yet small extension for OCaml standard library (full, compatibility)
 The purpose of this library is to add new functions to OCaml standard library
 modules, to modify some functions in order to get better performances or
 safety (tail-recursive) and also to provide new modules which should be useful
diff -ru packages/extlib/extlib.1.7.2/opam packages/extlib-compat/extlib-compat.1.7.2/opam
--- packages/extlib/extlib.1.7.2/opam   2017-05-08 15:04:08.000000000 +0100
+++ packages/extlib-compat/extlib-compat.1.7.2/opam     2017-07-13 16:30:28.139470319 +0100
@@ -20,14 +20,15 @@
   "Pietro Abate"
 ]
 build: [
-  [make "minimal=1" "build"]
+  [make "build"]
 ]
-install: [ [make "minimal=1" "install"] ]
+install: [ [make "install"] ]
 build-doc: [ [make "doc"] ]
-build-test: [ [make "minimal=1" "test"] ]
+build-test: [ [make "test"] ]
 remove: [
   ["ocamlfind" "remove" "extlib"]
 ]
+conflicts: ["extlib"]
 depends: [
   "ocamlfind" {build}
   "cppo" {build}
```

Difference with extlib-compat.1.7.0:
```diff
diff -ru packages/extlib-compat/extlib-compat.1.7.0/opam packages/extlib-compat/extlib-compat.1.7.2/opam
--- packages/extlib-compat/extlib-compat.1.7.0/opam     2017-05-08 15:04:08.000000000 +0100
+++ packages/extlib-compat/extlib-compat.1.7.2/opam     2017-07-13 16:30:28.139470319 +0100
@@ -3,7 +3,7 @@
 homepage: "https://github.com/ygrek/ocaml-extlib"
 dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
 bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
-# doc: ["http://ocaml-extlib.googlecode.com/svn/doc/apiref/index.html"]
+doc: ["http://ygrek.org.ua/p/extlib/doc/"]
 license: "LGPL-2.1 with OCaml linking exception"
 authors: [
   "Nicolas Cannasse"
@@ -34,4 +34,3 @@
   "cppo" {build}
   "base-bytes" {build}
 ]
-available: [ ocaml-version < "4.05.0" ]
diff -ru packages/extlib-compat/extlib-compat.1.7.0/url packages/extlib-compat/extlib-compat.1.7.2/url
--- packages/extlib-compat/extlib-compat.1.7.0/url      2017-05-08 15:04:08.000000000 +0100
+++ packages/extlib-compat/extlib-compat.1.7.2/url      2017-07-13 16:27:25.033566973 +0100
@@ -1,2 +1,3 @@
-archive: "https://github.com/ygrek/ocaml-extlib/archive/1.7.0.tar.gz"
-checksum: "b50b02d9e40d35cc20c82d9c881a1bf6"
+http: "http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.2.tar.gz"
+mirrors: ["https://github.com/ygrek/ocaml-extlib/releases/download/1.7.2/extlib-1.7.2.tar.gz"]
+checksum: "0f550dd06242828399a73387c49e0eed"
```