### PR TITLE
batteries 2.8.0

### DIFF
--- a/packages/batteries/batteries.2.8.0/descr
+++ b/packages/batteries/batteries.2.8.0/descr
@@ -1,0 +1,1 @@
+a community-maintained standard library extension

--- a/packages/batteries/batteries.2.8.0/opam
+++ b/packages/batteries/batteries.2.8.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name: "batteries"
+maintainer: "thelema314@gmail.com"
+authors: "OCaml batteries-included team"
+homepage: "http://batteries.forge.ocamlcore.org/"
+bug-reports: "https://github.com/ocaml-batteries-team/batteries-included/issues"
+dev-repo: "https://github.com/ocaml-batteries-team/batteries-included.git"
+license: "LGPL-2.1+ with OCaml linking exception"
+doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "batteries"]
+depends: [
+  "ocamlfind" {>= "1.5.3"}
+  "ocamlbuild" {build}
+  "qtest" {test & >= "2.5"}
+  "qcheck" {test & >= "0.6"}
+  "bisect" {test}
+  "num"
+]
+available: [ocaml-version >= "3.12.1" & ocaml-version < "4.07.0"]

--- a/packages/batteries/batteries.2.8.0/url
+++ b/packages/batteries/batteries.2.8.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.8.0/batteries-2.8.0.tar.gz"
+checksum: "2d9a811dcb47bae9f1159676d880a46b"


### PR DESCRIPTION
This minor release supports the -safe-string mode for OCaml
compilation, enforcing a type-level separation between (immutable)
strings and mutable byte sequences.

- support -safe-string compilation
  ocaml-batteries-team/batteries-included#673
  (Gabriel Scherer)

- Support for the upcoming OCaml release 4.06
  (Gabriel Scherer)
