### PR TITLE
apron: disable latest releases on Linux as their builds do not terminate

### DIFF
--- a/packages/apron/apron.20150820/opam
+++ b/packages/apron/apron.20150820/opam
@@ -25,6 +25,7 @@ depends: [
   "ocamlfind"
   "camlidl"
   "mlgmpidl"
+  "conf-perl"
 ]
 depopts: [
   "conf-ppl"
@@ -32,3 +33,4 @@ depopts: [
 available: [
   opam-version >= "1.2"
 ]
+available: [ os != "linux" ] # build does not terminate on alpine/debian

--- a/packages/apron/apron.20151015/opam
+++ b/packages/apron/apron.20151015/opam
@@ -28,3 +28,4 @@ depends: [
 depopts: [
   "conf-ppl"
 ]
+available: [ os != "linux" ] # build does not terminate on alpine/debian

--- a/packages/apron/apron.20160108/opam
+++ b/packages/apron/apron.20160108/opam
@@ -25,7 +25,9 @@ depends: [
   "camlidl"
   "mlgmpidl"
   "ocamlbuild" {build}
+  "conf-perl"
 ]
 depopts: [
   "conf-ppl"
 ]
+available: [ os != "linux" ] # build does not terminate on alpine/debian

--- a/packages/apron/apron.20160125/opam
+++ b/packages/apron/apron.20160125/opam
@@ -31,3 +31,4 @@ depends: [
 depopts: [
   "conf-ppl"
 ]
+available: [ os != "linux" ] # build does not terminate on alpine/debian


### PR DESCRIPTION
there appears to be a looping issue with a dependency phase that
causes CI servers to clog up with apron builds. It works fine with
manual testing on OSX, but Alpine/Debian all exhibit this nontermination
failure.  This PR disables it until the root issue can be identified.

cc @nberth 