### PR TITLE
Mirage 4.06.0 fixes

### DIFF
--- a/packages/cstruct/cstruct.2.3.2/opam
+++ b/packages/cstruct/cstruct.2.3.2/opam
@@ -53,4 +53,4 @@ depopts: [
   "lwt"
   "base-unix"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0" ]

--- a/packages/io-page-unix/io-page-unix.0.1.0/opam
+++ b/packages/io-page-unix/io-page-unix.0.1.0/opam
@@ -13,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "unix-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/io-page-unix/io-page-unix.0.9.9/opam
+++ b/packages/io-page-unix/io-page-unix.0.9.9/opam
@@ -13,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "unix-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/io-page-xen/io-page-xen.0.1.0/opam
+++ b/packages/io-page-xen/io-page-xen.0.1.0/opam
@@ -13,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "xen-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/io-page-xen/io-page-xen.0.9.9/opam
+++ b/packages/io-page-xen/io-page-xen.0.9.9/opam
@@ -13,3 +13,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "xen-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/mirage/mirage.1.1.0/opam
+++ b/packages/mirage/mirage.1.1.0/opam
@@ -25,5 +25,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage"
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/mirage/mirage.1.1.1/opam
+++ b/packages/mirage/mirage.1.1.1/opam
@@ -26,5 +26,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage"
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/mirage/mirage.1.1.2/opam
+++ b/packages/mirage/mirage.1.1.2/opam
@@ -25,5 +25,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage"
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/mirage/mirage.1.1.3/opam
+++ b/packages/mirage/mirage.1.1.3/opam
@@ -25,5 +25,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage"
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/mirage/mirage.1.2.0/opam
+++ b/packages/mirage/mirage.1.2.0/opam
@@ -25,5 +25,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage"
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]


### PR DESCRIPTION
Fixes for mirage, io-page-unix/xen and cstruct.2.3.2 to constrain on < ocaml 4.06.0