### PR TITLE
fix for conf-rdkit to support upcoming version of rdkit

### DIFF
--- a/packages/conf-rdkit/conf-rdkit.0.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.0.1/opam
@@ -7,8 +7,8 @@ dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD-3"
 build: [
   ["sh" "-c" "brew tap rdkit/rdkit && brew install rdkit"] {os = "darwin"}
-  ["c++" "test.cpp" "-o" "test"
-         "-I/usr/local/include" "-L/usr/local/lib" "-lRDGeneral"]
+  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include -L/usr/local/lib -lRDGeneral || \
+              c++ test.cpp -o test -I/usr/local/include -L/usr/local/lib -lRDKitRDGeneral"]
 ]
 install: ["./test"]
 remove: []


### PR DESCRIPTION
In the upcoming version of rdkit, installed libraries have new names.

I want this conf package to support any installed version of rdkit.
If, in the future, there is a need to detect the specific rdkit version installed, I will break this conf package into several ones.

PS: the package that relies on this conf one should arrive this week into the opam repo.