### PR TITLE
reason.1.13.7 - via opam-publish

### DIFF
--- a/packages/reason/reason.1.13.7/descr
+++ b/packages/reason/reason.1.13.7/descr
@@ -1,0 +1,5 @@
+Reason: Meta Language Toolchain
+
+reason allows development of Meta Language syntax trees in non-text format. It
+allows a development model that is equivalent to collaborating on syntax trees
+that have been committed to a source code repository.

--- a/packages/reason/reason.1.13.7/opam
+++ b/packages/reason/reason.1.13.7/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: "Jordan Walke <jordojw@gmail.com>"
+homepage: "https://github.com/facebook/reason"
+bug-reports: "https://github.com/facebook/reason/issues"
+license: "BSD. Additional patent grant provided."
+doc: "http://reasonml.github.io/"
+tags: "syntax"
+dev-repo: "git://github.com/facebook/reason.git"
+substs: "pkg/META"
+build: [
+  [make "compile_error"]
+  ["ocamlbuild" "-package" "topkg" "pkg/build.native"]
+  [
+    "./build.native"
+    "build"
+    "--native"
+    "%{ocaml-native}%"
+    "--native-dynlink"
+    "%{ocaml-native-dynlink}%"
+    "--utop"
+    "%{utop:installed}%"
+  ]
+]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {= "20170418"}
+  "utop" {>= "1.17"}
+  "merlin-extend" {>= "0.3"}
+  "result" {= "1.2"}
+  "topkg" {>= "0.8.1" & < "0.9"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0beta"}
+]
+conflicts: [
+  "utop" {< "1.17"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]

--- a/packages/reason/reason.1.13.7/url
+++ b/packages/reason/reason.1.13.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/facebook/reason/archive/1.13.7.tar.gz"
+checksum: "2463d7333d464fdbacc0ea262669374f"


### PR DESCRIPTION
Reason: Meta Language Toolchain

reason allows development of Meta Language syntax trees in non-text format. It
allows a development model that is equivalent to collaborating on syntax trees
that have been committed to a source code repository.


---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

Pull-request generated by opam-publish v0.3.4