### PR TITLE
Package datalog.0.5.2

### DIFF
--- a/packages/datalog/datalog.0.5.2/descr
+++ b/packages/datalog/datalog.0.5.2/descr
@@ -1,0 +1,9 @@
+An in-memory datalog implementation for OCaml.
+
+It features two main algorithm:
+- bottom-up focuses on big sets of rules with small relations, with frequent
+  updates of the relations. Therefore, it tries to achieve good behavior in
+  presence of incremental modifications of the relations.
+- top-down resembles prolog (and allows nested subterms). It handles
+  stratified negation and only explores the part of the search space that
+  is relevant to a given query.

--- a/packages/datalog/datalog.0.5.2/opam
+++ b/packages/datalog/datalog.0.5.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes@inria.fr>"
+homepage: "https://github.com/c-cube/datalog"
+bug-reports: "https://github.com/c-cube/datalog/issues"
+license: "BSD-2-Clause"
+doc: "http://cedeela.fr/~simon/software/datalog/index.html"
+tags: ["datalog" "relational" "query" "prolog"]
+dev-repo: "git://github.com/c-cube/datalog"
+build: ["./configure" "--bindir" bin "--docdir" "%{doc}%/datalog/"]
+install: [
+  [make "all" "install_file" "doc" "man"]
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "datalog"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "num"
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/datalog/datalog.0.5.2/url
+++ b/packages/datalog/datalog.0.5.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/datalog/archive/0.5.2.tar.gz"
+checksum: "d3165be0b6946d860904b708cc44bcde"


### PR DESCRIPTION
### `datalog.0.5.2`

An in-memory datalog implementation for OCaml.

It features two main algorithm:
- bottom-up focuses on big sets of rules with small relations, with frequent
  updates of the relations. Therefore, it tries to achieve good behavior in
  presence of incremental modifications of the relations.
- top-down resembles prolog (and allows nested subterms). It handles
  stratified negation and only explores the part of the search space that
  is relevant to a given query.



---
* Homepage: https://github.com/c-cube/datalog
* Source repo: git://github.com/c-cube/datalog
* Bug tracker: https://github.com/c-cube/datalog/issues

---

:camel: Pull-request generated by opam-publish v0.3.5