### PR TITLE
Package mirage-clock-unix.1.4.0

### DIFF
--- a/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/descr
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/descr
@@ -1,0 +1,15 @@
+Libraries and module types for portable clocks
+
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+
+The following sources are used:
+
+* The Unix version uses `gettimeofday` or `clock_gettime`, depending on
+  which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+* The freestanding version uses the paravirtual clock source from the hypervisor.

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+authors:      ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-clock"
+bug-reports:  "https://github.com/mirage/mirage-clock/issues"
+dev-repo:     "https://github.com/mirage/mirage-clock.git"
+doc:          "https://mirage.github.io/mirage-clock/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "lwt"
+  "configurator" {build}
+]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/url
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-clock/releases/download/v1.4.0/mirage-clock-1.4.0.tbz"
+checksum: "0cd3efd3f426c285ea1c473cc872cb81"


### PR DESCRIPTION
### `mirage-clock-unix.1.4.0`

Libraries and module types for portable clocks

This library implements portable support for an operating system timesource
that is compatible with the [MirageOS](https://mirage.io) library interfaces
found in: <https://github.com/mirage/mirage>

It implements an `MCLOCK` module that represents a monotonic timesource
since an arbitrary point, and `PCLOCK` which counts time since the Unix
epoch.

The following sources are used:

* The Unix version uses `gettimeofday` or `clock_gettime`, depending on
  which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
* The freestanding version uses the paravirtual clock source from the hypervisor.


---
* Homepage: https://github.com/mirage/mirage-clock
* Source repo: https://github.com/mirage/mirage-clock.git
* Bug tracker: https://github.com/mirage/mirage-clock/issues

---


---
### v1.4.0 (2017-07-25)

* Add support for windows to `mirage-clock-unix` (#32, @fdopen and @samoht)
:camel: Pull-request generated by opam-publish v0.3.5