### PR TITLE
git: constraint to cstruct <3.1.1 due to ocplib-endian dep

### DIFF
--- a/packages/git/git.1.6.0/opam
+++ b/packages/git/git.1.6.0/opam
@@ -61,5 +61,6 @@ conflicts: [
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.6.1/opam
+++ b/packages/git/git.1.6.1/opam
@@ -61,5 +61,6 @@ conflicts: [
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.6.2/opam
+++ b/packages/git/git.1.6.2/opam
@@ -61,5 +61,6 @@ conflicts: [
  "conduit"  {>= "0.99"}
  "alcotest" {< "0.4.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.7.0/opam
+++ b/packages/git/git.1.7.0/opam
@@ -66,5 +66,6 @@ conflicts: [
   "camlzip" {< "1.05"}
   "nocrypto" {< "0.2.0"}
   "mirage-flow" {> "1.1.0"}
+  "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.7.1/opam
+++ b/packages/git/git.1.7.1/opam
@@ -66,5 +66,6 @@ conflicts: [
  "camlzip"  {< "1.05"}
  "nocrypto" {< "0.2.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.7.2/opam
+++ b/packages/git/git.1.7.2/opam
@@ -65,5 +65,6 @@ conflicts: [
  "camlzip"  {< "1.05"}
  "nocrypto" {< "0.2.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.03.0"]

--- a/packages/git/git.1.8.0/opam
+++ b/packages/git/git.1.8.0/opam
@@ -67,5 +67,6 @@ conflicts: [
  "camlzip"  {< "1.05"}
  "nocrypto" {< "0.2.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/git/git.1.9.0/opam
+++ b/packages/git/git.1.9.0/opam
@@ -71,5 +71,6 @@ conflicts: [
  "mirage-fs-unix" {<"1.1.4"}
  "cmdliner" {>= "1.0.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.9.1/opam
+++ b/packages/git/git.1.9.1/opam
@@ -68,5 +68,6 @@ conflicts: [
  "camlzip"  {< "1.06"}
  "nocrypto" {< "0.2.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.9.2/opam
+++ b/packages/git/git.1.9.2/opam
@@ -68,5 +68,6 @@ conflicts: [
  "nocrypto" {< "0.2.0"}
  "cmdliner" {>= "1.0.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.9.3/opam
+++ b/packages/git/git.1.9.3/opam
@@ -67,5 +67,6 @@ conflicts: [
  "camlzip"  {< "1.06"}
  "nocrypto" {< "0.2.0"}
  "mirage-flow" {> "1.1.0"}
+ "cstruct"  {> "3.1.1"}
 ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
This is because cstruct 3.2.0 will remove ocplib-endian use
(mirage/ocaml-cstruct#177), which in turn causes a transitive
build failure on older versions of git (mirage/ocaml-git#233)