### PR TITLE
Package ocal.0.1.3

### DIFF
--- a/packages/ocal/ocal.0.1.3/descr
+++ b/packages/ocal/ocal.0.1.3/descr
@@ -1,0 +1,5 @@
+An improved Unix `cal` utility
+
+
+A replacement for the standard Unix `cal` utility. Partly because I could,
+partly because I'd become too irritated with its command line interface.

--- a/packages/ocal/ocal.0.1.3/opam
+++ b/packages/ocal/ocal.0.1.3/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "ocal"
+maintainer: "Richard Mortier <mort@cantab.net>"
+authors: [ "Richard Mortier" ]
+license: "ISC"
+
+homepage: "https://github.com/mor1/ocal"
+dev-repo: "https://github.com/mor1/ocal.git"
+bug-reports: "https://github.com/mor1/ocal/issues"
+doc: "https://mor1.github.io/ocal/"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "jbuilder"  {build & >="1.0+beta11"}
+  "astring"   {build}
+  "calendar"  {build}
+  "cmdliner"  {build}
+]

--- a/packages/ocal/ocal.0.1.3/url
+++ b/packages/ocal/ocal.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mor1/ocal/releases/download/0.1.3/ocal-0.1.3.tbz"
+checksum: "d44a7cfd060ef8b32694ff4ef44df1f3"


### PR DESCRIPTION
### `ocal.0.1.3`

An improved Unix `cal` utility


A replacement for the standard Unix `cal` utility. Partly because I could,
partly because I'd become too irritated with its command line interface.


---
* Homepage: https://github.com/mor1/ocal
* Source repo: https://github.com/mor1/ocal.git
* Bug tracker: https://github.com/mor1/ocal/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
### 0.1.3 (2017-08-02)

  * Upgrade build to use `jbuilder` and modern `opam`, `topkg`, etc
  * Fix a few warnings
:camel: Pull-request generated by opam-publish v0.3.5