### PR TITLE
re: add bound on ocaml version

### DIFF
--- a/packages/re/re.1.0/opam
+++ b/packages/re/re.1.0/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors: ["Jerome Vouillon" "Thomas Gazagnaire" "Anil Madhavapeddy"]
+homepage: "https://github.com/ocaml/ocaml-re"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -10,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/re/re.1.1.0/opam
+++ b/packages/re/re.1.1.0/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors: ["Jerome Vouillon" "Thomas Gazagnaire" "Anil Madhavapeddy"]
+homepage: "https://github.com/ocaml/ocaml-re"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -10,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/re/re.1.2.0/opam
+++ b/packages/re/re.1.2.0/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors: ["Jerome Vouillon" "Thomas Gazagnaire" "Anil Madhavapeddy"]
+homepage: "https://github.com/ocaml/ocaml-re"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -10,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/re/re.1.2.1/opam
+++ b/packages/re/re.1.2.1/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+authors: ["Jerome Vouillon" "Thomas Gazagnaire" "Anil Madhavapeddy"]
+homepage: "https://github.com/ocaml/ocaml-re"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -11,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/ocaml/ocaml-re"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/re/re.1.2.2/opam
+++ b/packages/re/re.1.2.2/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "jerome.vouillon@pps.univ-paris-diderot.fr"
+authors: ["Jerome Vouillon" "Thomas Gazagnaire" "Anil Madhavapeddy"]
+homepage: "https://github.com/ocaml/ocaml-re"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -11,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/ocaml/ocaml-re"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
Older versions of `re` won't work on 4.06 because of `-safe-string`.
