### PR TITLE
ketrew: not compatible with cohttp.1.0.0

### DIFF
--- a/packages/ketrew/ketrew.3.2.1/opam
+++ b/packages/ketrew/ketrew.3.2.1/opam
@@ -27,7 +27,7 @@ depends: [
   "yojson" "uri"
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.0"}
-  "cohttp-lwt-unix" {>= "0.99.0"}
+  "cohttp-lwt-unix" {>= "0.99.0" & <"1.0"}
   "lwt"
   "conduit"
   "lwt_react"


### PR DESCRIPTION
uses `Cohttp_lwt_body` which is now removed in 1.0+

revdep failure spotted in #10905 cc @smondet 