### PR TITLE
Constrain ocaml-migrate-parsetree.1.0.4 to OCaml < 4.06.0.

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
@@ -17,4 +17,4 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta10"}
 ]
-available: ocaml-version >= "4.02.0"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
The build currently fails with:

```
# File "src/ast_406.ml", line 829, characters 2-494:
# Error: This variant or record definition does not match that of type
#          Parsetree.with_constraint
#        The arities for field Pwith_typesubst differ.
```

/cc @let-def 