### PR TITLE
Package containers.1.3

### DIFF
--- a/packages/containers/containers.1.3/descr
+++ b/packages/containers/containers.1.3/descr
@@ -1,0 +1,12 @@
+A modular, clean and powerful extension of the OCaml standard library.
+
+Containers is an extension of OCaml's standard library (under BSD license)
+focused on data structures, combinators and iterators, without dependencies on
+unix, str or num. Every module is independent and is prefixed with 'CC' in the
+global namespace. Some modules extend the stdlib (e.g. CCList provides safe
+map/fold_right/append, and additional functions on lists).
+Alternatively, `open Containers` will bring enhanced versions of the standard
+modules into scope.
+
+It also features sub-libraries for dealing with threads, S-expressions,
+and the intricacies of unix.

--- a/packages/containers/containers.1.3/opam
+++ b/packages/containers/containers.1.3/opam
@@ -1,0 +1,47 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+doc: "http://cedeela.fr/~simon/software/containers/"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+dev-repo: "https://github.com/c-cube/ocaml-containers.git"
+build: [
+  [
+    "./configure"
+    "--prefix"
+    prefix
+    "--disable-bench"
+    "--disable-tests"
+    "--%{base-unix:enable}%-unix"
+    "--enable-docs"
+  ]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "containers"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "result"
+  "cppo" {build}
+  "ocamlbuild" {build}
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+  "qtest" {test}
+]
+conflicts: [
+  "sequence" {< "0.5"}
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages:
+  "
+Small release with many bugfixes and a few new functions.
+
+A summary hub.com/c-cube/ocaml-containers/issues/84
+changelog: https://github.com/c-cube/ocaml-containers/blob/1.3/CHANGELOG.adoc
+  "

--- a/packages/containers/containers.1.3/url
+++ b/packages/containers/containers.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-containers/archive/1.3.tar.gz"
+checksum: "4c483a6958a7292a5bd67d7da9a071e8"


### PR DESCRIPTION
### `containers.1.3`

A modular, clean and powerful extension of the OCaml standard library.

Containers is an extension of OCaml's standard library (under BSD license)
focused on data structures, combinators and iterators, without dependencies on
unix, str or num. Every module is independent and is prefixed with 'CC' in the
global namespace. Some modules extend the stdlib (e.g. CCList provides safe
map/fold_right/append, and additional functions on lists).
Alternatively, `open Containers` will bring enhanced versions of the standard
modules into scope.

It also features sub-libraries for dealing with threads, S-expressions,
and the intricacies of unix.



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---

:camel: Pull-request generated by opam-publish v0.3.5