### PR TITLE
(another) OCaml bindings for MPFR

### DIFF
--- a/packages/mlmpfr/mlmpfr.3.1.6/descr
+++ b/packages/mlmpfr/mlmpfr.3.1.6/descr
@@ -1,0 +1,1 @@
+OCaml C bindings for MPFR 3.1.6.

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -14,7 +14,7 @@ build: [
 ]
 install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
-depends: ["ocamlfind" "oasis"]
+depends: ["ocamlfind" "oasis" "ocaml" {>= "4.03.0"}]
 depexts: [
  [ ["ubuntu"] ["libmpfr-dev"] ]
  [ ["debian"] ["libmpfr-dev"] ]

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -14,7 +14,8 @@ build: [
 ]
 install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
-depends: ["ocamlfind" "oasis" "ocaml" {>= "4.03.0"}]
+depends: ["ocamlfind" "oasis"]
+available: [ ocaml-version >= "4.03" ]
 depexts: [
  [ ["ubuntu"] ["libmpfr-dev"] ]
  [ ["debian"] ["libmpfr-dev"] ]

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -8,6 +8,7 @@ bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
 license:      "LGPL-3.0"
 dev-repo:     "https://github.com/thvnx/mlmpfr.git"
 build: [
+  ["oasis" "setup"]
   ["./configure" "--prefix=%{prefix}%"]
   [make]
 ]

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -1,4 +1,4 @@
-opam-version: "2.0"
+opam-version: "1.2"
 name:         "mlmpfr"
 version:      "3.1.6"
 maintainer:   "Laurent Thévenoux <laurent.thevenoux@gmail.com>"

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name:         "mlmpfr"
+version:      "3.1.6"
+maintainer:   "Laurent Thévenoux <laurent.thevenoux@gmail.com>"
+authors:      "Laurent Thévenoux <laurent.thevenoux@gmail.com>"
+homepage:     "https://github.com/thvnx/mlmpfr"
+bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
+license:      "LGPL-3.0"
+dev-repo:     "https://github.com/thvnx/mlmpfr"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "mlmpfr"]
+depends: "ocamlfind"

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -15,7 +15,7 @@ build: [
 install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
 depends: ["ocamlfind" "oasis"]
-available: [ ocaml-version >= "4.03" ]
+available: [ ocaml-version >= "4.04" ]
 depexts: [
  [ ["ubuntu"] ["libmpfr-dev"] ]
  [ ["debian"] ["libmpfr-dev"] ]

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name:         "mlmpfr"
 version:      "3.1.6"
 maintainer:   "Laurent Thévenoux <laurent.thevenoux@gmail.com>"

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -14,4 +14,4 @@ build: [
 ]
 install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
-depends: "ocamlfind"
+depends: ["ocamlfind" "oasis"]

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -6,7 +6,7 @@ authors:      "Laurent Thévenoux <laurent.thevenoux@gmail.com>"
 homepage:     "https://github.com/thvnx/mlmpfr"
 bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
 license:      "LGPL-3.0"
-dev-repo:     "https://github.com/thvnx/mlmpfr"
+dev-repo:     "https://github.com/thvnx/mlmpfr.git"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -15,3 +15,7 @@ build: [
 install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
 depends: ["ocamlfind" "oasis"]
+depexts: [
+ [ ["ubuntu"] ["libmpfr-dev"] ]
+ [ ["debian"] ["libmpfr-dev"] ]
+]

--- a/packages/mlmpfr/mlmpfr.3.1.6/url
+++ b/packages/mlmpfr/mlmpfr.3.1.6/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/thvnx/mlmpfr.3.1.6.tar.gz"
+archive: "https://github.com/thvnx/mlmpfr/archive/mlmpfr.3.1.6.tar.gz"
 checksum: "9d1ead73e678fa2f51a70a933b0bf017"

--- a/packages/mlmpfr/mlmpfr.3.1.6/url
+++ b/packages/mlmpfr/mlmpfr.3.1.6/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/thvnx/mlmpfr/archive/mlmpfr.3.1.6.tar.gz"
-checksum: "9d1ead73e678fa2f51a70a933b0bf017"
+checksum: "9cb14670f034e0c588ecb96863cd6386"

--- a/packages/mlmpfr/mlmpfr.3.1.6/url
+++ b/packages/mlmpfr/mlmpfr.3.1.6/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/thvnx/mlmpfr.3.1.6.tar.gz"
-checksum: ""
+checksum: "9d1ead73e678fa2f51a70a933b0bf017"

--- a/packages/mlmpfr/mlmpfr.3.1.6/url
+++ b/packages/mlmpfr/mlmpfr.3.1.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/thvnx/mlmpfr.3.1.6.tar.gz"
+checksum: ""


### PR DESCRIPTION
# OCaml bindings for MPFR

This library introduces the `mpfr_float` type. It is an immutable data structure that contains a `mpfr_t` number, as well as an optional ternary value, as provided by (and described in) the [MPFR library](http://www.mpfr.org/). The library also introduces all the functions of the MPFR library.

A few distinctions are made from the original C library:
- the _mpfr__ prefix is ommited for all functions;
- _mpfr_init*_ and _mpfr_set*_ functions are not provided in order to implement these bindings with respect to the functional paradigm (i.e. immutability). Consequently, _mpfr_clear*_ functions are not provided too, and so, the garbage collector is in charge of memory management;
- functions managing the following (C) types are not supported: `unsigned long int`, `uintmax_t`, `intmax_t`, `float`, `long double`, `_Decimal64`, `mpz_t`, `mpq_t`, and `mpf_t`. Except for _mpfr_sqrt_ui_ and _mpfr_fac_ui_ which are partially supported on the range of the positive values of an OCaml signed integer. In fact, only the OCaml native types (`int`, `float`, and `string`) are supported, assuming that a `float` is a double-precision floating-point number and an `int` is a 64-bits signed integer. Thus, all functions named with _*_ui*_ or _*_d*_ are renamed here with _*_int*_ or _*_float*_, respectively;
- bindings to functions _mpfr_*printf_, _mpfr_*random*_, _mpfr_get_patches_, _mpfr_buildopt_*_, and macros _MPFR_VERSION*_ are not implemented.

Up-to-date with MPFR 3.1.6.