### PR TITLE
fmt 0.7.0 and 0.7.1 do not compile with 4.06.0

### DIFF
--- a/packages/fmt/fmt.0.7.0/opam
+++ b/packages/fmt/fmt.0.7.0/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/fmt.git"
 bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "BSD-3-Clause"
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}

--- a/packages/fmt/fmt.0.7.1/opam
+++ b/packages/fmt/fmt.0.7.1/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/fmt.git"
 bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "BSD-3-Clause"
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [ "ocamlfind" {build} "ocamlbuild" {build} ]
 depopts: [ "base-unix" "cmdliner" ]
 conflicts: [ "cmdliner" {< "0.9.8"} ]


### PR DESCRIPTION
cc @dbuenzli 