### PR TITLE
Package res.5.0.0

### DIFF
--- a/packages/res/res.5.0.0/descr
+++ b/packages/res/res.5.0.0/descr
@@ -1,0 +1,3 @@
+RES - Library for resizable, contiguous datastructures
+
+RES is a library containing resizable arrays, strings, and bitvectors.

--- a/packages/res/res.5.0.0/opam
+++ b/packages/res/res.5.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/res"
+doc: "https://mmottl.github.io/res/api"
+dev-repo: "https://github.com/mmottl/res.git"
+bug-reports: "https://github.com/mmottl/res/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "base-bytes"
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/res/res.5.0.0/url
+++ b/packages/res/res.5.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/res/releases/download/5.0.0/res-5.0.0.tbz"
+checksum: "895530e42bc39b3502bba1d90d83dc8e"


### PR DESCRIPTION
### `res.5.0.0`

RES - Library for resizable, contiguous datastructures

RES is a library containing resizable arrays, strings, and bitvectors.



---
* Homepage: https://mmottl.github.io/res
* Source repo: https://github.com/mmottl/res.git
* Bug tracker: https://github.com/mmottl/res/issues

---


---
### 5.0.0 (2017-08-02)

  * Switched to jbuilder and topkg
:camel: Pull-request generated by opam-publish v0.3.5