### PR TITLE
Constrain old versions of irc-client against < 4.06

### DIFF
--- a/packages/irc-client/irc-client.0.1.1/opam
+++ b/packages/irc-client/irc-client.0.1.1/opam
@@ -9,5 +9,5 @@ depends: [
 depopts: ["lwt"]
 patches: ["obuild-workaround.patch"]
 dev-repo: "git://github.com/johnelse/ocaml-irc-client"
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/irc-client/irc-client.0.1.2/opam
+++ b/packages/irc-client/irc-client.0.1.2/opam
@@ -10,5 +10,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/johnelse/ocaml-irc-client"
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/irc-client/irc-client.0.2.0/opam
+++ b/packages/irc-client/irc-client.0.2.0/opam
@@ -10,5 +10,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/johnelse/ocaml-irc-client"
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/irc-client/irc-client.0.2.1/opam
+++ b/packages/irc-client/irc-client.0.2.1/opam
@@ -10,5 +10,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/johnelse/ocaml-irc-client"
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/irc-client/irc-client.0.3.0/opam
+++ b/packages/irc-client/irc-client.0.3.0/opam
@@ -19,5 +19,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["lwt"]
-ocaml-version: [>= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 dev-repo: "git://github.com/johnelse/ocaml-irc-client"

--- a/packages/irc-client/irc-client.0.3.1/opam
+++ b/packages/irc-client/irc-client.0.3.1/opam
@@ -23,6 +23,4 @@ depends: [
   "ocamlfind"
 ]
 depopts: ["lwt"]
-available: [
-  ocaml-version >= "4.00.1"
-]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]

--- a/packages/irc-client/irc-client.0.3.2/opam
+++ b/packages/irc-client/irc-client.0.3.2/opam
@@ -23,6 +23,4 @@ depends: [
   "ocamlfind" {build}
 ]
 depopts: ["lwt"]
-available: [
-  ocaml-version >= "4.00.1"
-]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Old versions of irc-client didn't handled safe-string yet.
See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html