### PR TITLE
mstruct: add upper bounds on OCaml

### DIFF
--- a/packages/mstruct/mstruct.1.0.0/opam
+++ b/packages/mstruct/mstruct.1.0.0/opam
@@ -17,3 +17,5 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/mstruct/mstruct.1.0.0/opam
+++ b/packages/mstruct/mstruct.1.0.0/opam
@@ -2,6 +2,9 @@ opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 authors: [ "Thomas Gazagnaire" ]
 license: "ISC"
+homepage:     "https://github.com/mirage/ocaml-mstruct"
+dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -15,7 +18,6 @@ depends: [
   "cstruct" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
 available: [ocaml-version < "4.06.0"]
 

--- a/packages/mstruct/mstruct.1.1.0/opam
+++ b/packages/mstruct/mstruct.1.1.0/opam
@@ -17,3 +17,5 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/mstruct/mstruct.1.1.0/opam
+++ b/packages/mstruct/mstruct.1.1.0/opam
@@ -2,6 +2,9 @@ opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 authors: [ "Thomas Gazagnaire" ]
 license: "ISC"
+homepage:     "https://github.com/mirage/ocaml-mstruct"
+dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -15,7 +18,6 @@ depends: [
   "cstruct" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
 available: [ocaml-version < "4.06.0"]
 

--- a/packages/mstruct/mstruct.1.2.0/opam
+++ b/packages/mstruct/mstruct.1.2.0/opam
@@ -17,3 +17,5 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/mstruct/mstruct.1.2.0/opam
+++ b/packages/mstruct/mstruct.1.2.0/opam
@@ -2,6 +2,9 @@ opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 authors: [ "Thomas Gazagnaire" ]
 license: "ISC"
+homepage:     "https://github.com/mirage/ocaml-mstruct"
+dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -15,7 +18,6 @@ depends: [
   "cstruct" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
 available: [ocaml-version < "4.06.0"]
 

--- a/packages/mstruct/mstruct.1.3.0/opam
+++ b/packages/mstruct/mstruct.1.3.0/opam
@@ -17,3 +17,5 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/mstruct/mstruct.1.3.0/opam
+++ b/packages/mstruct/mstruct.1.3.0/opam
@@ -2,6 +2,9 @@ opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 authors: [ "Thomas Gazagnaire" ]
 license: "ISC"
+homepage:     "https://github.com/mirage/ocaml-mstruct"
+dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -15,7 +18,6 @@ depends: [
   "cstruct" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
 available: [ocaml-version < "4.06.0"]
 

--- a/packages/mstruct/mstruct.1.3.1/opam
+++ b/packages/mstruct/mstruct.1.3.1/opam
@@ -2,6 +2,9 @@ opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 authors: [ "Thomas Gazagnaire" ]
 license: "ISC"
+homepage:     "https://github.com/mirage/ocaml-mstruct"
+dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -15,7 +18,6 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
 available: [ocaml-version < "4.06.0"]
 

--- a/packages/mstruct/mstruct.1.3.1/opam
+++ b/packages/mstruct/mstruct.1.3.1/opam
@@ -17,3 +17,5 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-mstruct"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/mstruct/mstruct.1.3.2/opam
+++ b/packages/mstruct/mstruct.1.3.2/opam
@@ -19,3 +19,4 @@ depends: [
 patches: [
   "build_with_trunk.patch"
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/mstruct/mstruct.1.3.3/opam
+++ b/packages/mstruct/mstruct.1.3.3/opam
@@ -11,3 +11,4 @@ depends: [
   "jbuilder" {>="1.0+beta7"}
   "cstruct" {>= "1.4.0"}
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/mstruct/mstruct.1.3.4/opam
+++ b/packages/mstruct/mstruct.1.3.4/opam
@@ -16,3 +16,4 @@ depends: [
   "jbuilder" {build & >="1.0+beta9"}
   "cstruct" {>= "2.4.0"}
 ]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
These don't build with OCaml 4.06 with -safe-string

See #10606 for `mstruct.1.4.0` which is -safe-string safe