### PR TITLE
Fixed version number

### DIFF
--- a/packages/amqp-client/amqp-client.1.1.2/opam
+++ b/packages/amqp-client/amqp-client.1.1.2/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/andersfugmann/amqp-client"
 bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
 dev-repo: "https://github.com/andersfugmann/amqp-client.git"
 license: "BSD3"
-version: "1.1.1"
+version: "1.1.2"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 install: [jbuilder install]


### PR DESCRIPTION
The version field was 1.1.1 rather than 1.1.2.

To see the error:
```
$ opam update --debug
...
[ERROR] At
        ~/.opam/repo/default/packages/amqp-client/amqp-client.1.1.2/opam:8:15:
          Unexpected version 1.1.1
...
```