### PR TITLE
Package bsbnative.1.9.4.0004

### DIFF
--- a/packages/bsbnative/bsbnative.1.9.4.0004/descr
+++ b/packages/bsbnative/bsbnative.1.9.4.0004/descr
@@ -1,0 +1,3 @@
+bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt
+
+bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt

--- a/packages/bsbnative/bsbnative.1.9.4.0004/opam
+++ b/packages/bsbnative/bsbnative.1.9.4.0004/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+maintainer: "Hongbo Zhang <>"
+authors: "Hongbo Zhang <>"
+homepage: "https://github.com/bucklescript/bucklescript#readme"
+bug-reports: "https://github.com/bucklescript/bucklescript/issues"
+license: "SEE LICENSE IN LICENSE"
+tags: ["ocaml" "bucklescript" "stdlib" "functional programming"]
+dev-repo: "git+https://github.com/bucklescript/bucklescript.git"
+build: ["node" "scripts/install.js"]
+available: [ocaml-version = "4.02.3"]

--- a/packages/bsbnative/bsbnative.1.9.4.0004/url
+++ b/packages/bsbnative/bsbnative.1.9.4.0004/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bsansouci/bsb-native/archive/1.9.4.0004.tar.gz"
+checksum: "dccfba62c1f8859c07ce0d694bded2fb"


### PR DESCRIPTION
### `bsbnative.1.9.4.0004`

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt


---
* Homepage: https://github.com/bucklescript/bucklescript#readme
* Source repo: git+https://github.com/bucklescript/bucklescript.git
* Bug tracker: https://github.com/bucklescript/bucklescript/issues

---

:camel: Pull-request generated by opam-publish v0.3.5