### PR TITLE
imap needs base64 >= 2.0.0 (that's when Base64 was renamed to B64)

### DIFF
--- a/packages/imap/imap.1.1.0/opam
+++ b/packages/imap/imap.1.1.0/opam
@@ -9,7 +9,7 @@ build: [make]
 build-doc: [make "doc"]
 depends: [
   "uint"
-  "base64"
+  "base64" {>= "2.0.0"}
   "uutf" {<= "0.9.4"}
   "ocamlbuild" {build}
 ]

--- a/packages/imap/imap.1.1.1/opam
+++ b/packages/imap/imap.1.1.1/opam
@@ -9,7 +9,7 @@ build: [make]
 build-doc: [make "doc"]
 depends: [
   "uint"
-  "base64"
+  "base64" {>= "2.0.0"}
   "uutf" {<= "0.9.4"}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
cc @nojb upstream PR https://github.com/nojb/ocaml-imap/pull/29