### PR TITLE
bisect fails with safe-string

### DIFF
--- a/packages/bisect/bisect.1.3/opam
+++ b/packages/bisect/bisect.1.3/opam
@@ -28,3 +28,4 @@ patches: [
   "opam.patch"
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
I'm not entirely sure whether bisect is still used (I personally use bisect_ppx these days) //cc @xclerc (see http://obi.ocamllabs.io/logs/982d939c9d04f6940aa49f56edf6019b.txt for the failure)