### PR TITLE
Ppx_protocol_conv.0.9.0 - Renamed from ppx_deriving_protocol

### DIFF
--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/descr
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/descr
@@ -1,0 +1,12 @@
+Serialization and de-serialization of ocaml types to/from json, msgpack and xml_light.
+
+The syntax extension generates code to serialize and de-serialize
+types. The ppx itself does not contain any protocol specific code,
+but relies on 'drivers' that defines serialization and
+de-serialisation of basic types and structures.
+
+The library provides the following drivers for serialization
+and deserialization:
+* json (Yojson.Safe.json)
+* xml_light (Xml.xml)
+* msgpack (Msgpck.t)

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/descr
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/descr
@@ -7,6 +7,6 @@ de-serialisation of basic types and structures.
 
 The library provides the following drivers for serialization
 and deserialization:
-* json (Yojson.Safe.json)
-* xml_light (Xml.xml)
-* msgpack (Msgpck.t)
+ * json (Yojson.Safe.json)
+ * xml_light (Xml.xml)
+ * msgpack (Msgpck.t)

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx-deriving-protocol"
+dev-repo: "git+https://github.com/andersfugmann/ppx-deriving-protocol"
+bug-reports: "https://github.com/andersfugmann/ppx-deriving-protocol/issues"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+version: "0.9.0"
+depends: [
+  "yojson"
+  "xml-light"
+  "msgpck"
+  "base"
+  "ppx_type_conv"
+  "ppx_driver"
+  "jbuilder" {build}
+  "ppx_metaquot" {build}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/url
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andersfugmann/ppx_protocol_conv/archive/0.9.0.tar.gz"
+checksum: "7872cb84d648a7a5f57992211b5b9728"


### PR DESCRIPTION
New version, including renaming from ppx_deriving_protocol -> ppx_protocol_conv, since the library uses type_conv. 

I will do a PR for a transitional package for ppx_deriving_protocol once this is merged.