### PR TITLE
posixat: restrict to ocaml-version < 4.05.0

### DIFF
--- a/packages/posixat/posixat.v0.9.0/opam
+++ b/packages/posixat/posixat.v0.9.0/opam
@@ -13,4 +13,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta7"}
   "sexplib"  {>= "v0.9" & < "v0.10"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.05.0" ]


### PR DESCRIPTION
```
$ opam install posixat
The following actions will be performed:
  ∗  install posixat v0.9.0

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫
[default] https://opam.ocaml.org/archives/posixat.v0.9.0+opam.tar.gz downloaded

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫
[ERROR] The compilation of posixat failed at "jbuilder build -p posixat -j 4".

#=== ERROR while installing posixat.v0.9.0 ====================================#
# opam-version 1.2.2
# os           darwin
# command      jbuilder build -p posixat -j 4
# path         /Users/mroch/.opam/4.05.0/build/posixat.v0.9.0
# compiler     4.05.0
# exit-code    1
# env-file     /Users/mroch/.opam/4.05.0/build/posixat.v0.9.0/posixat-39867-e7966f.env
# stdout-file  /Users/mroch/.opam/4.05.0/build/posixat.v0.9.0/posixat-39867-e7966f.out
# stderr-file  /Users/mroch/.opam/4.05.0/build/posixat.v0.9.0/posixat-39867-e7966f.err
### stderr ###
# To keep the current behavior and get rid of this warning, add a field (fallback) to the rule.
# [...]
#       ocamlc src/posixat__.{cmi,cmo,cmt}
#       ocamlc src/posixat.{cmi,cmti} (exit 2)
# (cd _build/default && /Users/mroch/.opam/4.05.0/bin/ocamlc.opt -w -40 -g -bin-annot -I /Users/mroch/.opam/4.05.0/lib/base -I /Users/mroch/.opam/4.05.0/lib/base/caml -I /Users/mroch/.opam/4.05.0/lib/base/shadow_stdlib -I /Users/mroch/.opam/4.05.0/lib/ocaml -I /Users/mroch/.opam/4.05.0/lib/sexplib -I /Users/mroch/.opam/4.05.0/lib/sexplib/0 -no-alias-deps -I src -open Posixat__ -o src/posixat.cmi -c -intf src/posixat.mli)
# File "src/posixat.mli", line 12, characters 2-266:
# Error: This variant or record definition does not match that of type
#          Unix.open_flag
#        The field O_KEEPEXEC is only present in the original definition.
#
# Waiting for 3 jobs to finish.



=-=- Error report -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫
The following actions failed
  ∗  install posixat v0.9.0
No changes have been performed
```