### PR TITLE
dns-forward: add missing build dep on ppx_sexp_conv

### DIFF
--- a/packages/dns-forward/dns-forward.0.7.2/opam
+++ b/packages/dns-forward/dns-forward.0.7.2/opam
@@ -19,6 +19,7 @@ depends: [
   "topkg"      {build}
   "ppx_tools"  {build}
   "ppx_cstruct" {build}
+  "ppx_sexp_conv" {build}
   "cmdliner"
   "mirage-flow" {= "1.1.0"}
   "channel"

--- a/packages/dns-forward/dns-forward.0.7.2/opam
+++ b/packages/dns-forward/dns-forward.0.7.2/opam
@@ -28,7 +28,7 @@ depends: [
   "cstruct"     {>= "2.4" & <"3.0"}
   "cstruct-lwt"
   "result"
-  "lwt"         {>= "2.6.0"}
+  "lwt"         {>= "2.6.0" & <"3.0.0"}
   "logs"        {>= "0.5.0"}
   "mtime"       {< "1.0.0"}
   "sexplib"

--- a/packages/dns-forward/dns-forward.0.9.0/opam
+++ b/packages/dns-forward/dns-forward.0.9.0/opam
@@ -15,6 +15,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder"        {build & >= "1.0+beta10"}
+  "ppx_sexp_conv"   {build}
   "cstruct"         {>= "3.0.0"}
   "logs"            {>= "0.5.0"}
   "lwt"             {>= "2.7.0"}


### PR DESCRIPTION
Related to [mirage/ocaml-dns-forward#74]

Signed-off-by: David Scott <dave@recoil.org>