### PR TITLE
release mirage-xen-ocaml 3.0.5

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/descr
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/descr
@@ -1,0 +1,3 @@
+MirageOS headers for the OCaml runtime
+
+The package contains the OCaml runtime patches and build system.

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-ocaml-build"]
+install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+tags: ["org:mirage"]
+depends: [
+  "mirage-xen-posix" {>="2.6.0"}
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src"
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.04.2" & ocaml-version <= "4.05.0" & os = "linux"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/url
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-platform/archive/v3.0.5.tar.gz"
+checksum: "249e56facfe2ade94dd65866b2d97900"


### PR DESCRIPTION
This version supports OCaml 4.05.0 for the Xen target, so we can be only one major version behind ;)