### PR TITLE
Package postgresql.4.1.0

### DIFF
--- a/packages/postgresql/postgresql.4.1.0/descr
+++ b/packages/postgresql/postgresql.4.1.0/descr
@@ -1,0 +1,3 @@
+Bindings to the PostgreSQL library
+
+Postgresql offers library functions for accessing PostgreSQL databases.

--- a/packages/postgresql/postgresql.4.1.0/opam
+++ b/packages/postgresql/postgresql.4.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+dev-repo: "https://github.com/mmottl/postgresql-ocaml.git"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "base-bytes"
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+depexts: [
+  [["debian"] ["libpq-dev"]]
+  [["freebsd"] ["database/postgresql96-client"]]
+  [["openbsd"] ["database/postgresql96-client"]]
+  [["ubuntu"] ["libpq-dev"]]
+  [["centos"] ["postgresql-devel"]]
+  [["rhel"] ["postgresql-devel"]]
+  [["fedora"] ["postgresql-devel"]]
+  [["alpine"] ["postgresql-dev"]]
+  [["opensuse"] ["postgresql"]]
+  [["osx" "homebrew"] ["postgresql"]]
+  [["osx" "macports"] ["postgresql96"]]
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/postgresql/postgresql.4.1.0/url
+++ b/packages/postgresql/postgresql.4.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/postgresql-ocaml/releases/download/4.1.0/postgresql-4.1.0.tbz"
+checksum: "1245a17e3c251bbf2942e84acb7c737c"


### PR DESCRIPTION
### `postgresql.4.1.0`

Bindings to the PostgreSQL library

Postgresql offers library functions for accessing PostgreSQL databases.



---
* Homepage: https://mmottl.github.io/postgresql-ocaml
* Source repo: https://github.com/mmottl/postgresql-ocaml.git
* Bug tracker: https://github.com/mmottl/postgresql-ocaml/issues

---


---
### 4.1.0 (2017-08-02)

  * Switched to jbuilder and topkg
:camel: Pull-request generated by opam-publish v0.3.5