### PR TITLE
Add webdav.1.1.5

### DIFF
--- a/packages/webdav/webdav.1.1.5/descr
+++ b/packages/webdav/webdav.1.1.5/descr
@@ -1,0 +1,6 @@
+Implements the client side of the WebDAV protocol (RFC 4918)
+The file locking part of WebDAV is omitted, though.
+The library uses Ocamlnet's [netclient] library for client-side HTTP,
+and extends it by providing the required access methods for
+WebDAV. Additionally, there is also an implementation for Ocamlnet's
+Netfs.stream_fs abstraction modelling a simple file system.

--- a/packages/webdav/webdav.1.1.5/opam
+++ b/packages/webdav/webdav.1.1.5/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+license: "BSD (3-clause)"
+maintainer: "Jacques-Pascal Deplaix <jp.deplaix@gmail.com>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/webdav.html"
+dev-repo: "https://gitlab.camlcity.org/gerd/lib-webdav.git"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-webdav/issues"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "webdav"]
+depends: [
+  "ocamlfind" {build}
+  "omake" {build}
+  "ocamlnet" {>= "4.1.0"}
+  "pxp" {>= "1.2.8"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/webdav/webdav.1.1.5/url
+++ b/packages/webdav/webdav.1.1.5/url
@@ -1,0 +1,2 @@
+archive: "http://download.camlcity.org/download/webdav-1.1.5.tar.gz"
+checksum: "7a00bd5934d83ec227ec39d558e8d38e"


### PR DESCRIPTION
The latest version available on opam was 1.1 (released in 2011) and required OCaml < 4.01 and ocamlnet < 3.5.1.