### PR TITLE
cmdliner.1.0.1 - via opam-publish

### DIFF
--- a/packages/cmdliner/cmdliner.1.0.1/descr
+++ b/packages/cmdliner/cmdliner.1.0.1/descr
@@ -1,0 +1,15 @@
+Declarative definition of command line interfaces for OCaml
+
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html

--- a/packages/cmdliner/cmdliner.1.0.1/opam
+++ b/packages/cmdliner/cmdliner.1.0.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+available: [ocaml-version >= "4.01.0"]
+depends:[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+]]

--- a/packages/cmdliner/cmdliner.1.0.1/url
+++ b/packages/cmdliner/cmdliner.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.1.tbz"
+checksum: "6eb1083e64fa8775e5df16d8c9b1bc75"


### PR DESCRIPTION
Declarative definition of command line interfaces for OCaml

Cmdliner allows the declarative definition of command line interfaces
for OCaml.

It provides a simple and compositional mechanism to convert command
line arguments to OCaml values and pass them to your functions. The
module automatically handles syntax errors, help messages and UNIX man
page generation. It supports programs with single or multiple commands
and respects most of the [POSIX][1] and [GNU][2] conventions.

Cmdliner has no dependencies and is distributed under the ISC license.

[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html


---
* Homepage: http://erratique.ch/software/cmdliner
* Source repo: http://erratique.ch/repos/cmdliner.git
* Bug tracker: https://github.com/dbuenzli/cmdliner/issues

---


---
v1.0.1 2017-08-03 Zagreb
------------------------

- Add a `Makefile` to build and install cmdliner without `topkg` and
  opam `.install` files. Helps bootstraping opam in OS package
  managers. Thanks to Hendrik Tews for the patches.
Pull-request generated by opam-publish v0.3.4