### PR TITLE
Package topkg-care.0.9.1

### DIFF
--- a/packages/topkg-care/topkg-care.0.9.1/descr
+++ b/packages/topkg-care/topkg-care.0.9.1/descr
@@ -1,0 +1,25 @@
+The transitory OCaml software packager
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser

--- a/packages/topkg-care/topkg-care.0.9.1/opam
+++ b/packages/topkg-care/topkg-care.0.9.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+  "topkg" {= "0.9.1"}
+  "result"
+  "fmt"
+  "logs"
+  "bos" {>= "0.1.5"}
+  "cmdliner" {>= "1.0.0"}
+  "webbrowser"
+  "opam-format"
+]
+build:[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--dev-pkg" "%{pinned}%"
+]

--- a/packages/topkg-care/topkg-care.0.9.1/url
+++ b/packages/topkg-care/topkg-care.0.9.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/topkg/releases/topkg-0.9.1.tbz"
+checksum: "8978a0595db1a22e4251ec62735d4b84"


### PR DESCRIPTION
### `topkg-care.0.9.1`

The transitory OCaml software packager

Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution, creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml opam repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
[webbrowser][webbrowser] and `opam-format`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner
[webbrowser]: http://erratique.ch/software/webbrowser



---
* Homepage: http://erratique.ch/software/topkg
* Source repo: http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---


---
v0.9.1 2017-10-16 Zagreb
------------------------

- Make `topkg build` return a non-zero exit code when the build
  fails. Thanks to Etienne Millon for the patch.
- Improve `topkg doc` for `jbuilder` users. Thanks to Thomas
  Gazagnaire for the patch.
- `ocamlbuild` users: default to parallel builds. This can
  be controlled via the `--jobs` command line argument. Thanks
  to Edwin Török for the patch.
:camel: Pull-request generated by opam-publish v0.3.5