### PR TITLE
uutf: older versions do not compile on 4.06 due to safe-string

### DIFF
--- a/packages/uutf/uutf.0.9.1/opam
+++ b/packages/uutf/uutf.0.9.1/opam
@@ -12,5 +12,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "3.12.0"
+available: [ ocaml-version >= "3.12.0" & ocaml-version < "4.06.0" ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/uutf/uutf.0.9.3/opam
+++ b/packages/uutf/uutf.0.9.3/opam
@@ -18,4 +18,4 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version > "4.06.0" ]

--- a/packages/uutf/uutf.0.9.4/opam
+++ b/packages/uutf/uutf.0.9.4/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/uutf.git"
 bug-reports: "https://github.com/dbuenzli/uutf/issues"
 tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "BSD3"
-available: [ ocaml-version >= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}


### PR DESCRIPTION
cc @dbuenzli 