### PR TITLE
ctypes: constrain older versions that are not safe-string by default

### DIFF
--- a/packages/ctypes/ctypes.0.6.0/opam
+++ b/packages/ctypes/ctypes.0.6.0/opam
@@ -29,4 +29,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/ctypes/ctypes.0.6.1/opam
+++ b/packages/ctypes/ctypes.0.6.1/opam
@@ -29,4 +29,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/ctypes/ctypes.0.6.2/opam
+++ b/packages/ctypes/ctypes.0.6.2/opam
@@ -29,4 +29,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/ctypes/ctypes.0.6.3/opam
+++ b/packages/ctypes/ctypes.0.6.3/opam
@@ -29,4 +29,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/ctypes/ctypes.0.7.0/opam
+++ b/packages/ctypes/ctypes.0.7.0/opam
@@ -34,4 +34,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/ctypes/ctypes.0.7.1/opam
+++ b/packages/ctypes/ctypes.0.7.1/opam
@@ -34,4 +34,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/ctypes/ctypes.0.7.2/opam
+++ b/packages/ctypes/ctypes.0.7.2/opam
@@ -34,4 +34,4 @@ depopts: [
    "mirage-xen"
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
cc @yallop