### PR TITLE
+mirage-platform 3.0.4

### DIFF
--- a/packages/mirage-unix/mirage-unix.3.0.4/descr
+++ b/packages/mirage-unix/mirage-unix.3.0.4/descr
@@ -1,0 +1,1 @@
+MirageOS platform library for UNIX compilation

--- a/packages/mirage-unix/mirage-unix.3.0.4/opam
+++ b/packages/mirage-unix/mirage-unix.3.0.4/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
+dev-repo:     "https://github.com/mirage/mirage-platform.git"
+license:      "part ISC, part LGPL-2.1 with OCaml linking exception, part 3-clause BSD"
+build:   [make "unix-build"]
+install: [make "unix-install"   "PREFIX=%{prefix}%"]
+remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.7"}
+  "mirage-clock-unix" {>= "1.0.0"}
+  "shared-memory-ring" {>= "1.0.0"}
+  "mirage-profile" {>= "0.3"}
+  "logs"
+  "io-page-unix" {>= "2.0.0"}
+]
+conflicts: [
+  "mirage-types" { < "3.0.0" }
+]
+available: [ocaml-version >= "4.01.0"]
+tags: "org:mirage"

--- a/packages/mirage-unix/mirage-unix.3.0.4/url
+++ b/packages/mirage-unix/mirage-unix.3.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v3.0.4.tar.gz"
+checksum: "d7fdca71808546c8caf79205f8c4e5fc"

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/descr
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/descr
@@ -1,0 +1,3 @@
+MirageOS headers for the OCaml runtime
+
+The package contains the OCaml runtime patches and build system.

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-ocaml-build"]
+install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+tags: ["org:mirage"]
+depends: [
+  "mirage-xen-posix" {>="3.0.4"}
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src"
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.04.2" & ocaml-version <= "4.05.0" & os = "linux"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/url
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v3.0.4.tar.gz"
+checksum: "d7fdca71808546c8caf79205f8c4e5fc"

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/descr
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/descr
@@ -1,0 +1,5 @@
+MirageOS library for posix headers
+
+This package contains the header files to pretend a posix
+system (required to compile the OCaml runtime), plus minilibc and
+float formating.

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
+dev-repo:     "https://github.com/mirage/mirage-platform.git"
+
+build:   [make "xen-posix-build"]
+install: [make "xen-posix-install" "PREFIX=%{prefix}%"]
+remove:  [make "xen-posix-uninstall" "PREFIX=%{prefix}%"]
+
+depends: [
+  "mirage-xen-minios" {>= "0.7.0"}
+  "conf-pkg-config"
+]
+available: [ ocaml-version >= "4.01.0" & os = "linux" ]

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/url
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v3.0.4.tar.gz"
+checksum: "d7fdca71808546c8caf79205f8c4e5fc"

--- a/packages/mirage-xen/mirage-xen.3.0.4/descr
+++ b/packages/mirage-xen/mirage-xen.3.0.4/descr
@@ -1,0 +1,1 @@
+MirageOS library for Xen compilation

--- a/packages/mirage-xen/mirage-xen.3.0.4/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.4/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
+dev-repo:     "https://github.com/mirage/mirage-platform.git"
+license:      "part ISC, part LGPL-2.1 with OCaml linking exception, part 3-clause BSD"
+tags:         ["org:mirage"]
+
+build:   [make "xen-build"]
+install: [make "xen-install"   "PREFIX=%{prefix}%"]
+remove:  [make "xen-uninstall" "PREFIX=%{prefix}%"]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cstruct" {>= "1.0.1"}
+  "mirage-clock-freestanding" {>= "1.2.0"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "xen-gnt" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "minios-xen" {>= "0.9"}
+  "conf-pkg-config"
+  "mirage-profile" {>= "0.3"}
+  "mirage-xen-ocaml" {>= "3.0.4"}
+  "logs"
+  "io-page-xen" {>= "2.0.0"}
+]
+conflicts: [
+  "mirage-types" { < "3.0.0" }
+]
+available: [ ocaml-version >= "4.01.0" & os = "linux" ]

--- a/packages/mirage-xen/mirage-xen.3.0.4/url
+++ b/packages/mirage-xen/mirage-xen.3.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v3.0.4.tar.gz"
+checksum: "d7fdca71808546c8caf79205f8c4e5fc"


### PR DESCRIPTION
adds support for OCaml 4.04.2 to the xen backend