### PR TITLE
Use the gitlab URL for the findlib.1.7.3 archive

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.7.3/url
+++ b/packages/ocamlfind/ocamlfind.1.7.3/url
@@ -1,2 +1,2 @@
-archive: "http://download.camlcity.org/download/findlib-1.7.3.tar.gz"
-checksum: "7d57451218359f7b7dfc969e3684a6da"
+archive: "https://gitlab.camlcity.org/gerd/lib-findlib/repository/archive.tar.gz?ref=findlib-1.7.3"
+checksum: "b07084b952ea129629cabd24533048d2"


### PR DESCRIPTION
`download.camlcity.org` is down.

/cc @gerdstolpmann