### PR TITLE
irmin-http, mechaml, wcs-api, yurt: all depend on Cohttp_lwt_body

### DIFF
--- a/packages/horned_worm/horned_worm.0.1.1/opam
+++ b/packages/horned_worm/horned_worm.0.1.1/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/kkazuo/horned_worm.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "batteries" {>= "2.7.0"}
-  "cohttp-lwt-unix" {>= "0.99.0"}
+  "cohttp-lwt-unix" {>= "0.99.0" & < "1.0"}
   "logs" {>= "0.6.2"}
   "re" {>= "1.7.1"}
   "yojson" {>= "1.4.0"}

--- a/packages/horned_worm/horned_worm.0.3.1/opam
+++ b/packages/horned_worm/horned_worm.0.3.1/opam
@@ -7,7 +7,7 @@ license: "MIT"
 dev-repo: "https://github.com/kkazuo/horned_worm.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
-  "cohttp-async" {>= "0.99.0"}
+  "cohttp-async" {>= "0.99.0" & < "1.0"}
   "logs" {>= "0.6.2"}
   "re" {>= "1.7.1"}
   "yojson" {>= "1.4.0"}

--- a/packages/irmin-http/irmin-http.1.3.1/opam
+++ b/packages/irmin-http/irmin-http.1.3.1/opam
@@ -18,7 +18,7 @@ depends: [
   "crunch"
   "webmachine" {>= "0.3.2"}
   "irmin"  {>= "1.2.0"}
-  "cohttp-lwt" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99.0" & < "1.0"}
   "irmin-git" {test & >= "1.2.0"}
   "irmin-mem" {test & >= "1.2.0"}
   "alcotest"  {test}

--- a/packages/mechaml/mechaml.1.0.0/opam
+++ b/packages/mechaml/mechaml.1.0.0/opam
@@ -19,7 +19,7 @@ remove: ["ocamlfind" "remove" "mechaml"]
 depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "cohttp" {>= "0.21.0"}
+  "cohttp" {>= "0.21.0" & < "1.0"}
   "cohttp-lwt"
   "cohttp-lwt-unix"
   "lwt"

--- a/packages/wcs-api/wcs-api.2017-05-26.01/opam
+++ b/packages/wcs-api/wcs-api.2017-05-26.01/opam
@@ -23,7 +23,7 @@ build-test: [ ["jbuilder" "runtest"] ]
 depends: [
   "wcs-lib" {= "2017-05-26.01"}
   "lwt_ssl"
-  "cohttp-lwt-unix"
+  "cohttp-lwt-unix" { >="0.20.0" & <"1.0"}
 ]
 available: [
   ocaml-version >= "4.03.0"

--- a/packages/yurt/yurt.0.3/opam
+++ b/packages/yurt/yurt.0.3/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "conduit-lwt-unix" {>= "1.0.0"}
-  "cohttp-lwt-unix" {>= "0.99.0"}
+  "cohttp-lwt-unix" {>= "0.99.0" & < "1.0"}
   "ezjsonm" {>= "0.5.0"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
this is unavailable in cohttp 1.0+

hopefully last of the revdeps for #10759 