### PR TITLE
js-of-ocaml-ppx : not compatible with ppx_deriving.4.2.1

### DIFF
--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.1/opam
@@ -20,6 +20,7 @@ depopts: ["ppx_deriving" "ppx_tools"]
 
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}
+  "ppx_deriving" {>"4.2"}
 ]
 
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0/opam
@@ -20,6 +20,7 @@ depopts: ["ppx_deriving" "ppx_tools"]
 
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}
+  "ppx_deriving" {>"4.2"}
 ]
 
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
due to:

```
# File "ppx/ppx_deriving_json/lib/ppx_deriving_json.pp.ml", line 2782, characters 41-42:
 2782, characters 41-42:
# Error: This expression has type
#          Parsetree.expression -> string -> Parsetree.expression
#        but an expression was expected of type
#          Parsetree.expression -> Ppx_deriving.tyvar -> Parsetree.expression
#        Type string is not compatible with type
#          Ppx_deriving.tyvar = string Location.loc 
```

cc @hhugo @diml 