### PR TITLE
Package loga.0.0.2

### DIFF
--- a/packages/loga/loga.0.0.2/descr
+++ b/packages/loga/loga.0.0.2/descr
@@ -1,0 +1,1 @@
+A logging library for OCaml

--- a/packages/loga/loga.0.0.2/opam
+++ b/packages/loga/loga.0.0.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "yutopp <yutopp@gmail.com>"
+authors: "yutopp <yutopp@gmail.com>"
+homepage: "https://github.com/yutopp/loga"
+bug-reports: "https://github.com/yutopp/loga/issues"
+license: "Boost License Version 1.0"
+dev-repo: "https://github.com/yutopp/loga.git"
+build: ["omake" "PREFIX=%{prefix}%"]
+install: ["omake" "install" "PREFIX=%{prefix}%"]
+remove: ["omake" "uninstall"]
+depends: [
+  "ocaml-compiler-libs" {>= "v0.9.0"}
+  "omake" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/loga/loga.0.0.2/url
+++ b/packages/loga/loga.0.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/yutopp/loga/archive/0.0.2.tar.gz"
+checksum: "e060ceb7f0b7b9293fb4532cf39594ab"


### PR DESCRIPTION
### `loga.0.0.2`

A logging library for OCaml



---
* Homepage: https://github.com/yutopp/loga
* Source repo: https://github.com/yutopp/loga.git
* Bug tracker: https://github.com/yutopp/loga/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5