### PR TITLE
add bound on ocaml version

### DIFF
--- a/packages/gen_js_api/gen_js_api.1.0.4/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.4/opam
@@ -15,4 +15,4 @@ depends: [
   "ocamlfind" {build}
   "js_of_ocaml"
 ]
-available: [ocaml-version >= "4.05.0"]
+available: [ocaml-version >= "4.05.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
`gen_js_api.1.0.4` doesn't work on 4.06 because of an AST change.

upstream PR for fix: https://github.com/LexiFi/gen_js_api/pull/76

cc @alainfrisch @sbriais 