### PR TITLE
Add patches files to opam 

### DIFF
--- a/packages/acgtk/acgtk.1.3.1/files/Makefile.in.easy_format.and.yojson.patch
+++ b/packages/acgtk/acgtk.1.3.1/files/Makefile.in.easy_format.and.yojson.patch
@@ -1,0 +1,19 @@
+Index: src/scripting/Makefile.in
+===================================================================
+--- src/scripting/Makefile.in	(revision 635)
++++ src/scripting/Makefile.in	(working copy)
+@@ -26,12 +26,12 @@
+ ###############################
+ 
+ # Used libraries
+-LIBS += dyp.cma str.cma ANSITerminal.cma bigarray.cma cairo2.cma @EASY_FORMAT_PATH@/easy_format.cmo biniou.cma @YOJSON_PATH@/yojson.cmo ocf.cma
++LIBS += dyp.cma str.cma ANSITerminal.cma bigarray.cma cairo2.cma easy_format.cma biniou.cma yojson.cma ocf.cma
+ 
+ # The corresponding directories
+ # (if not in the main ocaml lib directory,
+ # ex. -I  +campl4
+-LIBDIR += @DYPGEN_INCLUDE@ @ANSITerminal_INCLUDE@ @OCamlCairo2_INCLUDE@ @BINIOU_INCLUDE@ @OCF_INCLUDE@
++LIBDIR += @DYPGEN_INCLUDE@ @ANSITerminal_INCLUDE@ @OCamlCairo2_INCLUDE@ @EASY_FORMAT_INCLUDE@ @YOJSON_INCLUDE@ @BINIOU_INCLUDE@ @OCF_INCLUDE@
+ 
+ # Directories to which the current source files depend on
+ PREVIOUS_DIRS = ../utils ../datalog.prover ../logic ../acg-data ../grammars

--- a/packages/acgtk/acgtk.1.3.1/files/Makefile.in.easy_format.patch
+++ b/packages/acgtk/acgtk.1.3.1/files/Makefile.in.easy_format.patch
@@ -1,0 +1,19 @@
+Index: src/scripting/Makefile.in
+===================================================================
+--- src/scripting/Makefile.in	(revision 635)
++++ src/scripting/Makefile.in	(working copy)
+@@ -26,12 +26,12 @@
+ ###############################
+ 
+ # Used libraries
+-LIBS += dyp.cma str.cma ANSITerminal.cma bigarray.cma cairo2.cma @EASY_FORMAT_PATH@/easy_format.cmo biniou.cma @YOJSON_PATH@/yojson.cmo ocf.cma
++LIBS += dyp.cma str.cma ANSITerminal.cma bigarray.cma cairo2.cma easy_format.cma biniou.cma @YOJSON_PATH@/yojson.cmo ocf.cma
+ 
+ # The corresponding directories
+ # (if not in the main ocaml lib directory,
+ # ex. -I  +campl4
+-LIBDIR += @DYPGEN_INCLUDE@ @ANSITerminal_INCLUDE@ @OCamlCairo2_INCLUDE@ @BINIOU_INCLUDE@ @OCF_INCLUDE@
++LIBDIR += @DYPGEN_INCLUDE@ @ANSITerminal_INCLUDE@ @OCamlCairo2_INCLUDE@ @EASY_FORMAT_INCLUDE@ @BINIOU_INCLUDE@ @OCF_INCLUDE@
+ 
+ # Directories to which the current source files depend on
+ PREVIOUS_DIRS = ../utils ../datalog.prover ../logic ../acg-data ../grammars

--- a/packages/acgtk/acgtk.1.3.1/files/Makefile.in.yojson.patch
+++ b/packages/acgtk/acgtk.1.3.1/files/Makefile.in.yojson.patch
@@ -1,0 +1,19 @@
+Index: src/scripting/Makefile.in
+===================================================================
+--- src/scripting/Makefile.in	(revision 635)
++++ src/scripting/Makefile.in	(working copy)
+@@ -26,12 +26,12 @@
+ ###############################
+ 
+ # Used libraries
+-LIBS += dyp.cma str.cma ANSITerminal.cma bigarray.cma cairo2.cma @EASY_FORMAT_PATH@/easy_format.cmo biniou.cma @YOJSON_PATH@/yojson.cmo ocf.cma
++LIBS += dyp.cma str.cma ANSITerminal.cma bigarray.cma cairo2.cma @EASY_FORMAT_PATH@/easy_format.cmo biniou.cma yojson.cma ocf.cma
+ 
+ # The corresponding directories
+ # (if not in the main ocaml lib directory,
+ # ex. -I  +campl4
+-LIBDIR += @DYPGEN_INCLUDE@ @ANSITerminal_INCLUDE@ @OCamlCairo2_INCLUDE@ @BINIOU_INCLUDE@ @OCF_INCLUDE@
++LIBDIR += @DYPGEN_INCLUDE@ @ANSITerminal_INCLUDE@ @OCamlCairo2_INCLUDE@ @YOJSON_INCLUDE@ @BINIOU_INCLUDE@ @OCF_INCLUDE@
+ 
+ # Directories to which the current source files depend on
+ PREVIOUS_DIRS = ../utils ../datalog.prover ../logic ../acg-data ../grammars

--- a/packages/acgtk/acgtk.1.3.1/files/configure.ac.patch
+++ b/packages/acgtk/acgtk.1.3.1/files/configure.ac.patch
@@ -1,0 +1,26 @@
+Index: config/configure.ac
+===================================================================
+--- config/configure.ac	(revision 656)
++++ config/configure.ac	(working copy)
+@@ -186,11 +186,12 @@
+ fi
+ 
+ # Look for Easy-format with ocamlfind
+-AC_ARG_VAR(EASY_FORMAT_PATH,[Directory where to find the Yojson library if not in a standard location])
++AC_ARG_VAR(EASY_FORMAT_PATH,[Directory where to find the Easy-format library if not in a standard location])
+ AC_LIB_CHECKING(Easy-format,easy-format,easy_format,easy-format,easy-format,Easy_format,"",true,$EASY_FORMAT_PATH)
+ 
+ if test "$FOUND_LIB" != "no" ; then
+    AC_SUBST(EASY_FORMAT_PATH,$LIB_PATH)
++   AC_SUBST(EASY_FORMAT_INCLUDE,$LIB_INCLUDE)
+ fi
+ 
+ # Look for biniou with ocamlfind
+@@ -207,6 +208,7 @@
+ 
+ if test "$FOUND_LIB" != "no" ; then
+    AC_SUBST(YOJSON_PATH,$LIB_PATH)
++   AC_SUBST(YOJSON_INCLUDE,$LIB_INCLUDE)
+ fi
+ 
+ # Look for ocf with ocamlfind

--- a/packages/acgtk/acgtk.1.3.1/files/configure.patch
+++ b/packages/acgtk/acgtk.1.3.1/files/configure.patch
@@ -1,0 +1,45 @@
+Index: configure
+===================================================================
+--- configure	(revision 652)
++++ configure	(working copy)
+@@ -594,9 +594,11 @@
+ CAMLP4_LIB
+ OCF_INCLUDE
+ OCF_PATH
++YOJSON_INCLUDE
+ YOJSON_PATH
+ BINIOU_INCLUDE
+ BINIOU_PATH
++EASY_FORMAT_INCLUDE
+ EASY_FORMAT_PATH
+ OCamlCairo2_INCLUDE
+ OCamlCairo2_PATH
+@@ -1322,8 +1324,8 @@
+               Directory where to find the OCaml Cairo bindings if not in a
+               standard location
+   EASY_FORMAT_PATH
+-              Directory where to find the Yojson library if not in a standard
+-              location
++              Directory where to find the Easy-format library if not in a
++              standard location
+   BINIOU_PATH Directory where to find the biniou library if not in a standard
+               location
+   YOJSON_PATH Directory where to find the Yojson library if not in a standard
+@@ -3429,6 +3431,8 @@
+ if test "$FOUND_LIB" != "no" ; then
+    EASY_FORMAT_PATH=$LIB_PATH
+ 
++   EASY_FORMAT_INCLUDE=$LIB_INCLUDE
++
+ fi
+ 
+ # Look for biniou with ocamlfind
+@@ -3771,6 +3775,8 @@
+ if test "$FOUND_LIB" != "no" ; then
+    YOJSON_PATH=$LIB_PATH
+ 
++   YOJSON_INCLUDE=$LIB_INCLUDE
++
+ fi
+ 
+ # Look for ocf with ocamlfind

--- a/packages/acgtk/acgtk.1.3.1/opam
+++ b/packages/acgtk/acgtk.1.3.1/opam
@@ -17,10 +17,21 @@ depends: [
   "bolt"
   "ANSITerminal"
   "cairo2"
+  "yojson"
+  "easy-format"
   "ocf"
 ]
 
 available: [ ocaml-version >= "4.03.0" ]
+
+
+patches: [
+  "configure.ac.patch"
+  "configure.patch"
+   "Makefile.in.easy_format.and.yojson.patch" {(easy-format:version >= "1.3.0") & (yojson:version >= "1.4.0")} 
+   "Makefile.in.easy_format.patch" {(easy-format:version >= "1.3.0") & (yojson:version < "1.4.0")} 
+   "Makefile.in.yojson.patch" {(easy-format:version < "1.3.0") & (yojson:version >= "1.4.0")} 
+]
 
 homepage: "http://acg.gforge.inria.fr/"
 license: "CeCILL"


### PR DESCRIPTION
I added patches files in files/ In order  to have acgtk.1.3.1 compile with easy-format:version >1.2.0 and yojson:version>1.3.3 as well.
