### PR TITLE
Use old io-page with old mirage-xen

### DIFF
--- a/packages/mirage-xen/mirage-xen.3.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-freestanding" {>= "1.2.0"}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.7"}
   "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}

--- a/packages/mirage-xen/mirage-xen.3.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-freestanding" {>= "1.2.0"}
   "lwt" {>= "2.4.3"}
   "shared-memory-ring" {>= "1.0.0" & < "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.3.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-freestanding" {>= "1.2.0"}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.7"}
   "shared-memory-ring-lwt"
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}

--- a/packages/mirage-xen/mirage-xen.3.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}
-  "io-page" {>= "1.5.0"}
+  "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-freestanding" {>= "1.2.0"}
   "lwt" {>= "2.4.3"}
   "shared-memory-ring-lwt"

--- a/packages/mirage-xen/mirage-xen.3.0.3/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}
   "mirage-clock-freestanding" {>= "1.2.0"}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.7"}
   "shared-memory-ring-lwt"
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}

--- a/packages/mirage-xen/mirage-xen.3.0.4/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}
   "mirage-clock-freestanding" {>= "1.2.0"}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.7"}
   "shared-memory-ring-lwt"
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}


### PR DESCRIPTION
Otherwise, the link fails with:

```
_build/main.native.o: In function `camlIo_page__get_addr_1481':
/home/opam/.opam/4.03.0/build/io-page.2.0.0/_build/default/lib/io_page.ml:32: undefined reference to `mirage_get_addr'
_build/main.native.o: In function `camlIo_page__get_page_1483':
/home/opam/.opam/4.03.0/build/io-page.2.0.0/_build/default/lib/io_page.ml:34: undefined reference to `mirage_get_addr'
_build/main.native.o: In function `camlIo_page__get_1519':
/home/opam/.opam/4.03.0/build/io-page.2.0.0/_build/default/lib/io_page.ml:44: undefined reference to `mirage_alloc_pages'
/home/opam/.opam/4.03.0/build/io-page.2.0.0/_build/default/lib/io_page.ml:42: undefined reference to `mirage_alloc_pages'
_build/main.native.o: In function `camlIo_page__21':
:(.data+0x3b900): undefined reference to `mirage_get_addr'
:(.data+0x3b908): undefined reference to `mirage_alloc_pages'
```