### PR TITLE
Package touist.3.4.1

### DIFF
--- a/packages/touist/touist.3.4.1/descr
+++ b/packages/touist/touist.3.4.1/descr
@@ -1,0 +1,13 @@
+The solver for the Touist language
+
+The Touist language is a friendly language for writing propositional
+logic (SAT), logic on real and integers (SMT) and quantified boolean
+formulas (QBF). This language aims to formalize real-life problems
+(e.g., the sudoku can be solved in a few lines). Touist embeds a SAT
+solver (minisat) and can be built with optionnal SMT and QBF solvers.
+Touist is also able to generate the latex, DIMACS, SMT-LIB and QDIMACS
+formats from a touist file.
+
+Optionnal solvers:
+- for using Yices2 (--smt --solve), run `opam install yices2`
+- for using Quantor (--qbf --solve), run `opam install qbf`

--- a/packages/touist/touist.3.4.1/opam
+++ b/packages/touist/touist.3.4.1/opam
@@ -1,0 +1,59 @@
+opam-version: "1.2"
+maintainer: "Maël Valais <mael.valais@gmail.com>"
+authors: ["Maël Valais <mael.valais@gmail.com>" "Olivier Lezaud"]
+homepage: "https://www.irit.fr/touist"
+bug-reports: "https://github.com/touist/touist/issues"
+license: "MIT"
+dev-repo: "https://github.com/touist/touist.git"
+build: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--prefix"
+    prefix
+    "--%{yices2:enable}%-yices2"
+    "--%{qbf:enable}%-qbf"
+  ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--enable-tests"
+    "--%{yices2:enable}%-yices2"
+    "--%{qbf:enable}%-qbf"
+  ]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: [
+  "ocaml" "%{etc}%/touist/setup.ml" "-C" "%{etc}%/touist" "-uninstall"
+]
+depends: [
+  ("cppo_ocamlbuild" {build & >= "1.6.0"} |
+   "cppo" {build & >= "0.9.4" & <= "1.5.0"})
+  "menhir" {>= "20151023"}
+  "minisat" {build}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {test}
+]
+depopts: ["qbf" "yices2"]
+conflicts: [
+  "qbf" {< "0.1"}
+  "yices2" {< "0.0.2"}
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages: [
+  "To install more solvers, see 'opam info touist'" {success}
+  "Built without yices2 (SMT solver)" {success & !yices2:installed}
+  "Built without qbf (QBF solver)" {success & !qbf:installed}
+  "Built with yices2 (SMT solver). See 'opam info touist' for license."
+    {success & yices2:installed}
+  "Built with qbf (QBF solver)" {success & qbf:installed}
+]

--- a/packages/touist/touist.3.4.1/url
+++ b/packages/touist/touist.3.4.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/touist/touist/archive/v3.4.1.tar.gz"
+checksum: "7be1923c383605cc48c3fbe0a4ab3593"


### PR DESCRIPTION
### `touist.3.4.1`

The solver for the Touist language

The Touist language is a friendly language for writing propositional
logic (SAT), logic on real and integers (SMT) and quantified boolean
formulas (QBF). This language aims to formalize real-life problems
(e.g., the sudoku can be solved in a few lines). Touist embeds a SAT
solver (minisat) and can be built with optionnal SMT and QBF solvers.
Touist is also able to generate the latex, DIMACS, SMT-LIB and QDIMACS
formats from a touist file.

Optionnal solvers:
- for using Yices2 (--smt --solve), run `opam install yices2`
- for using Quantor (--qbf --solve), run `opam install qbf`



---
* Homepage: https://www.irit.fr/touist
* Source repo: https://github.com/touist/touist.git
* Bug tracker: https://github.com/touist/touist/issues

---

:camel: Pull-request generated by opam-publish v0.3.5