### PR TITLE
Package ppx_dryunit.0.4.0

### DIFF
--- a/packages/ppx_dryunit/ppx_dryunit.0.4.0/descr
+++ b/packages/ppx_dryunit/ppx_dryunit.0.4.0/descr
@@ -1,0 +1,41 @@
+A detection tool for traditional unit testing in OCaml
+
+Dryunit is a detection tool for traditional test suites. This is an optional extension that provides similar functionallity as the main package and command line `dryunit` (which is the recommended way to get started).
+
+
+
+## Installation
+
+```sh
+opam install ppx_dryunit
+```
+
+
+
+## Usage
+
+It's activated appending this to the end of your `tests/main.ml`:
+
+```ocaml
+let () = [%dryunit]
+```
+
+
+
+Custom definitions are given using a record. All fields are optional and might be in any order.
+
+```ocaml
+let () =
+  [%dryunit
+    { cache_dir   = ".dryunit"
+    ; cache       = true
+    ; framework   = "alcotest"
+    ; ignore      = ""
+    ; filter      = ""
+    ; detection   = "file"
+    ; ignore_path = "self"
+    }
+  ]
+```
+
+For more information, checkout the [repository](https://github.com/gersonmoraes/dryunit).

--- a/packages/ppx_dryunit/ppx_dryunit.0.4.0/opam
+++ b/packages/ppx_dryunit/ppx_dryunit.0.4.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "gerson.xp@gmail.com"
+authors: "Gerson Moraes"
+homepage: "https://github.com/gersonmoraes/dryunit"
+bug-reports: "https://github.com/gersonmoraes/dryunit"
+dev-repo: "https://github.com/gersonmoraes/dryunit.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build}
+  "cppo" {build}
+  "ocaml-migrate-parsetree" {build}
+  "ppx_tools_versioned" {build}
+]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06"]

--- a/packages/ppx_dryunit/ppx_dryunit.0.4.0/url
+++ b/packages/ppx_dryunit/ppx_dryunit.0.4.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gersonmoraes/dryunit/archive/0.4.0.tar.gz"
+checksum: "4c5fbb8ad83a889cf5c2bdff3dfed129"

--- a/packages/ppx_dryunit/ppx_dryunit.0.4.0/url
+++ b/packages/ppx_dryunit/ppx_dryunit.0.4.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/gersonmoraes/dryunit/archive/0.4.0.tar.gz"
-checksum: "4c5fbb8ad83a889cf5c2bdff3dfed129"
+checksum: "14f1029a3c628eeaef50c025b454215e"


### PR DESCRIPTION
### `ppx_dryunit.0.4.0`

A detection tool for traditional unit testing in OCaml

Dryunit is a detection tool for traditional test suites. This is an optional extension that provides similar functionallity as the main package and command line `dryunit` (which is the recommended way to get started).



## Installation

```sh
opam install ppx_dryunit
```



## Usage

It's activated appending this to the end of your `tests/main.ml`:

```ocaml
let () = [%dryunit]
```



Custom definitions are given using a record. All fields are optional and might be in any order.

```ocaml
let () =
  [%dryunit
    { cache_dir   = ".dryunit"
    ; cache       = true
    ; framework   = "alcotest"
    ; ignore      = ""
    ; filter      = ""
    ; detection   = "file"
    ; ignore_path = "self"
    }
  ]
```

For more information, checkout the [repository](https://github.com/gersonmoraes/dryunit).


---
* Homepage: https://github.com/gersonmoraes/dryunit
* Source repo: https://github.com/gersonmoraes/dryunit.git
* Bug tracker: https://github.com/gersonmoraes/dryunit

---

:camel: Pull-request generated by opam-publish v0.3.5