### PR TITLE
[IMPORTANT] Add camomile.0.8.6 install and remove opam targets.

### DIFF
--- a/packages/camomile/camomile.0.8.6/opam
+++ b/packages/camomile/camomile.0.8.6/opam
@@ -9,9 +9,17 @@ build: [
   ["ocaml" "configure.ml" "--share" share]
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
+install: [
+  ["jbuilder" "install" "-p" name]
+]
+remove: [
+  ["ocaml" "configure.ml" "--share" share]
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "uninstall" "-p" name]
+]
 depends: [
-  "jbuilder" {build & >= "1.0+beta7"}
-  "cppo" {build}
+  "jbuilder" {>= "1.0+beta7"}
+  "cppo"
   "base-bytes"
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
Hey guys,

The latest `camomile.0.8.6` doesn't have `install` and `remove` targets, which breaks any project using it, in our case `liquidsoap`. Reported earlier:

> Our Liquidsoap server has started failing with this error since we recompiled it:
> Fatal error: exception Failure("Cannot find camomile database directory, usually located here: '/home/liquidsoap/.opam/4.05.0/share/database'. Use environment variable CAMOMILE_DIR or CAMOMILE_DATADIR to locate it precisely.")

This PR adds them, please consider for inclusion! Couple of questions, though:
* Is it possible to force a recompile when changing an already existing package?
* `remove` target is annoying. It seems that `jbuilder` needs the build-time files so the only way I was able to make it work was by recompiling again. Any advice on how to do it better?

Thanks!
