### PR TITLE
added omake.0.9.8.7

### DIFF
--- a/packages/omake/omake.0.9.8.7/descr
+++ b/packages/omake/omake.0.9.8.7/descr
@@ -1,0 +1,1 @@
+Build system designed for scalability and portability.

--- a/packages/omake/omake.0.9.8.7/opam
+++ b/packages/omake/omake.0.9.8.7/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "omake"
+version: "0.9.8.7"
+maintainer: "jun.furuse@gmail.com"
+authors: [
+  "Aleksey Nogin"
+  "Jason Hickey"
+]
+license: "GPL2"
+dev-repo: "https://github.com/camlspotter/omake-0.9.git"
+homepage: "https://github.com/camlspotter/omake-0.9/README.md"
+bug-reports: "https://github.com/camlspotter/omake-0.9/issues"
+
+build: [
+  [make "bootstrap" "PREFIX=%{prefix}%"]
+  [make "all" "PREFIX=%{prefix}%"]
+]
+
+install: [make "install" "PREFIX=%{prefix}%"]
+
+remove: [
+  [ "rm" "-f" "%{prefix}%/bin/omake" ]
+  [ "rm" "-f" "%{prefix}%/bin/osh" ]
+  [ "rm" "-rf" "%{prefix}%/lib/omake" ]
+]
+
+depends: ["ocamlfind"]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.07.0" ]

--- a/packages/omake/omake.0.9.8.7/url
+++ b/packages/omake/omake.0.9.8.7/url
@@ -1,1 +1,1 @@
-https://github.com/camlspotter/omake-0.9/archive/0.9.8.7.tar.gz
+archive: "https://github.com/camlspotter/omake-0.9/archive/0.9.8.7.tar.gz"

--- a/packages/omake/omake.0.9.8.7/url
+++ b/packages/omake/omake.0.9.8.7/url
@@ -1,0 +1,1 @@
+https://github.com/camlspotter/omake-0.9/archive/0.9.8.7.tar.gz

--- a/packages/unmagic/unmagic.1.0.2/opam
+++ b/packages/unmagic/unmagic.1.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "spotlib"
   "typerep"
   "ppx_typerep_conv" { build }
-  "ppx_deriving"
+  "ppx_deriving" { <= "4.1" } 
 ]
 available: [
   ocaml-version >= "4.03.0"


### PR DESCRIPTION
Ported omake.0.9.8.6-0.rc1 to OCaml 4.06.0.  Mac OS X requires this maintenance version since omake.0.10.x has some issues on it which are not fixed for long time.
