### PR TITLE
sexplib-deps: add upper bounds to jbuilder

### DIFF
--- a/packages/sexplib/sexplib.v0.9.0/opam
+++ b/packages/sexplib/sexplib.v0.9.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "base"     {= "v0.9.0"}
-  "jbuilder" {build & >= "1.0+beta4"}
+  "jbuilder" {build & >= "1.0+beta4" & < "1.0+beta12"}
   "num"
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/sexplib/sexplib.v0.9.1/opam
+++ b/packages/sexplib/sexplib.v0.9.1/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "--only-packages" "sexplib" "--root" "." "-j" jobs "@install"]
 ]
 depends: [
-  "jbuilder" {build & >= "1.0+beta2"}
+  "jbuilder" {build & >= "1.0+beta2" & < "1.0+beta12"}
   "num"
 ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
The `per_file` stanza was deprecated in 1.0+beta12, which these versions of sexplib depend on. Subsequent versions moved away from this feature.

This was part of the mega-pr ocaml/opam-repository#10286.