### PR TITLE
Add upper bound of lacaml version

### DIFF
--- a/packages/slap/slap.3.0.0/opam
+++ b/packages/slap/slap.3.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {>= "1.5.0"}
-  "lacaml" {>= "8.0.0"}
+  "lacaml" {>= "8.0.0" & < "10.0.0"}
   "cppo"
 ]
 depopts: [

--- a/packages/slap/slap.3.0.1/opam
+++ b/packages/slap/slap.3.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
-  "lacaml" {>= "8.0.0"}
+  "lacaml" {>= "8.0.0" & < "10.0.0"}
   "cppo" {build}
 ]
 depopts: [

--- a/packages/slap/slap.3.0.1/opam
+++ b/packages/slap/slap.3.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
   "lacaml" {>= "8.0.0" & < "10.0.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 depopts: [
   "ounit" {test}

--- a/packages/slap/slap.4.0.0/opam
+++ b/packages/slap/slap.4.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
-  "lacaml" {>= "8.0.0"}
+  "lacaml" {>= "8.0.0" & < "10.0.0"}
   "cppo" {build}
 ]
 depopts: [

--- a/packages/slap/slap.4.0.0/opam
+++ b/packages/slap/slap.4.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
   "lacaml" {>= "8.0.0" & < "10.0.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 depopts: [
   "ounit" {test}

--- a/packages/slap/slap.4.0.1/opam
+++ b/packages/slap/slap.4.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
-  "lacaml" {>= "8.0.0"}
+  "lacaml" {>= "8.0.0" & < "10.0.0"}
   "cppo" {build}
 ]
 depopts: [

--- a/packages/slap/slap.4.0.1/opam
+++ b/packages/slap/slap.4.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
   "lacaml" {>= "8.0.0" & < "10.0.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 depopts: [
   "ounit" {test}

--- a/packages/slap/slap.4.1.0/opam
+++ b/packages/slap/slap.4.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
-  "lacaml" {>= "8.0.0"}
+  "lacaml" {>= "8.0.0" & < "10.0.0"}
   "cppo" {build}
 ]
 depopts: [

--- a/packages/slap/slap.4.1.0/opam
+++ b/packages/slap/slap.4.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build & >= "1.5.0"}
   "lacaml" {>= "8.0.0" & < "10.0.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 depopts: [
   "ounit" {test}


### PR DESCRIPTION
SLAP https://github.com/akabe/slap does not support lacaml 10.0.0 or above currently.
I restrict lacaml versions.