### PR TITLE
Package pkcs11.0.11.0

### DIFF
--- a/packages/pkcs11/pkcs11.0.11.0/descr
+++ b/packages/pkcs11/pkcs11.0.11.0/descr
@@ -1,0 +1,6 @@
+Bindings to the PKCS#11 cryptographic API
+
+This library contains ctypes bindings to the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.

--- a/packages/pkcs11/pkcs11.0.11.0/opam
+++ b/packages/pkcs11/pkcs11.0.11.0/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build"
+    "--pinned" "%{pinned}%"
+    "--with-cmdliner" "%{cmdliner:installed}%"
+    "--with-driver" "%{ctypes:installed}%"
+  ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build"
+    "--pinned" "%{pinned}%"
+    "--tests" "true"
+    "--with-cmdliner" "%{cmdliner:installed}%"
+    "--with-driver" "%{ctypes:installed}%"
+  ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "hex" { >= "1.0.0" }
+  "integers"
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "zarith"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+depopts: [
+  "cmdliner"
+  "ctypes"
+  "ctypes-foreign"
+]
+conflicts: [
+  "ctypes" { < "0.12.0" }
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.02.0" & os != "darwin"]

--- a/packages/pkcs11/pkcs11.0.11.0/url
+++ b/packages/pkcs11/pkcs11.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/pkcs11/releases/download/v0.11.0/pkcs11-0.11.0.tbz"
+checksum: "cd22eeb7d4e49601c6c7a34499eb8fbf"


### PR DESCRIPTION
### `pkcs11.0.11.0`

Bindings to the PKCS#11 cryptographic API

This library contains ctypes bindings to the PKCS#11 API.

This API is used by smartcards and Hardware Security Modules to perform
cryptographic operations such as signature or encryption.



---
* Homepage: https://github.com/cryptosense/pkcs11
* Source repo: https://github.com/cryptosense/pkcs11.git
* Bug tracker: https://github.com/cryptosense/pkcs11/issues

---


---
v0.11.0 2017-11-30
==================

Breaking changes:

- Removed `Low_level` and `Intermediate_level` from `P11_driver.S`. (#60)

New features:

- PKCS11 v2.40 support:
  + CKR codes (#63)
  + DSA+SHA2 mechanisms (#66)
  + GOST mechanism types (#67)
  + `CKM_AES_KEY_WRAP` (#68)
- New supported mechanisms:
  - `CKM_DSA_SHA1`
  - `CKM_AES_CTR` (#71)
  - `CKM_AES_GCM` (#74)
  - `CKM_DSA_KEY_PAIR_GEN` and associated attributes (#77)
- Add `eq,ord,show,yojson` instances to most types in `P11`. (#62, #72)

Bug fixes:

- Fix a memory leak with reachable pointers (#74)

Refactoring:

- Rework `CK_MECHANISM` internals (#75)
- Rework `CK_ATTRIBUTE` internals (#76)

Build system:

- Use travis-opam 1.1.0 (#73)
:camel: Pull-request generated by opam-publish v0.3.5