### PR TITLE
Fix hardcaml+vg constraints for jsoo 3.0

### DIFF
--- a/packages/hardcaml/hardcaml.1.2.0/opam
+++ b/packages/hardcaml/hardcaml.1.2.0/opam
@@ -9,13 +9,16 @@ build: [
     "--with-ctypes" "%{ctypes:installed}%"
     "--with-ctypes-foreign" "%{ctypes-foreign:installed}%"
     "--with-camlp4" "%{camlp4:installed}%"
-    "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+    "--with-js_of_ocaml" "true"
     "--with-lwt" "%{lwt:installed}%"
   ] 
 ]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "camlp4"
+  "js_of_ocaml"
+  "js_of_ocaml-camlp4"
   "topkg" {build}
   "base-bytes" 
   "base-unix" 
@@ -23,14 +26,9 @@ depends: [
   "num"
 ]
 depopts: [ 
-  "camlp4" 
   "ctypes"
   "ctypes-foreign" 
-  "js_of_ocaml"
   "lwt"
 ]
 
-conflicts: [
-  "js_of_ocaml"  {>= "3.0"}
-]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/vg/vg.0.9.0/opam
+++ b/packages/vg/vg.0.9.0/opam
@@ -21,8 +21,10 @@ depends: [
   "gg" {>= "0.9.0"}
   "result"
   "uchar"
-  "js_of_ocaml" {> "2.6.0"} # Can be moved to depopt once this is distributed:
-                            # https://github.com/ocsigen/js_of_ocaml/pull/541
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-compiler" {>= "3.0"}
+  "js_of_ocaml-ocamlbuild" {>= "3.0"}
+  "js_of_ocaml-ppx" {>= "3.0"}
 ]
 depopts: [
   "uutf"
@@ -32,7 +34,6 @@ depopts: [
 conflicts: [
   "otfm" {< "0.3.0"}
   "uutf" {< "1.0.0"}
-  "js_of_ocaml" {>= "3.0"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"


### PR DESCRIPTION
#10056 #10198

Includes @dbuenzli fixes to get vg working with js_of_ocaml 3.0, and changes hardcaml to require camlp4 and js_of_ocaml for the now.

The hardcaml constraint is temporary as the dev version on longer uses camp4.