### PR TITLE
Package otr.0.3.4

### DIFF
--- a/packages/otr/otr.0.3.4/descr
+++ b/packages/otr/otr.0.3.4/descr
@@ -1,0 +1,9 @@
+Off the record implementation purely in OCaml
+
+
+This is an implementation of version 2 and 3 of the Off-the-record
+protocol (https://otr.cypherpunks.ca/Protocol-v3-4.0.0.html) in OCaml.
+
+Including the socialist millionairs protocol to authenticate a
+communication partner over an encrypted channel providing a shared
+secret.

--- a/packages/otr/otr.0.3.4/opam
+++ b/packages/otr/otr.0.3.4/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+homepage:     "https://github.com/hannesm/ocaml-otr"
+dev-repo:     "https://github.com/hannesm/ocaml-otr.git"
+bug-reports:  "https://github.com/hannesm/ocaml-otr/issues"
+doc:          "https://hannesm.github.io/ocaml-otr/doc"
+authors:      ["Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>"]
+license:      "BSD2"
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ppx_deriving" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_cstruct" {build}
+  "cstruct" {>= "1.9.0"}
+  "sexplib"
+  "nocrypto" {>= "0.5.3"}
+  "astring"
+  "rresult"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/otr/otr.0.3.4/url
+++ b/packages/otr/otr.0.3.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hannesm/ocaml-otr/releases/download/0.3.4/otr-0.3.4.tbz"
+checksum: "c257229e42650077c56d9a37c3ce307a"


### PR DESCRIPTION
### `otr.0.3.4`

Off the record implementation purely in OCaml


This is an implementation of version 2 and 3 of the Off-the-record
protocol (https://otr.cypherpunks.ca/Protocol-v3-4.0.0.html) in OCaml.

Including the socialist millionairs protocol to authenticate a
communication partner over an encrypted channel providing a shared
secret.


---
* Homepage: https://github.com/hannesm/ocaml-otr
* Source repo: https://github.com/hannesm/ocaml-otr.git
* Bug tracker: https://github.com/hannesm/ocaml-otr/issues

---


---
## 0.3.4 (2017-11-23)

* prefix modules with "Otr_"
* drop OCaml < 4.03.0 support
:camel: Pull-request generated by opam-publish v0.3.5