### PR TITLE
Package secp256k1.0.3.2

### DIFF
--- a/packages/secp256k1/secp256k1.0.3.2/descr
+++ b/packages/secp256k1/secp256k1.0.3.2/descr
@@ -1,0 +1,14 @@
+Elliptic curve library secp256k1 wrapper for Ocaml
+
+This library wrap the secp256k1 EC(DSA) library into an OCaml library. At 
+the moment only a subset of functionalities are available:
+
+- Context: create, clone, destroy, randomize
+- Elliptic curve: public key creation
+- ECDSA: verify, sign
+
+
+All exchanged data (pubkey, signature, seckey) are represented as hex 
+strings.
+
+

--- a/packages/secp256k1/secp256k1.0.3.2/opam
+++ b/packages/secp256k1/secp256k1.0.3.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Yoichi Hirai <i@yoichihirai.com>"
+]
+homepage: "https://github.com/dakk/secp256k1-ml"
+bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/secp256k1-ml"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta9"}
+  "base" {build & >= "v0.9.2"}
+  "stdio" {build & >= "v0.9.0"}
+  "configurator" {build & >= "v0.9.1"}
+  "hex" {test & >= "1.1.1"}
+  "ounit" {test & >= "2.2.2"}
+  "conf-secp256k1"
+  "base-bigarray"
+]
+

--- a/packages/secp256k1/secp256k1.0.3.2/url
+++ b/packages/secp256k1/secp256k1.0.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dakk/secp256k1-ml/archive/0.3.2.zip"
+checksum: "727d33d4627bad7f13ef2652c152598a"


### PR DESCRIPTION
### `secp256k1.0.3.2`

Elliptic curve library secp256k1 wrapper for Ocaml

This library wrap the secp256k1 EC(DSA) library into an OCaml library. At 
the moment only a subset of functionalities are available:

- Context: create, clone, destroy, randomize
- Elliptic curve: public key creation
- ECDSA: verify, sign


All exchanged data (pubkey, signature, seckey) are represented as hex 
strings.





---
* Homepage: https://github.com/dakk/secp256k1-ml
* Source repo: https://github.com/dakk/secp256k1-ml
* Bug tracker: https://github.com/dakk/secp256k1-ml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5