### PR TITLE
Package pcre.7.3.0

### DIFF
--- a/packages/pcre/pcre.7.3.0/descr
+++ b/packages/pcre/pcre.7.3.0/descr
@@ -1,0 +1,4 @@
+Bindings to the Perl Compatibility Regular Expressions library
+
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language.

--- a/packages/pcre/pcre.7.3.0/opam
+++ b/packages/pcre/pcre.7.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "base-bytes"
+  "base"
+  "stdio"
+  "configurator"
+  "conf-libpcre"
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/pcre/pcre.7.3.0/url
+++ b/packages/pcre/pcre.7.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/pcre-ocaml/releases/download/7.3.0/pcre-7.3.0.tbz"
+checksum: "bd10ffef7b99eb1c80f6071f87869698"


### PR DESCRIPTION
### `pcre.7.3.0`

Bindings to the Perl Compatibility Regular Expressions library

pcre-ocaml offers library functions for string pattern matching and
substitution, similar to the functionality offered by the Perl language.



---
* Homepage: https://mmottl.github.io/pcre-ocaml
* Source repo: https://github.com/mmottl/pcre-ocaml.git
* Bug tracker: https://github.com/mmottl/pcre-ocaml/issues

---


---
### 7.3.0 (2017-07-27)

  * Switched to jbuilder and topkg
:camel: Pull-request generated by opam-publish v0.3.5