### PR TITLE
ppx_deriving_yojson 3.1

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/descr
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/descr
@@ -1,0 +1,4 @@
+JSON codec generator for OCaml >=4.02
+
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator.

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving_yojson"
+doc: "http://whitequark.github.io/ppx_deriving_yojson"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+tags: [ "syntax" "json" ]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind"
+    "src_test/test_ppx_yojson.byte" "--"
+]
+depends: [
+  "yojson"
+  "result"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cppo" {build}
+  "cppo_ocamlbuild" {build}
+  "ounit"        {test}
+  "ppx_import"   {test & >= "1.1"}
+]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/url
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/v3.1.tar.gz"
+checksum: "83128c06b0569309351886d9fd0dbb74"


### PR DESCRIPTION
  * Fix ppx_deriving_yojson.runtime META file
    (ocaml-ppx/ppx_deriving_yojson#47)
    Étienne Millon
  * Support for inline records in variant types
    (ocaml-ppx/ppx_deriving_yojson#50)
    Gerd Stolpmann
  * OCaml 4.06 compatibility
    (ocaml-ppx/ppx_deriving_yojson#64, ocaml-ppx/ppx_deriving_yojson#66)
    Leonid Rozenberg, Gabriel Scherer