### PR TITLE
alcotest: add bound on ocaml version

### DIFF
--- a/packages/alcotest/alcotest.0.1.0/opam
+++ b/packages/alcotest/alcotest.0.1.0/opam
@@ -20,4 +20,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.2.0/opam
+++ b/packages/alcotest/alcotest.0.2.0/opam
@@ -20,4 +20,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.3.0/opam
+++ b/packages/alcotest/alcotest.0.3.0/opam
@@ -19,4 +19,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.3.1/opam
+++ b/packages/alcotest/alcotest.0.3.1/opam
@@ -19,4 +19,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.3.2/opam
+++ b/packages/alcotest/alcotest.0.3.2/opam
@@ -19,4 +19,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.3.3/opam
+++ b/packages/alcotest/alcotest.0.3.3/opam
@@ -19,4 +19,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.0/opam
+++ b/packages/alcotest/alcotest.0.4.0/opam
@@ -18,4 +18,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.1/opam
+++ b/packages/alcotest/alcotest.0.4.1/opam
@@ -18,4 +18,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.2/opam
+++ b/packages/alcotest/alcotest.0.4.2/opam
@@ -18,4 +18,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.3/opam
+++ b/packages/alcotest/alcotest.0.4.3/opam
@@ -18,4 +18,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.4/opam
+++ b/packages/alcotest/alcotest.0.4.4/opam
@@ -18,4 +18,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.5/opam
+++ b/packages/alcotest/alcotest.0.4.5/opam
@@ -18,4 +18,4 @@ depends: [
   "cmdliner"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.6/opam
+++ b/packages/alcotest/alcotest.0.4.6/opam
@@ -18,4 +18,4 @@ depends: [
   "result"
   "cmdliner"
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/alcotest/alcotest.0.4.7/opam
+++ b/packages/alcotest/alcotest.0.4.7/opam
@@ -18,4 +18,4 @@ depends: [
   "result"
   "cmdliner"
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Older versions of alcotest won't work with 4.06 because of `-safe-string`.
