### PR TITLE
Package sqlite3.4.2.0

### DIFF
--- a/packages/sqlite3/sqlite3.4.2.0/descr
+++ b/packages/sqlite3/sqlite3.4.2.0/descr
@@ -1,0 +1,5 @@
+sqlite3-ocaml - SQLite3 bindings for OCaml
+
+sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
+Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
+database engine with outstanding performance for many use cases.

--- a/packages/sqlite3/sqlite3.4.2.0/opam
+++ b/packages/sqlite3/sqlite3.4.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christian Szegedy <csdontspam@metamatix.com>"
+]
+license: "Expat"
+homepage: "http://mmottl.github.io/sqlite3-ocaml"
+doc: "https://mmottl.github.io/sqlite3-ocaml/api"
+dev-repo: "https://github.com/mmottl/sqlite3-ocaml.git"
+bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
+tags: [ "clib:sqlite3" "clib:pthread"  ]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-pkg-config" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+depexts: [
+  [["debian"] ["libsqlite3-dev"]]
+  [["freebsd"] ["database/sqlite3"]]
+  [["openbsd"] ["database/sqlite3"]]
+  [["ubuntu"] ["libsqlite3-dev"]]
+  [["centos"] ["sqlite-devel"]]
+  [["rhel"] ["sqlite-devel"]]
+  [["fedora"] ["sqlite-devel"]]
+  [["alpine"] ["sqlite-dev"]]
+  [["opensuse"] ["sqlite3-devel"]]
+  [["osx" "homebrew"] ["sqlite3"]]
+  [["osx" "macports"] ["sqlite3"]]
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/sqlite3/sqlite3.4.2.0/url
+++ b/packages/sqlite3/sqlite3.4.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/sqlite3-ocaml/releases/download/4.2.0/sqlite3-4.2.0.tbz"
+checksum: "ee2ea6437559185e88dc92da9252235b"


### PR DESCRIPTION
### `sqlite3.4.2.0`

sqlite3-ocaml - SQLite3 bindings for OCaml

sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
database engine with outstanding performance for many use cases.



---
* Homepage: http://mmottl.github.io/sqlite3-ocaml
* Source repo: https://github.com/mmottl/sqlite3-ocaml.git
* Bug tracker: https://github.com/mmottl/sqlite3-ocaml/issues

---


---
### 4.2.0 (2017-08-03)

  * Switched to jbuilder and topkg

  * Added backup functionality

    Thanks to Markus W. Weissmann <markus.weissmann@in.tum.de> for this
    contribution!
:camel: Pull-request generated by opam-publish v0.3.5