### PR TITLE
uwt.0.2.2 - via opam-publish

### DIFF
--- a/packages/uwt/uwt.0.2.2/descr
+++ b/packages/uwt/uwt.0.2.2/descr
@@ -1,0 +1,5 @@
+libuv bindings
+
+uwt provides OCaml bindings for libuv.
+The main loop of libuv is integrated into lwt,
+the light-weight cooperative threads library.

--- a/packages/uwt/uwt.0.2.2/opam
+++ b/packages/uwt/uwt.0.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/fdopen/uwt"
+dev-repo: "https://github.com/fdopen/uwt.git"
+bug-reports: "https://github.com/fdopen/uwt/issues"
+tags: ["clib:libuv"]
+build: ["omake" "-j%{jobs}%" "lib" "BUILD_LIBUV=true" "UWT_BUILD_JOBS=%{jobs}%"]
+install: [
+  ["omake" "opam-install" "PREFIX=%{prefix}%"]
+]
+build-test: [
+  ["omake" "test" ]
+]
+remove: [
+  ["ocamlfind" "remove" "uwt"]
+  ["rm" "-rf" "%{prefix}%/doc/uwt"]
+]
+available: [ocaml-version >= "4.02.1"]
+depends: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+  "base-bytes"
+  "conf-pkg-config" {build}
+  "ocamlfind" {build}
+  "cppo" {build & >= "1.3"}
+  "omake" {build}
+  "result"
+  "lwt" {>= "2.6.0"}
+  "ounit" {test & >= "2.0"}
+  "ppx_deriving" {test & >= "2.0"}
+  "ppx_import" {test & >= "1.0"}
+]

--- a/packages/uwt/uwt.0.2.2/url
+++ b/packages/uwt/uwt.0.2.2/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/fdopen/uwt/releases/download/0.2.2/uwt-0.2.2.tar.gz"
+checksum: "7e6f36ada01cfe65a22b27c6c8ac4ea1"


### PR DESCRIPTION
libuv bindings

uwt provides OCaml bindings for libuv.
The main loop of libuv is integrated into lwt,
the light-weight cooperative threads library.


---
* Homepage: https://github.com/fdopen/uwt
* Source repo: https://github.com/fdopen/uwt.git
* Bug tracker: https://github.com/fdopen/uwt/issues

---

Pull-request generated by opam-publish v0.3.4