### PR TITLE
LablGTK 2.18.6 for OCaml 4.06

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.6/descr
+++ b/packages/lablgtk/lablgtk.2.18.6/descr
@@ -1,0 +1,1 @@
+OCaml interface to GTK+

--- a/packages/lablgtk/lablgtk.2.18.6/files/lablgldir.patch
+++ b/packages/lablgtk/lablgtk.2.18.6/files/lablgldir.patch
@@ -1,0 +1,12 @@
+diff -Naur lablgtk-2.16.0.orig/configure lablgtk-2.16.0/configure
+--- lablgtk-2.16.0.orig/configure	2012-08-23 12:37:48.000000000 +0200
++++ lablgtk-2.16.0/configure	2013-08-21 11:16:50.707187151 +0200
+@@ -4066,7 +4066,7 @@
+       cat > conftest.ml << EOF
+       open Raw
+ EOF
+-      if $CAMLC -c -I "${LABLGLDIR:=+lablGL}" conftest.ml > /dev/null 2>&1 ; then
++      if $CAMLC -c -I "$LABLGLDIR" conftest.ml > /dev/null 2>&1 ; then
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LABLGLDIR" >&5
+ $as_echo "$LABLGLDIR" >&6; }
+       else

--- a/packages/lablgtk/lablgtk.2.18.6/files/lablgtk.install
+++ b/packages/lablgtk/lablgtk.2.18.6/files/lablgtk.install
@@ -1,0 +1,5 @@
+bin: [
+  "src/lablgtk2"
+  "src/gdk_pixbuf_mlsource"
+  "?src/lablgladecc2"
+]

--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -12,7 +12,7 @@ build: [
 install: [
   [make "install"]
 ]
-available: [ocaml-version >= "3.11.0"] # as indicated in README file
+available: [ocaml-version >= "4.06"] # for new -safe-string functions
 remove: [["ocamlfind" "remove" "lablgtk2"]]
 depends: ["ocamlfind" {>= "1.2.1"}]
 depopts: [

--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://lablgtk.forge.ocamlcore.org/"
+bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=220"
+dev-repo: "https://github.com/garrigue/lablgtk.git"
+license: "LGPL with linking exception"
+build: [
+  ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
+  [make "world"]
+]
+install: [
+  [make "install"]
+]
+available: [ocaml-version >= "3.11.0"] # as indicated in README file
+remove: [["ocamlfind" "remove" "lablgtk2"]]
+depends: ["ocamlfind" {>= "1.2.1"}]
+depopts: [
+  "conf-gtksourceview"
+  "conf-gnomecanvas"
+  "conf-glade"
+  "lablgl"
+]
+depexts: [
+  [["debian"] ["libgtk2.0-dev" "libexpat1-dev"]]
+  [["ubuntu"] ["libgtk2.0-dev" "libexpat1-dev"]]
+  [["homebrew" "osx"] ["gtk" "expat"]]
+  [["centos"] ["gtk2-devel"]]
+  [["fedora"] ["gtk2-devel"]]
+  [["oraclelinux"] ["gtk2-devel"]]
+  [["alpine"] ["gtk+2.0-dev"]]
+  [["opensuse"] ["gtk2-devel"]]
+]
+patches: ["lablgldir.patch"]
+post-messages: [
+  "This package requires gtk+ 2.0 development packages installed on your system" {failure}
+  "To solve pkg-config issues, you may need to do
+'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' and retry" {failure & (os = "darwin")}
+]

--- a/packages/lablgtk/lablgtk.2.18.6/url
+++ b/packages/lablgtk/lablgtk.2.18.6/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1726/lablgtk-2.18.6.tar.gz"
+checksum: "30e9eef159eb88db0dce2438a60a6402"


### PR DESCRIPTION
This release fixes compatibility with -safe-string and ocaml 4.06.