### PR TITLE
msgpack.1.0.0-1.2.1: not compatible with safe-string

### DIFF
--- a/packages/msgpack/msgpack.1.0.0/opam
+++ b/packages/msgpack/msgpack.1.0.0/opam
@@ -28,5 +28,5 @@ depends: [
 depopts: ["meta_conv"]
 conflicts: ["meta_conv" {>= "1.1.1"}]
 dev-repo: "git://github.com/msgpack/msgpack-ocaml"
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/msgpack/msgpack.1.1.0/opam
+++ b/packages/msgpack/msgpack.1.1.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 name: "msgpack"
 version: "1.1.0"
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 maintainer: "mzp.ppp@gmail.com"
 authors: "MIZUNO Hiroki <mzp.ppp@gmail.com>"
 homepage: "http://github.com/msgpack/msgpack-ocaml/"

--- a/packages/msgpack/msgpack.1.1.1/opam
+++ b/packages/msgpack/msgpack.1.1.1/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 name: "msgpack"
 version: "1.1.1"
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 maintainer: "mzp.ppp@gmail.com"
 authors: "MIZUNO Hiroki <mzp.ppp@gmail.com>"
 homepage: "http://github.com/msgpack/msgpack-ocaml/"

--- a/packages/msgpack/msgpack.1.2.0/opam
+++ b/packages/msgpack/msgpack.1.2.0/opam
@@ -24,4 +24,4 @@ depends: [
 ]
 
 depopts: ["meta_conv"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/msgpack/msgpack.1.2.1/opam
+++ b/packages/msgpack/msgpack.1.2.1/opam
@@ -24,4 +24,4 @@ depends: [
 ]
 
 depopts: ["meta_conv"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Versions 1.0.0-1.2.1 of msgpack do not handled safe-string.

See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html