### PR TITLE
New release of Menhir.

### DIFF
--- a/packages/menhir/menhir.20171013/descr
+++ b/packages/menhir/menhir.20171013/descr
@@ -1,0 +1,1 @@
+LR(1) parser generator

--- a/packages/menhir/menhir.20171013/opam
+++ b/packages/menhir/menhir.20171013/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+]
+homepage: "http://gallium.inria.fr/~fpottier/menhir/"
+dev-repo: "https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "menhir@inria.fr"
+build: [
+  [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+install: [
+  [make "-f" "Makefile" "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+remove: [
+  [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/menhir/menhir.20171013/url
+++ b/packages/menhir/menhir.20171013/url
@@ -1,0 +1,2 @@
+archive: "http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz"
+checksum: "620863edea40437390ee5e5bd82fba11"


### PR DESCRIPTION
Removes the script that checks the version of OCaml. (We have opam constraints for this purpose anyway.)