### PR TITLE
Package hashcons.1.3

### DIFF
--- a/packages/hashcons/hashcons.1.3/descr
+++ b/packages/hashcons/hashcons.1.3/descr
@@ -1,0 +1,8 @@
+OCaml hash-consing library
+
+The technique is described in this paper:
+
+*Sylvain Conchon and Jean-Christophe Filliâtre.* Type-Safe Modular Hash-Consing.
+In ACM SIGPLAN Workshop on ML, Portland, Oregon, September 2006.
+The PDF is available at
+<https://www.lri.fr/~filliatr/ftp/publis/hash-consing2.pdf>

--- a/packages/hashcons/hashcons.1.3/opam
+++ b/packages/hashcons/hashcons.1.3/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:   "sheets@alum.mit.edu"
+homepage:     "https://github.com/backtracking/ocaml-hashcons"
+dev-repo:     "https://github.com/backtracking/ocaml-hashcons.git"
+bug-reports:  "https://github.com/backtracking/ocaml-hashcons/issues"
+authors:      [ "Jean-Christophe Filliatre" ]
+license: "LGPL-2.1 with OCaml linking exception"
+build: [
+  ["autoconf"]
+  ["./configure"]
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "hashcons"]]
+depends: [
+  "conf-autoconf" {build}
+  "ocamlfind" {build}
+  "conf-which" {build}
+]

--- a/packages/hashcons/hashcons.1.3/url
+++ b/packages/hashcons/hashcons.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/backtracking/ocaml-hashcons/archive/1.3.tar.gz"
+checksum: "88b93515dd2667c4944574dfb50352bf"


### PR DESCRIPTION
### `hashcons.1.3`

OCaml hash-consing library

The technique is described in this paper:

*Sylvain Conchon and Jean-Christophe Filliâtre.* Type-Safe Modular Hash-Consing.
In ACM SIGPLAN Workshop on ML, Portland, Oregon, September 2006.
The PDF is available at
<https://www.lri.fr/~filliatr/ftp/publis/hash-consing2.pdf>



---
* Homepage: https://github.com/backtracking/ocaml-hashcons
* Source repo: https://github.com/backtracking/ocaml-hashcons.git
* Bug tracker: https://github.com/backtracking/ocaml-hashcons/issues

---

:camel: Pull-request generated by opam-publish v0.3.5