### PR TITLE
+mirage-profile.0.8.2

### DIFF
--- a/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/descr
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/descr
@@ -1,0 +1,8 @@
+Collect runtime profiling information in CTF format
+
+This library can be used to trace execution of OCaml/Lwt programs (such as Mirage unikernels) at the level of Lwt threads.
+The traces can be viewed using JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by tools supporting the [Common Trace Format (CTF)][ctf].
+Some example traces can be found in the blog post [Visualising an Asynchronous Monad](http://roscidus.com/blog/blog/2014/10/27/visualising-an-asynchronous-monad/).
+
+Libraries can use the functions mirage-profile provides to annotate the traces with extra information.
+When compiled against a normal version of Lwt, mirage-profile's functions are null-ops (or call the underlying untraced operation, as appropriate) and OCaml's cross-module inlining will optimise these calls away, meaning there should be no overhead in the non-profiling case.

--- a/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/opam
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/mirage/mirage-profile"
+dev-repo: "https://github.com/mirage/mirage-profile.git"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+doc: "https://mirage.github.io/mirage-profile"
+license: "BSD-2-clause"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+  "mirage-profile" {>="0.8.0"}
+  "mtime" {>= "1.0.0"}
+  "ocplib-endian"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/opam
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
-  "mirage-profile" {>="0.8.0"}
+  "mirage-profile" {="0.8.2"}
   "mtime" {>= "1.0.0"}
   "ocplib-endian"
 ]

--- a/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/url
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-profile/releases/download/v0.8.2/mirage-profile-0.8.2.tbz"
+checksum: "7f094bcb0b81746a712326ea583b2e76"

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/descr
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/descr
@@ -1,0 +1,8 @@
+Collect runtime profiling information in CTF format
+
+This library can be used to trace execution of OCaml/Lwt programs (such as Mirage unikernels) at the level of Lwt threads.
+The traces can be viewed using JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by tools supporting the [Common Trace Format (CTF)][ctf].
+Some example traces can be found in the blog post [Visualising an Asynchronous Monad](http://roscidus.com/blog/blog/2014/10/27/visualising-an-asynchronous-monad/).
+
+Libraries can use the functions mirage-profile provides to annotate the traces with extra information.
+When compiled against a normal version of Lwt, mirage-profile's functions are null-ops (or call the underlying untraced operation, as appropriate) and OCaml's cross-module inlining will optimise these calls away, meaning there should be no overhead in the non-profiling case.

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/mirage/mirage-profile"
+dev-repo: "https://github.com/mirage/mirage-profile.git"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+doc: "https://mirage.github.io/mirage-profile"
+license: "BSD-2-clause"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+  "mirage-profile" {>="0.8.0"}
+  "io-page-xen"
+  "io-page"
+  "mirage-xen-minios"
+  "ocplib-endian"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
-  "mirage-profile" {>="0.8.0"}
+  "mirage-profile" {="0.8.2"}
   "io-page-xen"
   "io-page"
   "mirage-xen-minios"

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/url
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-profile/releases/download/v0.8.2/mirage-profile-0.8.2.tbz"
+checksum: "7f094bcb0b81746a712326ea583b2e76"

--- a/packages/mirage-profile/mirage-profile.0.8.2/descr
+++ b/packages/mirage-profile/mirage-profile.0.8.2/descr
@@ -1,0 +1,8 @@
+Collect runtime profiling information in CTF format
+
+This library can be used to trace execution of OCaml/Lwt programs (such as Mirage unikernels) at the level of Lwt threads.
+The traces can be viewed using JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by tools supporting the [Common Trace Format (CTF)][ctf].
+Some example traces can be found in the blog post [Visualising an Asynchronous Monad](http://roscidus.com/blog/blog/2014/10/27/visualising-an-asynchronous-monad/).
+
+Libraries can use the functions mirage-profile provides to annotate the traces with extra information.
+When compiled against a normal version of Lwt, mirage-profile's functions are null-ops (or call the underlying untraced operation, as appropriate) and OCaml's cross-module inlining will optimise these calls away, meaning there should be no overhead in the non-profiling case.

--- a/packages/mirage-profile/mirage-profile.0.8.2/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/mirage/mirage-profile"
+dev-repo: "https://github.com/mirage/mirage-profile.git"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+doc: "https://mirage.github.io/mirage-profile"
+license: "BSD-2-clause"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_cstruct" {build}
+  "ocplib-endian"
+  "lwt"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mirage-profile/mirage-profile.0.8.2/url
+++ b/packages/mirage-profile/mirage-profile.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-profile/releases/download/v0.8.2/mirage-profile-0.8.2.tbz"
+checksum: "7f094bcb0b81746a712326ea583b2e76"


### PR DESCRIPTION
- add ocplib-endian to jbuild rules to support cstruct >= 3.2.0