### PR TITLE
uchar.0.0.1 build system does not comply with safe-string

### DIFF
--- a/packages/uchar/uchar.0.0.1/opam
+++ b/packages/uchar/uchar.0.0.1/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/ocaml/uchar.git"
 bug-reports: "https://github.com/ocaml/uchar/issues"
 tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
 license: "typeof OCaml system"
-available: [ ocaml-version >= "3.12.0" ]
+available: [ ocaml-version >= "3.12.0" & ocaml-version < "4.06.0" ]
 build:
 [
   [ "ocaml" "pkg/git.ml" ]


### PR DESCRIPTION
cc @dbuenzli 