### PR TITLE
Constrain old versions of inotify against < 4.06

### DIFF
--- a/packages/inotify/inotify.1.4/opam
+++ b/packages/inotify/inotify.1.4/opam
@@ -10,5 +10,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/whitequark/ocaml-inotify"
-available: os = "linux" | os = "darwin"
+available: [(os = "linux" | os = "darwin") & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/inotify/inotify.1.5/opam
+++ b/packages/inotify/inotify.1.5/opam
@@ -10,5 +10,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/whitequark/ocaml-inotify"
-available: os = "linux" | os = "darwin"
+available: [(os = "linux" | os = "darwin") & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/inotify/inotify.2.0/opam
+++ b/packages/inotify/inotify.2.0/opam
@@ -12,5 +12,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/whitequark/ocaml-inotify"
-available: os = "linux" | os = "darwin"
+available: [(os = "linux" | os = "darwin") & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]


### PR DESCRIPTION
Old versions of inotify didn't handled safe-string yet.
See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html