### PR TITLE
Package jbuilder.1.0+beta11

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta11/descr
+++ b/packages/jbuilder/jbuilder.1.0+beta11/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+jbuilder is a build system that was designed to simplify the release
+of Jane Street packages. It reads metadata from "jbuild" files
+following a very simple s-expression syntax.
+
+jbuilder is fast, it has very low-overhead and support parallel builds
+on all platforms. It has no system dependencies, all you need to build
+jbuilder and packages using jbuilder is OCaml. You don't need or make
+or bash as long as the packages themselves don't use bash explicitely.
+
+jbuilder supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/jbuilder/jbuilder.1.0+beta11/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta11/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/jbuilder"
+bug-reports: "https://github.com/janestreet/jbuilder/issues"
+dev-repo: "https://github.com/janestreet/jbuilder.git"
+license: "Apache-2.0"
+build: [
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--subst"] {pinned}
+  ["./boot.exe" "-j" jobs]
+]
+depends: [
+  # ocamlfind is not mandatory to build packages using
+  # jbuilder. However if it is present jbuilder will use it.  Making
+  # it a hard-dependency avoids problems when there is a previous
+  # ocamlfind in the PATH. We make it a "build" depepdency even though
+  # it is only a runtime dependency so that reinstalling ocamlfind
+  # doesn't resintall jbuilder
+  "ocamlfind" {build}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/jbuilder/jbuilder.1.0+beta11/url
+++ b/packages/jbuilder/jbuilder.1.0+beta11/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/jbuilder/releases/download/1.0+beta11/jbuilder-1.0.beta11.tbz"
+checksum: "e6f433574a0fe635ad4e126c043f5e00"


### PR DESCRIPTION
### `jbuilder.1.0+beta11`

Fast, portable and opinionated build system

jbuilder is a build system that was designed to simplify the release
of Jane Street packages. It reads metadata from "jbuild" files
following a very simple s-expression syntax.

jbuilder is fast, it has very low-overhead and support parallel builds
on all platforms. It has no system dependencies, all you need to build
jbuilder and packages using jbuilder is OCaml. You don't need or make
or bash as long as the packages themselves don't use bash explicitely.

jbuilder supports multi-package development by simply dropping multiple
repositories into the same directory.

It also supports multi-context builds, such as building against
several opam roots/switches simultaneously. This helps maintaining
packages across several versions of OCaml and gives cross-compilation
for free.



---
* Homepage: https://github.com/janestreet/jbuilder
* Source repo: https://github.com/janestreet/jbuilder.git
* Bug tracker: https://github.com/janestreet/jbuilder/issues

---


---
1.0+beta11 (21/07/2017)
-----------------------

- Fix the error message when there are more than one `<package>.opam`
  file for a given pacakge

- Report an error when in a wrapped library, a module that is not the
  toplevel module depends on the toplevel module. This doesn't make as
  such a module would in theory be inaccessible from the outside

- Add `${SCOPE_ROOT}` pointing to the root of the current scope, to
  fix some misuses of `${ROOT}`

- Fix useless hint when all missing dependencies are optional (#137)

- Fix a bug preventing one from generating `META.pkg.template` with a
  custom rule (#190)

- Fix compilation of reason projects: .rei files where ignored and
  caused the build to fail (#184)
:camel: Pull-request generated by opam-publish v0.3.4