### PR TITLE
ipv6-multicast: add lower bound for ipv6 support

### DIFF
--- a/packages/ipv6-multicast/ipv6-multicast.0.1/opam
+++ b/packages/ipv6-multicast/ipv6-multicast.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "lwt"
-  "ipaddr" {<"2.8.0"}
+  "ipaddr" {>="2.4.0" & <"2.8.0"}
 ]
 depopts: []
 build:


### PR DESCRIPTION
noted in revdep failure for #10134