### PR TITLE
LablTk 8.06.4 for OCaml 4.06

### DIFF
--- a/packages/labltk/labltk.8.06.4/descr
+++ b/packages/labltk/labltk.8.06.4/descr
@@ -1,0 +1,3 @@
+OCaml interface to Tcl/Tk, including OCaml library explorer OCamlBrowser
+
+For details, see https://forge.ocamlcore.org/projects/labltk/

--- a/packages/labltk/labltk.8.06.4/opam
+++ b/packages/labltk/labltk.8.06.4/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://labltk.forge.ocamlcore.org/"
+bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=343"
+dev-repo: "https://github.com/garrigue/labltk.git"
+license: "LGPL with linking exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all" "opt"]
+]
+install: [
+  [make "install"]
+]
+available: [ ocaml-version >= "4.06" ]
+remove: [["ocamlfind" "remove" "labltk"]]
+depends: ["ocamlfind" "conf-tcl" "conf-tk"]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]

--- a/packages/labltk/labltk.8.06.4/url
+++ b/packages/labltk/labltk.8.06.4/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1727/labltk-8.06.4.tar.gz"
+checksum: "48c3815461fb6d060dac9c7d574a7a4f"


### PR DESCRIPTION
New release of LablTk and OCamlBrowser for compatibility with OCaml 4.06.