### PR TITLE
Package numalib.0.1.0

### DIFF
--- a/packages/numalib/numalib.0.1.0/descr
+++ b/packages/numalib/numalib.0.1.0/descr
@@ -1,0 +1,10 @@
+Interface to Linux NUMA API
+
+This library provides an OCaml API to the Linux Non-Uniform Memory Access
+library including:
+
+* Raw low level access to the C functions
+* A high level API
+* Async support
+
+See the NUMA(3) man page for more information

--- a/packages/numalib/numalib.0.1.0/opam
+++ b/packages/numalib/numalib.0.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "numalib"
+maintainer: "Steve Bleazard <stevebleazard@googlemail.com>"
+authors: "Steve Bleazard <stevebleazard@googlemail.com>"
+homepage: "https://www.github.com/stevebleazard/ocaml-numa"
+bug-reports: "https://www.github.com/stevebleazard/ocaml-numa/issues"
+license: "MIT"
+dev-repo: "https://www.github.com/stevebleazard/ocaml-numa.git"
+doc: "https://stevebleazard.github.io/ocaml-numa/"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs "@install"]
+]
+
+depends: [
+  "jbuilder" {build}
+]
+

--- a/packages/numalib/numalib.0.1.0/url
+++ b/packages/numalib/numalib.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://www.github.com/stevebleazard/ocaml-numa/releases/download/v0.1.0/numalib-0.1.0.tbz"
+checksum: "628453a67dc6c029e842ea2bd4608835"


### PR DESCRIPTION
### `numalib.0.1.0`

Interface to Linux NUMA API

This library provides an OCaml API to the Linux Non-Uniform Memory Access
library including:

* Raw low level access to the C functions
* A high level API
* Async support

See the NUMA(3) man page for more information


---
* Homepage: https://www.github.com/stevebleazard/ocaml-numa
* Source repo: https://www.github.com/stevebleazard/ocaml-numa.git
* Bug tracker: https://www.github.com/stevebleazard/ocaml-numa/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
# v0.1.0

- Initial release
:camel: Pull-request generated by opam-publish v0.3.5