### PR TITLE
restrict core v0.9.0 to ocaml < 4.05.0

### DIFF
--- a/packages/core/core.v0.9.0/opam
+++ b/packages/core/core.v0.9.0/opam
@@ -22,4 +22,4 @@ depends: [
   "base-threads"
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.05.0" ]


### PR DESCRIPTION
core v0.9.0 contains a unix module that doesn't include `O_KEEPEXEC` in its `open_flag` definition, resulting in an unbuildable package on 4.05.0 which added that flag in its stdlib Unix module.

(discovered in https://github.com/ocaml/opam-repository/pull/10736)