### PR TITLE
Package graphql-lwt.0.3.0

### DIFF
--- a/packages/graphql-lwt/graphql-lwt.0.3.0/descr
+++ b/packages/graphql-lwt/graphql-lwt.0.3.0/descr
@@ -1,0 +1,3 @@
+Build GraphQL schemas with Lwt support
+
+`graphql-lwt` adds support for Lwt to `graphql`, so you can use Lwt in your GraphQL schema resolver functions.

--- a/packages/graphql-lwt/graphql-lwt.0.3.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.3.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "graphql"
+  "alcotest" {test}
+  "lwt"
+  "cohttp-lwt-unix" {>= "0.99"}
+  "crunch"
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql-lwt/graphql-lwt.0.3.0/url
+++ b/packages/graphql-lwt/graphql-lwt.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.3.0/graphql-0.3.0.tbz"
+checksum: "2c8d60515d2abed8dc1c54e6f7344b2a"


### PR DESCRIPTION
### `graphql-lwt.0.3.0`

Build GraphQL schemas with Lwt support

`graphql-lwt` adds support for Lwt to `graphql`, so you can use Lwt in your GraphQL schema resolver functions.



---
* Homepage: https://github.com/andreas/ocaml-graphql-server
* Source repo: https://github.com/andreas/ocaml-graphql-server.git
* Bug tracker: https://github.com/andreas/ocaml-graphql-server/issues

---


---
0.3.0 2017-08-31
---------------------------------

- Built-in HTTP server for graphql-lwt (#60)
:camel: Pull-request generated by opam-publish v0.3.5