### PR TITLE
Package ppx_deriving_protocol.0.8

### DIFF
--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/descr
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/descr
@@ -1,0 +1,8 @@
+Ppx for deriving protocol serialisation and de-serialisation of types
+
+The syntax extension generates code to serialise and de-serialise
+types.  The ppx itself does not contain any protocol specific code,
+but relies on 'drivers' that defines serialization and
+de-serialisation of basic types and structures.  The library provides
+both a json (Yojson.Safe.json) driver and a xml_light (Xml.xml)
+driver.

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
@@ -1,9 +1,9 @@
 opam-version: "1.2"
 maintainer: "Anders Fugmann <anders@fugmann.net>"
 authors: "Anders Fugmann"
-homepage: "https://github.com/andersfugmann/ppx_deriving-protocol"
-bug-reports: "https://github.com/andersfugmann/ppx_deriving-protocol/issues"
-dev-repo: "git+https://github.com/andersfugmann/ppx_deriving-protocol"
+homepage: "https://github.com/andersfugmann/ppx-deriving-protocol"
+bug-reports: "https://github.com/andersfugmann/ppx-deriving-protocol/issues"
+dev-repo: "git+https://github.com/andersfugmann/ppx-deriving-protocol"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 depends: [

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
@@ -15,3 +15,4 @@ depends: [
   "ppx_driver" {build}
   "jbuilder" {build}
 ]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
@@ -14,5 +14,6 @@ depends: [
   "ppx_type_conv" {build}
   "ppx_driver" {build}
   "jbuilder" {build}
+  "ppx_metaquot" {build}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_deriving-protocol"
+bug-reports: "https://github.com/andersfugmann/ppx_deriving-protocol/issues"
+dev-repo: "git+https://github.com/andersfugmann/ppx_deriving-protocol"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "yojson"
+  "xml-light"
+  "base"
+  "ppx_core" {build}
+  "ppx_type_conv" {build}
+  "ppx_driver" {build}
+  "jbuilder" {build}
+]

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/url
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/andersfugmann/ppx-deriving-protocol/archive/0.8.tar.gz"
+checksum: "ec0a4592399f5f2a0be3240f7ece182f"


### PR DESCRIPTION
### `ppx_deriving_protocol.0.8`

Ppx for deriving protocol serialisation and de-serialisation of types

The syntax extension generates code to serialise and de-serialise
types.  The ppx itself does not contain any protocol specific code,
but relies on 'drivers' that defines serialization and
de-serialisation of basic types and structures.  The library provides
both a json (Yojson.Safe.json) driver and a xml_light (Xml.xml)
driver.



---
* Homepage: https://github.com/andersfugmann/ppx_deriving-protocol
* Source repo: https://github.com/andersfugmann/ppx_deriving-protocol
* Bug tracker: https://github.com/andersfugmann/ppx_deriving-protocol/issues

---

:camel: Pull-request generated by opam-publish v0.3.5