### PR TITLE
Fix camlp4.4.05+1 when using safe-string

### DIFF
--- a/packages/camlp4/camlp4.4.05+1/files/safe-string.patch
+++ b/packages/camlp4/camlp4.4.05+1/files/safe-string.patch
@@ -1,0 +1,79 @@
+diff --git a/_tags b/_tags
+index 7a29e8aa4..e2124eaa5 100644
+--- a/_tags
++++ b/_tags
+@@ -17,6 +17,9 @@
+ # We want -g everywhere it's possible
+ true: debug
+ 
++# Enforce safe-string
++true: safe_string
++
+ <camlp4/**/*>: use_import
+ <camlp4/**/*.{byte,native}>: use_dynlink
+ <camlp4/config/gen_import.*>: use_ocamlcommon
+diff --git a/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml b/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
+index c7e57a1b3..8e270af21 100644
+--- a/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
++++ b/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
+@@ -77,15 +77,16 @@ module Make (Ast : Sig.Camlp4Ast) = struct
+   ;
+ 
+   value remove_underscores s =
+-    let l = String.length s in
++    let s = Bytes.of_string s in
++    let l = Bytes.length s in
+     let rec remove src dst =
+       if src >= l then
+-        if dst >= l then s else String.sub s 0 dst
++        if dst >= l then s else Bytes.sub s 0 dst
+       else
+-        match s.[src] with
++        match Bytes.get s src with
+         [ '_' -> remove (src + 1) dst
+         |  c  -> do { Bytes.set s dst c; remove (src + 1) (dst + 1) } ]
+-    in remove 0 0
++    in Bytes.to_string (remove 0 0)
+   ;
+ 
+   value mkloc = Loc.to_ocaml_location;
+diff --git a/camlp4/Camlp4Parsers/Camlp4AstLoader.ml b/camlp4/Camlp4Parsers/Camlp4AstLoader.ml
+index 7347a15e0..dfc60053b 100644
+--- a/camlp4/Camlp4Parsers/Camlp4AstLoader.ml
++++ b/camlp4/Camlp4Parsers/Camlp4AstLoader.ml
+@@ -32,9 +32,8 @@ module Make (Ast : Camlp4.Sig.Ast) = struct
+       let () = Stream.iter (Buffer.add_char buf) strm
+       in Buffer.contents buf in
+     let magic_len = String.length ast_magic in
+-    let buffer = String.create magic_len in
+     do {
+-      String.blit str 0 buffer 0 magic_len;
++      let buffer = String.sub str 0 magic_len;
+       if buffer = ast_magic then ()
+       else failwith (Format.sprintf "Bad magic: %S vs %S" buffer ast_magic);
+       Marshal.from_string str magic_len;
+diff --git a/camlp4/boot/Camlp4.ml b/camlp4/boot/Camlp4.ml
+index 44dfe6c39..2adc84762 100644
+--- a/camlp4/boot/Camlp4.ml
++++ b/camlp4/boot/Camlp4.ml
+@@ -15410,15 +15410,16 @@ module Struct =
+               with | (Failure _ as exn) -> Loc.raise loc exn
+ 
+             let remove_underscores s =
+-              let l = String.length s in
++              let s = Bytes.of_string s in
++              let l = Bytes.length s in
+               let rec remove src dst =
+                 if src >= l
+-                then if dst >= l then s else String.sub s 0 dst
++                then if dst >= l then s else Bytes.sub s 0 dst
+                 else
+-                  (match s.[src] with
++                  (match Bytes.get s src with
+                    | '_' -> remove (src + 1) dst
+                    | c -> (Bytes.set s dst c; remove (src + 1) (dst + 1)))
+-              in remove 0 0
++              in Bytes.to_string (remove 0 0)
+ 
+             let mkloc = Loc.to_ocaml_location
+ 

--- a/packages/camlp4/camlp4.4.05+1/opam
+++ b/packages/camlp4/camlp4.4.05+1/opam
@@ -3,6 +3,9 @@ authors: ["Daniel de Rauglaudre" "Nicolas Pouillard"]
 maintainer: "jeremie@dimino.org"
 homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
+patches: [
+  "safe-string.patch"
+]
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
   [make "clean"]


### PR DESCRIPTION
I suppose it will be safe to add this fix as soon as https://github.com/ocaml/camlp4/pull/124 is merged.