### PR TITLE
Add ppx_tools 5.1 for OCaml 4.06

### DIFF
--- a/packages/ppx_tools/ppx_tools.5.0/url
+++ b/packages/ppx_tools/ppx_tools.5.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/ocaml-ppx/ppx_tools/tarball/f70ca1d07d565989a0041e312e8efc00ff2ad87e"
-checksum: "5e1a86ff323fe772d69ca2d25abc2c9d"
+archive: "https://github.com/ocaml-ppx/ppx_tools/archive/5.0+4.04.0.tar.gz"
+checksum: "6f512acc15bdd09eb363babb333dc508"

--- a/packages/ppx_tools/ppx_tools.5.1+4.06.0/descr
+++ b/packages/ppx_tools/ppx_tools.5.1+4.06.0/descr
@@ -1,0 +1,1 @@
+Tools for authors of ppx rewriters and other syntactic tools

--- a/packages/ppx_tools/ppx_tools.5.1+4.06.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.1+4.06.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git"
+tags: [ "syntax" ]
+build: [[make "all"]]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "ppx_tools"]]
+depends: [
+  "ocamlfind" {>= "1.5.0"}
+]
+available: [ ocaml-version >= "4.06.0" & ocaml-version < "4.07" ]

--- a/packages/ppx_tools/ppx_tools.5.1+4.06.0/url
+++ b/packages/ppx_tools/ppx_tools.5.1+4.06.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-ppx/ppx_tools/archive/5.1+4.06.0.tar.gz"
+checksum: "6ba2e9690b1f579ba562b86022d1c308"


### PR DESCRIPTION
- I've added a constraint `ocaml-version < "4.07"` in order to be on the safe side.

- Also use a proper release URL for 5.0 on OCaml 4.04 (addresses https://github.com/ocaml-ppx/ppx_tools/issues/61).