### PR TITLE
cstruct-for-4.06: cstruct before 1.6.0 can't build on 4.06

### DIFF
--- a/packages/cstruct/cstruct.0.4.0/opam
+++ b/packages/cstruct/cstruct.0.4.0/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.4.1/opam
+++ b/packages/cstruct/cstruct.0.4.1/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.5.0/opam
+++ b/packages/cstruct/cstruct.0.5.0/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.5.1/opam
+++ b/packages/cstruct/cstruct.0.5.1/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.5.2/opam
+++ b/packages/cstruct/cstruct.0.5.2/opam
@@ -13,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.5.3/opam
+++ b/packages/cstruct/cstruct.0.5.3/opam
@@ -13,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.6.0/opam
+++ b/packages/cstruct/cstruct.0.6.0/opam
@@ -14,3 +14,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.6.1/opam
+++ b/packages/cstruct/cstruct.0.6.1/opam
@@ -14,3 +14,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.6.2/opam
+++ b/packages/cstruct/cstruct.0.6.2/opam
@@ -14,3 +14,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.7.0/opam
+++ b/packages/cstruct/cstruct.0.7.0/opam
@@ -18,3 +18,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.7.1/opam
+++ b/packages/cstruct/cstruct.0.7.1/opam
@@ -21,3 +21,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.8.0/opam
+++ b/packages/cstruct/cstruct.0.8.0/opam
@@ -21,3 +21,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.0.8.1/opam
+++ b/packages/cstruct/cstruct.0.8.1/opam
@@ -21,3 +21,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.0.0/opam
+++ b/packages/cstruct/cstruct.1.0.0/opam
@@ -21,3 +21,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.0.1/opam
+++ b/packages/cstruct/cstruct.1.0.1/opam
@@ -21,3 +21,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.1.0/opam
+++ b/packages/cstruct/cstruct.1.1.0/opam
@@ -22,3 +22,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.2.0/opam
+++ b/packages/cstruct/cstruct.1.2.0/opam
@@ -22,3 +22,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.3.0/opam
+++ b/packages/cstruct/cstruct.1.3.0/opam
@@ -24,3 +24,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.3.1/opam
+++ b/packages/cstruct/cstruct.1.3.1/opam
@@ -24,3 +24,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.4.0/opam
+++ b/packages/cstruct/cstruct.1.4.0/opam
@@ -24,3 +24,4 @@ depopts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-cstruct"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cstruct/cstruct.1.5.0/opam
+++ b/packages/cstruct/cstruct.1.5.0/opam
@@ -43,3 +43,4 @@ depopts: [
   "async"
   "lwt"
 ]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
Code generated by Oasis is not safe-string compatible.

See additional discussion in ocaml/opam-repository#10286.