### PR TITLE
Package opaca.0.1.5

### DIFF
--- a/packages/opaca/opaca.0.1.5/descr
+++ b/packages/opaca/opaca.0.1.5/descr
@@ -1,0 +1,8 @@
+A friendly OCaml project scaffolding tool
+
+Opaca quickly sets up a basic project to be used with jbuilder[link?] and topkg[link?]
+
+simply run `opaca new 'name'` to scaffold a library project,
+or `opaca new 'name' --bin` to scaffold an executable project.
+
+It doesn't do much beyond that

--- a/packages/opaca/opaca.0.1.5/opam
+++ b/packages/opaca/opaca.0.1.5/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+authors: "Mia Kathage"
+maintainer: "Mia Kathage <siboru@googlemail.com>"
+homepage: "https://github.com/spreadLink/opaca"
+bug-reports: "https://github.com/spreadLink/opaca/issues"
+dev-repo: "https://github.com/spreadLink/opaca.git"
+doc: "https://spreadlink.github.io/opaca/"
+license: "MIT License"
+build: ["jbuilder" "build"]
+available: [ocaml-version >= "4.03.0"]
+depends: [
+  "jbuilder" {build}
+  "topkg" {build}
+]

--- a/packages/opaca/opaca.0.1.5/url
+++ b/packages/opaca/opaca.0.1.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/spreadLink/opaca/releases/download/0.1.5/opaca-0.1.5.tbz"
+checksum: "36f70ae37a6fb0a61514e28f94223a2d"


### PR DESCRIPTION
### `opaca.0.1.5`

A friendly OCaml project scaffolding tool

Opaca quickly sets up a basic project to be used with jbuilder[link?] and topkg[link?]

simply run `opaca new 'name'` to scaffold a library project,
or `opaca new 'name' --bin` to scaffold an executable project.

It doesn't do much beyond that


---
* Homepage: https://github.com/spreadLink/opaca
* Source repo: https://github.com/spreadLink/opaca.git
* Bug tracker: https://github.com/spreadLink/opaca/issues

---


---
0.1.5
-----

when will i learn
:camel: Pull-request generated by opam-publish v0.3.5