### PR TITLE
Package reason-generate-types-from-graphql-schema.0.5

### DIFF
--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.5/descr
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.5/descr
@@ -1,0 +1,5 @@
+Generate Reason types from a graphql schema
+
+This package will generate Reason types from a remote graphql API.
+By sending an introspection query, it will get the schema json and from there, generate the typings.
+

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.5/opam
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.5/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "greg <greg@hackages.io>"
+authors: "greg <greg@hackages.io>"
+dev-repo: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git"
+bug-reports: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues"
+homepage: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema"
+build: [
+  ["ocamlbuild -r -use-ocamlfind  src/index.native"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "reason-generate-types-from-graphql-schema"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.5/url
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.5/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/archive/0.5.tar.gz"
+checksum: "813a78257c78840afb2b35bdacaa23b7"


### PR DESCRIPTION
### `reason-generate-types-from-graphql-schema.0.5`

Generate Reason types from a graphql schema

This package will generate Reason types from a remote graphql API.
By sending an introspection query, it will get the schema json and from there, generate the typings.




---
* Homepage: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema
* Source repo: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git
* Bug tracker: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues

---

:camel: Pull-request generated by opam-publish v0.3.5