### PR TITLE
imagemagick is broken on macos make it uninstallable there.

### DIFF
--- a/packages/imagemagick/imagemagick.0.33.1/opam
+++ b/packages/imagemagick/imagemagick.0.33.1/opam
@@ -5,6 +5,7 @@ homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: make
 remove: [[make "uninstall"]]
 depends: ["ocamlfind"]
+available: [os != "darwin"]
 depexts: [
   [["debian"] ["libgraphicsmagick1-dev" "libmagickcore-dev"]]
   [["ubuntu"] ["libmagickcore-dev"]]

--- a/packages/imagemagick/imagemagick.0.33.2/opam
+++ b/packages/imagemagick/imagemagick.0.33.2/opam
@@ -5,6 +5,7 @@ homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: make
 remove: [[make "uninstall"]]
 depends: ["ocamlfind"]
+available: [os != "darwin"]
 depexts: [
   [["debian"] ["libgraphicsmagick1-dev" "libmagickcore-dev"]]
   [["ubuntu"] ["libmagickcore-dev"]]

--- a/packages/imagemagick/imagemagick.0.33/opam
+++ b/packages/imagemagick/imagemagick.0.33/opam
@@ -5,6 +5,7 @@ homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: make
 remove: [[make "uninstall"]]
 depends: ["ocamlfind"]
+available: [os != "darwin"]
 depexts: [
   [["debian"] ["libgraphicsmagick1-dev" "libmagickcore-dev"]]
   [["ubuntu"] ["libmagickcore-dev"]]

--- a/packages/imagemagick/imagemagick.0.34-1/opam
+++ b/packages/imagemagick/imagemagick.0.34-1/opam
@@ -7,6 +7,7 @@ build: [[make]]
 install: [[make "find_install"]]
 remove: [["ocamlfind" "remove" "magick"]]
 depends: ["ocamlfind"]
+available: [os != "darwin"]
 depexts: [
   [["debian"] ["libgraphicsmagick1-dev" "libmagickcore-dev"]]
   [["ubuntu"] ["libmagickcore-dev"]]

--- a/packages/imagemagick/imagemagick.0.34/opam
+++ b/packages/imagemagick/imagemagick.0.34/opam
@@ -5,6 +5,7 @@ homepage: "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/"
 build: make
 remove: [["ocamlfind" "remove" "magick"]]
 depends: ["ocamlfind"]
+available: [os != "darwin"]
 depexts: [
   [["debian"] ["libgraphicsmagick1-dev" "libmagickcore-dev"]]
   [["ubuntu"] ["libmagickcore-dev"]]


### PR DESCRIPTION
The imagemagick package has been broken for a year now on macOS. And the maintainers are unresponsive, this PR simply makes it uninstallable there.

Closes https://github.com/ocaml/opam-repository/issues/8095

/cc @vouillon the maintainer of the package.