### PR TITLE
jbuilder is a build dependency for ppx_derivers

### DIFF
--- a/packages/ppx_derivers/ppx_derivers.1.0/opam
+++ b/packages/ppx_derivers/ppx_derivers.1.0/opam
@@ -9,5 +9,5 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]


### PR DESCRIPTION
To help avoid churn when jbuilder updates happen