### PR TITLE
uri: add upper-bound on OCaml 4.06

### DIFF
--- a/packages/uri/uri.1.9.4/opam
+++ b/packages/uri/uri.1.9.4/opam
@@ -30,4 +30,4 @@ depends: [
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
The previous versions are already uninstallable, either by direct
constraint or transitively via ppx_deriving.

Point release with the build fix is in #10610 