### PR TITLE
Package dryunit.0.4.0

### DIFF
--- a/packages/dryunit/dryunit.0.4.0/descr
+++ b/packages/dryunit/dryunit.0.4.0/descr
@@ -1,0 +1,34 @@
+A detection tool for traditional unit testing in OCaml
+
+Dryunit is a generates bootstrap code for test frameworks. As a result, you get to use plain old OCaml.
+For more information, checkout the [repository](https://github.com/gersonmoraes/dryunit).
+
+
+## Installation
+
+```
+opam install dryunit
+```
+
+## Conventions
+
+- Test files should either be called `tests.ml`  or `something_tests.ml`
+- Test functions should called `test_something`
+- By default, test executables are named `main`
+
+
+## Usage
+
+If you use jbuilder, you can get started using this:
+
+```sh
+mkdir tests
+dryunit init > tests/jbuild
+```
+
+You can also define the framework explicitly using `dryunit init alcotest`. Adding a sample test:
+
+```sh
+echo "let test_error () = raise Not_found" > tests/something_tests.ml
+jbuilder build tests/main.exe && _build/default/tests/main.exe
+```

--- a/packages/dryunit/dryunit.0.4.0/opam
+++ b/packages/dryunit/dryunit.0.4.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "gerson.xp@gmail.com"
+authors: "Gerson Moraes"
+homepage: "https://github.com/gersonmoraes/dryunit"
+bug-reports: "https://github.com/gersonmoraes/dryunit"
+dev-repo: "https://github.com/gersonmoraes/dryunit.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build}
+  "cppo" {build}
+  "cmdliner" {>= "1.0.2"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/dryunit/dryunit.0.4.0/url
+++ b/packages/dryunit/dryunit.0.4.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gersonmoraes/dryunit/archive/0.4.0.tar.gz"
+checksum: "4c5fbb8ad83a889cf5c2bdff3dfed129"

--- a/packages/dryunit/dryunit.0.4.0/url
+++ b/packages/dryunit/dryunit.0.4.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/gersonmoraes/dryunit/archive/0.4.0.tar.gz"
-checksum: "4c5fbb8ad83a889cf5c2bdff3dfed129"
+checksum: "14f1029a3c628eeaef50c025b454215e"


### PR DESCRIPTION
### `dryunit.0.4.0`

A detection tool for traditional unit testing in OCaml

Dryunit is a generates bootstrap code for test frameworks. As a result, you get to use plain old OCaml.
For more information, checkout the [repository](https://github.com/gersonmoraes/dryunit).


## Installation

```
opam install dryunit
```

## Conventions

- Test files should either be called `tests.ml`  or `something_tests.ml`
- Test functions should called `test_something`
- By default, test executables are named `main`


## Usage

If you use jbuilder, you can get started using this:

```sh
mkdir tests
dryunit init > tests/jbuild
```

You can also define the framework explicitly using `dryunit init alcotest`. Adding a sample test:

```sh
echo "let test_error () = raise Not_found" > tests/something_tests.ml
jbuilder build tests/main.exe && _build/default/tests/main.exe
```



---
* Homepage: https://github.com/gersonmoraes/dryunit
* Source repo: https://github.com/gersonmoraes/dryunit.git
* Bug tracker: https://github.com/gersonmoraes/dryunit

---

:camel: Pull-request generated by opam-publish v0.3.5