### PR TITLE
Packages cmdtui.0.4.3 and cmdtui-lambda-term.0.4.3

### DIFF
--- a/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/descr
+++ b/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/descr
@@ -1,0 +1,9 @@
+Interactive command completion and execution for building REPLs
+
+cmdtui is a module for declaring commands with completions and actions.
+It can return a dynamically generated list of completions based on partial user
+input.
+The base module doesn't depend on a particular terminal control library,
+and support for `lambda-term` based REPLs is provided in the `cmdtui.lambda-term` subpackage.
+
+cmdtui is distributed under the ISC license.

--- a/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
+++ b/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Török Edwin <edwin@etorok.net>"
+authors: ["Török Edwin <edwin@etorok.net>"]
+homepage: "https://gitlab.com/edwintorok/cmdtui"
+doc: "https://edwintorok.gitlab.io/cmdtui/doc"
+license: "ISC"
+dev-repo: "https://gitlab.com/edwintorok/cmdtui.git"
+bug-reports: "https://gitlab.com/edwintorok/cmdtui/issues"
+tags: []
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build}
+  "astring" { >= "0.8.3" }
+  "fmt" { >= "0.8.0" }
+  "lambda-term"
+  "cmdliner"
+  "logs"
+  "lwt"
+  "cmdtui"
+]
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/url
+++ b/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/url
@@ -1,0 +1,2 @@
+archive: "https://gitlab.com/edwintorok/cmdtui/uploads/6b3cad4a29a2b1f1a019e1a1ded0e429/cmdtui-0.4.3.tbz"
+checksum: "8a792d806efab956df37f2d9316f569f"

--- a/packages/cmdtui/cmdtui.0.4.3/descr
+++ b/packages/cmdtui/cmdtui.0.4.3/descr
@@ -1,0 +1,9 @@
+Interactive command completion and execution for building REPLs
+
+cmdtui is a module for declaring commands with completions and actions.
+It can return a dynamically generated list of completions based on partial user
+input.
+The base module doesn't depend on a particular terminal control library,
+and support for `lambda-term` based REPLs is provided in the `cmdtui.lambda-term` subpackage.
+
+cmdtui is distributed under the ISC license.

--- a/packages/cmdtui/cmdtui.0.4.3/opam
+++ b/packages/cmdtui/cmdtui.0.4.3/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Török Edwin <edwin@etorok.net>"
+authors: ["Török Edwin <edwin@etorok.net>"]
+homepage: "https://gitlab.com/edwintorok/cmdtui"
+doc: "https://edwintorok.gitlab.io/cmdtui/doc"
+license: "ISC"
+dev-repo: "https://gitlab.com/edwintorok/cmdtui.git"
+bug-reports: "https://gitlab.com/edwintorok/cmdtui/issues"
+tags: []
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "astring" { >= "0.8.3" }
+]
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/cmdtui/cmdtui.0.4.3/url
+++ b/packages/cmdtui/cmdtui.0.4.3/url
@@ -1,0 +1,2 @@
+archive: "https://gitlab.com/edwintorok/cmdtui/uploads/6b3cad4a29a2b1f1a019e1a1ded0e429/cmdtui-0.4.3.tbz"
+checksum: "8a792d806efab956df37f2d9316f569f"


### PR DESCRIPTION
Interactive command completion and execution for building REPLs

This pull-request concerns:
-`cmdtui.0.4.3`
-`cmdtui-lambda-term.0.4.3`



---
* Homepage: https://gitlab.com/edwintorok/cmdtui
* Source repo: https://gitlab.com/edwintorok/cmdtui.git
* Bug tracker: https://gitlab.com/edwintorok/cmdtui/issues

---

:camel: Pull-request generated by opam-publish v0.3.5