### PR TITLE
Constrain ppx_regexp 0.3.0 to OCaml < 4.06.0.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.3.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.0/opam
@@ -13,4 +13,4 @@ depends: [
   "ppx_metaquot" {build}
   "topkg-jbuilder" {build}
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
This is obsoleted by 0.3.1, so there is no need for it in future compiler versions. (Besides it currently depfails on `ppx_core`, though I presume that will be fixed.)