### PR TITLE
redis-sync.0.3.{4,5}: not compatible with safe-string

### DIFF
--- a/packages/redis-sync/redis-sync.0.3.4/opam
+++ b/packages/redis-sync/redis-sync.0.3.4/opam
@@ -12,4 +12,4 @@ depends: [
   "redis" {>="0.3.4"}
   "base-unix"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/redis-sync/redis-sync.0.3.5/opam
+++ b/packages/redis-sync/redis-sync.0.3.5/opam
@@ -12,4 +12,4 @@ depends: [
   "redis" {>= "0.3.5"}
   "base-unix"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Versions 0.3.{4,5} of redis-sync do not handled safe-string.

See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html