### PR TITLE
sexplib: add bound on ocaml version

### DIFF
--- a/packages/sexplib/sexplib.113.33.00+4.03/opam
+++ b/packages/sexplib/sexplib.113.33.00+4.03/opam
@@ -13,4 +13,4 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build & >= "1.3.2"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
`sexplib.113.33.00+4.03` is incompatible with 4.06 because of `-safe-string`.
