### PR TITLE
Add a conf package for capnproto

### DIFF
--- a/packages/capnp/capnp.1.0.0/opam
+++ b/packages/capnp/capnp.1.0.0/opam
@@ -9,6 +9,7 @@ depends: [
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"
+  "conf-capnproto" {build}
 ]
 dev-repo: "git://github.com/pelzlpj/capnp-ocaml"
 available: ocaml-version >= "4.01.0"

--- a/packages/capnp/capnp.1.0.1/opam
+++ b/packages/capnp/capnp.1.0.1/opam
@@ -9,6 +9,7 @@ depends: [
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"
+  "conf-capnproto" {build}
 ]
 dev-repo: "git://github.com/pelzlpj/capnp-ocaml"
 available: ocaml-version >= "4.01.0"

--- a/packages/capnp/capnp.2.0.1/opam
+++ b/packages/capnp/capnp.2.0.1/opam
@@ -10,6 +10,7 @@ depends: [
   "res"
   "uint"
   "camlp4"
+  "conf-capnproto" {build}
 ]
 dev-repo: "git://github.com/pelzlpj/capnp-ocaml"
 available: ocaml-version >= "4.01.0"

--- a/packages/capnp/capnp.2.1.0/opam
+++ b/packages/capnp/capnp.2.1.0/opam
@@ -12,7 +12,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core_kernel"
+  "core_kernel" {< "v0.9.0"}
   "sexplib" {<="v0.9.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}

--- a/packages/capnp/capnp.2.1.0/opam
+++ b/packages/capnp/capnp.2.1.0/opam
@@ -19,5 +19,6 @@ depends: [
   "res"
   "uint"
   "camlp4"
+  "conf-capnproto" {build}
 ]
 available: [ ocaml-version >= "4.01.0" & ocaml-version != "4.03.0" & ocaml-version != "4.04.0" ]

--- a/packages/capnp/capnp.2.1.1/opam
+++ b/packages/capnp/capnp.2.1.1/opam
@@ -12,7 +12,7 @@ remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
-  "core_kernel"
+  "core_kernel" {< "v0.9.0"}
   "sexplib" {<="v0.9.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}

--- a/packages/capnp/capnp.2.1.1/opam
+++ b/packages/capnp/capnp.2.1.1/opam
@@ -19,5 +19,6 @@ depends: [
   "res"
   "uint"
   "camlp4"
+  "conf-capnproto" {build}
 ]
 available: [ ocaml-version >= "4.01.0" & ocaml-version != "4.03.0" & ocaml-version != "4.04.0" ]

--- a/packages/capnp/capnp.3.0.0/opam
+++ b/packages/capnp/capnp.3.0.0/opam
@@ -17,12 +17,6 @@ depends: [
   "uint"
   "core" {test}
   "ounit" {test}
-]
-depexts: [
-  [["debian"] ["capnproto" "libcapnp-dev"]]
-  [["ubuntu"] ["capnproto" "libcapnp-dev"]]
-  [["fedora"] ["capnproto"]]
-  [["centos"] ["capnproto"]]
-  [["osx"] ["capnp"]]
+  "conf-capnproto" {build}
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/capnp/capnp.3.1.0/opam
+++ b/packages/capnp/capnp.3.1.0/opam
@@ -18,12 +18,6 @@ depends: [
   "uint"
   "core" {test}
   "ounit" {test}
-]
-depexts: [
-  [["debian"] ["capnproto" "libcapnp-dev"]]
-  [["ubuntu"] ["capnproto" "libcapnp-dev"]]
-  [["fedora"] ["capnproto"]]
-  [["centos"] ["capnproto"]]
-  [["osx"] ["capnp"]]
+  "conf-capnproto" {build}
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/conf-capnproto/conf-capnproto.0/descr
+++ b/packages/conf-capnproto/conf-capnproto.0/descr
@@ -1,0 +1,1 @@
+Virtual package relying on captnproto installation.

--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Jacques-Pascal Deplaix <jp.deplaix@gmail.com>"
+authors: [
+  "Sandstorm Development Group, Inc."
+  "Cloudflare, Inc."
+  "other contributors"
+]
+homepage: "https://capnproto.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "https://github.com/capnproto/capnproto.git"
+license: "MIT"
+build: [
+  ["capnpc" "--version"]
+]
+depexts: [
+  [["archlinux"] ["capnproto"]]
+  [["centos"] ["capnproto"]]
+  [["debian"] ["capnproto" "libcapnp-dev"]]
+  [["fedora"] ["capnproto"]]
+  [["gentoo"] ["capnproto"]]
+  [["homebrew" "osx"] ["capnp"]]
+  [["macports" "osx"] ["capnproto"]]
+  [["opensuse"] ["capnproto"]]
+  [["ubuntu"] ["capnproto" "libcapnp-dev"]]
+]


### PR DESCRIPTION
I was trying to install ```capnp-rpc-lwt``` and the following error appeared:
```
Error: Program capnpc not found in the tree or in PATH (context: default)
```
It seems that ```capnp-rpc-lwt``` is the only capnp-* packages that requires this command but maybe I missed something.
This conf package allows the user to know which external package to install is this case. It could also be useful for other opam packages which use this command.

cc @talex5 