### PR TITLE
utp: upper bound on lwt

### DIFF
--- a/packages/utp/utp.0.9.0/opam
+++ b/packages/utp/utp.0.9.0/opam
@@ -7,5 +7,5 @@ license: "MIT"
 dev-repo: "https://www.github.com/nojb/ocaml-utp.git"
 build: [make "all"]
 build-doc: [make "doc"]
-depends: ["base-bytes" "ocamlfind" {build} "lwt" {>= "2.4.7"}]
+depends: ["base-bytes" "ocamlfind" {build} "lwt" {>= "2.4.7" & <"3.1.0"}]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
this is because lwt-unix is no longer found in utp (probably as
a result of the slightly different directory layout that comes
from jbuilder in Lwt 3.1.0)

```
File "lib/utp_lwt.ml", line 231, characters 2-23:
Warning 10: this expression should have type unit.
ocamlc -a -o utp-lwt.cma utp.cma lib/utp_lwt.cmo
ocamlc -g -bin-annot -I `ocamlfind query lwt` -I lib/ -ccopt -L. -o ucat unix.cma bigarray.cma lwt.cma lwt-unix.cma utp-lwt.cma bin/ucat.ml
File "bin/ucat.ml", line 1:
Error: Cannot find file lwt-unix.cma
Makefile:51: recipe for target 'ucat' failed
```

cc @aantron @nojb