### PR TITLE
Package horned_worm.0.1.1

### DIFF
--- a/packages/horned_worm/horned_worm.0.1.1/descr
+++ b/packages/horned_worm/horned_worm.0.1.1/descr
@@ -1,0 +1,5 @@
+A functional Web app server.
+
+A functional Web app server.
+
+Greatly inspired by Suave.IO and GIRAFFE of F#, this is OCaml implementation.

--- a/packages/horned_worm/horned_worm.0.1.1/opam
+++ b/packages/horned_worm/horned_worm.0.1.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "obiwanko@me.com"
+authors: "Kazuo Koga"
+homepage: "https://github.com/kkazuo/horned_worm"
+bug-reports: "https://github.com/kkazuo/horned_worm/issues"
+license: "MIT"
+dev-repo: "https://github.com/kkazuo/horned_worm.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "batteries" {>= "2.7.0"}
+  "cohttp-lwt-unix" {>= "0.99.0"}
+  "logs" {>= "0.6.2"}
+  "re" {>= "1.7.1"}
+  "yojson" {>= "1.4.0"}
+  "jbuilder" {build & >= "1.0+beta13"}
+]
+available: [ocaml-version >= "4.04.1"]

--- a/packages/horned_worm/horned_worm.0.1.1/url
+++ b/packages/horned_worm/horned_worm.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/kkazuo/horned_worm/archive/v0.1.1.tar.gz"
+checksum: "034a8c3bc3fd17e67f27326c80333853"


### PR DESCRIPTION
### `horned_worm.0.1.1`

A functional Web app server.

A functional Web app server.

Greatly inspired by Suave.IO and GIRAFFE of F#, this is OCaml implementation.



---
* Homepage: https://github.com/kkazuo/horned_worm
* Source repo: https://github.com/kkazuo/horned_worm.git
* Bug tracker: https://github.com/kkazuo/horned_worm/issues

---

:camel: Pull-request generated by opam-publish v0.3.5