### PR TITLE
redis.0.3.{0,1,2,3,4,5}: not compatible with safe-string

### DIFF
--- a/packages/redis/redis.0.3.0/opam
+++ b/packages/redis/redis.0.3.0/opam
@@ -20,4 +20,4 @@ depends: [
   "re"
 ]
 depopts: "lwt"
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/redis/redis.0.3.1/opam
+++ b/packages/redis/redis.0.3.1/opam
@@ -21,4 +21,4 @@ depends: [
   "re"
 ]
 depopts: "lwt"
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/redis/redis.0.3.2/opam
+++ b/packages/redis/redis.0.3.2/opam
@@ -21,4 +21,4 @@ depends: [
   "re"
 ]
 depopts: "lwt"
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/redis/redis.0.3.3/opam
+++ b/packages/redis/redis.0.3.3/opam
@@ -20,4 +20,4 @@ depends: [
   "re"
 ]
 depopts: "lwt"
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/redis/redis.0.3.4/opam
+++ b/packages/redis/redis.0.3.4/opam
@@ -12,4 +12,4 @@ depends: [
   "uuidm"
   "re"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/redis/redis.0.3.5/opam
+++ b/packages/redis/redis.0.3.5/opam
@@ -12,4 +12,4 @@ depends: [
   "uuidm"
   "re"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Versions 0.3.{0,1,2,3,4,5} of redis do not handled safe-string.

See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html