### PR TITLE
Make Reason 1.13.7 work with latest topkg

### DIFF
--- a/packages/reason/reason.1.13.7/files/reason-1.13.7-topkg-compat.patch
+++ b/packages/reason/reason.1.13.7/files/reason-1.13.7-topkg-compat.patch
@@ -1,0 +1,79 @@
+diff --git a/Makefile b/Makefile
+index 42264a3..9de0d96 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,7 +16,7 @@ setup_convenient_bin_links:
+ 
+ precompile:
+ 	cp pkg/META.in pkg/META
+-	ocamlbuild -package topkg pkg/build.native
++	ocamlbuild -use-ocamlfind -package topkg pkg/build.native
+ 
+ build_without_utop: compile_error setup_convenient_bin_links precompile
+ 	./build.native build --utop false
+diff --git a/opam b/opam
+index c88f78a..d1c0e2c 100644
+--- a/opam
++++ b/opam
+@@ -13,7 +13,7 @@ tags: [ "syntax" ]
+ substs: [ "pkg/META" ]
+ build: [
+   [make "compile_error"]
+-  ["ocamlbuild" "-package" "topkg" "pkg/build.native"]
++  ["ocamlbuild" "-use-ocamlfind" "-package" "topkg" "pkg/build.native"]
+   ["./build.native" "build"
+                     "--native" "%{ocaml-native}%"
+                     "--native-dynlink" "%{ocaml-native-dynlink}%"
+@@ -21,11 +21,11 @@ build: [
+ ]
+ depends: [
+   "ocamlfind"               {build}
+-  "menhir"                  {= "20170418"}
++  "menhir"                  {>= "20170418" & <= "20170712"}
+   "utop"                    {>= "1.17"}
+   "merlin-extend"           {>= "0.3"}
+   "result"                  {=  "1.2"}
+-  "topkg"                   {>=  "0.8.1" & < "0.9"}
++  "topkg"                   {>=  "0.8.1"}
+   "ocaml-migrate-parsetree"
+   "ppx_tools_versioned"     {>= "5.0beta"}
+ ]
+@@ -34,4 +34,4 @@ depopts: [
+ conflicts: [
+   "utop" {< "1.17"}
+ ]
+-available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]
++available: [ ocaml-version >= "4.02" & ocaml-version < "4.06" ]
+diff --git a/opam.in b/opam.in
+index 69fe60f..18ca420 100644
+--- a/opam.in
++++ b/opam.in
+@@ -12,7 +12,7 @@ tags: [ "syntax" ]
+ substs: [ "pkg/META" ]
+ build: [
+   [make "compile_error"]
+-  ["ocamlbuild" "-package" "topkg" "pkg/build.native"]
++  ["ocamlbuild" "-use-ocamlfind" "-package" "topkg" "pkg/build.native"]
+   ["./build.native" "build"
+                     "--native" "%{ocaml-native}%"
+                     "--native-dynlink" "%{ocaml-native-dynlink}%"
+@@ -20,11 +20,11 @@ build: [
+ ]
+ depends: [
+   "ocamlfind"               {build}
+-  "menhir"                  {= "20170418"}
++  "menhir"                  {>= "20170418" & <= "20170712"}
+   "utop"                    {>= "1.17"}
+   "merlin-extend"           {>= "0.3"}
+   "result"                  {=  "1.2"}
+-  "topkg"                   {>=  "0.8.1" & < "0.9"}
++  "topkg"                   {>=  "0.8.1"}
+   "ocaml-migrate-parsetree"
+   "ppx_tools_versioned"     {>= "5.0beta"}
+ ]
+@@ -33,4 +33,4 @@ depopts: [
+ conflicts: [
+   "utop" {< "1.17"}
+ ]
+-available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]
++available: [ ocaml-version >= "4.02" & ocaml-version < "4.06" ]

--- a/packages/reason/reason.1.13.7/opam
+++ b/packages/reason/reason.1.13.7/opam
@@ -1,38 +1,38 @@
+
 opam-version: "1.2"
+name: "reason"
+version: "1.13.7"
 maintainer: "Jordan Walke <jordojw@gmail.com>"
-authors: "Jordan Walke <jordojw@gmail.com>"
-homepage: "https://github.com/facebook/reason"
-bug-reports: "https://github.com/facebook/reason/issues"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
 license: "BSD. Additional patent grant provided."
+homepage: "https://github.com/facebook/reason"
 doc: "http://reasonml.github.io/"
-tags: "syntax"
+bug-reports: "https://github.com/facebook/reason/issues"
 dev-repo: "git://github.com/facebook/reason.git"
-substs: "pkg/META"
+tags: [ "syntax" ]
+patches: [ "reason-1.13.7-topkg-compat.patch" ]
+substs: [ "pkg/META" ]
 build: [
   [make "compile_error"]
-  ["ocamlbuild" "-package" "topkg" "pkg/build.native"]
-  [
-    "./build.native"
-    "build"
-    "--native"
-    "%{ocaml-native}%"
-    "--native-dynlink"
-    "%{ocaml-native-dynlink}%"
-    "--utop"
-    "%{utop:installed}%"
-  ]
+  ["ocamlbuild" "-use-ocamlfind" "-package" "topkg" "pkg/build.native"]
+  ["./build.native" "build"
+                    "--native" "%{ocaml-native}%"
+                    "--native-dynlink" "%{ocaml-native-dynlink}%"
+                    "--utop" "%{utop:installed}%"]
 ]
 depends: [
-  "ocamlfind" {build}
-  "menhir" {= "20170418"}
-  "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
-  "result" {= "1.2"}
-  "topkg" {>= "0.8.1" & < "0.9"}
+  "ocamlfind"               {build}
+  "menhir"                  {>= "20170418" & <= "20170712"}
+  "utop"                    {>= "1.17"}
+  "merlin-extend"           {>= "0.3"}
+  "result"                  {=  "1.2"}
+  "topkg"                   {>=  "0.8.1"}
   "ocaml-migrate-parsetree"
-  "ppx_tools_versioned" {>= "5.0beta"}
+  "ppx_tools_versioned"     {>= "5.0beta"}
+]
+depopts: [
 ]
 conflicts: [
   "utop" {< "1.17"}
 ]
-available: [ocaml-version >= "4.02" & ocaml-version < "4.05"]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.06" ]


### PR DESCRIPTION
The changes are build tweaks, backported from upstream's master branch.