### PR TITLE
Package reason-generate-types-from-graphql-schema.0.9.1

### DIFF
--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.1/descr
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.1/descr
@@ -1,0 +1,4 @@
+Generate ReasonML types from a GraphQL API
+
+This package generates ReasonML types from a remote GraphQL server, by sending an introspection query
+

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.1/opam
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "greg <greg@hackages.io>"
+authors: "greg <greg@hackages.io>"
+dev-repo: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git"
+bug-reports: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues"
+homepage: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema"
+build: [
+  ["ocamlbuild -r -use-ocamlfind  src/index.byte"]
+]
+tags: ["reasonml" "graphql"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.1/url
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/archive/0.9.1.tar.gz"
+checksum: "b85c0c62fda662e37bf04da5f8b4f747"


### PR DESCRIPTION
### `reason-generate-types-from-graphql-schema.0.9.1`

Generate ReasonML types from a GraphQL API

This package generates ReasonML types from a remote GraphQL server, by sending an introspection query




---
* Homepage: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema
* Source repo: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git
* Bug tracker: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues

---

:camel: Pull-request generated by opam-publish v0.3.5