### PR TITLE
+dockerfile.3.1.0

### DIFF
--- a/packages/dockerfile-opam/dockerfile-opam.3.1.0/descr
+++ b/packages/dockerfile-opam/dockerfile-opam.3.1.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: http://docs.mirage.io/dockerfile
+- **Source:**: https://github.com/avsm/ocaml-dockerfile
+- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile-opam/dockerfile-opam.3.1.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.3.1.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "dockerfile" {>="3.0.0"}
+  "cmdliner"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile-opam/dockerfile-opam.3.1.0/url
+++ b/packages/dockerfile-opam/dockerfile-opam.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v3.1.0/dockerfile-3.1.0.tbz"
+checksum: "29029b66310492ba2a2ad5dca830d56f"

--- a/packages/dockerfile/dockerfile.3.1.0/descr
+++ b/packages/dockerfile/dockerfile.3.1.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: http://docs.mirage.io/dockerfile
+- **Source:**: https://github.com/avsm/ocaml-dockerfile
+- **Issues**: https://github.com/avsm/ocaml-dockerfile/issues
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile/dockerfile.3.1.0/opam
+++ b/packages/dockerfile/dockerfile.3.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "sexplib"
+  "base-bytes"
+  "fmt"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile/dockerfile.3.1.0/url
+++ b/packages/dockerfile/dockerfile.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v3.1.0/dockerfile-3.1.0.tbz"
+checksum: "29029b66310492ba2a2ad5dca830d56f"


### PR DESCRIPTION
--
* Mark OCaml 4.05.0 as a released stable version.
* Remove the Alpine 3.5 camlp4 hack as it has been fixed in a
  point release upstream.
* Add minimum constraint on sexplib in build rules (reported by @smondet)
* Add support for Alpine 3.6 and Debian 10 (Buster).
* Bump the most recent Debian Stable to Debian 9.
* Bump the most recent Alpine to Alpine 3.6.
* Add OCaml 4.04.2 as the most recent compiler