### PR TITLE
ppx_ast.v0.9.2

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.9.2/descr
+++ b/packages/ppx_ast/ppx_ast.v0.9.2/descr
@@ -1,0 +1,9 @@
+OCaml AST used by Jane Street ppx rewriters
+
+Ppx_ast selects a specific version of the OCaml Abstract Syntax Tree
+from the migrate-parsetree project that is not necessarily the same
+one as the one being used by the compiler.
+
+It also snapshots the corresponding parser and pretty-printer from the
+OCaml compiler, to create a full frontend independent of the version
+of OCaml.

--- a/packages/ppx_ast/ppx_ast.v0.9.2/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_ast"
+bug-reports: "https://github.com/janestreet/ppx_ast/issues"
+dev-repo: "https://github.com/janestreet/ppx_ast.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs "@install"]
+]
+depends: [
+  "jbuilder"                {build & >= "1.0+beta2"}
+  "ocaml-compiler-libs"     {>= "v0.9" & < "v0.10"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.06.0" ]

--- a/packages/ppx_ast/ppx_ast.v0.9.2/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.2/opam
@@ -11,6 +11,6 @@ build: [
 depends: [
   "jbuilder"                {build & >= "1.0+beta2"}
   "ocaml-compiler-libs"     {>= "v0.9" & < "v0.10"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
+  "ocaml-migrate-parsetree" {>= "1.0.5"}
 ]
 available: [ ocaml-version >= "4.06.0" ]

--- a/packages/ppx_ast/ppx_ast.v0.9.2/url
+++ b/packages/ppx_ast/ppx_ast.v0.9.2/url
@@ -1,0 +1,2 @@
+src: "https://github.com/janestreet/ppx_ast/archive/v0.9.2.tar.gz"
+checksum: "4541f1e3af69bbc45761a1fdc752d414"


### PR DESCRIPTION
Updates `ppx_ast` to support OCaml 4.06.0.