### PR TITLE
coclbas: upper bound on ppx_deriving

### DIFF
--- a/packages/coclobas/coclobas.0.0.0/opam
+++ b/packages/coclobas/coclobas.0.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "trakeva"
   "cmdliner"
-  "ppx_deriving"
+  "ppx_deriving" {<"4.2"}
   "ppx_deriving_yojson" {>= "3.0"}
   "uuidm"
   "base64"

--- a/packages/coclobas/coclobas.0.0.1/opam
+++ b/packages/coclobas/coclobas.0.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt" {>= "2.6.0"}
   "trakeva"
   "cmdliner"
-  "ppx_deriving"
+  "ppx_deriving" {<"4.2"}
   "ppx_deriving_yojson" {>= "3.0"}
   "uuidm"
   "base64"

--- a/packages/coclobas/coclobas.0.0.2/opam
+++ b/packages/coclobas/coclobas.0.0.2/opam
@@ -25,7 +25,7 @@ depends: [
   "lwt"
   "trakeva"
   "cmdliner"
-  "ppx_deriving"
+  "ppx_deriving" {<"4.2"}
   "ppx_deriving_yojson" {>= "3.0"}
   "uuidm"
   "base64"


### PR DESCRIPTION
this is because 4.2 generates an error on the `nonrec` flag now

noted in revdeps for #10136
cc @smondet 