### PR TITLE
constrain x509 and key-parsers to asn1-combinators < 0.2.0

### DIFF
--- a/packages/key-parsers/key-parsers.0.1.0/opam
+++ b/packages/key-parsers/key-parsers.0.1.0/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "key-parsers"]
 depends: [
   "ocamlfind" {build}
-  "asn1-combinators"
+  "asn1-combinators" {< "0.2.0"}
   "zarith"
   "ocamlbuild" {build}
 ]

--- a/packages/key-parsers/key-parsers.0.2.0/opam
+++ b/packages/key-parsers/key-parsers.0.2.0/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "key-parsers"]
 depends: [
   "ocamlfind" {build}
-  "asn1-combinators"
+  "asn1-combinators" {< "0.2.0"}
   "zarith"
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/key-parsers/key-parsers.0.3.0/opam
+++ b/packages/key-parsers/key-parsers.0.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ounit" {test}
   "ppx_blob" {test}
   "hex" {test}
-  "asn1-combinators"
+  "asn1-combinators" {< "0.2.0"}
   "zarith"
   "result"
 ]

--- a/packages/key-parsers/key-parsers.0.3.0/opam
+++ b/packages/key-parsers/key-parsers.0.3.0/opam
@@ -11,7 +11,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "key-parsers"]
 depends: [
   "ocamlfind" {build}
-  "ppx_deriving" {>= "2.0" & < "4.0"}
+  "ppx_deriving" {>= "3.0" & < "4.0"}
   "ppx_deriving_yojson"
   "ounit" {test}
   "ppx_blob" {test}

--- a/packages/key-parsers/key-parsers.0.4.0/opam
+++ b/packages/key-parsers/key-parsers.0.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ounit" {test & >= "2.0.0"}
   "ppx_blob" {test & >= "0.2"}
   "hex" {test & >= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
 ]

--- a/packages/key-parsers/key-parsers.0.5.0/opam
+++ b/packages/key-parsers/key-parsers.0.5.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ounit" {test & >= "2.0.0"}
   "ppx_blob" {test & >= "0.2"}
   "hex" {test & >= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "cstruct" {>= "1.6.0"}

--- a/packages/key-parsers/key-parsers.0.6.0/opam
+++ b/packages/key-parsers/key-parsers.0.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {test & >= "2.0.0"}
   "ppx_blob" {test & >= "0.2"}
   "hex" {test & >= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "topkg" {build}

--- a/packages/key-parsers/key-parsers.0.6.1/opam
+++ b/packages/key-parsers/key-parsers.0.6.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {test & >= "2.0.0"}
   "ppx_blob" {test & >= "0.2"}
   "hex" {test & >= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "topkg" {build}

--- a/packages/key-parsers/key-parsers.0.7.0/opam
+++ b/packages/key-parsers/key-parsers.0.7.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {test & >= "2.0.0"}
   "ppx_blob" {test & >= "0.2"}
   "hex" {test & >= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "topkg" {build}

--- a/packages/key-parsers/key-parsers.0.8.0/opam
+++ b/packages/key-parsers/key-parsers.0.8.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {test & >= "2.0.0"}
   "ppx_blob" {test & >= "0.2"}
   "hex" {test & >= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "topkg" {build}

--- a/packages/key-parsers/key-parsers.0.8.1/opam
+++ b/packages/key-parsers/key-parsers.0.8.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
   "ounit" {test & >= "2.0.0"}
   "hex" {test & >= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "topkg" {build}

--- a/packages/key-parsers/key-parsers.0.8.1/opam
+++ b/packages/key-parsers/key-parsers.0.8.1/opam
@@ -14,7 +14,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.2"}
   "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
   "ounit" {test & >= "2.0.0"}
   "hex" {test & >= "1.0.0"}

--- a/packages/key-parsers/key-parsers.0.9.0/opam
+++ b/packages/key-parsers/key-parsers.0.9.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
   "ounit" {test & >= "2.0.0"}
   "hex" {>= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "topkg" {build}

--- a/packages/key-parsers/key-parsers.0.9.1/opam
+++ b/packages/key-parsers/key-parsers.0.9.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
   "ounit" {test & >= "2.0.0"}
   "hex" {>= "1.0.0"}
-  "asn1-combinators" {>= "0.1.2"}
+  "asn1-combinators" {>= "0.1.2" & < "0.2.0"}
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "topkg" {build}

--- a/packages/x509/x509.0.1.0/opam
+++ b/packages/x509/x509.0.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "type_conv"
   "sexplib" {< "113.01.00"}
   "nocrypto" {= "0.1.0"}
-  "asn1-combinators"
+  "asn1-combinators" {< "0.2.0"}
   "ocamlbuild" {build}
 ]
 tags: [ "org:mirage" ]

--- a/packages/x509/x509.0.1.0/opam
+++ b/packages/x509/x509.0.1.0/opam
@@ -1,4 +1,7 @@
 opam-version: "1.2"
+homepage:     "https://github.com/mirleft/ocaml-x509"
+authors:      [ "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   [ "Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>" ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/x509/x509.0.2.0/opam
+++ b/packages/x509/x509.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "1.2.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.2.0" & < "0.5.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/x509/x509.0.2.1/opam
+++ b/packages/x509/x509.0.2.1/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "1.2.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.2.0" & < "0.5.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/x509/x509.0.3.0/opam
+++ b/packages/x509/x509.0.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "1.2.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.2.0" & < "0.5.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/x509/x509.0.3.1/opam
+++ b/packages/x509/x509.0.3.1/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct" {>= "1.2.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.2.0" & < "0.5.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/x509/x509.0.4.0/opam
+++ b/packages/x509/x509.0.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct" {>= "1.2.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.0" & < "0.5.2"}
   "ounit" {test}
   "ocamlbuild" {build}

--- a/packages/x509/x509.0.5.0/opam
+++ b/packages/x509/x509.0.5.0/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct" {>= "1.6.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.0" & < "0.5.3"}
   "base-bytes"
   "ounit" {test}

--- a/packages/x509/x509.0.5.1/opam
+++ b/packages/x509/x509.0.5.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "cstruct" {>= "1.6.0"}
   "sexplib"
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.3"}
   "base-bytes"
   "ounit" {test}

--- a/packages/x509/x509.0.5.2/opam
+++ b/packages/x509/x509.0.5.2/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "cstruct" {>= "1.6.0"}
   "sexplib"
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.3"}
   "base-bytes"
   "ounit" {test}

--- a/packages/x509/x509.0.5.3/opam
+++ b/packages/x509/x509.0.5.3/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "cstruct" {>= "1.6.0"}
   "sexplib"
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.3"}
   "base-bytes"
   "ounit" {test}


### PR DESCRIPTION
due to API changes, fixes the issues mentioned in #10837