### PR TITLE
constrain older biniou releases to <ocaml-4.06.0 due to safe-string

### DIFF
--- a/packages/biniou/biniou.1.0.12/opam
+++ b/packages/biniou/biniou.1.0.12/opam
@@ -17,4 +17,4 @@ depends: [
 install: [make "install" "BINDIR=%{bin}%"]
 
 # -bin-annot flag is used unconditionally, requiring ocaml >= 4.xx
-available: [ocaml-version >= "4.00"]
+available: [ocaml-version >= "4.00" & ocaml-version < "4.06.0" ]

--- a/packages/biniou/biniou.1.0.13/opam
+++ b/packages/biniou/biniou.1.0.13/opam
@@ -17,4 +17,5 @@ depends: [
 install: [make "install" "BINDIR=%{bin}%"]
 
 # -compat-32 flag is used unconditionally, requiring ocaml >= 4.01
-available: [ocaml-version >= "4.01"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
+

--- a/packages/biniou/biniou.1.0.5/opam
+++ b/packages/biniou/biniou.1.0.5/opam
@@ -9,3 +9,4 @@ depends: [
   "easy-format"
 ]
 install: [make "install" "BINDIR=%{bin}%"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/biniou/biniou.1.0.6/opam
+++ b/packages/biniou/biniou.1.0.6/opam
@@ -9,3 +9,4 @@ depends: [
   "easy-format"
 ]
 install: [make "install" "BINDIR=%{bin}%"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/biniou/biniou.1.0.9/opam
+++ b/packages/biniou/biniou.1.0.9/opam
@@ -10,3 +10,4 @@ depends: [
   "easy-format"
 ]
 install: [make "install" "BINDIR=%{bin}%"]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
fixes build failure in #10673