### PR TITLE
Constrain old versions of safepass against < 4.06 & Add the build attribute to ocamlfind

### DIFF
--- a/packages/safepass/safepass.1.0/opam
+++ b/packages/safepass/safepass.1.0/opam
@@ -3,7 +3,8 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 remove: [["ocamlfind" "remove" "ocaml-safepass"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/safepass/safepass.1.2/opam
+++ b/packages/safepass/safepass.1.2/opam
@@ -3,7 +3,8 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 remove: [["ocamlfind" "remove" "safepass"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/safepass/safepass.1.3/opam
+++ b/packages/safepass/safepass.1.3/opam
@@ -13,6 +13,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "safepass"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/safepass/safepass.2.0/opam
+++ b/packages/safepass/safepass.2.0/opam
@@ -17,6 +17,6 @@ remove: [
   ["rm" "-rf" safepass:doc]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Old versions of safepass didn't handled safe-string yet.
See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html

Also, ```ocamlfind``` is not used as a library so the ```build``` attribute must be added. cc @darioteixeira 