### PR TITLE
mirage-console-xen: depend on mirage-xen with io_page changes

### DIFF
--- a/packages/mirage-console-xen/mirage-console-xen.2.2.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.2.0/opam
@@ -18,6 +18,6 @@ depends: [
   "mirage-console-xen-proto" {>= "2.2.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" {>= "3.0.0"}
+  "mirage-xen" {>= "3.0.0" & <"3.0.2"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.2/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.2/opam
@@ -19,6 +19,6 @@ depends: [
   "mirage-console-xen-proto"
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen"
+  "mirage-xen" {>="3.0.0" & <"3.0.2"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.3/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.3/opam
@@ -20,6 +20,6 @@ depends: [
   "mirage-console-xen-proto"
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen"
+  "mirage-xen" {>="3.0.0" & <"3.0.2"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.4/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.4/opam
@@ -20,6 +20,6 @@ depends: [
   "xen-evtchn"
   "xen-gnt"
   "io-page-xen"
-  "mirage-xen"
+  "mirage-xen" {>="3.0.2"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
there was an interface change in mirage-xen-3.0.2 around iopage
vs cstruct that isnt currently reflected in constraints

noticed in failures for #9863