### PR TITLE
Constrain lablqt.0.4 to OCaml versions below 4.05.0.

### DIFF
--- a/packages/lablqt/lablqt.0.4/opam
+++ b/packages/lablqt/lablqt.0.4/opam
@@ -28,4 +28,4 @@ depends: [
   "cppo"        { test }
 ]
 
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.05.0"]


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/9924#issuecomment-318367107