### PR TITLE
mqtt.0.0.2: not compatible with safe-string

### DIFF
--- a/packages/mqtt/mqtt.0.0.2/opam
+++ b/packages/mqtt/mqtt.0.0.2/opam
@@ -18,5 +18,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/j0sh/ocaml-mqtt"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 install: [make "install"]


### PR DESCRIPTION
Version 0.0.2 of mqtt does not handled safe-string.

See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html