### PR TITLE
mlgmpidl.*: require OCaml version < 4.06

### DIFF
--- a/packages/mlgmpidl/mlgmpidl.1.2.1/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.1/opam
@@ -21,3 +21,4 @@ conflicts: [
   "apron" {= "20140725"}
   "apron" {= "20150518"}
 ]
+available: [ ocaml-version < "4.06" ]

--- a/packages/mlgmpidl/mlgmpidl.1.2.2/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.2/opam
@@ -21,3 +21,4 @@ conflicts: [
   "apron" {= "20140725"}
   "apron" {= "20150518"}
 ]
+available: [ ocaml-version < "4.06" ]

--- a/packages/mlgmpidl/mlgmpidl.1.2.3/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.3/opam
@@ -21,3 +21,4 @@ conflicts: [
   "apron" {= "20140725"}
   "apron" {= "20150518"}
 ]
+available: [ ocaml-version < "4.06" ]

--- a/packages/mlgmpidl/mlgmpidl.1.2.4/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.4/opam
@@ -21,3 +21,4 @@ conflicts: [
   "apron" {= "20140725"}
   "apron" {= "20150518"}
 ]
+available: [ ocaml-version < "4.06" ]


### PR DESCRIPTION
A new version of mlgmpidl that compile with OCaml ≥ 4.06 shall be released very soon,