### PR TITLE
qcheck.0.7 - via opam-publish

### DIFF
--- a/packages/qcheck/qcheck.0.7/descr
+++ b/packages/qcheck/qcheck.0.7/descr
@@ -1,0 +1,6 @@
+QuickCheck inspired property-based testing for OCaml.
+
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them.
+

--- a/packages/qcheck/qcheck.0.7/opam
+++ b/packages/qcheck/qcheck.0.7/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes <simon.cruanes@inria.fr>"
+homepage: "https://github.com/c-cube/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+doc: "http://cedeela.fr/~simon/software/qcheck/QCheck.html"
+tags: ["test" "property" "quickcheck"]
+dev-repo: "https://github.com/c-cube/qcheck.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+build-doc: [
+  ["./configure" "--enable-docs" "--docdir" "%{doc}%"]
+  [make "doc"]
+]
+remove: ["ocamlfind" "remove" "qcheck"]
+depends: ["ocamlfind" "base-bytes" "base-unix" "ounit"]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/qcheck/qcheck.0.7/url
+++ b/packages/qcheck/qcheck.0.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/qcheck/archive/0.7.tar.gz"
+checksum: "ca3c7d24200a8ca7e4390f1145eae3a9"


### PR DESCRIPTION
QuickCheck inspired property-based testing for OCaml.

This module allows to check invariants (properties of some types) over
randomly generated instances of the type. It provides combinators for
generating instances and printing them.



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---

Pull-request generated by opam-publish v0.3.3