### PR TITLE
Package lacaml.10.0.0

### DIFF
--- a/packages/lacaml/lacaml.10.0.0/descr
+++ b/packages/lacaml/lacaml.10.0.0/descr
@@ -1,0 +1,5 @@
+Lacaml - OCaml-bindings to BLAS and LAPACK
+
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices.

--- a/packages/lacaml/lacaml.10.0.0/opam
+++ b/packages/lacaml/lacaml.10.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "http://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+dev-repo: "https://github.com/mmottl/lacaml.git"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+tags: [ "clib:lapack" "clib:blas" ]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta13"}
+  "base-bytes"
+  "base-bigarray"
+]
+
+available: [ ocaml-version >= "4.05" ]

--- a/packages/lacaml/lacaml.10.0.0/url
+++ b/packages/lacaml/lacaml.10.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/lacaml/releases/download/10.0.0/lacaml-10.0.0.tbz"
+checksum: "fff8fd519689c59f798261e9652c9b1c"


### PR DESCRIPTION
### `lacaml.10.0.0`

Lacaml - OCaml-bindings to BLAS and LAPACK

Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
LAPACK-library (Linear Algebra routines).  It also contains many additional
convenience functions for vectors and matrices.



---
* Homepage: http://mmottl.github.io/lacaml
* Source repo: https://github.com/mmottl/lacaml.git
* Bug tracker: https://github.com/mmottl/lacaml/issues

---


---
### 10.0.0 (2017-10-20)

  * Switched to jbuilder and topkg

  * API changes

      * `trmm` and `trsm` now do not label argument `a` anymore

      * Many matrix functions now support an optional `patt` argument,
        which can be used to specify rectangular, triagonal, trapezoidal, and
        pentagonal patterns on which to perform an operation.

      * New functions

        * `Mat.sum_prod` computes the sum of elemenet-wise products of
          two matrices.  Some use cases are already covered by `Mat.gemm_trace`,
          but the latter does not support patterns.

  * Improved C-code to better support SIMD compiler optimizations

  * Many internal improvements, including untagged and unboxed passing of
    parameters to and from external functions.

  * Compilation now uses `-march=native -O3 -ffast-math` by default, which
    should be safe and exploit SIMD on platforms that support it to greatly
    improve performance of some operations.

  * Improved documentation

  * Improved configuration and build process
:camel: Pull-request generated by opam-publish v0.3.5