### PR TITLE
Package dryunit.0.3.1

### DIFF
--- a/packages/dryunit/dryunit.0.3.1/descr
+++ b/packages/dryunit/dryunit.0.3.1/descr
@@ -1,0 +1,3 @@
+A detection tool for traditional unit testing in OCaml
+
+Dryunit is a small command line tool and a ppx that detects your unit tests and auto-generate the correspondent bootstrap code on the fly in your build directory. As a result, you get to use plain old OCaml and all the tooling you already use.

--- a/packages/dryunit/dryunit.0.3.1/opam
+++ b/packages/dryunit/dryunit.0.3.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "gerson.xp@gmail.com"
+authors: "Gerson Moraes"
+homepage: "https://github.com/gersonmoraes/dryunit"
+bug-reports: "https://github.com/gersonmoraes/dryunit"
+dev-repo: "https://github.com/gersonmoraes/dryunit.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build}
+  "ppx_dryunit"
+  "cmdliner" {>= "1.0.2"}
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06"]

--- a/packages/dryunit/dryunit.0.3.1/url
+++ b/packages/dryunit/dryunit.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gersonmoraes/dryunit/archive/0.3.1.tar.gz"
+checksum: "88de92b9868adf8d3dc138db5fa789d8"


### PR DESCRIPTION
### `dryunit.0.3.1`

A detection tool for traditional unit testing in OCaml

Dryunit is a small command line tool and a ppx that detects your unit tests and auto-generate the correspondent bootstrap code on the fly in your build directory. As a result, you get to use plain old OCaml and all the tooling you already use.



---
* Homepage: https://github.com/gersonmoraes/dryunit
* Source repo: https://github.com/gersonmoraes/dryunit.git
* Bug tracker: https://github.com/gersonmoraes/dryunit

---

:camel: Pull-request generated by opam-publish v0.3.5