### PR TITLE
Package bsbnative.1.9.4

### DIFF
--- a/packages/bsbnative/bsbnative.1.9.4/opam
+++ b/packages/bsbnative/bsbnative.1.9.4/opam
@@ -9,6 +9,6 @@ authors: [ "Hongbo Zhang <>" ]
 maintainer: "hongbo_zhang <bobzhang1988@gmail.com>"
 tags: [ "ocaml" "bucklescript" "stdlib" "functional programming" ]
 build: [
-  [ "./scripts/opam_install.sh" ]
+  [ "./scripts/opam_install.sh" "%{sbin}%"  ]
 ]
 available: [ ocaml-version = "4.02.3" ]

--- a/packages/bsbnative/bsbnative.1.9.4/url
+++ b/packages/bsbnative/bsbnative.1.9.4/url
@@ -1,2 +1,2 @@
 http: "https://github.com/bsansouci/bsb-native/archive/1.9.4.tar.gz"
-checksum: "90fa52709385f28cc80b15e6f0f537e6"
+checksum: "95e9d441129b7376f30ec840b32df3aa"


### PR DESCRIPTION
### `bsbnative.1.9.4`

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt

bsb-native is BuckleScript's bsb but for ocamlc and ocamlopt


---
* Homepage: https://github.com/bucklescript/bucklescript#readme
* Source repo: git+https://github.com/bucklescript/bucklescript.git
* Bug tracker: https://github.com/bucklescript/bucklescript/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---

:camel: Pull-request generated by opam-publish v0.3.5