### PR TITLE
mlgmpidl.1.2.6: new url (fixing bytecode and native plugins)

### DIFF
--- a/packages/mlgmpidl/mlgmpidl.1.2.6/url
+++ b/packages/mlgmpidl/mlgmpidl.1.2.6/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/nberth/mlgmpidl/archive/1.2.6.tar.gz"
-checksum: "fc1b04a8260ee2a60c493e2ef3c49c30"
+checksum: "eda18d5542378b285e78590e200b399a"


### PR DESCRIPTION
This should fix issue https://github.com/nberth/mlgmpidl/issues/3