### PR TITLE
Use cc instead of gcc as C compiler where appropriate.

### DIFF
--- a/compilers/3.07/3.07+1/3.07+1.comp
+++ b/compilers/3.07/3.07+1/3.07+1.comp
@@ -5,7 +5,14 @@ patches: ["http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"]
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.07/3.07+2/3.07+2.comp
+++ b/compilers/3.07/3.07+2/3.07+2.comp
@@ -5,7 +5,14 @@ patches: ["http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"]
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.07/3.07/3.07.comp
+++ b/compilers/3.07/3.07/3.07.comp
@@ -4,7 +4,14 @@ src: "http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.08.0/3.08.0/3.08.0.comp
+++ b/compilers/3.08.0/3.08.0/3.08.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.08.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.08.1/3.08.1/3.08.1.comp
+++ b/compilers/3.08.1/3.08.1/3.08.1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.08.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.08.2/3.08.2/3.08.2.comp
+++ b/compilers/3.08.2/3.08.2/3.08.2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.08.2"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.08.3/3.08.3/3.08.3.comp
+++ b/compilers/3.08.3/3.08.3/3.08.3.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.08.3"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.08.4/3.08.4/3.08.4.comp
+++ b/compilers/3.08.4/3.08.4/3.08.4.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.08.4"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.09.0/3.09.0/3.09.0.comp
+++ b/compilers/3.09.0/3.09.0/3.09.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.09.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.09.1/3.09.1+metaocaml/3.09.1+metaocaml.comp
+++ b/compilers/3.09.1/3.09.1+metaocaml/3.09.1+metaocaml.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.09.1"
 src: "http://web.archive.org/web/20120209151915/www.metaocaml.org/dist/old/MetaOCaml_309_alpha_030.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "install"]
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]

--- a/compilers/3.09.1/3.09.1/3.09.1.comp
+++ b/compilers/3.09.1/3.09.1/3.09.1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.09.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.09.2/3.09.2/3.09.2.comp
+++ b/compilers/3.09.2/3.09.2/3.09.2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.09.2"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.09.3/3.09.3/3.09.3.comp
+++ b/compilers/3.09.3/3.09.3/3.09.3.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.09.3"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.10.0/3.10.0/3.10.0.comp
+++ b/compilers/3.10.0/3.10.0/3.10.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.10.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.10.1/3.10.1/3.10.1.comp
+++ b/compilers/3.10.1/3.10.1/3.10.1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.10.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.10.2/3.10.2/3.10.2.comp
+++ b/compilers/3.10.2/3.10.2/3.10.2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.10.2"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.11.0/3.11.0/3.11.0.comp
+++ b/compilers/3.11.0/3.11.0/3.11.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.11.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.11.1/3.11.1/3.11.1.comp
+++ b/compilers/3.11.1/3.11.1/3.11.1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.11.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.11.2/3.11.2/3.11.2.comp
+++ b/compilers/3.11.2/3.11.2/3.11.2.comp
@@ -3,7 +3,14 @@ version: "3.11.2"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.2.tar.gz"
 patches: ["http://www.ocamlpro.com/patches/3.11.2_binutils.patch"]
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.12.0/3.12.0/3.12.0.comp
+++ b/compilers/3.12.0/3.12.0/3.12.0.comp
@@ -5,7 +5,14 @@ patches:
   # S. Glondu's patch for binutils >= 2.21 (see bug report #5237)
   ["http://caml.inria.fr/mantis/file_download.php?file_id=418&type=bug"]
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/3.12.1/3.12.1/3.12.1.comp
+++ b/compilers/3.12.1/3.12.1/3.12.1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "3.12.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.00.0/4.00.0+debug-runtime/4.00.0+debug-runtime.comp
+++ b/compilers/4.00.0/4.00.0+debug-runtime/4.00.0+debug-runtime.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.00.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.00.1/4.00.1+BER/4.00.1+BER.comp
+++ b/compilers/4.00.1/4.00.1+BER/4.00.1+BER.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.00.1"
 src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-N100.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-no-tk"]
+  ["./configure"
+    "-prefix" prefix "-no-tk"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-no-tk"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "-C" "metalib" "patch"]
   [make "core"]
   [make "coreboot"]

--- a/compilers/4.00.1/4.00.1+debug-runtime/4.00.1+debug-runtime.comp
+++ b/compilers/4.00.1/4.00.1+debug-runtime/4.00.1+debug-runtime.comp
@@ -3,7 +3,14 @@ version: "4.00.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 patches: ["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.00.1/4.00.1+mirage-unix/4.00.1+mirage-unix.comp
+++ b/compilers/4.00.1/4.00.1+mirage-unix/4.00.1+mirage-unix.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.00.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.00.1/4.00.1+mirage-xen/4.00.1+mirage-xen.comp
+++ b/compilers/4.00.1/4.00.1+mirage-xen/4.00.1+mirage-xen.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.00.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.01.0/4.01.0+BER.comp
+++ b/compilers/4.01.0/4.01.0+BER.comp
@@ -6,7 +6,14 @@ patches:[
   "https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
 ]
 build: [
-  ["./configure" "-prefix" "%{prefix}%"]
+  ["./configure"
+    "-prefix" "%{prefix}%"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" "%{prefix}%"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   ["%{make}%" "world"]
   ["%{make}%" "world.opt"]
   ["%{make}%" "-i" "install"]

--- a/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
+++ b/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
@@ -3,7 +3,14 @@ version: "4.01.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/andrewray/mirage-fpga/releases/download/v0.1/freebsd10-armv6-natdynlink.patch"]
 build: [
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
+++ b/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
@@ -3,7 +3,14 @@ version: "4.01.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
+++ b/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
@@ -7,11 +7,20 @@ build: [
    "s/typedef greg_t context_reg;/#include <ucontext.h>\\ntypedef greg_t context_reg;/"
    "asmrun/signals_osdep.h"
   ]
-  ["./configure" "-prefix" prefix "-with-debug-runtime"
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
     "-cc" "/opt/lsb/bin/lsbcc"
     "-aspp" "/opt/lsb/bin/lsbcc -c"
     "-no-shared-libs"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "/opt/lsb/bin/lsbcc"
+    "-aspp" "/opt/lsb/bin/lsbcc -c"
+    "-no-shared-libs"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world.opt"]
   [make "install"]
 ]

--- a/compilers/4.01.0/4.01.0+profile/4.01.0+profile.comp
+++ b/compilers/4.01.0/4.01.0+profile/4.01.0+profile.comp
@@ -3,7 +3,14 @@ version: "4.01.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.01.0/4.01.0/4.01.0.comp
+++ b/compilers/4.01.0/4.01.0/4.01.0.comp
@@ -3,7 +3,14 @@ version: "4.01.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.0/4.02.0+improved-errors/4.02.0+improved-errors.comp
+++ b/compilers/4.02.0/4.02.0+improved-errors/4.02.0+improved-errors.comp
@@ -5,7 +5,14 @@ patches: [
   "https://gist.githubusercontent.com/andrewray/1928825fea090e50c0de/raw/e121b5cd176cdf6b882bc402276235b1c0a71b69/improved-error.patch"
 ]
 build: [
-  ["./configure" "-prefix" "%{prefix}%"]
+  ["./configure"
+    "-prefix" "%{prefix}%"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" "%{prefix}%"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   ["%{make}%" "world"]
   ["%{make}%" "world.opt"]
   ["%{make}%" "install"]

--- a/compilers/4.02.0/4.02.0+modular-implicits/4.02.0+modular-implicits.comp
+++ b/compilers/4.02.0/4.02.0+modular-implicits/4.02.0+modular-implicits.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.0"
 src: "https://github.com/ocamllabs/ocaml-modular-implicits/archive/modular-implicits.tar.gz"
 build: [
-  ["./configure" "-prefix" "%{prefix}%"]
+  ["./configure"
+    "-prefix" "%{prefix}%"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" "%{prefix}%"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   ["%{make}%" "world"]
   ["%{make}%" "world.opt"]
   ["%{make}%" "install"]

--- a/compilers/4.02.0/4.02.0+rc1/4.02.0+rc1.comp
+++ b/compilers/4.02.0/4.02.0+rc1/4.02.0+rc1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.0/4.02.0+trunk/4.02.0+trunk.comp
+++ b/compilers/4.02.0/4.02.0+trunk/4.02.0+trunk.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.02"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.0/4.02.0/4.02.0.comp
+++ b/compilers/4.02.0/4.02.0/4.02.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.0"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.1/4.02.1+BER/4.02.1+BER.comp
+++ b/compilers/4.02.1/4.02.1+BER/4.02.1+BER.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.1"
 src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-n102.tar.gz"
 build: [
-  ["./configure" "-prefix" "%{prefix}%"]
+  ["./configure"
+    "-prefix" "%{prefix}%"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" "%{prefix}%"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   ["%{make}%" "world" "bootstrap" "opt" "opt.opt"]
   ["%{make}%" "-i" "install"]
   ["%{make}%" "-C" "metalib" "all" "install"]

--- a/compilers/4.02.1/4.02.1+fp/4.02.1+fp.comp
+++ b/compilers/4.02.1/4.02.1+fp/4.02.1+fp.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.1/4.02.1+modular-implicits-ber/4.02.1+modular-implicits-ber.comp
+++ b/compilers/4.02.1/4.02.1+modular-implicits-ber/4.02.1+modular-implicits-ber.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.1"
 src: "https://github.com/yallop/ocaml/archive/modular-implicits-ber.tar.gz"
 build: [
-  ["./configure" "-prefix" "%{prefix}%"]
+  ["./configure"
+    "-prefix" "%{prefix}%"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" "%{prefix}%"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   ["%{make}%" "world" "opt" "opt.opt"]
   ["%{make}%" "install"]
   ["%{make}%" "-C" "metalib" "all" "install"]

--- a/compilers/4.02.1/4.02.1/4.02.1.comp
+++ b/compilers/4.02.1/4.02.1/4.02.1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.2/4.02.2+improved-errors/4.02.2+improved-errors.comp
+++ b/compilers/4.02.2/4.02.2+improved-errors/4.02.2+improved-errors.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.2"
 src: "https://github.com/charguer/ocaml/archive/4.02.2+improved-errors.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.2/4.02.2+rc1/4.02.2+rc1.comp
+++ b/compilers/4.02.2/4.02.2+rc1/4.02.2+rc1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.2"
 src: "http://github.com/ocaml/ocaml/tarball/4.02.2+rc1"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.2/4.02.2/4.02.2.comp
+++ b/compilers/4.02.2/4.02.2/4.02.2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.2"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.3/4.02.3+buckle-1/4.02.3+buckle-1.comp
+++ b/compilers/4.02.3/4.02.3+buckle-1/4.02.3+buckle-1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.3"
 src: "https://github.com/bloomberg/ocaml/archive/4.02.3+buckle-1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world.opt"]
   [make "install"]
 ]

--- a/compilers/4.02.3/4.02.3+buckle-master/4.02.3+buckle-master.comp
+++ b/compilers/4.02.3/4.02.3+buckle-master/4.02.3+buckle-master.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.3"
 src: "https://github.com/bloomberg/ocaml/archive/master.zip"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world.opt"]
   [make "install"]
 ]

--- a/compilers/4.02.3/4.02.3+bytecode-only/4.02.3+bytecode-only.comp
+++ b/compilers/4.02.3/4.02.3+bytecode-only/4.02.3+bytecode-only.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.3"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "install"]
 ]

--- a/compilers/4.02.3/4.02.3+curried-constr/4.02.3+curried-constr.comp
+++ b/compilers/4.02.3/4.02.3+curried-constr/4.02.3+curried-constr.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.3"
 src: "https://github.com/camlspotter/ocaml/archive/4.02.3+curried-constr.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world.opt"]
   [make "install"]
 ]

--- a/compilers/4.02.3/4.02.3+fp/4.02.3+fp.comp
+++ b/compilers/4.02.3/4.02.3+fp/4.02.3+fp.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.3"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.02.3/4.02.3/4.02.3.comp
+++ b/compilers/4.02.3/4.02.3/4.02.3.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.02.3"
 src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world.opt"]
   [make "install"]
 ]

--- a/compilers/4.03.0/4.03.0+beta1+flambda/4.03.0+beta1+flambda.comp
+++ b/compilers/4.03.0/4.03.0+beta1+flambda/4.03.0+beta1+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+beta1-no-debug/4.03.0+beta1-no-debug.comp
+++ b/compilers/4.03.0/4.03.0+beta1-no-debug/4.03.0+beta1-no-debug.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+beta1/4.03.0+beta1.comp
+++ b/compilers/4.03.0/4.03.0+beta1/4.03.0+beta1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta1"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+beta2+flambda/4.03.0+beta2+flambda.comp
+++ b/compilers/4.03.0/4.03.0+beta2+flambda/4.03.0+beta2+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0+beta2+flambda"
 src: "https://github.com/ocaml/ocaml/tarball/4.03.0+beta2"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+beta2-no-debug/4.03.0+beta2-no-debug.comp
+++ b/compilers/4.03.0/4.03.0+beta2-no-debug/4.03.0+beta2-no-debug.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://codeload.github.com/ocaml/ocaml/legacy.tar.gz/4.03.0+beta2"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+beta2/4.03.0+beta2.comp
+++ b/compilers/4.03.0/4.03.0+beta2/4.03.0+beta2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://codeload.github.com/ocaml/ocaml/legacy.tar.gz/4.03.0+beta2"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
+++ b/compilers/4.03.0/4.03.0+flambda/4.03.0+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
+++ b/compilers/4.03.0/4.03.0+fp+flambda/4.03.0+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
+++ b/compilers/4.03.0/4.03.0+fp/4.03.0+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+statistical-memprof/4.03.0+statistical-memprof.comp
+++ b/compilers/4.03.0/4.03.0+statistical-memprof/4.03.0+statistical-memprof.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/jhjourdan/ocaml/archive/memprof_4.03.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+trunk+flambda/4.03.0+trunk+flambda.comp
+++ b/compilers/4.03.0/4.03.0+trunk+flambda/4.03.0+trunk+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+trunk+fp+flambda/4.03.0+trunk+fp+flambda.comp
+++ b/compilers/4.03.0/4.03.0+trunk+fp+flambda/4.03.0+trunk+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+trunk+fp/4.03.0+trunk+fp.comp
+++ b/compilers/4.03.0/4.03.0+trunk+fp/4.03.0+trunk+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
+++ b/compilers/4.03.0/4.03.0+trunk/4.03.0+trunk.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.03"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.03.0/4.03.0/4.03.0.comp
+++ b/compilers/4.03.0/4.03.0/4.03.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+BER/4.04.0+BER.comp
+++ b/compilers/4.04.0/4.04.0+BER/4.04.0+BER.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-n104.tar.gz"
 build: [
-  ["./configure" "-prefix" "%{prefix}%"]
+  ["./configure"
+    "-prefix" "%{prefix}%"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" "%{prefix}%"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "bootstrap"]
   [make "world.opt"]

--- a/compilers/4.04.0/4.04.0+afl/4.04.0+afl.comp
+++ b/compilers/4.04.0/4.04.0+afl/4.04.0+afl.comp
@@ -4,7 +4,14 @@ src: "https://github.com/stedolan/ocaml/archive/afl-backport.tar.gz"
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["./configure" "-prefix" prefix]
+  ["./configure"
+    "-prefix" prefix
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+beta1+flambda/4.04.0+beta1+flambda.comp
+++ b/compilers/4.04.0/4.04.0+beta1+flambda/4.04.0+beta1+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.04.0+beta1"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+beta1/4.04.0+beta1.comp
+++ b/compilers/4.04.0/4.04.0+beta1/4.04.0+beta1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.04.0+beta1"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+beta2+flambda/4.04.0+beta2+flambda.comp
+++ b/compilers/4.04.0/4.04.0+beta2+flambda/4.04.0+beta2+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.04.0+beta2"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+beta2/4.04.0+beta2.comp
+++ b/compilers/4.04.0/4.04.0+beta2/4.04.0+beta2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/tarball/4.04.0+beta2"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.comp
+++ b/compilers/4.04.0/4.04.0+bytecode-only/4.04.0+bytecode-only.comp
@@ -3,8 +3,15 @@ version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
   [
-    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
-  ]
+    "./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "install"]
 ]

--- a/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
+++ b/compilers/4.04.0/4.04.0+copatterns/4.04.0+copatterns.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/yurug/ocaml4.04.0-copatterns/archive/V0.5.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.comp
+++ b/compilers/4.04.0/4.04.0+flambda/4.04.0+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.comp
+++ b/compilers/4.04.0/4.04.0+fp+flambda/4.04.0+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+fp/4.04.0+fp.comp
+++ b/compilers/4.04.0/4.04.0+fp/4.04.0+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.comp
+++ b/compilers/4.04.0/4.04.0+safe-string/4.04.0+safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+spacetime/4.04.0+spacetime.comp
+++ b/compilers/4.04.0/4.04.0+spacetime/4.04.0+spacetime.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0+trunk+forced_lto/4.04.0+trunk+forced_lto.comp
+++ b/compilers/4.04.0/4.04.0+trunk+forced_lto/4.04.0+trunk+forced_lto.comp
@@ -7,7 +7,14 @@ build: [
     "-exc"
     "echo \"* : lto = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"
   ]
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.0/4.04.0/4.04.0.comp
+++ b/compilers/4.04.0/4.04.0/4.04.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.0"
 src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+bytecode-only/4.04.1+bytecode-only.comp
+++ b/compilers/4.04.1/4.04.1+bytecode-only/4.04.1+bytecode-only.comp
@@ -3,8 +3,15 @@ version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
   [
-    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
-  ]
+    "./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "install"]
 ]

--- a/compilers/4.04.1/4.04.1+flambda/4.04.1+flambda.comp
+++ b/compilers/4.04.1/4.04.1+flambda/4.04.1+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+fp+flambda/4.04.1+fp+flambda.comp
+++ b/compilers/4.04.1/4.04.1+fp+flambda/4.04.1+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+fp/4.04.1+fp.comp
+++ b/compilers/4.04.1/4.04.1+fp/4.04.1+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+safe-string/4.04.1+safe-string.comp
+++ b/compilers/4.04.1/4.04.1+safe-string/4.04.1+safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1+spacetime/4.04.1+spacetime.comp
+++ b/compilers/4.04.1/4.04.1+spacetime/4.04.1+spacetime.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.1/4.04.1/4.04.1.comp
+++ b/compilers/4.04.1/4.04.1/4.04.1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.1"
 src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.2/4.04.2+bytecode-only/4.04.2+bytecode-only.comp
+++ b/compilers/4.04.2/4.04.2+bytecode-only/4.04.2+bytecode-only.comp
@@ -3,8 +3,15 @@ version: "4.04.2"
 src: "https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz"
 build: [
   [
-    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
-  ]
+    "./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "install"]
 ]

--- a/compilers/4.04.2/4.04.2+flambda/4.04.2+flambda.comp
+++ b/compilers/4.04.2/4.04.2+flambda/4.04.2+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.2"
 src: "https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.2/4.04.2+fp+flambda/4.04.2+fp+flambda.comp
+++ b/compilers/4.04.2/4.04.2+fp+flambda/4.04.2+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.2/4.04.2+fp/4.04.2+fp.comp
+++ b/compilers/4.04.2/4.04.2+fp/4.04.2+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.2/4.04.2+safe-string/4.04.2+safe-string.comp
+++ b/compilers/4.04.2/4.04.2+safe-string/4.04.2+safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.2"
 src: "https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.2/4.04.2+spacetime/4.04.2+spacetime.comp
+++ b/compilers/4.04.2/4.04.2+spacetime/4.04.2+spacetime.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.2"
 src: "https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.04.2/4.04.2/4.04.2.comp
+++ b/compilers/4.04.2/4.04.2/4.04.2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.04.2"
 src: "https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+afl/4.05.0+afl.comp
+++ b/compilers/4.05.0/4.05.0+afl/4.05.0+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+beta1+flambda/4.05.0+beta1+flambda.comp
+++ b/compilers/4.05.0/4.05.0+beta1+flambda/4.05.0+beta1+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+beta1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+beta1/4.05.0+beta1.comp
+++ b/compilers/4.05.0/4.05.0+beta1/4.05.0+beta1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+beta1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+beta2+flambda/4.05.0+beta2+flambda.comp
+++ b/compilers/4.05.0/4.05.0+beta2+flambda/4.05.0+beta2+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+beta2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+beta2/4.05.0+beta2.comp
+++ b/compilers/4.05.0/4.05.0+beta2/4.05.0+beta2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+beta2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+beta3/4.05.0+beta3.comp
+++ b/compilers/4.05.0/4.05.0+beta3/4.05.0+beta3.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+beta3.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+flambda/4.05.0+flambda.comp
+++ b/compilers/4.05.0/4.05.0+flambda/4.05.0+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+lto/4.05.0+lto.comp
+++ b/compilers/4.05.0/4.05.0+lto/4.05.0+lto.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/chambart/ocaml-1/archive/lto_4.05.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+rc1+flambda/4.05.0+rc1+flambda.comp
+++ b/compilers/4.05.0/4.05.0+rc1+flambda/4.05.0+rc1+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+rc1/4.05.0+rc1.comp
+++ b/compilers/4.05.0/4.05.0+rc1/4.05.0+rc1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+safe-string/4.05.0+safe-string.comp
+++ b/compilers/4.05.0/4.05.0+safe-string/4.05.0+safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+spacetime/4.05.0+spacetime.comp
+++ b/compilers/4.05.0/4.05.0+spacetime/4.05.0+spacetime.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-spacetime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+trunk+afl/4.05.0+trunk+afl.comp
+++ b/compilers/4.05.0/4.05.0+trunk+afl/4.05.0+trunk+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+trunk+flambda/4.05.0+trunk+flambda.comp
+++ b/compilers/4.05.0/4.05.0+trunk+flambda/4.05.0+trunk+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+trunk+fp+flambda/4.05.0+trunk+fp+flambda.comp
+++ b/compilers/4.05.0/4.05.0+trunk+fp+flambda/4.05.0+trunk+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+trunk+fp/4.05.0+trunk+fp.comp
+++ b/compilers/4.05.0/4.05.0+trunk+fp/4.05.0+trunk+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+trunk+safe-string/4.05.0+trunk+safe-string.comp
+++ b/compilers/4.05.0/4.05.0+trunk+safe-string/4.05.0+trunk+safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0+trunk/4.05.0+trunk.comp
+++ b/compilers/4.05.0/4.05.0+trunk/4.05.0+trunk.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.05.0/4.05.0/4.05.0.comp
+++ b/compilers/4.05.0/4.05.0/4.05.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.05.0"
 src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+afl/4.06.0+afl.comp
+++ b/compilers/4.06.0/4.06.0+afl/4.06.0+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta1+afl/4.06.0+beta1+afl.comp
+++ b/compilers/4.06.0/4.06.0+beta1+afl/4.06.0+beta1+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta1+default-unsafe-string/4.06.0+beta1+default-unsafe-string.comp
+++ b/compilers/4.06.0/4.06.0+beta1+default-unsafe-string/4.06.0+beta1+default-unsafe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta1+flambda/4.06.0+beta1+flambda.comp
+++ b/compilers/4.06.0/4.06.0+beta1+flambda/4.06.0+beta1+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta1+force-safe-string/4.06.0+beta1+force-safe-string.comp
+++ b/compilers/4.06.0/4.06.0+beta1+force-safe-string/4.06.0+beta1+force-safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta1+fp+flambda/4.06.0+beta1+fp+flambda.comp
+++ b/compilers/4.06.0/4.06.0+beta1+fp+flambda/4.06.0+beta1+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta1+fp/4.06.0+beta1+fp.comp
+++ b/compilers/4.06.0/4.06.0+beta1+fp/4.06.0+beta1+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta1/4.06.0+beta1.comp
+++ b/compilers/4.06.0/4.06.0+beta1/4.06.0+beta1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta2+afl/4.06.0+beta2+afl.comp
+++ b/compilers/4.06.0/4.06.0+beta2+afl/4.06.0+beta2+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta2+default-unsafe-string/4.06.0+beta2+default-unsafe-string.comp
+++ b/compilers/4.06.0/4.06.0+beta2+default-unsafe-string/4.06.0+beta2+default-unsafe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta2+flambda/4.06.0+beta2+flambda.comp
+++ b/compilers/4.06.0/4.06.0+beta2+flambda/4.06.0+beta2+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta2+force-safe-string/4.06.0+beta2+force-safe-string.comp
+++ b/compilers/4.06.0/4.06.0+beta2+force-safe-string/4.06.0+beta2+force-safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta2+fp+flambda/4.06.0+beta2+fp+flambda.comp
+++ b/compilers/4.06.0/4.06.0+beta2+fp+flambda/4.06.0+beta2+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta2+fp/4.06.0+beta2+fp.comp
+++ b/compilers/4.06.0/4.06.0+beta2+fp/4.06.0+beta2+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+beta2/4.06.0+beta2.comp
+++ b/compilers/4.06.0/4.06.0+beta2/4.06.0+beta2.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta2.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+default-unsafe-string/4.06.0+default-unsafe-string.comp
+++ b/compilers/4.06.0/4.06.0+default-unsafe-string/4.06.0+default-unsafe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+flambda/4.06.0+flambda.comp
+++ b/compilers/4.06.0/4.06.0+flambda/4.06.0+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+force-safe-string/4.06.0+force-safe-string.comp
+++ b/compilers/4.06.0/4.06.0+force-safe-string/4.06.0+force-safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+fp+flambda/4.06.0+fp+flambda.comp
+++ b/compilers/4.06.0/4.06.0+fp+flambda/4.06.0+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+fp/4.06.0+fp.comp
+++ b/compilers/4.06.0/4.06.0+fp/4.06.0+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+rc1+afl/4.06.0+rc1+afl.comp
+++ b/compilers/4.06.0/4.06.0+rc1+afl/4.06.0+rc1+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+rc1+default-unsafe-string/4.06.0+rc1+default-unsafe-string.comp
+++ b/compilers/4.06.0/4.06.0+rc1+default-unsafe-string/4.06.0+rc1+default-unsafe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+rc1+flambda/4.06.0+rc1+flambda.comp
+++ b/compilers/4.06.0/4.06.0+rc1+flambda/4.06.0+rc1+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+rc1+force-safe-string/4.06.0+rc1+force-safe-string.comp
+++ b/compilers/4.06.0/4.06.0+rc1+force-safe-string/4.06.0+rc1+force-safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+rc1+fp+flambda/4.06.0+rc1+fp+flambda.comp
+++ b/compilers/4.06.0/4.06.0+rc1+fp+flambda/4.06.0+rc1+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+rc1+fp/4.06.0+rc1+fp.comp
+++ b/compilers/4.06.0/4.06.0+rc1+fp/4.06.0+rc1+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+rc1/4.06.0+rc1.comp
+++ b/compilers/4.06.0/4.06.0+rc1/4.06.0+rc1.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0+statistical-memprof/4.06.0+statistical-memprof.comp
+++ b/compilers/4.06.0/4.06.0+statistical-memprof/4.06.0+statistical-memprof.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/jhjourdan/ocaml/archive/memprof_4.06.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "--statmemprof"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "--statmemprof"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "--statmemprof"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.0/4.06.0/4.06.0.comp
+++ b/compilers/4.06.0/4.06.0/4.06.0.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.0"
 src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc -O2 -pipe"
+    "-aspp" "cc -O2 -pipe -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.1/4.06.1+trunk+afl/4.06.1+trunk+afl.comp
+++ b/compilers/4.06.1/4.06.1+trunk+afl/4.06.1+trunk+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.1"
 src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.1/4.06.1+trunk+flambda/4.06.1+trunk+flambda.comp
+++ b/compilers/4.06.1/4.06.1+trunk+flambda/4.06.1+trunk+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.1"
 src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.1/4.06.1+trunk+fp+flambda/4.06.1+trunk+fp+flambda.comp
+++ b/compilers/4.06.1/4.06.1+trunk+fp+flambda/4.06.1+trunk+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.1/4.06.1+trunk+fp/4.06.1+trunk+fp.comp
+++ b/compilers/4.06.1/4.06.1+trunk+fp/4.06.1+trunk+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.1/4.06.1+trunk+safe-string/4.06.1+trunk+safe-string.comp
+++ b/compilers/4.06.1/4.06.1+trunk+safe-string/4.06.1+trunk+safe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.1"
 src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.06.1/4.06.1+trunk/4.06.1+trunk.comp
+++ b/compilers/4.06.1/4.06.1+trunk/4.06.1+trunk.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.06.1"
 src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.07.0/4.07.0+trunk+afl/4.07.0+trunk+afl.comp
+++ b/compilers/4.07.0/4.07.0+trunk+afl/4.07.0+trunk+afl.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.07.0"
 src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-afl-instrument"]
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.07.0/4.07.0+trunk+flambda/4.07.0+trunk+flambda.comp
+++ b/compilers/4.07.0/4.07.0+trunk+flambda/4.07.0+trunk+flambda.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.07.0"
 src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.07.0/4.07.0+trunk+fp+flambda/4.07.0+trunk+fp+flambda.comp
+++ b/compilers/4.07.0/4.07.0+trunk+fp+flambda/4.07.0+trunk+fp+flambda.comp
@@ -9,7 +9,17 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.07.0/4.07.0+trunk+fp/4.07.0+trunk+fp.comp
+++ b/compilers/4.07.0/4.07.0+trunk+fp/4.07.0+trunk+fp.comp
@@ -8,7 +8,16 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ]
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.07.0/4.07.0+trunk+unsafe-string/4.07.0+trunk+unsafe-string.comp
+++ b/compilers/4.07.0/4.07.0+trunk+unsafe-string/4.07.0+trunk+unsafe-string.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.07.0"
 src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-unsafe-string"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-unsafe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-unsafe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/compilers/4.07.0/4.07.0+trunk/4.07.0+trunk.comp
+++ b/compilers/4.07.0/4.07.0+trunk/4.07.0+trunk.comp
@@ -2,7 +2,14 @@ opam-version: "1"
 version: "4.07.0"
 src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
   [make "world"]
   [make "world.opt"]
   [make "install"]


### PR DESCRIPTION
FreeBSD, OpenBSD and darwin use clang as base system compiler.
OpenBSD suffers from outdated gcc still lingering in base.
Therefore use `cc` by default on those platforms.