### PR TITLE
ipaddr.2.8.0: Fix the dependency over sexplib

### DIFF
--- a/packages/ipaddr/ipaddr.2.8.0/opam
+++ b/packages/ipaddr/ipaddr.2.8.0/opam
@@ -26,6 +26,7 @@ depends: [
   "jbuilder" {build & >="1.0+beta7"}
   "base-bytes"
   "ppx_sexp_conv" {build & >="v0.9.0"}
+  "sexplib"
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]


### PR DESCRIPTION
Just got struck by a inconsistent interfaces error while upgrading my current switch.

Fixed upstream here: https://github.com/mirage/ocaml-ipaddr/pull/67
Related to: https://github.com/mirage/ocaml-ipaddr/issues/66