### PR TITLE
Package rawlink.0.6

### DIFF
--- a/packages/rawlink/rawlink.0.6/descr
+++ b/packages/rawlink/rawlink.0.6/descr
@@ -1,0 +1,30 @@
+Portable library to read and write raw packets.
+
+[![Build Status](https://travis-ci.org/haesbaert/rawlink.svg)](https://travis-ci.org/haesbaert/rawlink)
+
+Rawlink is an ocaml library for sending and receiving raw packets at the link
+layer level. Sometimes you need to have full control of the packet, including
+building the full ethernet frame.
+
+The API is platform independent, it uses BPF on real UNIXes and AF_SOCKET on
+linux. Some functionality is sacrificed so that the API is portable enough.
+
+Currently BPF and AF_PACKET are implemented, including filtering capabilities.
+Writing a BPF program is a pain in the ass, so no facilities are provided for
+it. If you need a BPF filter, I suggest you write a small .c file with a
+function that returns the BPF program as a string, check `rawlink_stubs.c` for
+an example.
+
+Both normal blocking functions as well as `Lwt` monadic variants are provided.
+
+A typical code for receiving all packets and just sending them back on an
+specified interface are detailed below:
+
+```
+let link = Rawlink.open_link "eth0" in
+let buf = Rawlink.read_packet link in
+Printf.printf "got a packet with %d bytes.\n%!" (Cstruct.len buf);
+Rawlink.send_packet link buf
+```
+
+Check the mli interface for more options.

--- a/packages/rawlink/rawlink.0.6/opam
+++ b/packages/rawlink/rawlink.0.6/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "rawlink"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/haesbaert/rawlink"
+bug-reports: "https://github.com/haesbaert/rawlink/issues"
+dev-repo: "https://github.com/haesbaert/rawlink.git"
+doc: "https://haesbaert.github.io/rawlink/api"
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+depends: [
+  "ocamlfind" {build}
+  "topkg" {build}
+  "lwt" {>= "2.4.7"}
+  "cstruct" {>= "3.2.0"}
+  "ppx_cstruct" {build}
+  "ocamlbuild" {build}
+]
+depexts: [[ ["alpine"] ["linux-headers"] ]]
+available: [ocaml-version >= "4.03.0"]
+

--- a/packages/rawlink/rawlink.0.6/url
+++ b/packages/rawlink/rawlink.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/haesbaert/rawlink/releases/download/v0.6/rawlink-0.6.tbz"
+checksum: "3f7cf16f5e41b14dac3f8e11536f414c"


### PR DESCRIPTION
### `rawlink.0.6`

Portable library to read and write raw packets.

[![Build Status](https://travis-ci.org/haesbaert/rawlink.svg)](https://travis-ci.org/haesbaert/rawlink)

Rawlink is an ocaml library for sending and receiving raw packets at the link
layer level. Sometimes you need to have full control of the packet, including
building the full ethernet frame.

The API is platform independent, it uses BPF on real UNIXes and AF_SOCKET on
linux. Some functionality is sacrificed so that the API is portable enough.

Currently BPF and AF_PACKET are implemented, including filtering capabilities.
Writing a BPF program is a pain in the ass, so no facilities are provided for
it. If you need a BPF filter, I suggest you write a small .c file with a
function that returns the BPF program as a string, check `rawlink_stubs.c` for
an example.

Both normal blocking functions as well as `Lwt` monadic variants are provided.

A typical code for receiving all packets and just sending them back on an
specified interface are detailed below:

```
let link = Rawlink.open_link "eth0" in
let buf = Rawlink.read_packet link in
Printf.printf "got a packet with %d bytes.\n%!" (Cstruct.len buf);
Rawlink.send_packet link buf
```

Check the mli interface for more options.


---
* Homepage: https://github.com/haesbaert/rawlink
* Source repo: https://github.com/haesbaert/rawlink.git
* Bug tracker: https://github.com/haesbaert/rawlink/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
## 0.6 (2017-11-24)

* Support ocaml 4.06
* Fix cstruct linking
:camel: Pull-request generated by opam-publish v0.3.5