### PR TITLE
+0install.2.12.3

### DIFF
--- a/packages/0install/0install.2.12.3/descr
+++ b/packages/0install/0install.2.12.3/descr
@@ -1,0 +1,6 @@
+The antidote to app-stores
+Zero Install is a decentralised cross-distribution software installation system.
+Other features include full support for shared libraries (with a SAT solver for
+dependency resolution), sharing between users, and integration with native platform
+package managers. It supports both binary and source packages, and works on Linux,
+Mac OS X, Unix and Windows systems.

--- a/packages/0install/0install.2.12.3/files/0install.install
+++ b/packages/0install/0install.2.12.3/files/0install.install
@@ -1,0 +1,19 @@
+bin: [
+  "dist/files/0install"
+  "dist/files/0install" {"0launch"}
+  "dist/files/0install" {"0store"}
+  "dist/files/0install" {"0store-secure-add"}
+  "dist/files/0install" {"0desktop"}
+  "dist/files/0install" {"0alias"}
+]
+lib: [
+  "?dist/files/gui_gtk.cmxs"
+  "?dist/files/gui_gtk.cma"
+]
+man: [
+  "0launch.1" {"man1/0launch.1"}
+  "0store-secure-add.1" {"man1/0store-secure-add.1"}
+  "0store.1" {"man1/0store.1"}
+  "0desktop.1" {"man1/0desktop.1"}
+  "0install.1" {"man1/0install.1"}
+]

--- a/packages/0install/0install.2.12.3/opam
+++ b/packages/0install/0install.2.12.3/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "http://0install.net/"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "https://github.com/0install/0install.git"
+build: [
+  [make "all"]
+]
+build-test: [
+  [make "test"]
+]
+depends: [
+  "yojson"
+  "xmlm"
+  "ounit" {test}
+  "lwt_react"
+  "ocurl" {>= "0.7.9"}
+  "sha"
+  "ocamlbuild" {build}
+  "cppo_ocamlbuild" {build}
+]
+depopts: [ "obus" "lablgtk" "lwt_glib" ]
+depexts: [
+  [["ubuntu"] ["unzip"]]
+  [["debian"] ["unzip"]]
+  [["osx" "homebrew"] ["gnupg"]]
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/0install/0install.2.12.3/url
+++ b/packages/0install/0install.2.12.3/url
@@ -1,0 +1,2 @@
+archive: "https://downloads.sf.net/project/zero-install/0install/2.12.3/0install-2.12.3.tar.bz2"
+checksum: "12d212264699a81e8b07d4410e907633"


### PR DESCRIPTION
This should work with OCaml 4.06, although the optional obus support won't work until https://github.com/diml/obus/pull/8 is merged and released.