### PR TITLE
An OCaml implementation of the BUILD_PATH_PREFIX_MAP specification

### DIFF
--- a/packages/build_path_prefix_map/build_path_prefix_map.0.2/descr
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.2/descr
@@ -1,0 +1,4 @@
+An OCaml implementation of the BUILD_PATH_PREFIX_MAP specification
+
+https://reproducible-builds.org/specs/build-path-prefix-map/
+

--- a/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: [ "Gabriel Scherer <gabriel.scherer@gmail.com>" ]
+license: "MIT"
+homepage: "https://gitlab.com/gasche/build_path_prefix_map"
+doc: "https://gitlab.com/gasche/build_path_prefix_map/blob/master/README.md"
+bug-reports: "https://gitlab.com/gasche/build_path_prefix_map/issues"
+dev-repo: "https://gitlab.com/gasche/build_path_prefix_map.git"
+build: [ "jbuilder" "build" ]
+build-test: [ "jbuilder" "runtest" ]
+build-doc: [
+  make "doc"
+]
+depends: [
+  "jbuilder" {build}
+]
+available: [ opam-version >= "1.2"
+           & ocaml-version >= "4.04.0" ]

--- a/packages/build_path_prefix_map/build_path_prefix_map.0.2/url
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.2/url
@@ -1,0 +1,2 @@
+http: "https://gitlab.com/gasche/build_path_prefix_map/repository/0.2/archive.tar.gz"
+checksum: "41db2fdf2e5098b6c4cf4131df704339"


### PR DESCRIPTION
https://reproducible-builds.org/specs/build-path-prefix-map/

Initial implementation, motivated by Ximin Luo during the Mirage
retreat in Marrakech.

(This is version 0.2, which supersedes 0.1 submitted in #10917.)