### PR TITLE
zarith-xen.1.7 and zarith-freestanding.1.7

### DIFF
--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
@@ -9,6 +9,6 @@ depends: [
   "ocaml-freestanding"
   "gmp-freestanding"
   "zarith" {= "1.4.1"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]
 patches: [ "config.diff" ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.4/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4/opam
@@ -9,6 +9,6 @@ depends: [
   "ocaml-freestanding"
   "gmp-freestanding"
   "zarith" {= "1.4"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]
 patches: [ "z_pp.pl.patch" "config.diff" ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.6/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.6/opam
@@ -9,6 +9,6 @@ depends: [
   "ocaml-freestanding"
   "gmp-freestanding" {> "6.0.0"}
   "zarith" {= "1.6"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]
 patches: [ "config.diff" ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/descr
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/descr
@@ -1,0 +1,5 @@
+Implements arithmetic and logical operations over arbitrary-precision integers
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy.

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/files/config.diff
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/files/config.diff
@@ -1,0 +1,17 @@
+--- a/configure	2016-07-22 21:53:10.872919000 +0200
++++ b/configure	2016-07-22 21:55:23.788871000 +0200
+@@ -340,12 +340,8 @@
+ if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
+     checkinc gmp.h
+     if test $? -eq 1; then
+-        checklib gmp
+-        if test $? -eq 1; then 
+-            gmp='OK'
+-            cclib="$cclib -lgmp"
+-            ccdef="-DHAS_GMP $ccdef"
+-        fi
++        gmp='OK'
++        ccdef="-DHAS_GMP $ccdef"
+     fi
+ fi
+ if test "$gmp" = 'mpir' -o "$gmp" = 'auto'; then

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/files/mirage-build.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/files/mirage-build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+# WARNING: if you pass invalid cflags here, zarith will silently
+# fall back to compiling with the default flags instead!
+CFLAGS="$(pkg-config --cflags gmp-freestanding ocaml-freestanding)" \
+LDFLAGS="$(pkg-config --libs gmp-freestanding)" \
+./configure -gmp
+
+if [ `uname -s` = "FreeBSD" ]; then
+    gmake
+else
+    make
+fi

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/files/mirage-install.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/files/mirage-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+cp libzarith.a "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+# This is a hack to get freestanding_linkopts into the host 'zarith' package.
+cat >>"$PREFIX/lib/zarith/META" <<EOM
+freestanding_linkopts = "-lzarith-freestanding -L@gmp-freestanding -lgmp-freestanding"
+EOM

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/files/mirage-uninstall.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/files/mirage-uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+
+rm -f "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+mv "$PREFIX/lib/zarith/META" "$PREFIX/lib/zarith/META.tmp"
+cat "$PREFIX/lib/zarith/META.tmp" | grep -v freestanding_linkopts > "$PREFIX/lib/zarith/META"
+rm -f "$PREFIX/lib/zarith/META.tmp"

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+authors: "Xavier Leroy"
+maintainer: "mirageos-devel"
+homepage: "https://forge.ocamlcore.org/projects/zarith"
+build: ["sh" "-eux" "./mirage-build.sh"]
+install: ["sh" "-eux" "./mirage-install.sh"]
+remove: ["sh" "-eux" "./mirage-uninstall.sh"]
+depends: [
+  "ocaml-freestanding"
+  "gmp-freestanding" {> "6.0.0"}
+  "zarith" {= "1.7"}
+  "ocamlfind"
+]
+patches: [ "config.diff" ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/opam
@@ -9,6 +9,6 @@ depends: [
   "ocaml-freestanding"
   "gmp-freestanding" {> "6.0.0"}
   "zarith" {= "1.7"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]
 patches: [ "config.diff" ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/url
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
+checksum: "80944e2755ebb848451a77dc2ad0651b"

--- a/packages/zarith-xen/zarith-xen.1.3/opam
+++ b/packages/zarith-xen/zarith-xen.1.3/opam
@@ -14,5 +14,5 @@ depends: [
   "mirage-xen-posix"
   "gmp-xen"
   "zarith" {>= "1.3" & < "1.4"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]

--- a/packages/zarith-xen/zarith-xen.1.4/opam
+++ b/packages/zarith-xen/zarith-xen.1.4/opam
@@ -8,5 +8,5 @@ depends: [
   "mirage-xen-posix"
   "gmp-xen"
   "zarith" {= "1.4"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]

--- a/packages/zarith-xen/zarith-xen.1.6/opam
+++ b/packages/zarith-xen/zarith-xen.1.6/opam
@@ -8,5 +8,5 @@ depends: [
   "mirage-xen-posix"
   "gmp-xen" {> "6.0.0"}
   "zarith" {= "1.6"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]

--- a/packages/zarith-xen/zarith-xen.1.7/descr
+++ b/packages/zarith-xen/zarith-xen.1.7/descr
@@ -1,0 +1,5 @@
+Implements arithmetic and logical operations over arbitrary-precision integers
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy.

--- a/packages/zarith-xen/zarith-xen.1.7/files/mirage-install.sh
+++ b/packages/zarith-xen/zarith-xen.1.7/files/mirage-install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+LDFLAGS=`pkg-config --libs gmp-xen`
+export LDFLAGS
+
+# WARNING: if you pass invalid cflags here, zarith will silently
+# fall back to compiling with the default flags instead!
+CFLAGS="`pkg-config --cflags gmp-xen mirage-xen-posix` -O2 -pedantic -fomit-frame-pointer -fno-builtin"
+export CFLAGS
+./configure
+make
+
+cp libzarith.a "$PREFIX/lib/zarith/libzarith-xen.a"
+
+cat >>"$PREFIX/lib/zarith/META" <<EOM
+xen_linkopts = "-lzarith-xen -L@gmp-xen -lgmp-xen"
+EOM

--- a/packages/zarith-xen/zarith-xen.1.7/files/mirage-uninstall.sh
+++ b/packages/zarith-xen/zarith-xen.1.7/files/mirage-uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+
+rm -f "$PREFIX/lib/zarith/libzarith-xen.a"
+
+mv "$PREFIX/lib/zarith/META" "$PREFIX/lib/zarith/META.tmp"
+cat "$PREFIX/lib/zarith/META.tmp" | grep -v xen_linkopts > "$PREFIX/lib/zarith/META"
+rm -f "$PREFIX/lib/zarith/META.tmp"

--- a/packages/zarith-xen/zarith-xen.1.7/opam
+++ b/packages/zarith-xen/zarith-xen.1.7/opam
@@ -8,5 +8,5 @@ depends: [
   "mirage-xen-posix"
   "gmp-xen" {> "6.0.0"}
   "zarith" {= "1.7"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]

--- a/packages/zarith-xen/zarith-xen.1.7/opam
+++ b/packages/zarith-xen/zarith-xen.1.7/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+authors: "Xavier Leroy"
+maintainer: "mirageos-devel"
+homepage: "https://forge.ocamlcore.org/projects/zarith"
+install: ["sh" "-eux" "./mirage-install.sh"]
+remove: ["sh" "-eux" "./mirage-uninstall.sh"]
+depends: [
+  "mirage-xen-posix"
+  "gmp-xen" {> "6.0.0"}
+  "zarith" {= "1.7"}
+  "ocamlfind"
+]

--- a/packages/zarith-xen/zarith-xen.1.7/url
+++ b/packages/zarith-xen/zarith-xen.1.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
+checksum: "80944e2755ebb848451a77dc2ad0651b"


### PR DESCRIPTION
in addition, this marks `ocamlfind` as `build`-only dependency for all zarith-xen/zarith-freestanding.