### PR TITLE
Require decompress >= 0.7 for imagelib.

### DIFF
--- a/packages/imagelib/imagelib.20171028/opam
+++ b/packages/imagelib/imagelib.20171028/opam
@@ -12,7 +12,7 @@ remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "decompress"
+  "decompress" {>= "0.7"}
 ]
 post-messages: [
   "imagelib requires convert (imagemagick) to handle format other than png and ppm."


### PR DESCRIPTION
Apparently, earlier versions of decompress have not been teste as well as 0.7, so just in case...