### PR TITLE
restrict all tar* to <4.06.0

### DIFF
--- a/packages/tar-format/tar-format.0.1.1/opam
+++ b/packages/tar-format/tar-format.0.1.1/opam
@@ -12,3 +12,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-tar"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.2.0/opam
+++ b/packages/tar-format/tar-format.0.2.0/opam
@@ -19,3 +19,4 @@ depends: [
 depopts: ["lwt"]
 dev-repo: "git://github.com/mirage/ocaml-tar"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.2.1/opam
+++ b/packages/tar-format/tar-format.0.2.1/opam
@@ -19,3 +19,4 @@ depends: [
 depopts: ["lwt"]
 dev-repo: "git://github.com/mirage/ocaml-tar"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.3.0/opam
+++ b/packages/tar-format/tar-format.0.3.0/opam
@@ -24,4 +24,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["lwt"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.4.0/opam
+++ b/packages/tar-format/tar-format.0.4.0/opam
@@ -33,4 +33,4 @@ conflicts: [
   "lwt" {< "2.4.7"}
 ]
 
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.4.1/opam
+++ b/packages/tar-format/tar-format.0.4.1/opam
@@ -38,4 +38,4 @@ depopts: ["lwt" "mirage-types-lwt"]
 conflicts: [
   "lwt" {< "2.4.7"}
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.4.2/opam
+++ b/packages/tar-format/tar-format.0.4.2/opam
@@ -32,4 +32,4 @@ depends: [
   "mirage-types-lwt"  {test}
 ]
 depopts: ["lwt" "mirage-types-lwt"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.5.0/opam
+++ b/packages/tar-format/tar-format.0.5.0/opam
@@ -34,4 +34,4 @@ depends: [
   "mirage-types-lwt"  {test & < "3.0.0"}
 ]
 depopts: ["lwt" "mirage-types-lwt"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.5.1/opam
+++ b/packages/tar-format/tar-format.0.5.1/opam
@@ -34,4 +34,4 @@ depends: [
   "mirage-types-lwt"  {test & < "3.0.0"}
 ]
 depopts: ["lwt" "mirage-types-lwt"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.6.0/opam
+++ b/packages/tar-format/tar-format.0.6.0/opam
@@ -36,4 +36,4 @@ depends: [
   "mirage-types-lwt"  {test & < "3.0.0"}
 ]
 depopts: ["lwt" "mirage-types-lwt"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.6.1/opam
+++ b/packages/tar-format/tar-format.0.6.1/opam
@@ -35,4 +35,4 @@ depends: [
   "mirage-types-lwt"  {test & < "3.0.0"}
 ]
 depopts: ["lwt" "mirage-types-lwt"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-format/tar-format.0.7.1/opam
+++ b/packages/tar-format/tar-format.0.7.1/opam
@@ -36,4 +36,4 @@ depopts: ["lwt" "mirage-types-lwt" "mirage-block" "mirage-block-lwt" "io-page"]
 conflicts: [
   "mirage-types-lwt" {< "3.0.0"}
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-mirage/tar-mirage.0.8.0/opam
+++ b/packages/tar-mirage/tar-mirage.0.8.0/opam
@@ -29,4 +29,4 @@ depends: [
 conflicts: [
   "mirage-types-lwt" {< "3.0.0"}
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar-unix/tar-unix.0.8.0/opam
+++ b/packages/tar-unix/tar-unix.0.8.0/opam
@@ -25,4 +25,4 @@ depends: [
   "result"
   "lwt"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/tar/tar.0.8.0/opam
+++ b/packages/tar/tar.0.8.0/opam
@@ -24,4 +24,4 @@ depends: [
   "re"
   "result"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
as reported by obi... //cc @djs55 there's already a safe-string patch upstream at https://github.com/mirage/ocaml-tar/pull/55 waiting for a merge and new release