### PR TITLE
Angstrom 0.6.0 tests require Alcotest >= 0.6.0 for int32.

### DIFF
--- a/packages/angstrom/angstrom.0.6.0/opam
+++ b/packages/angstrom/angstrom.0.6.0/opam
@@ -14,7 +14,7 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "result"


### PR DESCRIPTION
The Angstrom 0.6.0 tests require Alcotest 0.6.0 or above.  With earlier version the tests fail:
```
# File "lib_test/test_angstrom.ml", line 171, characters 15-29:
# Error: Unbound value Alcotest.int32
# Hint: Did you mean int?
```
/cc @seliopou 