### PR TITLE
solvuu-build: not compatible with 4.06.0 safe-string

### DIFF
--- a/packages/solvuu-build/solvuu-build.0.1.0/opam
+++ b/packages/solvuu-build/solvuu-build.0.1.0/opam
@@ -15,4 +15,4 @@ install: [
   [make "solvuu-build.install"]
 ]
 depends: ["ocamlfind" "ocamlbuild" "ocamlgraph"]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]

--- a/packages/solvuu-build/solvuu-build.0.2.0/opam
+++ b/packages/solvuu-build/solvuu-build.0.2.0/opam
@@ -20,6 +20,5 @@ depends: [
   "ocamlgraph"
 ]
 
-available: [
-  ocaml-version >= "4.02.0"
-]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
+

--- a/packages/solvuu-build/solvuu-build.0.3.0/opam
+++ b/packages/solvuu-build/solvuu-build.0.3.0/opam
@@ -13,4 +13,5 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: ["ocamlfind" "ocamlbuild" "ocamlgraph"]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
+


### PR DESCRIPTION
cc @agarwal -- a new release would be appreciated for 4.06.0 support of packages that use solvuu-build