### PR TITLE
Package conf-brotli.0.0.1

### DIFF
--- a/packages/conf-brotli/conf-brotli.0.0.1/descr
+++ b/packages/conf-brotli/conf-brotli.0.0.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on a brotli system installation.
+This package can only install if libbrotli is installed on the system.

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "fxfactorial"
+authors: "The Brotli Authors"
+homepage: "https://github.com/google/brotli"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "MIT"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+install: [ "pkg-config" "libbrotlidec" "libbrotlienc" ]
+depexts: [
+  [["debian"] ["libbrotli-dev"]]
+  [["freebsd"] ["libbrotli"]]
+  [["homebrew" "osx"] ["brotli"]]
+  [["ubuntu"] ["libbrotli-dev"]]
+]

--- a/packages/conf-brotli/conf-brotli.0.0.1/url
+++ b/packages/conf-brotli/conf-brotli.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/conf-brotli/archive/v0.0.1.tar.gz"
+checksum: "6cb875b80d51f9a26eb05db7f9779011"


### PR DESCRIPTION
### `conf-brotli.0.0.1`

Virtual package relying on a brotli system installation.
This package can only install if libbrotli is installed on the system.


---
* Homepage: https://github.com/google/brotli
* Source repo: https://github.com/ocaml/opam-repository.git
* Bug tracker: https://github.com/ocaml/opam-repository/issues

---

:camel: Pull-request generated by opam-publish v0.3.5