### PR TITLE
Package lambda-term.1.12.0

### DIFF
--- a/packages/lambda-term/lambda-term.1.12.0/descr
+++ b/packages/lambda-term/lambda-term.1.12.0/descr
@@ -1,0 +1,9 @@
+Terminal manipulation library for OCaml
+
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications.

--- a/packages/lambda-term/lambda-term.1.12.0/opam
+++ b/packages/lambda-term/lambda-term.1.12.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/lambda-term"
+bug-reports: "https://github.com/diml/lambda-term/issues"
+dev-repo: "git://github.com/diml/lambda-term.git"
+license: "BSD3"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "lwt"   {>= "2.7.0"}
+  "react"
+  "zed"   {>= "1.2"}
+  "camomile"
+  "lwt_react"
+  "jbuilder" {build & >= "1.0+beta9"}
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/lambda-term/lambda-term.1.12.0/url
+++ b/packages/lambda-term/lambda-term.1.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/lambda-term/releases/download/1.12.0/lambda-term-1.12.0.tbz"
+checksum: "5eaf97fc02e89d29a5f9e58d074e9a6a"


### PR DESCRIPTION
### `lambda-term.1.12.0`

Terminal manipulation library for OCaml

Lambda-term is a cross-platform library for manipulating the terminal. It
provides an abstraction for keys, mouse events, colors, as well as a set of
widgets to write curses-like applications. The main objective of lambda-term is
to provide a higher level functional interface to terminal manipulation than,
for example, ncurses, by providing a native OCaml interface instead of bindings
to a C library. Lambda-term integrates with zed to provide text edition
facilities in console applications.



---
* Homepage: https://github.com/diml/lambda-term
* Source repo: git://github.com/diml/lambda-term.git
* Bug tracker: https://github.com/diml/lambda-term/issues

---


---
1.12 (2017-11-05)
-----------

* Fix: copy & pasting the terminal output doesn't adds many spaces
  after the end of lines (#52, Deokhwan Kim, fixes diml/utop#186)
  
* -safe-string compatibility (#54)
:camel: Pull-request generated by opam-publish v0.3.5