### PR TITLE
Constrain old versions of containers against < 4.06

### DIFF
--- a/packages/containers/containers.0.10/opam
+++ b/packages/containers/containers.0.10/opam
@@ -34,6 +34,6 @@ depopts: [ "lwt" "sequence" "base-bigarray" "base-unix" "base-threads" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"

--- a/packages/containers/containers.0.11/opam
+++ b/packages/containers/containers.0.11/opam
@@ -34,6 +34,6 @@ depopts: [ "lwt" "sequence" "base-bigarray" "base-unix" "base-threads" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"

--- a/packages/containers/containers.0.3.3/opam
+++ b/packages/containers/containers.0.3.3/opam
@@ -25,5 +25,5 @@ tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
 dev-repo: "git://github.com/c-cube/ocaml-containers"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 install: [make "build" "install"]

--- a/packages/containers/containers.0.3.4/opam
+++ b/packages/containers/containers.0.3.4/opam
@@ -25,5 +25,5 @@ tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
 dev-repo: "git://github.com/c-cube/ocaml-containers"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 install: [make "build" "install"]

--- a/packages/containers/containers.0.4.1/opam
+++ b/packages/containers/containers.0.4.1/opam
@@ -26,5 +26,5 @@ tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
 dev-repo: "git://github.com/c-cube/ocaml-containers"
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: [make "build" "install"]

--- a/packages/containers/containers.0.4/opam
+++ b/packages/containers/containers.0.4/opam
@@ -26,5 +26,5 @@ tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
 dev-repo: "git://github.com/c-cube/ocaml-containers"
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: [make "build" "install"]

--- a/packages/containers/containers.0.5/opam
+++ b/packages/containers/containers.0.5/opam
@@ -23,6 +23,6 @@ depends: [
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"

--- a/packages/containers/containers.0.6.1/opam
+++ b/packages/containers/containers.0.6.1/opam
@@ -28,6 +28,6 @@ depopts: [ "lwt" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"

--- a/packages/containers/containers.0.6/opam
+++ b/packages/containers/containers.0.6/opam
@@ -28,6 +28,6 @@ depopts: [ "lwt" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"

--- a/packages/containers/containers.0.7/opam
+++ b/packages/containers/containers.0.7/opam
@@ -33,6 +33,6 @@ depopts: [ "lwt" "sequence" "base-bigarray" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"

--- a/packages/containers/containers.0.8/opam
+++ b/packages/containers/containers.0.8/opam
@@ -39,6 +39,6 @@ depopts: [ "lwt" "sequence" "base-bigarray" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"

--- a/packages/containers/containers.0.9/opam
+++ b/packages/containers/containers.0.9/opam
@@ -39,6 +39,6 @@ depopts: [ "lwt" "sequence" "base-bigarray" ]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "http://cedeela.fr/~simon/software/containers/"
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 dev-repo: "https://github.com/c-cube/ocaml-containers.git"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"


### PR DESCRIPTION
Old version of containers didn't handle safe-string yet.
See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html