### PR TITLE
Package cfstream.1.2.3

### DIFF
--- a/packages/cfstream/cfstream.1.2.3/descr
+++ b/packages/cfstream/cfstream.1.2.3/descr
@@ -1,0 +1,1 @@
+Stream operations in the style of Core's API.

--- a/packages/cfstream/cfstream.1.2.3/opam
+++ b/packages/cfstream/cfstream.1.2.3/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Ashish Agarwal <agarwal1975@gmail.com>"
+authors: [
+  "Philippe Veber <philippe.veber@gmail.com>"
+  "Ashish Agarwal <agarwal1975@gmail.com>"
+  "Drup <drupyog@zoho.com>"
+]
+homepage: "https://github.com/biocaml/cfstream"
+bug-reports: "https://github.com/biocaml/cfstream/issues"
+license: "LGPL + linking exception"
+dev-repo: "https://github.com/biocaml/cfstream.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+  "core_kernel" {>= "v0.9.0"}
+  "ounit"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/cfstream/cfstream.1.2.3/url
+++ b/packages/cfstream/cfstream.1.2.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/biocaml/cfstream/archive/1.2.3.tar.gz"
+checksum: "f324b76a5af6b612f6601a01f94449f0"


### PR DESCRIPTION
### `cfstream.1.2.3`

Stream operations in the style of Core's API.



---
* Homepage: https://github.com/biocaml/cfstream
* Source repo: https://github.com/biocaml/cfstream.git
* Bug tracker: https://github.com/biocaml/cfstream/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5