### PR TITLE
Package junit.1.0

### DIFF
--- a/packages/junit/junit.1.0/descr
+++ b/packages/junit/junit.1.0/descr
@@ -1,0 +1,25 @@
+JUnit
+
+ocaml-junit is a module for the creation of JUnit XML reports. It
+provides a typed API to produce valid reports. They are supposed to be
+accepted by Jenkins.
+
+## Installation
+
+opam pin add junit https://github.com/Khady/ocaml-junit.git
+
+## Documentation
+
+Available [here](https://khady.github.io/ocaml-junit/junit/)
+
+## References:
+
+- [Jenkins](https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd)
+- [JUnit-Schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd)
+- [Windyroad](http://windyroad.com.au/dl/Open%20Source/JUnit.xsd)
+- [a gist](https://gist.github.com/erikd/4192748)
+
+Those files are archived in directory [`schemes`](schemes)
+
+License: LGPL either version 3 of the License, or (at your option) any
+later version with OCaml linking exception.

--- a/packages/junit/junit.1.0/opam
+++ b/packages/junit/junit.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocaml-junit"
+bug-reports: "https://github.com/Khady/ocaml-junit/issues"
+license: "LGPLv3+ with OCaml linking exception"
+dev-repo: "https://github.com/Khady/ocaml-junit.git"
+doc: "https://khady.github.io/ocaml-junit/junit/"
+tags: ["junit" "jenkins"]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "ptime"
+  "tyxml" {>= "4.0.0"}
+  "odoc" {doc & >= "1.1.1"}
+]
+available: [ocaml-version >= "4.02.3"]
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+build-doc: [["jbuilder" "build" "@doc" "-p" name "-j" jobs]]

--- a/packages/junit/junit.1.0/url
+++ b/packages/junit/junit.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Khady/ocaml-junit/releases/download/1.0/junit-1.0.tbz"
+checksum: "419411defafe17efad70cb39f563203c"


### PR DESCRIPTION
### `junit.1.0`

JUnit

ocaml-junit is a module for the creation of JUnit XML reports. It
provides a typed API to produce valid reports. They are supposed to be
accepted by Jenkins.

## Installation

opam pin add junit https://github.com/Khady/ocaml-junit.git

## Documentation

Available [here](https://khady.github.io/ocaml-junit/junit/)

## References:

- [Jenkins](https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd)
- [JUnit-Schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd)
- [Windyroad](http://windyroad.com.au/dl/Open%20Source/JUnit.xsd)
- [a gist](https://gist.github.com/erikd/4192748)

Those files are archived in directory [`schemes`](schemes)

License: LGPL either version 3 of the License, or (at your option) any
later version with OCaml linking exception.


---
* Homepage: https://github.com/Khady/ocaml-junit
* Source repo: https://github.com/Khady/ocaml-junit.git
* Bug tracker: https://github.com/Khady/ocaml-junit/issues

---


---
## 1.0 (2017-09-5)

- move to jbuilder
- `Testsuite.make` expects `()` as last argument.
:camel: Pull-request generated by opam-publish v0.3.5