### PR TITLE
sexplib v0.9.2, ppx_inline_test v0.9.1, bin_prot v0.9.2

### DIFF
--- a/packages/bin_prot/bin_prot.v0.9.1/descr
+++ b/packages/bin_prot/bin_prot.v0.9.1/descr
@@ -1,0 +1,6 @@
+A binary protocol generator
+
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/bin_prot/bin_prot.v0.9.1/opam
+++ b/packages/bin_prot/bin_prot.v0.9.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/bin_prot"
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "https://github.com/janestreet/bin_prot.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.9" & < "v0.10"}
+  "jbuilder"                {build & >= "1.0+beta10"}
+  "ppx_compare"             {>= "v0.9" & < "v0.10"}
+  "ppx_custom_printf"       {>= "v0.9" & < "v0.10"}
+  "ppx_driver"              {>= "v0.9" & < "v0.10"}
+  "ppx_fields_conv"         {>= "v0.9" & < "v0.10"}
+  "ppx_sexp_conv"           {>= "v0.9" & < "v0.10"}
+  "ppx_variants_conv"       {>= "v0.9" & < "v0.10"}
+  "sexplib"                 {>= "v0.9" & < "v0.10"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+depopts: [
+  "mirage-xen-ocaml"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/bin_prot/bin_prot.v0.9.1/url
+++ b/packages/bin_prot/bin_prot.v0.9.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/bin_prot/archive/v0.9.1.tar.gz"
+checksum: "4f734f178e99c3d1227de7d096848d4b"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.9.2/descr
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.9.2/descr
@@ -1,0 +1,3 @@
+Syntax extension for writing in-line tests in ocaml code
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_inline_test/ppx_inline_test.v0.9.2/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.9.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.9" & < "v0.10"}
+  "jbuilder"                {build & >= "1.0+beta10"}
+  "ppx_core"                {>= "v0.9" & < "v0.10"}
+  "ppx_driver"              {>= "v0.9.1" & < "v0.10"}
+  "ppx_metaquot"            {>= "v0.9" & < "v0.10"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_inline_test/ppx_inline_test.v0.9.2/url
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.9.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/ppx_inline_test/archive/v0.9.2.tar.gz"
+checksum: "b1f06b6a27e7ee36f51e5b53d3655277"

--- a/packages/sexplib/sexplib.v0.9.2/descr
+++ b/packages/sexplib/sexplib.v0.9.2/descr
@@ -1,0 +1,6 @@
+Library for serializing OCaml values to and from S-expressions
+
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib/sexplib.v0.9.2/opam
+++ b/packages/sexplib/sexplib.v0.9.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/sexplib"
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "https://github.com/janestreet/sexplib.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "num"
+]
+
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/sexplib/sexplib.v0.9.2/url
+++ b/packages/sexplib/sexplib.v0.9.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/sexplib/archive/v0.9.2.tar.gz"
+checksum: "7d70f28d235a0ce28a57a5a2bf856326"


### PR DESCRIPTION
Minor releases of sexplib, ppx_inline_test and bin_prot. The only change in these 3 packages is the replacement of `per_file` by `per_module` in jbuild files. `per_file` was deprecated in jbuilder 1.0+beta10.