### PR TITLE
toml: add bound on ocaml version

### DIFF
--- a/packages/toml/toml.1.0.0/opam
+++ b/packages/toml/toml.1.0.0/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "support@toml.epimeros.org"
+authors: [ "Julien Sagot" "Emmanuel Surleau" "mackwic" ]
 homepage: "http://sagotch.github.io/To.ml/"
 build: [make "build"]
 remove: [
@@ -7,5 +8,5 @@ remove: [
 ]
 depends: ["ocamlfind" "menhir"]
 dev-repo: "git://github.com/sagotch/To.ml"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/toml/toml.2.0.0/opam
+++ b/packages/toml/toml.2.0.0/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 
 maintainer: "support@toml.epimeros.org"
+authors: [ "Julien Sagot" "Emmanuel Surleau" "mackwic" ]
 
 homepage: "http://sagotch.github.io/To.ml/"
 
@@ -9,5 +10,5 @@ remove: [ "ocamlfind" "remove" "toml"]
 
 depends: ["ocamlfind" "menhir"]
 dev-repo: "git://github.com/sagotch/To.ml"
-available: ocaml-version >= "4.02.0"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/toml/toml.2.1.0/opam
+++ b/packages/toml/toml.2.1.0/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 
 maintainer: "support@toml.epimeros.org"
+authors: [ "Julien Sagot" "Emmanuel Surleau" "mackwic" ]
 
 homepage: "http://sagotch.github.io/To.ml/"
 
@@ -9,5 +10,5 @@ remove: [ "ocamlfind" "remove" "toml"]
 
 depends: ["ocamlfind" "menhir"]
 dev-repo: "git://github.com/sagotch/To.ml"
-available: ocaml-version >= "4.02.0"
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/toml/toml.2.2.0/opam
+++ b/packages/toml/toml.2.2.0/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 
 maintainer: "support@toml.epimeros.org"
+authors: [ "Julien Sagot" "Emmanuel Surleau" "mackwic" ]
 
 homepage: "http://mackwic.github.io/To.ml/"
 
@@ -18,5 +19,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mackwic/To.ml"
-available: ocaml-version >= "4.01.0"
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/toml/toml.2.2.1/opam
+++ b/packages/toml/toml.2.2.1/opam
@@ -3,6 +3,7 @@ opam-version: "1.2"
 version: "2.2.1"
 
 maintainer: "support@toml.epimeros.org"
+authors: [ "Julien Sagot" "Emmanuel Surleau" "mackwic" ]
 
 homepage: "http://mackwic.github.io/To.ml/"
 
@@ -18,5 +19,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mackwic/To.ml"
-available: ocaml-version >= "4.01.0"
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/toml/toml.3.0.0/opam
+++ b/packages/toml/toml.3.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 
 version: "3.0.0"
 

--- a/packages/toml/toml.4.0.0/opam
+++ b/packages/toml/toml.4.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 
 version: "4.0.0"
 


### PR DESCRIPTION
`toml` doesn't work with 4.06 because of safe-string.

Upstream is already fixed, but not released: https://github.com/mackwic/To.ml/pull/49
