### PR TITLE
ppx_deriving_protobuf.2.6

### DIFF
--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/descr
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/descr
@@ -1,0 +1,2 @@
+A Protocol Buffers codec generator for OCaml >=4.02
+

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/opam
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving_protobuf"
+doc: "https://whitequark.github.io/ppx_deriving_protobuf"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving_protobuf/issues"
+dev-repo: "https://github.com/ocaml-ppx/ppx_deriving_protobuf.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+build-test: [
+  "ocamlbuild" "-classic-display" "-use-ocamlfind"
+    "src_test/test_ppx_protobuf.byte" "--"
+]
+build-doc: [
+  make "doc"
+]
+depends: [
+  "ocamlbuild"   {build}
+  "ocamlfind"    {build}
+  "cppo"         {build}
+  "cppo_ocamlbuild" {build}
+  "ppx_deriving" {>= "3.2" & < "5.0"}
+  "ounit"        {test}
+  "uint"         {test}
+]

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/url
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/ocaml-ppx/ppx_deriving_protobuf/archive/v2.6.tar.gz"
+checksum: "5970997dab8b0abdd8b82c77fd0cf634"


### PR DESCRIPTION
  * Support for NPM packaging (ocaml-ppx/ppx_deriving_protobuf#17)
    (Maxime Rasan)
  * Fix `varint` decoding (ocaml-ppx/ppx_deriving_protobuf#18)
    (There was a decoding bug for integers between 2^56 and 2^63)
    (Maxime Rasan)
  * Support for OCaml 4.06 (ocaml-ppx/ppx_deriving_protobuf#19)
    (Gabriel Scherer)

The homepage for the project has now moved to:
<https://github.com/ocaml-ppx/ppx_deriving_protobuf>