### PR TITLE
Package mechaml.1.0.0

### DIFF
--- a/packages/mechaml/mechaml.1.0.0/descr
+++ b/packages/mechaml/mechaml.1.0.0/descr
@@ -1,0 +1,12 @@
+Functional web scraping library based on Cohttp, Lambdasoup and Lwt
+
+Mechaml is a web scraping library that allows to :
+* Fetch web content
+* Analyze, fill and submit HTML forms
+* Handle cookies, headers and redirections
+
+Mechaml is built on top of existing libraries that provide low-level features : Cohttp (https://github.com/mirage/ocaml-cohttp) and
+Lwt (https://github.com/ocsigen/lwt) for asynchronous I/O and HTTP handling, and
+ Lambdasoup (https://github.com/aantron/lambda-soup) to parse HTML. It provides
+an interface that handles the interactions between these and add a few
+other features.

--- a/packages/mechaml/mechaml.1.0.0/opam
+++ b/packages/mechaml/mechaml.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "Yann Hamdaoui <yann.hamdaoui@gmail.com>"
+authors: "Yann Hamdaoui <yann.hamdaoui@gmail.com>"
+homepage: "https://github.com/yannham/mechaml"
+bug-reports: "https://github.com/yannham/mechaml/issues"
+license: "LGPL v3"
+dev-repo: "git://github.com/yannham/mechaml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+build-test: [
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+build-doc: ["make doc"]
+remove: ["ocamlfind" "remove" "mechaml"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "cohttp" {>= "0.21.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "lwt"
+  "uri"
+  "lambdasoup" {< "0.7.0"}
+  "alcotest" {test & >= "0.8.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/mechaml/mechaml.1.0.0/url
+++ b/packages/mechaml/mechaml.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/yannham/mechaml/archive/1.0.0.tar.gz"
+checksum: "eae9ae1c4614447314de681018886030"


### PR DESCRIPTION
### `mechaml.1.0.0`

Functional web scraping library based on Cohttp, Lambdasoup and Lwt

Mechaml is a web scraping library that allows to :
* Fetch web content
* Analyze, fill and submit HTML forms
* Handle cookies, headers and redirections

Mechaml is built on top of existing libraries that provide low-level features : Cohttp (https://github.com/mirage/ocaml-cohttp) and
Lwt (https://github.com/ocsigen/lwt) for asynchronous I/O and HTTP handling, and
 Lambdasoup (https://github.com/aantron/lambda-soup) to parse HTML. It provides
an interface that handles the interactions between these and add a few
other features.



---
* Homepage: https://github.com/yannham/mechaml
* Source repo: git://github.com/yannham/mechaml.git
* Bug tracker: https://github.com/yannham/mechaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5