### PR TITLE
github-unix: add an upper bound on cohttp

### DIFF
--- a/packages/github-unix/github-unix.3.0.0/opam
+++ b/packages/github-unix/github-unix.3.0.0/opam
@@ -29,6 +29,7 @@ build-test: [
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "github" {>="3.0.0"}
+  "cohttp" {>="0.20.0" & <"0.99"}
   "tls"
   "stringext"
   "lambda-term"


### PR DESCRIPTION
this was an implicit dependency previously, so add a concrete
one to fix the build.

fixes failure in #9967