### PR TITLE
Package reason.3.0.4

### DIFF
--- a/packages/reason/reason.3.0.4/descr
+++ b/packages/reason/reason.3.0.4/descr
@@ -1,0 +1,4 @@
+Reason: Syntax & Toolchain for OCaml
+
+Reason provides a new ES6-inspired syntax for OCaml. It's also the umbrella
+project for a set of tools for the OCaml & JavaScript ecosystems.

--- a/packages/reason/reason.3.0.4/opam
+++ b/packages/reason/reason.3.0.4/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: "Jordan Walke <jordojw@gmail.com>"
+homepage: "https://github.com/facebook/reason"
+bug-reports: "https://github.com/facebook/reason/issues"
+license: "BSD. Additional patent grant provided."
+doc: "http://reasonml.github.io/"
+tags: "syntax"
+dev-repo: "git://github.com/facebook/reason.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+  "ocamlfind" {build}
+  "menhir" {>= "20170418" & <= "20171013"}
+  "utop" {>= "1.17"}
+  "merlin-extend" {>= "0.3"}
+  "result" {= "1.2"}
+  "ocaml-migrate-parsetree"
+]
+conflicts: [
+  "utop" {< "1.17"}
+]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.07"]

--- a/packages/reason/reason.3.0.4/url
+++ b/packages/reason/reason.3.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/facebook/reason/archive/3.0.4.tar.gz"
+checksum: "0f831682e4d3c57efc1b7c2caadafd11"


### PR DESCRIPTION
### `reason.3.0.4`

Reason: Syntax & Toolchain for OCaml

Reason provides a new ES6-inspired syntax for OCaml. It's also the umbrella
project for a set of tools for the OCaml & JavaScript ecosystems.



---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

:camel: Pull-request generated by opam-publish v0.3.5