### PR TITLE
Package mccs.1.1+2

### DIFF
--- a/packages/mccs/mccs.1.1+2/descr
+++ b/packages/mccs/mccs.1.1+2/descr
@@ -1,0 +1,5 @@
+Multi Criteria CUDF Solver with OCaml bindings
+
+This is a stripped-down version of the mccs solver (written in C++), including
+OCaml bindings based on the cudf library. Note that it includes some correctness
+fixes, and a few changes not present in the upstream yet.

--- a/packages/mccs/mccs.1.1+2/opam
+++ b/packages/mccs/mccs.1.1+2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Claude Michel <claude.michel@unice.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+homepage: "http://www.i3s.unice.fr/~cpjm/misc/"
+bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
+license: "BSD-3-clause"
+dev-repo: "https://github.com/AltGr/ocaml-mccs.git"
+build: ["jbuilder" "build" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "conf-glpk"
+  "cudf" {>= "0.7"}
+]

--- a/packages/mccs/mccs.1.1+2/url
+++ b/packages/mccs/mccs.1.1+2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/ocaml-mccs/archive/1.1+2b.tar.gz"
+checksum: "6d2feeb5763b1894a8b44997a04c8f25"


### PR DESCRIPTION
### `mccs.1.1+2`

Multi Criteria CUDF Solver with OCaml bindings

This is a stripped-down version of the mccs solver (written in C++), including
OCaml bindings based on the cudf library. Note that it includes some correctness
fixes, and a few changes not present in the upstream yet.



---
* Homepage: http://www.i3s.unice.fr/~cpjm/misc/
* Source repo: https://github.com/AltGr/ocaml-mccs.git
* Bug tracker: https://github.com/AltGr/ocaml-mccs/issues

---

:camel: Pull-request generated by opam-publish v0.3.5