### PR TITLE
added a cppo_ocamlbuild dependency to utop

### DIFF
--- a/packages/utop/utop.1.16/opam
+++ b/packages/utop/utop.1.16/opam
@@ -25,6 +25,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.17/opam
+++ b/packages/utop/utop.1.17/opam
@@ -27,6 +27,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.18.1/opam
+++ b/packages/utop/utop.1.18.1/opam
@@ -27,6 +27,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.18.2/opam
+++ b/packages/utop/utop.1.18.2/opam
@@ -27,8 +27,9 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"
 ]
-available: [ ocaml-version >= "4.01" ]
+available: [ ocaml-version >= "4.01"  & ocaml-version <= "4.03" ]

--- a/packages/utop/utop.1.18/opam
+++ b/packages/utop/utop.1.18/opam
@@ -27,6 +27,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.19.1/opam
+++ b/packages/utop/utop.1.19.1/opam
@@ -28,6 +28,7 @@ depends: [
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
   "ppx_tools" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.19.2/opam
+++ b/packages/utop/utop.1.19.2/opam
@@ -30,6 +30,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.19.3/opam
+++ b/packages/utop/utop.1.19.3/opam
@@ -29,6 +29,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"

--- a/packages/utop/utop.1.19/opam
+++ b/packages/utop/utop.1.19/opam
@@ -28,6 +28,7 @@ depends: [
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
   "ppx_tools" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [
   "camlp4"


### PR DESCRIPTION
added a `cppo_ocamlbuild` dependency to `utop` versions from
`utop.1.16` to `utop.1.19.3`, as it was suggested after last `cppo` update: https://github.com/ocaml/opam-repository/pull/10047