### PR TITLE
Package hmap.0.8.1

### DIFF
--- a/packages/hmap/hmap.0.8.1/descr
+++ b/packages/hmap/hmap.0.8.1/descr
@@ -1,0 +1,8 @@
+Heterogeneous value maps for OCaml
+
+Hmap provides heterogeneous value maps for OCaml. These maps bind keys
+to values with arbitrary types. Keys witness the type of the value
+they are bound to which allows to add and lookup bindings in a type
+safe manner.
+
+Hmap has no dependency and is distributed under the ISC license.

--- a/packages/hmap/hmap.0.8.1/opam
+++ b/packages/hmap/hmap.0.8.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/hmap"
+doc: "http://erratique.ch/software/hmap/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/hmap.git"
+bug-reports: "http://github.com/dbuenzli/hmap/issues"
+tags: ["data-structure" "org:erratique"]
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+depopts: [  ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/hmap/hmap.0.8.1/url
+++ b/packages/hmap/hmap.0.8.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/hmap/releases/hmap-0.8.1.tbz"
+checksum: "04169252265a11d852e1547445177196"


### PR DESCRIPTION
### `hmap.0.8.1`

Heterogeneous value maps for OCaml

Hmap provides heterogeneous value maps for OCaml. These maps bind keys
to values with arbitrary types. Keys witness the type of the value
they are bound to which allows to add and lookup bindings in a type
safe manner.

Hmap has no dependency and is distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/hmap
* Source repo: http://erratique.ch/repos/hmap.git
* Bug tracker: http://github.com/dbuenzli/hmap/issues

---


---
v0.8.1 2017-10-03 Zagreb
------------------------

* Build depend on topkg.
:camel: Pull-request generated by opam-publish v0.3.5