### PR TITLE
Package dtoa.0.3.0

### DIFF
--- a/packages/dtoa/dtoa.0.3.0/descr
+++ b/packages/dtoa/dtoa.0.3.0/descr
@@ -1,0 +1,3 @@
+Converts OCaml floats into strings (doubles to ascii, "d to a"), using the efficient Grisu3 algorithm.
+
+This is a (partial) port of Google's double-conversion library from C++ to C.

--- a/packages/dtoa/dtoa.0.3.0/opam
+++ b/packages/dtoa/dtoa.0.3.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Marshall Roch <mroch@fb.com>"
+authors: "Marshall Roch <mroch@fb.com>"
+homepage: "https://github.com/flowtype/ocaml-dtoa"
+bug-reports: "https://github.com/flowtype/ocaml-dtoa/issues"
+license: "MIT"
+doc: "https://github.com/flowtype/ocaml-dtoa"
+dev-repo: "https://github.com/flowtype/ocaml-dtoa.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ounit" {test & >= "2.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/dtoa/dtoa.0.3.0/url
+++ b/packages/dtoa/dtoa.0.3.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/flowtype/ocaml-dtoa/archive/0.3.0.tar.gz"
-checksum: "27be1fc6369909b1b823a2663767b4ba"
+checksum: "b974e5ef17b357b0e8fe24c1fcc472c5"

--- a/packages/dtoa/dtoa.0.3.0/url
+++ b/packages/dtoa/dtoa.0.3.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/flowtype/ocaml-dtoa/archive/0.3.0.tar.gz"
-checksum: "6480cad9196a10861e853a6801c0a3d6"
+checksum: "27be1fc6369909b1b823a2663767b4ba"

--- a/packages/dtoa/dtoa.0.3.0/url
+++ b/packages/dtoa/dtoa.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/flowtype/ocaml-dtoa/archive/0.3.0.tar.gz"
+checksum: "6480cad9196a10861e853a6801c0a3d6"


### PR DESCRIPTION
### `dtoa.0.3.0`

Converts OCaml floats into strings (doubles to ascii, "d to a"), using the efficient Grisu3 algorithm.

This is a (partial) port of Google's double-conversion library from C++ to C.



---
* Homepage: https://github.com/flowtype/ocaml-dtoa
* Source repo: https://github.com/flowtype/ocaml-dtoa.git
* Bug tracker: https://github.com/flowtype/ocaml-dtoa/issues

---

:camel: Pull-request generated by opam-publish v0.3.5