### PR TITLE
amqp-client.1.1.2

### DIFF
--- a/packages/amqp-client/amqp-client.1.1.2/descr
+++ b/packages/amqp-client/amqp-client.1.1.2/descr
@@ -1,0 +1,6 @@
+Amqp client library compatable with async and lwt.
+
+This library provides high level client bindings for amqp. The library
+is tested against rabbitmq, but should work against other amqp
+servers. The library is written in pure OCaml and supports both Async
+and Lwt for concurrency.

--- a/packages/amqp-client/amqp-client.1.1.2/opam
+++ b/packages/amqp-client/amqp-client.1.1.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: [ "Anders Fugmann" ]
+homepage: "https://github.com/andersfugmann/amqp-client"
+bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
+dev-repo: "https://github.com/andersfugmann/amqp-client.git"
+license: "BSD3"
+version: "1.1.1"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+install: [jbuilder install]
+remove: [jbuilder uninstall]
+depends: [
+  "jbuilder" {build}
+  "xml-light" {build}
+  "ocplib-endian" {>= "0.6"}
+  "async" {test}
+  "lwt" {test}
+]
+depopts: [
+  "async"
+  "lwt"
+]
+conflicts: [
+  "lwt" {< "2.4.6"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/amqp-client/amqp-client.1.1.2/url
+++ b/packages/amqp-client/amqp-client.1.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andersfugmann/amqp-client/archive/1.1.2.tar.gz"
+checksum: "0cd25b9808251fbb5e19517d7a3aad4b"


### PR DESCRIPTION
Previous version did not include the async version dues to conflicting names in jbuilder which caused jbuilder to skip the async version. This version includes a crude and ugly hack to make jbuilder include both libraries even though the names conflict.