### PR TITLE
core.v0.9.0: does not compile on 4.06.0

### DIFF
--- a/packages/core/core.v0.9.0/opam
+++ b/packages/core/core.v0.9.0/opam
@@ -22,4 +22,4 @@ depends: [
   "base-threads"
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.05.0" ]

--- a/packages/core/core.v0.9.0/opam
+++ b/packages/core/core.v0.9.0/opam
@@ -22,4 +22,4 @@ depends: [
   "base-threads"
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/10626#issuecomment-343316570
cc @xclerc