### PR TITLE
Update OSDP package to handle ocplib-simplex 0.4.

### DIFF
--- a/packages/osdp/osdp.0.6.0/descr
+++ b/packages/osdp/osdp.0.6.0/descr
@@ -1,0 +1,6 @@
+OCaml Interface to SDP solvers.
+
+OSDP is an OCaml frontend library to semi-definite programming (SDP)
+numerical optimization solvers. This package will be installed with
+the solver SDPA. It will also be compiled with CSDP and Mosek support
+if they can be found in the PATH.

--- a/packages/osdp/osdp.0.6.0/opam
+++ b/packages/osdp/osdp.0.6.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Pierre Roux"
+authors: "Pierre Roux"
+homepage: "https://cavale.enseeiht.fr/osdp/"
+license: "LGPL"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind remove osdp"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild"
+  "zarith"
+  "ocplib-simplex" {>= "0.3"}
+  "conf-sdpa"
+]

--- a/packages/osdp/osdp.0.6.0/url
+++ b/packages/osdp/osdp.0.6.0/url
@@ -1,0 +1,2 @@
+http: "https://cavale.enseeiht.fr/osdp/osdp-0.6.0.tgz"
+checksum: "cf96179682e05c1585589adae532a7bc"


### PR DESCRIPTION
Ocplib-simplex 0.4 broke compatibility with previous version.