### PR TITLE
Package mrt-format.0.2.0

### DIFF
--- a/packages/mrt-format/mrt-format.0.2.0/descr
+++ b/packages/mrt-format/mrt-format.0.2.0/descr
@@ -1,0 +1,4 @@
+MRT parsing library and CLI
+
+
+A basic implementation of the [Multi-Threaded Routing Toolkit](https://tools.ietf.org/html/rfc6396) format, following my implementation in the [Python Routeing Toolkit](https://github.com/mor1/pyrt) and documentation in the [RFC](https://tools.ietf.org/html/rfc6396) and the [PyRT README](https://github.com/mor1/pyrt/blob/master/README.mrtd). Provides (incomplete) parsing libraries and a simple CLI tool.

--- a/packages/mrt-format/mrt-format.0.2.0/opam
+++ b/packages/mrt-format/mrt-format.0.2.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Richard Mortier <mort@cantab.net>"
+authors: [ "Richard Mortier" ]
+license: "ISC"
+
+homepage: "https://github.com/mor1/mrt-format"
+dev-repo: "https://github.com/mor1/mrt-format.git"
+bug-reports: "https://github.com/mor1/mrt-format/issues"
+doc: "https://mor1.github.io/mrt-format/"
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocamlfind"   {build}
+  "alcotest"    {test}
+  "cstruct"     {>= "1.0.1"}
+  "ppx_cstruct" {build}
+]

--- a/packages/mrt-format/mrt-format.0.2.0/url
+++ b/packages/mrt-format/mrt-format.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mor1/mrt-format/releases/download/0.2.0/mrt-format-0.2.0.tbz"
+checksum: "89db2bf6d242a128cd578bc3ab6d037f"


### PR DESCRIPTION
### `mrt-format.0.2.0`

MRT parsing library and CLI


A basic implementation of the [Multi-Threaded Routing Toolkit](https://tools.ietf.org/html/rfc6396) format, following my implementation in the [Python Routeing Toolkit](https://github.com/mor1/pyrt) and documentation in the [RFC](https://tools.ietf.org/html/rfc6396) and the [PyRT README](https://github.com/mor1/pyrt/blob/master/README.mrtd). Provides (incomplete) parsing libraries and a simple CLI tool.


---
* Homepage: https://github.com/mor1/mrt-format
* Source repo: https://github.com/mor1/mrt-format.git
* Bug tracker: https://github.com/mor1/mrt-format/issues

---


---
### 0.2.0 (2017-10-27)

  * Upgrade to use `jbuilder`, modern `opam`, `topkg`, etc
  * Fix warnings, generally tidy things up
:camel: Pull-request generated by opam-publish v0.3.5