### PR TITLE
reinstate z3 package from @Drup with a stable release

### DIFF
--- a/packages/Z3/Z3.4.5.0/descr
+++ b/packages/Z3/Z3.4.5.0/descr
@@ -1,0 +1,1 @@
+Z3 is an open source SMT solver by Microsoft.

--- a/packages/Z3/Z3.4.5.0/files/Z3.install
+++ b/packages/Z3/Z3.4.5.0/files/Z3.install
@@ -1,0 +1,2 @@
+libexec:[ "build/libz3.so" ]
+libexec:[ "build/api/ml/dllz3ml.so" ]

--- a/packages/Z3/Z3.4.5.0/opam
+++ b/packages/Z3/Z3.4.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: [
+  "Gabriel Radanne <drupyog@zoho.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+authors: "Z3 authors"
+homepage: "http://z3prover.github.io/"
+dev-repo: "https://github.com/Z3Prover/z3.git"
+bug-reports: "https://github.com/Z3Prover/z3/issues"
+license: "MIT"
+
+build: [
+  ["python" "scripts/mk_make.py" "--ml" "--prefix" prefix]
+  [make "-C" "build" "-j" jobs]
+]
+install: [
+  [make "-C" "build" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "Z3"]
+]
+depends: [
+  "ocamlfind" {build}
+  "num"
+  "conf-python-2-7"
+]
+
+messages: [
+  "Before installing any package depending on Z3, please export the following variable:
+  export LD_LIBRARY_PATH=\"$(ocamlfind printconf destdir)/stublibs:${LD_LIBRARY_PATH}\""
+]

--- a/packages/Z3/Z3.4.5.0/opam
+++ b/packages/Z3/Z3.4.5.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/Z3Prover/z3/issues"
 license: "MIT"
 
 build: [
-  ["python" "scripts/mk_make.py" "--ml" "--prefix" prefix]
+  ["python2.7" "scripts/mk_make.py" "--ml" "--prefix" prefix]
   [make "-C" "build" "-j" jobs]
 ]
 install: [

--- a/packages/Z3/Z3.4.5.0/url
+++ b/packages/Z3/Z3.4.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Z3Prover/z3/archive/z3-4.5.0.tar.gz"
+checksum: "f332befa0d66d81818a06279a0973e25"


### PR DESCRIPTION
Trying to resurrect the package for Z3 and its OCaml bindings.

Previously:
- https://github.com/ocaml/opam-repository/pull/3298 (addition)
- https://github.com/ocaml/opam-repository/pull/4217 (removal)

Licensing problems should be gone, since Z3 is now under MIT. I added a package for the last release and the `dev-repo` field.