### PR TITLE
Package alcotest-async.0.8.2

### DIFF
--- a/packages/alcotest-async/alcotest-async.0.8.2/descr
+++ b/packages/alcotest-async/alcotest-async.0.8.2/descr
@@ -1,0 +1,61 @@
+Logo](https://raw.githubusercontent.com/mirage/alcotest/master/alcotest-logo.png)
+
+Alcotest is a lightweight and colourful test framework.
+
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple `TESTABLE` module type, a `check` function to assert test
+predicates and a `run` function to perform a list of `unit -> unit`
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+
+[![Build Status](https://travis-ci.org/mirage/alcotest.svg)](https://travis-ci.org/mirage/alcotest)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/alcotest/alcotest/index.html)
+
+### Examples
+
+A simple example:
+
+```ocaml
+(* Build with `ocamlbuild -pkg alcotest simple.byte` *)
+
+(* A module with functions to test *)
+module To_test = struct
+  let capit letter = Char.uppercase letter
+  let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
+end
+
+(* The tests *)
+let capit () =
+  Alcotest.(check char) "same chars"  'A' (To_test.capit 'a')
+
+let plus () =
+  Alcotest.(check int) "same ints" 7 (To_test.plus [1;1;2;3])
+
+let test_set = [
+  "Capitalize" , `Quick, capit;
+  "Add entries", `Slow , plus ;
+]
+
+(* Run it *)
+let () =
+  Alcotest.run "My first test" [
+    "test_set", test_set;
+  ]
+```
+
+The result is a self-contained binary which displays the test results. Use
+`./simple.byte --help` to see the runtime options.
+
+```shell
+$ ./simple.native
+[OK]        test_set  0   Capitalize.
+[OK]        test_set  1   Add entries.
+Test Successful in 0.001s. 2 tests run.
+```
+
+See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
+folder for more examples.

--- a/packages/alcotest-async/alcotest-async.0.8.2/descr
+++ b/packages/alcotest-async/alcotest-async.0.8.2/descr
@@ -1,5 +1,3 @@
-Logo](https://raw.githubusercontent.com/mirage/alcotest/master/alcotest-logo.png)
-
 Alcotest is a lightweight and colourful test framework.
 
 Alcotest exposes simple interface to perform unit tests. It exposes
@@ -11,51 +9,3 @@ Alcotest provides a quiet and colorful output where only faulty runs
 are fully displayed at the end of the run (with the full logs ready to
 inspect), with a simple (yet expressive) query language to select the
 tests to run.
-
-[![Build Status](https://travis-ci.org/mirage/alcotest.svg)](https://travis-ci.org/mirage/alcotest)
-[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/alcotest/alcotest/index.html)
-
-### Examples
-
-A simple example:
-
-```ocaml
-(* Build with `ocamlbuild -pkg alcotest simple.byte` *)
-
-(* A module with functions to test *)
-module To_test = struct
-  let capit letter = Char.uppercase letter
-  let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
-end
-
-(* The tests *)
-let capit () =
-  Alcotest.(check char) "same chars"  'A' (To_test.capit 'a')
-
-let plus () =
-  Alcotest.(check int) "same ints" 7 (To_test.plus [1;1;2;3])
-
-let test_set = [
-  "Capitalize" , `Quick, capit;
-  "Add entries", `Slow , plus ;
-]
-
-(* Run it *)
-let () =
-  Alcotest.run "My first test" [
-    "test_set", test_set;
-  ]
-```
-
-The result is a self-contained binary which displays the test results. Use
-`./simple.byte --help` to see the runtime options.
-
-```shell
-$ ./simple.native
-[OK]        test_set  0   Capitalize.
-[OK]        test_set  1   Add entries.
-Test Successful in 0.001s. 2 tests run.
-```
-
-See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
-folder for more examples.

--- a/packages/alcotest-async/alcotest-async.0.8.2/opam
+++ b/packages/alcotest-async/alcotest-async.0.8.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder"  {build & >= "1.0+beta10"}
+  "alcotest"
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/alcotest-async/alcotest-async.0.8.2/url
+++ b/packages/alcotest-async/alcotest-async.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/alcotest/releases/download/0.8.2/alcotest-0.8.2.tbz"
+checksum: "477a48cae137160f4832bd24514363c0"


### PR DESCRIPTION
### `alcotest-async.0.8.2`

Logo](https://raw.githubusercontent.com/mirage/alcotest/master/alcotest-logo.png)

Alcotest is a lightweight and colourful test framework.

Alcotest exposes simple interface to perform unit tests. It exposes
a simple `TESTABLE` module type, a `check` function to assert test
predicates and a `run` function to perform a list of `unit -> unit`
test callbacks.

Alcotest provides a quiet and colorful output where only faulty runs
are fully displayed at the end of the run (with the full logs ready to
inspect), with a simple (yet expressive) query language to select the
tests to run.

[![Build Status](https://travis-ci.org/mirage/alcotest.svg)](https://travis-ci.org/mirage/alcotest)
[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/alcotest/alcotest/index.html)

### Examples

A simple example:

```ocaml
(* Build with `ocamlbuild -pkg alcotest simple.byte` *)

(* A module with functions to test *)
module To_test = struct
  let capit letter = Char.uppercase letter
  let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
end

(* The tests *)
let capit () =
  Alcotest.(check char) "same chars"  'A' (To_test.capit 'a')

let plus () =
  Alcotest.(check int) "same ints" 7 (To_test.plus [1;1;2;3])

let test_set = [
  "Capitalize" , `Quick, capit;
  "Add entries", `Slow , plus ;
]

(* Run it *)
let () =
  Alcotest.run "My first test" [
    "test_set", test_set;
  ]
```

The result is a self-contained binary which displays the test results. Use
`./simple.byte --help` to see the runtime options.

```shell
$ ./simple.native
[OK]        test_set  0   Capitalize.
[OK]        test_set  1   Add entries.
Test Successful in 0.001s. 2 tests run.
```

See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
folder for more examples.


---
* Homepage: https://github.com/mirage/alcotest/
* Source repo: https://github.com/mirage/alcotest.git
* Bug tracker: https://github.com/mirage/alcotest/issues/

---


---
### 0.8.2 (2017-08-21)

- add `Async` support: there is a new `alcotest-async` package containing
  an `Alcotest_async` module (#104, @rgrinberg)
:camel: Pull-request generated by opam-publish v0.3.5