### PR TITLE
Fix msgpack.1.3.0 dependencies

### DIFF
--- a/packages/msgpack/msgpack.1.3.0/opam
+++ b/packages/msgpack/msgpack.1.3.0/opam
@@ -26,7 +26,7 @@ available: [ ocaml-version >= "4.01.0" ]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "base-num"
+  "num"
   "base-bytes"
   "ounit" {test}
 ]


### PR DESCRIPTION
Is there a rule that distinguishes between ```base-x``` and ```x``` packages ? It seems to have different rules between ```bytes```, ```num```, ```camlp4``` and ```ocamlbuild```.