### PR TITLE
restrict old versions of ezmlm to old ocaml

### DIFF
--- a/packages/ezjsonm/ezjsonm.0.1.0/opam
+++ b/packages/ezjsonm/ezjsonm.0.1.0/opam
@@ -21,3 +21,4 @@ tags: [
 ]
 dev-repo: "git://github.com/mirage/ezjsonm"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/ezjsonm/ezjsonm.0.2.0/opam
+++ b/packages/ezjsonm/ezjsonm.0.2.0/opam
@@ -24,3 +24,4 @@ tags: [
 ]
 dev-repo: "git://github.com/mirage/ezjsonm"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/ezjsonm/ezjsonm.0.3.0/opam
+++ b/packages/ezjsonm/ezjsonm.0.3.0/opam
@@ -26,3 +26,4 @@ tags: [
 ]
 dev-repo: "git://github.com/mirage/ezjsonm"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/ezjsonm/ezjsonm.0.3.1/opam
+++ b/packages/ezjsonm/ezjsonm.0.3.1/opam
@@ -24,3 +24,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: "lwt"
+available: [ ocaml-version < "4.03.0" ]

--- a/packages/ezjsonm/ezjsonm.0.4.3/opam
+++ b/packages/ezjsonm/ezjsonm.0.4.3/opam
@@ -33,3 +33,4 @@ depopts: ["lwt"]
 conflicts: [
   "lwt" {< "2.4.7"}
 ]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
discovered from the logs in #10795 .//cc @samoht (0.4.3 was the first to contain a fix for ocaml 4.03, but still uses oasis)