### PR TITLE
+ppx_deriving.4.2

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.2/descr
+++ b/packages/ppx_deriving/ppx_deriving.4.2/descr
@@ -1,0 +1,5 @@
+Type-driven code generation for OCaml >=4.02
+
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.

--- a/packages/ppx_deriving/ppx_deriving.4.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://whitequark.github.io/ppx_deriving"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  # If there is no native dynlink, we can't use native builds
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native-dynlink}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_deriving.byte" "--"
+]
+build-doc: [
+  make "doc"
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.6.0"}
+  "cppo"       {build}
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {test}
+]
+available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" & ocaml-version < "4.06.0" ]

--- a/packages/ppx_deriving/ppx_deriving.4.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2/opam
@@ -23,6 +23,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build & >= "1.6.0"}
   "cppo"       {build}
+  "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
   "ppx_derivers"
   "ppx_tools"  {>= "4.02.3"}

--- a/packages/ppx_deriving/ppx_deriving.4.2/url
+++ b/packages/ppx_deriving/ppx_deriving.4.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving/archive/v4.2.tar.gz"
+checksum: "76231b39815ffd8ddbdcdc93ea930a75"


### PR DESCRIPTION
* Add support for OCaml 4.05.0.
* Use the `ocaml-migrate-parsetree` library to support multiple
  versions of OCaml.
* Fix comparison order of fields in records (ocaml-ppx/ppx_deriving#136).
* Silence an `unused rec flag` warning in generated code (ocaml-ppx/ppx_deriving#137).
* Monomorphize comparison function for builtin types (ocaml-ppx/ppx_deriving#115)
* Raise an error when `type nonrec` is encountered (ocaml-ppx/ppx_deriving#116).
* Display an error message when dynamic package loading fails.
* Add a `with_path` option to `@@deriving` to skip the module path
  in generated code (ocaml-ppx/ppx_deriving#120).

The homepage for the project has now moved to:
<https://github.com/ocaml-ppx/ppx_deriving>

cc @whitequark @diml @gasche 