### PR TITLE
Constrain old versions of pgocaml to avoid failures on 4.06 and add build attributs

### DIFF
--- a/packages/pgocaml/pgocaml.1.6/opam
+++ b/packages/pgocaml/pgocaml.1.6/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "extlib" {= "1.5.3"}
   "pcre"
   "calendar"

--- a/packages/pgocaml/pgocaml.1.6/opam
+++ b/packages/pgocaml/pgocaml.1.6/opam
@@ -1,5 +1,10 @@
-opam-version: "1"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+opam-version: "1.2"
+maintainer: "Dario Teixeira <dario.teixeira@nleyten.com>"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "http://pgocaml.forge.ocamlcore.org/"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0 with OCaml linking exception"
 build: [
   [make ".depend"]
   [make]

--- a/packages/pgocaml/pgocaml.1.7.1/opam
+++ b/packages/pgocaml/pgocaml.1.7.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "batteries" {>= "2.0.0"}
   "pcre"
   "calendar"
@@ -20,3 +20,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/pgocaml/pgocaml.1.7/opam
+++ b/packages/pgocaml/pgocaml.1.7/opam
@@ -11,7 +11,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "batteries" {>= "2.0.0"}
   "pcre"
   "calendar"
@@ -20,3 +20,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/pgocaml/pgocaml.2.0/opam
+++ b/packages/pgocaml/pgocaml.2.0/opam
@@ -12,12 +12,12 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "pcre"
   "calendar"
   "csv"
   "camlp4"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/pgocaml/pgocaml.2.1/opam
+++ b/packages/pgocaml/pgocaml.2.1/opam
@@ -20,3 +20,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/pgocaml/pgocaml.2.2/opam
+++ b/packages/pgocaml/pgocaml.2.2/opam
@@ -13,7 +13,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "base-bytes"
   "pcre"
   "calendar"


### PR DESCRIPTION
Build logs:
* http://obi.ocamllabs.io/logs/c874e40e2182d1f881c699dba7310b91.txt
* http://obi.ocamllabs.io/logs/26539dd764f72ffa3fef488161ccffb5.txt
* http://obi.ocamllabs.io/logs/051dad5fd80f1a55b24951643f45a502.txt
* http://obi.ocamllabs.io/logs/8dcf4fdcf39b7d4957f8fe877a987629.txt