### PR TITLE
Transitional package: ppx_deriving_protocol.0.8.1

### DIFF
--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8.1/descr
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8.1/descr
@@ -1,0 +1,5 @@
+Migrate to ppx_protocol_conv
+
+The package has been renamed to ppx_protocol_conv.
+This Virtual package just depends on ppx_protocol_conv,
+and should not be installed

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8.1/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+depends: [
+  "ppx_protocol_conv"
+]
+post-messages: [
+  "ppx_deriving_protocol has been renamed to ppx_protocol_conv"
+  "This virtual package only depends on ppx_protocol_conv."
+  "To uninstall this package run:"
+  "  opam remove ppx_deriving_protocol"
+]


### PR DESCRIPTION
Transitional package due to rename from `ppx_deriving_protocol` to `ppx_protocol_conv`.
This package only depends on the new package, and has no install files. The package prints a post install message to explains the rename. 





