### PR TITLE
amqp-client: Remove install/remove stanzas

### DIFF
--- a/packages/amqp-client/amqp-client.1.1.0/opam
+++ b/packages/amqp-client/amqp-client.1.1.0/opam
@@ -8,8 +8,6 @@ license: "BSD3"
 version: "1.1.0"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
 depends: [
   "jbuilder" {build}
   "xml-light" {build}

--- a/packages/amqp-client/amqp-client.1.1.1/opam
+++ b/packages/amqp-client/amqp-client.1.1.1/opam
@@ -8,8 +8,6 @@ license: "BSD3"
 version: "1.1.1"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
 depends: [
   "jbuilder" {build}
   "xml-light" {build}

--- a/packages/amqp-client/amqp-client.1.1.2/opam
+++ b/packages/amqp-client/amqp-client.1.1.2/opam
@@ -8,8 +8,6 @@ license: "BSD3"
 version: "1.1.2"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
 depends: [
   "jbuilder" {build}
   "xml-light" {build}

--- a/packages/amqp-client/amqp-client.1.1.3/opam
+++ b/packages/amqp-client/amqp-client.1.1.3/opam
@@ -8,8 +8,6 @@ license: "BSD3"
 version: "1.1.3"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
 depends: [
   "jbuilder" {build}
   "xml-light" {build}

--- a/packages/amqp-client/amqp-client.1.1.4/opam
+++ b/packages/amqp-client/amqp-client.1.1.4/opam
@@ -6,9 +6,7 @@ bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
 license: "BSD3"
 dev-repo: "https://github.com/andersfugmann/amqp-client.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
-install: [jbuilder install]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
-remove: [jbuilder uninstall]
 depends: [
   "jbuilder" {build}
   "xml-light" {build}


### PR DESCRIPTION
These fail anyway and in any case this is handled by `amqp-client.install` file which `jbuilder` will generate.

Related discussion to explain what was happening: https://github.com/ocaml/opam/issues/3132
Related pull request to upstream: https://github.com/andersfugmann/amqp-client/pull/15