### PR TITLE
Package dlm.0.3.0

### DIFF
--- a/packages/dlm/dlm.0.3.0/descr
+++ b/packages/dlm/dlm.0.3.0/descr
@@ -1,0 +1,7 @@
+Libdlm bindings
+
+[![Build Status](https://travis-ci.org/xapi-project/ocaml-dlm.svg?branch=master)](https://travis-ci.org/xapi-project/ocaml-dlm)
+
+Bindings to the Linux Distributed Lock Manager `libdlm(3)`.
+
+Documentation can be found [online](https://xapi-project.github.io/ocaml-dlm/doc/dlm/Dlm/index.html).

--- a/packages/dlm/dlm.0.3.0/opam
+++ b/packages/dlm/dlm.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "xen-api@list.xensource.com"
+authors: ["Edwin Török"]
+homepage: "https://github.com/xapi-project/ocaml-dlm/"
+bug-reports: "https://github.com/xapi-project/ocaml-dlm/issues"
+dev-repo: "https://github.com/xapi-project/ocaml-dlm.git"
+doc: "https://xapi-project.github.io/ocaml-dlm/doc"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [
+  ["jbuilder" "build" "--only" name "--root" "." "-j" jobs "@install"]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "ctypes" {>= "0.11.1"}
+  "lwt"
+  "unix-errno"
+  "ounit"
+  "uuidm"
+]
+
+depexts: [
+  [["debian"] ["libdlm-dev"]]
+  [["ubuntu"] ["libdlm-dev"]]
+  [["rhel"] ["dlm-devel"]]
+  [["centos"] ["dlm-devel"]]
+  [["fedora"] ["dlm-devel"]]
+  [["oraclelinux"] ["dlm-devel"]]
+  [["archlinux"] ["dlm-git"]]
+  [["opensuse"] ["libdlm-devel"]]
+]
+
+available: [ os = "linux" ]

--- a/packages/dlm/dlm.0.3.0/opam
+++ b/packages/dlm/dlm.0.3.0/opam
@@ -31,4 +31,4 @@ depexts: [
   [["opensuse"] ["libdlm-devel"]]
 ]
 
-available: [ os = "linux" ]
+available: [ os = "linux" & os != "alpine" ]

--- a/packages/dlm/dlm.0.3.0/url
+++ b/packages/dlm/dlm.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/ocaml-dlm/releases/download/v0.3.0/dlm-0.3.0.tbz"
+checksum: "dac7206c4f86fc1a1492cbdc3862e013"


### PR DESCRIPTION
### `dlm.0.3.0`

Libdlm bindings

[![Build Status](https://travis-ci.org/xapi-project/ocaml-dlm.svg?branch=master)](https://travis-ci.org/xapi-project/ocaml-dlm)

Bindings to the Linux Distributed Lock Manager `libdlm(3)`.

Documentation can be found [online](https://xapi-project.github.io/ocaml-dlm/doc/dlm/Dlm/index.html).


---
* Homepage: https://github.com/xapi-project/ocaml-dlm/
* Source repo: https://github.com/xapi-project/ocaml-dlm.git
* Bug tracker: https://github.com/xapi-project/ocaml-dlm/issues

---


---
v0.3.0 2017-09-05
-----------------

Update opam depext and README.
:camel: Pull-request generated by opam-publish v0.3.5