### PR TITLE
spotify-cli: not available on 4.06.0 due to safe-string

### DIFF
--- a/packages/spotify-cli/spotify-cli.0.2.0/opam
+++ b/packages/spotify-cli/spotify-cli.0.2.0/opam
@@ -16,3 +16,5 @@ depends: [
 ]
 dev-repo: "git://github.com/johnelse/spotify-cli"
 install: [make "PREFIX=%{prefix}%" "install"]
+available: [ ocaml-version < "4.06.0" ]
+

--- a/packages/spotify-cli/spotify-cli.0.3.0/opam
+++ b/packages/spotify-cli/spotify-cli.0.3.0/opam
@@ -21,3 +21,4 @@ depends: [
   "spotify-web-api"
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
although this is possibly just due to a transitive lwt breakage, see https://github.com/ocaml/opam-repository/issues/10960