### PR TITLE
Package ppx_deriving_morphism.0.4.1

### DIFF
--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/descr
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/descr
@@ -1,0 +1,5 @@
+Morphism generator for OCaml >=4.02
+
+ppx_deriving_morphism is a ppx_deriving plugin that provides
+a generator for records implementing openly recursive map and fold routines
+for arbitrary data structures.

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Christoph Höger <christoph.hoeger@tu-berlin.de>"
+authors: "Christoph Höger <christoph.hoeger@tu-berlin.de>"
+homepage: "https://github.com/choeger/ppx_deriving_morphism"
+bug-reports: "https://github.com/choeger/ppx_deriving_morphism/issues"
+license: "BSD"
+tags: "syntax"
+dev-repo: "git://github.com/choeger/ppx_deriving_morphism.git"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/build.ml"
+  "native=%{ocaml-native}%"
+  "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild"
+  "-classic-display"
+  "-use-ocamlfind"
+  "src_test/test_ppx_morphism.byte"
+  "--"
+]
+depends: [
+  "ppx_deriving" {>= "3.0" & < "5.0"}
+  "ppx_tools" {>= "4.02.3"}
+  "ocamlfind" {build}
+  "cppo" {build}
+  "ounit" {test}
+  "ppx_import" {test}
+]
+available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/url
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/choeger/ppx_deriving_morphism/archive/v0.4.1.tar.gz"
+checksum: "3c36dd9c6fa09b732990ca1bfbafbc66"


### PR DESCRIPTION
### `ppx_deriving_morphism.0.4.1`

Morphism generator for OCaml >=4.02

ppx_deriving_morphism is a ppx_deriving plugin that provides
a generator for records implementing openly recursive map and fold routines
for arbitrary data structures.



---
* Homepage: https://github.com/choeger/ppx_deriving_morphism
* Source repo: git://github.com/choeger/ppx_deriving_morphism.git
* Bug tracker: https://github.com/choeger/ppx_deriving_morphism/issues

---

:camel: Pull-request generated by opam-publish v0.3.5