### PR TITLE
Package notty.0.2.1

### DIFF
--- a/packages/notty/notty.0.2.1/descr
+++ b/packages/notty/notty.0.2.1/descr
@@ -1,0 +1,5 @@
+Declaring terminals.
+
+Notty is a declarative terminal library for OCaml structured around a notion
+of composable images. It tries to abstract away the basic terminal programming
+model, providing a simpler and a more expressive one.

--- a/packages/notty/notty.0.2.1/opam
+++ b/packages/notty/notty.0.2.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+homepage:     "https://github.com/pqwy/notty"
+dev-repo:     "https://github.com/pqwy/notty.git"
+bug-reports:  "https://github.com/pqwy/notty/issues"
+doc:          "http://pqwy.github.io/notty/doc"
+author:       "David Kaloper <david@numm.org>"
+maintainer:   "David Kaloper <david@numm.org>"
+license:      "ISC"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+          "--with-lwt" "%{lwt:installed}%"
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build & >="0.1.0"}
+  "uchar"
+  "uucp" {>= "2.0.0"}
+  "uuseg" {>= "1.0.0"}
+  "uutf" {>= "1.0.0"}
+]
+depopts: [ "lwt" ]
+conflicts: [
+  "ocb-stubblr" {<"0.1.0"}
+  "lwt" {<"2.5.2"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/notty/notty.0.2.1/url
+++ b/packages/notty/notty.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/pqwy/notty/releases/download/v0.2.1/notty-0.2.1.tbz"
+checksum: "f85f6d0099483230b2b60335ab4496d1"


### PR DESCRIPTION
### `notty.0.2.1`

Declaring terminals.

Notty is a declarative terminal library for OCaml structured around a notion
of composable images. It tries to abstract away the basic terminal programming
model, providing a simpler and a more expressive one.



---
* Homepage: https://github.com/pqwy/notty
* Source repo: https://github.com/pqwy/notty.git
* Bug tracker: https://github.com/pqwy/notty/issues

---


---
## v0.2.1 (2017-11-06)

* OCaml 4.06 compatible.
* Cache the internal representation of Unicode strings.
* Remove `I.ichar`. **breaking**
:camel: Pull-request generated by opam-publish v0.3.5