### PR TITLE
ocaml-migrate-parsetree: do not attempt to build on 4.06.0dev

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
@@ -17,4 +17,4 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta10"}
 ]
-available: ocaml-version >= "4.02.0"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
@@ -17,4 +17,4 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta10"}
 ]
-available: ocaml-version >= "4.02.0"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
A new release is required to keep up with the moving parsetree in the
dev version.

cc @let-def 