### PR TITLE
add irmin 1.3.0

### DIFF
--- a/packages/irmin-chunk/irmin-chunk.1.3.0/descr
+++ b/packages/irmin-chunk/irmin-chunk.1.3.0/descr
@@ -1,0 +1,5 @@
+Irmin backend to store raw contents into chunks
+
+Allow to store raw contents into a well-balanced rope-like structure, where
+leafs are chunk of all the same size. Also provides a functor to do it while
+keeping the store keys stable.

--- a/packages/irmin-chunk/irmin-chunk.1.3.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.1.3.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "irmin" {>= "1.3.0"}
+  "lwt"
+  "irmin-mem" {test & >= "1.3.0"}
+  "alcotest"  {test & >="0.4.1"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-chunk/irmin-chunk.1.3.0/url
+++ b/packages/irmin-chunk/irmin-chunk.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"

--- a/packages/irmin-fs/irmin-fs.1.3.0/descr
+++ b/packages/irmin-fs/irmin-fs.1.3.0/descr
@@ -1,0 +1,1 @@
+Generic file-system backend for Irmin

--- a/packages/irmin-fs/irmin-fs.1.3.0/opam
+++ b/packages/irmin-fs/irmin-fs.1.3.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "irmin"    {>= "1.3.0"}
+  "alcotest" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin-fs/irmin-fs.1.3.0/url
+++ b/packages/irmin-fs/irmin-fs.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"

--- a/packages/irmin-git/irmin-git.1.3.0/descr
+++ b/packages/irmin-git/irmin-git.1.3.0/descr
@@ -1,0 +1,4 @@
+Git backend for Irmin
+
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.

--- a/packages/irmin-git/irmin-git.1.3.0/opam
+++ b/packages/irmin-git/irmin-git.1.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "irmin"    {>= "1.3.0"}
+  "git"      {>= "1.11.0"}
+  "alcotest" {test}
+  "git-unix" {test & >= "1.11.0"}
+  "mtime"    {test & >= "1.0.0"}
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-git/irmin-git.1.3.0/url
+++ b/packages/irmin-git/irmin-git.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"

--- a/packages/irmin-http/irmin-http.1.3.0/descr
+++ b/packages/irmin-http/irmin-http.1.3.0/descr
@@ -1,0 +1,1 @@
+HTTP client and server for Irmin

--- a/packages/irmin-http/irmin-http.1.3.0/opam
+++ b/packages/irmin-http/irmin-http.1.3.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "crunch"
+  "webmachine" {>= "0.3.2"}
+  "irmin"  {>= "1.3.0"}
+  "cohttp" {>= "0.18.3" & < "0.99.0"}
+  "irmin-git" {test & >= "1.3.0"}
+  "irmin-mem" {test & >= "1.3.0"}
+  "alcotest"  {test}
+  "mtime"     {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-http/irmin-http.1.3.0/url
+++ b/packages/irmin-http/irmin-http.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"

--- a/packages/irmin-mem/irmin-mem.1.3.0/descr
+++ b/packages/irmin-mem/irmin-mem.1.3.0/descr
@@ -1,0 +1,1 @@
+In-memory backend for Irmin

--- a/packages/irmin-mem/irmin-mem.1.3.0/opam
+++ b/packages/irmin-mem/irmin-mem.1.3.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "irmin"    {>= "1.3.0"}
+  "alcotest" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin-mem/irmin-mem.1.3.0/url
+++ b/packages/irmin-mem/irmin-mem.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"

--- a/packages/irmin-mirage/irmin-mirage.1.3.0/descr
+++ b/packages/irmin-mirage/irmin-mirage.1.3.0/descr
@@ -1,0 +1,1 @@
+MirageOS-compatible Irmin stores

--- a/packages/irmin-mirage/irmin-mirage.1.3.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder"   {build & >= "1.0+beta10"}
+  "irmin"      {>= "1.3.0"}
+  "irmin-git"  {>= "1.3.0"}
+  "irmin-mem"  {>= "1.3.0"}
+  "git-mirage" {>= "1.11.0"}
+  "ptime"
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "result"
+]

--- a/packages/irmin-mirage/irmin-mirage.1.3.0/url
+++ b/packages/irmin-mirage/irmin-mirage.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"

--- a/packages/irmin-unix/irmin-unix.1.3.0/descr
+++ b/packages/irmin-unix/irmin-unix.1.3.0/descr
@@ -1,0 +1,5 @@
+Unix backends for Irmin
+
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.

--- a/packages/irmin-unix/irmin-unix.1.3.0/opam
+++ b/packages/irmin-unix/irmin-unix.1.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "irmin"      {>= "1.3.0"}
+  "irmin-mem"  {>= "1.3.0"}
+  "irmin-git"  {>= "1.3.0"}
+  "irmin-http" {>= "1.3.0"}
+  "irmin-fs"   {>= "1.3.0"}
+  "git-unix"   {>= "1.11.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "irmin-mirage" {test & >= "1.3.0"}
+  "alcotest"     {test}
+  "mtime"        {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-unix/irmin-unix.1.3.0/url
+++ b/packages/irmin-unix/irmin-unix.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"

--- a/packages/irmin/irmin.1.3.0/descr
+++ b/packages/irmin/irmin.1.3.0/descr
@@ -1,0 +1,7 @@
+Irmin, a distributed database that follows the same design principles as Git
+
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.

--- a/packages/irmin/irmin.1.3.0/opam
+++ b/packages/irmin/irmin.1.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "result"
+  "fmt"
+  "uri" {>= "1.3.12"}
+  "cstruct" {>= "1.6.0"}
+  "jsonm" {>= "1.0.0"}
+  "lwt" {>= "2.4.7"}
+  "ocamlgraph"
+  "hex" {>= "0.2.0"}
+  "logs" {>= "0.5.0"}
+  "astring"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.3.0/url
+++ b/packages/irmin/irmin.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.0/irmin-1.3.0.tbz"
+checksum: "52547b19962b54f1696537307696d0c4"


### PR DESCRIPTION
### 1.3.0 (2017-07-27)

**irmin-chunk**

Add a new package: `irmin-chunk`, which was initially in a separate repository
created by @mounirnasrallah and @samoht and ported to the new Irmin API by
@g2p (#464)

**irmin-unix**

Re-add the `irmin` binary, the example application which used to be
installed by irmin-unix` before we switched to use `jbuilder`
(#466, @samoht -- reported by @ouenzzo and @dudelson)

**irmin**

That releases saw a nice series of patches to improve the performance of
`Irmin.Tree` contributed by the Tezos team:

- Improve complexity of `Irmin.Tree` operations: on trivial benchmarks with
  a lot of values, this patch introduces a 10-times speed-up
  (#457, @OCamlPro-Henry)

- Add missing equality for `Irmin.Type` primitives (#458, @OCamlPro-Henry)

- Change the type of `Hash.digest` to also take a type representation
  (#458, @OCamlPro-Henry)

- add `Irmin.Type.{encode,decode}_cstruct` (#458, @OCamlPro-Henry)

- remove `Irmin.Contents.RAW` (#458, @OCamlPro-Henry)

- avoid unecessary serialization and deserialization when computing hashes
  of cstructs (#459, @OCamlPro-Henry)

- remove `{Type,Merge}.int` which might cause some issue on 32 bits platforms.
  Intead use the more explicit (and portable) `{Type,Merge}.int32` or
  `{Type,Merge}.int64` (#469, @samoht)