### PR TITLE
constrain tcpip >= 3.0.0 and <= 3.3.0 to ocaml-version < 4.06.0

### DIFF
--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -73,4 +73,4 @@ depends: [
 depopts: [
   "mirage-xen"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/tcpip/tcpip.3.1.0/opam
+++ b/packages/tcpip/tcpip.3.1.0/opam
@@ -73,4 +73,4 @@ depends: [
 depopts: [
   "mirage-xen"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/tcpip/tcpip.3.1.1/opam
+++ b/packages/tcpip/tcpip.3.1.1/opam
@@ -73,4 +73,4 @@ depends: [
 depopts: [
   "mirage-xen"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/tcpip/tcpip.3.1.2/opam
+++ b/packages/tcpip/tcpip.3.1.2/opam
@@ -73,4 +73,4 @@ depends: [
 depopts: [
   "mirage-xen"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -73,4 +73,4 @@ depends: [
 depopts: [
   "mirage-xen"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/tcpip/tcpip.3.1.4/opam
+++ b/packages/tcpip/tcpip.3.1.4/opam
@@ -73,4 +73,4 @@ depends: [
 depopts: [
   "mirage-xen"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/tcpip/tcpip.3.2.0/opam
+++ b/packages/tcpip/tcpip.3.2.0/opam
@@ -49,4 +49,4 @@ depends: [
   "io-page-unix"
   "randomconv"
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]

--- a/packages/tcpip/tcpip.3.3.0/opam
+++ b/packages/tcpip/tcpip.3.3.0/opam
@@ -48,4 +48,4 @@ depends: [
   "pcap-format" {test}
   "mirage-clock-unix" {test & >= "1.2.0"}
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
versions 3.0.0 <= n <= 3.3.0 of tcpip are incompatible with OCaml 4.06.0.

(versions before 3.0.0 are also incompatible but unlikely to be installed, and touching them is likely to turn up other problems, so I'll address them in a separate PR)