### PR TITLE
Package cryptodbm.0.84.1

### DIFF
--- a/packages/cryptodbm/cryptodbm.0.84.1/descr
+++ b/packages/cryptodbm/cryptodbm.0.84.1/descr
@@ -1,0 +1,9 @@
+Encrypted layer over the dbm library: access to serverless, key-value databases with symmetric encryption.
+This library provides an encrypted layer on top of the Dbm and Cryptokit packages. The improvements over Dbm are:
+  - A single database file may contain several independent subtables, identified by a name (a string).
+  - Each subtable can be signed and encrypted individually, or encrypted using a common password.
+  - The whole file can be signed.
+  - Obfuscating data is -optionally- appended to keys, data, and to the whole table, so that two databases with
+    the same content look significantly different, once encrypted.
+  - Encryption is symmetric: encryption and decryption both use the same password.
+  - Signature is symmetric: signing and verifying the signature both use the same signword.

--- a/packages/cryptodbm/cryptodbm.0.84.1/opam
+++ b/packages/cryptodbm/cryptodbm.0.84.1/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "Didier Le Botlan <github.lebotlan@dfgh.net>"
+authors: "Didier Le Botlan <github.lebotlan@dfgh.net>"
+homepage: "https://github.com/lebotlan/ocaml-cryptodbm"
+bug-reports: "https://github.com/lebotlan/ocaml-cryptodbm/issues"
+license: "MIT License"
+dev-repo: "git://github.com/lebotlan/ocaml-cryptodbm.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: ["ocamlfind" "jbuilder" "dbm" "fileutils" "cryptokit"]

--- a/packages/cryptodbm/cryptodbm.0.84.1/url
+++ b/packages/cryptodbm/cryptodbm.0.84.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/lebotlan/ocaml-cryptodbm/archive/v0.84.1.tar.gz"
+checksum: "34dc82d1cc5b731b226f26bdc073e41e"


### PR DESCRIPTION
### `cryptodbm.0.84.1`

Encrypted layer over the dbm library: access to serverless, key-value databases with symmetric encryption.
This library provides an encrypted layer on top of the Dbm and Cryptokit packages. The improvements over Dbm are:
  - A single database file may contain several independent subtables, identified by a name (a string).
  - Each subtable can be signed and encrypted individually, or encrypted using a common password.
  - The whole file can be signed.
  - Obfuscating data is -optionally- appended to keys, data, and to the whole table, so that two databases with
    the same content look significantly different, once encrypted.
  - Encryption is symmetric: encryption and decryption both use the same password.
  - Signature is symmetric: signing and verifying the signature both use the same signword.



---
* Homepage: https://github.com/lebotlan/ocaml-cryptodbm
* Source repo: git://github.com/lebotlan/ocaml-cryptodbm.git
* Bug tracker: https://github.com/lebotlan/ocaml-cryptodbm/issues

---

:camel: Pull-request generated by opam-publish v0.3.5