### PR TITLE
Release ppx_regexp.0.3.1.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.3.1/descr
+++ b/packages/ppx_regexp/ppx_regexp.0.3.1/descr
@@ -1,0 +1,24 @@
+Matching Regular Expressions with OCaml Patterns
+
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations of the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, with the following additions:
+
+  - `(?<var>...)` defines a group and binds whatever it matches as `var`.
+    The type of `var` will be `string` if the match is guaranteed given that
+    the whole pattern matches, and `string option` if the variable is bound
+    to or nested below an optionally matched group.
+
+  - `?<var>` at the start of a pattern binds group 0 as `var : string`.
+    This may not be the full string if the pattern is unanchored.
+
+A variable is allowed for the universal case and is bound to the matched
+string.  A regular alias is currently not allowed for patterns, since it is
+not obvious whether is should bind the full string or group 0.

--- a/packages/ppx_regexp/ppx_regexp.0.3.1/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "paurkedal@gmail.com"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+license: "LGPL-3 with OCaml linking exception"
+dev-repo: "https://github.com/paurkedal/ppx_regexp.git"
+build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+depends: [
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree"
+  "re"
+  "ppx_tools_versioned" {build}
+  "topkg-jbuilder" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/ppx_regexp/ppx_regexp.0.3.1/url
+++ b/packages/ppx_regexp/ppx_regexp.0.3.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/paurkedal/ppx_regexp/releases/download/v0.3.1/ppx_regexp-0.3.1.tbz"
+checksum: "aa1a1aa9e89ec38f2b0596877c9f2819"


### PR DESCRIPTION
I found a bug which warrants a new release.

- Fix accidental shadowing of open from another interface-less module using
  `ppx_regexp`.
- Support binding of group 0 and the universal pattern.
- Switch to `ppx_tools_versioned`. This provides support for 4.02.3 in the
  main branch.