### PR TITLE
Package sturgeon.0.3

### DIFF
--- a/packages/sturgeon/sturgeon.0.3/descr
+++ b/packages/sturgeon/sturgeon.0.3/descr
@@ -1,0 +1,9 @@
+A toolkit for communicating with Emacs
+
+Sturgeon implements various tools for manipulating Emacs from OCaml:
+- `Sturgeon_sexp` implements the Emacs dialect of S-expressions
+- `Sturgeon_session` implements an "session protocol" to make RPC to Emacs from OCaml and vice versa
+- `Sturgeon_stui` is a session implementing an [Inuit](https://github.com/let-def/inuit) backend: one can now runs text user-interface on an Emacs buffer
+- `Sturgeon_recipes_*` offers different "rendez-vous" points to connect to Emacs
+
+Sturgeon is distributed under the ISC license.

--- a/packages/sturgeon/sturgeon.0.3/opam
+++ b/packages/sturgeon/sturgeon.0.3/opam
@@ -1,0 +1,22 @@
+name: "sturgeon"
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: ["Frédéric Bour <frederic.bour@lakaban.net>"]
+homepage: "https://github.com/let-def/sturgeon"
+doc: "https://let-def.github.io/sturgeon/doc"
+license: "ISC"
+dev-repo: "https://github.com/let-def/sturgeon.git"
+bug-reports: "https://github.com/let-def/sturgeon/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "inuit"
+  "result"
+]
+depopts: []
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/sturgeon/sturgeon.0.3/url
+++ b/packages/sturgeon/sturgeon.0.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/let-def/sturgeon/releases/download/v0.3/sturgeon-0.3.tbz"
+checksum: "68a5767823cdb4ff26d6b7a6ad856172"


### PR DESCRIPTION
### `sturgeon.0.3`

A toolkit for communicating with Emacs

Sturgeon implements various tools for manipulating Emacs from OCaml:
- `Sturgeon_sexp` implements the Emacs dialect of S-expressions
- `Sturgeon_session` implements an "session protocol" to make RPC to Emacs from OCaml and vice versa
- `Sturgeon_stui` is a session implementing an [Inuit](https://github.com/let-def/inuit) backend: one can now runs text user-interface on an Emacs buffer
- `Sturgeon_recipes_*` offers different "rendez-vous" points to connect to Emacs

Sturgeon is distributed under the ISC license.



---
* Homepage: https://github.com/let-def/sturgeon
* Source repo: https://github.com/let-def/sturgeon.git
* Bug tracker: https://github.com/let-def/sturgeon/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
v0.3 2017-10-06 Paris
------------------------

Make emacs mode configuration more friendly.
In sync example, fix utf-8 related issues.
:camel: Pull-request generated by opam-publish v0.3.5