### PR TITLE
Package aifad.2.1.0

### DIFF
--- a/packages/aifad/aifad.2.1.0/descr
+++ b/packages/aifad/aifad.2.1.0/descr
@@ -1,0 +1,4 @@
+AIFAD - Automated Induction of Functions over Algebraic Datatypes
+
+AIFAD is a machine learning tool that generalizes decision tree learning to
+algebraic datatypes.

--- a/packages/aifad/aifad.2.1.0/opam
+++ b/packages/aifad/aifad.2.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/aifad"
+dev-repo: "https://github.com/mmottl/aifad.git"
+bug-reports: "https://github.com/mmottl/aifad/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "res"
+  "pcre"
+  "cfg"
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/aifad/aifad.2.1.0/url
+++ b/packages/aifad/aifad.2.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/aifad/releases/download/2.1.0/aifad-2.1.0.tbz"
+checksum: "3f8fa2879b448b7a0b9ad3624515b0e2"


### PR DESCRIPTION
### `aifad.2.1.0`

AIFAD - Automated Induction of Functions over Algebraic Datatypes

AIFAD is a machine learning tool that generalizes decision tree learning to
algebraic datatypes.



---
* Homepage: https://mmottl.github.io/aifad
* Source repo: https://github.com/mmottl/aifad.git
* Bug tracker: https://github.com/mmottl/aifad/issues

---


---
### 2.1.0 (2017-07-30)

  * Switched to jbuilder and topkg
:camel: Pull-request generated by opam-publish v0.3.5