### PR TITLE
Restrict prometheus-app.0.1 to using prometheus.0.1

### DIFF
--- a/packages/prometheus-app/prometheus-app.0.1/opam
+++ b/packages/prometheus-app/prometheus-app.0.1/opam
@@ -18,7 +18,7 @@ build-test: [
 
 depends: [
   "ocamlfind" {build}
-  "prometheus"
+  "prometheus" {<"0.2"}
   "fmt"
   "cohttp" {>="0.20.0" & <"0.99"}
   "lwt" {>="2.5.0"}


### PR DESCRIPTION
Error was:

```
Error: No implementations provided for the following modules:
         Str referenced from /home/opam/.opam/4.03.0/lib/prometheus-app/prometheus-app.cmxa(Prometheus_app)
```

/cc @samoht 