### PR TITLE
Package bsbnative.1.9.4

### DIFF
--- a/packages/bsbnative/bsbnative.1.9.4/descr
+++ b/packages/bsbnative/bsbnative.1.9.4/descr
@@ -1,0 +1,3 @@
+bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt
+
+bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt

--- a/packages/bsbnative/bsbnative.1.9.4/opam
+++ b/packages/bsbnative/bsbnative.1.9.4/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+name: "bsbnative"
+version: "1.9.4"
+license: "SEE LICENSE IN LICENSE"
+homepage: "https://github.com/bucklescript/bucklescript#readme"
+bug-reports: "https://github.com/bucklescript/bucklescript/issues"
+dev-repo: "git+https://github.com/bucklescript/bucklescript.git"
+authors: [ "Hongbo Zhang <>" ]
+maintainer: "hongbo_zhang <bobzhang1988@gmail.com>"
+tags: [ "ocaml" "bucklescript" "stdlib" "functional programming" ]
+build: [
+  [ "./scripts/opam_install.sh" ]
+]
+available: [ ocaml-version = "4.02.3" ]

--- a/packages/bsbnative/bsbnative.1.9.4/url
+++ b/packages/bsbnative/bsbnative.1.9.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/bsansouci/bsb-native/archive/1.9.4.tar.gz"
+checksum: "90fa52709385f28cc80b15e6f0f537e6"


### PR DESCRIPTION
### `bsbnative.1.9.4`

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt


---
* Homepage: https://github.com/bucklescript/bucklescript#readme
* Source repo: git+https://github.com/bucklescript/bucklescript.git
* Bug tracker: https://github.com/bucklescript/bucklescript/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---

:camel: Pull-request generated by opam-publish v0.3.5