### PR TITLE
Package fftw3.0.8

### DIFF
--- a/packages/fftw3/fftw3.0.8/descr
+++ b/packages/fftw3/fftw3.0.8/descr
@@ -1,0 +1,1 @@
+Binding to the famous Fast Fourier Transform library FFTW

--- a/packages/fftw3/fftw3.0.8/opam
+++ b/packages/fftw3/fftw3.0.8/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+maintainer: "Christophe.Troestler@umons.ac.be"
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/fftw-ocaml"
+dev-repo: "https://github.com/Chris00/fftw-ocaml.git"
+bug-reports: "https://github.com/Chris00/fftw-ocaml/issues"
+doc: "https://Chris00.github.io/fftw-ocaml/doc"
+tags: ["FFT"]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ] { os != "darwin" }
+  [ "env" "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
+    "jbuilder" "build" "-p" name "-j" jobs ] { os = "darwin" }
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+depends: [
+  "jbuilder" {build}
+  "cppo"     {build}
+  "configurator" {build}
+  "base"     {build}
+  "stdio"    {build}
+  "archimedes" {test}
+  "lacaml" {test}
+]
+available: [ ocaml-version >= "4.03.0" ]
+depexts: [
+  [ [ "ubuntu"  ] [ "libfftw3-dev" ] ]
+  [ [ "debian"  ] [ "libfftw3-dev" ] ]
+  [ [ "centos"  ] [ "fftw-devel" ] ]
+  [ [ "freebsd" ] [ "math/fftw3" ] ]
+  [ [ "openbsd" ] [ "math/fftw3" ] ]
+  [ [ "osx" "homebrew" ] [ "fftw" ] ]
+]

--- a/packages/fftw3/fftw3.0.8/url
+++ b/packages/fftw3/fftw3.0.8/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/fftw-ocaml/releases/download/0.8/fftw3-0.8.tbz"
+checksum: "abac0177c2c7f81dd14f70d3936e31a1"


### PR DESCRIPTION
### `fftw3.0.8`

Binding to the famous Fast Fourier Transform library FFTW



---
* Homepage: https://github.com/Chris00/fftw-ocaml
* Source repo: https://github.com/Chris00/fftw-ocaml.git
* Bug tracker: https://github.com/Chris00/fftw-ocaml/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
0.8 2017-11-23
--------------

- Conditionally define functions exported in `bigarray.h` in OCaml
  4.06.0.
- Port to `jbuilder` and `topkg`.
:camel: Pull-request generated by opam-publish v0.3.5