### PR TITLE
uuidm.0.9.5 uses ancient oasis which does not comply with safe-string

### DIFF
--- a/packages/uuidm/uuidm.0.9.5/opam
+++ b/packages/uuidm/uuidm.0.9.5/opam
@@ -1,5 +1,13 @@
 opam-version: "1.2"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uuidm"
+doc: "http://erratique.ch/software/uuidm/doc/Uuidm"
+dev-repo: "http://erratique.ch/repos/uuidm.git"
+bug-reports: "https://github.com/dbuenzli/uuidm/issues"
+tags: [ "uuid" "codec" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version < "4.06.0"]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]


### PR DESCRIPTION
cc @dbuenzli