### PR TITLE
Restrict ppx_type_conv to >4.03

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
@@ -16,4 +16,4 @@ depends: [
   "ocaml-migrate-parsetree" {>= "0.4"}
   "ppx_derivers"
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version > "4.03.0"]


### PR DESCRIPTION
Otherwise got errors like:
```
 File "src/hash.ml", line 115, characters 12-16:
 Cannot locate deriver sexp
 Command exited with code 2.
```