### PR TITLE
Package sslconf.0.8.2

### DIFF
--- a/packages/sslconf/sslconf.0.8.2/descr
+++ b/packages/sslconf/sslconf.0.8.2/descr
@@ -1,0 +1,12 @@
+An OCaml version of Openssl's NCONF library
+
+sslconf is a reimplementation of the Openssl NCONF library in OCaml.
+
+NCONF reads Openssl config files. It delivers a data structure and
+a query API. Under the data structure are hash tables with strings
+and name-value stacks as values. The query API hides details of
+implementation.
+
+sslconf has only OCaml code, so it can be used in a unikernel.
+
+sslconf is distributed under the ISC license.

--- a/packages/sslconf/sslconf.0.8.2/opam
+++ b/packages/sslconf/sslconf.0.8.2/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Tony Wuersch <tony.wuersch@gmail.com>"
+homepage: "https://github.com/awuersch/sslconf"
+dev-repo: "https://github.com/awuersch/sslconf.git"
+bug-reports: "https://github.com/awuersch/sslconf/issues"
+doc: "https://awuersch.github.io/sslconf/doc"
+authors: [
+  "Tony Wuersch <tony.wuersch@gmail.com>"
+]
+license: "ISC"
+depends: [
+  "jbuilder"
+  "ppx_sexp_conv"
+  "sexplib"
+  "astring"
+  "rresult"
+  "fpath"
+  "ounit"
+  "cmdliner"
+  "topkg"
+  "topkg-care"
+  "topkg-jbuilder"
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/sslconf/sslconf.0.8.2/url
+++ b/packages/sslconf/sslconf.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/awuersch/sslconf/releases/download/0.8.2/sslconf-0.8.2.tbz"
+checksum: "12af57e181fc8e7b1abdb2eb442e69eb"


### PR DESCRIPTION
### `sslconf.0.8.2`

An OCaml version of Openssl's NCONF library

sslconf is a reimplementation of the Openssl NCONF library in OCaml.

NCONF reads Openssl config files. It delivers a data structure and
a query API. Under the data structure are hash tables with strings
and name-value stacks as values. The query API hides details of
implementation.

sslconf has only OCaml code, so it can be used in a unikernel.

sslconf is distributed under the ISC license.



---
* Homepage: https://github.com/awuersch/sslconf
* Source repo: https://github.com/awuersch/sslconf.git
* Bug tracker: https://github.com/awuersch/sslconf/issues

---


---
## 0.8.2 (2017-10-25)

Added depends to sslconf.opam
:camel: Pull-request generated by opam-publish v0.3.5