### PR TITLE
Add support for macport openssl package.

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
+++ b/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -d "/usr/local/opt/openssl/" ]; then
+  # Homebrew
+  PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl
+else
+  # MacPorts
+  PKG_CONFIG_PATH=/opt/local/lib/pkgconfig pkg-config openssl
+fi

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -5,7 +5,7 @@ homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
 build: [
   ["pkg-config" "openssl"] {os != "darwin" & os != "freebsd" & os != "openbsd" & os != "netbsd"}
-  ["sh" "-exec" "PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl"] {os = "darwin"}
+  ["./osx-build.sh"] { os = "darwin" }
 ]
 depends: ["conf-pkg-config"]
 depexts: [
@@ -15,6 +15,7 @@ depexts: [
   [["oraclelinux"] ["openssl-devel"]]
   [["fedora"] ["openssl-devel"]]
   [["osx" "homebrew"] ["openssl"]]
+  [["osx" "macports"] ["openssl"]]
   [["alpine"] ["libressl-dev"]]
   [["nixpkgs"] ["openssl"]]
   [["archlinux"] ["openssl"]]

--- a/packages/ssl/ssl.0.5.5/files/osx-configure.sh
+++ b/packages/ssl/ssl.0.5.5/files/osx-configure.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+PREFIX=$1
+
+if [ -d "/usr/local/opt/openssl/" ]; then
+  # Homebrew
+  ./configure --prefix "${PREFIX}" CPPFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
+else
+  # MacPorts
+  ./configure --prefix "${PREFIX}" CPPFLAGS="-I/opt/local/include" LDFLAGS="-L/opt/local/lib"
+fi

--- a/packages/ssl/ssl.0.5.5/opam
+++ b/packages/ssl/ssl.0.5.5/opam
@@ -6,9 +6,7 @@ dev-repo: "https://github.com/savonet/ocaml-ssl.git"
 bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
 build: [
   ["./configure" "--prefix" prefix] { os != "darwin" }
-  ["sh" "-exc"
-   "./configure --prefix %{prefix}% CPPFLAGS=\"-I/usr/local/opt/openssl/include\" LDFLAGS=\"-L/usr/local/opt/openssl/lib\""
-  ] { os = "darwin" }
+  ["./osx-configure.sh" prefix] { os = "darwin" }
   [make]
 ]
 install: [[make "install"]]


### PR DESCRIPTION
This is a complement to #10453. The other provider for `openssl` on OSX is MacPorts and, of course, they use a different location. Please refer to #10453 for technical details.. Thanks for your consideration!