### PR TITLE
ppx_deriving_protocol.0.8.0: Rename github repository

### DIFF
--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
@@ -1,9 +1,9 @@
 opam-version: "1.2"
 maintainer: "Anders Fugmann <anders@fugmann.net>"
 authors: "Anders Fugmann"
-homepage: "https://github.com/andersfugmann/ppx-deriving-protocol"
-bug-reports: "https://github.com/andersfugmann/ppx-deriving-protocol/issues"
-dev-repo: "git+https://github.com/andersfugmann/ppx-deriving-protocol"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 depends: [

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/url
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/url
@@ -1,3 +1,2 @@
-http:
-  "https://github.com/andersfugmann/ppx-deriving-protocol/archive/0.8.tar.gz"
-checksum: "ec0a4592399f5f2a0be3240f7ece182f"
+archive: "https://github.com/andersfugmann/ppx_protocol_conv/archive/0.8.tar.gz"
+checksum: "6cb875b80d51f9a26eb05db7f9779011"

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/url
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/andersfugmann/ppx_protocol_conv/archive/0.8.tar.gz"
-checksum: "6cb875b80d51f9a26eb05db7f9779011"
+checksum: "0681551f28c0f725b491257ef13d7c99"


### PR DESCRIPTION
Due to a rename of the repository, links and url checksum are updated. 