### PR TITLE
add conf-afl for installing american fuzzy lop

### DIFF
--- a/packages/conf-afl/conf-afl.1/descr
+++ b/packages/conf-afl/conf-afl.1/descr
@@ -1,0 +1,1 @@
+American Fuzzy Lop by Michal Zalewski, a security-oriented fuzzer.

--- a/packages/conf-afl/conf-afl.1/opam
+++ b/packages/conf-afl/conf-afl.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "meetup@yomimono.org"
+homepage: "http://lcamtuf.coredump.cx/afl"
+bug-reports: "https://groups.google.com/forum/#!forum/afl-users"
+author: "Michal Zalewski"
+license: "Apache v2"
+build: [
+  ["afl-gcc" "--help"]
+]
+depexts: [
+  [["alpine"] ["afl"]]
+  [["debian"] ["afl"]]
+  [["fedora"] ["american-fuzzy-lop"]]
+  [["freebsd"] ["afl"]]
+  [["gentoo"] ["afl"]]
+  [["netbsd"] ["afl"]]
+  [["openbsd"] ["afl"]]
+  [["opensuse"] ["afl"]]
+  [["homebrew" "osx"] ["afl-fuzz"]]
+  [["macports" "osx"] ["afl"]]
+  [["ubuntu"] ["afl"]]
+]


### PR DESCRIPTION
`opam lint` will note that `dev-repo` is missing. AFL is developed privately, but the full source is released for each version.