### PR TITLE
Package gsl.1.20.0

### DIFF
--- a/packages/gsl/gsl.1.20.0/descr
+++ b/packages/gsl/gsl.1.20.0/descr
@@ -1,0 +1,6 @@
+GSL - Bindings to the GNU Scientific Library
+
+gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
+most frequently used functions for scientific computation including algorithms
+for optimization, differential equations, statistics, random number generation,
+linear algebra, etc.

--- a/packages/gsl/gsl.1.20.0/opam
+++ b/packages/gsl/gsl.1.20.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Olivier Andrieu <oandrieu@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+]
+license: "GPL-3+"
+homepage: "https://mmottl.github.io/gsl-ocaml"
+doc: "https://mmottl.github.io/gsl-ocaml/api"
+dev-repo: "https://github.com/mmottl/gsl-ocaml.git"
+bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-gsl"
+  "conf-pkg-config"
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/gsl/gsl.1.20.0/url
+++ b/packages/gsl/gsl.1.20.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/gsl-ocaml/releases/download/1.20.0/gsl-1.20.0.tbz"
+checksum: "12c2ff2cad2a8160f41703deffff1842"


### PR DESCRIPTION
### `gsl.1.20.0`

GSL - Bindings to the GNU Scientific Library

gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
most frequently used functions for scientific computation including algorithms
for optimization, differential equations, statistics, random number generation,
linear algebra, etc.



---
* Homepage: https://mmottl.github.io/gsl-ocaml
* Source repo: https://github.com/mmottl/gsl-ocaml.git
* Bug tracker: https://github.com/mmottl/gsl-ocaml/issues

---


---
### 1.20.0 (2017-08-01)

  * Switched to jbuilder and topkg
:camel: Pull-request generated by opam-publish v0.3.5