### PR TITLE
Package asn1-combinators.0.2.0

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.0/descr
+++ b/packages/asn1-combinators/asn1-combinators.0.2.0/descr
@@ -1,0 +1,10 @@
+Embed typed ASN.1 grammars in OCaml
+
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+
+asn1-combinators is distributed under the ISC license.

--- a/packages/asn1-combinators/asn1-combinators.0.2.0/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+tags: [ "org:mirage" ]
+available: [ ocaml-version >= "4.02.0" ]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+  "cstruct"
+  "zarith"
+  "ptime"
+  "ounit" {test}
+]
+depopts: []
+conflicts: [ "cstruct" {< "1.6.0"} ]

--- a/packages/asn1-combinators/asn1-combinators.0.2.0/url
+++ b/packages/asn1-combinators/asn1-combinators.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.0/asn1-combinators-0.2.0.tbz"
+checksum: "f695aec35f8934d20d966032adbf3520"


### PR DESCRIPTION
### `asn1-combinators.0.2.0`

Embed typed ASN.1 grammars in OCaml

asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
part of ASN.1, and embed the abstract syntax directly in the language. These
abstract syntax representations can be used for parsing, serialization, or
random testing.

The only ASN.1 encodings currently supported are BER and DER.

asn1-combinators is distributed under the ISC license.



---
* Homepage: https://github.com/mirleft/ocaml-asn1-combinators
* Source repo: https://github.com/mirleft/ocaml-asn1-combinators.git
* Bug tracker: https://github.com/mirleft/ocaml-asn1-combinators/issues

---


---
## v0.2.0 (2017-11-13)
* `OID`s are now fully abstract, with a simpler interface.
* `OID`s have custom comparison and hasing.
* `Time` is gone in favor of `Ptime`.
* `IMPLICIT` silently becomes `EXPLICIT` when necessary.
* Parse errors are reported through `Result`.
* Syntaxes now live in their own module, `Asn.S`.
* Rewrote the parser; no new features, but looks nicer from a distance.
* Various performance improvements.
* Documented the interface.
:camel: Pull-request generated by opam-publish v0.3.5