### PR TITLE
Package sslconf.0.8.3

### DIFF
--- a/packages/sslconf/sslconf.0.8.3/descr
+++ b/packages/sslconf/sslconf.0.8.3/descr
@@ -1,0 +1,12 @@
+An OCaml version of Openssl's NCONF library
+
+sslconf is a reimplementation of the Openssl NCONF library in OCaml.
+
+NCONF reads Openssl config files. It delivers a data structure and
+a query API. Under the data structure are hash tables with strings
+and name-value stacks as values. The query API hides details of
+implementation.
+
+sslconf has only OCaml code, so it can be used in a unikernel.
+
+sslconf is distributed under the ISC license.

--- a/packages/sslconf/sslconf.0.8.3/opam
+++ b/packages/sslconf/sslconf.0.8.3/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Tony Wuersch <tony.wuersch@gmail.com>"
+homepage: "https://github.com/awuersch/sslconf"
+dev-repo: "https://github.com/awuersch/sslconf.git"
+bug-reports: "https://github.com/awuersch/sslconf/issues"
+doc: "https://awuersch.github.io/sslconf/doc"
+authors: [
+  "Tony Wuersch <tony.wuersch@gmail.com>"
+]
+license: "ISC"
+depends: [
+  "jbuilder" {build}
+  "ppx_sexp_conv" {build}
+  "sexplib"
+  "astring"
+  "rresult"
+  "fpath"
+  "cmdliner"
+  "topkg-jbuilder" {build}
+  "ounit" {test}
+  "odoc" {doc}
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/sslconf/sslconf.0.8.3/url
+++ b/packages/sslconf/sslconf.0.8.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/awuersch/sslconf/releases/download/0.8.3/sslconf-0.8.3.tbz"
+checksum: "2a0da5a04934b18b15b36c5707809aa9"


### PR DESCRIPTION
### `sslconf.0.8.3`

An OCaml version of Openssl's NCONF library

sslconf is a reimplementation of the Openssl NCONF library in OCaml.

NCONF reads Openssl config files. It delivers a data structure and
a query API. Under the data structure are hash tables with strings
and name-value stacks as values. The query API hides details of
implementation.

sslconf has only OCaml code, so it can be used in a unikernel.

sslconf is distributed under the ISC license.



---
* Homepage: https://github.com/awuersch/sslconf
* Source repo: https://github.com/awuersch/sslconf.git
* Bug tracker: https://github.com/awuersch/sslconf/issues

---


---
## 0.8.3 (2017-10-26)

Responded to reviewer comments, ready to go.
:camel: Pull-request generated by opam-publish v0.3.5