### PR TITLE
Package ppxfind.1.2

### DIFF
--- a/packages/ppxfind/ppxfind.1.2/descr
+++ b/packages/ppxfind/ppxfind.1.2/descr
@@ -1,0 +1,3 @@
+ocamlfind ppx tool
+Ppxfind is a small command line tool that among other things allows
+to use old style ppx rewriters with jbuilder.

--- a/packages/ppxfind/ppxfind.1.2/opam
+++ b/packages/ppxfind/ppxfind.1.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/ppxfind"
+bug-reports: "https://github.com/diml/ppxfind/issues"
+dev-repo: "git://github.com/diml/ppxfind.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta16"}
+  "ocaml-migrate-parsetree"
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppxfind/ppxfind.1.2/url
+++ b/packages/ppxfind/ppxfind.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/ppxfind/releases/download/1.2/ppxfind-1.2.tbz"
+checksum: "3c6f81800bb816e190a64f9898481f82"


### PR DESCRIPTION
### `ppxfind.1.2`

ocamlfind ppx tool
Ppxfind is a small command line tool that among other things allows
to use old style ppx rewriters with jbuilder.



---
* Homepage: https://github.com/diml/ppxfind
* Source repo: git://github.com/diml/ppxfind.git
* Bug tracker: https://github.com/diml/ppxfind/issues

---


---
# 1.2

- Fix compatibility with OCaml 4.02 (#1, ZAN DoYe)
:camel: Pull-request generated by opam-publish v0.3.4