### PR TITLE
added packages/cpm/cpm.3.0.0

### DIFF
--- a/packages/cpm/cpm.3.0.0/descr
+++ b/packages/cpm/cpm.3.0.0/descr
@@ -1,0 +1,1 @@
+Classification Performance Metrics library (ROC AUC, BEDROC AUC, EF, PM, etc.)

--- a/packages/cpm/cpm.3.0.0/opam
+++ b/packages/cpm/cpm.3.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "cpm"
+authors: "Francois BERENGER <ligand@free.fr>"
+maintainer: "Francois BERENGER <ligand@free.fr>"
+homepage: "https://github.com/UnixJunkie/cpmlib"
+bug-reports: "https://github.com/UnixJunkie/cpmlib/issues"
+dev-repo: "https://github.com/UnixJunkie/cpmlib.git"
+license: "LGPL"
+build: [
+  ["obuild" "configure"]
+  ["obuild" "build" "lib-cpm"]
+]
+install: ["obuild" "install"]
+remove: ["ocamlfind" "remove" "cpm"]
+depends: [
+  "ocamlfind"
+  "obuild" {build}
+  "batteries"
+]
+available: [ocaml-version > "3.12.1"]

--- a/packages/cpm/cpm.3.0.0/url
+++ b/packages/cpm/cpm.3.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/UnixJunkie/cpmlib/archive/v3.0.0.tar.gz"
+checksum: "cb24212b20666e8e3ef7a73e4ec2567d"


### PR DESCRIPTION
- score labels are sorted using stable sort instead of sort
- added roc_curve functionality (can be dumped out to a file then gnuplot)
