### PR TITLE
Package duration.0.1.1

### DIFF
--- a/packages/duration/duration.0.1.1/descr
+++ b/packages/duration/duration.0.1.1/descr
@@ -1,0 +1,6 @@
+Conversions to various time units
+
+
+A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input.

--- a/packages/duration/duration.0.1.1/opam
+++ b/packages/duration/duration.0.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/duration"
+doc: "https://hannesm.github.io/duration/doc"
+dev-repo: "https://github.com/hannesm/duration.git"
+bug-reports: "https://github.com/hannesm/duration/issues"
+license: "ISC"
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "alcotest" {test & >= "0.8.1"}
+]
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]

--- a/packages/duration/duration.0.1.1/url
+++ b/packages/duration/duration.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hannesm/duration/releases/download/0.1.1/duration-0.1.1.tbz"
+checksum: "160e36e2ba16a01492c8c2b6d8c496ac"


### PR DESCRIPTION
### `duration.0.1.1`

Conversions to various time units


A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
has a range of up to 584 years.  Functions provided check the input and raise
on negative or out of bound input.


---
* Homepage: https://github.com/hannesm/duration
* Source repo: https://github.com/hannesm/duration.git
* Bug tracker: https://github.com/hannesm/duration/issues

---


---
## 0.1.1 (2017-11-18)

* test 4.05 and 4.06
* alcotest 0.8.1 compatibility (#2 by @yomimono)
* Don't ship with -warn-error +A, but use it in `./build`
:camel: Pull-request generated by opam-publish v0.3.5