### PR TITLE
Package ocaml-basics.0.5.0

### DIFF
--- a/packages/ocaml-basics/ocaml-basics.0.5.0/descr
+++ b/packages/ocaml-basics/ocaml-basics.0.5.0/descr
@@ -1,0 +1,1 @@
+Implements common functionnal patterns / abstractions

--- a/packages/ocaml-basics/ocaml-basics.0.5.0/opam
+++ b/packages/ocaml-basics/ocaml-basics.0.5.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Antoine Luciani <aluciani@advanced-schema.com>"
+authors: "Advanced Schema"
+homepage: "http://github.com/advanced-schema/ocaml-basics"
+bug-reports: "http://github.com/advanced-schema/ocaml-basics/issues"
+license: "MIT"
+dev-repo: "https://github.com/advanced-schema/ocaml-basics.git"
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {>= "1.0+beta16"}
+  "result" {>= "1.2"}
+  "ppx_sexp_conv" {>= "v0.9"}
+  "sexplib" {>= "v0.9"}
+  "ppx_deriving" {>= "4.0"}
+]
+available: [ ocaml-version >= "4.03" ]

--- a/packages/ocaml-basics/ocaml-basics.0.5.0/url
+++ b/packages/ocaml-basics/ocaml-basics.0.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/advanced-schema/ocaml-basics/releases/download/v0.5.0/ocaml-basics-0.5.0.tbz"
+checksum: "6d055a29c64351a36762c9e71bc00ec6"


### PR DESCRIPTION
### `ocaml-basics.0.5.0`

Implements common functionnal patterns / abstractions



---
* Homepage: http://github.com/advanced-schema/ocaml-basics
* Source repo: https://github.com/advanced-schema/ocaml-basics.git
* Bug tracker: http://github.com/advanced-schema/ocaml-basics/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
# v0.5.0

* `e63d564` Update change log.
* `2c57d7a` Adapt change log format to topkg workflow
* `56976e3` Create pkg/pkg.ml
* `ba78a8c` Create README.md
* `fa0c900` Add version value to Basics module
* `fe848c8` Replace oasis-based opam workflow by jbuilder-based one
* `73ed7a1` Replace _oasis by jbuild files
* `1b094ee` Fix compatibility with OCaml 4.03.0
* `a46775e` Rename opam file
:camel: Pull-request generated by opam-publish v0.3.5