### PR TITLE
mtime < 0.8.4 are not safe-string aware

### DIFF
--- a/packages/mtime/mtime.0.8.0/opam
+++ b/packages/mtime/mtime.0.8.0/opam
@@ -10,7 +10,7 @@ license: "BSD3"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind" {build}
-  "js_of_ocaml" {< "3.0.0"} # FIXME this should eventually be a deptopt
+  "js_of_ocaml" {< "3.0"} # FIXME this should eventually be a deptopt
   "ocamlbuild" {build}
 ]
 build: ["ocaml" "pkg/git.ml"]

--- a/packages/mtime/mtime.0.8.0/opam
+++ b/packages/mtime/mtime.0.8.0/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/mtime.git"
 bug-reports: "https://github.com/dbuenzli/mtime/issues"
 tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "BSD3"
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind"
   "js_of_ocaml" # FIXME this should eventually be a deptopt

--- a/packages/mtime/mtime.0.8.0/opam
+++ b/packages/mtime/mtime.0.8.0/opam
@@ -9,8 +9,8 @@ tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
-  "ocamlfind"
-  "js_of_ocaml" # FIXME this should eventually be a deptopt
+  "ocamlfind" {build}
+  "js_of_ocaml" {< "3.0.0"} # FIXME this should eventually be a deptopt
   "ocamlbuild" {build}
 ]
 build: ["ocaml" "pkg/git.ml"]

--- a/packages/mtime/mtime.0.8.1/opam
+++ b/packages/mtime/mtime.0.8.1/opam
@@ -10,7 +10,7 @@ license: "BSD3"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind" {build}
-  "js_of_ocaml" {< "3.0.0"} # FIXME this should eventually be a deptopt
+  "js_of_ocaml" {< "3.0"} # FIXME this should eventually be a deptopt
   "ocamlbuild" {build}
 ]
 build: ["ocaml" "pkg/git.ml"]

--- a/packages/mtime/mtime.0.8.1/opam
+++ b/packages/mtime/mtime.0.8.1/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/mtime.git"
 bug-reports: "https://github.com/dbuenzli/mtime/issues"
 tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "BSD3"
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind"
   "js_of_ocaml" # FIXME this should eventually be a deptopt

--- a/packages/mtime/mtime.0.8.1/opam
+++ b/packages/mtime/mtime.0.8.1/opam
@@ -9,8 +9,8 @@ tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
-  "ocamlfind"
-  "js_of_ocaml" # FIXME this should eventually be a deptopt
+  "ocamlfind" {build}
+  "js_of_ocaml" {< "3.0.0"} # FIXME this should eventually be a deptopt
   "ocamlbuild" {build}
 ]
 build: ["ocaml" "pkg/git.ml"]

--- a/packages/mtime/mtime.0.8.2/opam
+++ b/packages/mtime/mtime.0.8.2/opam
@@ -10,7 +10,7 @@ license: "BSD3"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind" {build}
-  "js_of_ocaml" {< "3.0.0"} # FIXME this should eventually be a deptopt
+  "js_of_ocaml" {< "3.0"} # FIXME this should eventually be a deptopt
   "ocamlbuild" {build}
 ]
 build: ["ocaml" "pkg/git.ml"]

--- a/packages/mtime/mtime.0.8.2/opam
+++ b/packages/mtime/mtime.0.8.2/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/mtime.git"
 bug-reports: "https://github.com/dbuenzli/mtime/issues"
 tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "BSD3"
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind"
   "js_of_ocaml" # FIXME this should eventually be a deptopt

--- a/packages/mtime/mtime.0.8.2/opam
+++ b/packages/mtime/mtime.0.8.2/opam
@@ -9,8 +9,8 @@ tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
-  "ocamlfind"
-  "js_of_ocaml" # FIXME this should eventually be a deptopt
+  "ocamlfind" {build}
+  "js_of_ocaml" {< "3.0.0"} # FIXME this should eventually be a deptopt
   "ocamlbuild" {build}
 ]
 build: ["ocaml" "pkg/git.ml"]

--- a/packages/mtime/mtime.0.8.3/opam
+++ b/packages/mtime/mtime.0.8.3/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/mtime.git"
 bug-reports: "https://github.com/dbuenzli/mtime/issues"
 tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "BSD-3-Clause"
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends:
 [
   "ocamlfind" {build}


### PR DESCRIPTION
due to the `topkg` based build system in `pkg` (since 0.8.4 the topkg package is used) //cc @dbuenzli 