### PR TITLE
Relax version constraint for coq.

### DIFF
--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -56,4 +56,4 @@ depends: [
   "camlp5"
   "num"
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.02.3" & ocaml-version <= "4.06.0"]

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -56,4 +56,4 @@ depends: [
   "camlp5"
   "num"
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version <= "4.06.0"]
+available: [ocaml-version >= "4.02.3" & ocaml-version]

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -56,4 +56,4 @@ depends: [
   "camlp5"
   "num"
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version]
+available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
As said, ocaml 4.06 and coq work.