### PR TITLE
4.06.0+beta1 switches

### DIFF
--- a/compilers/4.06.0/4.06.0+beta1+afl/4.06.0+beta1+afl.comp
+++ b/compilers/4.06.0/4.06.0+beta1+afl/4.06.0+beta1+afl.comp
@@ -1,0 +1,15 @@
+opam-version: "1"
+version: "4.06.0"
+src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-afl-instrument"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.0/4.06.0+beta1+afl/4.06.0+beta1+afl.descr
+++ b/compilers/4.06.0/4.06.0+beta1+afl/4.06.0+beta1+afl.descr
@@ -1,0 +1,1 @@
+4.06 beta1 with afl-fuzz instrumentation

--- a/compilers/4.06.0/4.06.0+beta1+default-unsafe-string/4.06.0+beta1+default-unsafe-string.comp
+++ b/compilers/4.06.0/4.06.0+beta1+default-unsafe-string/4.06.0+beta1+default-unsafe-string.comp
@@ -1,0 +1,15 @@
+opam-version: "1"
+version: "4.06.0"
+src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.0/4.06.0+beta1+default-unsafe-string/4.06.0+beta1+default-unsafe-string.descr
+++ b/compilers/4.06.0/4.06.0+beta1+default-unsafe-string/4.06.0+beta1+default-unsafe-string.descr
@@ -1,0 +1,1 @@
+First beta for 4.06.0, without safe strings by default

--- a/compilers/4.06.0/4.06.0+beta1+flambda/4.06.0+beta1+flambda.comp
+++ b/compilers/4.06.0/4.06.0+beta1+flambda/4.06.0+beta1+flambda.comp
@@ -1,0 +1,15 @@
+opam-version: "1"
+version: "4.06.0"
+src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.0/4.06.0+beta1+flambda/4.06.0+beta1+flambda.descr
+++ b/compilers/4.06.0/4.06.0+beta1+flambda/4.06.0+beta1+flambda.descr
@@ -1,0 +1,1 @@
+4.06 beta1 with flambda activated

--- a/compilers/4.06.0/4.06.0+beta1+force-safe-string/4.06.0+beta1+force-safe-string.comp
+++ b/compilers/4.06.0/4.06.0+beta1+force-safe-string/4.06.0+beta1+force-safe-string.comp
@@ -1,0 +1,11 @@
+opam-version: "1"
+version: "4.06.0"
+src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.0/4.06.0+beta1+force-safe-string/4.06.0+beta1+force-safe-string.descr
+++ b/compilers/4.06.0/4.06.0+beta1+force-safe-string/4.06.0+beta1+force-safe-string.descr
@@ -1,0 +1,1 @@
+4.06 beta1 with -safe-string enabled.

--- a/compilers/4.06.0/4.06.0+beta1+fp+flambda/4.06.0+beta1+fp+flambda.comp
+++ b/compilers/4.06.0/4.06.0+beta1+fp+flambda/4.06.0+beta1+fp+flambda.comp
@@ -1,0 +1,22 @@
+opam-version: "1"
+version: "4.06.0"
+src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.0/4.06.0+beta1+fp+flambda/4.06.0+beta1+fp+flambda.descr
+++ b/compilers/4.06.0/4.06.0+beta1+fp+flambda/4.06.0+beta1+fp+flambda.descr
@@ -1,0 +1,1 @@
+4.06 beta1 with frame-pointers and flambda activated

--- a/compilers/4.06.0/4.06.0+beta1+fp/4.06.0+beta1+fp.comp
+++ b/compilers/4.06.0/4.06.0+beta1+fp/4.06.0+beta1+fp.comp
@@ -1,0 +1,21 @@
+opam-version: "1"
+version: "4.06.0"
+src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.0/4.06.0+beta1+fp/4.06.0+beta1+fp.descr
+++ b/compilers/4.06.0/4.06.0+beta1+fp/4.06.0+beta1+fp.descr
@@ -1,0 +1,1 @@
+4.06 beta1 with frame-pointers

--- a/compilers/4.06.0/4.06.0+beta1/4.06.0+beta1.comp
+++ b/compilers/4.06.0/4.06.0+beta1/4.06.0+beta1.comp
@@ -1,0 +1,15 @@
+opam-version: "1"
+version: "4.06.0"
+src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.0/4.06.0+beta1/4.06.0+beta1.descr
+++ b/compilers/4.06.0/4.06.0+beta1/4.06.0+beta1.descr
@@ -1,0 +1,1 @@
+First beta for 4.06.0


### PR DESCRIPTION
@damiendoligez and myself just tagged 4.06.0+beta1 today, here are the corresponding opam-repository switches. I just reused the 4.06.0+trunk+foo feature switches and copied them, with the minor change that the safe-string configuration changed ( https://github.com/ocaml/ocaml/pull/1386 ):

- `+safe-string` is now named `+force-safe-string` to follow the configure option
- given that the compile-time `-safe-string` option is now activated by default, and that this currently breaks a lot of packages, we provide a new `+default-unsafe-string` switch with the same safe-string settings as previous OCaml versions. (Of course we hope people will fix their software to work under the official switch.)