### PR TITLE
ptime 0.8.0 is not safe-string safe

### DIFF
--- a/packages/ptime/ptime.0.8.0/opam
+++ b/packages/ptime/ptime.0.8.0/opam
@@ -7,7 +7,7 @@ dev-repo: "http://erratique.ch/repos/ptime.git"
 bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "BSD-3-Clause"
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
  "ocamlfind" {build}
  "ocamlbuild" {build}


### PR DESCRIPTION
same reason as mtime, cc @dbuenzli 