### PR TITLE
zed.1.{2,3,4,5}: not compatible with safe-string

### DIFF
--- a/packages/zed/zed.1.2/opam
+++ b/packages/zed/zed.1.2/opam
@@ -14,5 +14,5 @@ depends: [
   "react"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "3.12"
+available: [ocaml-version >= "3.12" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/zed/zed.1.3/opam
+++ b/packages/zed/zed.1.3/opam
@@ -15,5 +15,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/diml/zed"
-available: ocaml-version >= "3.12"
+available: [ocaml-version >= "3.12" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/zed/zed.1.4/opam
+++ b/packages/zed/zed.1.4/opam
@@ -16,5 +16,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/diml/zed"
-available: ocaml-version >= "3.12"
+available: [ocaml-version >= "3.12" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/zed/zed.1.5/opam
+++ b/packages/zed/zed.1.5/opam
@@ -14,4 +14,4 @@ depends: [
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-available: ocaml-version >= "4.02.3"
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/zed/zed.1.6/opam
+++ b/packages/zed/zed.1.6/opam
@@ -16,4 +16,4 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/zed/zed.1.6/opam
+++ b/packages/zed/zed.1.6/opam
@@ -16,4 +16,4 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Versions 1.2, 1.3, 1.4, 1.5 and 1.6 of zed do not handled safe-string.

See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html