### PR TITLE
Fix compilation of qocamlbrowser and add new version

### DIFF
--- a/packages/qocamlbrowser/qocamlbrowser.0.2.8/descr
+++ b/packages/qocamlbrowser/qocamlbrowser.0.2.8/descr
@@ -1,0 +1,2 @@
+OCamlBrowser clone written with OCaml and QtQuick 2.
+

--- a/packages/qocamlbrowser/qocamlbrowser.0.2.8/opam
+++ b/packages/qocamlbrowser/qocamlbrowser.0.2.8/opam
@@ -15,5 +15,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/Kakadu/QOcamlBrowser_quick"
-available: (ocaml-version >= "4.02.0") & (ocaml-version < "4.04.0")
+available: (ocaml-version >= "4.04.0")
 install: [make "install" "PREFIX=%{prefix}%"]

--- a/packages/qocamlbrowser/qocamlbrowser.0.2.8/url
+++ b/packages/qocamlbrowser/qocamlbrowser.0.2.8/url
@@ -1,0 +1,3 @@
+archive: "https://github.com/Kakadu/QOcamlBrowser_quick/archive/0.2.8.tar.gz"
+checksum: "ead8d48aa009f1da9fea8005423f1f0b"
+


### PR DESCRIPTION
old version restricted to < 4.04
new one added

Inspired by https://github.com/ocaml/opam-repository/pull/9915