### PR TITLE
rpc: release version 2.0.0

### DIFF
--- a/packages/rpc/rpc.2.0.0/descr
+++ b/packages/rpc/rpc.2.0.0/descr
@@ -1,0 +1,6 @@
+A library to deal with RPCs in OCaml
+
+This library provides a PPX and a camlp4 syntax extension to generate functions
+to convert values of a given type to and from their RPC representations. In
+order to do so, it is sufficient to add `[@@deriving rpc]` (or `with rpc` in
+case of camlp4) to the corresponding type definition.

--- a/packages/rpc/rpc.2.0.0/opam
+++ b/packages/rpc/rpc.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+homepage: "https://github.com/mirage/ocaml-rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [configure]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "rpclib"]
+  ["ocamlfind" "remove" "ppx_deriving_rpc"]
+]
+build-test: [
+    [make]
+    [make "test"]
+]
+depends: [
+  "oasis" {build}
+  "cppo"  {build}
+  "ocamlfind"
+  "type_conv" {>= "108.07.01"}
+  "ppx_deriving"
+  "cow"
+  "xmlm"
+  "lwt"
+  "cmdliner"
+  "rresult"
+  "async"
+]
+depopts: [ "js_of_ocaml" ]

--- a/packages/rpc/rpc.2.0.0/url
+++ b/packages/rpc/rpc.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-rpc/archive/v2.0.0.tar.gz"
+checksum: "9c0e70d1c770c6a1c8721cc1a5677f8d"


### PR DESCRIPTION
This includes many bug fixes, improved compliance on jsonrpc
standard and a new api call to obtain the jsonrpc version and
jsonrpc id in conjunction with the content.

This is likely to be the last version before the port to jbuilder.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>