### PR TITLE
Package kyotocabinet.0.1

### DIFF
--- a/packages/kyotocabinet/kyotocabinet.0.1/descr
+++ b/packages/kyotocabinet/kyotocabinet.0.1/descr
@@ -1,0 +1,5 @@
+OCaml bindings for Kyoto Cabinet DBM
+
+Kyoto Cabinet is a key-value store featuring
+both B+ tree and hash databases
+with either in-memory or on-disk persistence.

--- a/packages/kyotocabinet/kyotocabinet.0.1/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Didier Wenzek <didier.wenzek@acidalie.com>"
+authors: "Didier Wenzek <didier.wenzek@acidalie.com>"
+homepage: "https://github.com/didier-wenzek/ocaml-kyotocabinet"
+bug-reports: "https://github.com/didier-wenzek/ocaml-kyotocabinet/issues"
+license: "GPL"
+dev-repo: "https://github.com/didier-wenzek/ocaml-kyotocabinet.git"
+build: [
+  "jbuilder" "build" "--only" "kyotocabinet" "--root" "." "-j" jobs "@install"
+]
+build-test: [ "jbuilder" "runtest" "-p" name ]
+depends: "jbuilder"
+depexts: [
+  [[ "ubuntu"] ["libkyotocabinet-dev"]]
+  [[ "debian"] ["libkyotocabinet-dev"]]
+  [[ "fedora"] ["kyotocabinet-devel"]]
+  [[ "osx" "homebrew"] ["kyoto-cabinet"]]
+  [[ "osx" "macports"] ["kyotocabinet"]]
+]

--- a/packages/kyotocabinet/kyotocabinet.0.1/url
+++ b/packages/kyotocabinet/kyotocabinet.0.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/didier-wenzek/ocaml-kyotocabinet/archive/1.0.tar.gz"
+checksum: "f075dd4386c9fbfb6abdccfad75f9751"


### PR DESCRIPTION
### `kyotocabinet.0.1`

OCaml bindings for Kyoto Cabinet DBM

Kyoto Cabinet is a key-value store featuring
both B+ tree and hash databases
with either in-memory or on-disk persistence.



---
* Homepage: https://github.com/didier-wenzek/ocaml-kyotocabinet
* Source repo: https://github.com/didier-wenzek/ocaml-kyotocabinet.git
* Bug tracker: https://github.com/didier-wenzek/ocaml-kyotocabinet/issues

---

:camel: Pull-request generated by opam-publish v0.3.5