### PR TITLE
vpnkit.0.1.1: not compatible with safe-string

### DIFF
--- a/packages/vpnkit/vpnkit.0.1.1/opam
+++ b/packages/vpnkit/vpnkit.0.1.1/opam
@@ -65,3 +65,5 @@ depends: [
   "uuidm"
   "ezjsonm" {>= "0.4.0"}
 ]
+
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
cc @djs55