### PR TITLE
Package tsdl.0.9.5

### DIFF
--- a/packages/tsdl/tsdl.0.9.5/descr
+++ b/packages/tsdl/tsdl.0.9.5/descr
@@ -1,0 +1,11 @@
+Thin bindings to SDL for OCaml
+
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.5][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the ISC license.
+
+[sdl]: http://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes

--- a/packages/tsdl/tsdl.0.9.5/opam
+++ b/packages/tsdl/tsdl.0.9.5/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/tsdl"
+doc: "http://erratique.ch/software/tsdl/doc/Tsdl"
+dev-repo: "http://erratique.ch/repos/tsdl.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
+        "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.02.0" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "conf-sdl2"
+  "result"
+  "ctypes" {>= "0.9.0"}
+  "ctypes-foreign" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/tsdl/tsdl.0.9.5/url
+++ b/packages/tsdl/tsdl.0.9.5/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/tsdl/releases/tsdl-0.9.5.tbz"
+checksum: "1adbb9ce9b4508a13d99e42268331870"


### PR DESCRIPTION
### `tsdl.0.9.5`

Thin bindings to SDL for OCaml

Tsdl is an OCaml library providing thin bindings to the cross-platform
SDL C library.

Tsdl depends on the [SDL 2.0.5][sdl] C library (or later),
[ocaml-ctypes][ctypes] and the `result` compatibility package.
Tsdl is distributed under the ISC license.

[sdl]: http://www.libsdl.org/
[ctypes]: https://github.com/ocamllabs/ocaml-ctypes



---
* Homepage: http://erratique.ch/software/tsdl
* Source repo: http://erratique.ch/repos/tsdl.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---


---
v0.9.5 2017-07-24 Zagreb
------------------------

- Support for audio queue API. Thanks to Erik Løvlie for the patch.
:camel: Pull-request generated by opam-publish v0.3.5