### PR TITLE
git: 1.6.0-1.6.2 are not compatible with safe-string

### DIFF
--- a/packages/git/git.1.6.0/opam
+++ b/packages/git/git.1.6.0/opam
@@ -63,4 +63,4 @@ conflicts: [
  "mirage-flow" {> "1.1.0"}
  "cstruct"  {> "3.1.1"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/git/git.1.6.1/opam
+++ b/packages/git/git.1.6.1/opam
@@ -63,4 +63,4 @@ conflicts: [
  "mirage-flow" {> "1.1.0"}
  "cstruct"  {> "3.1.1"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]

--- a/packages/git/git.1.6.2/opam
+++ b/packages/git/git.1.6.2/opam
@@ -63,4 +63,4 @@ conflicts: [
  "mirage-flow" {> "1.1.0"}
  "cstruct"  {> "3.1.1"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
cc @samoht