### PR TITLE
Add Bisect_ppx 1.3.1

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.1.2.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.2.0/opam
@@ -26,4 +26,4 @@ depends: [
 conflicts: [
   "ocveralls" {<= "0.3.2"}
 ]
-available: ocaml-version >= "4.02.0"
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/bisect_ppx/bisect_ppx.1.3.1/descr
+++ b/packages/bisect_ppx/bisect_ppx.1.3.1/descr
@@ -1,0 +1,19 @@
+Code coverage for OCaml
+
+Bisect_ppx helps you test thoroughly. It is a small preprocessor that inserts
+instrumentation at places in your code, such as if-then-else and match
+expressions. After you run tests, Bisect_ppx gives a nice HTML report showing
+which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, then run the
+report tool on the generated visitation files.
+
+This is an advanced fork of the original Bisect coverage tool. It has many
+improvements and updates.
+
+- Much more thorough code instrumentation, so you can find more gaps in your
+  testing.
+- Fast operation by default.
+- More legible and appealing HTML reports.
+- Various bugfixes.
+- No camlp4 dependency.

--- a/packages/bisect_ppx/bisect_ppx.1.3.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.1/opam
@@ -1,4 +1,4 @@
-version: "1.3.0"
+version: "1.3.1"
 opam-version: "1.2"
 maintainer: [
   "Anton Bachin <antonbachin@yahoo.com>"
@@ -16,7 +16,7 @@ dev-repo: "https://github.com/aantron/bisect_ppx.git"
 
 depends: [
   "base-unix"
-  "jbuilder" {build & >= "1.0+beta10"}
+  "jbuilder" {build & >= "1.0+beta13"}
   # This will be removed when bisect_ppx-ocamlbuild is fully factored
   # out. It is not a build dependency because Ocamlbuild must be present
   # each time the plugin is used, even after it is built and installed.
@@ -30,7 +30,7 @@ conflicts: [
 ]
 # Note that Bisect_ppx effectively requires 4.02.3, because Jbuilder requires
 # it. 4.02.0 is the natural constraint of Bisect_ppx.
-available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]
+available: ocaml-version >= "4.02.0"
 
 messages: [
   "For the Ocamlbuild plugin, please install package bisect_ppx-ocamlbuild"

--- a/packages/bisect_ppx/bisect_ppx.1.3.1/url
+++ b/packages/bisect_ppx/bisect_ppx.1.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.3.1.tar.gz"
+checksum: "9b76f6f192307ec7098ded5e36670df2"


### PR DESCRIPTION
Bisect_ppx 1.3.1 mainly adds `-safe-string` support, which makes it compatible with OCaml 4.06. In case anyone is worried, Bisect_ppx wasn't actually mutating any strings. It just assumed that `bytes` and `string` were equivalent, e.g. by using polymorphic comparison between them.

See the full [changelog](https://github.com/aantron/bisect_ppx/releases/tag/1.3.1) for other, minor bugfixes.

This commit also constrains earlier releases of Bisect_ppx to require OCaml < 4.06, since they will not build with `-safe-string` enabled. This affects only the two preceding releases; earlier releases already have tighter OCaml constraints.

cc @rleonid