### PR TITLE
Update earlier descriptions of visitors to require ocaml < 4.05.

### DIFF
--- a/packages/visitors/visitors.20170127/opam
+++ b/packages/visitors/visitors.20170127/opam
@@ -21,4 +21,4 @@ depends: [
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
 ]
-available: [ ocaml-version >= "4.03" ]
+available: [ ocaml-version >= "4.03" & ocaml-version < 4.05 ]

--- a/packages/visitors/visitors.20170127/opam
+++ b/packages/visitors/visitors.20170127/opam
@@ -21,4 +21,4 @@ depends: [
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
 ]
-available: [ ocaml-version >= "4.03" & ocaml-version < 4.05 ]
+available: [ ocaml-version >= "4.03" & ocaml-version < "4.05" ]

--- a/packages/visitors/visitors.20170308/opam
+++ b/packages/visitors/visitors.20170308/opam
@@ -21,4 +21,4 @@ depends: [
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
 ]
-available: [ ocaml-version >= "4.03" ]
+available: [ ocaml-version >= "4.03" & ocaml-version < 4.05 ]

--- a/packages/visitors/visitors.20170308/opam
+++ b/packages/visitors/visitors.20170308/opam
@@ -21,4 +21,4 @@ depends: [
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
 ]
-available: [ ocaml-version >= "4.03" & ocaml-version < 4.05 ]
+available: [ ocaml-version >= "4.03" & ocaml-version < "4.05" ]

--- a/packages/visitors/visitors.20170317/opam
+++ b/packages/visitors/visitors.20170317/opam
@@ -21,4 +21,4 @@ depends: [
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
 ]
-available: [ ocaml-version >= "4.03" ]
+available: [ ocaml-version >= "4.03" & ocaml-version < 4.05 ]

--- a/packages/visitors/visitors.20170317/opam
+++ b/packages/visitors/visitors.20170317/opam
@@ -21,4 +21,4 @@ depends: [
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
 ]
-available: [ ocaml-version >= "4.03" & ocaml-version < 4.05 ]
+available: [ ocaml-version >= "4.03" & ocaml-version < "4.05" ]

--- a/packages/visitors/visitors.20170404/opam
+++ b/packages/visitors/visitors.20170404/opam
@@ -23,4 +23,4 @@ depends: [
   "ppx_deriving" {>= "4.0"}
   "result"
 ]
-available: [ ocaml-version >= "4.02.2" & ocaml-version < 4.05 ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.05" ]

--- a/packages/visitors/visitors.20170404/opam
+++ b/packages/visitors/visitors.20170404/opam
@@ -23,4 +23,4 @@ depends: [
   "ppx_deriving" {>= "4.0"}
   "result"
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < 4.05 ]

--- a/packages/visitors/visitors.20170420/opam
+++ b/packages/visitors/visitors.20170420/opam
@@ -23,4 +23,4 @@ depends: [
   "ppx_deriving" {>= "4.0"}
   "result"
 ]
-available: [ ocaml-version >= "4.02.2" & ocaml-version < 4.05 ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.05" ]

--- a/packages/visitors/visitors.20170420/opam
+++ b/packages/visitors/visitors.20170420/opam
@@ -23,4 +23,4 @@ depends: [
   "ppx_deriving" {>= "4.0"}
   "result"
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < 4.05 ]

--- a/packages/visitors/visitors.20170725/opam
+++ b/packages/visitors/visitors.20170725/opam
@@ -23,4 +23,4 @@ depends: [
   "ppx_deriving" {>= "4.0"}
   "result"
 ]
-available: [ ocaml-version >= "4.02.2" & ocaml-version < 4.05 ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.05" ]

--- a/packages/visitors/visitors.20170725/opam
+++ b/packages/visitors/visitors.20170725/opam
@@ -23,4 +23,4 @@ depends: [
   "ppx_deriving" {>= "4.0"}
   "result"
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.02.2" & ocaml-version < 4.05 ]


### PR DESCRIPTION
I hope I am doing this right.
Earlier versions of the visitors package will not compile with ocaml 4.05,
so I think I should add this constraint to their description files.
Francois.
