### PR TITLE
Package qtest.2.7

### DIFF
--- a/packages/qtest/qtest.2.7/descr
+++ b/packages/qtest/qtest.2.7/descr
@@ -1,0 +1,6 @@
+iTeML / qtest : Inline (Unit) Tests for OCaml.
+
+qtest extracts inline unit tests written using a special
+syntax in comments. Those tests are then run using the oUnit framework
+and the qcheck library.  The possibilities range from trivial tests --
+extremely simple to use -- to sophisticated random generation of test cases.

--- a/packages/qtest/qtest.2.7/opam
+++ b/packages/qtest/qtest.2.7/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Vincent Hugot <vincent.hugot@gmail.com>"
+authors: [
+  "Vincent Hugot <vincent.hugot@gmail.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+homepage: "https://github.com/vincent-hugot/iTeML"
+bug-reports: "https://github.com/vincent-hugot/iTeML/issues"
+doc:
+  "https://github.com/vincent-hugot/iTeML/blob/master/README.adoc#introduction"
+tags: ["test" "property" "quickcheck"]
+dev-repo: "git@github.com:vincent-hugot/iTeML.git"
+build: [make "build"]
+install: [make "BIN=%{bin}%" "install"]
+remove: ["rm" "%{bin}%/qtest"]
+depends: [
+  "ocamlfind"
+  "base-bytes"
+  "ounit" {>= "2.0.0"}
+  "ocamlbuild" {build}
+  "qcheck" {>= "0.5"}
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/qtest/qtest.2.7/url
+++ b/packages/qtest/qtest.2.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vincent-hugot/iTeML/archive/v2.7.tar.gz"
+checksum: "ba6bfd86f2fd35773669a706b4cfe704"


### PR DESCRIPTION
### `qtest.2.7`

iTeML / qtest : Inline (Unit) Tests for OCaml.

qtest extracts inline unit tests written using a special
syntax in comments. Those tests are then run using the oUnit framework
and the qcheck library.  The possibilities range from trivial tests --
extremely simple to use -- to sophisticated random generation of test cases.



---
* Homepage: https://github.com/vincent-hugot/iTeML
* Source repo: git@github.com:vincent-hugot/iTeML.git
* Bug tracker: https://github.com/vincent-hugot/iTeML/issues

---

:camel: Pull-request generated by opam-publish v0.3.5