### PR TITLE
charrua-unix uses Tuntap.gettifaddrs_v4, which is only present since …

### DIFF
--- a/packages/charrua-unix/charrua-unix.0.1/opam
+++ b/packages/charrua-unix/charrua-unix.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "sexplib" {<"113.09.00"}
   "camlp4" {build}
   "ocamlbuild" {build}
-  "tuntap"
+  "tuntap" {> "1.2.0"}
   "cstruct" {<"2.0"}
   "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.1/opam
+++ b/packages/charrua-unix/charrua-unix.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "sexplib" {<"113.09.00"}
   "camlp4" {build}
   "ocamlbuild" {build}
-  "tuntap" {> "1.2.0"}
+  "tuntap" {>= "1.2.0"}
   "cstruct" {<"2.0"}
   "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.3/opam
+++ b/packages/charrua-unix/charrua-unix.0.3/opam
@@ -18,5 +18,5 @@ depends: [
   "charrua-core" {>= "0.3" & <"0.4"}
   "cmdliner"
   "rawlink"
-  "tuntap"
+  "tuntap" {>= "1.2.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.4/opam
+++ b/packages/charrua-unix/charrua-unix.0.4/opam
@@ -18,5 +18,5 @@ depends: [
   "charrua-core" {= "0.4"}
   "cmdliner"
   "rawlink"
-  "tuntap"
+  "tuntap" {>= "1.2.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.5/opam
+++ b/packages/charrua-unix/charrua-unix.0.5/opam
@@ -18,6 +18,6 @@ depends: [
   "charrua-core" {>= "0.5"}
   "cmdliner"
   "rawlink"
-  "tuntap"
+  "tuntap" {>= "1.2.0"}
   "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.6/opam
+++ b/packages/charrua-unix/charrua-unix.0.6/opam
@@ -21,6 +21,6 @@ depends: [
   "charrua-core" {>= "0.5"}
   "cmdliner"
   "rawlink"
-  "tuntap"
+  "tuntap" {>= "1.2.0"}
   "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.9/opam
+++ b/packages/charrua-unix/charrua-unix.0.9/opam
@@ -18,6 +18,6 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink"
-  "tuntap"
+  "tuntap" {>= "1.2.0"}
   "mtime" {>="1.0.0"}
 ]


### PR DESCRIPTION
…tuntap 1.2.0

upstream PR at https://github.com/mirage/charrua-core/pull/75