### PR TITLE
Package hdf5.0.1.4

### DIFF
--- a/packages/hdf5/hdf5.0.1.4/descr
+++ b/packages/hdf5/hdf5.0.1.4/descr
@@ -1,0 +1,3 @@
+Manages HDF5 files used for storing large amounts of data
+
+The library manages reading and writing to HDF5 files. HDF5 file format is used for storing and organizing large amounts of data. Also provided is a fast way of working with large arrays of records, much faster than OCaml arrays of records.

--- a/packages/hdf5/hdf5.0.1.4/opam
+++ b/packages/hdf5/hdf5.0.1.4/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Vladimir Brankov <vbrankov@janestreet.com>"
+authors: "Vladimir Brankov <vbrankov@janestreet.com>"
+homepage: "https://github.com/vbrankov/hdf5-ocaml"
+bug-reports: "https://github.com/vbrankov/hdf5-ocaml/issues"
+license: "MIT"
+dev-repo: "git@github.com:vbrankov/hdf5-ocaml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "hdf5_caml"]
+  ["ocamlfind" "remove" "hdf5_raw"]
+]
+depends: [
+  "ocamlfind" {build}
+  "cppo" {build}
+  "cppo_ocamlbuild" {build}
+]
+depexts: [
+  [["alpine"] ["hdf5"]]
+  [["centos"] ["epel-release" "hdf5-devel"]]
+  [["debian"] ["libhdf5-serial-dev"]]
+  [["homebrew" "osx"] ["homebrew/science/hdf5"]]
+  [["ubuntu"] ["libhdf5-serial-dev"]]
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/hdf5/hdf5.0.1.4/url
+++ b/packages/hdf5/hdf5.0.1.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vbrankov/hdf5-ocaml/archive/v0.1.4.tar.gz"
+checksum: "1fe2ba3b4eeb48b59e0adebc5e876a2b"


### PR DESCRIPTION
### `hdf5.0.1.4`

Manages HDF5 files used for storing large amounts of data

The library manages reading and writing to HDF5 files. HDF5 file format is used for storing and organizing large amounts of data. Also provided is a fast way of working with large arrays of records, much faster than OCaml arrays of records.



---
* Homepage: https://github.com/vbrankov/hdf5-ocaml
* Source repo: git@github.com:vbrankov/hdf5-ocaml.git
* Bug tracker: https://github.com/vbrankov/hdf5-ocaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5