### PR TITLE
Package rope.0.6

### DIFF
--- a/packages/rope/rope.0.6/descr
+++ b/packages/rope/rope.0.6/descr
@@ -1,0 +1,8 @@
+Ropes ("heavyweight strings")
+
+Ropes ("heavyweight strings") are a scalable string implementation:
+they are designed for efficient operation that involve the string as a
+whole.  Operations such as concatenation, and substring take time that
+is nearly independent of the length of the string.  Unlike strings,
+ropes are a reasonable representation for very long strings such as
+edit buffers or mail messages.

--- a/packages/rope/rope.0.6/opam
+++ b/packages/rope/rope.0.6/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-rope"
+dev-repo: "https://github.com/Chris00/ocaml-rope.git"
+bug-reports: "https://github.com/Chris00/ocaml-rope/issues"
+doc: "https://Chris00.github.io/ocaml-rope/doc"
+tags: [ "datastructure"  ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "base-bytes"
+  "jbuilder" {build}
+  "benchmark" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/rope/rope.0.6/url
+++ b/packages/rope/rope.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-rope/releases/download/0.6/rope-0.6.tbz"
+checksum: "a238dea21241eb3103acff6f164256a2"


### PR DESCRIPTION
### `rope.0.6`

Ropes ("heavyweight strings")

Ropes ("heavyweight strings") are a scalable string implementation:
they are designed for efficient operation that involve the string as a
whole.  Operations such as concatenation, and substring take time that
is nearly independent of the length of the string.  Unlike strings,
ropes are a reasonable representation for very long strings such as
edit buffers or mail messages.



---
* Homepage: https://github.com/Chris00/ocaml-rope
* Source repo: https://github.com/Chris00/ocaml-rope.git
* Bug tracker: https://github.com/Chris00/ocaml-rope/issues

---


---
0.6 2017-11-17 
--------------

- Enrich the library to have all functions of the `String` module.
- Add `rope.top` findlib library so one can just do `#require
  "rope.top";;` in the toplevel (REPL).
- Compatible with `-safe-string` and code improvements based on string
  immutability.
- Port to `jbuilder`.
- Fix all warnings.
- Clarify the license for files in `bench/` and fix FSF address.
:camel: Pull-request generated by opam-publish v0.3.5