### PR TITLE
Package sslconf.0.8.1

### DIFF
--- a/packages/sslconf/sslconf.0.8.1/descr
+++ b/packages/sslconf/sslconf.0.8.1/descr
@@ -1,0 +1,12 @@
+An OCaml version of Openssl's NCONF library
+
+sslconf is a reimplementation of the Openssl NCONF library in OCaml.
+
+NCONF reads Openssl config files. It delivers a data structure and
+a query API. Under the data structure are hash tables with strings
+and name-value stacks as values. The query API hides details of
+implementation.
+
+sslconf has only OCaml code, so it can be used in a unikernel.
+
+sslconf is distributed under the ISC license.

--- a/packages/sslconf/sslconf.0.8.1/opam
+++ b/packages/sslconf/sslconf.0.8.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Tony Wuersch <tony.wuersch@gmail.com>"
+homepage: "https://github.com/awuersch/sslconf"
+dev-repo: "https://github.com/awuersch/sslconf.git"
+bug-reports: "https://github.com/awuersch/sslconf/issues"
+doc: "https://awuersch.github.io/sslconf/doc"
+authors: [
+  "Tony Wuersch <tony.wuersch@gmail.com>"
+]
+license: "ISC"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/sslconf/sslconf.0.8.1/url
+++ b/packages/sslconf/sslconf.0.8.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/awuersch/sslconf/releases/download/0.8.1/sslconf-0.8.1.tbz"
+checksum: "6fc6eb20360b5f8cab14e3e547dbdb41"


### PR DESCRIPTION
### `sslconf.0.8.1`

An OCaml version of Openssl's NCONF library

sslconf is a reimplementation of the Openssl NCONF library in OCaml.

NCONF reads Openssl config files. It delivers a data structure and
a query API. Under the data structure are hash tables with strings
and name-value stacks as values. The query API hides details of
implementation.

sslconf has only OCaml code, so it can be used in a unikernel.

sslconf is distributed under the ISC license.



---
* Homepage: https://github.com/awuersch/sslconf
* Source repo: https://github.com/awuersch/sslconf.git
* Bug tracker: https://github.com/awuersch/sslconf/issues

---


---
## 0.8.1 (2017-10-25)

With Rresult, without Bisect_ppx. More compatibility?
:camel: Pull-request generated by opam-publish v0.3.5