### PR TITLE
Package dtoa.0.3.1

### DIFF
--- a/packages/dtoa/dtoa.0.3.1/descr
+++ b/packages/dtoa/dtoa.0.3.1/descr
@@ -1,0 +1,3 @@
+Converts OCaml floats into strings (doubles to ascii, "d to a"), using the efficient Grisu3 algorithm.
+
+This is a (partial) port of Google's double-conversion library from C++ to C.

--- a/packages/dtoa/dtoa.0.3.1/opam
+++ b/packages/dtoa/dtoa.0.3.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Marshall Roch <mroch@fb.com>"
+authors: ["Marshall Roch <mroch@fb.com>"]
+homepage: "https://github.com/flowtype/ocaml-dtoa"
+doc: "https://github.com/flowtype/ocaml-dtoa"
+license: "MIT"
+dev-repo: "https://github.com/flowtype/ocaml-dtoa.git"
+bug-reports: "https://github.com/flowtype/ocaml-dtoa/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends:
+[
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ounit" {test & >= "2.0.0"}
+]
+depopts: []
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/dtoa/dtoa.0.3.1/url
+++ b/packages/dtoa/dtoa.0.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/flowtype/ocaml-dtoa/releases/download/v0.3.1/dtoa-0.3.1.tbz"
+checksum: "c782646b12a03015dcecf687ea120a05"


### PR DESCRIPTION
### `dtoa.0.3.1`

Converts OCaml floats into strings (doubles to ascii, "d to a"), using the efficient Grisu3 algorithm.

This is a (partial) port of Google's double-conversion library from C++ to C.



---
* Homepage: https://github.com/flowtype/ocaml-dtoa
* Source repo: https://github.com/flowtype/ocaml-dtoa.git
* Bug tracker: https://github.com/flowtype/ocaml-dtoa/issues

---

:camel: Pull-request generated by opam-publish v0.3.5