### PR TITLE
Package lacaml.10.0.1

### DIFF
--- a/packages/lacaml/lacaml.10.0.1/descr
+++ b/packages/lacaml/lacaml.10.0.1/descr
@@ -1,0 +1,5 @@
+Lacaml - OCaml-bindings to BLAS and LAPACK
+
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices.

--- a/packages/lacaml/lacaml.10.0.1/opam
+++ b/packages/lacaml/lacaml.10.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "http://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+dev-repo: "https://github.com/mmottl/lacaml.git"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+tags: [ "clib:lapack" "clib:blas" ]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta13"}
+  "base-bytes"
+  "base-bigarray"
+]
+
+available: [ ocaml-version >= "4.05" ]

--- a/packages/lacaml/lacaml.10.0.1/url
+++ b/packages/lacaml/lacaml.10.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/lacaml/releases/download/10.0.1/lacaml-10.0.1.tbz"
+checksum: "c4833993a409bd4ea4391630b03f65ad"


### PR DESCRIPTION
### `lacaml.10.0.1`

Lacaml - OCaml-bindings to BLAS and LAPACK

Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
LAPACK-library (Linear Algebra routines).  It also contains many additional
convenience functions for vectors and matrices.



---
* Homepage: http://mmottl.github.io/lacaml
* Source repo: https://github.com/mmottl/lacaml.git
* Bug tracker: https://github.com/mmottl/lacaml/issues

---


---
### 10.0.1 (2017-10-21)

  * Fixed wrongly capitalized build targets missed due to Mac OS X file
    system case insensitivity.
:camel: Pull-request generated by opam-publish v0.3.5