### PR TITLE
Package stb_truetype.0.3

### DIFF
--- a/packages/stb_truetype/stb_truetype.0.3/descr
+++ b/packages/stb_truetype/stb_truetype.0.3/descr
@@ -1,0 +1,8 @@
+OCaml bindings to stb_truetype, a public domain font rasterizer
+
+Stb_truetype is an OCaml binding to stb_truetype from Sean Barrett, [Nothings](http://nothings.org/):
+
+  stb_truetype.h: public domain C truetype rasterization library 
+
+The OCaml binding is released under CC-0 license.  It has no dependency beside
+working OCaml and C compilers (stb_truetype is self-contained).

--- a/packages/stb_truetype/stb_truetype.0.3/opam
+++ b/packages/stb_truetype/stb_truetype.0.3/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/stb_truetype"
+bug-reports: "https://github.com/let-def/stb_truetype"
+license: "CC0"
+dev-repo: "https://github.com/let-def/stb_truetype.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "stb_truetype"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/stb_truetype/stb_truetype.0.3/url
+++ b/packages/stb_truetype/stb_truetype.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/stb_truetype/archive/v0.3.tar.gz"
+checksum: "da2a5e3c58c9d0d96a13edc3292e059d"


### PR DESCRIPTION
### `stb_truetype.0.3`

OCaml bindings to stb_truetype, a public domain font rasterizer

Stb_truetype is an OCaml binding to stb_truetype from Sean Barrett, [Nothings](http://nothings.org/):

  stb_truetype.h: public domain C truetype rasterization library 

The OCaml binding is released under CC-0 license.  It has no dependency beside
working OCaml and C compilers (stb_truetype is self-contained).



---
* Homepage: https://github.com/let-def/stb_truetype
* Source repo: https://github.com/let-def/stb_truetype.git
* Bug tracker: https://github.com/let-def/stb_truetype

---

:camel: Pull-request generated by opam-publish v0.3.5