### PR TITLE
capnp-rpc-unix uses Fmt.failwith, which requires 0.8.4

### DIFF
--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "cmdliner"
   "cstruct-lwt"
   "astring"
-  "fmt"
+  "fmt" { >= "0.8.4" }
   "logs"
   "jbuilder" {build & >= "1.0+beta10" }
 ]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "cmdliner"
   "cstruct-lwt"
   "astring"
-  "fmt"
+  "fmt" { >= "0.8.4" }
   "logs"
   "jbuilder" {build & >= "1.0+beta10" }
 ]


### PR DESCRIPTION
upstream PR https://github.com/mirage/capnp-rpc/pull/139