### PR TITLE
Package reason.3.0.0

### DIFF
--- a/packages/reason/reason.3.0.0/descr
+++ b/packages/reason/reason.3.0.0/descr
@@ -1,0 +1,5 @@
+Reason: Syntax & Toolchain for OCaml
+
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem.

--- a/packages/reason/reason.3.0.0/opam
+++ b/packages/reason/reason.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: "Jordan Walke <jordojw@gmail.com>"
+homepage: "https://github.com/facebook/reason"
+bug-reports: "https://github.com/facebook/reason/issues"
+license: "BSD. Additional patent grant provided."
+doc: "http://reasonml.github.io/"
+tags: "syntax"
+dev-repo: "git://github.com/facebook/reason.git"
+substs: "pkg/META"
+build: [
+  [make "compile_error"]
+  ["ocamlbuild" "-use-ocamlfind" "-package" "topkg" "pkg/build.native"]
+  [
+    "./build.native"
+    "build"
+    "--native"
+    "%{ocaml-native}%"
+    "--native-dynlink"
+    "%{ocaml-native-dynlink}%"
+    "--utop"
+    "%{utop:installed}%"
+  ]
+]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {>= "20170418" & <= "20170712"}
+  "utop" {>= "1.17"}
+  "merlin-extend" {>= "0.3"}
+  "result" {= "1.2"}
+  "topkg" {>= "0.9.1"}
+  "ocaml-migrate-parsetree"
+]
+conflicts: [
+  "utop" {< "1.17"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.06"]

--- a/packages/reason/reason.3.0.0/url
+++ b/packages/reason/reason.3.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/facebook/reason/archive/3.0.0.tar.gz"
+checksum: "79bae65f06317ad540b5de401b24bb60"


### PR DESCRIPTION
### `reason.3.0.0`

Reason: Syntax & Toolchain for OCaml

Reason gives OCaml a new syntax that is remniscient of languages like
JavaScript. It's also the umbrella project for a set of tools for the OCaml &
JavaScript ecosystem.



---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

:camel: Pull-request generated by opam-publish v0.3.5