### PR TITLE
Package ocamlformat_support.0.1

### DIFF
--- a/packages/ocamlformat_support/ocamlformat_support.0.1/descr
+++ b/packages/ocamlformat_support/ocamlformat_support.0.1/descr
@@ -1,0 +1,3 @@
+Support package for OCamlFormat
+
+Consists of a patched version of the OCaml standard library Format module.

--- a/packages/ocamlformat_support/ocamlformat_support.0.1/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.1/opam
@@ -3,6 +3,7 @@ maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
 authors: "Pierre Weis"
 homepage: "https://github.com/ocaml-ppx/ocamlformat/tree/support"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
 license: "LGPL-2 with OCaml linking exception"
 available: [ ocaml-version >= "4.04.0" ]
 depends: [

--- a/packages/ocamlformat_support/ocamlformat_support.0.1/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Pierre Weis"
+homepage: "https://github.com/ocaml-ppx/ocamlformat/tree/support"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+license: "LGPL-2 with OCaml linking exception"
+available: [ ocaml-version >= "4.04.0" ]
+depends: [
+  "jbuilder" {build}
+]
+build: [
+  [make]
+]

--- a/packages/ocamlformat_support/ocamlformat_support.0.1/url
+++ b/packages/ocamlformat_support/ocamlformat_support.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.1.tar.gz"
+checksum: "17a6f4d3ced0d279e5d9064acb034e2c"


### PR DESCRIPTION
### `ocamlformat_support.0.1`

Support package for OCamlFormat

Consists of a patched version of the OCaml standard library Format module.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat/tree/support
* Source repo: 
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---
### opam-lint failures
- **WARNING** 37 Missing field 'dev-repo'

---

:camel: Pull-request generated by opam-publish v0.3.5