### PR TITLE
yojson.1.2.0: not compatible with safe-string

### DIFF
--- a/packages/yojson/yojson.1.2.0/opam
+++ b/packages/yojson/yojson.1.2.0/opam
@@ -10,3 +10,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mjambon/yojson"
 install: [make "install" "BINDIR=%{bin}%"]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
Version 1.2.0 of yojson does not handled safe-string.

See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html