### PR TITLE
Num package version 1.1

### DIFF
--- a/packages/num/num.1.1/descr
+++ b/packages/num/num.1.1/descr
@@ -1,0 +1,1 @@
+The legacy Num library for arbitrary-precision integer and rational arithmetic

--- a/packages/num/num.1.1/opam
+++ b/packages/num/num.1.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "num"
+version: "1.1"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Valérie Ménissier-Morain"
+  "Pierre Weis"
+  "Xavier Leroy"
+]
+license: "LGPL 2.1 with OCaml linking exception"
+
+homepage: "https://github.com/ocaml/num/"
+bug-reports: "https://github.com/ocaml/num/issues"
+dev-repo: "https://github.com/ocaml/num.git"
+
+build: [
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+
+depends: [
+  "ocamlfind" { >= "1.7.3" }
+]
+conflicts: [ "base-num" ]
+available: [ ocaml-version >= "4.06.0" ]
+

--- a/packages/num/num.1.1/url
+++ b/packages/num/num.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/num/archive/v1.1.tar.gz"
+checksum: "710cbe18b144955687a03ebab439ff2b"


### PR DESCRIPTION
This is the legacy Num library for arbitrary-precision integer and rational arithmetic.

Release 1.1 improves OCaml 4.06 compatibility and installs .cmx files that were omitted by mistake.
