### PR TITLE
Package spelll.0.2

### DIFF
--- a/packages/spelll/spelll.0.2/descr
+++ b/packages/spelll/spelll.0.2/descr
@@ -1,0 +1,1 @@
+Fuzzy string searching, using Levenshtein automaton. Can be used for spell-checking.

--- a/packages/spelll/spelll.0.2/opam
+++ b/packages/spelll/spelll.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/spelll"
+bug-reports: "https://github.com/c-cube/spelll/issues"
+doc: "http://cedeela.fr/~simon/software/spelll/"
+tags: ["spell" "levenshtein" "automaton" "typo" "edit" "distance"]
+dev-repo: "git://github.com/c-cube/spelll"
+build: [
+  ["./configure" "--docdir" "%{doc}%/spelll/"]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "spelll"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "base-bytes"
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/spelll/spelll.0.2/url
+++ b/packages/spelll/spelll.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/spelll/archive/0.2.tar.gz"
+checksum: "dbe46f10969efba4b84882ba14001c1b"


### PR DESCRIPTION
### `spelll.0.2`

Fuzzy string searching, using Levenshtein automaton. Can be used for spell-checking.



---
* Homepage: https://github.com/c-cube/spelll
* Source repo: git://github.com/c-cube/spelll
* Bug tracker: https://github.com/c-cube/spelll/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5