### PR TITLE
irmin: add bounds

### DIFF
--- a/packages/irmin/irmin.0.12.0/opam
+++ b/packages/irmin/irmin.0.12.0/opam
@@ -32,7 +32,7 @@ depends: [
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "cstruct" {>= "1.6.0"}
   "mirage-tc" {>= "0.3.0"}
   "mstruct"

--- a/packages/irmin/irmin.1.0.0/opam
+++ b/packages/irmin/irmin.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.7.8"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}

--- a/packages/irmin/irmin.1.0.1/opam
+++ b/packages/irmin/irmin.1.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.7.8"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}

--- a/packages/irmin/irmin.1.0.2/opam
+++ b/packages/irmin/irmin.1.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.9.0"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}

--- a/packages/irmin/irmin.1.1.0/opam
+++ b/packages/irmin/irmin.1.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.9.0"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}

--- a/packages/irmin/irmin.1.2.0/opam
+++ b/packages/irmin/irmin.1.2.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build}
   "result"
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
   "cstruct" {>= "1.6.0"}
   "jsonm" {>= "1.0.0"}

--- a/packages/irmin/irmin.1.2.0/opam
+++ b/packages/irmin/irmin.1.2.0/opam
@@ -22,4 +22,4 @@ depends: [
   "logs" {>= "0.5.0"}
   "astring"
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]

--- a/packages/irmin/irmin.1.3.0/opam
+++ b/packages/irmin/irmin.1.3.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "result"
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
   "cstruct" {>= "1.6.0"}
   "jsonm" {>= "1.0.0"}

--- a/packages/irmin/irmin.1.3.0/opam
+++ b/packages/irmin/irmin.1.3.0/opam
@@ -25,4 +25,4 @@ depends: [
   "logs" {>= "0.5.0"}
   "astring"
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Recent versions of `irmin` don't work with older versions of `fmt`.

Also add bound on OCaml version because of safe-string. Already fixed upstream: https://github.com/mirage/irmin/pull/477 but beware: irmin release 1.3.1 does not include this fix.

cc @samoht 