### PR TITLE
sosa.0.3.0 - via opam-publish

### DIFF
--- a/packages/sosa/sosa.0.3.0/descr
+++ b/packages/sosa/sosa.0.3.0/descr
@@ -1,0 +1,5 @@
+Sane OCaml String API
+
+The Sosa library is a set of APIs (module types) that define what a
+string of characters should be, and a set of modules and functors that
+implement them.

--- a/packages/sosa/sosa.0.3.0/opam
+++ b/packages/sosa/sosa.0.3.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "seb@mondet.org"
+homepage: "http://www.hammerlab.org/docs/sosa/master/index.html"
+bug-reports: "https://github.com/hammerlab/sosa/issues"
+dev-repo: "https://github.com/hammerlab/sosa.git"
+authors: [
+  "Sebastien Mondet <seb@mondet.org>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Isaac Hodes <isaachodes@gmail.com>"
+  "Jeff Hammerbacher <jeff.hammerbacher@gmail.com>"
+]
+available:  [ ocaml-version >= "4.02.0" ]
+install: [ 
+    [ make "build" ]
+    [ make "install" ]
+]
+remove: [
+    [ make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/sosa/sosa.0.3.0/url
+++ b/packages/sosa/sosa.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hammerlab/sosa/archive/sosa.0.3.0.tar.gz"
+checksum: "5d21343b5960f014c182b20f028eb27f"


### PR DESCRIPTION
Sane OCaml String API

The Sosa library is a set of APIs (module types) that define what a
string of characters should be, and a set of modules and functors that
implement them.


---
* Homepage: http://www.hammerlab.org/docs/sosa/master/index.html
* Source repo: https://github.com/hammerlab/sosa.git
* Bug tracker: https://github.com/hammerlab/sosa/issues

---

Pull-request generated by opam-publish v0.3.4