### PR TITLE
Package odig.0.0.3

### DIFF
--- a/packages/odig/odig.0.0.3/descr
+++ b/packages/odig/odig.0.0.3/descr
@@ -1,0 +1,7 @@
+Mine installed OCaml packages
+
+odig is a library and command line tool to mine installed OCaml
+packages. It supports package distribution documentation and metadata
+lookups and generates cross-referenced API documentation.
+
+odig is distributed under the ISC license.

--- a/packages/odig/odig.0.0.3/opam
+++ b/packages/odig/odig.0.0.3/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/odig"
+doc: "http://erratique.ch/software/odig/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/odig.git"
+bug-reports: "https://github.com/dbuenzli/odig/issues"
+tags: [ "org:erratique" "build" "dev" "meta" "doc" "packaging" ]
+available: [ ocaml-version >= "4.03"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-unix"
+  "rresult" {>= "0.5.0"}
+  "asetmap"
+  "fpath"
+  "fmt"
+  "logs"
+  "bos" {>= "1.6.0"}
+  "cmdliner" {>= "1.0.0"}
+  "mtime" {>= "1.0.0"}
+  "webbrowser"
+  "opam-format"
+]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+           "--etc-dir" "%{odig:etc}%"
+           "--lib-dir" "%{lib}%" ]

--- a/packages/odig/odig.0.0.3/url
+++ b/packages/odig/odig.0.0.3/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/odig/releases/odig-0.0.3.tbz"
+checksum: "74232d175582fa504215b77190b7f921"


### PR DESCRIPTION
### `odig.0.0.3`

Mine installed OCaml packages

odig is a library and command line tool to mine installed OCaml
packages. It supports package distribution documentation and metadata
lookups and generates cross-referenced API documentation.

odig is distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/odig
* Source repo: http://erratique.ch/repos/odig.git
* Bug tracker: https://github.com/dbuenzli/odig/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them: "odig"

---


---
v0.0.3 2017-10-31 Zagreb
------------------------

- Fix obscure build bug on 4.06.0 (#32)
:camel: Pull-request generated by opam-publish v0.3.5