### PR TITLE
optcomp: add bound on ocaml version

### DIFF
--- a/packages/optcomp/optcomp.1.4/opam
+++ b/packages/optcomp/optcomp.1.4/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://github.com/diml/optcomp"
+authors: ["Jérémie Dimino"]
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/optcomp/optcomp.1.4/opam
+++ b/packages/optcomp/optcomp.1.4/opam
@@ -15,3 +15,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/optcomp/optcomp.1.5/opam
+++ b/packages/optcomp/optcomp.1.5/opam
@@ -19,5 +19,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/diml/optcomp"
-available: ocaml-version >= "3.12"
+available: [ocaml-version >= "3.12" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/optcomp/optcomp.1.6/opam
+++ b/packages/optcomp/optcomp.1.6/opam
@@ -19,5 +19,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/diml/optcomp"
-available: ocaml-version >= "3.12"
+available: [ocaml-version >= "3.12" & ocaml-version < "4.06.0"]
 install: [make "install"]


### PR DESCRIPTION
`optcomp` doesn't work on 4.06 because of safe-string.

Upstream PR for the fix: https://github.com/diml/optcomp/pull/4
