### PR TITLE
Package github-jsoo.3.0.1

### DIFF
--- a/packages/github-jsoo/github-jsoo.3.0.1/descr
+++ b/packages/github-jsoo/github-jsoo.3.0.1/descr
@@ -1,0 +1,23 @@
+GitHub APIv3 OCaml Library
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-github.svg)](https://travis-ci.org/mirage/ocaml-github)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/ocaml-github/)
+
+This library provides an OCaml interface to the [GitHub
+APIv3](https://developer.github.com/v3/) (JSON). It is compatible with
+[MirageOS](https://mirage.io) and also compiles to pure JavaScript via
+[js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+
+It is [not yet complete](#api-support-coverage) but
+[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib/github.atd)
+contains the data types that have been bound so far.
+
+There are several tests and examples in
+[lib_test](https://github.com/mirage/ocaml-github/tree/master/lib_test)
+for small bits of
+functionality. [jar](https://github.com/mirage/ocaml-github/tree/master/jar)
+contains utility programs that use the [git jar](#git-jar) facility for
+stored tokens.
+
+If you are interested in easily using this library to listen for GitHub
+web hook events, you should look at [dsheets/ocaml-github-hooks](https://github.com/dsheets/ocaml-github-hooks).

--- a/packages/github-jsoo/github-jsoo.3.0.1/opam
+++ b/packages/github-jsoo/github-jsoo.3.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+homepage: "https://github.com/mirage/ocaml-github"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+dev-repo: "https://github.com/mirage/ocaml-github.git"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+  "git"
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml"
+  "github"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/github-jsoo/github-jsoo.3.0.1/url
+++ b/packages/github-jsoo/github-jsoo.3.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-github/archive/v3.0.1.tar.gz"
+checksum: "4505cc25fbadf7d9d0e3a46d3c1ee128"


### PR DESCRIPTION
### `github-jsoo.3.0.1`

GitHub APIv3 OCaml Library

[![Build Status](https://travis-ci.org/mirage/ocaml-github.svg)](https://travis-ci.org/mirage/ocaml-github)
[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/ocaml-github/)

This library provides an OCaml interface to the [GitHub
APIv3](https://developer.github.com/v3/) (JSON). It is compatible with
[MirageOS](https://mirage.io) and also compiles to pure JavaScript via
[js_of_ocaml](http://ocsigen.org/js_of_ocaml).

It is [not yet complete](#api-support-coverage) but
[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib/github.atd)
contains the data types that have been bound so far.

There are several tests and examples in
[lib_test](https://github.com/mirage/ocaml-github/tree/master/lib_test)
for small bits of
functionality. [jar](https://github.com/mirage/ocaml-github/tree/master/jar)
contains utility programs that use the [git jar](#git-jar) facility for
stored tokens.

If you are interested in easily using this library to listen for GitHub
web hook events, you should look at [dsheets/ocaml-github-hooks](https://github.com/dsheets/ocaml-github-hooks).


---
* Homepage: https://github.com/mirage/ocaml-github
* Source repo: https://github.com/mirage/ocaml-github.git
* Bug tracker: https://github.com/mirage/ocaml-github/issues

---

:camel: Pull-request generated by opam-publish v0.3.5