### PR TITLE
Package csv-lwt.2.0

### DIFF
--- a/packages/csv-lwt/csv-lwt.2.0/descr
+++ b/packages/csv-lwt/csv-lwt.2.0/descr
@@ -1,0 +1,8 @@
+A pure OCaml library to read and write CSV files, LWT version.
+
+This is a pure OCaml library to read and write CSV files, including
+all extensions used by Excel — e.g. quotes, newlines, 8 bit characters
+in fields, \"0 etc. A special representation of rows of CSV files with
+a header is provided. The library comes with a handy command line tool
+called csvtool for handling CSV files from shell scripts.  This
+version can be used with the monadic concurrency library LWT.

--- a/packages/csv-lwt/csv-lwt.2.0/opam
+++ b/packages/csv-lwt/csv-lwt.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Richard Jones"
+           "Christophe Troestler" ]
+tags: [ "csv" "database" "science"  ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-csv"
+dev-repo: "https://github.com/Chris00/ocaml-csv.git"
+bug-reports: "https://github.com/Chris00/ocaml-csv/issues"
+doc: "https://Chris00.github.io/ocaml-csv/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "csv" {= "2.0"}
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+  "lwt"
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/csv-lwt/csv-lwt.2.0/url
+++ b/packages/csv-lwt/csv-lwt.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-csv/releases/download/2.0/csv-2.0.tbz"
+checksum: "b21dff064ec2151923cce97564688ea5"


### PR DESCRIPTION
### `csv-lwt.2.0`

A pure OCaml library to read and write CSV files, LWT version.

This is a pure OCaml library to read and write CSV files, including
all extensions used by Excel — e.g. quotes, newlines, 8 bit characters
in fields, \"0 etc. A special representation of rows of CSV files with
a header is provided. The library comes with a handy command line tool
called csvtool for handling CSV files from shell scripts.  This
version can be used with the monadic concurrency library LWT.



---
* Homepage: https://github.com/Chris00/ocaml-csv
* Source repo: https://github.com/Chris00/ocaml-csv.git
* Bug tracker: https://github.com/Chris00/ocaml-csv/issues

---


---
2.0 2017-09-02
--------------

- Split the package into `csv` and `csv-lwt`.
- Port to `jbuilder` and `topkg`.
:camel: Pull-request generated by opam-publish v0.3.5