### PR TITLE
dnssd.0.5.0 - via opam-publish

### DIFF
--- a/packages/dnssd/dnssd.0.5.0/descr
+++ b/packages/dnssd/dnssd.0.5.0/descr
@@ -1,0 +1,19 @@
+DNS Service Discovery for macOS
+
+This library contains bindings to the functions in `dns_sd.h`, which
+are used to perform generic DNS queries using the macOS resolver.
+This is the best way to ensure that the query results match the
+results obtained by other apps on OSX.
+
+## Usage example
+
+In a toplevel:
+
+```ocaml
+Dnssd.query "dave.recoil.org" Dns.Packet.Q_A;;
+- : (Dns.Packet.rr list, Dnssd.error) result =
+Ok
+  [{Dns.Packet.name = <abstr>; cls = Dns.Packet.RR_IN; flush = false; ttl = 187l; rdata = Dns.Packet.A <abstr>};
+   {Dns.Packet.name = <abstr>; cls = Dns.Packet.RR_IN; flush = false; ttl = 187l; rdata = Dns.Packet.CNAME <abstr>};
+   {Dns.Packet.name = <abstr>; cls = Dns.Packet.RR_IN; flush = false; ttl = 187l; rdata = Dns.Packet.CNAME <abstr>}]
+```

--- a/packages/dnssd/dnssd.0.5.0/opam
+++ b/packages/dnssd/dnssd.0.5.0/opam
@@ -24,6 +24,7 @@ depends: [
   "lwt"
   "logs"
   "fmt"
+  "cstruct" {>= "2.3.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "alcotest" {test}
 ]

--- a/packages/dnssd/dnssd.0.5.0/opam
+++ b/packages/dnssd/dnssd.0.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-osx-dnssd"
+dev-repo: "https://github.com/mirage/ocaml-osx-dnssd.git"
+bug-reports: "https://github.com/mirage/ocaml-osx-dnssd/issues"
+doc: "https://mirage.github.io/ocaml-osx-dnssd/"
+tags: [
+  "org:mirage"
+]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-j" jobs]
+]
+
+build-test: [
+  [ "jbuilder" "runtest" ]
+]
+
+depends: [
+  "dns"
+  "lwt"
+  "logs"
+  "fmt"
+  "jbuilder" {build & >= "1.0+beta10"}
+  "alcotest" {test}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/dnssd/dnssd.0.5.0/url
+++ b/packages/dnssd/dnssd.0.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-osx-dnssd/releases/download/v0.5.0/dnssd-0.5.0.tbz"
+checksum: "8208d2ee22d572ea42da2a1e258c5d5a"


### PR DESCRIPTION
DNS Service Discovery for macOS

This library contains bindings to the functions in `dns_sd.h`, which
are used to perform generic DNS queries using the macOS resolver.
This is the best way to ensure that the query results match the
results obtained by other apps on OSX.

## Usage example

In a toplevel:

```ocaml
Dnssd.query "dave.recoil.org" Dns.Packet.Q_A;;
- : (Dns.Packet.rr list, Dnssd.error) result =
Ok
  [{Dns.Packet.name = <abstr>; cls = Dns.Packet.RR_IN; flush = false; ttl = 187l; rdata = Dns.Packet.A <abstr>};
   {Dns.Packet.name = <abstr>; cls = Dns.Packet.RR_IN; flush = false; ttl = 187l; rdata = Dns.Packet.CNAME <abstr>};
   {Dns.Packet.name = <abstr>; cls = Dns.Packet.RR_IN; flush = false; ttl = 187l; rdata = Dns.Packet.CNAME <abstr>}]
```

---
* Homepage: https://github.com/mirage/ocaml-osx-dnssd
* Source repo: https://github.com/mirage/ocaml-osx-dnssd.git
* Bug tracker: https://github.com/mirage/ocaml-osx-dnssd/issues

---


---
## v0.5.0 (2017-07-24)

- packaging and test improvements (#8, #9 @djs55 and @samoht)
Pull-request generated by opam-publish v0.3.4