### PR TITLE
Package libudev.0.2.1

### DIFF
--- a/packages/libudev/libudev.0.2.1/descr
+++ b/packages/libudev/libudev.0.2.1/descr
@@ -1,0 +1,1 @@
+Bindings to libudev for OCaml

--- a/packages/libudev/libudev.0.2.1/opam
+++ b/packages/libudev/libudev.0.2.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Armael <armael@isomorphis.me>"
+authors: ["Armael <armael@isomorphis.me>"]
+homepage: "https://github.com/Armael/ocaml-libudev"
+dev-repo: "git+https://github.com/Armael/ocaml-libudev.git"
+bug-reports: "https://github.com/Armael/ocaml-libudev/issues"
+license: "MIT"
+available: [ (ocaml-version >= "4.01.0") ]
+depends: [ "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build & >= "0.9.0"}
+           "conf-libudev"
+           "ctypes" {>= "0.4.1"}
+           "ctypes-foreign"
+           "stdint" ]
+build:
+[
+  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%" ]
+]

--- a/packages/libudev/libudev.0.2.1/url
+++ b/packages/libudev/libudev.0.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Armael/ocaml-libudev/archive/v0.2.1.zip"
+checksum: "ebec53b5b36a08fc37ff9220a275110c"


### PR DESCRIPTION
### `libudev.0.2.1`

Bindings to libudev for OCaml



---
* Homepage: https://github.com/Armael/ocaml-libudev
* Source repo: git+https://github.com/Armael/ocaml-libudev.git
* Bug tracker: https://github.com/Armael/ocaml-libudev/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5