### PR TITLE
ocamlnet.4.1.2 doesn't build with 4.04.2+flambda due to Mantis 7426.

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -58,5 +58,7 @@ depopts: [
   "pcre"
   "camlzip"
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.05.0" & compiler != "4.04.0+flambda" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.05.0"
+            & compiler != "4.04.0+flambda"
+            & compiler != "4.04.2+flambda" ]
 install: [make "install"]


### PR DESCRIPTION
cf. https://github.com/ocaml/opam-repository/pull/8246