### PR TITLE
alcotest uses fmt.cli, which is only in >= fmt.0.7.1

### DIFF
--- a/packages/alcotest/alcotest.0.4.10/opam
+++ b/packages/alcotest/alcotest.0.4.10/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "oasis"      {build}
-  "fmt"
+  "fmt" {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.4.11/opam
+++ b/packages/alcotest/alcotest.0.4.11/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "oasis"      {build}
-  "fmt"
+  "fmt"   {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.4.9/opam
+++ b/packages/alcotest/alcotest.0.4.9/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "oasis"      {build}
-  "fmt"
+  "fmt"   {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.5.0/opam
+++ b/packages/alcotest/alcotest.0.5.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"
+  "fmt"   {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.6.0/opam
+++ b/packages/alcotest/alcotest.0.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"
+  "fmt"   {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.7.0/opam
+++ b/packages/alcotest/alcotest.0.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"   {>= "0.7.1"}
+  "fmt"   {>= "0.8.0"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.7.0/opam
+++ b/packages/alcotest/alcotest.0.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"
+  "fmt"   {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.7.1/opam
+++ b/packages/alcotest/alcotest.0.7.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"   {>= "0.7.1"}
+  "fmt"   {>= "0.8.0"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.7.1/opam
+++ b/packages/alcotest/alcotest.0.7.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"
+  "fmt"   {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.7.2/opam
+++ b/packages/alcotest/alcotest.0.7.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"   {>= "0.7.1"}
+  "fmt"   {>= "0.8.0"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.7.2/opam
+++ b/packages/alcotest/alcotest.0.7.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
-  "fmt"
+  "fmt"   {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.8.0/opam
+++ b/packages/alcotest/alcotest.0.8.0/opam
@@ -15,7 +15,7 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder"  {build & >= "1.0+beta10"}
-  "fmt"       {>= "0.7.1"}
+  "fmt"       {>= "0.8.0"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.8.0/opam
+++ b/packages/alcotest/alcotest.0.8.0/opam
@@ -15,7 +15,7 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder"  {build & >= "1.0+beta10"}
-  "fmt"
+  "fmt"       {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.8.1/opam
+++ b/packages/alcotest/alcotest.0.8.1/opam
@@ -15,7 +15,7 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder"  {build & >= "1.0+beta10"}
-  "fmt"       {>= "0.7.1"}
+  "fmt"       {>= "0.8.0"}
   "astring"
   "result"
   "cmdliner"

--- a/packages/alcotest/alcotest.0.8.1/opam
+++ b/packages/alcotest/alcotest.0.8.1/opam
@@ -15,7 +15,7 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder"  {build & >= "1.0+beta10"}
-  "fmt"
+  "fmt"       {>= "0.7.1"}
   "astring"
   "result"
   "cmdliner"


### PR DESCRIPTION
cc @samoht (and upstream PR at https://github.com/mirage/alcotest/pull/116)