### PR TITLE
git: conflict with new cohttp 0.99

### DIFF
--- a/packages/git/git.1.7.1/opam
+++ b/packages/git/git.1.7.1/opam
@@ -59,6 +59,7 @@ depopts: [
 ]
 conflicts: [
  "cohttp"   {< "0.19.1"}
+ "cohttp"   {>= "0.99.0"}
  "conduit"  {< "0.8.4"}
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}

--- a/packages/git/git.1.7.2/opam
+++ b/packages/git/git.1.7.2/opam
@@ -58,6 +58,7 @@ depopts: [
 ]
 conflicts: [
  "cohttp"   {< "0.19.1"}
+ "cohttp"   {>= "0.99.0"}
  "conduit"  {< "0.8.4"}
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}

--- a/packages/git/git.1.8.0/opam
+++ b/packages/git/git.1.8.0/opam
@@ -60,6 +60,7 @@ depopts: [
 ]
 conflicts: [
  "cohttp"   {< "0.19.1"}
+ "cohttp"   {>= "0.99.0"}
  "conduit"  {< "0.8.4"}
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}

--- a/packages/git/git.1.9.0/opam
+++ b/packages/git/git.1.9.0/opam
@@ -61,6 +61,7 @@ depopts: [
 ]
 conflicts: [
  "cohttp"   {< "0.19.1"}
+ "cohttp"   {>= "0.99.0"}
  "conduit"  {< "0.8.4"}
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}

--- a/packages/git/git.1.9.1/opam
+++ b/packages/git/git.1.9.1/opam
@@ -61,6 +61,7 @@ depopts: [
 ]
 conflicts: [
  "cohttp"   {< "0.19.1"}
+ "cohttp"   {>= "0.99.0"}
  "conduit"  {< "0.8.4"}
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}

--- a/packages/git/git.1.9.2/opam
+++ b/packages/git/git.1.9.2/opam
@@ -60,6 +60,7 @@ depopts: [
 ]
 conflicts: [
  "cohttp"   {< "0.19.1"}
+ "cohttp"   {>= "0.99.0"}
  "conduit"  {< "0.8.4"}
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}

--- a/packages/git/git.1.9.3/opam
+++ b/packages/git/git.1.9.3/opam
@@ -60,6 +60,7 @@ depopts: [
 ]
 conflicts: [
  "cohttp"   {< "0.19.1"}
+ "cohttp"   {>= "0.99.0"}
  "conduit"  {< "0.8.4"}
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}


### PR DESCRIPTION
its not enough to conflict on conduit, since the new cohttp doesnt
depend on conduit except in the lwt/async subpackages

noticed in revdeps for #9824