### PR TITLE
Fix lwt 3.1.0 dependency

### DIFF
--- a/packages/lwt/lwt.3.1.0/opam
+++ b/packages/lwt/lwt.3.1.0/opam
@@ -24,7 +24,7 @@ build: [
 build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
 
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   # We are only using ocamlfind during configuration of the Unix binding.
   "ocamlfind" {build & >= "1.5.0"}


### PR DESCRIPTION
Doesn't compile with earlier cppo, see eg https://travis-ci.org/ocaml/opam/jobs/256281794

Note that I had trouble with 3.0.0 as well, and this doesn't fix it.

@aantron : could you make sure the fix is upstreamed ?