### PR TITLE
cmdliner: restrict older versions to <4.06.0 due to safe-string

### DIFF
--- a/packages/cmdliner/cmdliner.0.9.2/opam
+++ b/packages/cmdliner/cmdliner.0.9.2/opam
@@ -13,5 +13,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "3.12.0"
+available: [ ocaml-version >= "3.12.0" & ocaml-version < "4.06.0" ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/cmdliner/cmdliner.0.9.4/opam
+++ b/packages/cmdliner/cmdliner.0.9.4/opam
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "3.12.0"]
+available: [ ocaml-version >= "3.12.0" ]
 build: 
 [
   ["./pkg/pkg-git" ] 

--- a/packages/cmdliner/cmdliner.0.9.5/opam
+++ b/packages/cmdliner/cmdliner.0.9.5/opam
@@ -10,7 +10,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "3.12.0"]
+available: [ ocaml-version >= "3.12.0" & ocaml-version < "4.06.0" ]
 build: 
 [
   ["ocaml" "pkg/git.ml" ] 

--- a/packages/cmdliner/cmdliner.0.9.6/opam
+++ b/packages/cmdliner/cmdliner.0.9.6/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 build: 
 [
   ["ocaml" "pkg/git.ml" ] 

--- a/packages/cmdliner/cmdliner.0.9.7/opam
+++ b/packages/cmdliner/cmdliner.0.9.7/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "BSD3"
-available: [ocaml-version >= "3.12.1"]
+available: [ ocaml-version >= "3.12.1" & ocaml-version < "4.06.0" ]
 patches: ["backport_pre_4_00_0.patch" {ocaml-version < "4.00.0"}]
 build:
 [

--- a/packages/cmdliner/cmdliner.0.9.8/opam
+++ b/packages/cmdliner/cmdliner.0.9.8/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "BSD3"
-available: [ocaml-version >= "3.12.0"]
+available: [ ocaml-version >= "3.12.0" & ocaml-version < "4.06.0" ]
 build:
 [
   ["ocaml" "pkg/git.ml" ]


### PR DESCRIPTION
not that cmdliner.0.9.4 does compile successfully with safe-string
so is not constrained.