### PR TITLE
Package conf-secp256k1.1.0.0

### DIFF
--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/descr
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/descr
@@ -1,0 +1,2 @@
+Virtual package relying on a secp256k1 lib system installation.
+This package can only install if the secp256k1 lib is installed on the system.

--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: "Davide Gessa <gessadavide@gmail.com>"
+homepage: "https://github.com/dakk/conf-secp256k1"
+bug-reports: "https://github.com/dakk/conf-secp256k1/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/conf-secp256k1"
+
+depexts: [
+  [["debian"] ["libsecp256k1-0" "libsecp256k1-dev"]]
+  [["gentoo"] ["dev-libs/libsecp256k1"]]
+  [["homebrew" "osx"] ["secp256k1"]]
+  [["archlinux"] ["libsecp256k1-git"]]
+  [["ubuntu"] ["libsecp256k1-0" "libsecp256k1-dev"]]
+]

--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/url
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dakk/conf-secp256k1/archive/1.0.0.tar.gz"
+checksum: "6492be9ed737be2a2b9f4db7d015b1e8"


### PR DESCRIPTION
### `conf-secp256k1.1.0.0`

Virtual package relying on a secp256k1 lib system installation.
This package can only install if the secp256k1 lib is installed on the system.



---
* Homepage: https://github.com/dakk/conf-secp256k1
* Source repo: https://github.com/dakk/conf-secp256k1
* Bug tracker: https://github.com/dakk/conf-secp256k1/issues

---

:camel: Pull-request generated by opam-publish v0.3.5