### PR TITLE
Package decompress.0.7

### DIFF
--- a/packages/decompress/decompress.0.7/descr
+++ b/packages/decompress/decompress.0.7/descr
@@ -1,0 +1,63 @@
+Pure OCaml implementation of Zlib
+
+[![Build Status](https://travis-ci.org/mirage/decompress.svg?branch=master)](https://travis-ci.org/mirage/decompress)
+
+Decompress is a pure implementation of `zlib`. The goal is to create an
+available package for Mirage OS for `zlib` in OCaml (instead a C code).
+
+We respect the interface of `zlib` and all flush mode is available
+(experimental):
+
+- `SYNC_FLUSH`
+- `PARTIAL_FLUSH`
+- `FULL_FLUSH`
+
+The interface proposed is a non-blocking interface.
+
+
+Documentation: https://mirage.github.io/decompress/api.docdir/
+
+
+## Installation
+
+Decompress can be installed with `opam`:
+
+    opam install decompress
+
+## Sample programs
+
+Sample program are located in the `bin` directory of the distribution. It can be
+built with (dependancy with Unix module, the `cmdliner` package and a C code):
+
+    ocamlbuild -use-ocamlfind bin/dpipe.native
+
+Another good example is provided in `bin/easy.ml` with the signature:
+
+```ocaml
+val compress   : ?level:int -> string -> string
+val uncompress : string -> string
+```
+
+And you can compile this program with:
+
+    ocamlbuild -use-ocamlfind bin/easy.native
+
+But keep in your mind, it's an easy example and it's not optimized for a
+productive environment - so, don't copy/paste and think.
+
+The documentation is
+available [online](https://mirage.github.io/decompress/api.docdir/) to
+understand how to use Decompress.
+
+## Build Requirements
+
+ * OCaml >= 4.02.0
+ * `base-bytes` meta-package
+ * Bigarray module (provided by the standard library of OCaml)
+ * `topkg`, `ocamlfind` and `ocamlbuild` to build the project
+
+If you want to compile the test program, you need:
+
+ * `camlzip` to compare `decompress` with `zlib`
+ * `re`
+ * `alcotest`

--- a/packages/decompress/decompress.0.7/opam
+++ b/packages/decompress/decompress.0.7/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+  "--with-cmdliner" "%{cmdliner:installed}%"
+]
+
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+
+depends: [
+  "ocamlbuild"     {build}
+  "ocamlfind"      {build}
+  "topkg"          {build}
+  "base-bytes"
+  "camlzip"        {test}
+  "re"             {test}
+  "alcotest"       {test}
+]
+
+depopts: [
+  "cmdliner"
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/decompress/decompress.0.7/url
+++ b/packages/decompress/decompress.0.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/decompress/releases/download/v0.7/decompress-0.7.tbz"
+checksum: "2e4a75f3ca15d0bcad6701d374db1a4d"


### PR DESCRIPTION
### `decompress.0.7`

Pure OCaml implementation of Zlib

[![Build Status](https://travis-ci.org/mirage/decompress.svg?branch=master)](https://travis-ci.org/mirage/decompress)

Decompress is a pure implementation of `zlib`. The goal is to create an
available package for Mirage OS for `zlib` in OCaml (instead a C code).

We respect the interface of `zlib` and all flush mode is available
(experimental):

- `SYNC_FLUSH`
- `PARTIAL_FLUSH`
- `FULL_FLUSH`

The interface proposed is a non-blocking interface.


Documentation: https://mirage.github.io/decompress/api.docdir/


## Installation

Decompress can be installed with `opam`:

    opam install decompress

## Sample programs

Sample program are located in the `bin` directory of the distribution. It can be
built with (dependancy with Unix module, the `cmdliner` package and a C code):

    ocamlbuild -use-ocamlfind bin/dpipe.native

Another good example is provided in `bin/easy.ml` with the signature:

```ocaml
val compress   : ?level:int -> string -> string
val uncompress : string -> string
```

And you can compile this program with:

    ocamlbuild -use-ocamlfind bin/easy.native

But keep in your mind, it's an easy example and it's not optimized for a
productive environment - so, don't copy/paste and think.

The documentation is
available [online](https://mirage.github.io/decompress/api.docdir/) to
understand how to use Decompress.

## Build Requirements

 * OCaml >= 4.02.0
 * `base-bytes` meta-package
 * Bigarray module (provided by the standard library of OCaml)
 * `topkg`, `ocamlfind` and `ocamlbuild` to build the project

If you want to compile the test program, you need:

 * `camlzip` to compare `decompress` with `zlib`
 * `re`
 * `alcotest`


---
* Homepage: https://github.com/mirage/decompress
* Source repo: https://github.com/mirage/decompress.git
* Bug tracker: https://github.com/mirage/decompress/issues

---


---
v0.7 2017-10-18 Paris (France)
------------------------------------
* Fixed Inflate.write function
* Fixed internal state to stick in a internal final state
* Fixed compilation with js_of_ocaml (use trampoline function to avoid
  stack-overflow)
* Fixed clash of name about state variable in the Inflate module
* Add afl program
* Export Adler-32 modules
* Add -i and -o option in the dpipe binary to inform the size of the
  internal chunk
* Change the value of -mode in the dpipe binary
:camel: Pull-request generated by opam-publish v0.3.5