### PR TITLE
Package tube.3.1

### DIFF
--- a/packages/tube/tube.3.1/descr
+++ b/packages/tube/tube.3.1/descr
@@ -1,0 +1,3 @@
+Typesafe abstraction on top of Lwt_io channels
+
+A typesafe abstraction on top of Lwt_io channels in order to avoid things like unsafe operations (i.e. https://github.com/ocsigen/lwt/issues/345 ) when running in practice.

--- a/packages/tube/tube.3.1/opam
+++ b/packages/tube/tube.3.1/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+maintainer: "alin.popa@gmail.com"
+authors: "Alin Popa"
+homepage: "https://github.com/alinpopa/tube"
+bug-reports: "https://github.com/alinpopa/tube/issues"
+license: "LGPL-3 with OCaml linking exception"
+dev-repo: "https://github.com/alinpopa/tube.git"
+build: ["jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs "@install"]
+depends: ["jbuilder" "core" "lwt"]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/tube/tube.3.1/url
+++ b/packages/tube/tube.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/alinpopa/tube/archive/3.1.tar.gz"
+checksum: "f0296816262dd219ceb9b0c3f50a6d6f"


### PR DESCRIPTION
### `tube.3.1`

Typesafe abstraction on top of Lwt_io channels

A typesafe abstraction on top of Lwt_io channels in order to avoid things like unsafe operations (i.e. https://github.com/ocsigen/lwt/issues/345 ) when running in practice.



---
* Homepage: https://github.com/alinpopa/tube
* Source repo: https://github.com/alinpopa/tube.git
* Bug tracker: https://github.com/alinpopa/tube/issues

---

:camel: Pull-request generated by opam-publish v0.3.5