### PR TITLE
Package ocaml-migrate-parsetree.1.0.5

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
+dev-repo: "git://github.com/let-def/ocaml-migrate-parsetree.git"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/archive/v1.0.5.tar.gz"
+checksum: "3bb704c1d63c928b13f59e6a1ac8603d"


### PR DESCRIPTION
### `ocaml-migrate-parsetree.1.0.5`

Convert OCaml parsetrees between different versions 

This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
High-level functions help making PPX rewriters independent of a compiler version.



---
* Homepage: https://github.com/let-def/ocaml-migrate-parsetree
* Source repo: git://github.com/let-def/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/let-def/ocaml-migrate-parsetree/issues

---

:camel: Pull-request generated by opam-publish v0.3.5