### PR TITLE
Package gsl.1.20.2

### DIFF
--- a/packages/gsl/gsl.1.20.2/descr
+++ b/packages/gsl/gsl.1.20.2/descr
@@ -1,0 +1,6 @@
+GSL - Bindings to the GNU Scientific Library
+
+gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
+most frequently used functions for scientific computation including algorithms
+for optimization, differential equations, statistics, random number generation,
+linear algebra, etc.

--- a/packages/gsl/gsl.1.20.2/opam
+++ b/packages/gsl/gsl.1.20.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Olivier Andrieu <oandrieu@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+]
+license: "GPL-3+"
+homepage: "https://mmottl.github.io/gsl-ocaml"
+doc: "https://mmottl.github.io/gsl-ocaml/api"
+dev-repo: "https://github.com/mmottl/gsl-ocaml.git"
+bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-gsl" {build}
+  "conf-pkg-config" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/gsl/gsl.1.20.2/url
+++ b/packages/gsl/gsl.1.20.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/gsl-ocaml/releases/download/1.20.2/gsl-1.20.2.tbz"
+checksum: "c9a57b2c06ec3c9a6edfb7d3e636c2b9"


### PR DESCRIPTION
### `gsl.1.20.2`

GSL - Bindings to the GNU Scientific Library

gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
most frequently used functions for scientific computation including algorithms
for optimization, differential equations, statistics, random number generation,
linear algebra, etc.



---
* Homepage: https://mmottl.github.io/gsl-ocaml
* Source repo: https://github.com/mmottl/gsl-ocaml.git
* Bug tracker: https://github.com/mmottl/gsl-ocaml/issues

---


---
### 1.20.2 (2017-10-15)

  * Fixed a configuration bug leading to wrong include paths
:camel: Pull-request generated by opam-publish v0.3.5