### PR TITLE
core_kernel: fix building with gcc < 4.5 on OpenBSD

### DIFF
--- a/packages/core_kernel/core_kernel.v0.9.0/files/mpopcnt.patch
+++ b/packages/core_kernel/core_kernel.v0.9.0/files/mpopcnt.patch
@@ -1,0 +1,11 @@
+--- src/jbuild.orig	Wed Oct 18 14:02:49 2017
++++ src/jbuild	Wed Oct 18 14:02:51 2017
+@@ -24,7 +24,7 @@
+     sexplib
+     typerep
+     variantslib))
+-  (c_flags (:standard -D_LARGEFILE64_SOURCE -mpopcnt))
++  (c_flags (:standard -D_LARGEFILE64_SOURCE))
+   (c_library_flags (:include rt-flags))
+   (c_names
+    ;; If you add c stubs in here, ask yourself this question: would it make sense/can it

--- a/packages/core_kernel/core_kernel.v0.9.0/opam
+++ b/packages/core_kernel/core_kernel.v0.9.0/opam
@@ -8,6 +8,7 @@ license: "Apache-2.0"
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
+patches: [ "mpopcnt.patch" {os = "openbsd"} ]
 depends: [
   "base"                    {>= "v0.9" & < "v0.10"}
   "bin_prot"                {>= "v0.9" & < "v0.10"}


### PR DESCRIPTION
no ``-mpopcnt`` available there.

Is there a way to filter for the C compiler flavour / version instead of for the OS?