### PR TITLE
Package inuit.0.3

### DIFF
--- a/packages/inuit/inuit.0.3/descr
+++ b/packages/inuit/inuit.0.3/descr
@@ -1,0 +1,7 @@
+Make interactive text-based user-interfaces in OCaml
+
+Inuit is an abstraction for interactively updating a text buffer. 
+It is designed to be use with a backend that will present the buffer to the end user.
+[Sturgeon](https://github.com/let-def/sturgeon) is a backend targeting emacs buffers.
+
+Inuit is distributed under the ISC license.

--- a/packages/inuit/inuit.0.3/opam
+++ b/packages/inuit/inuit.0.3/opam
@@ -1,0 +1,21 @@
+name: "inuit"
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: ["Frédéric Bour <frederic.bour@lakaban.net>"]
+homepage: "https://github.com/let-def/inuit"
+doc: "https://let-def.github.io/inuit/doc"
+license: "ISC"
+dev-repo: "https://github.com/let-def/inuit.git"
+bug-reports: "https://github.com/let-def/inuit/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "grenier" {>= "0.4"}
+]
+depopts: []
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/inuit/inuit.0.3/url
+++ b/packages/inuit/inuit.0.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/let-def/inuit/releases/download/v0.3/inuit-0.3.tbz"
+checksum: "13ddd022196286655e0e971fe28aa1b1"


### PR DESCRIPTION
### `inuit.0.3`

Make interactive text-based user-interfaces in OCaml

Inuit is an abstraction for interactively updating a text buffer. 
It is designed to be use with a backend that will present the buffer to the end user.
[Sturgeon](https://github.com/let-def/sturgeon) is a backend targeting emacs buffers.

Inuit is distributed under the ISC license.



---
* Homepage: https://github.com/let-def/inuit
* Source repo: https://github.com/let-def/inuit.git
* Bug tracker: https://github.com/let-def/inuit/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
v0.3 2017-10-09 Paris
--------------------------

Disable click on the right border of a region (cursor must be inside, not on
the border).
Tweak Widget.Tree api.
:camel: Pull-request generated by opam-publish v0.3.5