### PR TITLE
add certify version 0.1

### DIFF
--- a/packages/certify/certify.0.1/descr
+++ b/packages/certify/certify.0.1/descr
@@ -1,0 +1,1 @@
+Utility for signing x509 certificates and creating CSRs.

--- a/packages/certify/certify.0.1/opam
+++ b/packages/certify/certify.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "meetup@yomimono.org"
+homepage:     "https://github.com/yomimono/ocaml-certify"
+dev-repo:     "https://github.com/yomimono/ocaml-certify.git"
+bug-reports:  "https://github.com/yomimono/ocaml-certify/issues"
+authors: [
+  "Mindy Preston"
+]
+tags: ["org:mirage"]
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+
+install: [make "install"]
+remove: ["ocamlfind" "remove" "certify"]
+depends: [
+  "ocamlfind" {build}
+  "asn1-combinators" {< "0.2.0"}
+  "nocrypto" {>= "0.5.0"}
+  "x509" {>= "0.4.0"}
+  "cmdliner"
+]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/certify/certify.0.1/url
+++ b/packages/certify/certify.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/yomimono/ocaml-certify/archive/v0.1.tar.gz"
+checksum: "11e64da56bd16a28598554656eb153aa"


### PR DESCRIPTION
`certify` is a utility for making x509 certificate-signing requests and self-signed certificates; it is also capable of signing certificates.

A forthcoming version 0.2 will be compatible with newer versions of the package's dependencies, as well as OCaml 4.06.0.