### PR TITLE
adds lwt-parallel 0.1.2

### DIFF
--- a/packages/lwt-parallel/lwt-parallel.0.1.2/descr
+++ b/packages/lwt-parallel/lwt-parallel.0.1.2/descr
@@ -1,0 +1,3 @@
+Lwt-enabled multiprocessing library
+
+Allows to run lwt threads in different process.

--- a/packages/lwt-parallel/lwt-parallel.0.1.2/opam
+++ b/packages/lwt-parallel/lwt-parallel.0.1.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "lwt-parallel"
+version: "0.1.2"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "Ivan Gotovchits <ivg@ieee.org>"
+homepage: "https://github.com/ivg/parallel"
+bug-reports: "https://github.com/ivg/parallel/issues"
+dev-repo: "https://github.com/ivg/parallel.git"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "lwt-parallel"]
+depends: [
+  "base-unix"
+  "lwt" {>= "2.7.0"}
+  "ocamlfind" {build}
+  "oasis" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/lwt-parallel/lwt-parallel.0.1.2/url
+++ b/packages/lwt-parallel/lwt-parallel.0.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ivg/parallel/archive/v0.1.2.tar.gz"
+checksum: "e24c31f2b1e14d2805449ee689306134"


### PR DESCRIPTION
* updated to the lwt.3.0.0 interface (we are using a common ground
  interface that is available both in 2.7 and 3.0)

* fixed a bug with a leftover process