### PR TITLE
restrict rawlink to <4.06.0

### DIFF
--- a/packages/rawlink/rawlink.0.1/opam
+++ b/packages/rawlink/rawlink.0.1/opam
@@ -12,4 +12,4 @@ depends: [
   "cstruct" {>="1.0.1" & <"2.0.0"}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02"]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.06.0"]

--- a/packages/rawlink/rawlink.0.2/opam
+++ b/packages/rawlink/rawlink.0.2/opam
@@ -12,4 +12,4 @@ depends: [
   "cstruct" {>="1.0.1" & <"2.0.0"}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02"]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.06.0"]

--- a/packages/rawlink/rawlink.0.3/opam
+++ b/packages/rawlink/rawlink.0.3/opam
@@ -12,4 +12,4 @@ depends: [
   "cstruct" {>="1.0.1" & <"2.0.0"}
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.02"]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.06.0"]

--- a/packages/rawlink/rawlink.0.4/opam
+++ b/packages/rawlink/rawlink.0.4/opam
@@ -16,5 +16,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [[ ["alpine"] ["linux-headers"] ]]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
 

--- a/packages/rawlink/rawlink.0.5/opam
+++ b/packages/rawlink/rawlink.0.5/opam
@@ -17,5 +17,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [[ ["alpine"] ["linux-headers"] ]]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]
 


### PR DESCRIPTION
cc @haesbaert there's an upstream PR https://github.com/haesbaert/rawlink/pull/5 to support safe-string