### PR TITLE
Package sturgeon.0.4

### DIFF
--- a/packages/sturgeon/sturgeon.0.4/descr
+++ b/packages/sturgeon/sturgeon.0.4/descr
@@ -1,0 +1,9 @@
+A toolkit for communicating with Emacs
+
+Sturgeon implements various tools for manipulating Emacs from OCaml:
+- `Sturgeon_sexp` implements the Emacs dialect of S-expressions
+- `Sturgeon_session` implements an "session protocol" to make RPC to Emacs from OCaml and vice versa
+- `Sturgeon_stui` is a session implementing an [Inuit](https://github.com/let-def/inuit) backend: one can now runs text user-interface on an Emacs buffer
+- `Sturgeon_recipes_*` offers different "rendez-vous" points to connect to Emacs
+
+Sturgeon is distributed under the ISC license.

--- a/packages/sturgeon/sturgeon.0.4/opam
+++ b/packages/sturgeon/sturgeon.0.4/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: ["Frédéric Bour <frederic.bour@lakaban.net>"]
+homepage: "https://github.com/let-def/sturgeon"
+doc: "https://let-def.github.io/sturgeon/doc"
+license: "ISC"
+dev-repo: "https://github.com/let-def/sturgeon.git"
+bug-reports: "https://github.com/let-def/sturgeon/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "inuit"
+  "result"
+]
+depopts: []
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%" ]]
+post-messages: [
+  "sturgeon installed.
+
+Emacs setup:
+
+Add opam emacs directory to your load-path if it is not there yet:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))))
+
+Load sturgeon file:
+  (require 'sturgeon)
+"
+]

--- a/packages/sturgeon/sturgeon.0.4/url
+++ b/packages/sturgeon/sturgeon.0.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/let-def/sturgeon/releases/download/v0.4/sturgeon-0.4.tbz"
+checksum: "7ad28bb3a3504f29c0c63afe9fd32c64"


### PR DESCRIPTION
### `sturgeon.0.4`

A toolkit for communicating with Emacs

Sturgeon implements various tools for manipulating Emacs from OCaml:
- `Sturgeon_sexp` implements the Emacs dialect of S-expressions
- `Sturgeon_session` implements an "session protocol" to make RPC to Emacs from OCaml and vice versa
- `Sturgeon_stui` is a session implementing an [Inuit](https://github.com/let-def/inuit) backend: one can now runs text user-interface on an Emacs buffer
- `Sturgeon_recipes_*` offers different "rendez-vous" points to connect to Emacs

Sturgeon is distributed under the ISC license.



---
* Homepage: https://github.com/let-def/sturgeon
* Source repo: https://github.com/let-def/sturgeon.git
* Bug tracker: https://github.com/let-def/sturgeon/issues

---


---
v0.4 2017-11-12 Paris
------------------------

Fix a bug with serialization and deserialization of escaped string (triggered by a non-ascii character followed by three numbers).
Make emacs setup a bit more automatic and/or user-friendly.
:camel: Pull-request generated by opam-publish v0.3.5