### PR TITLE
ppx_import.1.4

### DIFF
--- a/packages/ppx_import/ppx_import.1.1/opam
+++ b/packages/ppx_import/ppx_import.1.1/opam
@@ -17,6 +17,7 @@ build-test: [
 depends: [
   "ppx_tools"    {>= "0.99.1"}
   "ocamlfind"    {build}
+  "ocamlbuild"   {build}
   "cppo"         {build}
   "cppo_ocamlbuild" {build}
   "ounit"        {test}

--- a/packages/ppx_import/ppx_import.1.1/opam
+++ b/packages/ppx_import/ppx_import.1.1/opam
@@ -22,4 +22,6 @@ depends: [
   "ounit"        {test}
   "ppx_deriving" {test & >= "2.0"}
 ]
-available: [ ocaml-version >= "4.02.0" & opam-version >= "1.2.2" ]
+available: [ opam-version >= "1.2.2"
+  & ocaml-version >= "4.02.0"
+  & ocaml-version < "4.06.0" ]

--- a/packages/ppx_import/ppx_import.1.2/opam
+++ b/packages/ppx_import/ppx_import.1.2/opam
@@ -23,6 +23,7 @@ build-test: [
 depends: [
   "ppx_tools" {>= "0.99.1"}
   "ocamlfind" {build}
+  "ocamlbuild"   {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ounit" {test}

--- a/packages/ppx_import/ppx_import.1.2/opam
+++ b/packages/ppx_import/ppx_import.1.2/opam
@@ -28,4 +28,6 @@ depends: [
   "ounit" {test}
   "ppx_deriving" {test & >= "2.0"}
 ]
-available: [ocaml-version >= "4.02.0" & opam-version >= "1.2.2"]
+available: [ opam-version >= "1.2.2"
+  & ocaml-version >= "4.02.0"
+  & ocaml-version < "4.06.0" ]

--- a/packages/ppx_import/ppx_import.1.3/descr
+++ b/packages/ppx_import/ppx_import.1.3/descr
@@ -1,0 +1,1 @@
+A syntax extension for importing declarations from interface files

--- a/packages/ppx_import/ppx_import.1.3/opam
+++ b/packages/ppx_import/ppx_import.1.3/opam
@@ -17,7 +17,9 @@ build-test: [
 depends: [
   "ppx_tools"    {>= "0.99.1"}
   "ocamlfind"    {build}
+  "ocamlbuild"   {build}
   "cppo"         {build}
+  "cppo_ocamlbuild" {build}
   "ounit"        {test}
   "ppx_deriving" {test & >= "2.0"}
 ]

--- a/packages/ppx_import/ppx_import.1.3/opam
+++ b/packages/ppx_import/ppx_import.1.3/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_import"
+bug-reports: "https://github.com/whitequark/ppx_import/issues"
+dev-repo: "git://github.com/whitequark/ppx_import.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_import.byte" "--"
+]
+depends: [
+  "ppx_tools"    {>= "0.99.1"}
+  "ocamlfind"    {build}
+  "cppo"         {build}
+  "ounit"        {test}
+  "ppx_deriving" {test & >= "2.0"}
+]
+available: [ opam-version >= "1.2.2"
+  & ocaml-version >= "4.02.0"
+  & ocaml-version < "4.06.0" ]

--- a/packages/ppx_import/ppx_import.1.3/url
+++ b/packages/ppx_import/ppx_import.1.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_import/archive/v1.3.tar.gz"
+checksum: "63591a48804d12dcdd02289c5f051fcb"

--- a/packages/ppx_import/ppx_import.1.4/descr
+++ b/packages/ppx_import/ppx_import.1.4/descr
@@ -1,0 +1,1 @@
+A syntax extension for importing declarations from interface files

--- a/packages/ppx_import/ppx_import.1.4/opam
+++ b/packages/ppx_import/ppx_import.1.4/opam
@@ -17,7 +17,9 @@ build-test: [
 depends: [
   "ppx_tools"    {>= "0.99.1"}
   "ocamlfind"    {build}
+  "ocamlbuild"   {build}
   "cppo"         {build}
+  "cppo_ocamlbuild" {build}
   "ounit"        {test}
   "ppx_deriving" {test & >= "2.0"}
 ]

--- a/packages/ppx_import/ppx_import.1.4/opam
+++ b/packages/ppx_import/ppx_import.1.4/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_import"
+bug-reports: "https://github.com/whitequark/ppx_import/issues"
+dev-repo: "git://github.com/whitequark/ppx_import.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_import.byte" "--"
+]
+depends: [
+  "ppx_tools"    {>= "0.99.1"}
+  "ocamlfind"    {build}
+  "cppo"         {build}
+  "ounit"        {test}
+  "ppx_deriving" {test & >= "2.0"}
+]
+available: [ opam-version >= "1.2.2"
+  & ocaml-version >= "4.02.0" ]

--- a/packages/ppx_import/ppx_import.1.4/url
+++ b/packages/ppx_import/ppx_import.1.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_import/archive/v1.4.tar.gz"
+checksum: "c1b409cd33456a97f36d8446f9320ff6"


### PR DESCRIPTION
The new release brings support for OCaml 4.06.
Older releases are marked as incompatible with OCaml 4.06.