### PR TITLE
add camlp5 7.02, needed by ocaml 4.06

### DIFF
--- a/packages/camlp5/camlp5.7.02/descr
+++ b/packages/camlp5/camlp5.7.02/descr
@@ -1,0 +1,1 @@
+Preprocessor-pretty-printer of OCaml

--- a/packages/camlp5/camlp5.7.02/files/camlp5.install
+++ b/packages/camlp5/camlp5.7.02/files/camlp5.install
@@ -1,0 +1,12 @@
+bin: [
+  "ocpp/ocpp" {"ocpp5"}
+  "etc/mkcamlp5.opt.sh" {"mkcamlp5.opt"}
+  "etc/mkcamlp5.sh" {"mkcamlp5"}
+  "etc/camlp5sch"
+  "meta/camlp5r.opt"
+  "boot/camlp5r"
+  "compile/camlp5o.fast.opt" {"camlp5o.opt"}
+  "etc/camlp5o"
+  "boot/camlp5"
+]
+lib: ["etc/META"]

--- a/packages/camlp5/camlp5.7.02/opam
+++ b/packages/camlp5/camlp5.7.02/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Nicolas Pelletier"]
+homepage: "https://camlp5.github.io"
+license: "BSD-3-Clause"
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+available: [ocaml-version >= "4.02" & ocaml-version <= "4.06.0"]
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+dev-repo: "https://github.com/camlp5/camlp5.git"
+doc: "https://camlp5.github.io/doc/html"
+install: [make "install"]

--- a/packages/camlp5/camlp5.7.02/url
+++ b/packages/camlp5/camlp5.7.02/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/camlp5/camlp5/archive/rel702.tar.gz"
+checksum: "99ffb34eda1b9cebd36d423f9c5b01a2"


### PR DESCRIPTION
With ocaml 4.06+beta2 installed, opam install camlp5 fails the version check: camlp5 7.01 requires at most ocaml 4.05. The site https://camlp5.github.io mentions that camlp5 7.02 is compatible with ocaml 4.06. I was able to install camlp5 7.02 with opam with the proposed addition.