### PR TITLE
Constrain old versions of csv against < 4.06

### DIFF
--- a/packages/csv/csv.1.2.4/opam
+++ b/packages/csv/csv.1.2.4/opam
@@ -20,3 +20,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/csv/csv.1.2.6/opam
+++ b/packages/csv/csv.1.2.6/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/csv/csv.1.3.0/opam
+++ b/packages/csv/csv.1.3.0/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/csv/csv.1.3.1/opam
+++ b/packages/csv/csv.1.3.1/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/csv/csv.1.3.2/opam
+++ b/packages/csv/csv.1.3.2/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/csv/csv.1.3.3/opam
+++ b/packages/csv/csv.1.3.3/opam
@@ -18,3 +18,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/csv/csv.1.3.4/opam
+++ b/packages/csv/csv.1.3.4/opam
@@ -21,3 +21,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
Old versions of csv didn't handled safe-string yet.
See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html