### PR TITLE
xenstore.2.0.0: require cstruct >= 3.2.0

### DIFF
--- a/packages/xenstore/xenstore.2.0.0/opam
+++ b/packages/xenstore/xenstore.2.0.0/opam
@@ -21,7 +21,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
-  "cstruct" {>= "2.4.0"}
+  "cstruct" {>= "3.2.0"}
   "ppx_cstruct" {build}
   "ppx_tools" {build}
   "lwt"


### PR DESCRIPTION
The to_bytes function used in this version of xenstore has been introduced in cstruct 3.2.0.