### PR TITLE
uucp/uucd/uunf: mark unavailable in >=4.06.0 due to safe-string

### DIFF
--- a/packages/uucd/uucd.0.9.0/opam
+++ b/packages/uucd/uucd.0.9.0/opam
@@ -6,8 +6,9 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "uucd"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "xmlm"
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/uucd/uucd.1.0.0/opam
+++ b/packages/uucd/uucd.1.0.0/opam
@@ -14,8 +14,8 @@ build: [
   ["./pkg/build" "true"]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "xmlm"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]

--- a/packages/uucd/uucd.2.0.0/opam
+++ b/packages/uucd/uucd.2.0.0/opam
@@ -6,9 +6,9 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 doc: "http://erratique.ch/software/uucd/doc/Uucd"
 tags: [ "unicode" "database" "decoder" ]
 license: "BSD3"
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "xmlm"
   "ocamlbuild" {build}
 ]

--- a/packages/uucd/uucd.3.0.0/opam
+++ b/packages/uucd/uucd.3.0.0/opam
@@ -7,9 +7,9 @@ bug-reports: "https://github.com/dbuenzli/uucd/issues"
 doc: "http://erratique.ch/software/uucd/doc/Uucd"
 tags: [ "unicode" "database" "decoder" "org:erratique" ]
 license: "BSD3"
-available: [ ocaml-version >= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "xmlm"
   "ocamlbuild" {build}
 ]

--- a/packages/uucp/uucp.0.9.0/opam
+++ b/packages/uucp/uucp.0.9.0/opam
@@ -7,11 +7,11 @@ doc: "http://erratique.ch/software/uucp/doc/Uucp"
 tags: [ "unicode" "text" "character" ]
 license: "BSD3"
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 build: 
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/uucp/uucp.0.9.1/opam
+++ b/packages/uucp/uucp.0.9.1/opam
@@ -8,11 +8,11 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "BSD3"
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 build: 
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/uucp/uucp.1.0.0/opam
+++ b/packages/uucp/uucp.1.0.0/opam
@@ -8,11 +8,11 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "BSD3"
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 build: 
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/uucp/uucp.1.1.0/opam
+++ b/packages/uucp/uucp.1.1.0/opam
@@ -8,11 +8,11 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "BSD3"
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 build:
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/uunf/uunf.1.0.0/opam
+++ b/packages/uunf/uunf.1.0.0/opam
@@ -7,9 +7,9 @@ dev-repo: "http://erratique.ch/repos/uunf.git"
 bug-reports: "https://github.com/dbuenzli/uunf/issues"
 tags: [ "unicode" "text" "normalization" "org:erratique" ]
 license: "BSD3"
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
 depopts: [ "uutf" "cmdliner" ]


### PR DESCRIPTION
additionally, mark `ocamlfind` as `{build}` dependency. //cc @dbuenzli 