### PR TITLE
omp 1.0.5: add ocaml < 4.06.0

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
@@ -17,4 +17,4 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta10"}
 ]
-available: ocaml-version >= "4.02.0"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
4.06 AST changed a little bit since ocaml-migrate-parsetree 1.0.5 release.
This constraint prevents some breakage.