### PR TITLE
Package topkg-jbuilder.0.2.0

### DIFF
--- a/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/descr
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/descr
@@ -1,0 +1,4 @@
+Helpers for using topkg with jbuilder
+
+Topkg-jbuilder exposes helpers for using topkg-care in projects using
+Jbuilder.

--- a/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/opam
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Jérémie Dimino"]
+license:      "BSD3"
+homepage:     "https://github.com/samoht/topkg-jbuilder"
+bug-reports:  "https://github.com/samoht/utop/topkg-jbuilder"
+dev-repo:     "https://github.com/samoht/topkg-jbuilder.git"
+doc:          "https://samoht.github.io/topkg-jbuilder/"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "topkg"
+]

--- a/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/url
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/topkg-jbuilder/releases/download/0.2.0/topkg-jbuilder-0.2.0.tbz"
+checksum: "83bbcbb0b52da0fba935f449dfd9d3e4"


### PR DESCRIPTION
### `topkg-jbuilder.0.2.0`

Helpers for using topkg with jbuilder

Topkg-jbuilder exposes helpers for using topkg-care in projects using
Jbuilder.



---
* Homepage: https://github.com/samoht/topkg-jbuilder
* Source repo: https://github.com/samoht/topkg-jbuilder.git
* Bug tracker: https://github.com/samoht/utop/topkg-jbuilder

---


---
0.2.0
-----

- make `topkg doc` work, so that `topkg publish doc` also works (#3,
  Thomas Gazagnaire)

- Run tests during `topkg distrib` and pass `--dev` when the dev mode
  is selected by topkg (#4, Török Edwin)
:camel: Pull-request generated by opam-publish v0.3.5