### PR TITLE
Package reason-generate-types-from-graphql-schema.0.7

### DIFF
--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.7/descr
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.7/descr
@@ -1,0 +1,5 @@
+Generate Reason types from a graphql schema
+
+This package will generate Reason types from a remote graphql API.
+By sending an introspection query, it will get the schema json and from there, generate the typings.
+

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.7/opam
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.7/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "greg <greg@hackages.io>"
+authors: "greg <greg@hackages.io>"
+build: [
+  ["ocamlbuild -r -use-ocamlfind  src/index.native"]
+]
+tags: ["reasonml" "graphql"]
+dev-repo: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git"
+bug-reports: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues"
+homepage: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema"
+install: ["./index.native"]
+remove: ["ocamlfind" "remove" "reason-generate-types-from-graphql-schema"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "cohttp" {build}
+  "lwt" {build}
+  "Yojson" {build}
+]

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.7/url
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.7/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/archive/0.7.tar.gz"
+checksum: "52ec88a0b76311c3fa8aab56b62edcf2"


### PR DESCRIPTION
### `reason-generate-types-from-graphql-schema.0.7`

Generate Reason types from a graphql schema

This package will generate Reason types from a remote graphql API.
By sending an introspection query, it will get the schema json and from there, generate the typings.




---
* Homepage: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema
* Source repo: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git
* Bug tracker: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues

---

:camel: Pull-request generated by opam-publish v0.3.5