### PR TITLE
obuild: add bound on ocaml version

### DIFF
--- a/packages/obuild/obuild.0.0.1/opam
+++ b/packages/obuild/obuild.0.0.1/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.1/opam
+++ b/packages/obuild/obuild.0.0.1/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/vincenthz/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.2/opam
+++ b/packages/obuild/obuild.0.0.2/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.2/opam
+++ b/packages/obuild/obuild.0.0.2/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/vincenthz/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.3/opam
+++ b/packages/obuild/obuild.0.0.3/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.3/opam
+++ b/packages/obuild/obuild.0.0.3/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/vincenthz/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.4/opam
+++ b/packages/obuild/obuild.0.0.4/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.4/opam
+++ b/packages/obuild/obuild.0.0.4/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/vincenthz/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.5/opam
+++ b/packages/obuild/obuild.0.0.5/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.5/opam
+++ b/packages/obuild/obuild.0.0.5/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.6/opam
+++ b/packages/obuild/obuild.0.0.6/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.6/opam
+++ b/packages/obuild/obuild.0.0.6/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.7/opam
+++ b/packages/obuild/obuild.0.0.7/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.7/opam
+++ b/packages/obuild/obuild.0.0.7/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.8/opam
+++ b/packages/obuild/obuild.0.0.8/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.0.8/opam
+++ b/packages/obuild/obuild.0.0.8/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "tab@snarc.org"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.9/opam
+++ b/packages/obuild/obuild.0.0.9/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.0.9/opam
+++ b/packages/obuild/obuild.0.0.9/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.0/opam
+++ b/packages/obuild/obuild.0.1.0/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.1.0/opam
+++ b/packages/obuild/obuild.0.1.0/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.1/opam
+++ b/packages/obuild/obuild.0.1.1/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.1.1/opam
+++ b/packages/obuild/obuild.0.1.1/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.2/opam
+++ b/packages/obuild/obuild.0.1.2/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.1.2/opam
+++ b/packages/obuild/obuild.0.1.2/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.3/opam
+++ b/packages/obuild/obuild.0.1.3/opam
@@ -1,4 +1,9 @@
 opam-version: "1.2"
+
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+
 maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]

--- a/packages/obuild/obuild.0.1.3/opam
+++ b/packages/obuild/obuild.0.1.3/opam
@@ -4,3 +4,4 @@ build: [
   ["./bootstrap"]
 ]
 dev-repo: "git://github.com/ocaml-obuild/obuild"
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.4/opam
+++ b/packages/obuild/obuild.0.1.4/opam
@@ -8,3 +8,4 @@ maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.4/opam
+++ b/packages/obuild/obuild.0.1.4/opam
@@ -3,6 +3,7 @@ opam-version: "1.2"
 homepage: "https://github.com/ocaml-obuild/obuild"
 bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
 dev-repo: "https://github.com/ocaml-obuild/obuild.git"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
 
 maintainer: "jmaloberti@gmail.com"
 build: [

--- a/packages/obuild/obuild.0.1.5/opam
+++ b/packages/obuild/obuild.0.1.5/opam
@@ -9,3 +9,4 @@ maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.6/opam
+++ b/packages/obuild/obuild.0.1.6/opam
@@ -9,3 +9,4 @@ maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.7/opam
+++ b/packages/obuild/obuild.0.1.7/opam
@@ -9,3 +9,4 @@ maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/obuild/obuild.0.1.8/opam
+++ b/packages/obuild/obuild.0.1.8/opam
@@ -9,3 +9,4 @@ maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]
 ]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
`obuild` doesn't work on 4.06 because of the safe-string default.

The fix is already done upstream:
https://github.com/ocaml-obuild/obuild/commit/668a70a5b1f14fb5a176cd3b81477f0bd3d5bd8a

The last missing thing is a release.
cc @ocaml/ocamlbuild-dev 
