### PR TITLE
restrict vpnkit to dns-forward < 0.10.0

### DIFF
--- a/packages/vpnkit/vpnkit.0.0.0/opam
+++ b/packages/vpnkit/vpnkit.0.0.0/opam
@@ -36,7 +36,7 @@ depends: [
   "tcpip" { >= "2.8.0" & < "3.0.0" }
   "pcap-format"
   "dns"
-  "dns-forward"
+  "dns-forward" {< "0.10.0"}
   "datakit-server" {< "0.10.0"}
   "hashcons" {= "1.0.1"}
   "pcap-format" { >= "0.4.0" }

--- a/packages/vpnkit/vpnkit.0.1.1/opam
+++ b/packages/vpnkit/vpnkit.0.1.1/opam
@@ -34,7 +34,7 @@ depends: [
   "dns" {>= "0.19.1"}
   "dns-lwt"
   "dnssd" {>= "0.2"}
-  "dns-forward"
+  "dns-forward" {< "0.10.0"}
   "cstruct-lwt" {>= "3.0.0"}
   "datakit-server" {>= "0.11.0"}
   "datakit-server-9p" {>= "0.11.0"}

--- a/packages/vpnkit/vpnkit.0.1.1/opam
+++ b/packages/vpnkit/vpnkit.0.1.1/opam
@@ -63,5 +63,5 @@ depends: [
   "protocol-9p-unix" {>= "0.11.2"}
   "mirage-vnetif" {>= "0.4.0"}
   "uuidm"
-  "ezjsonm"
+  "ezjsonm" {>= "0.4.0"}
 ]


### PR DESCRIPTION
cc @djs55 -- this is observed in https://github.com/mirage/mirage-protocols/pull/9 and https://github.com/mirage/ocaml-ipaddr/pull/67