### PR TITLE
constrain ppx_deriving 4.2.1 to ocaml > 4.03.0

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2.1/opam
@@ -30,4 +30,4 @@ depends: [
   "result"
   "ounit"      {test}
 ]
-available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]
+available: [ ocaml-version > "4.03.0" & opam-version >= "1.2" ]


### PR DESCRIPTION
ppx_deriving 4.2.1 is great to have released, but it does not contain a fix for https://github.com/ocaml-ppx/ppx_deriving/issues/147 (duplicated code when using it with 4.03).  ppx_deriving 4.2 is listed as available for OCaml > 4.03.0 because of this issue; propagate that to 4.2.1.