### PR TITLE
Package stdint.0.5.0

### DIFF
--- a/packages/stdint/stdint.0.5.0/descr
+++ b/packages/stdint/stdint.0.5.0/descr
@@ -1,0 +1,9 @@
+signed and unsigned integer types having specified widths
+The stdint library provides signed and unsigned integer types of various
+fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical),
+conversion to and from buffers in both big endian and little endian byte order.

--- a/packages/stdint/stdint.0.5.0/opam
+++ b/packages/stdint/stdint.0.5.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+  "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+]
+homepage: "https://github.com/andrenth/ocaml-stdint"
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+license: "MIT"
+doc: "http://stdint.forge.ocamlcore.org/doc/"
+dev-repo: "https://github.com/andrenth/ocaml-stdint.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "stdint"]
+depends: [
+  "base-bytes"
+  "ocamlfind" {>= "1.5"}
+  "ocamlbuild" {build}
+]

--- a/packages/stdint/stdint.0.5.0/url
+++ b/packages/stdint/stdint.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-stdint/archive/0.5.0.tar.gz"
+checksum: "fefa9d456e1a22edbb32b6c1848b1663"


### PR DESCRIPTION
### `stdint.0.5.0`

signed and unsigned integer types having specified widths
The stdint library provides signed and unsigned integer types of various
fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
This interface is similar to Int32 and Int64 from the base library but provides
more functions and constants like arithmetic and bit-wise operations, constants
like maximum and minimum values, infix operators conversion to and from every
other integer type (including int, float and nativeint), parsing from and
conversion to readable strings (binary, octal, decimal, hexademical),
conversion to and from buffers in both big endian and little endian byte order.



---
* Homepage: https://github.com/andrenth/ocaml-stdint
* Source repo: https://github.com/andrenth/ocaml-stdint.git
* Bug tracker: https://github.com/andrenth/ocaml-stdint/issues

---

:camel: Pull-request generated by opam-publish v0.3.5