### PR TITLE
New release of stone 0.5.1, compatible with -safe-string

### DIFF
--- a/packages/stone/stone.0.1/opam
+++ b/packages/stone/stone.0.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "armael.gueneau@ens-lyon.fr"
+author: "armael@isomorphis.me"
+homepage: "http://dev.isomorphis.me/stone"
+bug-reports: "http://github.com/Armael/stone/issues"
 build: [
   ["./configure" "--bin-dir" bin]
   [make]

--- a/packages/stone/stone.0.1/opam
+++ b/packages/stone/stone.0.1/opam
@@ -19,3 +19,4 @@ patches: [
 ]
 dev-repo: "git://github.com/Armael/stone"
 install: [make "install"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.1/opam
+++ b/packages/stone/stone.0.1/opam
@@ -13,7 +13,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "cow" {< "0.6.0"}
+  "cow" {>= "0.5.0" & < "0.6.0"}
   "config-file"
 ]
 patches: [

--- a/packages/stone/stone.0.2/opam
+++ b/packages/stone/stone.0.2/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "armael.gueneau@ens-lyon.fr"
+author: "armael@isomorphis.me"
+homepage: "http://dev.isomorphis.me/stone"
+bug-reports: "http://github.com/Armael/stone/issues"
 build: [
   ["./configure" "--bin-dir" bin]
   [make]

--- a/packages/stone/stone.0.2/opam
+++ b/packages/stone/stone.0.2/opam
@@ -15,3 +15,4 @@ depends: [
 ]
 dev-repo: "git://github.com/Armael/stone"
 install: [make "install"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.2/opam
+++ b/packages/stone/stone.0.2/opam
@@ -13,7 +13,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "cow" {< "0.6.0"}
+  "cow" {>= "0.5.0" & < "0.6.0"}
   "config-file"
 ]
 dev-repo: "git://github.com/Armael/stone"

--- a/packages/stone/stone.0.3.1/opam
+++ b/packages/stone/stone.0.3.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "armael.gueneau@ens-lyon.fr"
+author: "armael@isomorphis.me"
+homepage: "http://dev.isomorphis.me/stone"
+bug-reports: "http://github.com/Armael/stone/issues"
 build: [
   ["./configure" "--bin-dir" bin]
   [make]

--- a/packages/stone/stone.0.3.1/opam
+++ b/packages/stone/stone.0.3.1/opam
@@ -16,3 +16,4 @@ depends: [
 ]
 dev-repo: "git://github.com/Armael/stone"
 install: [make "install"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.3.2/opam
+++ b/packages/stone/stone.0.3.2/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "armael.gueneau@ens-lyon.fr"
+author: "armael@isomorphis.me"
+homepage: "http://dev.isomorphis.me/stone"
+bug-reports: "http://github.com/Armael/stone/issues"
 build: [
   ["./configure" "--bin-dir" bin]
   [make]

--- a/packages/stone/stone.0.3.2/opam
+++ b/packages/stone/stone.0.3.2/opam
@@ -16,3 +16,4 @@ depends: [
 ]
 dev-repo: "git://github.com/Armael/stone"
 install: [make "install"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.3.3/opam
+++ b/packages/stone/stone.0.3.3/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "armael.gueneau@ens-lyon.fr"
+author: "armael@isomorphis.me"
+homepage: "http://dev.isomorphis.me/stone"
+bug-reports: "http://github.com/Armael/stone/issues"
 build: [
   ["./configure" "--bin-dir" bin]
   [make]

--- a/packages/stone/stone.0.3.3/opam
+++ b/packages/stone/stone.0.3.3/opam
@@ -16,3 +16,4 @@ depends: [
 ]
 dev-repo: "git://github.com/Armael/stone"
 install: [make "install"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.3.4/opam
+++ b/packages/stone/stone.0.3.4/opam
@@ -19,3 +19,4 @@ depends: [
   "config-file"
   "omd"
   ]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.3/opam
+++ b/packages/stone/stone.0.3/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "armael.gueneau@ens-lyon.fr"
+author: "armael@isomorphis.me"
+homepage: "http://dev.isomorphis.me/stone"
+bug-reports: "http://github.com/Armael/stone/issues"
 build: [
   ["./configure" "--bin-dir" bin]
   [make]

--- a/packages/stone/stone.0.3/opam
+++ b/packages/stone/stone.0.3/opam
@@ -16,3 +16,4 @@ depends: [
 ]
 dev-repo: "git://github.com/Armael/stone"
 install: [make "install"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.4.0/opam
+++ b/packages/stone/stone.0.4.0/opam
@@ -21,3 +21,4 @@ depends: [
   "inotify" {>= "2.3"}
   "omd"
   ]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.5.0/opam
+++ b/packages/stone/stone.0.5.0/opam
@@ -21,3 +21,4 @@ depends: [
   "inotify" {>= "2.3"}
   "omd"
   ]
+available: [ ocaml-version < "4.06" ]

--- a/packages/stone/stone.0.5.1/descr
+++ b/packages/stone/stone.0.5.1/descr
@@ -1,0 +1,2 @@
+Simple static website generator, useful for a portfolio or documentation pages
+Full documentation is available at http://dev.isomorphis.me/stone/

--- a/packages/stone/stone.0.5.1/opam
+++ b/packages/stone/stone.0.5.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "armael@isomorphis.me"
+author: "armael@isomorphis.me"
+homepage: "http://dev.isomorphis.me/stone"
+bug-reports: "http://github.com/Armael/stone/issues"
+dev-repo: "http://github.com/Armael/stone.git"
+build: [
+  ["./configure" "--bin-dir" bin]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["./configure" "--bin-dir" bin]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "cow" {>= "2.0.0"}
+  "base-bytes"
+  "config-file"
+  "crunch"
+  "inotify" {>= "2.3"}
+  "omd"
+  ]

--- a/packages/stone/stone.0.5.1/url
+++ b/packages/stone/stone.0.5.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Armael/stone/archive/v0.5.1.tar.gz"
+checksum: "0866e3637b35df94fae173416fede7a3"


### PR DESCRIPTION
Additionally, add constraints for old versions of stone that do not compile with ocaml 4.06