### PR TITLE
Package ocal.0.2.0

### DIFF
--- a/packages/ocal/ocal.0.2.0/descr
+++ b/packages/ocal/ocal.0.2.0/descr
@@ -1,0 +1,5 @@
+An improved Unix `cal` utility
+
+
+A replacement for the standard Unix `cal` utility. Partly because I could,
+partly because I'd become too irritated with its command line interface.

--- a/packages/ocal/ocal.0.2.0/opam
+++ b/packages/ocal/ocal.0.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Richard Mortier <mort@cantab.net>"
+authors: [ "Richard Mortier" ]
+license: "ISC"
+
+homepage: "https://github.com/mor1/ocal"
+dev-repo: "https://github.com/mor1/ocal.git"
+bug-reports: "https://github.com/mor1/ocal/issues"
+doc: "https://mor1.github.io/ocal/"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "jbuilder"  {build & >="1.0+beta11"}
+  "astring"   {build}
+  "calendar"  {build}
+  "cmdliner"  {build}
+  "notty"     {build}
+]

--- a/packages/ocal/ocal.0.2.0/url
+++ b/packages/ocal/ocal.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mor1/ocal/releases/download/0.2.0/ocal-0.2.0.tbz"
+checksum: "f02a27641320597af859a01a36d4c93d"


### PR DESCRIPTION
### `ocal.0.2.0`

An improved Unix `cal` utility


A replacement for the standard Unix `cal` utility. Partly because I could,
partly because I'd become too irritated with its command line interface.


---
* Homepage: https://github.com/mor1/ocal
* Source repo: https://github.com/mor1/ocal.git
* Bug tracker: https://github.com/mor1/ocal/issues

---


---
### 0.2.0 (2017-08-28)

  * Update `pkg/pkg.ml` to *not* build docs during `topkg publish`
  * Use [notty](https://pqwy.github.io/notty/) for layout
  * Add option to display week-of-year
  * Set timezone to be Local rather than UTC
:camel: Pull-request generated by opam-publish v0.3.5