### PR TITLE
Add hashids.1.0.0 and dependencies (and migrate all my packages to jbuilder)

### DIFF
--- a/packages/DrawGrammar/DrawGrammar.0.1.0/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.1.0/opam
@@ -17,6 +17,6 @@ depends: [
   "menhir"
   "JsOfOCairo"
   "cairo2"
-  "General"
+  "General" {< "0.4"}
 ]
 available: [ocaml-version >= "4.02.2" & ocaml-version < "4.06.0"]

--- a/packages/DrawGrammar/DrawGrammar.0.2.0/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.0/opam
@@ -19,6 +19,6 @@ depends: [
   "menhir"
   "JsOfOCairo"
   "cairo2"
-  "General" {>= "0.2"}
+  "General" {>= "0.2" & < "0.4"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/DrawGrammar/DrawGrammar.0.2.1/descr
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/descr
@@ -1,0 +1,3 @@
+Draw railroad diagrams of EBNF grammars
+
+An [interactive demo](http://jacquev6.github.io/DrawGrammar/) is available.

--- a/packages/DrawGrammar/DrawGrammar.0.2.1/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+homepage: "https://jacquev6.github.io/DrawGrammar/"
+bug-reports: "http://github.com/jacquev6/DrawGrammar/issues/"
+license: "MIT"
+doc: "https://jacquev6.github.io/DrawGrammar/"
+dev-repo: "https://github.com/jacquev6/DrawGrammar.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "menhir"
+  "JsOfOCairo" {>= "1.0.1"}
+  "cairo2"
+  "General" {>= "0.4.0"}
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/DrawGrammar/DrawGrammar.0.2.1/url
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jacquev6/DrawGrammar/archive/0.2.1.tar.gz"
+checksum: "c47a0dd33a72959cc83cb6d851bb0ad4"

--- a/packages/General/General.0.4.0/descr
+++ b/packages/General/General.0.4.0/descr
@@ -1,0 +1,1 @@
+Rich functionality for built-in and basic OCaml types

--- a/packages/General/General.0.4.0/opam
+++ b/packages/General/General.0.4.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+homepage: "https://jacquev6.github.io/General/"
+bug-reports: "http://github.com/jacquev6/General/issues/"
+license: "MIT"
+doc: "https://jacquev6.github.io/General/"
+dev-repo: "https://github.com/jacquev6/General.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "cppo" {build & >= "1.3.0"}
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/General/General.0.4.0/url
+++ b/packages/General/General.0.4.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jacquev6/General/archive/0.4.0.tar.gz"
+checksum: "bca274800b824bd0e492a5abf038867c"

--- a/packages/JsOfOCairo/JsOfOCairo.1.0.1/descr
+++ b/packages/JsOfOCairo/JsOfOCairo.1.0.1/descr
@@ -1,0 +1,5 @@
+Library to reuse Cairo-based drawing code in web browsers
+
+JsOfOCairo is an OCaml (4.02.3+) library to reuse Cairo-based drawing code in web browsers.
+It's an adapter, implementing (a reasonable subset of) the interface of [Cairo OCaml](https://github.com/Chris00/ocaml-cairo/)
+targeting HTML5 canvas elements as exposed to OCaml by [js_of_ocaml](https://ocsigen.org/js_of_ocaml/) (3.0.0+).

--- a/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+homepage: "https://github.com/jacquev6/JsOfOCairo"
+bug-reports: "http://github.com/jacquev6/JsOfOCairo/issues/"
+license: "MIT"
+doc: "https://github.com/jacquev6/JsOfOCairo"
+dev-repo: "https://github.com/jacquev6/JsOfOCairo.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "js_of_ocaml-compiler" {build & >= "3.0" & < "4.0"}
+  "js_of_ocaml-ppx" {build & >= "3.0" & < "4.0"}
+  "js_of_ocaml" {>= "3.0" & < "4.0"}
+  "cairo2"
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/JsOfOCairo/JsOfOCairo.1.0.1/url
+++ b/packages/JsOfOCairo/JsOfOCairo.1.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jacquev6/JsOfOCairo/archive/1.0.1.tar.gz"
+checksum: "7852380f27e01dd02a73d2365fd1b195"

--- a/packages/hashids/hashids.1.0.0/descr
+++ b/packages/hashids/hashids.1.0.0/descr
@@ -1,0 +1,1 @@
+[hashids](http://hashids.org/): generate short, unique, non-sequential ids from numbers, that you can also decode

--- a/packages/hashids/hashids.1.0.0/opam
+++ b/packages/hashids/hashids.1.0.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+homepage: "https://jacquev6.github.io/hashids-ocaml/"
+bug-reports: "http://github.com/jacquev6/hashids-ocaml/issues/"
+license: "MIT"
+doc: "https://jacquev6.github.io/hashids-ocaml/"
+dev-repo: "https://github.com/jacquev6/hashids-ocaml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "General" {>= "0.4.0"}
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/hashids/hashids.1.0.0/url
+++ b/packages/hashids/hashids.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jacquev6/hashids-ocaml/archive/1.0.0.tar.gz"
+checksum: "73987f5924ff28825747e0744895f9e7"

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/opam
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/opam
@@ -20,7 +20,7 @@ remove: ["rm" "-f" "%{prefix}%/bin/sphinxcontrib-ocaml-autodoc"]
 depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "General"
+  "General" {< "0.4"}
   "yojson"
 ]
 available: [ocaml-version = "4.05.0"]

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/opam
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.2.0/opam
@@ -20,7 +20,7 @@ remove: ["rm" "-f" "%{prefix}%/bin/sphinxcontrib-ocaml-autodoc"]
 depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "General" {< "0.4"}
+  "General" {>= "0.2" & < "0.4"}
   "yojson"
 ]
 available: [ocaml-version = "4.05.0"]

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/descr
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/descr
@@ -1,0 +1,5 @@
+Sphinx extension to document OCaml libraries
+
+sphinxcontrib-ocaml is a [Sphinx](http://www.sphinx-doc.org/) (1.6.3+) extension to document OCaml libraries.
+It provides a Sphinx domain for OCaml and [autodoc](http://www.sphinx-doc.org/en/stable/ext/autodoc.html)-like
+directives to generate documentation from source code.

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/opam
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+homepage: "https://jacquev6.github.io/sphinxcontrib-ocaml/"
+bug-reports: "http://github.com/jacquev6/sphinxcontrib-ocaml/issues/"
+license: "MIT"
+doc: "https://jacquev6.github.io/sphinxcontrib-ocaml/"
+dev-repo: "https://github.com/jacquev6/sphinxcontrib-ocaml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "General" {>= "0.4.0"}
+  "yojson"
+]
+available: [ocaml-version = "4.05.0"]

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/url
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/jacquev6/sphinxcontrib-ocaml/archive/0.3.0.tar.gz"
+checksum: "35e3beb49a190cef70074ad3e276a385"


### PR DESCRIPTION
This is a new version of #10209. @samoht noted that my install method was fragile and suggested porting to jbuilder. After digging a bit, I'm enthusiastic about jbuilder, so I've migrated all my packages.

Each package was added using `opam-publish prepare`:

- [General 0.4.0](https://jacquev6.github.io/General): Rich functionality for built-in and basic OCaml types
- [hashids 1.0.0](https://jacquev6.github.io/hashids-ocaml/): [hashids](http://hashids.org/): generate short, unique, non-sequential ids from numbers, that you can also decode
- [DrawGrammar 0.2.1](https://jacquev6.github.io/DrawGrammar/): Draw railroad diagrams of EBNF grammars
- [JsOfOCairo 1.0.1](https://github.com/jacquev6/JsOfOCairo): Library to reuse Cairo-based drawing code in web browsers
- [sphinxcontrib-ocaml 0.3.0](https://jacquev6.github.io/sphinxcontrib-ocaml/): Sphinx extension to document OCaml libraries