### PR TITLE
mirage-{net,protocols}-lwt: add lower bound on ipaddr

### DIFF
--- a/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/opam
@@ -18,5 +18,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg"      {build & >= "0.8.0"}
   "mirage-net" {>= "1.0.0"}
-  "lwt" "ipaddr" "cstruct" "io-page"
+  "lwt"
+  "ipaddr" {>= "1.0.0"}
+  "cstruct" "io-page"
 ]

--- a/packages/mirage-net-lwt/mirage-net-lwt.1.1.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.1.1.0/opam
@@ -19,5 +19,7 @@ depends: [
   "jbuilder" {build & >="1.0+beta7"}
   "topkg"    {build & >= "0.8.0"}
   "mirage-net" {>= "1.0.0"}
-  "lwt" "ipaddr" "cstruct" "io-page" "result"
+  "lwt"
+  "ipaddr" {>= "1.0.0"}
+  "cstruct" "io-page" "result"
 ]

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
   "mirage-protocols" {= "1.0.0"}
-  "ipaddr"
+  "ipaddr" {>= "1.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.1.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
   "mirage-protocols" { = "1.1.0" }
-  "ipaddr"
+  "ipaddr" {>= "1.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.2.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta9" }
   "mirage-protocols" { >= "1.1.0" }
-  "ipaddr"
+  "ipaddr" {>= "1.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]


### PR DESCRIPTION
The type `Macaddr.t` was introduced in `ipaddr.0.2.0`. This should
fix the build failure seen here:

https://travis-ci.org/mirage/ocaml-tar/builds/297632212

Signed-off-by: David Scott <dave@recoil.org>