### PR TITLE
ocamlnet-4.1.5

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.5/descr
+++ b/packages/ocamlnet/ocamlnet.4.1.5/descr
@@ -1,0 +1,10 @@
+Internet protocols (HTTP, CGI, e-mail etc.) and helper data structures
+(mail messages, character sets, etc.)
+
+Ocamlnet is an enhanced system platform library for Ocaml. As the name
+suggests, large parts of it have to do with network programming, but
+it is actually not restricted to this. Other parts deal with the
+management of multiple worker processes, and the interaction with
+other programs running on the same machine. You can also view Ocamlnet
+as an extension of the system interface as provided by the Unix module
+of the standard library.

--- a/packages/ocamlnet/ocamlnet.4.1.5/files/ocamlnet.install
+++ b/packages/ocamlnet/ocamlnet.4.1.5/files/ocamlnet.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/rpc-generator/ocamlrpcgen"
+  "src/netplex/netplex-admin"
+]

--- a/packages/ocamlnet/ocamlnet.4.1.5/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.5/opam
@@ -1,0 +1,65 @@
+opam-version: "1.2"
+maintainer: "vb@luminar.eu.org"
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.4/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-%{conf-gssapi:enable}%-gssapi"
+    "-%{conf-gnutls:enable}%-gnutls"
+    "-%{pcre:enable}%-pcre"
+    "-%{lablgtk:enable}%-gtk2"
+    "-%{camlzip:enable}%-zip"
+    "-with-nethttpd"
+  ]
+  [make "all"]
+  [make "opt"]
+]
+authors: ["Gerd Stolpmann"]
+remove: [
+  ["ocamlfind" "remove" "equeue"]
+  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
+  ["ocamlfind" "remove" "netcamlbox"]
+  ["ocamlfind" "remove" "netcgi2"]
+  ["ocamlfind" "remove" "netcgi2-plex"]
+  ["ocamlfind" "remove" "netclient"]
+  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
+  ["ocamlfind" "remove" "nethttpd"]
+  ["ocamlfind" "remove" "netmulticore"]
+  ["ocamlfind" "remove" "netplex"]
+  ["ocamlfind" "remove" "netshm"]
+  ["ocamlfind" "remove" "netstring"]
+  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
+  ["ocamlfind" "remove" "netsys"]
+  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
+  ["ocamlfind" "remove" "netunidata"]
+  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
+  ["ocamlfind" "remove" "pop"]
+  ["ocamlfind" "remove" "rpc"]
+  ["ocamlfind" "remove" "rpc-auth-local"]
+  ["ocamlfind" "remove" "rpc-generator"]
+  ["ocamlfind" "remove" "shell"]
+  ["ocamlfind" "remove" "smtp"]
+
+]
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "base-bytes"
+]
+depopts: [
+  "conf-gnutls"
+  "conf-gssapi"
+  "lablgtk"
+  "pcre"
+  "camlzip"
+]
+available: [ ocaml-version >= "4.00.0"
+           & compiler != "4.04.0+flambda"
+           & compiler != "4.04.1+flambda"
+           & compiler != "4.04.2+flambda" ]
+install: [make "install"]

--- a/packages/ocamlnet/ocamlnet.4.1.5/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.5/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
-doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.4/doc/html-main/index.html"]
+doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.5/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [

--- a/packages/ocamlnet/ocamlnet.4.1.5/url
+++ b/packages/ocamlnet/ocamlnet.4.1.5/url
@@ -1,0 +1,2 @@
+archive: "http://download.camlcity.org/download/ocamlnet-4.1.5.tar.gz"
+checksum: "9db5012d73fc8fe8936fb9a0726e5d04"


### PR DESCRIPTION
Upgrades opam to ocamlnet-4.1.5. See http://projects.camlcity.org/projects/dl/ocamlnet-4.1.5/ChangeLog for the short list of changes. Most importantly, fixes an incompatibility with GNU nettle-3.4 (which was recently released). 