### PR TITLE
ocaml-uint is incompatible with OCaml 4.06 due to use of mutable string

### DIFF
--- a/packages/uint/uint.1.0.2/opam
+++ b/packages/uint/uint.1.0.2/opam
@@ -11,3 +11,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/uint/uint.1.0.3/opam
+++ b/packages/uint/uint.1.0.3/opam
@@ -11,3 +11,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/uint/uint.1.1.0/opam
+++ b/packages/uint/uint.1.1.0/opam
@@ -11,3 +11,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/uint/uint.1.1.1/opam
+++ b/packages/uint/uint.1.1.1/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/uint/uint.1.1.4/opam
+++ b/packages/uint/uint.1.1.4/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/uint/uint.1.1.5/opam
+++ b/packages/uint/uint.1.1.5/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/uint/uint.1.2.0/opam
+++ b/packages/uint/uint.1.2.0/opam
@@ -12,3 +12,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
See upstream issue+PR:
  https://github.com/andrenth/ocaml-uint/issues/14
  https://github.com/andrenth/ocaml-uint/pull/15

Note: opam-lint is going to complain on this one as the packaging
metadata is very minimal.