### PR TITLE
Constrain old versions of why3 & why3-base against < 4.06

### DIFF
--- a/packages/why3-base/why3-base.0.85/opam
+++ b/packages/why3-base/why3-base.0.85/opam
@@ -56,3 +56,4 @@ conflicts: [
   "coq" {>= "8.5"}
 ]
 install: [make "install" "install-lib"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/why3-base/why3-base.0.86.2/opam
+++ b/packages/why3-base/why3-base.0.86.2/opam
@@ -17,7 +17,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [
   [

--- a/packages/why3-base/why3-base.0.86.3/opam
+++ b/packages/why3-base/why3-base.0.86.3/opam
@@ -17,7 +17,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [
   [

--- a/packages/why3-base/why3-base.0.86/opam
+++ b/packages/why3-base/why3-base.0.86/opam
@@ -17,7 +17,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [
   [

--- a/packages/why3-base/why3-base.0.87.0/opam
+++ b/packages/why3-base/why3-base.0.87.0/opam
@@ -17,7 +17,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [
   [

--- a/packages/why3-base/why3-base.0.87.1/opam
+++ b/packages/why3-base/why3-base.0.87.1/opam
@@ -21,7 +21,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 
 patches: "disable-ocamldep-native.patch"
 

--- a/packages/why3-base/why3-base.0.87.2/opam
+++ b/packages/why3-base/why3-base.0.87.2/opam
@@ -21,7 +21,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 
 patches: "gmain-build.patch"
 

--- a/packages/why3-base/why3-base.0.87.3/opam
+++ b/packages/why3-base/why3-base.0.87.3/opam
@@ -21,7 +21,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [

--- a/packages/why3-base/why3-base.0.88.0/opam
+++ b/packages/why3-base/why3-base.0.88.0/opam
@@ -21,7 +21,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.06.0" ]
 
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [

--- a/packages/why3/why3.0.73/opam
+++ b/packages/why3/why3.0.73/opam
@@ -25,3 +25,4 @@ depends: [
 depopts: ["lablgtk"]
 patches: ["opam.patch"]
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/why3/why3.0.80/opam
+++ b/packages/why3/why3.0.80/opam
@@ -24,3 +24,4 @@ depends: [
 ]
 depopts: ["lablgtk"]
 install: [make "install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/why3/why3.0.81/opam
+++ b/packages/why3/why3.0.81/opam
@@ -54,3 +54,4 @@ conflicts: [
   "ocamlgraph" {< "1.8.2"}
 ]
 install: [make "install" "install-lib"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/why3/why3.0.82/opam
+++ b/packages/why3/why3.0.82/opam
@@ -53,3 +53,4 @@ conflicts: [
   "ocamlgraph" {< "1.8.2"}
 ]
 install: [make "install" "install-lib"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/why3/why3.0.83/opam
+++ b/packages/why3/why3.0.83/opam
@@ -50,3 +50,4 @@ conflicts: [
   "ocamlgraph" {< "1.8.2"}
 ]
 install: [make "install" "install-lib"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/why3/why3.0.84/opam
+++ b/packages/why3/why3.0.84/opam
@@ -39,3 +39,4 @@ conflicts: [
   "ocamlgraph" {< "1.8.2"}
 ]
 install: [make "install" "install-lib"]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
Old versions of why3 & why3-base didn't handled safe-string yet.
See: http://obi.ocamllabs.io/by-version/a35c37ca/index.html