### PR TITLE
Package bpf.0.2

### DIFF
--- a/packages/bpf/bpf.0.2/descr
+++ b/packages/bpf/bpf.0.2/descr
@@ -1,0 +1,4 @@
+Embedded eBPF assembler
+
+Generate BPF programs directly from OCaml, for use with Linux kernel
+socket/seccomp/event filters or to generate machine code with ubpf JIT for userspace.

--- a/packages/bpf/bpf.0.2/opam
+++ b/packages/bpf/bpf.0.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "ygrek <ygrek@autistici.org>"
+authors: ["ygrek <ygrek@autistici.org>"]
+homepage: "https://github.com/ygrek/ocaml-bpf"
+doc: "http://ygrek.org.ua/p/ocaml-bpf/api/"
+license: "BSD3"
+dev-repo: "https://github.com/ygrek/ocaml-bpf.git"
+bug-reports: "https://github.com/ygrek/ocaml-bpf/issues"
+tags: ["org:ygrek"]
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ppx_deriving"
+]
+depopts: [  ]
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]

--- a/packages/bpf/bpf.0.2/url
+++ b/packages/bpf/bpf.0.2/url
@@ -1,0 +1,3 @@
+archive: "http://ygrek.org.ua/p/release/ocaml-bpf/bpf-0.2.tbz"
+mirrors: ["https://github.com/ygrek/ocaml-bpf/releases/download/0.2/bpf-0.2.tbz"]
+checksum: "f1df7018dd45fc057da8c437f1a86270"


### PR DESCRIPTION
### `bpf.0.2`

Embedded eBPF assembler

Generate BPF programs directly from OCaml, for use with Linux kernel
socket/seccomp/event filters or to generate machine code with ubpf JIT for userspace.



---
* Homepage: https://github.com/ygrek/ocaml-bpf
* Source repo: https://github.com/ygrek/ocaml-bpf.git
* Bug tracker: https://github.com/ygrek/ocaml-bpf/issues

---


---
0.2 2017-09-30
--------------
- optionally allow jump backwards
:camel: Pull-request generated by opam-publish v0.3.5