### PR TITLE
ocaml-basics: upper bound on ppx_deriving

### DIFF
--- a/packages/ocaml-basics/ocaml-basics.0.3.0/opam
+++ b/packages/ocaml-basics/ocaml-basics.0.3.0/opam
@@ -18,6 +18,6 @@ depends: [
   "result" {>= "1.2"}
   "ppx_sexp_conv" {>= "v0.9"}
   "sexplib" {>= "v0.9"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & <"4.2"}
 ]
 available: [ocaml-version >= "4.04"]

--- a/packages/ocaml-basics/ocaml-basics.0.4.0/opam
+++ b/packages/ocaml-basics/ocaml-basics.0.4.0/opam
@@ -18,6 +18,6 @@ depends: [
   "result" {>= "1.2"}
   "ppx_sexp_conv" {>= "v0.9"}
   "sexplib" {>= "v0.9"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & <"4.2"}
 ]
 available: [ocaml-version >= "4.04"]


### PR DESCRIPTION
newer ppx_deriving errors on local exceptions

noted in revdeps for #10136 

the error is odd since it is in fact running on ocaml 4.04.2

```
# File "lib/OBMap.ml", line 33, characters 2-228: local exceptions are not supported before OCaml 4.04
# File "lib/OBMap.ml", line 1:
# Error: Error while running external preprocessor
# Command line: /home/opam/.opam/ocaml-base-compiler.4.04.2/lib/ppx_deriving/./ppx_deriving package:ppx_sexp_conv '/tmp/camlppxaf81bb' '/tmp/camlppxeb974b'
# 
# Command exited with code 2.
# E: Failure("Command ''/home/opam/.opam/ocaml-base-compiler.4.04.2/bin/ocamlbuild' lib/basics.cma lib/basics.cmxa lib/basics.a lib/basics.cmxs -tag debug' terminated with error code 10")
```