### PR TITLE
Package jbuilder.1.0+beta15

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta15/url
+++ b/packages/jbuilder/jbuilder.1.0+beta15/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/jbuilder/archive/1.0+beta15.tar.gz"
-checksum: "0f08358c0a7a178955edc41cc1288c20"
+archive: "https://github.com/janestreet/jbuilder/releases/download/1.0+beta15/jbuilder-1.0.beta15.tbz"
+checksum: "bbf69b88ba3786d5a2bba2288737d4dd"


### PR DESCRIPTION
### `jbuilder.1.0+beta15`

Fast, portable and opinionated build system

jbuilder is a build system that was designed to simplify the release
of Jane Street packages. It reads metadata from "jbuild" files
following a very simple s-expression syntax.

jbuilder is fast, it has very low-overhead and support parallel builds
on all platforms. It has no system dependencies, all you need to build
jbuilder and packages using jbuilder is OCaml. You don't need or make
or bash as long as the packages themselves don't use bash explicitely.

jbuilder supports multi-package development by simply dropping multiple
repositories into the same directory.

It also supports multi-context builds, such as building against
several opam roots/switches simultaneously. This helps maintaining
packages across several versions of OCaml and gives cross-compilation
for free.



---
* Homepage: https://github.com/janestreet/jbuilder
* Source repo: https://github.com/janestreet/jbuilder.git
* Bug tracker: https://github.com/janestreet/jbuilder/issues

---


---
1.0+beta15 (04/11/2017)
-----------------------

- Change the semantic of aliases: there are no longer aliases that are
  recursive such as `install` or `runtest`. All aliases are
  non-recursive. However, when requesting an alias from the command
  line, this request the construction of the alias in the specified
  directory and all its children recursively. This allows users to get
  the same behavior as previous recursive aliases for their own
  aliases, such as `example`. Inside jbuild files, one can use `(deps
  (... (alias_rec xxx) ...))` to get the same behavior as on the
  command line. (#268)

- Include sub libraries that have a `.` in the generated documentation index
  (#280).

- Fix "up" links to the top-level index in the odoc generated documentation
  (#282).

- Fix `ARCH_SIXTYFOUR` detection for OCaml 4.06.0 (#303)
:camel: Pull-request generated by opam-publish v0.3.5