### PR TITLE
shared-memory-ring: add bound on ocaml version

### DIFF
--- a/packages/shared-memory-ring/shared-memory-ring.1.2.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.2.0/opam
@@ -23,4 +23,4 @@ depends: [
   "mirage-profile"
   "ounit" {test}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]

--- a/packages/shared-memory-ring/shared-memory-ring.1.3.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.3.0/opam
@@ -23,4 +23,4 @@ depends: [
   "mirage-profile"
   "ounit" {test}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
@@ -20,4 +20,4 @@ depends: [
   "mirage-profile"
   "ounit" {test}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
@@ -20,4 +20,4 @@ depends: [
   "mirage-profile"
   "ounit" {test}
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
Older versions of `shared-memory-ring` don't work on 4.06 because of safe-string.

Already fixed [upstream](https://github.com/mirage/shared-memory-ring/pull/35) and in [3.0.0](https://github.com/ocaml/opam-repository/pull/10697/files).