### PR TITLE
tuntap, charrua-client*, dns-lwt-unix, tcpip.3.2.0: jbuilder is a build dependency

### DIFF
--- a/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
@@ -16,7 +16,7 @@ build: [
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
-  "jbuilder" {>="1.0+beta9"}
+  "jbuilder" {build & >="1.0+beta9"}
   "ounit" {test}
   "alcotest"     {test}
   "charrua-core" {>= "0.9"}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.9/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.9/opam
@@ -16,7 +16,7 @@ build: [
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
-  "jbuilder" {>="1.0+beta9"}
+  "jbuilder" {build & >="1.0+beta9"}
   "ounit" {test}
   "alcotest"     {test}
   "charrua-core" {>= "0.9"}

--- a/packages/charrua-client/charrua-client.0.9/opam
+++ b/packages/charrua-client/charrua-client.0.9/opam
@@ -18,7 +18,7 @@ build-test: [
 ]
 
 depends: [
-  "jbuilder" {>="1.0+beta9"}
+  "jbuilder" {build & >= "1.0+beta9"}
   "ounit" {test}
   "alcotest"     {test}
   "charrua-core" {>= "0.9"}

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.0.0/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.0.0/opam
@@ -16,8 +16,8 @@ build: [
 ]
 
 depends: [
-  "jbuilder" {>="1.0+beta9"}
-  "dns-lwt" {>="1.0.0"}
+  "jbuilder" {build & >= "1.0+beta9"}
+  "dns-lwt" {>= "1.0.0"}
   "base-unix"
   "cmdliner"
 ]

--- a/packages/tcpip/tcpip.3.2.0/opam
+++ b/packages/tcpip/tcpip.3.2.0/opam
@@ -20,7 +20,7 @@ build-test: [
 ]
 
 depends: [
-  "jbuilder" {>="1.0+beta9"}
+  "jbuilder" {build & >= "1.0+beta9"}
   "configurator" {build}
   "rresult"
   "cstruct" {>= "3.0.2"}

--- a/packages/tuntap/tuntap.1.5.0/opam
+++ b/packages/tuntap/tuntap.1.5.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "jbuilder"    {>= "1.0+beta9"}
+  "jbuilder"    {build & >= "1.0+beta9"}
   "ipaddr"      {>= "2.4.0"}
   "cmdliner"
   "ounit"       {test}


### PR DESCRIPTION
reported upstream as well: https://github.com/mirage/ocaml-tuntap/pull/23 and https://github.com/mirage/charrua-core/pull/72