### PR TITLE
Package ocal.0.2.1

### DIFF
--- a/packages/ocal/ocal.0.2.1/descr
+++ b/packages/ocal/ocal.0.2.1/descr
@@ -1,0 +1,5 @@
+An improved Unix `cal` utility
+
+
+A replacement for the standard Unix `cal` utility. Partly because I could,
+partly because I'd become too irritated with its command line interface.

--- a/packages/ocal/ocal.0.2.1/opam
+++ b/packages/ocal/ocal.0.2.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Richard Mortier <mort@cantab.net>"
+authors: [ "Richard Mortier" ]
+license: "ISC"
+
+homepage: "https://github.com/mor1/ocal"
+dev-repo: "https://github.com/mor1/ocal.git"
+bug-reports: "https://github.com/mor1/ocal/issues"
+doc: "https://mor1.github.io/ocal/"
+
+available: [ ocaml-version >= "4.02.3" ]
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "jbuilder"  {build & >="1.0+beta11"}
+  "astring"   {build}
+  "calendar"  {build}
+  "cmdliner"  {build}
+  "notty"     {build & >="0.2.0"}
+]

--- a/packages/ocal/ocal.0.2.1/url
+++ b/packages/ocal/ocal.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mor1/ocal/releases/download/0.2.1/ocal-0.2.1.tbz"
+checksum: "f7f22d6276ddf82d6055fdc59af1376d"


### PR DESCRIPTION
### `ocal.0.2.1`

An improved Unix `cal` utility


A replacement for the standard Unix `cal` utility. Partly because I could,
partly because I'd become too irritated with its command line interface.


---
* Homepage: https://github.com/mor1/ocal
* Source repo: https://github.com/mor1/ocal.git
* Bug tracker: https://github.com/mor1/ocal/issues

---


---
### 0.2.1 (2017-11-30)

  * Update to use [notty][] 0.2.0 after breaking API change
  * Change default to display week-of-year; `-w` now stops display
  * Fix compiler and library constraints
  * Fix display of current month by default
:camel: Pull-request generated by opam-publish v0.3.5