### PR TITLE
restrict angstom-lwt-unix to <4.06.0

### DIFF
--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.6.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.6.0/opam
@@ -18,4 +18,4 @@ depends: [
   "lwt"
   "base-unix"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.7.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.7.0/opam
@@ -18,4 +18,4 @@ depends: [
   "lwt"
   "base-unix"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
cc @seliopou (via http://obi.ocamllabs.io/logs/2a78da8610334bf991cb988508040e85.txt):
```
# File "lwt/angstrom_lwt_unix.ml", line 44, characters 31-61:
# Error: This expression has type string but an expression was expected of type
#          bytes
```