### PR TITLE
Num library: introduce standalone package num.1.0

### DIFF
--- a/packages/base-num/base-num.base/opam
+++ b/packages/base-num/base-num.base/opam
@@ -1,4 +1,3 @@
 opam-version: "1"
 maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
-# Once Num is removed from the OCaml core distribution, reflect this below
-# available: [ ocaml-version < "4.06.0" ]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/num/num.0/opam
+++ b/packages/num/num.0/opam
@@ -14,3 +14,4 @@ dev-repo: "https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
 
 depends: [ "base-num" ]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/num/num.1.0/descr
+++ b/packages/num/num.1.0/descr
@@ -1,0 +1,1 @@
+The legacy Num library for arbitrary-precision integer and rational arithmetic

--- a/packages/num/num.1.0/opam
+++ b/packages/num/num.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "num"
+version: "1.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Valérie Ménissier-Morain"
+  "Pierre Weis"
+  "Xavier Leroy"
+]
+license: "LGPL 2.1 with OCaml linking exception"
+
+homepage: "https://github.com/ocaml/num/"
+bug-reports: "https://github.com/ocaml/num/issues"
+dev-repo: "https://github.com/ocaml/num.git"
+
+build: [
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+
+depends: [
+  "ocamlfind" { >= "1.7.3" }
+]
+conflicts: [ "base-num" ]
+available: [ ocaml-version >= "4.0.6" ]

--- a/packages/num/num.1.0/url
+++ b/packages/num/num.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/num/archive/v1.0.tar.gz"
+checksum: "a4c359108d0b885bf43909e705b21291"


### PR DESCRIPTION
The Num library (for arbitrary-precision integer and rational arithmetic) is no longer part of the core OCaml distribution since version 4.06.0 (more exactly: since commit ocaml/ocaml@967ff73).

This commit reflects this situation by
* stating that the "base-num" package is available for OCaml < 4.06.0
* adding a package num.1.0 for the standalone distribution of Num (https://github.com/ocaml/num)

