### PR TITLE
Package inuit.0.4

### DIFF
--- a/packages/inuit/inuit.0.4/descr
+++ b/packages/inuit/inuit.0.4/descr
@@ -1,0 +1,7 @@
+Make interactive text-based user-interfaces in OCaml
+
+Inuit is an abstraction for interactively updating a text buffer. 
+It is designed to be use with a backend that will present the buffer to the end user.
+[Sturgeon](https://github.com/let-def/sturgeon) is a backend targeting emacs buffers.
+
+Inuit is distributed under the ISC license.

--- a/packages/inuit/inuit.0.4/opam
+++ b/packages/inuit/inuit.0.4/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: ["Frédéric Bour <frederic.bour@lakaban.net>"]
+homepage: "https://github.com/let-def/inuit"
+doc: "https://let-def.github.io/inuit/doc"
+license: "ISC"
+dev-repo: "https://github.com/let-def/inuit.git"
+bug-reports: "https://github.com/let-def/inuit/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "grenier" {>= "0.4"}
+]
+depopts: []
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]

--- a/packages/inuit/inuit.0.4/url
+++ b/packages/inuit/inuit.0.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/let-def/inuit/releases/download/v0.4/inuit-0.4.tbz"
+checksum: "d9c9b2755aff410c38976b3ef1b3c2a5"


### PR DESCRIPTION
### `inuit.0.4`

Make interactive text-based user-interfaces in OCaml

Inuit is an abstraction for interactively updating a text buffer. 
It is designed to be use with a backend that will present the buffer to the end user.
[Sturgeon](https://github.com/let-def/sturgeon) is a backend targeting emacs buffers.

Inuit is distributed under the ISC license.



---
* Homepage: https://github.com/let-def/inuit
* Source repo: https://github.com/let-def/inuit.git
* Bug tracker: https://github.com/let-def/inuit/issues

---


---
v0.4 2017-11-12 Paris
--------------------------

Introduce an experimental `Inuit_format` module to integrate with stdlib
`Format.formatter`.
Minor: `Inuit_base.utf8_length` takes an optional offset.
:camel: Pull-request generated by opam-publish v0.3.5