### PR TITLE
Package opaca.0.1.3

### DIFF
--- a/packages/opaca/opaca.0.1.3/descr
+++ b/packages/opaca/opaca.0.1.3/descr
@@ -1,0 +1,8 @@
+A friendly OCaml project scaffolding tool
+
+Opaca quickly sets up a basic project to be used with jbuilder[link?] and topkg[link?]
+
+simply run `opaca new 'name'` to scaffold a library project,
+or `opaca new 'name' --bin` to scaffold an executable project.
+
+It doesn't do much beyond that

--- a/packages/opaca/opaca.0.1.3/opam
+++ b/packages/opaca/opaca.0.1.3/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+name: "opaca"
+authors: "Mia Kathage"
+maintainer: "Mia Kathage <siboru@googlemail.com>"
+homepage: "https://github.com/spreadLink/opaca"
+bug-reports: "https://github.com/spreadLink/opaca/issues"
+dev-repo: "https://github.com/spreadLink/opaca.git"
+doc: "https://spreadlink.github.io/opaca/"
+license: "MIT License"
+build: ["jbuilder" "build"]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "topkg" {build}
+]

--- a/packages/opaca/opaca.0.1.3/url
+++ b/packages/opaca/opaca.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/spreadLink/opaca/releases/download/0.1.3/opaca-0.1.3.tbz"
+checksum: "319a27a1a00ac380f711fe690ba0bba9"


### PR DESCRIPTION
### `opaca.0.1.3`

A friendly OCaml project scaffolding tool

Opaca quickly sets up a basic project to be used with jbuilder[link?] and topkg[link?]

simply run `opaca new 'name'` to scaffold a library project,
or `opaca new 'name' --bin` to scaffold an executable project.

It doesn't do much beyond that


---
* Homepage: https://github.com/spreadLink/opaca
* Source repo: https://github.com/spreadLink/opaca.git
* Bug tracker: https://github.com/spreadLink/opaca/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
0.1.3
-----

fixed some typos <.<'
:camel: Pull-request generated by opam-publish v0.3.5