### PR TITLE
Package anycache.0.7.4 and 2 others

### DIFF
--- a/packages/anycache-async/anycache-async.0.7.4/descr
+++ b/packages/anycache-async/anycache-async.0.7.4/descr
@@ -1,0 +1,8 @@
+Scan-resistant LRU/2Q cache
+
+anycache is a scan-resistant LRU/2Q cache.
+See the [documentation][basics] for details on the algorithm used.
+
+[basics]: https://edwintorok.gitlab.io/ocaml-anycache/doc/Anycache.html#basics
+
+anycache is distributed under the ISC license.

--- a/packages/anycache-async/anycache-async.0.7.4/opam
+++ b/packages/anycache-async/anycache-async.0.7.4/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Török Edwin <edwin@etorok.net>"
+authors: ["Török Edwin <edwin@etorok.net>"]
+homepage: "https://gitlab.com/edwintorok/ocaml-anycache"
+doc: "https://edwintorok.gitlab.io/ocaml-anycache/doc"
+license: "ISC"
+dev-repo: "https://gitlab.com/edwintorok/ocaml-anycache.git"
+bug-reports: "https://gitlab.com/edwintorok/ocaml-anycache/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "topkg-jbuilder" {build}
+  "alcotest" { test & >= "0.7.2" }
+  "base-bytes"
+  "anycache"
+  "core"
+  "async_kernel"
+  "async_unix"
+]
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/anycache-async/anycache-async.0.7.4/url
+++ b/packages/anycache-async/anycache-async.0.7.4/url
@@ -1,0 +1,2 @@
+archive: "https://gitlab.com/edwintorok/ocaml-anycache/uploads/47d27fb2e3ac835994d7b546872b12cb/anycache-0.7.4.tbz"
+checksum: "66a9853877b97187f6eb118b9d865a9a"

--- a/packages/anycache-lwt/anycache-lwt.0.7.4/descr
+++ b/packages/anycache-lwt/anycache-lwt.0.7.4/descr
@@ -1,0 +1,8 @@
+Scan-resistant LRU/2Q cache
+
+anycache is a scan-resistant LRU/2Q cache.
+See the [documentation][basics] for details on the algorithm used.
+
+[basics]: https://edwintorok.gitlab.io/ocaml-anycache/doc/Anycache.html#basics
+
+anycache is distributed under the ISC license.

--- a/packages/anycache-lwt/anycache-lwt.0.7.4/opam
+++ b/packages/anycache-lwt/anycache-lwt.0.7.4/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Török Edwin <edwin@etorok.net>"
+authors: ["Török Edwin <edwin@etorok.net>"]
+homepage: "https://gitlab.com/edwintorok/ocaml-anycache"
+doc: "https://edwintorok.gitlab.io/ocaml-anycache/doc"
+license: "ISC"
+dev-repo: "https://gitlab.com/edwintorok/ocaml-anycache.git"
+bug-reports: "https://gitlab.com/edwintorok/ocaml-anycache/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "topkg-jbuilder" {build}
+  "alcotest" { test & >= "0.7.2" }
+  "base-bytes"
+  "anycache"
+  "lwt"
+]
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/anycache-lwt/anycache-lwt.0.7.4/url
+++ b/packages/anycache-lwt/anycache-lwt.0.7.4/url
@@ -1,0 +1,2 @@
+archive: "https://gitlab.com/edwintorok/ocaml-anycache/uploads/47d27fb2e3ac835994d7b546872b12cb/anycache-0.7.4.tbz"
+checksum: "66a9853877b97187f6eb118b9d865a9a"

--- a/packages/anycache/anycache.0.7.4/descr
+++ b/packages/anycache/anycache.0.7.4/descr
@@ -1,0 +1,8 @@
+Scan-resistant LRU/2Q cache
+
+anycache is a scan-resistant LRU/2Q cache.
+See the [documentation][basics] for details on the algorithm used.
+
+[basics]: https://edwintorok.gitlab.io/ocaml-anycache/doc/Anycache.html#basics
+
+anycache is distributed under the ISC license.

--- a/packages/anycache/anycache.0.7.4/opam
+++ b/packages/anycache/anycache.0.7.4/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Török Edwin <edwin@etorok.net>"
+authors: ["Török Edwin <edwin@etorok.net>"]
+homepage: "https://gitlab.com/edwintorok/ocaml-anycache"
+doc: "https://edwintorok.gitlab.io/ocaml-anycache/doc"
+license: "ISC"
+dev-repo: "https://gitlab.com/edwintorok/ocaml-anycache.git"
+bug-reports: "https://gitlab.com/edwintorok/ocaml-anycache/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "topkg-jbuilder" {build}
+  "alcotest" { test & >= "0.7.2" }
+  "base-bytes"
+  "result"
+  "lru"
+]
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/anycache/anycache.0.7.4/url
+++ b/packages/anycache/anycache.0.7.4/url
@@ -1,0 +1,2 @@
+archive: "https://gitlab.com/edwintorok/ocaml-anycache/uploads/47d27fb2e3ac835994d7b546872b12cb/anycache-0.7.4.tbz"
+checksum: "66a9853877b97187f6eb118b9d865a9a"


### PR DESCRIPTION
Scan-resistant LRU/2Q cache

This pull-request concerns:
-`anycache.0.7.4`
-`anycache-lwt.0.7.4`
-`anycache-async.0.7.4`



---
* Homepage: https://gitlab.com/edwintorok/ocaml-anycache
* Source repo: https://gitlab.com/edwintorok/ocaml-anycache.git
* Bug tracker: https://gitlab.com/edwintorok/ocaml-anycache/issues

---

:camel: Pull-request generated by opam-publish v0.3.5