### PR TITLE
Constrain mpris & obus against OCaml < 4.06 and revert #10961

### DIFF
--- a/packages/mpris/mpris.0.1.0/opam
+++ b/packages/mpris/mpris.0.1.0/opam
@@ -9,5 +9,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/johnelse/ocaml-mpris"
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/obus/obus.1.1.7/opam
+++ b/packages/obus/obus.1.1.7/opam
@@ -18,3 +18,4 @@ depends: [
 ]
 dev-repo: "git://github.com/diml/obus"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/spotify-cli/spotify-cli.0.2.0/opam
+++ b/packages/spotify-cli/spotify-cli.0.2.0/opam
@@ -16,5 +16,3 @@ depends: [
 ]
 dev-repo: "git://github.com/johnelse/spotify-cli"
 install: [make "PREFIX=%{prefix}%" "install"]
-available: [ ocaml-version < "4.06.0" ]
-

--- a/packages/spotify-cli/spotify-cli.0.3.0/opam
+++ b/packages/spotify-cli/spotify-cli.0.3.0/opam
@@ -21,4 +21,3 @@ depends: [
   "spotify-web-api"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
See: #10961 
Build log: http://obi.ocamllabs.io/by-version/a35c37ca/index.html

cc @avsm 