### PR TITLE
Package ocp-index-top.0.5.0

### DIFF
--- a/packages/ocp-index-top/ocp-index-top.0.5.0/descr
+++ b/packages/ocp-index-top/ocp-index-top.0.5.0/descr
@@ -1,0 +1,1 @@
+Documentation in the OCaml toplevel

--- a/packages/ocp-index-top/ocp-index-top.0.5.0/opam
+++ b/packages/ocp-index-top/ocp-index-top.0.5.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+author: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "https://github.com/reynir/ocp-index-top.git"
+homepage: "https://github.com/reynir/ocp-index-top/"
+bug-reports:  "https://github.com/reynir/ocp-index-top/issues"
+doc: "https://reynir.github.io/ocp-index-top/"
+license: "BSD-2-clause"
+available: [ ocaml-version > "4.01.0" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cppo" {build}
+  "cppo_ocamlbuild" {build}
+  "ocp-index"
+]

--- a/packages/ocp-index-top/ocp-index-top.0.5.0/url
+++ b/packages/ocp-index-top/ocp-index-top.0.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/reynir/ocp-index-top/releases/download/v0.5.0/ocp-index-top-0.5.0.tbz"
+checksum: "3d3087576c60a10ee2cdceecf784bdd9"


### PR DESCRIPTION
### `ocp-index-top.0.5.0`

Documentation in the OCaml toplevel



---
* Homepage: https://github.com/reynir/ocp-index-top/
* Source repo: https://github.com/reynir/ocp-index-top.git
* Bug tracker: https://github.com/reynir/ocp-index-top/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.5.0
------

- Use print functions provided by ocp-index.lib / LibIndex. This means that the
  type is printed as well.
:camel: Pull-request generated by opam-publish v0.3.5