### PR TITLE
hex: add upper bound on the OCaml version

### DIFF
--- a/packages/hex/hex.0.1.0/opam
+++ b/packages/hex/hex.0.1.0/opam
@@ -1,12 +1,15 @@
 opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Trevor Summers Smith"]
+homepage:     "https://github.com/mirage/ocaml-hex"
+bug-reports:  "https://github.com/mirage/ocaml-hex/issues"
+dev-repo:     "https://github.com/mirage/ocaml-hex.git"
 build: make
 remove: ["ocamlfind" "remove" "hex"]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/mirage/ocaml-hex"
 install: [make "install"]
 available: [ocaml-version < "4.06.0"]
 

--- a/packages/hex/hex.0.1.0/opam
+++ b/packages/hex/hex.0.1.0/opam
@@ -8,3 +8,5 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-hex"
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/hex/hex.0.2.0/opam
+++ b/packages/hex/hex.0.2.0/opam
@@ -17,4 +17,4 @@ depends: [
   "cstruct" {>= "1.5.0"}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/hex/hex.0.2.0/opam
+++ b/packages/hex/hex.0.2.0/opam
@@ -17,3 +17,4 @@ depends: [
   "cstruct" {>= "1.5.0"}
   "ocamlbuild" {build}
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/hex/hex.1.0.0/opam
+++ b/packages/hex/hex.1.0.0/opam
@@ -21,3 +21,4 @@ depends: [
   "cstruct" {>= "1.7.0"}
   "ocamlbuild" {build}
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/hex/hex.1.1.0/opam
+++ b/packages/hex/hex.1.1.0/opam
@@ -11,3 +11,5 @@ depends: [
   "jbuilder" {build & >="1.0+beta8"}
   "cstruct" {>= "1.7.0"}
 ]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/hex/hex.1.1.1/opam
+++ b/packages/hex/hex.1.1.1/opam
@@ -14,3 +14,5 @@ depends: [
   "jbuilder" {build & >="1.0+beta8"}
   "cstruct" {>= "1.7.0"}
 ]
+available: [ocaml-version < "4.06.0"]
+


### PR DESCRIPTION
These old versions don't build with OCaml 4.06 with -safe-string.

The fixed version is in `hex.1.2.0` in #10603
