### PR TITLE
ounit.1.1.2: add bound on ocaml version

### DIFF
--- a/packages/ounit/ounit.1.1.2/opam
+++ b/packages/ounit/ounit.1.1.2/opam
@@ -13,3 +13,4 @@ depends: [
   "camlp4"
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
Old `ounit` doesn't work with `-safe-string`.
