### PR TITLE
mirage-time-unix.1.2.0 - via opam-publish

### DIFF
--- a/packages/mirage-time-unix/mirage-time-unix.1.2.0/descr
+++ b/packages/mirage-time-unix/mirage-time-unix.1.2.0/descr
@@ -1,0 +1,1 @@
+Implementation of `Mirage_time_lwt.S` for the Unix backend

--- a/packages/mirage-time-unix/mirage-time-unix.1.2.0/opam
+++ b/packages/mirage-time-unix/mirage-time-unix.1.2.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-time"
+bug-reports:   "https://github.com/mirage/mirage-time/issues"
+dev-repo:      "https://github.com/mirage/mirage-time.git"
+doc:           "https://mirage.github.io/mirage-time/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "lwt" "duration"
+]

--- a/packages/mirage-time-unix/mirage-time-unix.1.2.0/url
+++ b/packages/mirage-time-unix/mirage-time-unix.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-time/releases/download/v1.2.0/mirage-time-1.2.0.tbz"
+checksum: "428555a6f49ac55dcfeb7fcde8d4c378"


### PR DESCRIPTION
Implementation of `Mirage_time_lwt.S` for the Unix backend


---
* Homepage: https://github.com/mirage/mirage-time
* Source repo: https://github.com/mirage/mirage-time.git
* Bug tracker: https://github.com/mirage/mirage-time/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
### v1.2.0 (2017-07-21)

* Add a mirage-time-unix module defining a `Time` module (#4, @samoht)
Pull-request generated by opam-publish v0.3.4