### PR TITLE
Package git-unix.1.11.1

### DIFF
--- a/packages/git-unix/git-unix.1.11.1/descr
+++ b/packages/git-unix/git-unix.1.11.1/descr
@@ -1,0 +1,5 @@
+Unix backend for the Git protocol(s)
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git-unix/git-unix.1.11.1/opam
+++ b/packages/git-unix/git-unix.1.11.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "test/git-unix"]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "logs"
+  "git-http" {>= "1.11.0"}
+  "conduit"  {>= "0.8.4" < "1.0.0"}
+  "nocrypto" {>= "0.2.0"}
+  "mtime"    {>= "1.0.0"}
+  "base-unix"
+  "alcotest" {test}
+  "io-page"  {test & >= "1.6.1"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-unix/git-unix.1.11.1/url
+++ b/packages/git-unix/git-unix.1.11.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.1/git-1.11.1.tbz"
+checksum: "438dcbefab624c8c6b772d1b175eb16a"


### PR DESCRIPTION
### `git-unix.1.11.1`

Unix backend for the Git protocol(s)

The library comes with a command-line tool called `ogit` which shares
a similar interface with `git`, but where all operations are mapped to
the API exposed `ocaml-git` (and hence using only OCaml code).



---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---


---
### 1.11.1 (2017-07-25)

- [git-unix] Fix linking issue of the `ogit` binary on some package
  configurations (#225, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5