### PR TITLE
capnp-rpc-lwt requires Uri.with_userinfo, which is only in uri >= 1.6.0

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-kv-lwt"
   "mirage-clock"
   "base64"
-  "uri"
+  "uri" {>= "1.6.0"}
   "jbuilder" {build & >= "1.0+beta10" }
   "alcotest" {test}
 ]

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-kv-lwt"
   "mirage-clock"
   "base64"
-  "uri"
+  "uri" {>= "1.6.0"}
   "jbuilder" {build & >= "1.0+beta10" }
   "alcotest-lwt" {test}
 ]


### PR DESCRIPTION
upstream PR https://github.com/mirage/capnp-rpc/pull/138