### PR TITLE
reverting findlib url to download.camlcity.org, and specify a mirror

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.7.3/url
+++ b/packages/ocamlfind/ocamlfind.1.7.3/url
@@ -1,2 +1,3 @@
-archive: "https://gitlab.camlcity.org/gerd/lib-findlib/repository/archive.tar.gz?ref=findlib-1.7.3"
-checksum: "b07084b952ea129629cabd24533048d2"
+archive: "http://download.camlcity.org/download/findlib-1.7.3.tar.gz"
+checksum: "7d57451218359f7b7dfc969e3684a6da"
+mirrors: [ "http://download2.camlcity.org/download/findlib-1.7.3.tar.gz" ]


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/10383 is a bad idea because the gitlab VM runs on the same machine, and is also not failsafe. I remembered that there is a mirror of download.camlcity.org, and provided that opam is clever enough to pick the mirror in case of a failure, this should be the better solution.