### PR TITLE
ppx_deriving 4.2.1

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.2.1/descr
+++ b/packages/ppx_deriving/ppx_deriving.4.2.1/descr
@@ -1,0 +1,5 @@
+Type-driven code generation for OCaml >=4.02
+
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.

--- a/packages/ppx_deriving/ppx_deriving.4.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2.1/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving"
+doc: "https://whitequark.github.io/ppx_deriving"
+bug-reports: "https://github.com/whitequark/ppx_deriving/issues"
+dev-repo: "https://github.com/whitequark/ppx_deriving.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  # If there is no native dynlink, we can't use native builds
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native-dynlink}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_deriving.byte" "--"
+]
+build-doc: [
+  make "doc"
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.6.0"}
+  "cppo"       {build}
+  "cppo_ocamlbuild" {build}
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {test}
+]
+available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]

--- a/packages/ppx_deriving/ppx_deriving.4.2.1/url
+++ b/packages/ppx_deriving/ppx_deriving.4.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ppx_deriving/archive/v4.2.1.tar.gz"
+checksum: "2195fccf2a527c3ff9ec5b4e36e2f0a8"


### PR DESCRIPTION
This is a minor release on top of 4.2 (instead of a minor release on
top of 4.1 as was originally discussed). The goal is to release this
first, ask user feedback on whether it solves their issues, and make
a 4.1 maintenance release if the issues with driverification are still
there.

The changelog is as follows

  * Add support for OCaml 4.06.0
  
    ocaml-ppx/ppx_deriving#154, ocaml-ppx/ppx_deriving#155, ocaml-ppx/ppx_deriving#156, ocaml-ppx/ppx_deriving#159
    (Gabriel Scherer, Fabian, Leonid Rozenberg)
  * Consider { with_path = false } when printing record fields
    ocaml-ppx/ppx_deriving#157
    (François Pottier)