### PR TITLE
Package statmemprof-emacs.0.1.0

### DIFF
--- a/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/descr
+++ b/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/descr
@@ -1,0 +1,6 @@
+Emacs client for statistical memory profiler
+
+statmemprof-emacs is an Sturgeon/emacs front-end of the statmemprof
+statistical memory profiler for OCaml.
+
+statmemprof-emacs is distributed under the MIT license.

--- a/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/opam
+++ b/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Jacques-Henri Jourdan <jacques-henri.jourdan@normalesup.org>"
+authors: ["Jacques-Henri Jourdan <jacques-henri.jourdan@normalesup.org>"
+          "Frédéric Bour <frederic.bour@lakaban.net>"]
+homepage: "https://github.com/jhjourdan/statmemprof-emacs"
+doc: "https://jhjourdan.mketjh.fr//statmemprof-emacs/doc"
+license: "MIT"
+dev-repo: "https://github.com/jhjourdan/statmemprof-emacs.git"
+bug-reports: "https://github.com/jhjourdan/statmemprof-emacs/issues"
+tags: []
+available: [ compiler = "4.03.0+statistical-memprof"
+           | compiler = "4.06.0+statistical-memprof" ]
+depends:
+[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "sturgeon" { >= "0.3" }
+  "inuit" { >= "0.3" }
+]
+depopts: []
+build: [[ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%" ]]

--- a/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/url
+++ b/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/jhjourdan/statmemprof-emacs/releases/download/v0.1.0/statmemprof-emacs-0.1.0.tbz"
+checksum: "880f6e5d87d0c2e657cd98c359b77b93"


### PR DESCRIPTION
### `statmemprof-emacs.0.1.0`

Emacs client for statistical memory profiler

statmemprof-emacs is an Sturgeon/emacs front-end of the statmemprof
statistical memory profiler for OCaml.

statmemprof-emacs is distributed under the MIT license.



---
* Homepage: https://github.com/jhjourdan/statmemprof-emacs
* Source repo: https://github.com/jhjourdan/statmemprof-emacs.git
* Bug tracker: https://github.com/jhjourdan/statmemprof-emacs/issues

---


---
v0.1.0 2017-11-12
-----------------

First release.
:camel: Pull-request generated by opam-publish v0.3.5