### PR TITLE
conf-qt: don't run a script that calls 'sudo add-apt-repository'

### DIFF
--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -15,4 +15,5 @@ available: [ os != "darwin" ]
 
 depexts: [
   [ ["ubuntu"] ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"] ]
+  [ ["debian"] ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"] ]
 ]

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -16,4 +16,5 @@ available: [ os != "darwin" ]
 depexts: [
   [ ["ubuntu"] ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"] ]
   [ ["debian"] ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"] ]
+  [ ["alpine"] ["qt5-qtbase-dev" "qt5-qtdeclarative-dev"] ]
 ]

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -17,4 +17,5 @@ depexts: [
   [ ["ubuntu"] ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"] ]
   [ ["debian"] ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"] ]
   [ ["alpine"] ["qt5-qtbase-dev" "qt5-qtdeclarative-dev"] ]
+  [ ["centos"] ["qt5-qtbase-devel" "qt5-qtdeclarative-devel"] ]
 ]

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -14,6 +14,5 @@ build: [
 available: [ os != "darwin" ]
 
 depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/Kakadu/7dc6f7c9f8760f7fbace/raw/295dd3528cf9cf2be7a67a9752e530353bb6211b/get_qt.sh" ] ]
   [ ["ubuntu"] ["qt5-default" "qtdeclarative5-dev"] ]
 ]

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -14,5 +14,5 @@ build: [
 available: [ os != "darwin" ]
 
 depexts: [
-  [ ["ubuntu"] ["qt5-default" "qtdeclarative5-dev"] ]
+  [ ["ubuntu"] ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"] ]
 ]


### PR DESCRIPTION
The `source linux` `depext` [script](https://gist.githubusercontent.com/Kakadu/7dc6f7c9f8760f7fbace/raw/295dd3528cf9cf2be7a67a9752e530353bb6211b/get_qt.sh) for `conf-qt` is Ubuntu-specific:

```
sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu trusty universe"
sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu trusty main"
```

and has surprising and enduring effects on other systems (e.g. Debian).  Removing this will probably make the CI fail, but is better for users.

/cc @Kakadu