### PR TITLE
Make conf-libev compatible with -safe-string

### DIFF
--- a/packages/conf-libev/conf-libev.4-11/files/discover.ml
+++ b/packages/conf-libev/conf-libev.4-11/files/discover.ml
@@ -26,9 +26,7 @@ let cut_tail l = List.rev (List.tl (List.rev l))
 
 let string_split sep source =
   let copy_part index offset =
-    let dst = String.create (offset - index) in
-    let () = String.blit source index dst 0 (offset - index) in
-    dst
+    String.sub source index (offset - index)
   in
   let l = String.length source in
   let rec loop prev current acc =


### PR DESCRIPTION
4.06 enables `-safe-string` by default, so this effectively makes `conf-libev` compatible with 4.06.

Fixes #10394.

cc @hcarty