### PR TITLE
Add Lwt 3.1.0 – concurrency library

### DIFF
--- a/packages/lwt/lwt.3.1.0/descr
+++ b/packages/lwt/lwt.3.1.0/descr
@@ -1,0 +1,10 @@
+Concurrency based on promises
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.3.1.0/opam
+++ b/packages/lwt/lwt.3.1.0/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+version: "3.1.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%"
+                                    "-use-camlp4" "%{camlp4:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "ocaml" "src/util/install_filter.ml" ]
+]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "cppo" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+  # We are only using ocamlfind during configuration of the Unix binding.
+  "ocamlfind" {build & >= "1.5.0"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+  # result is needed as long as Lwt still supports OCaml 4.02.
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "camlp4"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+
+messages: [
+  "For module Lwt_ssl, please install package lwt_ssl"
+  {ssl:installed & !lwt_ssl:installed}
+  "For module Lwt_glib, please install package lwt_glib"
+  {lablgtk:installed & !lwt_glib:installed}
+  "For module Lwt_react, please install package lwt_react"
+  {react:installed & !lwt_react:installed}
+]
+post-messages: [
+  "Lwt 4.0.0 will make some breaking changes to packaging in late 2017. See
+  https://github.com/ocsigen/lwt/issues/453"
+]

--- a/packages/lwt/lwt.3.1.0/url
+++ b/packages/lwt/lwt.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.1.0.tar.gz"
+checksum: "e80364e38c5fae791a6506b9c113fd29"

--- a/packages/lwt_glib/lwt_glib.1.1.0/descr
+++ b/packages/lwt_glib/lwt_glib.1.1.0/descr
@@ -1,0 +1,1 @@
+GLib integration for Lwt

--- a/packages/lwt_glib/lwt_glib.1.1.0/opam
+++ b/packages/lwt_glib/lwt_glib.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+version: "1.1.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "base-unix"
+  "conf-glib-2" {build}
+  "conf-pkg-config" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "3.0.0"}
+]

--- a/packages/lwt_glib/lwt_glib.1.1.0/url
+++ b/packages/lwt_glib/lwt_glib.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.1.0.tar.gz"
+checksum: "e80364e38c5fae791a6506b9c113fd29"

--- a/packages/lwt_react/lwt_react.1.1.0/descr
+++ b/packages/lwt_react/lwt_react.1.1.0/descr
@@ -1,0 +1,1 @@
+Helpers for using React with Lwt

--- a/packages/lwt_react/lwt_react.1.1.0/opam
+++ b/packages/lwt_react/lwt_react.1.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+version: "1.1.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "3.0.0"}
+  "react" {>= "1.0.0"}
+]

--- a/packages/lwt_react/lwt_react.1.1.0/url
+++ b/packages/lwt_react/lwt_react.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.1.0.tar.gz"
+checksum: "e80364e38c5fae791a6506b9c113fd29"

--- a/packages/lwt_ssl/lwt_ssl.1.1.0/descr
+++ b/packages/lwt_ssl/lwt_ssl.1.1.0/descr
@@ -1,0 +1,1 @@
+Lwt-friendly OpenSSL bindings

--- a/packages/lwt_ssl/lwt_ssl.1.1.0/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+version: "1.1.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "base-unix"
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "3.0.0"}
+  "ssl" {>= "0.5.0"}
+]

--- a/packages/lwt_ssl/lwt_ssl.1.1.0/url
+++ b/packages/lwt_ssl/lwt_ssl.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.1.0.tar.gz"
+checksum: "e80364e38c5fae791a6506b9c113fd29"


### PR DESCRIPTION
...providing promises and parallelized I/O.

<br/>

A major goal of this release cycle was making Lwt much easier to work on and contribute to. From the [changelog](https://github.com/ocsigen/lwt/releases/tag/3.1.0):

<br/>

> Additions
>
> - Port to Jbuilder (ocsigen/lwt#374, Andrew Ray).
> - [`Lwt_io.establish_server_with_client_address`](https://ocsigen.org/lwt/dev/api/Lwt_io#VALestablish_server_with_client_address) (ocsigen/lwt#346, Rudi Grinberg).
> - [`Lwt_unix.getcwd`](https://ocsigen.org/lwt/dev/api/Lwt_unix#VALgetcwd) (ocsigen/lwt#403, Raphaël Proust).
>
> Planned to break in 4.0.0
>
> - Delete [`lwt.simple-top`](https://github.com/ocsigen/lwt/blob/615fca15a0cdd6f57a5fc13396f754f77ec1d738/src/simple_top/lwt_simple_top.ml#L22) (ocsigen/lwt#371).
> - Delete [`Lwt_chan`](https://github.com/ocsigen/lwt/blob/615fca15a0cdd6f57a5fc13396f754f77ec1d738/src/unix/lwt_chan.mli#L25) (ocsigen/lwt#441).
>
> Fixes
>
> - Make [`Lwt_log`](https://ocsigen.org/lwt/dev/api/Lwt_log) functions tail-recursive (ocsigen/lwt#348, Jan Doms).
> - Make more of [`Lwt_list`](https://ocsigen.org/lwt/dev/api/Lwt_list) tail-recursive (ocsigen/lwt#347, Jan Doms).
> - Improve string messages in exceptions (ocsigen/lwt#368, ocsigen/lwt#382, Jan Doms, Raphaël Proust).
> - Don't call [`Unix.set_nonblock`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#VALset_nonblock) or [`Unix.clear_nonblock`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#VALclear_nonblock) unnecessarily on some fds (ocsigen/lwt#356, David Sheets).
> - [`Lwt_unix.sleep`](https://ocsigen.org/lwt/dev/api/Lwt_unix#VALsleep) and [`Lwt_unix.timeout`](https://ocsigen.org/lwt/dev/api/Lwt_unix#VALtimeout) returning too early when using libev (ocsigen/lwt#433, Stijn Devriendt).
> - [`Lwt_sequence.fold_r`](https://ocsigen.org/lwt/dev/api/Lwt_sequence#VALfold_r) iterating the wrong way in some cases (ocsigen/lwt#405, Stijn Devriendt).
> - Build conflicts in some cases due to duplicate `cst_to_constr` function (ocsigen/lwt#362, Jérémie Dimino).
> - Don't use deprecated [`readdir_r`](http://man7.org/linux/man-pages/man3/readdir_r.3.html) system call (ocsigen/lwt#430, Raphaël Proust).
>
> Miscellaneous
>
> - The Lwt core, [`lwt.ml`](https://github.com/ocsigen/lwt/blob/615fca15a0cdd6f57a5fc13396f754f77ec1d738/src/core/lwt.ml#L27), has been thoroughly refactored and commented (ocsigen/lwt#354, reviewed Gabriel Radanne, Edwin Török, Raphaël Proust, Jan Doms, Fabian Hemmer, Sebastien Mondet, Simon Cruanes, Anil Madhavapeddy, Pierre Chambart, and many others).
> - Lots of [tests](https://github.com/ocsigen/lwt/tree/615fca15a0cdd6f57a5fc13396f754f77ec1d738/test/core) for most of the Lwt core (ocsigen/lwt#339, ocsigen/lwt#389, ocsigen/lwt#392, ocsigen/lwt#440, ocsigen/lwt#448, ocsigen/lwt#450, Joseph Thomas, Ryan Slade).
> - Documentation fixes (including by Joseph Thomas, Raphaël Proust, Richard Degenne, Stavros Polymenis).
> - [Contributing documentation](https://github.com/ocsigen/lwt/tree/615fca15a0cdd6f57a5fc13396f754f77ec1d738#contributing) (ocsigen/lwt#379).
> - Massively adjust whitespace for legibility (ocsigen/lwt#400, ocsigen/lwt#409, ocsigen/lwt#416, Richard Degenne).
> - Improvements to CI (Etienne Millon, Raphael Rafatpanah, Zack Coker, Yotam Barnoy).
> - The additional packages [`lwt_ssl`](http://opam.ocaml.org/packages/lwt_ssl/), [`lwt_react`](http://opam.ocaml.org/packages/lwt_react/), [`lwt_glib`](http://opam.ocaml.org/packages/lwt_glib/) get new minor releases, the change being new Jbuilder build systems (ocsigen/lwt#374, Andrew Ray).