### PR TITLE
Fix checksum of ppx_tools 5.0

### DIFF
--- a/packages/ppx_tools/ppx_tools.0.99.1/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.1/opam
@@ -4,5 +4,5 @@ build: [make "all"]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]
 available: [ (ocaml-version >= "4.02.0") & (ocaml-version < "4.03.0") ]
-dev-repo: "git://github.com/alainfrisch/ppx_tools"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools"
 install: [make "install"]

--- a/packages/ppx_tools/ppx_tools.0.99.1/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
 build: [make "all"]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]

--- a/packages/ppx_tools/ppx_tools.0.99.1/url
+++ b/packages/ppx_tools/ppx_tools.0.99.1/url
@@ -1,3 +1,2 @@
-archive: "http://github.com/alainfrisch/ppx_tools/archive/ppx_tools_0.99.1.tar.gz"
+archive: "http://github.com/ocaml-ppx/ppx_tools/archive/ppx_tools_0.99.1.tar.gz"
 checksum: "9e73018bafd7ff3ca4cab4206a605c30"
-

--- a/packages/ppx_tools/ppx_tools.0.99.2/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.2/opam
@@ -4,5 +4,5 @@ build: [make "all"]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]
 available: [ (ocaml-version >= "4.02.0") & (ocaml-version < "4.03.0") ]
-dev-repo: "git://github.com/alainfrisch/ppx_tools"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools"
 install: [make "install"]

--- a/packages/ppx_tools/ppx_tools.0.99.2/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.2/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
 build: [make "all"]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]

--- a/packages/ppx_tools/ppx_tools.0.99.2/url
+++ b/packages/ppx_tools/ppx_tools.0.99.2/url
@@ -1,2 +1,2 @@
-archive: "http://github.com/alainfrisch/ppx_tools/archive/ppx_tools_0.99.2.tar.gz"
+archive: "http://github.com/ocaml-ppx/ppx_tools/archive/ppx_tools_0.99.2.tar.gz"
 checksum: "94926dda74fa4720d4d3edac57ba5fee"

--- a/packages/ppx_tools/ppx_tools.0.99.3/opam
+++ b/packages/ppx_tools/ppx_tools.0.99.3/opam
@@ -1,9 +1,9 @@
 opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
 authors: ["Alain Frisch <alain.frisch@lexifi.com>"]
-homepage: "https://github.com/alainfrisch/ppx_tools"
-bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
-dev-repo: "https://github.com/alainfrisch/ppx_tools.git"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "https://github.com/ocaml-ppx/ppx_tools.git"
 build: [[make "all"]]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "ppx_tools"]]

--- a/packages/ppx_tools/ppx_tools.0.99/opam
+++ b/packages/ppx_tools/ppx_tools.0.99/opam
@@ -4,5 +4,5 @@ build: [make "all"]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]
 available: [ ocaml-version = "4.02.0" ]
-dev-repo: "git://github.com/alainfrisch/ppx_tools"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools"
 install: [make "install"]

--- a/packages/ppx_tools/ppx_tools.0.99/opam
+++ b/packages/ppx_tools/ppx_tools.0.99/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
 build: [make "all"]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: ["ocamlfind" {>= "1.5.0"}]

--- a/packages/ppx_tools/ppx_tools.0.99/url
+++ b/packages/ppx_tools/ppx_tools.0.99/url
@@ -1,3 +1,2 @@
-archive: "http://github.com/alainfrisch/ppx_tools/archive/ppx_tools_0.99.tar.gz"
+archive: "http://github.com/ocaml-ppx/ppx_tools/archive/ppx_tools_0.99.tar.gz"
 checksum: "c4f244de537ec23f015251f604a748f9"
-

--- a/packages/ppx_tools/ppx_tools.5.0+4.02.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.0+4.02.0/opam
@@ -2,9 +2,9 @@ opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
 authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
 license: "MIT"
-homepage: "https://github.com/alainfrisch/ppx_tools"
-bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
-dev-repo: "git://github.com/alainfrisch/ppx_tools.git#4.02"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git#4.02"
 tags: [ "syntax" ]
 build: [[make "all"]]
 install: [[make "install"]]

--- a/packages/ppx_tools/ppx_tools.5.0+4.02.0/url
+++ b/packages/ppx_tools/ppx_tools.5.0+4.02.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/alainfrisch/ppx_tools/archive/5.0+4.02.0.tar.gz"
+archive: "https://github.com/ocaml-ppx/ppx_tools/archive/5.0+4.02.0.tar.gz"
 checksum: "2f2bbe2ef0d16a6371d25a9e78854b3d"

--- a/packages/ppx_tools/ppx_tools.5.0+4.03.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.0+4.03.0/opam
@@ -2,9 +2,9 @@ opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
 authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
 license: "MIT"
-homepage: "https://github.com/alainfrisch/ppx_tools"
-bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
-dev-repo: "git://github.com/alainfrisch/ppx_tools.git#4.03"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git#4.03"
 tags: [ "syntax" ]
 build: [[make "all"]]
 install: [[make "install"]]

--- a/packages/ppx_tools/ppx_tools.5.0+4.03.0/url
+++ b/packages/ppx_tools/ppx_tools.5.0+4.03.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/alainfrisch/ppx_tools/archive/5.0+4.03.0.tar.gz"
+archive: "https://github.com/ocaml-ppx/ppx_tools/archive/5.0+4.03.0.tar.gz"
 checksum: "5ca9f031ca0b2e986fc8e3514dfd70d9"

--- a/packages/ppx_tools/ppx_tools.5.0+4.05.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.0+4.05.0/opam
@@ -2,9 +2,9 @@ opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
 authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
 license: "MIT"
-homepage: "https://github.com/alainfrisch/ppx_tools"
-bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
-dev-repo: "git://github.com/alainfrisch/ppx_tools.git#4.05"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git#4.05"
 tags: [ "syntax" ]
 build: [[make "all"]]
 install: [[make "install"]]

--- a/packages/ppx_tools/ppx_tools.5.0+4.05.0/url
+++ b/packages/ppx_tools/ppx_tools.5.0+4.05.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/alainfrisch/ppx_tools/archive/5.0+4.05.0.tar.gz"
+archive: "https://github.com/ocaml-ppx/ppx_tools/archive/5.0+4.05.0.tar.gz"
 checksum: "cf455545d5df2ed447a101f1d44454e9"

--- a/packages/ppx_tools/ppx_tools.5.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.0/opam
@@ -2,9 +2,9 @@ opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
 authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
 license: "MIT"
-homepage: "https://github.com/alainfrisch/ppx_tools"
-bug-reports: "https://github.com/alainfrisch/ppx_tools/issues"
-dev-repo: "git://github.com/alainfrisch/ppx_tools.git"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git"
 tags: [ "syntax" ]
 build: [[make "all"]]
 install: [[make "install"]]

--- a/packages/ppx_tools/ppx_tools.5.0/url
+++ b/packages/ppx_tools/ppx_tools.5.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/alainfrisch/ppx_tools/tarball/f70ca1d07d565989a0041e312e8efc00ff2ad87e"
-checksum: "1e18ffaa90d51cba9e6d5eb7bd186637"
+archive: "https://github.com/ocaml-ppx/ppx_tools/tarball/f70ca1d07d565989a0041e312e8efc00ff2ad87e"
+checksum: "5e1a86ff323fe772d69ca2d25abc2c9d"


### PR DESCRIPTION
Also it moved to ocaml-ppx so I'm removing one layer of redirects. It will still redirect to some URL, into some `legacy.tar.gz` but I have no idea what is even happening.

Why is the checksum different? Who knows. I would think the move of the repository does not change things but apparently it does.