### PR TITLE
Add jbuilder upperbounds to datakit

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "tests/%{name}%"]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "3.0.0"}
   "datakit-github"    {>= "0.11.0"}

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
@@ -10,7 +10,7 @@ doc:          "https://docker.github.io/datakit/"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & < "1.0+beta12"}
   "cmdliner"
   "irmin-watcher"
   "irmin"      {>= "1.2.0"}

--- a/packages/datakit-client-9p/datakit-client-9p.0.11.0/opam
+++ b/packages/datakit-client-9p/datakit-client-9p.0.11.0/opam
@@ -11,7 +11,7 @@ doc:          "https://docker.github.io/datakit/"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & < "1.0+beta12"}
   "astring"
   "logs"
   "fmt"

--- a/packages/datakit-client-git/datakit-client-git.0.11.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "tests/datakit-git"]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & < "1.0+beta12"}
   "datakit-client" {>= "0.11.0"}
   "irmin-git" {>= "1.2.0"}
   "irmin-watcher" {>= "0.3.0"}

--- a/packages/datakit-client/datakit-client.0.11.0/opam
+++ b/packages/datakit-client/datakit-client.0.11.0/opam
@@ -11,7 +11,7 @@ doc:          "https://docker.github.io/datakit/"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & < "1.0+beta12"}
   "astring"
   "result"
   "fmt"

--- a/packages/datakit-server-9p/datakit-server-9p.0.11.0/opam
+++ b/packages/datakit-server-9p/datakit-server-9p.0.11.0/opam
@@ -11,7 +11,7 @@ doc:          "https://docker.github.io/datakit/"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & < "1.0+beta12"}
   "datakit-server"  {>= "0.11.0"}
   "mirage-flow-lwt"
   "protocol-9p" {>= "0.11.0"}

--- a/packages/datakit/datakit.0.11.0/opam
+++ b/packages/datakit/datakit.0.11.0/opam
@@ -15,7 +15,7 @@ build-test: [
 ]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & < "1.0+beta12"}
   "cmdliner"
   "rresult" "astring" "fmt" "asetmap"
   "git"         {>= "1.11.0"}


### PR DESCRIPTION
These versions are all using per_file which will be removed in the upcoming
jbuilder release.

cc @talex5  @avsm