### PR TITLE
Package reason-generate-types-from-graphql-schema.0.9.3

### DIFF
--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.3/descr
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.3/descr
@@ -1,0 +1,4 @@
+Generate ReasonML types from a GraphQL API
+
+This package generates ReasonML types from a remote GraphQL server, by sending an introspection query
+

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.3/opam
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.3/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "greg <greg@hackages.io>"
+authors: "greg <greg@hackages.io>"
+dev-repo: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git"
+bug-reports: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues"
+homepage: "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema"
+build: [
+  ["ocamlbuild -r -use-ocamlfind  src/index.native"]
+]
+tags: ["reasonml" "graphql"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]

--- a/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.3/url
+++ b/packages/reason-generate-types-from-graphql-schema/reason-generate-types-from-graphql-schema.0.9.3/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/archive/0.9.3.tar.gz"
+checksum: "37bd393ee5d413863166b61ee767b8e5"


### PR DESCRIPTION
### `reason-generate-types-from-graphql-schema.0.9.3`

Generate ReasonML types from a GraphQL API

This package generates ReasonML types from a remote GraphQL server, by sending an introspection query




---
* Homepage: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema
* Source repo: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema.git
* Bug tracker: https://github.com/Gregoirevda/reason-generate-types-from-graphql-schema/issues

---

:camel: Pull-request generated by opam-publish v0.3.5