### PR TITLE
cppo: add bound on ocaml version

### DIFF
--- a/packages/cppo/cppo.0.9.3/opam
+++ b/packages/cppo/cppo.0.9.3/opam
@@ -1,6 +1,7 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
 license: "BSD-3-Clause"
 build: [[make]]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.0.9.4/opam
+++ b/packages/cppo/cppo.0.9.4/opam
@@ -10,3 +10,4 @@ remove: [
 
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install-lib"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.0.0/opam
+++ b/packages/cppo/cppo.1.0.0/opam
@@ -9,3 +9,4 @@ remove: [
 ]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install-lib"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.0.1/opam
+++ b/packages/cppo/cppo.1.0.1/opam
@@ -9,3 +9,4 @@ remove: [
 ]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install-lib"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.1.0/opam
+++ b/packages/cppo/cppo.1.1.0/opam
@@ -9,3 +9,4 @@ remove: [
 ]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install-lib"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.1.1/opam
+++ b/packages/cppo/cppo.1.1.1/opam
@@ -9,3 +9,4 @@ remove: [
 ]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install-lib"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.1.2/opam
+++ b/packages/cppo/cppo.1.1.2/opam
@@ -9,3 +9,4 @@ remove: [
 ]
 depends: ["ocamlfind" "ocamlbuild"]
 install: [make "install-lib"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.2.2/opam
+++ b/packages/cppo/cppo.1.2.2/opam
@@ -16,3 +16,4 @@ remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
 depends: ["ocamlfind" "ocamlbuild"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.3.0/opam
+++ b/packages/cppo/cppo.1.3.0/opam
@@ -16,3 +16,4 @@ remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
 depends: ["ocamlfind" "ocamlbuild"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.3.1/opam
+++ b/packages/cppo/cppo.1.3.1/opam
@@ -16,3 +16,4 @@ remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
 depends: ["ocamlfind" "ocamlbuild"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.3.2/opam
+++ b/packages/cppo/cppo.1.3.2/opam
@@ -16,3 +16,4 @@ remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
 depends: ["ocamlfind" "ocamlbuild"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cppo/cppo.1.4.0/opam
+++ b/packages/cppo/cppo.1.4.0/opam
@@ -16,3 +16,4 @@ remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
 ]
 depends: ["ocamlfind" "ocamlbuild"]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
Older versions of `cppo` won't work on 4.06 because of `-safe-string`.
