### PR TITLE
Release ocaml-freestanding 0.2.2

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/descr
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/descr
@@ -1,0 +1,3 @@
+Freestanding OCaml runtime
+
+This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer.

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "https://github.com/mirage/ocaml-freestanding.git"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind"
+  "ocaml-src"
+  ("solo5-kernel-ukvm" | "solo5-kernel-virtio" | "solo5-kernel-muen")
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+]
+available: [
+  ocaml-version >= "4.02.3" & ocaml-version < "4.06.0" &
+  (arch = "x86_64" | arch = "amd64")
+]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/url
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-freestanding/archive/v0.2.2.tar.gz"
+checksum: "4253d233a48a7af2911778b3fdbb506a"


### PR DESCRIPTION
This release primarily fixes support for OCaml 4.04.1+ and adds support
for OCaml 4.05, plus some minor changes landed on master in the mean
time.