### PR TITLE
sequence: add bound on ocaml version

### DIFF
--- a/packages/sequence/sequence.0.1/opam
+++ b/packages/sequence/sequence.0.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.2/opam
+++ b/packages/sequence/sequence.0.2/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.3.1/opam
+++ b/packages/sequence/sequence.0.3.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.3.2/opam
+++ b/packages/sequence/sequence.0.3.2/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.3.3/opam
+++ b/packages/sequence/sequence.0.3.3/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.3.4/opam
+++ b/packages/sequence/sequence.0.3.4/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.3.5/opam
+++ b/packages/sequence/sequence.0.3.5/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.3.6.1/opam
+++ b/packages/sequence/sequence.0.3.6.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 doc: ["http://cedeela.fr/~simon/software/sequence/Sequence.html"]
 tags: [

--- a/packages/sequence/sequence.0.3.6/opam
+++ b/packages/sequence/sequence.0.3.6/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 doc: ["http://cedeela.fr/~simon/software/sequence/Sequence.html"]
 tags: [

--- a/packages/sequence/sequence.0.3.7/opam
+++ b/packages/sequence/sequence.0.3.7/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 build: [make "all" "doc"]
 remove: [
     ["ocamlfind" "remove" "sequence"]

--- a/packages/sequence/sequence.0.3/opam
+++ b/packages/sequence/sequence.0.3/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 homepage: "https://github.com/c-cube/sequence/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]

--- a/packages/sequence/sequence.0.4.1/opam
+++ b/packages/sequence/sequence.0.4.1/opam
@@ -16,3 +16,4 @@ homepage: "https://github.com/c-cube/sequence/"
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/sequence/sequence.0.4.1/opam
+++ b/packages/sequence/sequence.0.4.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 build: [
   ["./configure" "--disable-docs"]
   [make "all"]

--- a/packages/sequence/sequence.0.4/opam
+++ b/packages/sequence/sequence.0.4/opam
@@ -16,3 +16,4 @@ homepage: "https://github.com/c-cube/sequence/"
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/sequence/sequence.0.4/opam
+++ b/packages/sequence/sequence.0.4/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 build: [
   ["./configure" "--disable-docs"]
   [make "all"]

--- a/packages/sequence/sequence.0.5.1/opam
+++ b/packages/sequence/sequence.0.5.1/opam
@@ -17,3 +17,4 @@ depopts: ["delimcc"]
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/sequence/sequence.0.5.1/opam
+++ b/packages/sequence/sequence.0.5.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 build: [
   ["./configure" "--disable-docs" "--%{delimcc:enable}%-invert"]
   [make "all"]

--- a/packages/sequence/sequence.0.5.2/opam
+++ b/packages/sequence/sequence.0.5.2/opam
@@ -17,3 +17,4 @@ depopts: ["delimcc"]
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/sequence/sequence.0.5.2/opam
+++ b/packages/sequence/sequence.0.5.2/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 build: [
   ["./configure" "--disable-docs" "--%{delimcc:enable}%-invert"]
   [make "all"]

--- a/packages/sequence/sequence.0.5.3/opam
+++ b/packages/sequence/sequence.0.5.3/opam
@@ -17,3 +17,4 @@ depopts: ["delimcc"]
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/sequence/sequence.0.5.3/opam
+++ b/packages/sequence/sequence.0.5.3/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 build: [
   ["./configure" "--disable-docs" "--%{delimcc:enable}%-invert"]
   [make "all"]

--- a/packages/sequence/sequence.0.5/opam
+++ b/packages/sequence/sequence.0.5/opam
@@ -17,3 +17,4 @@ depopts: ["delimcc"]
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/sequence/sequence.0.5/opam
+++ b/packages/sequence/sequence.0.5/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
 build: [
   ["./configure" "--disable-docs" "--%{delimcc:enable}%-invert"]
   [make "all"]


### PR DESCRIPTION
Some old versions of `sequence` (0.4 to 0.5.3) don't work on 4.06 because of safe-string.
