### PR TITLE
continue #10381: conflict git with cstruct > 3.1.1

### DIFF
--- a/packages/git/git.1.10.0/opam
+++ b/packages/git/git.1.10.0/opam
@@ -20,4 +20,5 @@ depends: [
   "astring"
   "ocplib-endian" {>= "0.6.0"}
 ]
+conflicts: [ "cstruct"  {> "3.1.1"} ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.11.0/opam
+++ b/packages/git/git.1.11.0/opam
@@ -29,4 +29,5 @@ depends: [
   "nocrypto" {test}
   "mtime"    {test & >= "1.0.0"}
 ]
+conflicts: [ "cstruct"  {> "3.1.1"} ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.11.2/opam
+++ b/packages/git/git.1.11.2/opam
@@ -29,4 +29,5 @@ depends: [
   "nocrypto" {test}
   "mtime"    {test & >= "1.0.0"}
 ]
+conflicts: [ "cstruct"  {> "3.1.1"} ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
now that cstruct.3.2 is released, git.1.10.0 and git.1.11.0 and git.1.11.2 are broken with that cstruct release.  The fix is already in git master (https://github.com/mirage/ocaml-git/pull/233), but a release of git is necessary.

//cc @samoht  