### PR TITLE
Package codept.0.10.1 - 4.06 support

### DIFF
--- a/packages/codept/codept.0.10.1/descr
+++ b/packages/codept/codept.0.10.1/descr
@@ -1,0 +1,12 @@
+alternative ocaml dependency analyzer
+
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+   when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis.

--- a/packages/codept/codept.0.10.1/opam
+++ b/packages/codept/codept.0.10.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "codept"
+version: "0.10.1"
+author: "octachron <octa@polychoron.fr>"
+maintainer: "octachron <octa@polychoron.fr>"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+license: "gpl-3"
+dev-repo: "https://github.com/Octachron/codept.git"
+build: [
+  ["./configure" "--%{ocamlbuild:enable}%-ocamlbuild"]
+  [make "all"]
+]
+build-test: [
+  [make "alt2-tests"]
+]
+build-doc: [
+  [make "alt2-docs"]
+]
+depopts:["ocamlbuild"]
+depends: ["base-unix"]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/codept/codept.0.10.1/url
+++ b/packages/codept/codept.0.10.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Octachron/codept/archive/0.10.1.tar.gz"
+checksum: "37550464ac0c18b6c565cdfca2b78349"


### PR DESCRIPTION
This minor updates 4.06 support to handle deep destructive module substitution and fixes a bug with ocamlfind ppx packages that were silently dropped.