### PR TITLE
Package ocaml-topexpect.0.3

### DIFF
--- a/packages/ocaml-topexpect/ocaml-topexpect.0.3/descr
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.3/descr
@@ -1,0 +1,3 @@
+Simulate and post-process ocaml toplevel sessions
+
+A variant of ocaml-expect from toplevel_expect_test that mimics ocaml toplevel more closely

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: [
+  "Frederic Bour <frederic.bour@lakaban.net>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/let-def/topexpect"
+bug-reports: "https://github.com/let-def/topexpect"
+license: "MIT"
+dev-repo: "https://github.com/let-def/topexpect.git"
+build: [make]
+depends: [
+  "ocamlfind" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_deriving" {build}
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.3/url
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/topexpect/archive/v0.3.tar.gz"
+checksum: "e1db7e1cffaa8d0bbc8c86ecf59e67d3"


### PR DESCRIPTION
### `ocaml-topexpect.0.3`

Simulate and post-process ocaml toplevel sessions

A variant of ocaml-expect from toplevel_expect_test that mimics ocaml toplevel more closely



---
* Homepage: https://github.com/let-def/topexpect
* Source repo: https://github.com/let-def/topexpect.git
* Bug tracker: https://github.com/let-def/topexpect

---

:camel: Pull-request generated by opam-publish v0.3.5