### PR TITLE
Package git.1.11.1

### DIFF
--- a/packages/git/git.1.11.1/descr
+++ b/packages/git/git.1.11.1/descr
@@ -1,0 +1,13 @@
+Git format and protocol in pure OCaml
+
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects. For instance, it is
+possible to make a pack file position independent (as the Zlib
+compression might change the relative offsets between the packed
+objects), to generate pack indexes from pack files, or to expand
+the filesystem of a given commit.

--- a/packages/git/git.1.11.1/opam
+++ b/packages/git/git.1.11.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "build" "test/git"]
+
+depends: [
+  "jbuilder"   {build}
+  "mstruct"    {>= "1.3.1"}
+  "ocamlgraph"
+  "uri"        {>= "1.3.12"}
+  "lwt"        {>= "2.4.7"}
+  "logs"
+  "fmt"
+  "hex"
+  "astring"
+  "ocplib-endian"
+  "decompress" {>= "0.6"}
+  "alcotest" {test}
+  "nocrypto" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.11.1/url
+++ b/packages/git/git.1.11.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.1/git-1.11.1.tbz"
+checksum: "438dcbefab624c8c6b772d1b175eb16a"


### PR DESCRIPTION
### `git.1.11.1`

Git format and protocol in pure OCaml

Support for on-disk and in-memory Git stores. Can read and write all
the Git objects: the usual blobs, trees, commits and tags but also
the pack files, pack indexes and the index file (where the staging area
lives).

All the objects share a consistent API, and convenience functions are
provided to manipulate the different objects. For instance, it is
possible to make a pack file position independent (as the Zlib
compression might change the relative offsets between the packed
objects), to generate pack indexes from pack files, or to expand
the filesystem of a given commit.



---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---


---
### 1.11.1 (2017-07-25)

- [git-unix] Fix linking issue of the `ogit` binary on some package
  configurations (#225, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5