### PR TITLE
Constrain old versions of coq against < 4.06

### DIFF
--- a/packages/coq/coq.8.5.0/opam
+++ b/packages/coq/coq.8.5.0/opam
@@ -30,3 +30,4 @@ depends: [
 ]
 patches: ["ephemeron-rename.patch"]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/coq/coq.8.5.0~camlp4/opam
+++ b/packages/coq/coq.8.5.0~camlp4/opam
@@ -26,5 +26,5 @@ depends: [
   "num"
 ]
 patches: ["ephemeron-rename.patch"]
-available: [ (ocaml-version >= "4.02.0") ]
+available: [ (ocaml-version >= "4.02.0") & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/coq/coq.8.5.1/opam
+++ b/packages/coq/coq.8.5.1/opam
@@ -29,3 +29,4 @@ depends: [
   "num"
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/coq/coq.8.5.2/opam
+++ b/packages/coq/coq.8.5.2/opam
@@ -29,3 +29,4 @@ depends: [
   "num"
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/coq/coq.8.5.2~camlp4/opam
+++ b/packages/coq/coq.8.5.2~camlp4/opam
@@ -25,5 +25,5 @@ depends: [
   "camlp4"
   "num"
 ]
-available: [ (ocaml-version >= "4.02.0") ]
+available: [ (ocaml-version >= "4.02.0") & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/coq/coq.8.5.3/opam
+++ b/packages/coq/coq.8.5.3/opam
@@ -30,5 +30,5 @@ depends: [
   "camlp5" 
   "num"
 ]
-available: [ocaml-version >= "3.12.1"]
+available: [ocaml-version >= "3.12.1" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/coq/coq.8.6.1/opam
+++ b/packages/coq/coq.8.6.1/opam
@@ -31,5 +31,5 @@ depends: [
   "camlp5"
   "num"
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/coq/coq.8.6/opam
+++ b/packages/coq/coq.8.6/opam
@@ -31,5 +31,5 @@ depends: [
   "camlp5"
   "num"
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 install: [make "install"]


### PR DESCRIPTION
Old version of coq didn't handled safe-string yet.
See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html