### PR TITLE
Package root1d.0.5

### DIFF
--- a/packages/root1d/root1d.0.5/descr
+++ b/packages/root1d/root1d.0.5/descr
@@ -1,0 +1,26 @@
+Find roots of 1D functions
+
+The module `Root1D` provides a collection of functions to seek roots
+of functions `float → float`.
+
+
+Installation
+------------
+
+The easier way of installing this package is by using [opam][]:
+
+```shell
+opam install root1d
+```
+
+To compile bu hand, install [jbuilder][] and do `jbuilder build`.
+
+
+[opam]: https://opam.ocaml.org/
+[jbuilder]: https://github.com/janestreet/jbuilder
+
+Documentation
+-------------
+
+See the [signature of `Root1D`](src/Root1D.mli).  It can also be
+consulted rendered to [HTML](http://math.umons.ac.be/an/software/doc/Root1D/).

--- a/packages/root1d/root1d.0.5/opam
+++ b/packages/root1d/root1d.0.5/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Edgar Friendly <thelema314@gmail.com>" ]
+tags: ["scientfic" "root finding"]
+license: "ISC"
+homepage: "https://github.com/Chris00/root1d"
+dev-repo: "https://github.com/Chris00/root1d.git"
+bug-reports: "https://github.com/Chris00/root1d/issues"
+doc: "https://Chris00.github.io/root1d/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder"  {build & >="1.0+beta9"}
+]
+depopts: [
+  "benchmark"
+]
+available: [ ocaml-version >= "4.0.0" ]

--- a/packages/root1d/root1d.0.5/url
+++ b/packages/root1d/root1d.0.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/root1d/releases/download/0.5/root1d-0.5.tbz"
+checksum: "3cf56f6370eb6e425dd9aa2439092582"


### PR DESCRIPTION
### `root1d.0.5`

Find roots of 1D functions

The module `Root1D` provides a collection of functions to seek roots
of functions `float → float`.


Installation
------------

The easier way of installing this package is by using [opam][]:

```shell
opam install root1d
```

To compile bu hand, install [jbuilder][] and do `jbuilder build`.


[opam]: https://opam.ocaml.org/
[jbuilder]: https://github.com/janestreet/jbuilder

Documentation
-------------

See the [signature of `Root1D`](src/Root1D.mli).  It can also be
consulted rendered to [HTML](http://math.umons.ac.be/an/software/doc/Root1D/).


---
* Homepage: https://github.com/Chris00/root1d
* Source repo: https://github.com/Chris00/root1d.git
* Bug tracker: https://github.com/Chris00/root1d/issues

---


---
0.5 2017-08-14
--------------

- Use jbuilder and Topkg.
- Changed license to ISC.
:camel: Pull-request generated by opam-publish v0.3.5