### PR TITLE
Release jupyter and jupyter-archimedes 2.0.0

### DIFF
--- a/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/descr
+++ b/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/descr
@@ -1,0 +1,3 @@
+A Jupyter-friendly 2D plotting library (Archimedes backend)
+
+This library registers Jupyter backend to Archimedes, a simple and easy-to-use 2D plotting library. You can embed chart images into Jupyter notebooks.

--- a/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/opam
+++ b/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: [
+  "Akinori ABE <aabe.65535@gmail.com>"
+]
+authors: [
+  "Akinori ABE"
+]
+license: "MIT"
+homepage: "https://akabe.github.io/ocaml-jupyter/"
+bug-reports: "https://github.com/akabe/ocaml-jupyter/issues"
+dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
+
+available: [ ocaml-version >= "4.02.0" ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta14"}
+  "jupyter" {>= "2.0.0"}
+  "cairo2"
+  "archimedes"
+]

--- a/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/url
+++ b/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/akabe/ocaml-jupyter/releases/download/v2.0.0/jupyter-2.0.0.tbz"
+checksum: "99e49849c88b139356cea2eb142cae84"

--- a/packages/jupyter/jupyter.2.0.0/descr
+++ b/packages/jupyter/jupyter.2.0.0/descr
@@ -1,0 +1,3 @@
+An OCaml kernel for Jupyter notebook
+
+OCaml Jupyter provides an OCaml REPL on Jupyter (a great interface with markdown/HTML documentation, LaTeX formula by MathJax, and image embedding). This is useful for data analysis in OCaml.

--- a/packages/jupyter/jupyter.2.0.0/opam
+++ b/packages/jupyter/jupyter.2.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "1.2"
+name: "jupyter"
+maintainer: [
+  "Akinori ABE <aabe.65535@gmail.com>"
+]
+authors: [
+  "Akinori ABE"
+]
+license: "MIT"
+homepage: "https://akabe.github.io/ocaml-jupyter/"
+bug-reports: "https://github.com/akabe/ocaml-jupyter/issues"
+dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
+
+available: [ ocaml-version >= "4.02.0" ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+install: [
+  [ "./kernelspec.sh" "install" ]
+]
+remove: [
+  [ "./kernelspec.sh" "uninstall" ]
+]
+depends: [
+  "base-threads"
+  "base-unix"
+  "uuidm" {>= "0.9.6"}
+  "base64" {>= "2.1.2"}
+  "lwt" {>= "3.0.0"}
+  "stdint" {>= "0.4.2"}
+  "zmq" {>= "4.0-8"}
+  "lwt-zmq" {>= "2.1.0"}
+  "yojson" {>= "1.3.3"}
+  "ppx_deriving_yojson" {>= "3.0"}
+  "cryptokit" {>= "1.12"}
+  "ocamlfind" {build & >= "1.5.0"}
+  "jbuilder" {build & >= "1.0+beta14"}
+]
+depopts: [
+  "merlin"
+]
+conflicts: [
+  "merlin" {< "3.0.0"}
+]
+
+post-messages: [
+  "If Jupyter is installed, ocaml-jupyter kernel is already available."
+  "Otherwise you setup Jupyter and the OCaml kernel as follows:"
+  ""
+  "$ pip install jupyter"
+  "$ jupyter kernelspec install --name ocaml-jupyter \\
+    %{share}%/ocaml-jupyter"
+  {success}
+]

--- a/packages/jupyter/jupyter.2.0.0/url
+++ b/packages/jupyter/jupyter.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/akabe/ocaml-jupyter/releases/download/v2.0.0/jupyter-2.0.0.tbz"
+checksum: "99e49849c88b139356cea2eb142cae84"


### PR DESCRIPTION
Release note: https://github.com/akabe/ocaml-jupyter/releases/tag/v2.0.0