### PR TITLE
Fix invalid escapes in clangml.3.9.1.2

### DIFF
--- a/packages/clangml/clangml.3.9.1.2/opam
+++ b/packages/clangml/clangml.3.9.1.2/opam
@@ -6,10 +6,10 @@ homepage: "https://github.com/Antique-team/clangml"
 bug-reports: "https://github.com/Antique-team/clangml/issues"
 dev-repo: "https://github.com/Antique-team/clangml.git"
 build: [
-  ["sh" "-c" "test -d ${HOME}/usr/clang39 \
-    || ( wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz \
-      && tar -xf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz \
-      && mkdir -p ${HOME}/usr/clang39 \
+  ["sh" "-c" "test -d ${HOME}/usr/clang39 \\
+    || ( wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz \\
+      && tar -xf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz \\
+      && mkdir -p ${HOME}/usr/clang39 \\
       && mv clang+llvm-3.9.0-x86_64-apple-darwin/* ${HOME}/usr/clang39 )"] {os = "darwin"}
   [make]
 ]


### PR DESCRIPTION
#9810 causing problems converting the repo to opam 2.0 with `opam admin upgrade`

/cc @AltGr (shouldn't this be caught in linting?), @thierry-martinez (I can't test this)