### PR TITLE
datakit-ci: Fix version constraint over session

### DIFF
--- a/packages/datakit-ci/datakit-ci.0.11.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.11.0/opam
@@ -28,7 +28,7 @@ depends: [
   "io-page"
   "pbkdf"
   "webmachine" {>= "0.4.0"}
-  "session" {>= "0.3.0"}
+  "session" {>= "0.3.0" & < "0.4.0"}
   "redis-lwt"
   "asetmap"
   "github-unix"


### PR DESCRIPTION
Starting from session 0.4.0, the sub-package ```session.redis-lwt``` has been separated out as ```session-redis-lwt```