### PR TITLE
Package gen.0.5

### DIFF
--- a/packages/gen/gen.0.5/descr
+++ b/packages/gen/gen.0.5/descr
@@ -1,0 +1,4 @@
+Simple and efficient iterators (modules Gen and GenLabels).
+
+Now provides additional modules GenClone and GenMList for lower-level control
+over persistency and duplication of iterators.

--- a/packages/gen/gen.0.5/opam
+++ b/packages/gen/gen.0.5/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/gen/"
+bug-reports: "https://github.com/c-cube/gen/issues"
+doc: "http://cedeela.fr/~simon/software/gen/"
+tags: ["gen" "iterator" "iter" "fold"]
+dev-repo: "https://github.com/c-cube/gen.git"
+build: [
+  ["./configure" "--disable-docs" "--disable-tests" "--disable-bench"]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "gen"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/gen/gen.0.5/url
+++ b/packages/gen/gen.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/gen/archive/0.5.tar.gz"
+checksum: "521a106f9d200ca71635fa5887535436"


### PR DESCRIPTION
### `gen.0.5`

Simple and efficient iterators (modules Gen and GenLabels).

Now provides additional modules GenClone and GenMList for lower-level control
over persistency and duplication of iterators.



---
* Homepage: https://github.com/c-cube/gen/
* Source repo: https://github.com/c-cube/gen.git
* Bug tracker: https://github.com/c-cube/gen/issues

---

:camel: Pull-request generated by opam-publish v0.3.5