### PR TITLE
Package ppxfind.1.0

### DIFF
--- a/packages/ppxfind/ppxfind.1.0/descr
+++ b/packages/ppxfind/ppxfind.1.0/descr
@@ -1,0 +1,3 @@
+ocamlfind ppx tool
+Ppxfind is a small command line tool that among other things allows
+to use old style ppx rewriters with jbuilder.

--- a/packages/ppxfind/ppxfind.1.0/opam
+++ b/packages/ppxfind/ppxfind.1.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/ppxfind"
+bug-reports: "https://github.com/diml/ppxfind/issues"
+dev-repo: "git://github.com/diml/ppxfind.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta16"}
+]

--- a/packages/ppxfind/ppxfind.1.0/opam
+++ b/packages/ppxfind/ppxfind.1.0/opam
@@ -12,4 +12,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-migrate-parsetree"
 ]
-available: [ ocaml-version >= "4.04.0" ]
+available: [ ocaml-version >= "4.05.0" ]

--- a/packages/ppxfind/ppxfind.1.0/opam
+++ b/packages/ppxfind/ppxfind.1.0/opam
@@ -12,3 +12,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-migrate-parsetree"
 ]
+available: [ ocaml-version >= "4.04.0" ]

--- a/packages/ppxfind/ppxfind.1.0/opam
+++ b/packages/ppxfind/ppxfind.1.0/opam
@@ -10,4 +10,5 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta16"}
+  "ocaml-migrate-parsetree"
 ]

--- a/packages/ppxfind/ppxfind.1.0/url
+++ b/packages/ppxfind/ppxfind.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/ppxfind/releases/download/1.0/ppxfind-1.0.tbz"
+checksum: "f6ecd337cb5435517508c1a8ed3558ca"


### PR DESCRIPTION
### `ppxfind.1.0`

ocamlfind ppx tool
Ppxfind is a small command line tool that among other things allows
to use old style ppx rewriters with jbuilder.



---
* Homepage: https://github.com/diml/ppxfind
* Source repo: git://github.com/diml/ppxfind.git
* Bug tracker: https://github.com/diml/ppxfind/issues

---


---
# 1.0

Initial import
:camel: Pull-request generated by opam-publish v0.3.4