### PR TITLE
old versions of vchan do not work with recent xenstore_transport

### DIFF
--- a/packages/vchan/vchan.0.9.5/opam
+++ b/packages/vchan/vchan.0.9.5/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}
-  "xenstore_transport"
+  "xenstore_transport" {< "0.9.6"}
   "xen-evtchn" {>= "1.0.3" & < "2.0.0"}
   "xen-gnt" {< "2.0.0"}
   "cmdliner"

--- a/packages/vchan/vchan.0.9.6/opam
+++ b/packages/vchan/vchan.0.9.6/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-types" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}
-  "xenstore_transport"
+  "xenstore_transport" {< "0.9.6"}
   "xen-evtchn" {>= "1.0.3" & < "2.0.0"}
   "xen-gnt" { < "2.0.0" }
   "cmdliner"

--- a/packages/vchan/vchan.0.9.7/opam
+++ b/packages/vchan/vchan.0.9.7/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-types" {>= "1.1.3" & < "2.0.0"}
   "io-page" {< "1.3.0"}
   "xenstore" {>= "1.2.2"}
-  "xenstore_transport"
+  "xenstore_transport" {< "0.9.6"}
   "xen-evtchn" {>= "1.0.3" & < "2.0.0"}
   "xen-gnt" {< "2.0.0"}
   "cmdliner"


### PR DESCRIPTION
See https://github.com/xapi-project/ocaml-xenstore-clients/pull/8 for a fix

/cc @jonludlam 