### PR TITLE
odoc 1.2.0 – new OCaml API docs generator

### DIFF
--- a/packages/doc-ock-html/doc-ock-html.1.2.0/descr
+++ b/packages/doc-ock-html/doc-ock-html.1.2.0/descr
@@ -1,0 +1,5 @@
+From doc-ock to HTML
+
+Doc-ock-html generates HTML documentation using [Doc-ock][doc-ock]
+
+doc-ock: https://github.com/ocaml-doc/doc-ock

--- a/packages/doc-ock-html/doc-ock-html.1.2.0/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.2.0/opam
@@ -1,0 +1,23 @@
+version: "1.2.0"
+opam-version: "1.2"
+maintainer: "Thomas Refis <trefis@janestreet.com>"
+author: "Thomas Refis <trefis@janestreet.com>"
+homepage:  "https://github.com/ocaml-doc/doc-ock-html"
+doc: "https://ocaml-doc.github.com/doc-ock-html/"
+license: "ISC"
+dev-repo: "http://github.com/ocaml-doc/doc-ock-html.git"
+bug-reports: "https://github.com/ocaml-doc/odoc/issues"
+tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
+
+available: [ ocaml-version >= "4.03.0" ]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "doc-ock" {>= "1.2.0" }
+  "tyxml" {>= "4.0.0" }
+  "xmlm" ]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/doc-ock-html/doc-ock-html.1.2.0/url
+++ b/packages/doc-ock-html/doc-ock-html.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-doc/doc-ock-html/archive/v1.2.0.tar.gz"
+checksum: "fa942cd747d72115575b040bbabaf863"

--- a/packages/doc-ock-xml/doc-ock-xml.1.2.0/descr
+++ b/packages/doc-ock-xml/doc-ock-xml.1.2.0/descr
@@ -1,0 +1,5 @@
+XML printer and parser for Doc-Ock
+
+Doc-ock-xml is an XML printer and parser for [Doc-ock][doc-ock]
+
+doc-ock: https://github.com/ocaml-doc/doc-ock

--- a/packages/doc-ock-xml/doc-ock-xml.1.2.0/opam
+++ b/packages/doc-ock-xml/doc-ock-xml.1.2.0/opam
@@ -1,0 +1,24 @@
+version: "1.2.0"
+opam-version: "1.2"
+maintainer: "lpw25@cl.cam.ac.uk"
+authors: [
+ "Leo White <lpw25@cl.cam.ac.uk>"
+ "David Sheets <sheets@alum.mit.edu>" ]
+homepage:  "https://github.com/ocaml-doc/doc-ock-xml"
+doc: "https://ocaml-doc.github.com/doc-ock-xml/"
+license: "ISC"
+dev-repo: "http://github.com/ocaml-doc/doc-ock-xml.git"
+bug-reports: "https://github.com/ocaml-doc/doc-ock-xml/issues"
+tags: ["doc" "xml" "ocaml" "org:ocaml-doc"]
+
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "xmlm"
+  "menhir"
+  "doc-ock" {>= "1.2.0" } ]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/doc-ock-xml/doc-ock-xml.1.2.0/url
+++ b/packages/doc-ock-xml/doc-ock-xml.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-doc/doc-ock-xml/archive/v1.2.0.tar.gz"
+checksum: "ad4b41051bcc2472da27c23e77b1ac5c"

--- a/packages/doc-ock/doc-ock.1.2.0/descr
+++ b/packages/doc-ock/doc-ock.1.2.0/descr
@@ -1,0 +1,3 @@
+Extract documentation from OCaml files
+
+Doc-ock is a library extract documentation from OCaml files

--- a/packages/doc-ock/doc-ock.1.2.0/opam
+++ b/packages/doc-ock/doc-ock.1.2.0/opam
@@ -1,0 +1,24 @@
+version: "1.2.0"
+opam-version: "1.2"
+maintainer: "lpw25@cl.cam.ac.uk"
+authors: [ "Leo White <lpw25@cl.cam.ac.uk>"
+           "Thomas Refis <trefis@janestreet.com>" ]
+homepage: "https://github.com/ocaml-doc/doc-ock"
+doc: "https://ocaml-doc.github.com/doc-ock/"
+license: "ISC"
+dev-repo: "http://github.com/ocaml-doc/doc-ock.git"
+bug-reports: "https://github.com/ocaml-doc/odoc/issues"
+tags: ["doc" "ocaml" "org:ocaml-doc"]
+
+available: [ ocaml-version >= "4.03.0" ]
+depends: [
+  "cppo" {build}
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "octavius"
+]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/doc-ock/doc-ock.1.2.0/url
+++ b/packages/doc-ock/doc-ock.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-doc/doc-ock/archive/v1.2.0.tar.gz"
+checksum: "ef6e96f69b9ed195415cbb620a3e88ea"

--- a/packages/octavius/octavius.1.2.0/descr
+++ b/packages/octavius/octavius.1.2.0/descr
@@ -1,0 +1,3 @@
+Ocamldoc comment syntax parser
+
+Octavius is a library to parse the `ocamldoc` comment syntax.

--- a/packages/octavius/octavius.1.2.0/opam
+++ b/packages/octavius/octavius.1.2.0/opam
@@ -1,0 +1,22 @@
+version: "1.2.0"
+opam-version: "1.2"
+name: "octavius"
+maintainer: "leo@lpw25.net"
+authors: [ "Leo White <leo@lpw25.net>" ]
+homepage: "https://github.com/ocaml-doc/octavius"
+doc: "http://ocaml-doc.github.io/octavius/"
+license: "ISC"
+dev-repo: "http://github.com/ocaml-doc/octavius.git"
+bug-reports: "https://github.com/ocaml-doc/octavius/issues"
+tags: ["doc" "ocamldoc" "org:ocaml-doc"]
+
+available: [ ocaml-version >= "4.03.0"]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "topkg" {build & >= "0.7.5"} ]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/octavius/octavius.1.2.0/url
+++ b/packages/octavius/octavius.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-doc/octavius/archive/v1.2.0.tar.gz"
+checksum: "3e6049c39045354853d9dc3a197133ac"

--- a/packages/odoc/odoc.1.2.0/descr
+++ b/packages/odoc/odoc.1.2.0/descr
@@ -1,0 +1,3 @@
+An OCaml API documentation tool
+
+`odoc` is an OCaml API documentation tool

--- a/packages/odoc/odoc.1.2.0/opam
+++ b/packages/odoc/odoc.1.2.0/opam
@@ -1,0 +1,33 @@
+version: "1.2.0"
+opam-version: "1.2"
+name: "odoc"
+author: "Thomas Refis <trefis@janestreet.com>"
+maintainer: "Thomas Refis <trefis@janestreet.com>"
+doc: "https://ocaml-doc.github.com/odoc/"
+homepage: "http://github.com/ocaml-doc/odoc"
+license: "ISC"
+dev-repo: "http://github.com/ocaml-doc/odoc.git"
+bug-reports: "https://github.com/ocaml-doc/odoc/issues"
+tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
+
+available: [ ocaml-version >= "4.03.0" ]
+
+
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "doc-ock" {>= "1.2.0" }
+  "doc-ock-html" {>= "1.2.0" }
+  "doc-ock-xml" {>= "1.2.0" }
+  "tyxml" {>= "4.0.0" }
+  "bos"
+  "fpath"
+  "result"
+  "xmlm"
+  "cmdliner" ]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["ocaml" "bin/set-etc" "bin/odoc_etc.ml" odoc:etc]
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/odoc/odoc.1.2.0/url
+++ b/packages/odoc/odoc.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-doc/odoc/archive/v1.2.0.tar.gz"
+checksum: "fd71747460a501106915e63402ef1757"


### PR DESCRIPTION
From the [changelog](https://github.com/ocaml-doc/odoc/releases/tag/v1.2.0):

> - Support for standalone documentation pages (`.mld` files) (ocaml-doc/odoc#61).
> - Display `[@@deprecated]` attributes as the `@deprecated` tag (ocaml-doc/odoc#57).
> - Allow each component of OCaml paths to be disambiguated using the `kind-identifer` syntax (part of ocaml-doc/odoc#61).
> - Support OCaml 4.06.
> - Fix spurious leading blank lines in verbatim text (ocaml-doc/octavius#6).

cc @lpw25 @trefis @avsm