### PR TITLE
Package stdint.0.4.1

### DIFF
--- a/packages/stdint/stdint.0.4.1/descr
+++ b/packages/stdint/stdint.0.4.1/descr
@@ -1,0 +1,9 @@
+signed and unsigned integer types having specified widths
+The stdint library provides signed and unsigned integer types of various
+fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical),
+conversion to and from buffers in both big endian and little endian byte order.

--- a/packages/stdint/stdint.0.4.1/opam
+++ b/packages/stdint/stdint.0.4.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andre@hostnet.com.br>"
+authors: [
+  "Andre Nathan" "Jeff Shaw" "Florian Pichlmeier" "Markus W. Weissmann"
+]
+homepage: "https://github.com/andrenth/ocaml-stdint"
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-stdint.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "project"]
+depends: "ocamlfind"

--- a/packages/stdint/stdint.0.4.1/url
+++ b/packages/stdint/stdint.0.4.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-stdint/archive/0.4.1.tar.gz"
+checksum: "bbdf81f5d3685deebfbc10f74fc6bd53"


### PR DESCRIPTION
### `stdint.0.4.1`

signed and unsigned integer types having specified widths
The stdint library provides signed and unsigned integer types of various
fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
This interface is similar to Int32 and Int64 from the base library but provides
more functions and constants like arithmetic and bit-wise operations, constants
like maximum and minimum values, infix operators conversion to and from every
other integer type (including int, float and nativeint), parsing from and
conversion to readable strings (binary, octal, decimal, hexademical),
conversion to and from buffers in both big endian and little endian byte order.



---
* Homepage: https://github.com/andrenth/ocaml-stdint
* Source repo: https://github.com/andrenth/ocaml-stdint.git
* Bug tracker: https://github.com/andrenth/ocaml-stdint/issues

---

:camel: Pull-request generated by opam-publish v0.3.5