### PR TITLE
Package plotkicadsch.0.1.3

### DIFF
--- a/packages/plotkicadsch/plotkicadsch.0.1.3/descr
+++ b/packages/plotkicadsch/plotkicadsch.0.1.3/descr
@@ -1,0 +1,8 @@
+Schematic plotter
+
+PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures. In the future, export to other formats may be available (PDF, PNG).
+
+## Objectives
+This project is mainly an attempt at using ocaml with functional programing on a pet real-world project.
+
+The quality of the output is not a first requirement (meaning: not supposed to match Kicad one to one), but the accuracy of positioning matters. The end objective is to be able to provide a visual diff on sch files for version control.

--- a/packages/plotkicadsch/plotkicadsch.0.1.3/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.1.3/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+author: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+license: "ISC"
+dev-repo: "https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+ "ocamlfind"
+ "pcre"
+ "tyxml" {>= "4.0.0"}
+ "lwt"
+ "base64"
+ "sha"
+ "git"
+ "git-unix"
+]
+available: [ ocaml-version >= "4.03" ]

--- a/packages/plotkicadsch/plotkicadsch.0.1.3/url
+++ b/packages/plotkicadsch/plotkicadsch.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/jnavila/plotkicadsch/releases/download/0.1.3/plotkicadsch-0.1.3.tbz"
+checksum: "484dcf99fe0fa0b913ca589c43f876e6"


### PR DESCRIPTION
### `plotkicadsch.0.1.3`

Schematic plotter

PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures. In the future, export to other formats may be available (PDF, PNG).

## Objectives
This project is mainly an attempt at using ocaml with functional programing on a pet real-world project.

The quality of the output is not a first requirement (meaning: not supposed to match Kicad one to one), but the accuracy of positioning matters. The end objective is to be able to provide a visual diff on sch files for version control.


---
* Homepage: https://jnavila.github.io/plotkicadsch/
* Source repo: https://github.com/jnavila/plotkicadsch.git
* Bug tracker: https://github.com/jnavila/plotkicadsch/issues

---


---
v0.0.1
------

 - Initial release
:camel: Pull-request generated by opam-publish v0.3.5