### PR TITLE
Package moss.0.1

### DIFF
--- a/packages/moss/moss.0.1/descr
+++ b/packages/moss/moss.0.1/descr
@@ -1,0 +1,9 @@
+A client for the MOSS plagiarism detection service.
+
+This package provides an OCaml client for the MOSS (Measure Of
+Software Similarity) plagiarism detection service.  It is based on the
+original submission script.  The MOSS system only runs on Stanford's
+servers — you cannot run your own instance — so you need to obtain an
+account first.
+
+MOSS: http://theory.stanford.edu/~aiken/moss/

--- a/packages/moss/moss.0.1/opam
+++ b/packages/moss/moss.0.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["MOSS"]
+license: "ISC"
+homepage: "https://github.com/Chris00/ocaml-moss"
+dev-repo: "https://github.com/Chris00/ocaml-moss.git"
+bug-reports: "https://github.com/Chris00/ocaml-moss/issues"
+doc: "https://Chris00.github.io/ocaml-moss/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "base-unix"
+  "base-bytes"
+  "uri"
+]

--- a/packages/moss/moss.0.1/url
+++ b/packages/moss/moss.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-moss/releases/download/0.1/moss-0.1.tbz"
+checksum: "0714310644bfa8077871b3fb85beb92a"


### PR DESCRIPTION
### `moss.0.1`

A client for the MOSS plagiarism detection service.

This package provides an OCaml client for the MOSS (Measure Of
Software Similarity) plagiarism detection service.  It is based on the
original submission script.  The MOSS system only runs on Stanford's
servers — you cannot run your own instance — so you need to obtain an
account first.

MOSS: http://theory.stanford.edu/~aiken/moss/



---
* Homepage: https://github.com/Chris00/ocaml-moss
* Source repo: https://github.com/Chris00/ocaml-moss.git
* Bug tracker: https://github.com/Chris00/ocaml-moss/issues

---


---
0.1 2017-08-31
--------------

- First version of the MOSS client.
:camel: Pull-request generated by opam-publish v0.3.5