### PR TITLE
ocamlfind: add bounds for 4.06.0

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
 build: [
   [
     "./configure"
@@ -19,5 +24,8 @@ build: [
 depends: [
   "conf-m4"
 ]
-available: ocaml-version > "3.12.2"
+available: [
+    ocaml-version >= "3.12.2"
+  & ocaml-version < "4.06.0" # ocamlfind refers to bignum
+]
 install: [make "install"]

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
 build: [
   [
     "./configure"
@@ -20,5 +25,8 @@ build: [
 depends: [
   "conf-m4"
 ]
-available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align
+available: [
+    ocaml-version >= "3.08" # ocamlfind uses Arg.align
+  & ocaml-version < "4.06.0" # ocamlfind refers to bignum
+]
 install: [make "install"]

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
 build: [
   [
     "./configure"
@@ -20,5 +25,8 @@ build: [
 depends: [
   "conf-m4"
 ]
-available: [ocaml-version >= "3.08"] # ocamlfind uses Arg.align
+available: [
+    ocaml-version >= "3.08" # ocamlfind uses Arg.align
+  & ocaml-version < "4.06.0" # ocamlfind refers to bignum
+]
 install: [make "install"]

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
 build: [
   [
     "./configure"
@@ -27,6 +32,9 @@ depends: [
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0
-available: [ (ocaml-version >= "3.12.0") |
-             ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0")) ]
+available: [
+    (ocaml-version >= "3.12.0") |
+    ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0"))
+  & ocaml-version < "4.06.0"  # ocamlfind uses unsafe strings
+]
 install: [make "install"]

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
 build: [
   [
     "./configure"
@@ -26,6 +31,9 @@ depends: [
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0
-available: [ (ocaml-version >= "3.12.0") |
-             ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0")) ]
+available: [
+    (ocaml-version >= "3.12.0") |
+    ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0"))
+  & ocaml-version < "4.06.0"  # ocamlfind uses unsafe strings
+]
 install: [make "install"]

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
 build: [
   [
     "./configure"
@@ -27,6 +32,9 @@ depends: [
 ]
 # needs 3.10.0 for ocamldep -modules but for some reason, when using
 # 3.11 an ocamlfind test needs native dynamic linking which is only from 3.12.0
-available: [ (ocaml-version >= "3.12.0") |
-             ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0")) ]
+available: [
+    (ocaml-version >= "3.12.0") |
+    ((ocaml-version >= "3.10.0") & (ocaml-version < "3.11.0"))
+  & ocaml-version < "4.06.0"  # ocamlfind uses unsafe strings
+]
 install: [make "install"]

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+
 patches: [ "1.5.4-sed-bsd-compat.patch" ]
 build: [
   [
@@ -25,5 +30,8 @@ remove: [
 depends: [
   "conf-m4"
 ]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+available: [
+    ocaml-version >= "3.12.0" # ocamlfind refers to cmxs
+  & ocaml-version < "4.06.0"  # ocamlfind uses unsafe strings
+]
 install: [make "install"]

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -19,4 +19,7 @@ remove: [
 depends: [
   "conf-m4" {build}
 ]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+available: [
+    ocaml-version >= "3.12.0" # ocamlfind refers to cmxs
+  & ocaml-version < "4.06.0"  # ocamlfind uses unsafe strings
+]

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -16,7 +16,10 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+available: [
+    ocaml-version >= "3.12.0" # ocamlfind refers to cmxs
+  & ocaml-version < "4.06.0"  # ocamlfind uses unsafe strings
+]
 depends: [
   "conf-m4" {build}
 ]

--- a/packages/ocamlfind/ocamlfind.1.6.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.1/opam
@@ -16,7 +16,10 @@ remove: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
   [make "uninstall"]
 ]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+available: [
+    ocaml-version >= "3.12.0" # ocamlfind refers to cmxs
+  & ocaml-version < "4.06.0"  # ocamlfind refers to bignum
+]
 depends: [
   "conf-m4" {build}
 ]

--- a/packages/ocamlfind/ocamlfind.1.6.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.2/opam
@@ -21,7 +21,10 @@ remove: [
   ["rm" "-f" "%{bin}%/ocaml"] {preinstalled}
 ]
 patches: [ "termux.patch" ]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+available: [
+    ocaml-version >= "3.12.0" # ocamlfind refers to cmxs
+  & ocaml-version < "4.06.0"  # ocamlfind refers to bignum
+]
 depends: [
   "conf-m4" {build}
 ]

--- a/packages/ocamlfind/ocamlfind.1.7.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.1/opam
@@ -21,7 +21,10 @@ remove: [
   ["rm" "-f" "%{bin}%/ocaml"] {preinstalled}
 ]
 patches: [ "termux.patch" ]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+available: [
+    ocaml-version >= "3.12.0" # ocamlfind refers to cmxs
+  & ocaml-version < "4.06.0"  # ocamlfind refers to bignum
+]
 depends: [
   "conf-m4" {build}
 ]

--- a/packages/ocamlfind/ocamlfind.1.7.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.2/opam
@@ -20,7 +20,10 @@ remove: [
   [make "uninstall"]
   ["rm" "-f" "%{bin}%/ocaml"] {preinstalled}
 ]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+available: [
+    ocaml-version >= "3.12.0" # ocamlfind refers to cmxs
+  & ocaml-version < "4.06.0"  # ocamlfind refers to bignum
+]
 depends: [
   "conf-m4" {build}
 ]


### PR DESCRIPTION
Older versions of `ocamlfind` won't work on 4.06.0, either because `bignum` was removed, or because of `-safe-string`.
