### PR TITLE
utop: add bound on ocaml version

### DIFF
--- a/packages/utop/utop.1.19.3/opam
+++ b/packages/utop/utop.1.19.3/opam
@@ -34,4 +34,4 @@ depends: [
 depopts: [
   "camlp4"
 ]
-available: [ ocaml-version >= "4.01" ]
+available: [ ocaml-version >= "4.01" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
`utop.1.19.3` doesn't work on 4.06 because the field `out_indent` was added to `Format.formatter_out_functions`. This is already fixed upstream: https://github.com/diml/utop/pull/221