### PR TITLE
Updated conf-libmosquitto to use MacOS Homebrew

### DIFF
--- a/packages/conf-libmosquitto/conf-libmosquitto.1/opam
+++ b/packages/conf-libmosquitto/conf-libmosquitto.1/opam
@@ -3,9 +3,13 @@ maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
 authors: [ "Markus W. Weissmann <markus.weissmann@in.tum.de>" ]
 homepage: "https://mosquitto.org/"
 license: [ "Eclipse Public License v1.0" "Eclipse Distribution License 1.0" ]
-build: [["ls" "/usr/include/mosquitto.h"]]
+build: [
+  ["ls" "/usr/include/mosquitto.h" {os != "darwin"}]
+  ["brew" "ls" "--versions" "mosquitto" {os = "darwin"}]
+]
 depexts: [
   [["debian"] ["libmosquitto-dev" ]]
   [["ubuntu"] ["libmosquitto-dev"]]
   [["alpine"] ["mosquitto-dev"]]
+  [["darwin"] ["mosquitto"]]
 ]

--- a/packages/conf-libmosquitto/conf-libmosquitto.1/opam
+++ b/packages/conf-libmosquitto/conf-libmosquitto.1/opam
@@ -11,5 +11,5 @@ depexts: [
   [["debian"] ["libmosquitto-dev" ]]
   [["ubuntu"] ["libmosquitto-dev"]]
   [["alpine"] ["mosquitto-dev"]]
-  [["darwin"] ["mosquitto"]]
+  [["osx" "homebrew"] ["mosquitto"]]
 ]


### PR DESCRIPTION
Duplicate of #10362 except made to use `homebrew ls --versions mosquitto` instead of clunky `ls /usr/local/Cellar/mosquitto/1.4.14_1/include`.