### PR TITLE
Package ANSITerminal.0.8

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8/descr
+++ b/packages/ANSITerminal/ANSITerminal.0.8/descr
@@ -1,0 +1,5 @@
+Basic control of ANSI compliant terminals and the windows shell
+
+ANSITerminal is a module allowing to use the colors and cursor
+movements on ANSI terminals. It also works on the windows shell (but
+this part is currently work in progress).

--- a/packages/ANSITerminal/ANSITerminal.0.8/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler"
+           "Vincent Hugot" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ANSITerminal"
+dev-repo: "https://github.com/Chris00/ANSITerminal.git"
+bug-reports: "https://github.com/Chris00/ANSITerminal/issues"
+doc: "https://Chris00.github.io/ANSITerminal/doc"
+tags: [ "terminal"  ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+]

--- a/packages/ANSITerminal/ANSITerminal.0.8/url
+++ b/packages/ANSITerminal/ANSITerminal.0.8/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ANSITerminal/releases/download/0.8/ANSITerminal-0.8.tbz"
+checksum: "b3fc33f17823e85c86a4d9cf4498c40e"


### PR DESCRIPTION
### `ANSITerminal.0.8`

Basic control of ANSI compliant terminals and the windows shell

ANSITerminal is a module allowing to use the colors and cursor
movements on ANSI terminals. It also works on the windows shell (but
this part is currently work in progress).



---
* Homepage: https://github.com/Chris00/ANSITerminal
* Source repo: https://github.com/Chris00/ANSITerminal.git
* Bug tracker: https://github.com/Chris00/ANSITerminal/issues

---


---
0.8 — 2017-11-08
----------------

- Only use escape sequences or Windows calls when the stdout or stderr
  is a TTY. (issue #1).
- Port to jbuilder
:camel: Pull-request generated by opam-publish v0.3.5