### PR TITLE
Package bsbnative.1.9.4

### DIFF
--- a/packages/bsbnative/bsbnative.1.9.4/descr
+++ b/packages/bsbnative/bsbnative.1.9.4/descr
@@ -1,0 +1,3 @@
+bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt
+
+bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt

--- a/packages/bsbnative/bsbnative.1.9.4/opam
+++ b/packages/bsbnative/bsbnative.1.9.4/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+maintainer: "Hongbo Zhang <>"
+authors: "Hongbo Zhang <>"
+homepage: "https://github.com/bucklescript/bucklescript#readme"
+bug-reports: "https://github.com/bucklescript/bucklescript/issues"
+license: "SEE LICENSE IN LICENSE"
+tags: ["ocaml" "bucklescript" "stdlib" "functional programming"]
+dev-repo: "git+https://github.com/bucklescript/bucklescript.git"
+build: ["node" "scripts/install.js"]
+available: [ocaml-version = "4.02.3"]

--- a/packages/bsbnative/bsbnative.1.9.4/url
+++ b/packages/bsbnative/bsbnative.1.9.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bsansouci/bsb-native/archive/1.9.4.tar.gz"
+checksum: "f4dafc50f34c2d3cf338afa6af175dea"


### PR DESCRIPTION
### `bsbnative.1.9.4`

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt



---
* Homepage: https://github.com/bucklescript/bucklescript#readme
* Source repo: git+https://github.com/bucklescript/bucklescript.git
* Bug tracker: https://github.com/bucklescript/bucklescript/issues

---

:camel: Pull-request generated by opam-publish v0.3.5