### PR TITLE
Package amqp-client.1.1.4

### DIFF
--- a/packages/amqp-client/amqp-client.1.1.4/descr
+++ b/packages/amqp-client/amqp-client.1.1.4/descr
@@ -1,0 +1,6 @@
+Amqp client library compatable with async and lwt.
+
+This library provides high level client bindings for amqp. The library
+is tested against rabbitmq, but should work against other amqp
+servers. The library is written in pure OCaml and supports both Async
+and Lwt for concurrency.

--- a/packages/amqp-client/amqp-client.1.1.4/opam
+++ b/packages/amqp-client/amqp-client.1.1.4/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/amqp-client"
+bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
+license: "BSD3"
+dev-repo: "https://github.com/andersfugmann/amqp-client.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+install: [jbuilder install]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+remove: [jbuilder uninstall]
+depends: [
+  "jbuilder" {build}
+  "xml-light" {build}
+  "ocplib-endian" {>= "0.6"}
+  "async" {test}
+  "lwt" {test}
+]
+depopts: ["async" "lwt"]
+conflicts: [
+  "lwt" {< "2.4.6"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/amqp-client/amqp-client.1.1.4/url
+++ b/packages/amqp-client/amqp-client.1.1.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andersfugmann/amqp-client/archive/1.1.4.tar.gz"
+checksum: "9094e13ffda6ab9ee06eca6588fe841d"


### PR DESCRIPTION
### `amqp-client.1.1.4`

Amqp client library compatable with async and lwt.

This library provides high level client bindings for amqp. The library
is tested against rabbitmq, but should work against other amqp
servers. The library is written in pure OCaml and supports both Async
and Lwt for concurrency.



---
* Homepage: https://github.com/andersfugmann/amqp-client
* Source repo: https://github.com/andersfugmann/amqp-client.git
* Bug tracker: https://github.com/andersfugmann/amqp-client/issues

---

:camel: Pull-request generated by opam-publish v0.3.5