### PR TITLE
Update Coq packages

### DIFF
--- a/packages/coq/coq.8.7.0/files/coq.install
+++ b/packages/coq/coq.8.7.0/files/coq.install
@@ -2,6 +2,7 @@ bin: [
   "bin/gallina"
   "bin/coqwc"
   "bin/coqtop"
+  "bin/coqtop.byte"
   "bin/coqmktop"
   "bin/coqdoc"
   "bin/coqdep"

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -22,11 +22,34 @@ build: [
   ]
   [make "-j%{jobs}%"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq"]
+install: [make "install"]
+remove: [
+  ["rm" "-R" "%{lib}%/coq" "%{share}%/coq"]
+  ["rm"
+  "%{man}%/man1/coqc.1"
+  "%{man}%/man1/coqchk.1"
+  "%{man}%/man1/coqdep.1"
+  "%{man}%/man1/coqdoc.1"
+  "%{man}%/man1/coqide.1"
+  "%{man}%/man1/coq_makefile.1"
+  "%{man}%/man1/coqmktop.1"
+  "%{man}%/man1/coq-tex.1"
+  "%{man}%/man1/coqtop.1"
+  "%{man}%/man1/coqtop.byte.1"
+  "%{man}%/man1/coqtop.opt.1"
+  "%{man}%/man1/coqwc.1"
+  "%{man}%/man1/gallina.1"
+  "%{share}%/texmf/tex/latex/misc/coqdoc.sty"
+  "%{share}%/emacs/site-lisp/coq-font-lock.el"
+  "%{share}%/emacs/site-lisp/coq-inferior.el"
+  "%{share}%/emacs/site-lisp/gallina-db.el"
+  "%{share}%/emacs/site-lisp/gallina.el"
+  "%{share}%/emacs/site-lisp/gallina-syntax.el"
+  ]
+]
 depends: [
   "ocamlfind"
   "camlp5"
   "num"
 ]
 available: [ocaml-version >= "4.02.3"]
-install: [make "install"]

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -21,8 +21,12 @@ build: [
     "-coqide" "no"
   ]
   [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" "byte"]
 ]
-install: [make "install"]
+install: [
+  [make "install"]
+  [make "install-byte"]
+]
 remove: [
   ["rm" "-R" "%{lib}%/coq" "%{share}%/coq"]
   ["rm"

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -56,4 +56,4 @@ depends: [
   "camlp5"
   "num"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -10,17 +10,12 @@ license: "LGPL 2.1"
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{lib}%/camlp5"
-    "-coqide"
-    "no"
+    "-camlp5dir" "%{lib}%/camlp5"
+    "-coqide" "no"
     "-debug"
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -4,7 +4,7 @@ version: "8.7.0"
 maintainer: "Maxime Dénès <mail@maximedenes.fr>"
 authors: "The Coq development team, INRIA, CNRS, University Paris Sud, University Paris 7, Ecole Polytechnique."
 homepage: "https://coq.inria.fr/"
-bug-reports: "https://coq.inria.fr/bugs/"
+bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 build: [

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -6,17 +6,19 @@ authors: "The Coq development team, INRIA, CNRS, University Paris Sud, Universit
 homepage: "https://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "https://github.com/coq/coq.git"
-license: "LGPL 2.1"
+license: "LGPL-2.1"
 build: [
   [
     "./configure"
     "-configdir" "%{lib}%/coq/config"
-    "-mandir" man
     "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
     "-usecamlp5"
     "-camlp5dir" "%{lib}%/camlp5"
     "-coqide" "no"
-    "-debug"
   ]
   [make "-j%{jobs}%"]
 ]

--- a/packages/coqide/coqide.8.7.0/opam
+++ b/packages/coqide/coqide.8.7.0/opam
@@ -29,7 +29,7 @@ depends: [
   "lablgtk"
   "conf-gtksourceview"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
 install: [
   make
   "install-ide-bin"

--- a/packages/coqide/coqide.8.7.0/opam
+++ b/packages/coqide/coqide.8.7.0/opam
@@ -11,9 +11,11 @@ build: [
   [
     "./configure"
     "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
     "-mandir" man
     "-docdir" doc
-    "-prefix" prefix
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
     "-usecamlp5"
     "-camlp5dir" "%{lib}%/camlp5"
   ]

--- a/packages/coqide/coqide.8.7.0/opam
+++ b/packages/coqide/coqide.8.7.0/opam
@@ -4,7 +4,7 @@ version: "8.7.0"
 maintainer: "Maxime Dénès <mail@maximedenes.fr>"
 authors: "The Coq development team, INRIA, CNRS, University Paris Sud, University Paris 7, Ecole Polytechnique."
 homepage: "https://coq.inria.fr/"
-bug-reports: "https://coq.inria.fr/bugs/"
+bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 build: [

--- a/packages/coqide/coqide.8.7.0/opam
+++ b/packages/coqide/coqide.8.7.0/opam
@@ -10,17 +10,12 @@ license: "LGPL-2.1"
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-docdir"
-    doc
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-docdir" doc
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{lib}%/camlp5"
+    "-camlp5dir" "%{lib}%/camlp5"
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]


### PR DESCRIPTION
This syncs the Coq packages with the development packages at <https://github.com/coq/opam-coq-archive/tree/master/core-dev>. Notable changes:

* Also compile and install the bytecode version of `coqtop`.
* Make sure that everything that gets installed, also gets uninstalled again.
* Fix compiling on Cygwin.
* Update issue tracker URL.

Cc @maximedenes 