### PR TITLE
gdbprofiler 0.2

### DIFF
--- a/packages/gdbprofiler/gdbprofiler.0.2/descr
+++ b/packages/gdbprofiler/gdbprofiler.0.2/descr
@@ -1,0 +1,3 @@
+gdbprofiler, a profiler for native OCaml and other executables
+
+gdbprofiler (aka rich man's profiler) is a gdb-based sampling profiler that uses gdb or lldb

--- a/packages/gdbprofiler/gdbprofiler.0.2/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.2/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+name: "gdbprofiler"
+maintainer: "copy@copy.sh"
+authors: "copy"
+homepage: "https://github.com/copy/gdbprofiler"
+bug-reports: "https://github.com/copy/gdbprofiler/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "https://github.com/copy/gdbprofiler.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "menhir" {build}
+  "lwt" {>= "2.4.6"}
+  "containers" {>= "0.20"}
+  "yojson"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/gdbprofiler/gdbprofiler.0.2/url
+++ b/packages/gdbprofiler/gdbprofiler.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/copy/gdbprofiler/archive/0.2.tar.gz"
+checksum: "25397fb88367eeb6eb7cec8a4196112b"


### PR DESCRIPTION
gdbprofiler (aka rich man's profiler) is a gdb-based sampling profiler that uses gdb or lldb