### PR TITLE
Add Lwt_ssl 1.1.1 – compatibility with 4.06

### DIFF
--- a/packages/lwt_ssl/lwt_ssl.1.1.1/descr
+++ b/packages/lwt_ssl/lwt_ssl.1.1.1/descr
@@ -1,0 +1,1 @@
+Lwt-friendly OpenSSL bindings

--- a/packages/lwt_ssl/lwt_ssl.1.1.1/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+version: "1.1.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "base-unix"
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "3.0.0"}
+  "ssl" {>= "0.5.0"}
+]

--- a/packages/lwt_ssl/lwt_ssl.1.1.1/url
+++ b/packages/lwt_ssl/lwt_ssl.1.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/lwt_ssl-1.1.1.tar.gz"
+checksum: "8e19fab3f53abd809806b842f4ba1003"


### PR DESCRIPTION
There is only one change:

> Compatibility with `-safe-string`, and thus OCaml 4.06. `Lwt_ssl.read` and `Lwt_ssl.write` now take a buffer of type `bytes` as argument, rather than a buffer of type `string`.

I decided this is a bugfix, rather than a breaking change, because

- Any code that was using `read` with a `string` buffer is inherently violating the assumptions of `-safe-string`, on by default in 4.06. `Lwt_ssl` finally being forced to choose between `string` and `bytes` is not what is actually breaking that code.
- All code that I found through opam and a GitHub search either
  - does not use the changed functions at all (there are other reading and writing functions in, or that can be used with, `Lwt_ssl`), or
  - will actually break on 4.06 for other reasons, at the same time as `Lwt_ssl` would break it (EDIT: s/for other reasons/due to other usage of `string` and `bytes`).

Related:

- https://github.com/ocsigen/lwt/pull/479 "Make Lwt_ssl -safe-string-compatible"
- https://github.com/ocaml/opam-repository/pull/10446 "Released lwt_ssl not compatible with OCaml 4.06"