### PR TITLE
menhir: add bound on ocaml version

### DIFF
--- a/packages/menhir/menhir.20120123/opam
+++ b/packages/menhir/menhir.20120123/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+]
+homepage: "http://gallium.inria.fr/~fpottier/menhir/"
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: ["ocamlfind"]
 install: [
@@ -10,3 +15,4 @@ install: [
   "libdir=%{lib}%/menhir"
   "mandir=%{man}%/man1"
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/menhir/menhir.20130116/opam
+++ b/packages/menhir/menhir.20130116/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+]
+homepage: "http://gallium.inria.fr/~fpottier/menhir/"
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: ["ocamlfind"]
 install: [
@@ -10,3 +15,4 @@ install: [
   "libdir=%{lib}%/menhir"
   "mandir=%{man}%/man1"
 ]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
Older versions of `menhir` won't work on 4.06 because of `-safe-string`.
