### PR TITLE
Package zed.1.6

### DIFF
--- a/packages/zed/zed.1.6/descr
+++ b/packages/zed/zed.1.6/descr
@@ -1,0 +1,9 @@
+Abstract engine for text edition in OCaml
+
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities.

--- a/packages/zed/zed.1.6/opam
+++ b/packages/zed/zed.1.6/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/zed"
+bug-reports: "https://github.com/diml/zed/issues"
+dev-repo: "git://github.com/diml/zed.git"
+license: "BSD3"
+depends: [
+  "jbuilder" {build & >= "1.0+beta9"}
+  "base-bytes"
+  "camomile" {>= "0.8"}
+  "react"
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/zed/zed.1.6/url
+++ b/packages/zed/zed.1.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/zed/releases/download/1.6/zed-1.6.tbz"
+checksum: "f75c3094af1a22f9801d5ca5eb2d40e0"


### PR DESCRIPTION
### `zed.1.6`

Abstract engine for text edition in OCaml

Zed is an abstract engine for text edition. It can be used to write text
editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
Unicode specification, and implements an UTF-8 encoded string type with
validation, and a rope datastructure to achieve efficient operations on large
Unicode buffers. Zed also features a regular expression search on ropes. To
support efficient text edition capabilities, Zed provides macro recording and
cursor management facilities.



---
* Homepage: https://github.com/diml/zed
* Source repo: git://github.com/diml/zed.git
* Bug tracker: https://github.com/diml/zed/issues

---


---
1.6 (2017-11-05)
----------------

* safe-string compatibility (#8)
:camel: Pull-request generated by opam-publish v0.3.5