### PR TITLE
thrift.0.9.0: not compatible with safe-string

### DIFF
--- a/packages/thrift/thrift.0.9.0/opam
+++ b/packages/thrift/thrift.0.9.0/opam
@@ -8,3 +8,4 @@ depends: [
 ]
 dev-repo: "git://github.com/vbmithr/ocaml-thrift-lib"
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
Version thrift.0.9.0 of thrift does not handled safe-string.

See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html