### PR TITLE
Package stdint.0.4.2

### DIFF
--- a/packages/stdint/stdint.0.4.2/descr
+++ b/packages/stdint/stdint.0.4.2/descr
@@ -1,0 +1,9 @@
+signed and unsigned integer types having specified widths
+The stdint library provides signed and unsigned integer types of various
+fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical),
+conversion to and from buffers in both big endian and little endian byte order.

--- a/packages/stdint/stdint.0.4.2/opam
+++ b/packages/stdint/stdint.0.4.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+  "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+]
+license: "MIT"
+homepage: "https://github.com/andrenth/ocaml-stdint"
+doc: "http://stdint.forge.ocamlcore.org/doc/"
+dev-repo: "https://github.com/andrenth/ocaml-stdint.git"
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "stdint"]
+]
+build-doc: [ "ocaml" "setup.ml" "-doc" ]
+depends: [
+  "base-bytes"
+  "ocamlfind" {>= "1.5"}
+  "ocamlbuild" {build}
+]

--- a/packages/stdint/stdint.0.4.2/url
+++ b/packages/stdint/stdint.0.4.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-stdint/archive/0.4.2.tar.gz"
+checksum: "dde8a4e4429bffa4bd7c6a2b4bae1f4e"


### PR DESCRIPTION
### `stdint.0.4.2`

signed and unsigned integer types having specified widths
The stdint library provides signed and unsigned integer types of various
fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
This interface is similar to Int32 and Int64 from the base library but provides
more functions and constants like arithmetic and bit-wise operations, constants
like maximum and minimum values, infix operators conversion to and from every
other integer type (including int, float and nativeint), parsing from and
conversion to readable strings (binary, octal, decimal, hexademical),
conversion to and from buffers in both big endian and little endian byte order.



---
* Homepage: https://github.com/andrenth/ocaml-stdint
* Source repo: https://github.com/andrenth/ocaml-stdint.git
* Bug tracker: https://github.com/andrenth/ocaml-stdint/issues

---

:camel: Pull-request generated by opam-publish v0.3.5