### PR TITLE
duppy.0.7.0

### DIFF
--- a/packages/duppy/duppy.0.7.0/descr
+++ b/packages/duppy/duppy.0.7.0/descr
@@ -1,0 +1,1 @@
+Library providing monadic threads

--- a/packages/duppy/duppy.0.7.0/opam
+++ b/packages/duppy/duppy.0.7.0/opam
@@ -20,5 +20,6 @@ depopts: [
   "osx-secure-transport"
 ]
 conflicts: ["liquidsoap" {<= "1.2.1"}]
+available: [ ocaml-version >= "4.02.3" ]
 bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
 dev-repo: "https://github.com/savonet/ocaml-duppy.git"

--- a/packages/duppy/duppy.0.7.0/opam
+++ b/packages/duppy/duppy.0.7.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-duppy"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "duppy"]
+depends: [
+  "camlp4"
+  "ocamlfind"
+  "pcre"
+]
+depopts: [
+  "ssl"
+  "osx-secure-transport"
+]
+conflicts: ["liquidsoap" {<= "1.2.1"}]
+bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
+dev-repo: "https://github.com/savonet/ocaml-duppy.git"

--- a/packages/duppy/duppy.0.7.0/url
+++ b/packages/duppy/duppy.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/savonet/ocaml-duppy/releases/download/0.7.0/ocaml-duppy-0.7.0.tar.gz"
+checksum: "609d9116adc8835abb088d7e0bc27ac9"


### PR DESCRIPTION
This releases fixes compilation with OCaml compilers where `string <> bytes`.