### PR TITLE
Package sphinxcontrib-ocaml.0.2.0

### DIFF
--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/descr
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/descr
@@ -1,0 +1,5 @@
+Sphinx extension to document OCaml libraries
+
+sphinxcontrib-ocaml is a [Sphinx](http://www.sphinx-doc.org/) (1.6.3+) extension to document OCaml libraries.
+It provides a Sphinx domain for OCaml and [autodoc](http://www.sphinx-doc.org/en/stable/ext/autodoc.html)-like
+directives to generate documentation from source code.

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/opam
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+homepage: "https://jacquev6.github.io/sphinxcontrib-ocaml/"
+bug-reports: "http://github.com/jacquev6/sphinxcontrib-ocaml/issues/"
+license: "MIT"
+doc: "https://jacquev6.github.io/sphinxcontrib-ocaml/"
+dev-repo: "https://github.com/jacquev6/sphinxcontrib-ocaml.git"
+build: [
+  "sh"
+  "-c"
+  "cd ocaml_autodoc; ocamlbuild -use-ocamlfind ocaml_autodoc.native"
+]
+install: [
+  "cp"
+  "ocaml_autodoc/_build/ocaml_autodoc.native"
+  "%{prefix}%/bin/sphinxcontrib-ocaml-autodoc"
+]
+remove: ["rm" "-f" "%{prefix}%/bin/sphinxcontrib-ocaml-autodoc"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "General"
+  "yojson"
+]
+available: [ocaml-version = "4.05.0"]

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/url
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jacquev6/sphinxcontrib-ocaml/archive/0.2.0.tar.gz"
+checksum: "d6929b9b99e0d07441146688b7c22b49"


### PR DESCRIPTION
### `sphinxcontrib-ocaml.0.2.0`

Sphinx extension to document OCaml libraries

sphinxcontrib-ocaml is a [Sphinx](http://www.sphinx-doc.org/) (1.6.3+) extension to document OCaml libraries.
It provides a Sphinx domain for OCaml and [autodoc](http://www.sphinx-doc.org/en/stable/ext/autodoc.html)-like
directives to generate documentation from source code.



---
* Homepage: https://jacquev6.github.io/sphinxcontrib-ocaml/
* Source repo: https://github.com/jacquev6/sphinxcontrib-ocaml.git
* Bug tracker: http://github.com/jacquev6/sphinxcontrib-ocaml/issues/

---

:camel: Pull-request generated by opam-publish v0.3.5