### PR TITLE
pyml.20171117

### DIFF
--- a/packages/pyml/pyml.20171117/descr
+++ b/packages/pyml/pyml.20171117/descr
@@ -1,0 +1,1 @@
+OCaml bindings for Python

--- a/packages/pyml/pyml.20171117/opam
+++ b/packages/pyml/pyml.20171117/opam
@@ -10,7 +10,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocamlfind" {build}
-  "stdcompat"
+  "stdcompat" {>= "1"}
 ]
 depopts: ["utop"]
 version: "20171117"

--- a/packages/pyml/pyml.20171117/opam
+++ b/packages/pyml/pyml.20171117/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://pyml.gforge.inria.fr"
+bug-reports: "http://pyml.gforge.inria.fr/tracker"
+license: "BSD"
+dev-repo: "https://scm.gforge.inria.fr/anonscm/git/pyml/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "ocamlfind" {build}
+  "stdcompat"
+]
+depopts: ["utop"]
+version: "20171117"

--- a/packages/pyml/pyml.20171117/opam
+++ b/packages/pyml/pyml.20171117/opam
@@ -13,4 +13,4 @@ depends: [
   "stdcompat" {>= "1"}
 ]
 depopts: ["utop"]
-version: "20171117"
+available: [ocaml-version >= "3.12.1" & ocaml-version < "4.07.0"]

--- a/packages/pyml/pyml.20171117/url
+++ b/packages/pyml/pyml.20171117/url
@@ -1,3 +1,3 @@
 http: "http://pyml.gforge.inria.fr/pyml-20171117.tar.gz"
-checksum: "4180fad1728162f69785dc2f01b1c805"
+checksum: "285ba07b973f713c66991faf5382814d"
 

--- a/packages/pyml/pyml.20171117/url
+++ b/packages/pyml/pyml.20171117/url
@@ -1,0 +1,3 @@
+http: "http://pyml.gforge.inria.fr/pyml-20171117.tar.gz"
+checksum: "4180fad1728162f69785dc2f01b1c805"
+


### PR DESCRIPTION
This version uses `stdcompat` to ensure compatibilty with respect to old versions of OCaml (from 3.12.0).