### PR TITLE
Package pcre.7.3.3

### DIFF
--- a/packages/pcre/pcre.7.3.3/descr
+++ b/packages/pcre/pcre.7.3.3/descr
@@ -1,0 +1,4 @@
+Bindings to the Perl Compatibility Regular Expressions library
+
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language.

--- a/packages/pcre/pcre.7.3.3/opam
+++ b/packages/pcre/pcre.7.3.3/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "base-bytes"
+  "conf-libpcre" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/pcre/pcre.7.3.3/url
+++ b/packages/pcre/pcre.7.3.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/pcre-ocaml/releases/download/7.3.3/pcre-7.3.3.tbz"
+checksum: "4ba5c78aac3cae832cc7fd00dbc474d3"


### PR DESCRIPTION
### `pcre.7.3.3`

Bindings to the Perl Compatibility Regular Expressions library

pcre-ocaml offers library functions for string pattern matching and
substitution, similar to the functionality offered by the Perl language.



---
* Homepage: https://mmottl.github.io/pcre-ocaml
* Source repo: https://github.com/mmottl/pcre-ocaml.git
* Bug tracker: https://github.com/mmottl/pcre-ocaml/issues

---


---
### 7.3.3 (2017-10-17)

  * Fixed external declaration bug in internal regexp compile function
:camel: Pull-request generated by opam-publish v0.3.5