### PR TITLE
uri: add bound on ocaml version

### DIFF
--- a/packages/uri/uri.1.1/opam
+++ b/packages/uri/uri.1.1/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+]
 tags: [
   "url"
   "uri"
@@ -18,3 +23,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.0/opam
+++ b/packages/uri/uri.1.3.0/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+]
 tags: [
   "url"
   "uri"
@@ -17,3 +22,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.1/opam
+++ b/packages/uri/uri.1.3.1/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+]
 tags: [
   "url"
   "uri"
@@ -17,3 +22,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.10/opam
+++ b/packages/uri/uri.1.3.10/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"
@@ -28,3 +29,4 @@ conflicts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-uri"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.11/opam
+++ b/packages/uri/uri.1.3.11/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"
@@ -28,3 +29,4 @@ conflicts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-uri"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.12/opam
+++ b/packages/uri/uri.1.3.12/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"
@@ -28,3 +29,4 @@ conflicts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-uri"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.13/opam
+++ b/packages/uri/uri.1.3.13/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"

--- a/packages/uri/uri.1.3.2/opam
+++ b/packages/uri/uri.1.3.2/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+]
 tags: [
   "url"
   "uri"
@@ -17,3 +22,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.3/opam
+++ b/packages/uri/uri.1.3.3/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+]
 tags: [
   "url"
   "uri"
@@ -17,3 +22,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.4/opam
+++ b/packages/uri/uri.1.3.4/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+]
 tags: [
   "url"
   "uri"
@@ -17,3 +22,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.5/opam
+++ b/packages/uri/uri.1.3.5/opam
@@ -1,5 +1,10 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+]
 tags: [
   "url"
   "uri"
@@ -18,3 +23,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-uri"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/uri/uri.1.3.6/opam
+++ b/packages/uri/uri.1.3.6/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"
@@ -27,5 +28,5 @@ conflicts: [
   "ounit" {< "1.0.2"}
 ]
 dev-repo: "git://github.com/mirage/ocaml-uri"
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/uri/uri.1.3.8/opam
+++ b/packages/uri/uri.1.3.8/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"
@@ -27,5 +28,5 @@ conflicts: [
   "ounit" {< "1.0.2"}
 ]
 dev-repo: "git://github.com/mirage/ocaml-uri"
-available: ocaml-version >= "4.0.0"
+available: [ocaml-version >= "4.0.0" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/uri/uri.1.3.9/opam
+++ b/packages/uri/uri.1.3.9/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
 maintainer: "anil@recoil.org"
 authors: [
   "Anil Madhavapeddy"
@@ -28,3 +29,4 @@ conflicts: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-uri"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
Older versions of `uri` won't work on 4.06 because of `-safe-string`.
