### PR TITLE
Package fstar.0.9.5.0

### DIFF
--- a/packages/fstar/fstar.0.9.5.0/descr
+++ b/packages/fstar/fstar.0.9.5.0/descr
@@ -1,0 +1,1 @@
+An ML-like language with a type system for program verification.

--- a/packages/fstar/fstar.0.9.5.0/opam
+++ b/packages/fstar/fstar.0.9.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+version: "0.9.5.0"
+maintainer: "taramana@microsoft.com"
+authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.com>,Tahina Ramananandro <taramana@microsoft.com>"
+homepage: "http://fstar-lang.org"
+license: "Apache"
+depends: [
+  "ocamlfind"
+  "batteries"
+  "zarith"
+  "stdint"
+  "yojson"
+  "ocamlbuild" {build}
+  "fileutils"
+  "menhir" { >= "20161115" }
+  "pprint"
+]
+depexts: [
+  [ ["osx" "homebrew"] ["coreutils"] ]
+]
+build: [
+  [ "./configure" ]
+  [make "PREFIX=%{prefix}%" "-C" "src/ocaml-output"]
+  [make "PREFIX=%{prefix}%" "-C" "ulib/ml"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "-C" "src/ocaml-output" "install"]
+]
+remove: [
+  [ "rm" "-rf"
+      "%{prefix}%/lib/fstar"
+      "%{prefix}%/doc/fstar"
+      "%{prefix}%/etc/fstar"
+      "%{prefix}%/bin/fstar"
+      "%{prefix}%/share/fstar" ]
+]
+available: [ ocaml-version >= "4.02.3" & (ocaml-version < "4.03.0" | ocaml-version >= "4.04.0") ]
+dev-repo: "git://github.com/FStarLang/FStar"
+bug-reports: "https://github.com/FStarLang/FStar/issues"

--- a/packages/fstar/fstar.0.9.5.0/opam
+++ b/packages/fstar/fstar.0.9.5.0/opam
@@ -19,7 +19,6 @@ depexts: [
   [ ["osx" "homebrew"] ["coreutils"] ]
 ]
 build: [
-  [ "./configure" ]
   [make "PREFIX=%{prefix}%" "-C" "src/ocaml-output"]
   [make "PREFIX=%{prefix}%" "-C" "ulib/ml"]
 ]

--- a/packages/fstar/fstar.0.9.5.0/url
+++ b/packages/fstar/fstar.0.9.5.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/FStarLang/FStar/archive/v0.9.5.0-opam.tar.gz"
-checksum: "f606bb69914a2da6513a791431fe2ffb"
+checksum: "2f41e85f48daa0f6f436ee4806350e5c"

--- a/packages/fstar/fstar.0.9.5.0/url
+++ b/packages/fstar/fstar.0.9.5.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/FStarLang/FStar/archive/v0.9.5.0-opam.tar.gz"
-checksum: "2f41e85f48daa0f6f436ee4806350e5c"
+checksum: "aeb396184a96dc957f04c28675159170"

--- a/packages/fstar/fstar.0.9.5.0/url
+++ b/packages/fstar/fstar.0.9.5.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/FStarLang/FStar/archive/v0.9.5.0-opam.tar.gz"
-checksum: "3ae2466811d0323f1168b6d2ccd167bc"
+checksum: "f606bb69914a2da6513a791431fe2ffb"

--- a/packages/fstar/fstar.0.9.5.0/url
+++ b/packages/fstar/fstar.0.9.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/FStarLang/FStar/archive/v0.9.5.0-opam.tar.gz"
+checksum: "3ae2466811d0323f1168b6d2ccd167bc"


### PR DESCRIPTION
This is another big release of the F* programming language with lots of changes and new features compared to v0.9.4.0

# Main new features

- Proofs by reification (see this [paper](https://arxiv.org/abs/1703.00055))
- A revision of the libraries based on a new formal account of monotonic state (see this [paper](https://arxiv.org/abs/1707.02466))
- Extraction of programs with user-defined effects
- Experimental support for tactics
- [New IDE protocol](https://github.com/FStarLang/FStar/wiki/Editor-support-for-F*) and [new IDE features](https://github.com/FStarLang/fstar-mode.el): autocompletion, evaluation, real-time syntax checking, jump-to-definition, type-at-point, etc.

# Changes and other improvements
- A reorganization of the library and a single `fstarlib.cmxa` against which to link all F* programs compiled to OCaml (this change is incompatible with previous versions of F*)
- A new printer of source terms
- Revised error reporting from failed SMT queries
- Improved support for separate compilation via a binary format for checked modules
- Fixed a ton of bugs ([179 closed GitHub issues](https://github.com/FStarLang/FStar/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20closed%3A%222017-02-02%20..%202017-08-23%22%20))
