### PR TITLE
Package pomap.4.0.0

### DIFF
--- a/packages/pomap/pomap.4.0.0/descr
+++ b/packages/pomap/pomap.4.0.0/descr
@@ -1,0 +1,4 @@
+POMAP - Partially Ordered Maps for OCaml
+
+POMAP supports creating and manipulating partially ordered maps in a purely
+functional and efficient way.

--- a/packages/pomap/pomap.4.0.0/opam
+++ b/packages/pomap/pomap.4.0.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/pomap"
+doc: "https://mmottl.github.io/pomap/api"
+dev-repo: "https://github.com/mmottl/pomap.git"
+bug-reports: "https://github.com/mmottl/pomap/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/pomap/pomap.4.0.0/url
+++ b/packages/pomap/pomap.4.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/pomap/releases/download/4.0.0/pomap-4.0.0.tbz"
+checksum: "ee7f9c232c07208c4e4c202393e726d7"


### PR DESCRIPTION
### `pomap.4.0.0`

POMAP - Partially Ordered Maps for OCaml

POMAP supports creating and manipulating partially ordered maps in a purely
functional and efficient way.



---
* Homepage: https://mmottl.github.io/pomap
* Source repo: https://github.com/mmottl/pomap.git
* Bug tracker: https://github.com/mmottl/pomap/issues

---


---
### 4.0.0 (2017-08-02)

  * Switched to jbuilder and topkg
:camel: Pull-request generated by opam-publish v0.3.5