### PR TITLE
cry.0.6.1

### DIFF
--- a/packages/cry/cry.0.6.1/descr
+++ b/packages/cry/cry.0.6.1/descr
@@ -1,0 +1,1 @@
+The cry library is an implementation of the shout protocol to connect to audio diffusion servers such as icecast

--- a/packages/cry/cry.0.6.1/opam
+++ b/packages/cry/cry.0.6.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-cry"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "cry"]
+conflicts: ["liquidsoap" {<= "1.2.1"}]
+depends: ["ocamlfind"]
+depopts: ["ssl" "osx-secure-transport"]
+bug-reports: "https://github.com/savonet/ocaml-cry/issues"
+dev-repo: "https://github.com/savonet/ocaml-cry.git"

--- a/packages/cry/cry.0.6.1/url
+++ b/packages/cry/cry.0.6.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/savonet/ocaml-cry/releases/download/0.6.1/ocaml-cry-0.6.1.tar.gz"
+checksum: "049153e5e4cb97bcc864095075ad2c06"


### PR DESCRIPTION
Cry 0.6.0 has a rather important bug when resolving hostnames. This release ships a fix for it.