### PR TITLE
datakit-ci: Fix version constraint over datakit-github

### DIFF
--- a/packages/datakit-ci/datakit-ci.0.11.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.11.0/opam
@@ -16,7 +16,7 @@ depends: [
   "multipart-form-data"
   "datakit-client" {>= "0.11.0"}
   "datakit-client-9p" {>= "0.11.0"}
-  "datakit-github" {>= "0.11.0"}
+  "datakit-github" {>= "0.11.0" & < "0.12.0"}
   "protocol-9p-unix" {>= "0.11.0"}
   "astring"
   "cmdliner"


### PR DESCRIPTION
```datakit-github``` changed its interface in 0.12.0 and ```datakit-ci.0.11.0``` is using the old one.