### PR TITLE
ascii85 - version 0.4, port to jbuilder

### DIFF
--- a/packages/ascii85/ascii85.0.4/descr
+++ b/packages/ascii85/ascii85.0.4/descr
@@ -1,0 +1,7 @@
+ascii85 - Adobe's Ascii85 encoding as a module and a command line tool
+
+The ascii85 module implements the Ascii85 encoding as defined by Adobe for
+use in the PostScript language. The module is accompanied by a small
+utility ascii85enc to encode files from the command line.
+
+

--- a/packages/ascii85/ascii85.0.4/opam
+++ b/packages/ascii85/ascii85.0.4/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+name: "ascii85"
+version: "0.4"
+maintainer: "Christian Lindig <lindig@gmail.com>"
+authors: "Christian Lindig <lindig@gmail.com>"
+homepage: "https://github.com/lindig/ascii85"
+bug-reports: "https://github.com/lindig/ascii85/issues"
+license: "BSD"
+dev-repo: "https://github.com/lindig/ascii85.git"
+build: [
+ ["jbuilder" "build" "-j" jobs "@install"]
+]
+depends: [
+  "jbuilder" {build}
+]

--- a/packages/ascii85/ascii85.0.4/url
+++ b/packages/ascii85/ascii85.0.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/lindig/ascii85/archive/v0.4.zip"
+checksum: "96490bb34b76a748fa1504755c97bb83"


### PR DESCRIPTION
The ascii85 module implements the Ascii85 encoding as defined by Adobe for
use in the PostScript language. The module is accompanied by a small
utility ascii85enc to encode files from the command line.

Signed-off-by: Christian Lindig <lindig@gmail.com>