### PR TITLE
Bisect_ppx 1.3.0 – code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.0/descr
+++ b/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.0/descr
@@ -1,0 +1,1 @@
+Ocamlbuild plugin for Bisect_ppx, the coverage tool

--- a/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.0/opam
+++ b/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.0/opam
@@ -1,0 +1,23 @@
+version: "1.0.0"
+opam-version: "1.2"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "Public Domain"
+homepage: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+dev-repo: "https://github.com/aantron/bisect_ppx.git"
+
+depends: [
+  # Bisect_ppx pulls in Ocamlbuild.
+  "bisect_ppx" {>= "1.0.0"}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.0/url
+++ b/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.3.0.tar.gz"
+checksum: "d247c2203a0d141078e40fadcfcf8258"

--- a/packages/bisect_ppx/bisect_ppx.1.3.0/descr
+++ b/packages/bisect_ppx/bisect_ppx.1.3.0/descr
@@ -1,0 +1,19 @@
+Code coverage for OCaml
+
+Bisect_ppx helps you test thoroughly. It is a small preprocessor that inserts
+instrumentation at places in your code, such as if-then-else and match
+expressions. After you run tests, Bisect_ppx gives a nice HTML report showing
+which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, then run the
+report tool on the generated visitation files.
+
+This is an advanced fork of the original Bisect coverage tool. It has many
+improvements and updates.
+
+- Much more thorough code instrumentation, so you can find more gaps in your
+  testing.
+- Fast operation by default.
+- More legible and appealing HTML reports.
+- Various bugfixes.
+- No camlp4 dependency.

--- a/packages/bisect_ppx/bisect_ppx.1.3.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.0/opam
@@ -1,0 +1,49 @@
+version: "1.3.0"
+opam-version: "1.2"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "MPL2"
+homepage: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+dev-repo: "https://github.com/aantron/bisect_ppx.git"
+
+depends: [
+  "base-unix"
+  "jbuilder" {build & >= "1.0+beta10"}
+  # This will be removed when bisect_ppx-ocamlbuild is fully factored
+  # out. It is not a build dependency because Ocamlbuild must be present
+  # each time the plugin is used, even after it is built and installed.
+  "ocamlbuild"
+  "ocaml-migrate-parsetree" {>= "1.0.3"}
+  "ounit" {test}
+  "ppx_tools_versioned"
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+# Note that Bisect_ppx effectively requires 4.02.3, because Jbuilder requires
+# it. 4.02.0 is the natural constraint of Bisect_ppx.
+available: ocaml-version >= "4.02.0"
+
+messages: [
+  "For the Ocamlbuild plugin, please install package bisect_ppx-ocamlbuild"
+  {ocamlbuild:installed & !bisect_ppx-ocamlbuild:installed}
+]
+post-messages: [
+  "The future Bisect_ppx 2.0.0 will make breaking changes in late 2017. See
+  https://github.com/aantron/bisect_ppx/releases/tag/1.3.0"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]

--- a/packages/bisect_ppx/bisect_ppx.1.3.0/url
+++ b/packages/bisect_ppx/bisect_ppx.1.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.3.0.tar.gz"
+checksum: "d247c2203a0d141078e40fadcfcf8258"


### PR DESCRIPTION
Bisect_ppx shows which parts of your code are *not* visited by your test suite:

>  https://github.com/aantron/bisect_ppx

This release 1.3.0 adds [better Jbuilder compatibility](https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#Jbuilder). See the [full changelog](https://github.com/aantron/bisect_ppx/releases/tag/1.3.0).

The Ocamlbuild plugin is factored out into a new OPAM and Findlib package `bisect_ppx-ocamlbuild`. You can continue using `bisect_ppx.ocamlbuild` for now, but `bisect_ppx-ocamlbuild` will be the only way to link the plugin after Bisect_ppx 2.0.0.

We have changed the license from GPL 3 to [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/FAQ/), which is considerably more permissive.

cc @rleonid