### PR TITLE
Cryptokit version 1.12

### DIFF
--- a/packages/cryptokit/cryptokit.1.12/descr
+++ b/packages/cryptokit/cryptokit.1.12/descr
@@ -1,0 +1,6 @@
+A library of cryptographic primitives.
+
+Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers
+(ARCfour), public-key crypto (RSA, DH), hashes (SHA-1, SHA-256,
+SHA-3), MACs, compression, random number generation -- all presented
+with a compositional, extensible interface.

--- a/packages/cryptokit/cryptokit.1.12/opam
+++ b/packages/cryptokit/cryptokit.1.12/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: ["Xavier Leroy"]
+bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
+homepage: "https://github.com/xavierleroy/cryptokit"
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "conf-zlib"
+  "conf-gmp-powm-sec"
+  "zarith" { >= "1.4" }
+]
+available: [ ocaml-version >= "4.02.0" ]
+build: make
+install: [make "install"]
+remove: [["ocamlfind" "remove" "cryptokit"]]

--- a/packages/cryptokit/cryptokit.1.12/url
+++ b/packages/cryptokit/cryptokit.1.12/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xavierleroy/cryptokit/archive/release112.tar.gz"
+checksum: "77b7d6da73a065b831ccec31d31e7666"


### PR DESCRIPTION
As recently released from https://github.com/xavierleroy/cryptokit/

The patches contained in the package for version 1.11 have been integrated upstream and are no longer needed.