### PR TITLE
Package ocaml-gist.0.0.1

### DIFF
--- a/packages/ocaml-gist/ocaml-gist.0.0.1/descr
+++ b/packages/ocaml-gist/ocaml-gist.0.0.1/descr
@@ -1,0 +1,1 @@
+A tool to create online OCaml gist experiences for the web

--- a/packages/ocaml-gist/ocaml-gist.0.0.1/opam
+++ b/packages/ocaml-gist/ocaml-gist.0.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "sandermail@gmail.com"
+authors: "Sander Spies"
+homepage: "https://github.com/SanderSpies/ocaml-gist"
+bug-reports: "https://github.com/SanderSpies/ocaml-gist/issues"
+license: "MIT"
+dev-repo: "https://github.com/SanderSpies/ocaml-gist.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "ocamlfind"
+  "js_of_ocaml" {dev}
+  "js_of_ocaml-compiler" {dev}
+  "js_of_ocaml-toplevel"
+  "yojson"
+  "cmdliner"
+  "ocaml-webworker"
+]
+available: [ocaml-version = "4.04.2"]

--- a/packages/ocaml-gist/ocaml-gist.0.0.1/url
+++ b/packages/ocaml-gist/ocaml-gist.0.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/SanderSpies/ocaml-gist/archive/0.0.2.tar.gz"
+checksum: "54b32dd6ea42e2a3c395db67df1ed60b"


### PR DESCRIPTION
### `ocaml-gist.0.0.1`

A tool to create online OCaml gist experiences for the web



---
* Homepage: https://github.com/SanderSpies/ocaml-gist
* Source repo: https://github.com/SanderSpies/ocaml-gist.git
* Bug tracker: https://github.com/SanderSpies/ocaml-gist/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5