### PR TITLE
uchar.0.0.2 - via opam-publish

### DIFF
--- a/packages/uchar/uchar.0.0.2/descr
+++ b/packages/uchar/uchar.0.0.2/descr
@@ -1,0 +1,10 @@
+Compatibility library for OCaml's Uchar module
+
+The `uchar` package provides a compatibility library for the
+[`Uchar`][1] module introduced in OCaml 4.03.
+
+The `uchar` package is distributed under the license of the OCaml
+compiler. See [LICENSE](LICENSE) for details.
+
+[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html
+

--- a/packages/uchar/uchar.0.0.2/opam
+++ b/packages/uchar/uchar.0.0.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://ocaml.org"
+doc: "https://ocaml.github.io/uchar/"
+dev-repo: "https://github.com/ocaml/uchar.git"
+bug-reports: "https://github.com/ocaml/uchar/issues"
+tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
+license: "typeof OCaml system"
+available: [ ocaml-version >= "3.12.0" ]
+depends: [ "ocamlbuild" {build} ]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                           "native-dynlink=%{ocaml-native-dynlink}%"]
+]

--- a/packages/uchar/uchar.0.0.2/url
+++ b/packages/uchar/uchar.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz"
+checksum: "c9ba2c738d264c420c642f7bb1cf4a36"


### PR DESCRIPTION
Compatibility library for OCaml's Uchar module

The `uchar` package provides a compatibility library for the
[`Uchar`][1] module introduced in OCaml 4.03.

The `uchar` package is distributed under the license of the OCaml
compiler. See [LICENSE](LICENSE) for details.

[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html



---
* Homepage: http://ocaml.org
* Source repo: https://github.com/ocaml/uchar.git
* Bug tracker: https://github.com/ocaml/uchar/issues

---


---
v0.0.2 2017-07-16 Zagreb
------------------------

- Safe-string support. Thanks to Jacques-Pascal Deplaix for
  the help.
- Remove Uchar.dump. It's no longer part of the API since
  4.05. See MPR7500 and GPR1081.

Pull-request generated by opam-publish v0.3.4