### PR TITLE
release labltk-8.06.3 for ocaml 4.05

### DIFF
--- a/packages/labltk/labltk.8.06.3/descr
+++ b/packages/labltk/labltk.8.06.3/descr
@@ -1,0 +1,3 @@
+OCaml interface to Tcl/Tk, including OCaml library explorer OCamlBrowser
+
+For details, see https://forge.ocamlcore.org/projects/labltk/

--- a/packages/labltk/labltk.8.06.3/opam
+++ b/packages/labltk/labltk.8.06.3/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://labltk.forge.ocamlcore.org/"
+bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=343"
+dev-repo: "https://github.com/garrigue/labltk.git"
+license: "LGPL with linking exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all" "opt"]
+]
+install: [
+  [make "install"]
+]
+available: [ ocaml-version >= "4.04" ]
+remove: [["ocamlfind" "remove" "labltk"]]
+depends: ["ocamlfind" "conf-tcl" "conf-tk"]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]

--- a/packages/labltk/labltk.8.06.3/opam
+++ b/packages/labltk/labltk.8.06.3/opam
@@ -12,7 +12,7 @@ build: [
 install: [
   [make "install"]
 ]
-available: [ ocaml-version >= "4.04" ]
+available: [ ocaml-version >= "4.05" ]
 remove: [["ocamlfind" "remove" "labltk"]]
 depends: ["ocamlfind" "conf-tcl" "conf-tk"]
 post-messages: [

--- a/packages/labltk/labltk.8.06.3/url
+++ b/packages/labltk/labltk.8.06.3/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1701/labltk-8.06.3.tar.gz"
+checksum: "55c00fcd70381ec426b74568301c1a2e"


### PR DESCRIPTION
8.06.2 does not compile with ocaml 4.05...