### PR TITLE
Package rlp.0.1

### DIFF
--- a/packages/rlp/rlp.0.1/descr
+++ b/packages/rlp/rlp.0.1/descr
@@ -1,0 +1,10 @@
+RLP: Recursive Length Prefix Encoding
+
+RLP(*1) is a way to encode multi-way trees as byte strings. This library provides an encode and a decode function.
+A tree's node can be a byte string or a node with arbitrarily many child nodes. A node can also have zero nodes.
+Equivalently, this library can serialize s-expressions whose atoms are byte string literals.
+
+RLP is heavily used in the Ethereum protocol(*2), but might be useful elsewhere as well.
+
+*1: https://github.com/ethereum/wiki/wiki/RLP
+*2: https://ethereum.org/

--- a/packages/rlp/rlp.0.1/opam
+++ b/packages/rlp/rlp.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Yoichi Hirai <i@yoichihirai.com>"
+authors: "Yoichi Hirai <i@yoichihirai.com>"
+homepage: "https://github.com/pirapira/rlp-ocaml"
+bug-reports: "https://github.com/pirapira/rlp-ocaml/issues/new"
+license: "Apache 2.0"
+dev-repo: "https://github.com/pirapira/rlp-ocaml.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-doc"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocaml" "setup.ml" "-uninstall"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit"
+  "rope"
+  "hex"
+  "num"
+]

--- a/packages/rlp/rlp.0.1/url
+++ b/packages/rlp/rlp.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/pirapira/rlp-ocaml/archive/0.1.tar.gz"
+checksum: "4b1b75a8cc60fd2e742c36107e3fa41c"


### PR DESCRIPTION
### `rlp.0.1`

RLP: Recursive Length Prefix Encoding

RLP(*1) is a way to encode multi-way trees as byte strings. This library provides an encode and a decode function.
A tree's node can be a byte string or a node with arbitrarily many child nodes. A node can also have zero nodes.
Equivalently, this library can serialize s-expressions whose atoms are byte string literals.

RLP is heavily used in the Ethereum protocol(*2), but might be useful elsewhere as well.

*1: https://github.com/ethereum/wiki/wiki/RLP
*2: https://ethereum.org/



---
* Homepage: https://github.com/pirapira/rlp-ocaml
* Source repo: https://github.com/pirapira/rlp-ocaml.git
* Bug tracker: https://github.com/pirapira/rlp-ocaml/issues/new

---

:camel: Pull-request generated by opam-publish v0.3.5