### PR TITLE
herelib: add bound on ocaml version

### DIFF
--- a/packages/herelib/herelib.109.08.00/opam
+++ b/packages/herelib/herelib.109.08.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.08.00/opam
+++ b/packages/herelib/herelib.109.08.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/herelib/herelib.109.09.00/opam
+++ b/packages/herelib/herelib.109.09.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.09.00/opam
+++ b/packages/herelib/herelib.109.09.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/herelib/herelib.109.10.00/opam
+++ b/packages/herelib/herelib.109.10.00/opam
@@ -8,3 +8,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/herelib/herelib.109.10.00/opam
+++ b/packages/herelib/herelib.109.10.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.11.00/opam
+++ b/packages/herelib/herelib.109.11.00/opam
@@ -8,3 +8,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/herelib/herelib.109.11.00/opam
+++ b/packages/herelib/herelib.109.11.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.12.00/opam
+++ b/packages/herelib/herelib.109.12.00/opam
@@ -12,4 +12,4 @@ depends: [
 bug-reports: "https://github.com/janestreet/herelib/issues"
 dev-repo: "git://github.com/janestreet/herelib"
 install: [make "install"]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/herelib/herelib.109.13.00/opam
+++ b/packages/herelib/herelib.109.13.00/opam
@@ -8,3 +8,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/herelib/herelib.109.13.00/opam
+++ b/packages/herelib/herelib.109.13.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.14.00/opam
+++ b/packages/herelib/herelib.109.14.00/opam
@@ -8,3 +8,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/herelib/herelib.109.14.00/opam
+++ b/packages/herelib/herelib.109.14.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.15.00/opam
+++ b/packages/herelib/herelib.109.15.00/opam
@@ -8,3 +8,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/herelib/herelib.109.15.00/opam
+++ b/packages/herelib/herelib.109.15.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.35.00/opam
+++ b/packages/herelib/herelib.109.35.00/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.35.00/opam
+++ b/packages/herelib/herelib.109.35.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/herelib/herelib.109.35.02/opam
+++ b/packages/herelib/herelib.109.35.02/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "opensource@janestreet.com"
+homepage: "https://github.com/janestreet/herelib"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.35.02/opam
+++ b/packages/herelib/herelib.109.35.02/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: [make "install"]


### PR DESCRIPTION
older versions of `herelib` don't work on 4.06 because of safe-string