### PR TITLE
Pull BER n100 sources from the github mirror.

### DIFF
--- a/compilers/4.00.1/4.00.1+BER/4.00.1+BER.comp
+++ b/compilers/4.00.1/4.00.1+BER/4.00.1+BER.comp
@@ -1,16 +1,15 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
-patches: ["http://eneide.happyleptic.org/~rixed/metaocaml-opam/ber.patch"]
+src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-N100.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-no-tk"]
+  [make "-C" "metalib" "patch"]
   [make "core"]
   [make "coreboot"]
   [make "all"]
-  [make "ocamlopt"]
   [make "-i" "install"]
-  [make "-C" "ber-metaocaml-100" "all"]
-  [make "-C" "ber-metaocaml-100" "install"]
+  [make "-C" "metalib" "all"]
+  [make "-C" "metalib" "install"]
 ]
 packages: [
   "base-unix"


### PR DESCRIPTION
The patch file is no longer available from `eneide.happyleptic.org`.