### PR TITLE
Package ppx_dryunit.0.3.1

### DIFF
--- a/packages/ppx_dryunit/ppx_dryunit.0.3.1/descr
+++ b/packages/ppx_dryunit/ppx_dryunit.0.3.1/descr
@@ -1,0 +1,5 @@
+A detection tool for traditional unit testing in OCaml
+
+Dryunit is a small command line tool and a ppx that detects your unit tests and auto-generate the correspondent bootstrap code on the fly in your build directory. As a result, you get to use plain old OCaml and all the tooling you already use.
+
+*Warning*: the entry point of this project is the package `dryunit`.

--- a/packages/ppx_dryunit/ppx_dryunit.0.3.1/opam
+++ b/packages/ppx_dryunit/ppx_dryunit.0.3.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "gerson.xp@gmail.com"
+authors: "Gerson Moraes"
+homepage: "https://github.com/gersonmoraes/dryunit"
+bug-reports: "https://github.com/gersonmoraes/dryunit"
+dev-repo: "https://github.com/gersonmoraes/dryunit.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+  "cppo" {build}
+  "ocaml-migrate-parsetree" {build}
+  "ppx_tools_versioned" {build}
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06"]

--- a/packages/ppx_dryunit/ppx_dryunit.0.3.1/url
+++ b/packages/ppx_dryunit/ppx_dryunit.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gersonmoraes/dryunit/archive/0.3.1.tar.gz"
+checksum: "88de92b9868adf8d3dc138db5fa789d8"


### PR DESCRIPTION
### `ppx_dryunit.0.3.1`

A detection tool for traditional unit testing in OCaml

Dryunit is a small command line tool and a ppx that detects your unit tests and auto-generate the correspondent bootstrap code on the fly in your build directory. As a result, you get to use plain old OCaml and all the tooling you already use.

*Warning*: the entry point of this project is the package `dryunit`.



---
* Homepage: https://github.com/gersonmoraes/dryunit
* Source repo: https://github.com/gersonmoraes/dryunit.git
* Bug tracker: https://github.com/gersonmoraes/dryunit

---

:camel: Pull-request generated by opam-publish v0.3.5