### PR TITLE
add tcpip 3.3.1

### DIFF
--- a/packages/tcpip/tcpip.3.3.1/descr
+++ b/packages/tcpip/tcpip.3.3.1/descr
@@ -1,0 +1,50 @@
+An OCaml TCP/IP networking stack
+
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* ETHERNET
+* ARP
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+
+## Implementations
+
+There are two implementations of the IP, ICMP, UDP, and TCP module types -
+the `socket` stack, and the `direct` stack.
+
+### The `socket` stack
+
+The `socket` stack uses socket calls to a traditional operating system to
+provide the functionality described in the module types.
+
+See the [`src/stack-unix/`](./src/stack-unix/) directory for the modules used as implementations of the
+`socket` stack. 
+
+The `socket` stack is used for testing or other applications which do not
+expect to run as unikernels.
+
+### The `direct` stack
+
+The `direct` stack expects to write to a device implementing the `NETIF` module
+type defined for MirageOS.
+
+See the [`src/`](./src/) directory for the modules used as implementations of the
+`direct` stack, which is the expected stack for most MirageOS applications.
+
+The `direct` stack is the only usable set of implementations for
+applications which will run as unikernels on a hypervisor target.
+
+## Community
+
+* WWW: <https://mirage.io>
+* E-mail: <mirageos-devel@lists.xenproject.org>
+* Issues: <https://github.com/mirage/mirage-tcpip/issues>
+* API docs: <http://docs.mirage.io/tcpip/index.html>
+
+## License
+
+`mirage-tcpip` is distributed under the ISC license.

--- a/packages/tcpip/tcpip.3.3.1/opam
+++ b/packages/tcpip/tcpip.3.3.1/opam
@@ -1,0 +1,51 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder"     {build & >="1.0+beta10"}
+  "configurator" {build}
+  "rresult"
+  "cstruct" {>= "3.0.2"}
+  "cstruct-lwt"
+  "mirage-net" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.1.0"}
+  "mirage-protocols-lwt" {>= "1.1.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "2.2.0"}
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+  "duration"
+  "io-page-unix"
+  "randomconv"
+  "mirage-flow" {test & >= "1.2.0"}
+  "mirage-vnetif" {test & >= "0.4.0"}
+  "alcotest" {test & >="0.7.0"}
+  "pcap-format" {test}
+  "mirage-clock-unix" {test & >= "1.2.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/tcpip/tcpip.3.3.1/url
+++ b/packages/tcpip/tcpip.3.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-tcpip/releases/download/v3.3.1/tcpip-3.3.1.tbz"
+checksum: "a619790aa8efcbf1c79aebde4409d780"


### PR DESCRIPTION
This release is compatible with OCaml 4.06.0.  A separate PR will bound older releases to OCaml versions previous to 4.06.0.