### PR TITLE
+zarith.1.6

### DIFF
--- a/packages/zarith/zarith.1.6/descr
+++ b/packages/zarith/zarith.1.6/descr
@@ -1,0 +1,5 @@
+Implements arithmetic and logical operations over arbitrary-precision integers
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy.

--- a/packages/zarith/zarith.1.6/opam
+++ b/packages/zarith/zarith.1.6/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Xavier Leroy"
+homepage: "https://github.com/ocaml/Zarith"
+bug-reports: "https://github.com/ocaml/Zarith/issues"
+dev-repo: "https://github.com/ocaml/Zarith.git"
+build: [
+  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/usr/local/include\" ./configure"] { os = "openbsd" | os = "freebsd" }
+  ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"] { os = "darwin" }
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove:  ["ocamlfind" "remove" "zarith"]
+depends: [
+  "ocamlfind"
+  "conf-gmp"
+  "conf-perl" {build}
+]

--- a/packages/zarith/zarith.1.6/url
+++ b/packages/zarith/zarith.1.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/Zarith/archive/release-1.6.tar.gz"
+checksum: "6cc3023620048236d2e8d3a21d5f0940"


### PR DESCRIPTION
changes:
- On Linux and BSD, keep the stack non-executable.
- Fixed spurious installation error if shared libraries not supported [Bernhard Schommer]
- clarify documentation of Q.of_string