### PR TITLE
qtest: add bound on OCaml version

### DIFF
--- a/packages/qtest/qtest.2.0.0/opam
+++ b/packages/qtest/qtest.2.0.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "vincent.hugot@gmail.com"
+authors: "Vincent Hugot <vincent.hugot@gmail.com>"
+homepage: "https://github.com/vincent-hugot/iTeML"
+bug-reports: "https://github.com/vincent-hugot/iTeML/issues"
 remove: [["ocaml" "do.ml" "qtest" "remove" prefix]]
 depends: [
   "ocamlfind"

--- a/packages/qtest/qtest.2.0.0/opam
+++ b/packages/qtest/qtest.2.0.0/opam
@@ -8,5 +8,5 @@ depends: [
   "ounit"
 ]
 dev-repo: "git://github.com/vincent-hugot/iTeML"
-available: ocaml-version > "3.12.0"
+available: [ocaml-version > "3.12.0" & ocaml-version < "4.06.0"]
 install: ["ocaml" "do.ml" "qtest" "install" prefix]

--- a/packages/qtest/qtest.2.0.1/opam
+++ b/packages/qtest/qtest.2.0.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "vincent.hugot@gmail.com"
+authors: "Vincent Hugot <vincent.hugot@gmail.com>"
+homepage: "https://github.com/vincent-hugot/iTeML"
+bug-reports: "https://github.com/vincent-hugot/iTeML/issues"
 remove: [["ocaml" "do.ml" "qtest" "remove" prefix]]
 depends: [
   "ocamlfind"

--- a/packages/qtest/qtest.2.0.1/opam
+++ b/packages/qtest/qtest.2.0.1/opam
@@ -8,5 +8,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/vincent-hugot/iTeML"
-available: ocaml-version > "3.12.0"
+available: [ocaml-version > "3.12.0" & ocaml-version < "4.06.0"]
 install: ["ocaml" "do.ml" "qtest" "install" prefix]

--- a/packages/qtest/qtest.2.1.0/opam
+++ b/packages/qtest/qtest.2.1.0/opam
@@ -14,4 +14,4 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [  ocaml-version >= "4.00.0" ]
+available: [  ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]

--- a/packages/qtest/qtest.2.1.1/opam
+++ b/packages/qtest/qtest.2.1.1/opam
@@ -15,4 +15,4 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/qtest/qtest.2.2/opam
+++ b/packages/qtest/qtest.2.2/opam
@@ -23,4 +23,4 @@ depends: [
   "base-bytes"
 ]
 conflicts: "qcheck"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/qtest/qtest.2.3/opam
+++ b/packages/qtest/qtest.2.3/opam
@@ -23,4 +23,4 @@ depends: [
   "base-bytes"
 ]
 conflicts: "qcheck"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/qtest/qtest.2.4/opam
+++ b/packages/qtest/qtest.2.4/opam
@@ -23,4 +23,4 @@ depends: [
   "base-bytes"
 ]
 conflicts: "qcheck"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/qtest/qtest.2.5/opam
+++ b/packages/qtest/qtest.2.5/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "qcheck" {>= "0.5"}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 post-messages:
   "Version similar to 2.4, except it uses qcheck as an external library
   instead of embedding it. There should be no other difference.

--- a/packages/qtest/qtest.2.6/opam
+++ b/packages/qtest/qtest.2.6/opam
@@ -19,4 +19,4 @@ depends: [
   "ocamlbuild" {build}
   "qcheck" {>= "0.5"}
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Older versions of `qtest` don't work with 4.06 because of `-safe-string`.
The latest vesion (2.7) is OK.
