### PR TITLE
Remove voaacenc from liquidsoap optional deps.

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.3.3/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.3/opam
@@ -51,7 +51,6 @@ depopts: [
   "ssl"
   "taglib"
   "theora"
-  "voaacenc"
   "vorbis"
   "xmlplaylist"
   "yojson"


### PR DESCRIPTION
Support for this module was dropped with release `1.3.0`.