### PR TITLE
Package ppx_bitstring.2.0.2

### DIFF
--- a/packages/ppx_bitstring/ppx_bitstring.2.0.2/descr
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.2/descr
@@ -1,0 +1,2 @@
+PPX extension for the bitstring library.
+PPX implementation of the original bitstring camlp4 extension.

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.2/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Xavier Guérin <ghub@applepine.org>"
+authors: "Xavier Guérin <ghub@applepine.org>"
+homepage: "https://github.com/xguerin/ppx_bitstring"
+bug-reports: "https://github.com/xguerin/ppx_bitstring/issues"
+license: "ISC"
+dev-repo: "https://github.com/xguerin/ppx_bitstring.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "bitstring" {>= "2.1.0"}
+  "jbuilder" {build}
+  "ppx_tools_versioned" {build}
+  "ocaml-migrate-parsetree" {build & >= "1.0.5"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.2/url
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/xguerin/ppx_bitstring/archive/v2.0.2.tar.gz"
+checksum: "b126678ff21fe933a568ecba96b00c5e"


### PR DESCRIPTION
### `ppx_bitstring.2.0.2`

PPX extension for the bitstring library.
PPX implementation of the original bitstring camlp4 extension.



---
* Homepage: https://github.com/xguerin/ppx_bitstring
* Source repo: https://github.com/xguerin/ppx_bitstring.git
* Bug tracker: https://github.com/xguerin/ppx_bitstring/issues

---

:camel: Pull-request generated by opam-publish v0.3.5