### PR TITLE
ZArith version 1.7

### DIFF
--- a/packages/zarith/zarith.1.7/descr
+++ b/packages/zarith/zarith.1.7/descr
@@ -1,0 +1,5 @@
+Implements arithmetic and logical operations over arbitrary-precision integers
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy.

--- a/packages/zarith/zarith.1.7/opam
+++ b/packages/zarith/zarith.1.7/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "zarith"
+version: "1.7"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/ocaml/Zarith"
+bug-reports: "https://github.com/ocaml/Zarith/issues"
+dev-repo: "https://github.com/ocaml/Zarith.git"
+build: [
+  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/usr/local/include\" ./configure"] { os = "openbsd" | os = "freebsd" }
+  ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"] { os = "darwin" }
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove:  ["ocamlfind" "remove" "zarith"]
+depends: [
+  "ocamlfind"
+  "conf-gmp"
+  "conf-perl" {build}
+]

--- a/packages/zarith/zarith.1.7/url
+++ b/packages/zarith/zarith.1.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
+checksum: "80944e2755ebb848451a77dc2ad0651b"


### PR DESCRIPTION
The modern library for arbitrary-precision integer and rational arithmetic.

New in release 1.7:
* Issue #14, pull request #15: ARM assembly code was broken.
* Fix tests so that they work even if the legacy Num library is unavailable, as is the case in a base install of OCaml 4.06.