### PR TITLE
[dont merge yet!] Hardcaml+Vg - check CI build

### DIFF
--- a/packages/hardcaml/hardcaml.1.2.0/opam
+++ b/packages/hardcaml/hardcaml.1.2.0/opam
@@ -9,13 +9,16 @@ build: [
     "--with-ctypes" "%{ctypes:installed}%"
     "--with-ctypes-foreign" "%{ctypes-foreign:installed}%"
     "--with-camlp4" "%{camlp4:installed}%"
-    "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+    "--with-js_of_ocaml" "true"
     "--with-lwt" "%{lwt:installed}%"
   ] 
 ]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "camlp4"
+  "js_of_ocaml"
+  "js_of_ocaml-camlp4"
   "topkg" {build}
   "base-bytes" 
   "base-unix" 
@@ -23,14 +26,9 @@ depends: [
   "num"
 ]
 depopts: [ 
-  "camlp4" 
   "ctypes"
   "ctypes-foreign" 
-  "js_of_ocaml"
   "lwt"
 ]
 
-conflicts: [
-  "js_of_ocaml"  {>= "3.0"}
-]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/vg/vg.0.9.0/opam
+++ b/packages/vg/vg.0.9.0/opam
@@ -21,8 +21,10 @@ depends: [
   "gg" {>= "0.9.0"}
   "result"
   "uchar"
-  "js_of_ocaml" {> "2.6.0"} # Can be moved to depopt once this is distributed:
-                            # https://github.com/ocsigen/js_of_ocaml/pull/541
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-compiler" {>= "3.0"}
+  "js_of_ocaml-ocamlbuild" {>= "3.0"}
+  "js_of_ocaml-ppx" {>= "3.0"}
 ]
 depopts: [
   "uutf"
@@ -32,7 +34,6 @@ depopts: [
 conflicts: [
   "otfm" {< "0.3.0"}
   "uutf" {< "1.0.0"}
-  "js_of_ocaml" {>= "3.0"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"


### PR DESCRIPTION
Fix constraints for hardcaml and vg, caused by js_of_ocaml 3.0 - #10056 

@dbuenzli @avsm what is the correct etiquette for fixing these pull requests together?

Note; the escalation of dependencies in hardcaml on camlp4 and js_of_ocaml is temporary as I have a fully ppx (and jbuilder) version working.