### PR TITLE
tensorflow: older versions have an upper bound on core_kernel

### DIFF
--- a/packages/tensorflow/tensorflow.0.0.1/opam
+++ b/packages/tensorflow/tensorflow.0.0.1/opam
@@ -7,7 +7,7 @@ build: [make "tensorflow.lib"]
 authors: [ "Laurent Mazare" "Nicolas Oury" ]
 
 depends: [
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/tensorflow/tensorflow.0.0.2/opam
+++ b/packages/tensorflow/tensorflow.0.0.2/opam
@@ -8,7 +8,7 @@ authors: [ "Laurent Mazare" "Nicolas Oury" ]
 
 
 depends: [
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/tensorflow/tensorflow.0.0.4/opam
+++ b/packages/tensorflow/tensorflow.0.0.4/opam
@@ -9,7 +9,7 @@ authors: [ "Laurent Mazare" "Nicolas Oury" ]
 
 depends: [
   "cmdliner"
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/tensorflow/tensorflow.0.0.5/opam
+++ b/packages/tensorflow/tensorflow.0.0.5/opam
@@ -9,7 +9,7 @@ build: [make "tensorflow.lib"]
 
 depends: [
   "cmdliner"
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/tensorflow/tensorflow.0.0.6/opam
+++ b/packages/tensorflow/tensorflow.0.0.6/opam
@@ -9,7 +9,7 @@ build: [make "tensorflow.lib"]
 
 depends: [
   "cmdliner"
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/tensorflow/tensorflow.0.0.7/opam
+++ b/packages/tensorflow/tensorflow.0.0.7/opam
@@ -9,7 +9,7 @@ build: [make "tensorflow.lib"]
 
 depends: [
   "cmdliner"
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/tensorflow/tensorflow.0.0.8/opam
+++ b/packages/tensorflow/tensorflow.0.0.8/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/LaurentMazare/tensorflow-ocaml.git"
 build: [make "libtensorflowcstubs.a" "tensorflow_core.lib" "tensorflow.lib"]
 depends: [
   "cmdliner"
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/tensorflow/tensorflow.0.0.9/opam
+++ b/packages/tensorflow/tensorflow.0.0.9/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/LaurentMazare/tensorflow-ocaml.git"
 build: [make "libtensorflowcstubs.a" "tensorflow_core.lib" "tensorflow.lib"]
 depends: [
   "cmdliner"
-  "core_kernel"
+  "core_kernel" { < "v0.9.0" }
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "ocamlfind" {build}


### PR DESCRIPTION
due to

```
 File "src/graph/node.ml", line 137, characters 14-30:
 Error: This expression has type
          equal:(string -> string -> bool) -> attr option
        but an expression was expected of type
          'a Core_kernel.Std.Option.t = 'a option
```

