### PR TITLE
bitcoinml.0.2 - via opam-publish

### DIFF
--- a/packages/bitcoinml/bitcoinml.0.2/descr
+++ b/packages/bitcoinml/bitcoinml.0.2/descr
@@ -1,0 +1,4 @@
+Bitcoin data-structures library for OCaml 
+
+Bitcoin data-structures library for OCaml. Modules documentation is 
+available at https://dakk.github.io/bitcoinml/

--- a/packages/bitcoinml/bitcoinml.0.2/opam
+++ b/packages/bitcoinml/bitcoinml.0.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: "Davide Gessa <gessadavide@gmail.com>"
+homepage: "https://github.com/dakk/bitcoinml"
+bug-reports: "https://github.com/dakk/bitcoinml/issues"
+license: "MIT"
+dev-repo: "https://github.com/dakk/bitcoinml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta9"}
+  "base" {build & >= "v0.9.2"}
+  "stdio" {build & >= "v0.9.0"}
+  "configurator" {build & >= "v0.9.1"}
+  "bitstring" {build & >= "2.1.0"}
+  "ppx_bitstring" {build & >= "2.0.0"}
+  "bignum" {build & >= "v0.9.0"}
+  "cryptokit" {build & >= "1.11"}
+  "stdint" {build & >= "0.3.0-0"}
+  "ounit" {test & >= "2.2.2"}
+  "odoc" {test & >= "1.1.1"}
+]
+

--- a/packages/bitcoinml/bitcoinml.0.2/url
+++ b/packages/bitcoinml/bitcoinml.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dakk/bitcoinml/archive/0.2.0.zip"
+checksum: "4d5db3ca0eee6d79a4ab4c20c2eaaf1a"


### PR DESCRIPTION
Bitcoin data-structures library for OCaml 

Bitcoin data-structures library for OCaml. Modules documentation is 
available at https://dakk.github.io/bitcoinml/


---
* Homepage: https://github.com/dakk/bitcoinml
* Source repo: https://github.com/dakk/bitcoinml.git
* Bug tracker: https://github.com/dakk/bitcoinml/issues

---

Pull-request generated by opam-publish v0.3.2