### PR TITLE
Package ocp-index-top.0.4.2

### DIFF
--- a/packages/ocp-index-top/ocp-index-top.0.4.2/descr
+++ b/packages/ocp-index-top/ocp-index-top.0.4.2/descr
@@ -1,0 +1,1 @@
+Documentation in the OCaml toplevel

--- a/packages/ocp-index-top/ocp-index-top.0.4.2/opam
+++ b/packages/ocp-index-top/ocp-index-top.0.4.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+author: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "https://github.com/reynir/ocp-index-top.git"
+homepage: "https://github.com/reynir/ocp-index-top/"
+bug-reports:  "https://github.com/reynir/ocp-index-top/issues"
+doc: "https://reynir.github.io/ocp-index-top/"
+license: "BSD-2-clause"
+available: [ ocaml-version > "4.01.0" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cppo" {build}
+  "ocp-index"
+]

--- a/packages/ocp-index-top/ocp-index-top.0.4.2/url
+++ b/packages/ocp-index-top/ocp-index-top.0.4.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/reynir/ocp-index-top/releases/download/v0.4.2/ocp-index-top-0.4.2.tbz"
+checksum: "8b20e031ac910c394d74f7b05b106981"


### PR DESCRIPTION
### `ocp-index-top.0.4.2`

Documentation in the OCaml toplevel



---
* Homepage: https://github.com/reynir/ocp-index-top/
* Source repo: https://github.com/reynir/ocp-index-top.git
* Bug tracker: https://github.com/reynir/ocp-index-top/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.4.2
------

- Implement resolution for class types.
- Implement `#doc_foo` directives for each namespace `foo` (e.g. `#doc_type` and `#doc_module`).
:camel: Pull-request generated by opam-publish v0.3.5