### PR TITLE
Update compiler version constraints and OS constraints for libudev v0.1, v0.1.1 and v0.2

### DIFF
--- a/packages/libudev/libudev.0.1.1/opam
+++ b/packages/libudev/libudev.0.1.1/opam
@@ -15,11 +15,8 @@ build: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "conf-libudev"
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign"
   "stdint"
-]
-depexts: [
-  [["debian"] ["libudev-dev"]]
-  [["ubuntu"] ["libudev-dev"]]
 ]

--- a/packages/libudev/libudev.0.1.1/opam
+++ b/packages/libudev/libudev.0.1.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/Armael/ocaml-libudev"
 bug-reports: "https://github.com/Armael/ocaml-libudev/issues"
 license: "MIT"
 dev-repo: "https://github.com/Armael/ocaml-libudev.git"
-available: [ ocaml-version >= "4.01.0" ]
+available: [ (ocaml-version >= "4.01.0") & (ocaml-version < "4.06") ]
 build: [
   "ocaml"
   "pkg/build.ml"

--- a/packages/libudev/libudev.0.1/opam
+++ b/packages/libudev/libudev.0.1/opam
@@ -15,11 +15,8 @@ build: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "conf-libudev"
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign"
   "stdint"
-]
-depexts: [
-  [["debian"] ["libudev-dev"]]
-  [["ubuntu"] ["libudev-dev"]]
 ]

--- a/packages/libudev/libudev.0.1/opam
+++ b/packages/libudev/libudev.0.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/Armael/ocaml-libudev"
 bug-reports: "https://github.com/Armael/ocaml-libudev/issues"
 license: "MIT"
 dev-repo: "https://github.com/Armael/ocaml-libudev.git"
-available: [ ocaml-version >= "4.01.0" ]
+available: [ (ocaml-version >= "4.01.0") & (ocaml-version < "4.06") ]
 build: [
   "ocaml"
   "pkg/build.ml"

--- a/packages/libudev/libudev.0.2/opam
+++ b/packages/libudev/libudev.0.2/opam
@@ -14,12 +14,9 @@ build: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "conf-libudev"
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign"
   "stdint"
-]
-depexts: [
-  [["debian"] ["libudev-dev"]]
-  [["ubuntu"] ["libudev-dev"]]
 ]
 available: [ (ocaml-version >= "4.01.0") & (ocaml-version < "4.06") ]

--- a/packages/libudev/libudev.0.2/opam
+++ b/packages/libudev/libudev.0.2/opam
@@ -22,4 +22,4 @@ depexts: [
   [["debian"] ["libudev-dev"]]
   [["ubuntu"] ["libudev-dev"]]
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ (ocaml-version >= "4.01.0") & (ocaml-version < "4.06") ]


### PR DESCRIPTION
Libudev versions v0.1, v0.1.1 and v0.2 do not build with ocaml 4.06 (because of -safe-string). This PR updates compiler version constraints accordingly. Also specify that they only build on linux.