### PR TITLE
Package ppx_graphql.0.1.0

### DIFF
--- a/packages/ppx_graphql/ppx_graphql.0.1.0/descr
+++ b/packages/ppx_graphql/ppx_graphql.0.1.0/descr
@@ -1,0 +1,7 @@
+Write type-safe GraphQL queries
+
+Given a introspection query response in `schema.json`, the expression `[%graphql {| query { ... } |} ]` is rewritten to a 3-tuple `(query, kvariables, parse)`: 
+
+- `query` (type `string`) is the GraphQL query to be submitted.
+- `kvariables` (type `(Yojson.Basic.json -> 'a) -> arg1:_ -> ... -> argn:_ -> unit -> 'a`) is a function to construct the JSON value to submit as query variables. The labels and types of `argx` are extracted from the query. Required variables appear as labeled arguments, optional variables appear as optional arguments.
+- `parse` is a function for parsing the JSON response from the server and has the type `Yojson.Basic.json -> < ... >`. The shape of the object type corresponds to the returned response.

--- a/packages/ppx_graphql/ppx_graphql.0.1.0/opam
+++ b/packages/ppx_graphql/ppx_graphql.0.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ppx_graphql"
+doc: "https://andreas.github.io/ppx_graphql/"
+bug-reports: "https://github.com/andreas/ppx_graphql/issues"
+dev-repo: "https://github.com/andreas/ppx_graphql.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "graphql"
+  "yojson"
+  "alcotest" {test & >= "0.4.5"}
+]

--- a/packages/ppx_graphql/ppx_graphql.0.1.0/url
+++ b/packages/ppx_graphql/ppx_graphql.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ppx_graphql/releases/download/0.1.0/ppx_graphql-0.1.0.tbz"
+checksum: "867fd458e920f747f5557fdba257ce12"


### PR DESCRIPTION
### `ppx_graphql.0.1.0`

Write type-safe GraphQL queries

Given a introspection query response in `schema.json`, the expression `[%graphql {| query { ... } |} ]` is rewritten to a 3-tuple `(query, kvariables, parse)`: 

- `query` (type `string`) is the GraphQL query to be submitted.
- `kvariables` (type `(Yojson.Basic.json -> 'a) -> arg1:_ -> ... -> argn:_ -> unit -> 'a`) is a function to construct the JSON value to submit as query variables. The labels and types of `argx` are extracted from the query. Required variables appear as labeled arguments, optional variables appear as optional arguments.
- `parse` is a function for parsing the JSON response from the server and has the type `Yojson.Basic.json -> < ... >`. The shape of the object type corresponds to the returned response.



---
* Homepage: https://github.com/andreas/ppx_graphql
* Source repo: https://github.com/andreas/ppx_graphql.git
* Bug tracker: https://github.com/andreas/ppx_graphql/issues

---


---
0.1.0 2017-08-22
---------------------------------

Initial public release.
:camel: Pull-request generated by opam-publish v0.3.5