### PR TITLE
Package misuja.0.0.0

### DIFF
--- a/packages/misuja/misuja.0.0.0/descr
+++ b/packages/misuja/misuja.0.0.0/descr
@@ -1,6 +1,6 @@
 A library to drive the MIDI system of the Jack Audio Connection Kit.
 
-Misuja is a low-latency “MIDI communcations thread” implemented in C
+Misuja is a low-latency “MIDI communications thread” implemented in C
 which is manipulated with an OCaml API (communicating through
 ring-buffers provided by the Jack API).
 

--- a/packages/misuja/misuja.0.0.0/descr
+++ b/packages/misuja/misuja.0.0.0/descr
@@ -1,0 +1,6 @@
+A library to drive the MIDI system of the Jack Audio Connection Kit.
+
+Misuja is a low-latency “MIDI communcations thread” implemented in C
+which is manipulated with an OCaml API (communicating through
+ring-buffers provided by the Jack API).
+

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -18,7 +18,7 @@ depexts: [
   [["alpine"] ["jack-dev"]]
   [["fedora"] ["jack-audio-connection-kit-devel"]]
   # Those RPMs depend on the EPEL package repository:
-  [["centos"] ["jack-audio-connection-kit-devel"]]
+  [["centos"] ["epel-release" "jack-audio-connection-kit-devel"]]
   [["rhel"] ["jack-audio-connection-kit-devel"]]
   # This one seems to require: "openSUSE Multimedia Libs"
   [["opensuse"] ["libjack-devel"]]

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -13,12 +13,16 @@ depends: [
   "base-unix"
 ]
 depexts: [
-  [["alpine"] ["jack-dev"]]
-  [["centos"] ["jack-audio-connection-kit-devel"]]
-  [["debian"] ["libjack-jackd2-dev"]]
-  [["fedora"] ["jack-audio-connection-kit-devel"]]
-  [["opensuse"] ["libjack-devel"]]
-  [["rhel"] ["jack-audio-connection-kit-devel"]]
   [["ubuntu"] ["libjack-jackd2-dev"]]
+  [["debian"] ["libjack-jackd2-dev"]]
+  [["alpine"] ["jack-dev"]]
+  [["fedora"] ["jack-audio-connection-kit-devel"]]
+  # Those RPMs depend on the EPEL package repository:
+  [["centos"] ["jack-audio-connection-kit-devel"]]
+  [["rhel"] ["jack-audio-connection-kit-devel"]]
+  # This one seems to require: "openSUSE Multimedia Libs"
+  [["opensuse"] ["libjack-devel"]]
+  # Cf. https://github.com/ocaml/opam-repository/pull/10167 for OSX:
+  [["homebrew" "osx"] ["jack"]]
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: "Seb Mondet <seb@mondet.org>"
+homepage: "https://gitlab.com/smondet/misuja"
+bug-reports: "https://gitlab.com/smondet/misuja/issues"
+license: "MIT"
+dev-repo: "https://gitlab.com/smondet/misuja.git"
+build: [make "lib"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+]
+depexts: [
+  [["alpine"] ["jack-dev"]]
+  [["centos"] ["jack-audio-connection-kit-devel"]]
+  [["debian"] ["libjack-jackd2-dev"]]
+  [["fedora"] ["jack-audio-connection-kit-devel"]]
+  [["opensuse"] ["libjack-devel"]]
+  [["rhel"] ["jack-audio-connection-kit-devel"]]
+  [["ubuntu"] ["libjack-jackd2-dev"]]
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/misuja/misuja.0.0.0/url
+++ b/packages/misuja/misuja.0.0.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://gitlab.com/smondet/misuja/repository/misuja.0.0.0/archive.tar.gz"
+checksum: "a30de68e28d4edd1073b1bb6110e613b"


### PR DESCRIPTION
### `misuja.0.0.0`

A library to drive the MIDI system of the Jack Audio Connection Kit.

Misuja is a low-latency “MIDI communcations thread” implemented in C
which is manipulated with an OCaml API (communicating through
ring-buffers provided by the Jack API).




---
* Homepage: https://gitlab.com/smondet/misuja
* Source repo: https://gitlab.com/smondet/misuja.git
* Bug tracker: https://gitlab.com/smondet/misuja/issues

---

:camel: Pull-request generated by opam-publish v0.3.5