### PR TITLE
Released lwt_ssl not compatible with OCaml 4.06

### DIFF
--- a/packages/lwt_ssl/lwt_ssl.1.0.0/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.0.0/opam
@@ -21,3 +21,4 @@ depends: [
   "lwt" {>= "2.7.0" & < "3.0.0"}
   "ssl" {>= "0.5.0"}
 ]
+available: ocaml-version < "4.06.0"

--- a/packages/lwt_ssl/lwt_ssl.1.0.1/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.0.1/opam
@@ -28,3 +28,4 @@ depends: [
   "ssl" {>= "0.5.0"}
   "base-unix"
 ]
+available: ocaml-version < "4.06.0"

--- a/packages/lwt_ssl/lwt_ssl.1.1.0/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.0/opam
@@ -24,3 +24,4 @@ depends: [
   "lwt" {>= "3.0.0"}
   "ssl" {>= "0.5.0"}
 ]
+available: ocaml-version < "4.06.0"


### PR DESCRIPTION
...so constrain it. See https://github.com/ocsigen/lwt/pull/479. The problem was incompatibility with `-safe-string`.

Prior to Lwt 3.0.0, `lwt_ssl` was an optional dependency, and part of, Lwt. I'm not sure if those releases of Lwt should also be constrained. It seems excessive. On the other hand, people doing `opam install ssl lwt` on 4.06 with Lwt < 3.0.0 will get failed builds.