### PR TITLE
opam-publish 1.0 bootstrap test (DO NOT MERGE)

### DIFF
--- a/packages/opam-publish/opam-publish.1.0.0~beta/opam
+++ b/packages/opam-publish/opam-publish.1.0.0~beta/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+build: [ "jbuilder" "build" "-p" name ]
+depends: [
+  "opam-core" {build & >= "2.0.0~beta5"}
+  "opam-format" {build & >= "2.0.0~beta5"}
+  "opam-state" {build & >= "2.0.0~beta5"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  ("github" {build & >= "2.0.0" & < "3.0.0"} |
+   "github-unix" {build & >= "3.0.0"})
+]
+tags: [ "flags:plugin" ]
+url {
+  src: "https://github.com/ocaml/opam-publish/archive/1.0.0-beta.tar.gz"
+  checksum: [
+    "md5=7968f0213f5078aa0bcfb57a70cddbcd"
+    "sha512=5d1a12044eb4e12fbc37b11c66c3baa9450d9668e61972af23ae590e98a7d6a5c45cbb44928b1ab3b69f7bc26a7b48245b6b0c441d46635ecf65a0b44f044385"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.1.0.0~beta`



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v0.3.5