### PR TITLE
Add xenctrl.0.10.0

### DIFF
--- a/packages/xenctrl/xenctrl.0.10.0/descr
+++ b/packages/xenctrl/xenctrl.0.10.0/descr
@@ -1,0 +1,3 @@
+Low-level Xen hypercall bindings.
+
+This package should compile and work against Xen 4.2, 4.3, 4.4, 4.5, 4.6 and 4.7.

--- a/packages/xenctrl/xenctrl.0.10.0/opam
+++ b/packages/xenctrl/xenctrl.0.10.0/opam
@@ -1,0 +1,51 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: [
+  "David Scott"
+  "Jonathan Ludlam"
+  "Andrew Cooper"
+  "Bob Ball"
+  "Euan Harris"
+  "John Else"
+  "Mike McClurg"
+  "Rob Hoes"
+  "Si Beaumont"
+  "Thomas Sanders"
+  "Vincent Bernadoff"
+]
+homepage: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs"
+bug-reports: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/issues"
+license: "LGPL"
+dev-repo: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs.git"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["./configure"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "lwt"
+  "cmdliner"
+  "ocamlbuild" {build}
+]
+depexts: [
+  [["debian"] ["libxen-dev" "uuid-dev"]]
+  [["ubuntu"] ["libxen-dev" "uuid-dev"]]
+  [["centos"] ["xen-devel" "libuuid-devel"]]
+  [["fedora"] ["xen-devel"]]
+  [["rhel"] ["xen-devel"]]
+  [["oraclelinux"] ["xen-devel"]]
+  [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
+  [["alpine"] ["xen-dev"]]
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/xenctrl/xenctrl.0.10.0/url
+++ b/packages/xenctrl/xenctrl.0.10.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/archive/v0.10.0.tar.gz"
+checksum: "3cab9cb2b031e1dfe4de9afcc440d9aa"


### PR DESCRIPTION
Changes since the last release (0.9.32):
* Remove cpuid_check
* Fix linking with -lxentoollog
* Fix compilation on CentOS 7: add libuuid-devel as a depext to the opam file

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>