### PR TITLE
mirage-logs.0.3 uses Ptime.v, which is only available since ptime.0.8.1

### DIFF
--- a/packages/mirage-logs/mirage-logs.0.3.0/opam
+++ b/packages/mirage-logs/mirage-logs.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "logs" { >= "0.5.0" }
-  "ptime"
+  "ptime" { >= "0.8.1" }
   "mirage-clock" { >= "1.2.0"}
   "mirage-profile"
   "lwt"


### PR DESCRIPTION
upstream PR https://github.com/mirage/mirage-logs/pull/12