### PR TITLE
restrict ocaml-version for omake.0.9.8.6-0.rc1

### DIFF
--- a/packages/omake/omake.0.9.8.6-0.rc1/opam
+++ b/packages/omake/omake.0.9.8.6-0.rc1/opam
@@ -1,14 +1,29 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+authors: [
+  "Aleksey Nogin"
+  "Jason Hickey"
+  "Gerd Stolpmann"
+]
+license: "GPL2"
+dev-repo: "https://github.com/ocaml-omake/omake.git"
+homepage: "http://projects.camlcity.org/projects/omake.html"
+bug-reports: "https://github.com/ocaml-omake/issues"
+depends: ["ocamlfind"]
 build: [
   [make "bootstrap" "PREFIX=%{prefix}%"]
   [make "all" "PREFIX=%{prefix}%"]
 ]
-depends: ["ocamlfind"]
+remove: [
+  [ "rm" "-f" "%{prefix}%/bin/omake" ]
+  [ "rm" "-f" "%{prefix}%/bin/osh" ]
+  [ "rm" "-rf" "%{prefix}%/lib/omake" ]
+]
+install: [make "install" "PREFIX=%{prefix}%"]
 patches: [
   "opam.patch"
   "fam.patch"
   "readline.patch"
   "netbsd_fam.patch"
 ]
-install: [make "install" "PREFIX=%{prefix}%"]
+available: [ ocaml-version < "4.06.0"]


### PR DESCRIPTION
it was forgotten in 4d0ac21583f73330da92db35d7f6aa2ed0c9281c
see: https://ci.ocaml.io/log/saved/docker-build-095e3f9853d924cbc68e96927a2fd0c2/06acdfeea2510cd4ed64ed9c06df3299cee887fd