### PR TITLE
pipebang: does not compile on safe-string so ocaml-version<4.06

### DIFF
--- a/packages/pipebang/pipebang.109.09.00/opam
+++ b/packages/pipebang/pipebang.109.09.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.10.00/opam
+++ b/packages/pipebang/pipebang.109.10.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.11.00/opam
+++ b/packages/pipebang/pipebang.109.11.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.13.00/opam
+++ b/packages/pipebang/pipebang.109.13.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.13.00/opam
+++ b/packages/pipebang/pipebang.109.13.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.14.00/opam
+++ b/packages/pipebang/pipebang.109.14.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.14.00/opam
+++ b/packages/pipebang/pipebang.109.14.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.15.00/opam
+++ b/packages/pipebang/pipebang.109.15.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.15.00/opam
+++ b/packages/pipebang/pipebang.109.15.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.28.00/opam
+++ b/packages/pipebang/pipebang.109.28.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.28.00/opam
+++ b/packages/pipebang/pipebang.109.28.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.28.02/opam
+++ b/packages/pipebang/pipebang.109.28.02/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.28.02/opam
+++ b/packages/pipebang/pipebang.109.28.02/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.60.00/opam
+++ b/packages/pipebang/pipebang.109.60.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.109.60.00/opam
+++ b/packages/pipebang/pipebang.109.60.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.110.01.00/opam
+++ b/packages/pipebang/pipebang.110.01.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.1"
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
 install: [make "install"]

--- a/packages/pipebang/pipebang.110.01.00/opam
+++ b/packages/pipebang/pipebang.110.01.00/opam
@@ -7,5 +7,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.00.1" & ocaml-version < "4.06.0" ]
 install: [make "install"]


### PR DESCRIPTION
this is quite an old library -- i'm surprised its targetable on 4.04+ at all :-) cc @trefis to check this is ok