### PR TITLE
Package zipperposition.1.4

### DIFF
--- a/packages/zipperposition/zipperposition.1.4/descr
+++ b/packages/zipperposition/zipperposition.1.4/descr
@@ -1,0 +1,8 @@
+A fully automatic theorem prover for typed first-order and beyond.
+
+Zipperposition is intended to be a superposition prover for full first
+order logic, plus some extensions (datatypes, recursive functions, arithmetic
+for integers and rationals, higher-order, induction).
+The accent is on flexibility, modularity and simplicity rather than
+performance, to allow quick experimenting on automated theorem proving. It
+generates TSTP traces or graphviz files for nice graphical display.

--- a/packages/zipperposition/zipperposition.1.4/opam
+++ b/packages/zipperposition/zipperposition.1.4/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/zipperposition"
+bug-reports: "https://github.com/c-cube/zipperposition/issues"
+tags: ["logic" "unification" "term" "superposition" "prover"]
+dev-repo: "https://github.com/c-cube/zipperposition.git"
+build: [
+  [
+    "./configure"
+    "--bindir"
+    "%{bin}%"
+    "--disable-tests"
+    "--disable-docs"
+    "--%{menhir:enable}%-parsers"
+    "--disable-hornet-prover"
+    "--enable-zipperposition-prover"
+    "--disable-solving"
+    "--disable-qcheck"
+    "--disable-tools"
+  ]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "logtk"]
+  ["ocamlfind" "remove" "libzipperposition"]
+  ["rm" "-f" "%{bin}%/zipperposition"]
+  ["rm" "-f" "%{bin}%/hornet"]
+]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "containers" {>= "1.0"}
+  "sequence" {>= "0.4"}
+  "msat" {>= "0.5"}
+  "menhir" {build}
+]
+depopts: [
+  "qcheck" {test}
+]
+conflicts: "logtk"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/zipperposition/zipperposition.1.4/url
+++ b/packages/zipperposition/zipperposition.1.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/zipperposition/archive/1.4.tar.gz"
+checksum: "fdd087327b584dbd661172a5fde55a04"


### PR DESCRIPTION
### `zipperposition.1.4`

A fully automatic theorem prover for typed first-order and beyond.

Zipperposition is intended to be a superposition prover for full first
order logic, plus some extensions (datatypes, recursive functions, arithmetic
for integers and rationals, higher-order, induction).
The accent is on flexibility, modularity and simplicity rather than
performance, to allow quick experimenting on automated theorem proving. It
generates TSTP traces or graphviz files for nice graphical display.



---
* Homepage: https://github.com/c-cube/zipperposition
* Source repo: https://github.com/c-cube/zipperposition.git
* Bug tracker: https://github.com/c-cube/zipperposition/issues

---

:camel: Pull-request generated by opam-publish v0.3.5