### PR TITLE
Package nonstd.0.0.3

### DIFF
--- a/packages/nonstd/nonstd.0.0.3/descr
+++ b/packages/nonstd/nonstd.0.0.3/descr
@@ -1,0 +1,4 @@
+Non-standard mini-library
+
+Core-style (labels, exceptionless) pure-OCaml super-light library
+providing basic modules: List, Option, Int. and Float.

--- a/packages/nonstd/nonstd.0.0.3/opam
+++ b/packages/nonstd/nonstd.0.0.3/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "seb@mondet.org"
+authors: [
+  "Sebastien Mondet <seb@modnet.org>" "Leonid Rozenberg <leonidr@gmail.com>"
+]
+homepage: "https://bitbucket.org/smondet/nonstd"
+bug-reports: "https://bitbucket.org/smondet/nonstd"
+dev-repo: "https://bitbucket.org/smondet/nonstd.git"
+build: [
+  "jbuilder" "build" "--only" "nonstd" "--root" "." "-j" jobs "@install"
+]
+depends: [
+  "ocamlfind"
+  "jbuilder" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/nonstd/nonstd.0.0.3/url
+++ b/packages/nonstd/nonstd.0.0.3/url
@@ -1,0 +1,2 @@
+http: "https://bitbucket.org/smondet/nonstd/get/nonstd.0.0.3.tar.gz"
+checksum: "784401ed67aa323e03544e0f801abefd"


### PR DESCRIPTION
### `nonstd.0.0.3`

Non-standard mini-library

Core-style (labels, exceptionless) pure-OCaml super-light library
providing basic modules: List, Option, Int. and Float.



---
* Homepage: https://bitbucket.org/smondet/nonstd
* Source repo: https://bitbucket.org/smondet/nonstd.git
* Bug tracker: https://bitbucket.org/smondet/nonstd

---

:camel: Pull-request generated by opam-publish v0.3.5