### PR TITLE
`conf-time`

### DIFF
--- a/packages/bap/bap.0.9.4/opam
+++ b/packages/bap/bap.0.9.4/opam
@@ -41,6 +41,7 @@ remove: [
 
 depends: [
   "base-unix"
+  "conf-time"
   "bitstring"
   "camlzip"
   "cmdliner"
@@ -65,8 +66,9 @@ depexts: [
                 "libzip-dev"
                 "libcurl4-gnutls-dev"
                 "llvm-3.4-dev"
-                "time" "clang"
-                "llvm" "m4"
+                "clang"
+                "llvm"
+                "m4"
                 ]]
 ]
 

--- a/packages/bap/bap.0.9.5/opam
+++ b/packages/bap/bap.0.9.5/opam
@@ -40,6 +40,7 @@ remove: [
 depends: [
   "base-unix"
   "bitstring"
+  "conf-time"
   "camlzip"
   "cmdliner" {= "0.9.6"}
   "cohttp" {= "0.15.0"}
@@ -63,8 +64,9 @@ depexts: [
                 "libzip-dev"
                 "libcurl4-gnutls-dev"
                 "llvm-3.4-dev"
-                "time" "clang"
-                "llvm" "m4"
+                "clang"
+                "llvm"
+                "m4"
                 ]]
 ]
 

--- a/packages/bap/bap.0.9.6/opam
+++ b/packages/bap/bap.0.9.6/opam
@@ -38,6 +38,7 @@ remove: [
 
 depends: [
   "base-unix"
+  "conf-time"
   "bitstring"
   "camlzip"
   "cmdliner" {= "0.9.6"}
@@ -63,8 +64,9 @@ depexts: [
                 "libzip-dev"
                 "libcurl4-gnutls-dev"
                 "llvm-3.4-dev"
-                "time" "clang"
-                "llvm" "m4"
+                "llvm"
+                "clang"
+                "m4"
                 ]]
 ]
 

--- a/packages/bap/bap.0.9.7/opam
+++ b/packages/bap/bap.0.9.7/opam
@@ -37,6 +37,7 @@ remove: [
 
 depends: [
   "base-unix"
+  "conf-time"
   "bitstring"
   "camlzip"
   "cmdliner" {= "0.9.6"}
@@ -62,7 +63,6 @@ depexts: [
         "libzip-dev"
         "libcurl4-gnutls-dev"
         "llvm-3.4-dev"
-        "time"
         "clang"
         "llvm"
         "m4"

--- a/packages/bap/bap.0.9.8/opam
+++ b/packages/bap/bap.0.9.8/opam
@@ -37,6 +37,7 @@ remove: [
 
 depends: [
   "base-unix"
+  "conf-time"
   "bitstring"
   "camlzip"
   "cmdliner" {= "0.9.6"}
@@ -63,7 +64,6 @@ depexts: [
         "libzip-dev"
         "libcurl4-gnutls-dev"
         "llvm-3.4-dev"
-        "time"
         "clang"
         "llvm"
         "m4"

--- a/packages/bap/bap.0.9.9/opam
+++ b/packages/bap/bap.0.9.9/opam
@@ -37,6 +37,7 @@ remove: [
 
 depends: [
   "base-unix"
+  "conf-time"
   "bitstring"
   "camlzip"
   "cmdliner" {>= "0.9.6"}
@@ -63,7 +64,6 @@ depexts: [
         "libzip-dev"
         "libcurl4-gnutls-dev"
         "llvm-3.4-dev"
-        "time"
         "clang"
         "llvm"
         "m4"

--- a/packages/bitstring/bitstring.2.0.3/opam
+++ b/packages/bitstring/bitstring.2.0.3/opam
@@ -8,14 +8,6 @@ build: [
   [make "srcdir=./"]
 ]
 remove: [["ocamlfind" "remove" "bitstring"]]
-depends: [
-  "ocamlfind"
-  "base-unix"
-  "camlp4"
-]
-depexts: [
-  [["debian"] ["time"]]
-  [["ubuntu"] ["time"]]
-]
+depends: ["ocamlfind" "base-unix" "camlp4" "conf-time"]
 available: [ (ocaml-version >= "3.10") & (ocaml-version < "4.02") ]
 install: [make "install"]

--- a/packages/bitstring/bitstring.2.0.4/opam
+++ b/packages/bitstring/bitstring.2.0.4/opam
@@ -15,10 +15,10 @@ patches: [
   "fix_404.patch"
 ]
 remove: [["ocamlfind" "remove" "bitstring"]]
-depends: ["ocamlfind" {build} "camlp4" {build}]
-depexts: [
-  [["debian"] ["time"]]
-  [["ubuntu"] ["time"]]
+depends: [
+  "ocamlfind" {build}
+  "camlp4" {build}
+  "conf-time"
 ]
 available: [ ocaml-version >= "3.10" ]
 install: [make "install"]

--- a/packages/bitstring/bitstring.2.1.0/opam
+++ b/packages/bitstring/bitstring.2.1.0/opam
@@ -18,10 +18,10 @@ patches: [
   "fix_404.patch"
 ]
 remove: [["ocamlfind" "remove" "bitstring"]]
-depends: ["ocamlfind" {build} "camlp4" {build}]
-depexts: [
-  [["debian"] ["time"]]
-  [["ubuntu"] ["time"]]
+depends: [
+  "ocamlfind" {build}
+  "camlp4" {build}
+  "conf-time"
 ]
 available: [ ocaml-version >= "3.10" ]
 install: [make "install"]

--- a/packages/conf-time/conf-time.1/descr
+++ b/packages/conf-time/conf-time.1/descr
@@ -1,0 +1,3 @@
+Virtual package relying on the "time" command
+
+This package can only install if the "time" command is installed on the system.  It does not enforce having the GNU utility: it may find a BSD time command (BSD, OSX) or a Busybox command (Alpine) that have different options. The only common functionality is "time <command>".

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["POSIX"]
+homepage: "https://github.com/ocaml/opam-repository/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+license: "GPL"
+build: [["which" "time"]]
+depends: ["conf-which"]
+depexts: [
+  [["debian"] ["time"]]
+  [["ubuntu"] ["time"]]
+  [["centos"] ["time"]]
+  [["fedora"] ["time"]]
+  [["archlinux"] ["time"]]
+]

--- a/packages/cstruct/cstruct.1.6.0/opam
+++ b/packages/cstruct/cstruct.1.6.0/opam
@@ -39,6 +39,7 @@ depends: [
   "ocplib-endian"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}
+  "conf-time"
 ]
 depopts: [
   "camlp4"
@@ -47,7 +48,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.01.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.1.7.0/opam
+++ b/packages/cstruct/cstruct.1.7.0/opam
@@ -45,6 +45,7 @@ depends: [
   "ocplib-endian"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}
+  "conf-time"
 ]
 depopts: [
   "camlp4"
@@ -53,7 +54,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.01.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.1.7.1/opam
+++ b/packages/cstruct/cstruct.1.7.1/opam
@@ -45,6 +45,7 @@ depends: [
   "ocplib-endian"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}
+  "conf-time"
 ]
 depopts: [
   "camlp4"
@@ -53,7 +54,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.01.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.1.8.0/opam
+++ b/packages/cstruct/cstruct.1.8.0/opam
@@ -43,10 +43,11 @@ remove:  [
 depends: [
   "ocamlfind" {build}
   "type_conv" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "camlp4"
@@ -56,7 +57,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.1.9.0/opam
+++ b/packages/cstruct/cstruct.1.9.0/opam
@@ -43,10 +43,11 @@ remove:  [
 depends: [
   "ocamlfind" {build}
   "type_conv" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "camlp4"
@@ -56,7 +57,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.2.0.0/opam
+++ b/packages/cstruct/cstruct.2.0.0/opam
@@ -40,10 +40,11 @@ remove:  [
 ]
 depends: [
   "ocamlfind" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "ppx_tools"
@@ -52,7 +53,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.2.1.0/opam
+++ b/packages/cstruct/cstruct.2.1.0/opam
@@ -40,10 +40,11 @@ remove:  [
 ]
 depends: [
   "ocamlfind" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "ppx_tools"
@@ -52,7 +53,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.2.2.0/opam
+++ b/packages/cstruct/cstruct.2.2.0/opam
@@ -40,10 +40,11 @@ remove:  [
 ]
 depends: [
   "ocamlfind" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "ppx_tools"
@@ -52,7 +53,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.04.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.2.3.0/opam
+++ b/packages/cstruct/cstruct.2.3.0/opam
@@ -40,10 +40,11 @@ remove:  [
 ]
 depends: [
   "ocamlfind" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "ppx_tools"
@@ -52,7 +53,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.05.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.2.3.1/opam
+++ b/packages/cstruct/cstruct.2.3.1/opam
@@ -41,10 +41,11 @@ remove:  [
 ]
 depends: [
   "ocamlfind" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "ppx_tools"
@@ -53,7 +54,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.05.0"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.2.3.2/opam
+++ b/packages/cstruct/cstruct.2.3.2/opam
@@ -41,10 +41,11 @@ remove:  [
 ]
 depends: [
   "ocamlfind" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
+  "conf-time"
 ]
 depopts: [
   "ppx_tools"
@@ -53,7 +54,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.3"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]

--- a/packages/cstruct/cstruct.2.4.1/opam
+++ b/packages/cstruct/cstruct.2.4.1/opam
@@ -42,12 +42,13 @@ remove:  [
 ]
 depends: [
   "ocamlfind" {build}
-  "ounit"     {test}
+  "ounit" {test}
   "ocplib-endian"
   "sexplib"
   "base-bytes"
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
+  "conf-time"
 ]
 depopts: [
   "async"
@@ -55,7 +56,3 @@ depopts: [
   "base-unix"
 ]
 available: [ocaml-version >= "4.02.3"]
-depexts: [
-  [ ["debian"] ["time"] ]
-  [ ["ubuntu"] ["time"] ]
-]


### PR DESCRIPTION
I got the idea from looking at #9832 which seems to fail finding `/usr/bin/time` on CentOS. This change does in itself solve this problem (the only depext moved around are the existing ones for debian and ubunutu), and I'm not very knowledgeable in `conf-*` packages (is `which time` a reasonable build command?), but this goes in the spirit of #5791.