### PR TITLE
Package ppx_view.1.0.0-3-g2cbdb2a

### DIFF
--- a/packages/ppx_view/ppx_view.1.0.0-3-g2cbdb2a/descr
+++ b/packages/ppx_view/ppx_view.1.0.0-3-g2cbdb2a/descr
@@ -1,0 +1,2 @@
+A ppx rewriter that provides pattern matching on abstract types by
+transforming patterns into views/expressions.

--- a/packages/ppx_view/ppx_view.1.0.0-3-g2cbdb2a/opam
+++ b/packages/ppx_view/ppx_view.1.0.0-3-g2cbdb2a/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "xclerc@janestreet.com"
+authors: ["Xavier Clerc"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocaml-ppx/ppx_view"
+bug-reports: "https://github.com/ocaml-ppx/ppx_view"
+dev-repo: "https://github.com/ocaml-ppx/ppx_view.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ocaml-migrate-parsetree"
+]

--- a/packages/ppx_view/ppx_view.1.0.0-3-g2cbdb2a/url
+++ b/packages/ppx_view/ppx_view.1.0.0-3-g2cbdb2a/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-ppx/ppx_view/releases/download/1.0.0-3-g2cbdb2a/ppx_view-1.0.0-3-g2cbdb2a.tbz"
+checksum: "a478b0be1efa50b4460b78fe0cb2677e"


### PR DESCRIPTION
### `ppx_view.1.0.0-3-g2cbdb2a`

A ppx rewriter that provides pattern matching on abstract types by
transforming patterns into views/expressions.



---
* Homepage: https://github.com/ocaml-ppx/ppx_view
* Source repo: https://github.com/ocaml-ppx/ppx_view.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_view

---


---
1.0.0
-----

* Initial release
:camel: Pull-request generated by opam-publish v0.3.5