### PR TITLE
session conflicts with cohttp.0.99.0

### DIFF
--- a/packages/session/session.0.1.0/opam
+++ b/packages/session/session.0.1.0/opam
@@ -43,3 +43,6 @@ depopts: [
   "postgresql"
   "webmachine"
 ]
+conflicts: [
+  "cohttp" {>= "0.99.0"}
+]

--- a/packages/session/session.0.2.0/opam
+++ b/packages/session/session.0.2.0/opam
@@ -43,3 +43,6 @@ depopts: [
   "postgresql"
   "webmachine"
 ]
+conflicts: [
+  "cohttp" {>= "0.99.0"}
+]

--- a/packages/session/session.0.3.0/opam
+++ b/packages/session/session.0.3.0/opam
@@ -49,4 +49,5 @@ depopts: [
 ]
 conflicts: [
   "redis" {>="0.3.4"}
+  "cohttp" {>= "0.99.0"}
 ]

--- a/packages/session/session.0.3.2/opam
+++ b/packages/session/session.0.3.2/opam
@@ -56,3 +56,6 @@ depopts: [
   "redis-lwt"
   "webmachine"
 ]
+conflicts: [
+  "cohttp" {>= "0.99.0"}
+]


### PR DESCRIPTION
This is not always the case, but if you install session + async + cohttp.0.99.0
then it will just fail with:

    ocamlfind: Package `cohttp-async' not found - required by `cohttp.async'

/cc @seliopou 