### PR TITLE
Add switch 4.05.0+musl+static+flambda

### DIFF
--- a/compilers/4.05.0/4.05.0+musl+static+flambda/4.05.0+musl+static+flambda.comp
+++ b/compilers/4.05.0/4.05.0+musl+static+flambda/4.05.0+musl+static+flambda.comp
@@ -1,0 +1,21 @@
+opam-version: "1"
+version: "4.05.0"
+src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "musl-clang -Os"
+    "-aspp" "musl-clang -c"
+    "-libs" "-static"
+    "-no-curses" "-no-graph"
+    "-no-shared-libs"
+    ]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.05.0/4.05.0+musl+static+flambda/4.05.0+musl+static+flambda.descr
+++ b/compilers/4.05.0/4.05.0+musl+static+flambda/4.05.0+musl+static+flambda.descr
@@ -1,0 +1,3 @@
+Official 4.05.0 release compiled with musl-clang -static and with flambda activated
+
+Required musl-clang to be installed (pacman -S musl on Arch Linux and apt-get install musl-tools on Debian)


### PR DESCRIPTION
I cannot tell why the musl switches were dropped in the `4.05.0` recipes, but here's a patch to recreate one of them.

My ultimate goal was to create a toolchain that, in addition to be portable across all Linux distros, would also generate binaries that are the same way. The first objective is achieved with this switch, but the latter is not, since the resulting executables link glibc.

This also disables `graph` like `4.02.3+musl+static` did. Not sure how important that is for a switch that's intended to be used for building all or most of opam.