### PR TITLE
ppx_core v0.9.3 and ppx_type_conv v0.9.1

### DIFF
--- a/packages/ppx_core/ppx_core.v0.9.3/descr
+++ b/packages/ppx_core/ppx_core.v0.9.3/descr
@@ -1,0 +1,3 @@
+Standard library for ppx rewriters
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_core/ppx_core.v0.9.3/opam
+++ b/packages/ppx_core/ppx_core.v0.9.3/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+homepage: "https://github.com/janestreet/ppx_core"
+bug-reports: "https://github.com/janestreet/ppx_core/issues"
+license: "Apache-2.0"
+dev-repo: "https://github.com/janestreet/ppx_core.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base" {>= "v0.9.4" & < "v0.10"}
+  "jbuilder" {build & >= "1.0+beta16"}
+  "ocaml-compiler-libs" {>= "v0.9" & < "v0.10"}
+  "ppx_ast" {>= "v0.9.2" & < "v0.10"}
+  "ppx_traverse_builtins" {>= "v0.9" & < "v0.10"}
+  "stdio" {>= "v0.9.1" & < "v0.10"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ppx_core/ppx_core.v0.9.3/opam
+++ b/packages/ppx_core/ppx_core.v0.9.3/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "base" {>= "v0.9.4" & < "v0.10"}
+  "base" {>= "v0.9.3" & < "v0.10"}
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-compiler-libs" {>= "v0.9" & < "v0.10"}
   "ppx_ast" {>= "v0.9.0" & < "v0.10"}

--- a/packages/ppx_core/ppx_core.v0.9.3/opam
+++ b/packages/ppx_core/ppx_core.v0.9.3/opam
@@ -12,7 +12,7 @@ depends: [
   "base" {>= "v0.9.4" & < "v0.10"}
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-compiler-libs" {>= "v0.9" & < "v0.10"}
-  "ppx_ast" {>= "v0.9.2" & < "v0.10"}
+  "ppx_ast" {>= "v0.9.0" & < "v0.10"}
   "ppx_traverse_builtins" {>= "v0.9" & < "v0.10"}
   "stdio" {>= "v0.9.1" & < "v0.10"}
 ]

--- a/packages/ppx_core/ppx_core.v0.9.3/url
+++ b/packages/ppx_core/ppx_core.v0.9.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/ppx_core/archive/v0.9.3.tar.gz"
+checksum: "c986055a9da5e03c4a3db0bee47d9d2d"

--- a/packages/ppx_core/ppx_core.v0.9.3/url
+++ b/packages/ppx_core/ppx_core.v0.9.3/url
@@ -1,2 +1,2 @@
 http: "https://github.com/janestreet/ppx_core/archive/v0.9.3.tar.gz"
-checksum: "c986055a9da5e03c4a3db0bee47d9d2d"
+checksum: "344ca008fb57a09b57efb849ef90dc75"

--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.1/descr
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.1/descr
@@ -1,0 +1,3 @@
+Support Library for type-driven code generators
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+homepage: "https://github.com/janestreet/ppx_type_conv"
+bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
+license: "Apache-2.0"
+dev-repo: "https://github.com/janestreet/ppx_type_conv.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta16"}
+  "ppx_core" {>= "v0.9" & < "v0.10"}
+  "ppx_driver" {>= "v0.9" & < "v0.10"}
+  "ppx_metaquot" {>= "v0.9" & < "v0.10"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+  "ppx_derivers"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.1/url
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/ppx_type_conv/archive/v0.9.1.tar.gz"
+checksum: "85dbc534149d79dc775c11689614366b"


### PR DESCRIPTION
This PR fixes the last remaining issues when using both ppx_type_conv and ppx_deriving on the same file.