### PR TITLE
Lwt: require cppo >= 1.1.0

### DIFF
--- a/packages/lwt/lwt.2.7.1/opam
+++ b/packages/lwt/lwt.2.7.1/opam
@@ -39,7 +39,7 @@ depends: [
   "ocamlfind" {build & >= "1.5.0"}
   "ocamlbuild" {build}
   "result"
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   # See https://github.com/ocsigen/lwt/issues/266
   ( "base-no-ppx" | "ppx_tools" {build} )
 ]

--- a/packages/lwt/lwt.3.0.0/opam
+++ b/packages/lwt/lwt.3.0.0/opam
@@ -36,7 +36,7 @@ depends: [
   "ocamlfind" {build & >= "1.5.0"}
   "ocamlbuild" {build}
   "result"
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   # See https://github.com/ocsigen/lwt/issues/266
   ( "base-no-ppx" | "ppx_tools" {build} )
 ]


### PR DESCRIPTION
Lwt uses cppo's `-V`, which was [added in cppo 1.1.0](https://github.com/mjambon/cppo/blob/641b058f6334e2fcc575f91faefaa693294115c4/Changes#L28).

@rgrinberg fixed this in the Lwt repo in https://github.com/ocsigen/lwt/pull/460.

@AltGr fixed this in the published Lwt 3.1.0 `opam` file in https://github.com/ocaml/opam-repository/pull/9966.

This PR just finishes the process off by adding a bound to the remaining published Lwt `opam` files that mention cppo (3.0.0 and 2.7.1).