### PR TITLE
mirage-profile requires cstruct <3.2.0 since it doesn't specify its o…

### DIFF
--- a/packages/mirage-profile/mirage-profile.0.7.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.7.0/opam
@@ -18,7 +18,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-profile"]
 depends: [
   "ocamlfind" {build}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "3.2.0"}
   "ppx_cstruct" {build}
   "ppx_tools" {build}
   "ocplib-endian"

--- a/packages/mirage-profile/mirage-profile.0.8.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "3.2.0"}
   "ppx_cstruct" {build}
   "ocplib-endian"
   "lwt"

--- a/packages/mirage-profile/mirage-profile.0.8.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.1/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "3.2.0"}
   "ppx_cstruct" {build}
   "ocplib-endian"
   "lwt"


### PR DESCRIPTION
…cplib-endian dependency properly in its build system

upstream issue report https://github.com/mirage/mirage-profile/issues/30