### PR TITLE
Add camlp4.4.06+system.

### DIFF
--- a/packages/camlp4/camlp4.4.06+system/descr
+++ b/packages/camlp4/camlp4.4.06+system/descr
@@ -1,0 +1,13 @@
+Camlp4 is a system for writing extensible parsers for programming languages
+
+It provides a set of OCaml libraries that are used to define grammars as well
+as loadable syntax extensions of such grammars. Camlp4 stands for Caml
+Preprocessor and Pretty-Printer and one of its most important applications is
+the definition of domain-specific extensions of the syntax of OCaml.
+
+Camlp4 was part of the official OCaml distribution until its version 4.01.0.
+Since then it has been replaced by a simpler system which is easier to maintain
+and to learn: ppx rewriters and extension points.
+
+This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
+you were using `+I camlp4` to directly locate Camlp4, this will no longer work.

--- a/packages/camlp4/camlp4.4.06+system/opam
+++ b/packages/camlp4/camlp4.4.06+system/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+authors: ["Daniel de Rauglaudre" "Nicolas Pouillard"]
+maintainer: "jeremie@dimino.org"
+homepage: "https://github.com/ocaml/camlp4"
+license: "LGPLv2"
+build: [
+  ["sh" "./make.sh"]
+]
+available: [ preinstalled & (ocaml-version >= "4.06") & (ocaml-version < "4.07") ]
+bug-reports: "https://github.com/ocaml/camlp4/issues"
+dev-repo: "https://github.com/ocaml/camlp4.git"
+depexts: [
+  [["debian"] ["camlp4-extra"]]
+  [["ubuntu"] ["camlp4-extra"]]
+  [["osx" "homebrew"] ["camlp4"]]
+]

--- a/packages/camlp4/camlp4.4.06+system/url
+++ b/packages/camlp4/camlp4.4.06+system/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/camlp4/archive/system.0.tar.gz"
+checksum: "2ed2db83471da3f6668689492590e7d7"


### PR DESCRIPTION
It is merely a copy of camlp4.4.05+system, with the `ocaml-version` constraints updated, and the `authors` field from camlp4.4.06+1.

Re. https://github.com/ocaml/opam-repository/pull/10455