### PR TITLE
8 packages from ocaml/opam at 2.0.0~beta5

### DIFF
--- a/packages/opam-client/opam-client.2.0.0~beta5/descr
+++ b/packages/opam-client/opam-client.2.0.0~beta5/descr
@@ -1,3 +1,0 @@
-opam 2.0 development libraries
-
-Actions on the opam root, switches, installations, and front-end.

--- a/packages/opam-client/opam-client.2.0.0~beta5/opam
+++ b/packages/opam-client/opam-client.2.0.0~beta5/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
@@ -23,4 +23,11 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: ocaml-version >= "4.02.3"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-client/opam-client.2.0.0~beta5/url
+++ b/packages/opam-client/opam-client.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"

--- a/packages/opam-core/opam-core.2.0.0~beta5/descr
+++ b/packages/opam-core/opam-core.2.0.0~beta5/descr
@@ -1,4 +1,0 @@
-opam 2.0 development libraries
-
-Small standard library extensions, and generic system interaction modules used
-by opam.

--- a/packages/opam-core/opam-core.2.0.0~beta5/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta5/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
@@ -24,4 +24,11 @@ depends: [
   "re" {>= "1.5.0"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: ocaml-version >= "4.02.3"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-core/opam-core.2.0.0~beta5/url
+++ b/packages/opam-core/opam-core.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"

--- a/packages/opam-devel/opam-devel.2.0.0~beta5/descr
+++ b/packages/opam-devel/opam-devel.2.0.0~beta5/descr
@@ -1,6 +1,0 @@
-opam 2.0.0 beta version
-
-This package compiles (bootstraps) the beta version of opam 2.0.0. For
-consistency and safety of the installation, the binaries are not installed into
-the PATH, but into lib/opam-devel, from where the user can manually install them
-system-wide.

--- a/packages/opam-devel/opam-devel.2.0.0~beta5/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta5/opam
@@ -12,25 +12,30 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-build-test: [make "tests"]
 depends: [
   "opam-client" {= "2.0.0~beta5"}
   "cmdliner" {>= "0.9.8"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
 post-messages: [
-  "
-The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
-    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+"The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/* /usr/local/bin
 
 If you just want to give it a try without altering your current installation, you could use instead:
-    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\"
-  "
-    {success}
+    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""
+  {success}
 ]
+available: ocaml-version >= "4.02.3"
+run-test: [make "tests"]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.0.0~beta5/url
+++ b/packages/opam-devel/opam-devel.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"

--- a/packages/opam-format/opam-format.2.0.0~beta5/descr
+++ b/packages/opam-format/opam-format.2.0.0~beta5/descr
@@ -1,3 +1,0 @@
-opam 2.0 development libraries
-
-Definition of opam datastructures and its file interface.

--- a/packages/opam-format/opam-format.2.0.0~beta5/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta5/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
@@ -22,4 +22,11 @@ depends: [
   "opam-file-format" {>= "2.0.0~beta5"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: ocaml-version >= "4.02.3"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-format/opam-format.2.0.0~beta5/url
+++ b/packages/opam-format/opam-format.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"

--- a/packages/opam-installer/opam-installer.2.0.0~beta5/descr
+++ b/packages/opam-installer/opam-installer.2.0.0~beta5/descr
@@ -1,4 +1,0 @@
-Short description
-
-Long
-description

--- a/packages/opam-installer/opam-installer.2.0.0~beta5/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~beta5/opam
@@ -12,10 +12,11 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["touch" "src/tools/.merlin-exists"]
+  # ^ see https://github.com/janestreet/jbuilder/issues/257
   [make "%{name}%.install"]
 ]
 depends: [
@@ -23,4 +24,11 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: ocaml-version >= "4.02.3"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.0.0~beta5/url
+++ b/packages/opam-installer/opam-installer.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"

--- a/packages/opam-repository/opam-repository.2.0.0~beta5/descr
+++ b/packages/opam-repository/opam-repository.2.0.0~beta5/descr
@@ -1,4 +1,0 @@
-opam 2.0 development libraries
-
-This library includes repository and remote sources handling, including
-curl/wget, rsync, git, mercurial, darcs backends.

--- a/packages/opam-repository/opam-repository.2.0.0~beta5/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~beta5/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
@@ -21,4 +21,11 @@ depends: [
   "opam-format" {= "2.0.0~beta5"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: ocaml-version >= "4.02.3"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.0.0~beta5/url
+++ b/packages/opam-repository/opam-repository.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"

--- a/packages/opam-solver/opam-solver.2.0.0~beta5/descr
+++ b/packages/opam-solver/opam-solver.2.0.0~beta5/descr
@@ -1,4 +1,0 @@
-opam 2.0 development libraries
-
-Solver and Cudf interaction. This library is based on the Cudf and Dose
-libraries, and handles calls to the external solver from opam.

--- a/packages/opam-solver/opam-solver.2.0.0~beta5/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~beta5/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
@@ -24,4 +24,11 @@ depends: [
   "cudf" {>= "0.7"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: ocaml-version >= "4.02.3"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.0.0~beta5/url
+++ b/packages/opam-solver/opam-solver.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"

--- a/packages/opam-state/opam-state.2.0.0~beta5/descr
+++ b/packages/opam-state/opam-state.2.0.0~beta5/descr
@@ -1,3 +1,0 @@
-opam 2.0 development libraries
-
-Handling of the ~/.opam hierarchy, repository and switch states.

--- a/packages/opam-state/opam-state.2.0.0~beta5/opam
+++ b/packages/opam-state/opam-state.2.0.0~beta5/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
@@ -21,4 +21,11 @@ depends: [
   "opam-repository" {= "2.0.0~beta5"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
-available: [ocaml-version >= "4.02.3"]
+available: ocaml-version >= "4.02.3"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
+  checksum: [
+    "md5=9347fabff36c99bc631b30b1007e20db"
+    "sha512=39db31528b62e7de12c2c8097d4ab14dd36ca540cc32a4d8d70589922b1b9311abd459e8e2ae1e010c84e881040cba9ecba86782b43def7f3fa666c0a9a3d7e8"
+  ]
+}

--- a/packages/opam-state/opam-state.2.0.0~beta5/url
+++ b/packages/opam-state/opam-state.2.0.0~beta5/url
@@ -1,2 +1,0 @@
-http: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
-checksum: "9347fabff36c99bc631b30b1007e20db"


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.0.0~beta5`
-`opam-core.2.0.0~beta5`
-`opam-devel.2.0.0~beta5`
-`opam-format.2.0.0~beta5`
-`opam-installer.2.0.0~beta5`
-`opam-repository.2.0.0~beta5`
-`opam-solver.2.0.0~beta5`
-`opam-state.2.0.0~beta5`



---
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v0.3.5