### PR TITLE
ocamlsdl: patch for safe-string

### DIFF
--- a/packages/ocamlsdl/ocamlsdl.0.9.1/files/safe-string.diff
+++ b/packages/ocamlsdl/ocamlsdl.0.9.1/files/safe-string.diff
@@ -1,0 +1,19 @@
+diff -r -u ocamlsdl-0.9.1/src/sdlmouse.ml ocamlsdl-0.9.1.fix/src/sdlmouse.ml
+--- a/src/sdlmouse.ml	2011-04-10 17:33:52.000000000 +0200
++++ b/src/sdlmouse.ml	2017-11-23 17:13:19.000000000 +0100
+@@ -49,12 +49,12 @@
+     = "ml_SDL_Cursor_data"
+ 
+ let string_of_bits x =
+-  let s = String.make 8 ' ' in
++  let s = Bytes.make 8 ' ' in
+   for i=0 to 7 do
+     if x land (1 lsl i) <> 0
+-    then s.[7-i] <- '@'
++    then Bytes.set s (7-i) '@'
+   done ;
+-  s
++  Bytes.to_string s
+ 
+ let pprint_cursor c =
+   let { data = data ; mask = mask } = cursor_data c in

--- a/packages/ocamlsdl/ocamlsdl.0.9.1/opam
+++ b/packages/ocamlsdl/ocamlsdl.0.9.1/opam
@@ -23,3 +23,4 @@ depexts: [
    [["osx" "homebrew"] ["sdl"]]
 ]
 install: [make "install"]
+patches: [ "safe-string.diff" {ocaml-version >= "4.06.0"} ]

--- a/packages/ocamlsdl/ocamlsdl.0.9.1/opam
+++ b/packages/ocamlsdl/ocamlsdl.0.9.1/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: [
   [
@@ -24,3 +24,12 @@ depexts: [
 ]
 install: [make "install"]
 patches: [ "safe-string.diff" {ocaml-version >= "4.06.0"} ]
+
+authors: [
+  "Frederic Brunel <brunel@mail.dotcom.fr>"
+  "Luc Mazardo <luc@mazardo.com>"
+  "Sami Mäkelä <sajuma@utu.fi>"
+  "Olivier Andrieu <oliv__a@users.sourceforge.net>"
+  "Julien Boulnois <jboulnois@gmail.com>"
+]
+homepage: "http://ocamlsdl.sourceforge.net/"


### PR DESCRIPTION
Add a very short patch to make `ocamlsdl` compile on 4.06.

Upstream is a CVS repo on sourceforge that (AFAICT) wasn't touched since 2012.
The "homepage" field is my best guess.
