### PR TITLE
Package sugar.0.7.3

### DIFF
--- a/packages/sugar/sugar.0.7.3/descr
+++ b/packages/sugar/sugar.0.7.3/descr
@@ -1,0 +1,4 @@
+Monadic library for error aware expressions
+
+Sugar is a small monadic library that tries to simplify the use of error aware
+expressions with a monadic interface.

--- a/packages/sugar/sugar.0.7.3/opam
+++ b/packages/sugar/sugar.0.7.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Gerson Moraes <gerson@digirati.com.br>"
+authors: "Gerson Moraes <gerson@digirati.com.br>"
+homepage: "https://github.com/gersonmoraes/ocaml-sugar"
+bug-reports: "https://github.com/gersonmoraes/ocaml-sugar/issues"
+license: "MIT"
+doc: "https://gersonmoraes.github.io/ocaml-sugar/doc"
+dev-repo: "http://github.com/gersonmoraes/ocaml-sugar.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {>= "1.0+beta11"}
+  "result" {>= "1.2"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/sugar/sugar.0.7.3/url
+++ b/packages/sugar/sugar.0.7.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gersonmoraes/ocaml-sugar/archive/0.7.3.tar.gz"
+checksum: "d681da5b126491305a8559babacebadf"


### PR DESCRIPTION
### `sugar.0.7.3`

Monadic library for error aware expressions

Sugar is a small monadic library that tries to simplify the use of error aware
expressions with a monadic interface.



---
* Homepage: https://github.com/gersonmoraes/ocaml-sugar
* Source repo: http://github.com/gersonmoraes/ocaml-sugar.git
* Bug tracker: https://github.com/gersonmoraes/ocaml-sugar/issues

---

:camel: Pull-request generated by opam-publish v0.3.5