### PR TITLE
+ mesh 0.9.8

### DIFF
--- a/packages/mesh-display/mesh-display.0.8.9/descr
+++ b/packages/mesh-display/mesh-display.0.8.9/descr
@@ -1,0 +1,1 @@
+Triangular mesh representation using the graphics module

--- a/packages/mesh-display/mesh-display.0.8.9/opam
+++ b/packages/mesh-display/mesh-display.0.8.9/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+tags: []
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "ocamlfind" {build & >= "1.5"}
+  "jbuilder" {build}
+  "configurator" {build}
+  "mesh" {= "0.8.9"}
+  "graphics"
+]

--- a/packages/mesh-display/mesh-display.0.8.9/url
+++ b/packages/mesh-display/mesh-display.0.8.9/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.8.9/mesh-0.8.9.tbz"
+checksum: "bdc6e96fba4c37035c3121583ca9e3cd"

--- a/packages/mesh-easymesh/mesh-easymesh.0.8.9/descr
+++ b/packages/mesh-easymesh/mesh-easymesh.0.8.9/descr
@@ -1,0 +1,7 @@
+Triangular mesh generation with EasyMesh
+
+[EasyMesh][] is a two-dimensional quality mesh generator developed by
+Bojan Niceno and available from MIT.  This module provides an
+interface calling the program EasyMesh to perform the mesh generation.
+
+[EasyMesh]: http://web.mit.edu/easymesh_v1.4/www/easymesh.html

--- a/packages/mesh-easymesh/mesh-easymesh.0.8.9/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.8.9/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+tags: [ "Mesh" "Triangulation" "PDE" ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+depends: [
+  "ocamlfind" {build & >= "1.5"}
+  "jbuilder"  {build & >="1.0+beta9"}
+  "configurator" {build}
+  "base-bigarray"
+  "base-bytes"
+  "mesh" {= "0.8.9"}
+  "lacaml"    {test}
+]

--- a/packages/mesh-easymesh/mesh-easymesh.0.8.9/url
+++ b/packages/mesh-easymesh/mesh-easymesh.0.8.9/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.8.9/mesh-0.8.9.tbz"
+checksum: "bdc6e96fba4c37035c3121583ca9e3cd"

--- a/packages/mesh-triangle/mesh-triangle.0.8.9/descr
+++ b/packages/mesh-triangle/mesh-triangle.0.8.9/descr
@@ -1,0 +1,8 @@
+Binding to the triangle mesh generator
+
+This module is a binding to the [Triangle][] library which was awarded
+the James Hardy Wilkinson Prize in Numerical Software in 2003.  If
+libtriangle-dev is not installed on your system, it will install a
+local copy for this library.
+
+[Triangle]: http://www.cs.cmu.edu/~quake/triangle.html

--- a/packages/mesh-triangle/mesh-triangle.0.8.9/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.8.9/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+tags: [ "clib:triangle"  ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+depends: [
+  "ocamlfind" {build & >= "1.5"}
+  "jbuilder"  {build & >="1.0+beta9"}
+  "configurator" {build}
+  "base-bigarray"
+  "base-bytes"
+  "mesh" {= "0.8.9"}
+  "lacaml"    {test}
+]
+

--- a/packages/mesh-triangle/mesh-triangle.0.8.9/url
+++ b/packages/mesh-triangle/mesh-triangle.0.8.9/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.8.9/mesh-0.8.9.tbz"
+checksum: "bdc6e96fba4c37035c3121583ca9e3cd"

--- a/packages/mesh/mesh.0.8.9/descr
+++ b/packages/mesh/mesh.0.8.9/descr
@@ -1,0 +1,6 @@
+Triangular mesh generation and manipulation
+
+This is an interface to various mesh generators, in particular
+triangle. It also provides functions to optimize the numbering of mesh
+points and to export meshes and piecewise linear functions defined on
+them to TikZ, Scilab, Matlab, and Mathematica formats.

--- a/packages/mesh/mesh.0.8.9/opam
+++ b/packages/mesh/mesh.0.8.9/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+tags: [ "Mesh" "Triangulation" "PDE" ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+depends: [
+  "ocamlfind" {build & >= "1.5"}
+  "jbuilder"  {build & >="1.0+beta9"}
+  "configurator" {build}
+  "base-bigarray"
+  "base-bytes"
+  "lacaml"    {test}
+]

--- a/packages/mesh/mesh.0.8.9/url
+++ b/packages/mesh/mesh.0.8.9/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.8.9/mesh-0.8.9.tbz"
+checksum: "bdc6e96fba4c37035c3121583ca9e3cd"


### PR DESCRIPTION
This library defines a data structure for triangular meshes and provides several functions to manipulate them.  In particular, a binding to [Triangle][] is provided.  It also allows to export meshes of functions defined on their nodes to LaTeX, SciLab, Matlab, Mathematica, and Graphics.
    
[Triangle]: https://www.cs.cmu.edu/~quake/triangle.html

Changes
-------

- Split the package into `mesh`, `mesh-display`, `mesh-easymesh` and
  `mesh-triangle`.
- Port to `jbuilder` and `topkg`.