### PR TITLE
bitstring: add bound on OCaml version

### DIFF
--- a/packages/bitstring/bitstring.2.0.4/opam
+++ b/packages/bitstring/bitstring.2.0.4/opam
@@ -20,5 +20,5 @@ depends: [
   "camlp4" {build}
   "conf-time"
 ]
-available: [ ocaml-version >= "3.10" ]
+available: [ ocaml-version >= "3.10" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/bitstring/bitstring.2.1.0/opam
+++ b/packages/bitstring/bitstring.2.1.0/opam
@@ -23,5 +23,5 @@ depends: [
   "camlp4" {build}
   "conf-time"
 ]
-available: [ ocaml-version >= "3.10" ]
+available: [ ocaml-version >= "3.10" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/bitstring/bitstring.2.1.1/opam
+++ b/packages/bitstring/bitstring.2.1.1/opam
@@ -23,5 +23,5 @@ depends: [
   "camlp4" {build}
   "conf-time"
 ]
-available: [ ocaml-version >= "3.10" ]
+available: [ ocaml-version >= "3.10" & ocaml-version < "4.06.0" ]
 install: [make "install"]


### PR DESCRIPTION
`bitstring` doesn't work with 4.06 because of `-safe-string`.

Fix sent upstream: https://github.com/xguerin/bitstring/pull/3
