### PR TITLE
Package secp256k1.0.3.0

### DIFF
--- a/packages/secp256k1/secp256k1.0.3.0/descr
+++ b/packages/secp256k1/secp256k1.0.3.0/descr
@@ -1,0 +1,14 @@
+Elliptic curve library secp256k1 wrapper for Ocaml
+
+This library wrap the secp256k1 EC(DSA) library into an OCaml library. At 
+the moment only a subset of functionalities are available:
+
+- Context: create, clone, destroy, randomize
+- Elliptic curve: public key creation
+- ECDSA: verify, sign
+
+
+All exchanged data (pubkey, signature, seckey) are represented as hex 
+strings.
+
+

--- a/packages/secp256k1/secp256k1.0.3.0/opam
+++ b/packages/secp256k1/secp256k1.0.3.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Yoichi Hirai <i@yoichihirai.com>"
+]
+homepage: "https://github.com/dakk/secp256k1-ml"
+bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/secp256k1-ml"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta9"}
+  "base" {build & >= "v0.9.2"}
+  "stdio" {build & >= "v0.9.0"}
+  "configurator" {build & >= "v0.9.1"}
+  "hex" {test & >= "1.1.1"}
+  "ounit" {test & >= "2.2.2"}
+  "base-bigarray"
+]
+depexts: [
+  [["archlinux"] ["libsecp256k1-git"]]
+  [["debian"] ["libsecp256k1" "libsecp256k1-dev"]]
+  [["gentoo"] ["libsecp256k1"]]
+  [["ubuntu"] ["libsecp256k1" "libsecp256k1-dev"]]
+]

--- a/packages/secp256k1/secp256k1.0.3.0/url
+++ b/packages/secp256k1/secp256k1.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dakk/secp256k1-ml/archive/0.3.0.zip"
+checksum: "4a4a3f162fe0e9ab409ab6176133d0f3"


### PR DESCRIPTION
### `secp256k1.0.3.0`

Elliptic curve library secp256k1 wrapper for Ocaml

This library wrap the secp256k1 EC(DSA) library into an OCaml library. At 
the moment only a subset of functionalities are available:

- Context: create, clone, destroy, randomize
- Elliptic curve: public key creation
- ECDSA: verify, sign


All exchanged data (pubkey, signature, seckey) are represented as hex 
strings.





---
* Homepage: https://github.com/dakk/secp256k1-ml
* Source repo: https://github.com/dakk/secp256k1-ml
* Bug tracker: https://github.com/dakk/secp256k1-ml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5