### PR TITLE
Package salsa20.0.1.0

### DIFF
--- a/packages/salsa20/salsa20.0.1.0/descr
+++ b/packages/salsa20/salsa20.0.1.0/descr
@@ -1,0 +1,31 @@
+Family of encryption functions, in pure OCaml
+
+A pure OCaml implementation of [Salsa20](http://cr.yp.to/salsa20.html) encryption function family.
+
+## Installation
+
+```
+opam install salsa20
+```
+
+## Usage
+
+```ocaml
+utop[0]> #require "nocrypto";;
+utop[1]> #require "nocrypto.unix";;
+utop[2]> Nocrypto_entropy_unix.initialize ();;
+- : unit = ()
+utop[3]> let key = Nocrypto.Rng.generate 32;;
+val key : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 32}
+utop[4]> let nonce = Cstruct.create 8;;
+val nonce : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 8}
+utop[5]> #require "salsa20";;
+utop[6]> let state = Salsa20.create key nonce;;
+val state : Salsa20.t = <abstr>
+utop[7]> Salsa20.encrypt (Cstruct.of_string "My secret text") state |> Cstruct.to_string;;
+- : string = " 2\193\020`\142\182\234\188H[R\241V"
+```
+
+* Key can either 32 (recommended) or 16 bytes
+* Salsa20 state may use a different hashing function,
+  the recommended [`Salsa20_core.salsa20_20_core`](https://abeaumont.github.io/ocaml-salsa20-core/Salsa20_core.html#VALsalsa20_20_core) is used by default.

--- a/packages/salsa20/salsa20.0.1.0/opam
+++ b/packages/salsa20/salsa20.0.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name:         "salsa20"
+homepage:     "https://github.com/abeaumont/ocaml-salsa20"
+dev-repo:     "https://github.com/abeaumont/ocaml-salsa20.git"
+bug-reports:  "https://github.com/abeaumont/ocaml-salsa20/issues"
+author:       "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+maintainer:   "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+license:      "BSD2"
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.3"}
+  "salsa20-core" {>= "0.1.0"}
+  "alcotest" {test}
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/salsa20/salsa20.0.1.0/url
+++ b/packages/salsa20/salsa20.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/abeaumont/ocaml-salsa20/archive/0.1.0.tar.gz"
+checksum: "473a7d5e6cf73e4095e5007af56c836b"


### PR DESCRIPTION
### `salsa20.0.1.0`

Family of encryption functions, in pure OCaml

A pure OCaml implementation of [Salsa20](http://cr.yp.to/salsa20.html) encryption function family.

## Installation

```
opam install salsa20
```

## Usage

```ocaml
utop[0]> #require "nocrypto";;
utop[1]> #require "nocrypto.unix";;
utop[2]> Nocrypto_entropy_unix.initialize ();;
- : unit = ()
utop[3]> let key = Nocrypto.Rng.generate 32;;
val key : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 32}
utop[4]> let nonce = Cstruct.create 8;;
val nonce : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 8}
utop[5]> #require "salsa20";;
utop[6]> let state = Salsa20.create key nonce;;
val state : Salsa20.t = <abstr>
utop[7]> Salsa20.encrypt (Cstruct.of_string "My secret text") state |> Cstruct.to_string;;
- : string = " 2\193\020`\142\182\234\188H[R\241V"
```

* Key can either 32 (recommended) or 16 bytes
* Salsa20 state may use a different hashing function,
  the recommended [`Salsa20_core.salsa20_20_core`](https://abeaumont.github.io/ocaml-salsa20-core/Salsa20_core.html#VALsalsa20_20_core) is used by default.


---
* Homepage: https://github.com/abeaumont/ocaml-salsa20
* Source repo: https://github.com/abeaumont/ocaml-salsa20.git
* Bug tracker: https://github.com/abeaumont/ocaml-salsa20/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
# 0.1.0 (2017-10-30)

* Initial release
:camel: Pull-request generated by opam-publish v0.3.5