### PR TITLE
Package wtf8.1.0.1

### DIFF
--- a/packages/wtf8/wtf8.1.0.1/descr
+++ b/packages/wtf8/wtf8.1.0.1/descr
@@ -1,0 +1,3 @@
+Encoder and decoder for WTF-8
+
+WTF-8 is a superset of UTF-8 that allows unpaired surrogates.

--- a/packages/wtf8/wtf8.1.0.1/opam
+++ b/packages/wtf8/wtf8.1.0.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Marshall Roch <mroch@fb.com>"
+authors: ["Marshall Roch <mroch@fb.com>"]
+homepage: "https://github.com/flowtype/ocaml-wtf8"
+doc: "https://github.com/flowtype/ocaml-wtf8"
+license: "MIT"
+dev-repo: "https://github.com/flowtype/ocaml-wtf8.git"
+bug-reports: "https://github.com/flowtype/ocaml-wtf8/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends:
+[
+  "jbuilder" {build & >= "1.0+beta7"}
+]
+depopts: []
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/wtf8/wtf8.1.0.1/url
+++ b/packages/wtf8/wtf8.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/flowtype/ocaml-wtf8/releases/download/v1.0.1/wtf8-1.0.1.tbz"
+checksum: "843fb4ee0d36b22c4ad1f2fb28afe8f8"


### PR DESCRIPTION
### `wtf8.1.0.1`

Encoder and decoder for WTF-8

WTF-8 is a superset of UTF-8 that allows unpaired surrogates.



---
* Homepage: https://github.com/flowtype/ocaml-wtf8
* Source repo: https://github.com/flowtype/ocaml-wtf8.git
* Bug tracker: https://github.com/flowtype/ocaml-wtf8/issues

---


---
v1.0.1
--------------------------

Fix ocaml 4.02.3 compatibility
:camel: Pull-request generated by opam-publish v0.3.5