### PR TITLE
Constrain `ppx_deriving_yojson` to OCaml < 4.05.0

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
@@ -8,6 +8,7 @@ doc: "http://whitequark.github.io/ppx_deriving_yojson"
 tags: ["syntax" "json"]
 dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
 substs: "pkg/META"
+available : [ ocaml-version < "4.05.0" ]
 build: [
   "ocaml"
   "pkg/build.ml"


### PR DESCRIPTION
See

- https://travis-ci.org/hammerlab/ketrew/jobs/268471254#L569
- https://github.com/ocaml-ppx/ppx_deriving_yojson/issues/56