### PR TITLE
Add an upper bound constraint against 4.06.0 to various Jane Street packages

### DIFF
--- a/packages/base/base.v0.9.0/opam
+++ b/packages/base/base.v0.9.0/opam
@@ -14,4 +14,4 @@ depends: [
 conflicts: [
   "sexplib" {>= "v0.9.1"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/base/base.v0.9.1/opam
+++ b/packages/base/base.v0.9.1/opam
@@ -12,4 +12,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta2" & < "1.0+beta8"}
   "sexplib"  {>= "v0.9.1" & < "v0.10"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/base/base.v0.9.2/opam
+++ b/packages/base/base.v0.9.2/opam
@@ -15,4 +15,4 @@ depends: [
 depopts: [
   "base-native-int63"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/bin_prot/bin_prot.v0.9.0/opam
+++ b/packages/bin_prot/bin_prot.v0.9.0/opam
@@ -23,4 +23,4 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/core/core.v0.9.0/opam
+++ b/packages/core/core.v0.9.0/opam
@@ -22,4 +22,4 @@ depends: [
   "base-threads"
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/ppx_driver/ppx_driver.v0.9.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.9.0/opam
@@ -15,4 +15,4 @@ depends: [
   "ocaml-migrate-parsetree" {>= "0.4"}
   "ocamlbuild"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
(applies to 0.9.x versions.)