### PR TITLE
Package lacaml.10.0.2

### DIFF
--- a/packages/lacaml/lacaml.10.0.2/descr
+++ b/packages/lacaml/lacaml.10.0.2/descr
@@ -1,0 +1,5 @@
+Lacaml - OCaml-bindings to BLAS and LAPACK
+
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices.

--- a/packages/lacaml/lacaml.10.0.2/opam
+++ b/packages/lacaml/lacaml.10.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "http://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+dev-repo: "https://github.com/mmottl/lacaml.git"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+tags: [ "clib:lapack" "clib:blas" ]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta13"}
+  "base-bytes"
+  "base-bigarray"
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/lacaml/lacaml.10.0.2/url
+++ b/packages/lacaml/lacaml.10.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/lacaml/releases/download/10.0.2/lacaml-10.0.2.tbz"
+checksum: "8cd88ef10f1b014e85a9f89d89b4a35a"


### PR DESCRIPTION
### `lacaml.10.0.2`

Lacaml - OCaml-bindings to BLAS and LAPACK

Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
LAPACK-library (Linear Algebra routines).  It also contains many additional
convenience functions for vectors and matrices.



---
* Homepage: http://mmottl.github.io/lacaml
* Source repo: https://github.com/mmottl/lacaml.git
* Bug tracker: https://github.com/mmottl/lacaml/issues

---


---
### 10.0.2 (2017-11-08)

  * Fixed bugs accessing lower pentagonal matrix patterns

  * Fixed library override issue on Mac OS X
:camel: Pull-request generated by opam-publish v0.3.5