### PR TITLE
Package jemalloc.0.1

### DIFF
--- a/packages/jemalloc/jemalloc.0.1/descr
+++ b/packages/jemalloc/jemalloc.0.1/descr
@@ -1,0 +1,3 @@
+Bindings to jemalloc mallctl api
+
+Exposes helpers to access jemalloc control api, retrieve allocator statistics and change allocator settings.

--- a/packages/jemalloc/jemalloc.0.1/opam
+++ b/packages/jemalloc/jemalloc.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "joris.giovannangeli@ahrefs.com"
+authors: "joris giovannangeli"
+homepage: "https://github.com/ahrefs/ocaml-jemalloc"
+bug-reports: "https://github.com/ahrefs/ocaml-jemalloc/issues"
+license: "MIT"
+tags: "clib:jemalloc"
+dev-repo: "git://github.com/ahrefs/ocaml-jemalloc"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "jemalloc_ctl"]
+depends: [
+  ("oasis" {build & >= "0.4.7"} | "oasis-mirage" {build & >= "0.4.7"})
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+depexts: [
+  [ [ "alpine"] [ "jemalloc-dev" ] ]
+  [ ["debian"] ["libjemalloc-dev"] ]
+  [ ["ubuntu"] ["libjemalloc-dev"] ]
+  [ ["fedora"] ["jemalloc-devel"] ]
+  [ ["mageia"] ["jemalloc-devel"] ]
+  [ ["rhel"] ["jemalloc-devel"] ]
+  [ ["centos"] ["jemalloc-devel"] ]
+  [ ["osx"] [ "jemalloc"] ]
+]
+available: [ocaml-version >= "4.04.1"]

--- a/packages/jemalloc/jemalloc.0.1/url
+++ b/packages/jemalloc/jemalloc.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ahrefs/ocaml-jemalloc/archive/0.1.tar.gz"
+checksum: "94bcdd7e97ef4d9494534c19641512a3"


### PR DESCRIPTION
### `jemalloc.0.1`

Bindings to jemalloc mallctl api

Exposes helpers to access jemalloc control api, retrieve allocator statistics and change allocator settings.



---
* Homepage: https://github.com/ahrefs/ocaml-jemalloc
* Source repo: git://github.com/ahrefs/ocaml-jemalloc
* Bug tracker: https://github.com/ahrefs/ocaml-jemalloc/issues

---

:camel: Pull-request generated by opam-publish v0.3.5