### PR TITLE
xenstore: add bound on ocaml version

### DIFF
--- a/packages/xenstore/xenstore.1.3.0/opam
+++ b/packages/xenstore/xenstore.1.3.0/opam
@@ -31,4 +31,4 @@ depexts: [
   [["centos"] ["xen-devel"]]
   [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]

--- a/packages/xenstore/xenstore.1.4.0/opam
+++ b/packages/xenstore/xenstore.1.4.0/opam
@@ -26,4 +26,4 @@ depends: [
   "lwt"
   "ounit" {build}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
`xenstore` doesn't work with 4.06 because of safe-string

Note: there is an upstream PR (still open) to fix it: https://github.com/mirage/ocaml-xenstore/pull/35

cc @avsm : I can't find Dave Scott's github account.
