### PR TITLE
ReactiveML version 1.09.05.

### DIFF
--- a/packages/rml/rml.1.09.05/descr
+++ b/packages/rml/rml.1.09.05/descr
@@ -1,0 +1,6 @@
+ReactiveML: a programming language for implementing interactive systems.
+ReactiveML is based on the synchronous reactive model embedded in an ML
+language (here a subset of OCaml). It provides synchronous parallel
+composition and dynamic features like the dynamic creation of processes.
+In ReactiveML, the reactive model is integrated at the language level
+(not as a library) which leads to safer and more natural programming.

--- a/packages/rml/rml.1.09.05/opam
+++ b/packages/rml/rml.1.09.05/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+homepage: "http://reactiveml.org"
+maintainer: "devel@reactiveml.org"
+author: "Louis Mandel louis@reactiveml.org"
+bug-reports: "bugs@reactiveml.org"
+build: [
+["./configure" "--prefix" "%{prefix}%"]
+[make]
+]
+install: [
+ [make "install"]
+]
+remove: [
+ ["./configure" "--prefix" "%{prefix}%"]
+ [make "uninstall"]
+]
+available: [ocaml-version >= "4.02"]
+depends: [
+ "ocamlbuild"
+ "num"
+]

--- a/packages/rml/rml.1.09.05/url
+++ b/packages/rml/rml.1.09.05/url
@@ -1,0 +1,2 @@
+archive: "http://rml.lri.fr/distrib/rml-1.09.05-2017-10-10.tar.gz"
+checksum: "55b0603d353f833254faa9721c9d2db6"


### PR DESCRIPTION
New version that compiles using `-safe-strings`. It should work with OCaml 4.06.
It requires OCaml 4.02 because of the Bytes module.