### PR TITLE
New releasse of dns-forward

### DIFF
--- a/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/descr
+++ b/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/descr
@@ -1,0 +1,1 @@
+Lwt implementation for the `dns-forward` library

--- a/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
+++ b/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "dave@recoil.org"
+authors:      ["David Scott"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-dns-forward"
+bug-reports:  "https://github.com/mirage/ocaml-dns-forward/issues"
+dev-repo:     "https://github.com/mirage/ocaml-dns-forward.git"
+doc:          "https://mirage.github.io/ocaml-dns-forward/"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder"     {build & >= "1.0+beta10"}
+  "dns-forward"  {>= "0.8.5"}
+  "lwt"          {>= "2.7.0"}
+  "cstruct-lwt"  {>= "3.0.0"}
+  "io-page-unix" {>= "2.0.0"}
+  "mirage-clock-unix"
+  "alcotest"   {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/url
+++ b/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-dns-forward/releases/download/v0.9.0/dns-forward-0.9.0.tbz"
+checksum: "851d7b0ad1658586ff6554117dedf845"

--- a/packages/dns-forward/dns-forward.0.9.0/descr
+++ b/packages/dns-forward/dns-forward.0.9.0/descr
@@ -1,0 +1,8 @@
+Library and tools for creating forwarding DNS servers
+
+Features:
+
+- UDP and TCP DNS forwarding
+- support for sending queries to specific servers based on domain
+- dynamic configuration updates
+- extra records (e.g. from /etc/hosts)

--- a/packages/dns-forward/dns-forward.0.9.0/opam
+++ b/packages/dns-forward/dns-forward.0.9.0/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer:   "dave@recoil.org"
+authors:      ["David Scott"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-dns-forward"
+bug-reports:  "https://github.com/mirage/ocaml-dns-forward/issues"
+dev-repo:     "https://github.com/mirage/ocaml-dns-forward.git"
+doc:          "https://mirage.github.io/ocaml-dns-forward/"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder"        {build & >= "1.0+beta10"}
+  "cstruct"         {>= "3.0.0"}
+  "logs"            {>= "0.5.0"}
+  "lwt"             {>= "2.7.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-clock-lwt"
+  "mirage-channel-lwt"
+  "mirage-time-lwt"
+  "duration"
+  "dns"
+  "rresult"
+  "astring"
+  "fmt"
+  "result"
+  "mtime"
+  "sexplib"
+  "ipaddr"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/dns-forward/dns-forward.0.9.0/url
+++ b/packages/dns-forward/dns-forward.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-dns-forward/releases/download/v0.9.0/dns-forward-0.9.0.tbz"
+checksum: "851d7b0ad1658586ff6554117dedf845"


### PR DESCRIPTION
CHANGES:
- Port to MirageOS 3.0 (mirage/ocaml-dns-forward#70, @samoht)