### PR TITLE
mirage-block-unix: fix missing dependency

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
+authors: ["Dave Scott <dave@recoil.org>"]
 maintainer: "dave@recoil.org"
+homepage: "https://github.com/mirage/mirage-block-unix"
+bug-reports: "https://github.com/mirage/mirage-block-unix/issues"
 build: make
 remove: [[make "uninstall"]]
 depends: [

--- a/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "2.3.0"}
-  "io-page-unix" {>= "1.0.0"}
+  "io-page" {>= "1.0.0"} & ("io-page" {< "2.0.0"} | "io-page-unix")
   "ounit"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.1/opam
@@ -7,7 +7,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "2.3.0"}
-  "io-page" {>= "1.0.0"}
+  "io-page-unix" {>= "1.0.0"}
   "ounit"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-block-unix/mirage-block-unix.1.2.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
-  "io-page" {>= "1.0.0"}
+  "io-page-unix" {>= "1.0.0"}
   "ounit"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-block-unix/mirage-block-unix.1.2.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.1.2.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
-  "io-page-unix" {>= "1.0.0"}
+  "io-page" {>= "1.0.0"} & ("io-page" {< "2.0.0"} | "io-page-unix")
   "ounit"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
`mirage-block-unix` versions 1.2.1 and 1.2.2 need the findlib package `io-page.unix`, which was provided by `io-page` in older versions, but not by `io-page.2.0.0` and later.
