### PR TITLE
Package mariadb.0.8.2

### DIFF
--- a/packages/mariadb/mariadb.0.8.2/descr
+++ b/packages/mariadb/mariadb.0.8.2/descr
@@ -1,0 +1,4 @@
+OCaml bindings to MariaDB
+
+OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its
+nonblocking API.

--- a/packages/mariadb/mariadb.0.8.2/opam
+++ b/packages/mariadb/mariadb.0.8.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/ocaml-mariadb"
+bug-reports: "https://github.com/andrenth/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-mariadb.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "mariadb"]
+  ["ocamlfind" "remove" "mariadb_bindings"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ctypes" {>= "0.7.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/mariadb/mariadb.0.8.2/url
+++ b/packages/mariadb/mariadb.0.8.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-mariadb/archive/0.8.2.tar.gz"
+checksum: "629ad60f2c1adf29de37e5c4380f4ad5"


### PR DESCRIPTION
### `mariadb.0.8.2`

OCaml bindings to MariaDB

OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its
nonblocking API.



---
* Homepage: https://github.com/andrenth/ocaml-mariadb
* Source repo: https://github.com/andrenth/ocaml-mariadb.git
* Bug tracker: https://github.com/andrenth/ocaml-mariadb/issues

---

:camel: Pull-request generated by opam-publish v0.3.5