### PR TITLE
opam-bundle.0.3 - via opam-publish

### DIFF
--- a/packages/opam-bundle/opam-bundle.0.3/descr
+++ b/packages/opam-bundle/opam-bundle.0.3/descr
@@ -1,0 +1,14 @@
+A tool that creates stand-alone source bundles from opam packages
+
+opam-bundle is a command-line tool that, given a selection of packages,
+generates a .tar.gz (and optionally a self-extracting) archive containing their
+sources, and everything needed to bootstrap and compile them:
+- the sources of their dependencies
+- the sources of the chosen version of OCaml
+- the sources of opam
+- a set of scripts to bootstrap, check and install external dependencies,
+  compile all the above, install the packages within a sandbox, and optionally
+  put wrapper scripts within your PATH
+
+This is expected to be done as normal user, with constrained calls to `sudo`
+when needed for depexts and wrappers installation.

--- a/packages/opam-bundle/opam-bundle.0.3/opam
+++ b/packages/opam-bundle/opam-bundle.0.3/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/AltGr/opam-bundle"
+bug-reports: "https://github.com/AltGr/opam-bundle/issues"
+license: "GPL-3"
+tags: ["org:ocamlpro" "flags:plugin"]
+dev-repo: "https://github.com/AltGr/opam-bundle.git"
+build: [make]
+depends: [
+  "ocamlfind"
+  "cmdliner"
+  "opam-client" {>= "2.0.0~beta3.1"}
+]

--- a/packages/opam-bundle/opam-bundle.0.3/url
+++ b/packages/opam-bundle/opam-bundle.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/opam-bundle/archive/0.3.tar.gz"
+checksum: "17cbc9e06db1e4cd916652d9e788812b"


### PR DESCRIPTION
A tool that creates stand-alone source bundles from opam packages

opam-bundle is a command-line tool that, given a selection of packages,
generates a .tar.gz (and optionally a self-extracting) archive containing their
sources, and everything needed to bootstrap and compile them:
- the sources of their dependencies
- the sources of the chosen version of OCaml
- the sources of opam
- a set of scripts to bootstrap, check and install external dependencies,
  compile all the above, install the packages within a sandbox, and optionally
  put wrapper scripts within your PATH

This is expected to be done as normal user, with constrained calls to `sudo`
when needed for depexts and wrappers installation.


---
* Homepage: https://github.com/AltGr/opam-bundle
* Source repo: https://github.com/AltGr/opam-bundle.git
* Bug tracker: https://github.com/AltGr/opam-bundle/issues

---

Pull-request generated by opam-publish v0.3.4