### PR TITLE
Package conf-numa.0.1.0

### DIFF
--- a/packages/conf-numa/conf-numa.0.1.0/descr
+++ b/packages/conf-numa/conf-numa.0.1.0/descr
@@ -1,0 +1,4 @@
+Package relying on libnuma
+
+Virtual package relying on a libnuma system installation.
+This package can only install if the libnuma lib is installed on the system.

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Steve Bleazard <stevebleazard@googlemail.com>"
+authors: "Steve Bleazard <stevebleazard@googlemail.com>"
+homepage: "https://www.github.com/stevebleazard/ocaml-conf-numa"
+bug-reports: "https://www.github.com/stevebleazard/ocaml-conf-numa/issues"
+license: "MIT"
+dev-repo: "https://www.github.com/stevebleazard/ocaml-conf-numa.git"
+
+depexts: [
+  [["debian"] ["libnuma-dev"]]
+  [["ubuntu"] ["libnuma-dev"]]
+  [["centos"] ["numactl-libs" "numactl-devel"]]
+  [["fedora"] ["numactl-libs" "numactl-devel"]]
+  [["opensuse"] ["libnuma-devel"]]
+  [["alpine"] ["libnuma-dev"]]
+]
+
+available: [ os != "darwin" & os != "freebsd" & os != "openbsd" ]

--- a/packages/conf-numa/conf-numa.0.1.0/url
+++ b/packages/conf-numa/conf-numa.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://www.github.com/stevebleazard/ocaml-conf-numa/releases/download/v0.1.0/conf-numa-0.1.0.tbz"
+checksum: "7f5a5d170a8f8718162b021072e17ec2"


### PR DESCRIPTION
### `conf-numa.0.1.0`

Package relying on libnuma

Virtual package relying on a libnuma system installation.
This package can only install if the libnuma lib is installed on the system.


---
* Homepage: https://www.github.com/stevebleazard/ocaml-conf-numa
* Source repo: https://www.github.com/stevebleazard/ocaml-conf-numa.git
* Bug tracker: https://www.github.com/stevebleazard/ocaml-conf-numa/issues

---


---
# v0.1.0

- Initial release
:camel: Pull-request generated by opam-publish v0.3.5