### PR TITLE
New release of datakit

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/descr
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/descr
@@ -1,0 +1,8 @@
+A bi-directional bridge between the GitHub API and Datakit
+
+The package provides a bi-directional bridge between the GitHub API
+and Datakit, so you can talk to the GitHub API using filesystem and
+Git-like commands only. The `datakit-github` programs can start a
+webhook server to listen for GitHub events in real time, and project
+it into a Git repository. It also monitors that Git repository for
+user-provided changes, and translate them into GitHub API calls.

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "tests/%{name}%"]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cmdliner"
+  "lwt" {>= "3.0.0"}
+  "datakit-github"    {>= "0.12.0"}
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-client-git"
+  "logs" "fmt"
+  "mtime" {>= "1.0.0"}
+  "asl" "win-eventlog"
+  "uri" {>= "1.8.0"}
+  "hvsock" {>= "0.8.1"}
+  "hex" "nocrypto"
+  "prometheus-app"
+  "protocol-9p-unix" {>= "0.11.0"}
+  "datakit-client" {>= "0.12.0"}
+  "github-hooks-unix" {>= "0.2.0"}
+  "github" {>= "2.1.0"}
+  "alcotest" {test}
+  "datakit"  {test & >= "0.12.0"}
+]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/url
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.12.0/descr
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.12.0/descr
@@ -1,0 +1,21 @@
+DataKit Local-Git bridge
+
+This service is a drop-in replacement for the DataKit-GitHub bridge
+that instead just monitors a local Git repository. It is useful for
+testing a new DataKitCI configuration without having to configure
+GitHub integration first.
+
+The local bridge monitors the state of one or more local Git
+repositories, writing the current head of each branch to
+DataKit. DataKitCI can be configured to run the CI tests against the
+project each time a commit is made.
+
+Once you are happy with the way the CI is working, you can replace
+this service with the GitHub bridge service to have the CI test a
+project hosted on GitHub instead.
+
+Unlike the GitHub bridge, this service:
+
+- only reports on branches, not tags or pull requests;
+- does not report build statuses from other CI systems; and
+- does not push the statuses set by the CI anywhere.

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.12.0/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.12.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "thomas.leonard@docker.com"
+authors:      ["Thomas Leonard"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cmdliner"
+  "irmin-watcher"
+  "irmin"      {>= "1.2.0"}
+  "irmin-unix" {>= "1.2.0"}
+  "lwt" {>= "3.0.0"}
+  "logs" "fmt"
+  "protocol-9p-unix" {>= "0.11.0"}
+  "datakit-client" {>= "0.12.0"}
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-github" {>= "0.12.0"}
+]

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.12.0/url
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-ci/datakit-ci.0.12.0/descr
+++ b/packages/datakit-ci/datakit-ci.0.12.0/descr
@@ -1,0 +1,7 @@
+Continuous Integration service using DataKit
+
+DataKitCI is a continuous integration service that monitors your
+GitHub project and tests each branch, tag and pull request. It
+displays the test results as status indicators in the GitHub UI. It
+keeps all of its state and logs in DataKit, rather than a traditional
+relational database, allowing review with the usual Git tools.

--- a/packages/datakit-ci/datakit-ci.0.12.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.0/opam
@@ -1,0 +1,44 @@
+opam-version: "1.2"
+maintainer:   "datakit@docker.com"
+authors:      ["Thomas© Leonard" "Anil Madhavapeddy"
+               "Dave Tucker" "Thomas Gazagnaire" ]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "ci/tests"]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "multipart-form-data"
+  "datakit-client" {>= "0.12.0"}
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-github" {>= "0.12.0"}
+  "protocol-9p-unix" {>= "0.11.0"}
+  "astring"
+  "cmdliner"
+  "fmt"
+  "logs"
+  "tyxml" {>= "4.0.0"}
+  "tls"
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "io-page"
+  "pbkdf"
+  "webmachine" {>= "0.4.0"}
+  "session-redis-lwt" {>= "0.4.0"}
+  "session-webmachine" {>= "0.4.0"}
+  "redis-lwt"
+  "asetmap"
+  "github-unix" {>= "3.0.0"}
+  "prometheus-app"
+  "lwt" {>= "3.0.0"}
+  "ppx_sexp_conv" {build}
+  "crunch" {build}
+  "datakit" {test & >= "0.12.0"}
+  "irmin-unix" {test & >= "1.2.0"}
+  "alcotest" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/datakit-ci/datakit-ci.0.12.0/url
+++ b/packages/datakit-ci/datakit-ci.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-client-9p/datakit-client-9p.0.12.0/descr
+++ b/packages/datakit-client-9p/datakit-client-9p.0.12.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit-client-9p/datakit-client-9p.0.12.0/opam
+++ b/packages/datakit-client-9p/datakit-client-9p.0.12.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "astring"
+  "logs"
+  "fmt"
+  "cstruct"          {> "2.2.0"}
+  "datakit-client"   {>= "0.12.0"}
+  "protocol-9p-unix" {>= "0.11.0"}
+  "cmdliner"
+]

--- a/packages/datakit-client-9p/datakit-client-9p.0.12.0/url
+++ b/packages/datakit-client-9p/datakit-client-9p.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-client-git/datakit-client-git.0.12.0/descr
+++ b/packages/datakit-client-git/datakit-client-git.0.12.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit-client-git/datakit-client-git.0.12.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.12.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "tests/datakit-git"]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "datakit-client" {>= "0.12.0"}
+  "irmin-git" {>= "1.2.0"}
+  "irmin-watcher"
+  "git-unix"
+  "alcotest"  {test}
+  "irmin-mem" {test}
+  "irmin-git" {test}
+]

--- a/packages/datakit-client-git/datakit-client-git.0.12.0/url
+++ b/packages/datakit-client-git/datakit-client-git.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-client/datakit-client.0.12.0/descr
+++ b/packages/datakit-client/datakit-client.0.12.0/descr
@@ -1,0 +1,5 @@
+A library to connect to DataKit servers
+
+The library currently only provides only a 9p client to talk to
+Datakit, but other filesystem protocols will be available in the
+future.

--- a/packages/datakit-client/datakit-client.0.12.0/opam
+++ b/packages/datakit-client/datakit-client.0.12.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "astring"
+  "result"
+  "fmt"
+  "lwt"
+  "cstruct" {> "2.2.0"}
+]

--- a/packages/datakit-client/datakit-client.0.12.0/url
+++ b/packages/datakit-client/datakit-client.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-github/datakit-github.0.12.0/descr
+++ b/packages/datakit-github/datakit-github.0.12.0/descr
@@ -1,0 +1,1 @@
+Abstraction of the GitHub API, suitable for DataKit clients

--- a/packages/datakit-github/datakit-github.0.12.0/opam
+++ b/packages/datakit-github/datakit-github.0.12.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cmdliner"
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.8.0"}
+  "asetmap"
+  "logs"
+  "fmt"
+  "result"
+  "datakit-client-9p"  {>= "0.12.0"}
+  "datakit-client-git" {>= "0.12.0"}
+]

--- a/packages/datakit-github/datakit-github.0.12.0/url
+++ b/packages/datakit-github/datakit-github.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-server-9p/datakit-server-9p.0.12.0/descr
+++ b/packages/datakit-server-9p/datakit-server-9p.0.12.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit-server-9p/datakit-server-9p.0.12.0/opam
+++ b/packages/datakit-server-9p/datakit-server-9p.0.12.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "datakit-server"  {>= "0.12.0"}
+  "mirage-flow-lwt"
+  "protocol-9p" {>= "0.11.0"}
+  "sexplib"
+]

--- a/packages/datakit-server-9p/datakit-server-9p.0.12.0/url
+++ b/packages/datakit-server-9p/datakit-server-9p.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit-server/datakit-server.0.12.0/descr
+++ b/packages/datakit-server/datakit-server.0.12.0/descr
@@ -1,0 +1,6 @@
+A library to write Datakit servers
+
+The library exposes a VFS interface, that servers can use to write
+introspection libraries -- for instance to expose runtime parameters
+over 9p. The library does not depend on Irmin so is relatively
+lightweight to embed in any application.

--- a/packages/datakit-server/datakit-server.0.12.0/opam
+++ b/packages/datakit-server/datakit-server.0.12.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "astring"
+  "logs"
+  "rresult"
+  "fmt"
+  "lwt"     {>= "3.0.0"}
+  "cstruct" {>= "2.2.0"}
+]

--- a/packages/datakit-server/datakit-server.0.12.0/url
+++ b/packages/datakit-server/datakit-server.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"

--- a/packages/datakit/datakit.0.12.0/descr
+++ b/packages/datakit/datakit.0.12.0/descr
@@ -1,0 +1,12 @@
+Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.

--- a/packages/datakit/datakit.0.12.0/opam
+++ b/packages/datakit/datakit.0.12.0/opam
@@ -1,0 +1,44 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Leonard" "Magnus Skjegstad"
+               "David Scott" "Thomas Gazagnaire"]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: [
+  ["jbuilder" "runtest" "tests/datakit"]
+  ["jbuilder" "runtest" "tests/datakit-9p"]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cmdliner"
+  "rresult" "astring" "fmt" "asetmap"
+  "git"         {>= "1.11.0"}
+  "uri"
+  "irmin"       {>= "1.2.0"}
+  "irmin-mem"   {>= "1.2.0"}
+  "irmin-git"   {>= "1.2.0"}
+  "cstruct"     {>= "2.2"}
+  "result"
+  "lwt"         {>= "3.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "mirage-flow"
+  "named-pipe"  {>= "0.4.0"}
+  "hvsock"      {>= "0.8.1"}
+  "logs"        {>= "0.5.0"}
+  "win-eventlog"
+  "asl"         {>= "0.10"}
+  "mtime"       {>= "1.0.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "prometheus-app"
+  "protocol-9p-unix"  {>= "0.11.0"}
+  "datakit-server-9p" {>= "0.12.0"}
+  "datakit-client-9p" {test & >= "0.12.0"}
+  "alcotest"          {test & >= "0.8.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/datakit/datakit.0.12.0/url
+++ b/packages/datakit/datakit.0.12.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.0/datakit-0.12.0.tbz"
+checksum: "3ac6e63eda6034507537c6439f0f8963"


### PR DESCRIPTION
CHANGES:

- all: update to latest version of alcotest, conduit, session, ocaml-github,
  ocaml-github-hooks and cohttp (moby/datakit#612, @samoht and @djs55)

- github: make `User.t` abstract (moby/datakit#594, @samoht)
- github: turn `Webhook.events` into a promise (moby/datakit#598, @samoht)
- github: add a `Comment` module to model PR and issue comments (moby/datakit#595, @samoht)
- github: change `PR.owner` to be of type `User.t` (moby/datakit#599, @samoht)

- github-bridge: add the ability to sync PR's coments (moby/datakit#595, @samoht)

- go-client: handle large values when reading / writing in 9db (moby/datakit#292, @simonferquel)
- go-client: fix the handling of defaults over upgrade (moby/datakit#605, @djs55)
- go-client: improve transaction API (moby/datakit#606, @djs55)