### PR TITLE
Re-add Camomile.0.8.6

### DIFF
--- a/packages/camomile/camomile.0.8.6/descr
+++ b/packages/camomile/camomile.0.8.6/descr
@@ -1,0 +1,5 @@
+A comprehensive Unicode library
+Camomile is a Unicode library for OCaml. Camomile provides Unicode
+character type, UTF-8, UTF-16, UTF-32 strings, conversion to/from
+about 200 encodings, collation and locale-sensitive case mappings, and
+more. The library is currently designed for Unicode Standard 3.2.

--- a/packages/camomile/camomile.0.8.6/opam
+++ b/packages/camomile/camomile.0.8.6/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/yoriyuki/Camomile/issues"
 dev-repo: "https://github.com/yoriyuki/Camomile.git"
 license: "LGPL-2+ with OCaml linking exception"
 build: [
-  ["ocaml" "configure.ml" "--share" share]
+  ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/camomile/camomile.0.8.6/opam
+++ b/packages/camomile/camomile.0.8.6/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Jacques-Pascal Deplaix <jp.deplaix@gmail.com>"
+authors: ["Yoriyuki Yamagata"]
+homepage: "https://github.com/yoriyuki/Camomile/wiki"
+bug-reports: "https://github.com/yoriyuki/Camomile/issues"
+dev-repo: "https://github.com/yoriyuki/Camomile.git"
+license: "LGPL-2+ with OCaml linking exception"
+build: [
+  ["ocaml" "configure.ml" "--share" share]
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "cppo" {build}
+  "base-bytes"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/camomile/camomile.0.8.6/url
+++ b/packages/camomile/camomile.0.8.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/yoriyuki/Camomile/archive/rel-0.8.6.tar.gz"
+checksum: "38630489140dd6ca0e25792fbb3ab1a1"


### PR DESCRIPTION
@toots This time I finally located the cause of your problem: the default directory as far as camomile was concerned was in ```%{share}%```. But this variable is not equal to ```~/.opam/<switch>/share/camomile``` but rather ```~/.opam/<switch>/share```.

I've tested it and liquidsoap works (at least ```./liquidsoap``` doesn't raise an error related to camomile anymore). I also tested using this small test-case which previously failed:
```ocaml
module C = CamomileLibraryDyn.Camomile.CharEncoding
```

cc @gasche 