### PR TITLE
io-page: add upper bounds on the OCaml version

### DIFF
--- a/packages/io-page/io-page.1.0.0/opam
+++ b/packages/io-page/io-page.1.0.0/opam
@@ -18,3 +18,5 @@ depends: [
 conflicts: ["io-page-xen" "io-page-unix"]
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/io-page/io-page.1.1.0/opam
+++ b/packages/io-page/io-page.1.1.0/opam
@@ -1,5 +1,14 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+homepage:     "https://github.com/mirage/io-page"
+dev-repo:     "https://github.com/mirage/io-page.git"
+bug-reports:  "https://github.com/mirage/io-page/issues"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy"
+  "Dave Scott"
+  "Thomas Gazagnaire"
+]
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -15,7 +24,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
-dev-repo: "git://github.com/mirage/io-page"
 install: [make "install"]
 available: [ocaml-version < "4.06.0"]
 

--- a/packages/io-page/io-page.1.1.0/opam
+++ b/packages/io-page/io-page.1.1.0/opam
@@ -17,3 +17,5 @@ depends: [
 conflicts: ["io-page-xen" "io-page-unix"]
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/io-page/io-page.1.1.1/opam
+++ b/packages/io-page/io-page.1.1.1/opam
@@ -1,5 +1,14 @@
 opam-version: "1.2"
 maintainer: "anil@recoil.org"
+homepage:     "https://github.com/mirage/io-page"
+dev-repo:     "https://github.com/mirage/io-page.git"
+bug-reports:  "https://github.com/mirage/io-page/issues"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy"
+  "Dave Scott"
+  "Thomas Gazagnaire"
+]
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -15,7 +24,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
-dev-repo: "git://github.com/mirage/io-page"
 install: [make "install"]
 available: [ ocaml-version < "4.06.0"]
 

--- a/packages/io-page/io-page.1.1.1/opam
+++ b/packages/io-page/io-page.1.1.1/opam
@@ -17,3 +17,5 @@ depends: [
 conflicts: ["io-page-xen" "io-page-unix"]
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0"]
+

--- a/packages/io-page/io-page.1.2.0/opam
+++ b/packages/io-page/io-page.1.2.0/opam
@@ -22,5 +22,5 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 conflicts: ["io-page-xen" "io-page-unix"]

--- a/packages/io-page/io-page.1.3.0/opam
+++ b/packages/io-page/io-page.1.3.0/opam
@@ -21,5 +21,5 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 conflicts: ["io-page-xen" "io-page-unix"]

--- a/packages/io-page/io-page.1.4.0/opam
+++ b/packages/io-page/io-page.1.4.0/opam
@@ -21,5 +21,5 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 conflicts: ["io-page-xen" "io-page-unix"]

--- a/packages/io-page/io-page.1.5.0/opam
+++ b/packages/io-page/io-page.1.5.0/opam
@@ -21,5 +21,5 @@ depends: [
   "ounit" {test}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 conflicts: ["io-page-xen" "io-page-unix"]

--- a/packages/io-page/io-page.1.5.1/opam
+++ b/packages/io-page/io-page.1.5.1/opam
@@ -26,4 +26,4 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/io-page/io-page.1.6.0/opam
+++ b/packages/io-page/io-page.1.6.0/opam
@@ -26,4 +26,4 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/io-page/io-page.1.6.1/opam
+++ b/packages/io-page/io-page.1.6.1/opam
@@ -26,4 +26,4 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/io-page/io-page.2.0.0/opam
+++ b/packages/io-page/io-page.2.0.0/opam
@@ -20,4 +20,4 @@ depends: [
   "configurator" {build}
   "cstruct" {>= "2.0.0"}
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
These fail to build with OCaml 4.06 by default with -safe-string.

The OCaml 4.06 fixed version is `io-page.2.0.1` in #10605 