### PR TITLE
Package key-parsers.0.9.2

### DIFF
--- a/packages/key-parsers/key-parsers.0.9.2/descr
+++ b/packages/key-parsers/key-parsers.0.9.2/descr
@@ -1,0 +1,3 @@
+Parsers for multiple key formats
+
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or Elliptic curve public and private keys.

--- a/packages/key-parsers/key-parsers.0.9.2/opam
+++ b/packages/key-parsers/key-parsers.0.9.2/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+author: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
+  "ounit" {test & >= "2.0.0"}
+  "hex" {>= "1.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "zarith" {>= "1.4.1"}
+  "result" {>= "1.2"}
+  "topkg" {build}
+  "ppx_bin_prot"
+  "cstruct" {>= "1.6.0"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/key-parsers/key-parsers.0.9.2/url
+++ b/packages/key-parsers/key-parsers.0.9.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/key-parsers/releases/download/0.9.2/key-parsers-0.9.2.tbz"
+checksum: "0d3c9a10ff6840c73f69621d14f840db"


### PR DESCRIPTION
### `key-parsers.0.9.2`

Parsers for multiple key formats

This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or Elliptic curve public and private keys.



---
* Homepage: https://github.com/cryptosense/key-parsers
* Source repo: https://github.com/cryptosense/key-parsers.git
* Bug tracker: https://github.com/cryptosense/key-parsers/issues

---


---
## 0.9.2

*2017-12-12*

- Switch to `asn1-combinators >= 0.2.0`
- Refactor `Kp_asn1`
- Add documentation and README
:camel: Pull-request generated by opam-publish v0.3.5