### PR TITLE
Package ocaml-topexpect.0.2

### DIFF
--- a/packages/ocaml-topexpect/ocaml-topexpect.0.2/descr
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.2/descr
@@ -1,0 +1,3 @@
+Simulate and post-process ocaml toplevel sessions
+
+A variant of ocaml-expect from toplevel_expect_test that mimics ocaml toplevel more closely

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.2/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.2/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/topexpect"
+bug-reports: "https://github.com/let-def/topexpect"
+license: "MIT"
+dev-repo: "https://github.com/let-def/topexpect.git"
+build: [make]
+depends: ["ocamlfind" "ppx_sexp_conv" "ppx_deriving"]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.2/url
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/topexpect/archive/v0.2.tar.gz"
+checksum: "d7385c7b230fb02daafe50f04236268a"


### PR DESCRIPTION
### `ocaml-topexpect.0.2`

Simulate and post-process ocaml toplevel sessions

A variant of ocaml-expect from toplevel_expect_test that mimics ocaml toplevel more closely



---
* Homepage: https://github.com/let-def/topexpect
* Source repo: https://github.com/let-def/topexpect.git
* Bug tracker: https://github.com/let-def/topexpect

---

:camel: Pull-request generated by opam-publish v0.3.5