### PR TITLE
git: depend on crc <= 1.0.0

### DIFF
--- a/packages/git/git.1.7.0/opam
+++ b/packages/git/git.1.7.0/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt" {>= "2.4.7"}
   "hex"
   "stringext"
-  "crc"
+  "crc" {<= "1.0.0"}
   "ocplib-endian"
   "alcotest" {test}
   "mirage-types-lwt" {test}

--- a/packages/git/git.1.7.1/opam
+++ b/packages/git/git.1.7.1/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt" {>= "2.4.7"}
   "hex"
   "stringext"
-  "crc"
+  "crc" {<= "1.0.0"}
   "ocplib-endian"
   "alcotest" {test}
   "mirage-types-lwt" {test}

--- a/packages/git/git.1.7.2/opam
+++ b/packages/git/git.1.7.2/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt"        {>= "2.4.7" & <"2.7.0"}
   "hex"
   "stringext"
-  "crc"
+  "crc"       {<= "1.0.0"}
   "ocplib-endian"
   "alcotest"         {test}
   "mirage-types-lwt" {test}

--- a/packages/git/git.1.8.0/opam
+++ b/packages/git/git.1.8.0/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt"
   "hex"
   "astring"
-  "crc"
+  "crc"       {<= "1.0.0"}
   "ocplib-endian"
   "alcotest"         {test}
   "mirage-types-lwt" {test}

--- a/packages/git/git.1.9.0/opam
+++ b/packages/git/git.1.9.0/opam
@@ -32,7 +32,7 @@ depends: [
   "fmt"
   "hex"
   "astring"
-  "crc"
+  "crc"       {<= "1.0.0"}
   "ocplib-endian" {>= "0.6"}
   "alcotest"         {test}
   "mirage-types-lwt" {test}

--- a/packages/git/git.1.9.1/opam
+++ b/packages/git/git.1.9.1/opam
@@ -32,7 +32,7 @@ depends: [
   "fmt"
   "hex"
   "astring"
-  "crc"
+  "crc"       {<= "1.0.0"}
   "ocplib-endian" {>= "0.6"}
   "alcotest"         {test}
   "mirage-types-lwt" {test}


### PR DESCRIPTION
//cc @samoht this is due to newer crc won't contain these xen_linkopts https://github.com/xapi-project/ocaml-crc/pull/27
this only affects old git packages (nowadays git ships with its own crc32 module implemented in ocaml)