### PR TITLE
Package notty.0.2.0

### DIFF
--- a/packages/notty/notty.0.2.0/descr
+++ b/packages/notty/notty.0.2.0/descr
@@ -1,0 +1,5 @@
+Declaring terminals
+
+Notty is a declarative terminal library for OCaml structured around a notion
+of composable images. It tries to abstract away the basic terminal programming
+model, providing a simpler and more expressive one.

--- a/packages/notty/notty.0.2.0/opam
+++ b/packages/notty/notty.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+homepage:     "https://github.com/pqwy/notty"
+dev-repo:     "https://github.com/pqwy/notty.git"
+bug-reports:  "https://github.com/pqwy/notty/issues"
+doc:          "http://pqwy.github.io/notty/doc"
+author:       "David Kaloper <david@numm.org>"
+maintainer:   "David Kaloper <david@numm.org>"
+license:      "ISC"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+          "--with-lwt" "%{lwt:installed}%"
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build & >="0.1.0"}
+  "uchar"
+  "uucp" {>= "2.0.0"}
+  "uuseg" {>= "1.0.0"}
+  "uutf" {>= "1.0.0"}
+]
+depopts: [ "lwt" ]
+conflicts: [
+  "ocb-stubblr" {<"0.1.0"}
+  "lwt" {<"2.5.2"}
+]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/notty/notty.0.2.0/url
+++ b/packages/notty/notty.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/notty/releases/download/v0.2.0/notty-0.2.0.tbz"
+checksum: "a9805a234ac56a414aa12849ed5907d6"


### PR DESCRIPTION
### `notty.0.2.0`

Declaring terminals

Notty is a declarative terminal library for OCaml structured around a notion
of composable images. It tries to abstract away the basic terminal programming
model, providing a simpler and more expressive one.



---
* Homepage: https://github.com/pqwy/notty
* Source repo: https://github.com/pqwy/notty.git
* Bug tracker: https://github.com/pqwy/notty/issues

---


---
## v0.2.0 (2017-10-31)

* All-around speed and memory improvements.
* Draw over lines cell-by-cell instead of using erase-and-skip.
  Slower, but flicker-free drawing.
* `Term.create`: optionally inhibit synthetic TTY signals.
* Cursor origin moved from `(1, 1)` to `(0, 0)`. **breaking**
* `#key` renamed to `#special`. **breaking**
* Added `Term.fds` to get connected file descriptors.
* Added `A.equal` and `I.equal`.
* Switched over to `Uchar.t`. **breaking**
* Separated ASCII from the rest of Unicode input. **breaking**
* Added image pretty-printer `I.pp`.
* Added `notty.top` for use in the toplevel.
* Removed `I.tile`. **breaking**
* Added `I.tabulate`, generalizing `I.tile`.
* Added support for 24-bit color.
* Added `Notty_*.show_cursor` and `Notty_*.move_cursor` for manual cursor
  positioning in inline mode.
* Removed `output_image_endline`. Can be replaced by `eol`. **breaking**
* `Notty_*.output_image` lost the `~clear` parameter. Can be replaced in various
  ways by cursor positioning.
* `Notty_unix.output_image ~chan` renamed to `~fd`. **breaking**
* Added support for bracketed paste.
* More example programs.
:camel: Pull-request generated by opam-publish v0.3.5