### PR TITLE
Biniou 1.1.0 (port to jbuilder and to using Bytes for mutable strings)

### DIFF
--- a/packages/biniou/biniou.1.1.0/descr
+++ b/packages/biniou/biniou.1.1.0/descr
@@ -1,0 +1,1 @@
+Binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve

--- a/packages/biniou/biniou.1.1.0/files/biniou.install
+++ b/packages/biniou/biniou.1.1.0/files/biniou.install
@@ -1,0 +1,4 @@
+bin: [
+  "?bdump.byte"   {"bdump"}
+  "?bdump.native" {"bdump"}
+]

--- a/packages/biniou/biniou.1.1.0/opam
+++ b/packages/biniou/biniou.1.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+
+homepage: "https://github.com/mjambon/biniou"
+bug-reports: "https://github.com/mjambon/biniou/issues"
+dev-repo: "https://github.com/mjambon/biniou.git"
+license: "BSD-3-Clause"
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+
+depends: [
+  "conf-which" {build}
+  "jbuilder" {build}
+  "easy-format"
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/biniou/biniou.1.1.0/url
+++ b/packages/biniou/biniou.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mjambon/biniou/archive/v1.1.0.tar.gz"
+checksum: "bbd7187f4e106c920ce88ef14ed8d7fe"


### PR DESCRIPTION
The `opam` file has changed. It's a copy of [the one found with the sources](https://github.com/mjambon/biniou/blob/master/biniou.opam).

I'm not sure about what to put/keep in `files/`. I just copied `files/biniou.install` from the previous release biniou.1.0.13.
