### PR TITLE
ocplib-endian: 0.8 is not compatible with safe-string

### DIFF
--- a/packages/ocplib-endian/ocplib-endian.0.8/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.8/opam
@@ -18,3 +18,4 @@ depends: [
 ]
 dev-repo: "https://github.com/OCamlPro/ocplib-endian.git"
 bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
cc @chambart 