### PR TITLE
Package bn128.0.1.2

### DIFF
--- a/packages/bn128/bn128.0.1.2/descr
+++ b/packages/bn128/bn128.0.1.2/descr
@@ -1,0 +1,7 @@
+Barreto-Naehrig 128 Elliptic Curve pairing function library in OCAML
+
+bn128-ml is an OCAML library providing access to the Barreto-Naehrig-128
+elliptic curve, including field operations over the relevant field,
+elliptic curve operations over the G1, G2, and G12 curves, and a
+pairing function which accepts a point in G1 and a point in G2 and
+pairs it into a point in G12.

--- a/packages/bn128/bn128.0.1.2/opam
+++ b/packages/bn128/bn128.0.1.2/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Dwight Guth <dwight.guth@runtimeverification.com>"
+authors: "Dwight Guth <dwight.guth@runtimeverification.com>"
+homepage: "https://github.com/runtimeverification/bn128-ml"
+bug-reports: "https://github.com/runtimeverification/bn128-ml/issues"
+license: "UIUC"
+dev-repo: "http://github.com/runtimeverification/bn128-ml.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "bn128"]
+depends: ["ocamlfind" "zarith"]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/bn128/bn128.0.1.2/url
+++ b/packages/bn128/bn128.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/runtimeverification/bn128-ml/archive/0.1.2.tar.gz"
+checksum: "9d660c5c6322de8378021bc24f1821b3"


### PR DESCRIPTION
### `bn128.0.1.2`

Barreto-Naehrig 128 Elliptic Curve pairing function library in OCAML

bn128-ml is an OCAML library providing access to the Barreto-Naehrig-128
elliptic curve, including field operations over the relevant field,
elliptic curve operations over the G1, G2, and G12 curves, and a
pairing function which accepts a point in G1 and a point in G2 and
pairs it into a point in G12.



---
* Homepage: https://github.com/runtimeverification/bn128-ml
* Source repo: http://github.com/runtimeverification/bn128-ml.git
* Bug tracker: https://github.com/runtimeverification/bn128-ml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5