### PR TITLE
minor metadata fixes

### DIFF
--- a/compilers/3.09.1/3.09.1+metaocaml/3.09.1+metaocaml.comp
+++ b/compilers/3.09.1/3.09.1+metaocaml/3.09.1+metaocaml.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.09.1"
-src: "http://web.archive.org/web/20120209151915/http://www.metaocaml.org/dist/old/MetaOCaml_309_alpha_030.tar.gz"
+src: "http://web.archive.org/web/20120209151915/www.metaocaml.org/dist/old/MetaOCaml_309_alpha_030.tar.gz"
 build: [
   ["./configure" "-prefix" prefix]
   [make "world"]

--- a/packages/bitcoinml/bitcoinml.0.2.4/opam
+++ b/packages/bitcoinml/bitcoinml.0.2.4/opam
@@ -30,6 +30,3 @@ depends: [
   "odoc" {test & >= "1.1.1"}
 ]
 
-depexts: [
-]
-

--- a/packages/lemonade-sqlite/lemonade-sqlite.0.1.0/opam
+++ b/packages/lemonade-sqlite/lemonade-sqlite.0.1.0/opam
@@ -31,6 +31,6 @@ depends: [
   "sqlite3" {>= "2.0.9"}
 ]
 depexts: [
-  [["osx"] "sqlite3"]
-  [["ubuntu"] "sqlite3"]
+  [["osx"] ["sqlite3"]]
+  [["ubuntu"] ["sqlite3"]]
 ]

--- a/packages/ocamlspot/ocamlspot.4.02.1.2.3.0/opam
+++ b/packages/ocamlspot/ocamlspot.4.02.1.2.3.0/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 version: "4.02.1.2.3.0"
-authors: "Jun Furuse"
+authors: "Jun Furuse <jun.furuse@gmail.com>"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocamlspot/"
 bug-reports: "https://bitbucket.org/camlspotter/ocamlspot/issues?status=new&status=open"
@@ -17,4 +17,3 @@ remove: [
 available: [
   ocaml-version >= "4.02.1" & ocaml-version < "4.03.0"
 ]
-author: "jun.furuse@gmail.com"


### PR DESCRIPTION
I'm playing with opam-builder right now, and the new version based on opam 2.0 runs the automated repository conversion code. This generally works fine on the public opam-repository, except for a few warnings due to oddities in some opam files. The present PR fixes all the oddities, hoping to get these warnings out of the way.