### PR TITLE
rope: use github archive

### DIFF
--- a/packages/rope/rope.0.5/opam
+++ b/packages/rope/rope.0.5/opam
@@ -13,6 +13,7 @@ remove: [["ocamlfind" "remove" "rope"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depopts: ["benchmark"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/rope/rope.0.5/url
+++ b/packages/rope/rope.0.5/url
@@ -1,2 +1,2 @@
-archive: "https://forge.ocamlcore.org/frs/download.php/1156/rope-0.5.tar.gz"
-checksum: "b95fe5c4f54785f6bdf4e9cb2d51040b"
+archive: "https://github.com/Chris00/ocaml-rope/archive/0.5.tar.gz"
+checksum: "4c4539d3324b8df494e0889f2c0f96d0"


### PR DESCRIPTION
Use the github archive instead of the ocamlcore.org hosted tar, which contains a prebuilt setup.ml that is incompatible with OCaml 4.06.

Note that the "download" link in http://rope.forge.ocamlcore.org/ also points to its github release page.