### PR TITLE
Constrain opam-lib packages < 4.06.0

### DIFF
--- a/packages/opam-lib/opam-lib.0.9.4/opam
+++ b/packages/opam-lib/opam-lib.0.9.4/opam
@@ -28,4 +28,5 @@ install: [
   [make "libinstall-with-ocamlbuild"]
   ["rm" "opam.install"]
 ]
-[available: ocaml-version < "4.06.0"]
+available: [ocaml-version < "4.06.0"]
+

--- a/packages/opam-lib/opam-lib.0.9.4/opam
+++ b/packages/opam-lib/opam-lib.0.9.4/opam
@@ -28,3 +28,4 @@ install: [
   [make "libinstall-with-ocamlbuild"]
   ["rm" "opam.install"]
 ]
+[available: ocaml-version < "4.06.0"]

--- a/packages/opam-lib/opam-lib.0.9.6/opam
+++ b/packages/opam-lib/opam-lib.0.9.6/opam
@@ -23,3 +23,4 @@ install: [
   [make "libinstall-with-ocamlbuild"]
   ["rm" "opam.install"]
 ]
+[available: ocaml-version < "4.06.0"]

--- a/packages/opam-lib/opam-lib.0.9.6/opam
+++ b/packages/opam-lib/opam-lib.0.9.6/opam
@@ -23,4 +23,4 @@ install: [
   [make "libinstall-with-ocamlbuild"]
   ["rm" "opam.install"]
 ]
-[available: ocaml-version < "4.06.0"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -27,3 +27,4 @@ depends: [
   "ocamlfind" {build}
   "jsonm"
 ]
+[available: ocaml-version < "4.06.0"]

--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -27,4 +27,4 @@ depends: [
   "ocamlfind" {build}
   "jsonm"
 ]
-[available: ocaml-version < "4.06.0"]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
Constrain opam-lib.{0.9.4, 0.9.6, 1.3.1} to only download to compilers older than 4.06.0