### PR TITLE
+ott.0.26

### DIFF
--- a/packages/ott/ott.0.26/descr
+++ b/packages/ott/ott.0.26/descr
@@ -1,0 +1,9 @@
+Ott is a tool for writing definitions of programming languages and calculi
+
+It takes as input a definition of a language syntax and semantics, in a concise
+and readable ASCII notation that is close to what one would write in informal
+mathematics. It generates LaTeX to build a typeset version of the definition,
+and Coq, HOL, and Isabelle versions of the definition. Additionally, it can be
+run as a filter, taking a LaTeX/Coq/Isabelle/HOL source file with embedded
+(symbolic) terms of the defined language, parsing them and replacing them by
+target-system terms.

--- a/packages/ott/ott.0.26/files/ott.install
+++ b/packages/ott/ott.0.26/files/ott.install
@@ -1,0 +1,3 @@
+bin: ["src/ott"]
+doc: ["doc/ott_manual_0.25.pdf" "doc/ott_manual_0.25.html"]
+share: ["emacs/ottmode.el" {"emacs/ottmode.el"} "tex/ottlayout.sty" {"tex/ottlayout.sty"}]

--- a/packages/ott/ott.0.26/files/ott.install
+++ b/packages/ott/ott.0.26/files/ott.install
@@ -1,3 +1,3 @@
 bin: ["src/ott"]
 doc: ["doc/ott_manual_0.25.pdf" "doc/ott_manual_0.25.html"]
-share: ["emacs/ottmode.el" {"emacs/ottmode.el"} "tex/ottlayout.sty" {"tex/ottlayout.sty"}]
+share: ["emacs/ott-mode.el" {"emacs/ott-mode.el"} "tex/ottlayout.sty" {"tex/ottlayout.sty"}]

--- a/packages/ott/ott.0.26/opam
+++ b/packages/ott/ott.0.26/opam
@@ -5,6 +5,7 @@ homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
 dev-repo: "https://github.com/ott-lang/ott.git"
 bug-reports: "https://github.com/ott-lang/ott/issues"
 license: "part BSD3, part LGPL 2.1"
+available: [ ocaml-version >= "4.00.0" ]
 
 build: [
   [ make "world" ]

--- a/packages/ott/ott.0.26/opam
+++ b/packages/ott/ott.0.26/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens"]
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+
+build: [
+  [ make "world" ]
+]

--- a/packages/ott/ott.0.26/url
+++ b/packages/ott/ott.0.26/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ott-lang/ott/archive/0.26.tar.gz"
+checksum: "8aee607f1a386b3e12b1dfe0c2cf7ca1"


### PR DESCRIPTION
changes:
- 2017-02-10 Add command-line option `-tex_suppress_category <string>` to suppress productions or rules with the specified category string.
- 2017-02-13 Add command-line option `-tex_suppress_ntr <string>` to suppress the grammar rule with that principal nonterminal root.
- 2017-05-28 fixes for Coq 8.5 and 8.6, contributed by @palmskog
- 2017-05-29 - 2017-06-14 Add experimental support for generating a standalone lexer, menhir parser, and pretty printer, as illustrated in `tests/menhir_tests/test10menhir`
- 2017-07-17 fixes for OCaml `-safe-string`, contributed by @jpdeplaix
- 2017-09-07 example of "literate" ott spec, in `tests/test10literate`
- 2017-09-21 use `Type` instead of `Set` in Coq list functions, contributed by @palmskog

