### PR TITLE
Package x509.0.6.0

### DIFF
--- a/packages/x509/x509.0.6.0/descr
+++ b/packages/x509/x509.0.6.0/descr
@@ -5,6 +5,6 @@ of certificates which include public keys and identifiers, signed by an
 authority.  Authorities must be exchanged over a second channel to establish the
 trust relationship.  This library implements most parts of
 [RFC5280](https://tools.ietf.org/html/rfc5280) and
-[RFC6125]((https://tools.ietf.org/html/rfc6125).
+[RFC6125](https://tools.ietf.org/html/rfc6125).
 
 Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).

--- a/packages/x509/x509.0.6.0/descr
+++ b/packages/x509/x509.0.6.0/descr
@@ -1,0 +1,10 @@
+Public Key Infrastructure purely in OCaml
+
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority.  Authorities must be exchanged over a second channel to establish the
+trust relationship.  This library implements most parts of
+[RFC5280](https://tools.ietf.org/html/rfc5280) and
+[RFC6125]((https://tools.ietf.org/html/rfc6125).
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).

--- a/packages/x509/x509.0.6.0/opam
+++ b/packages/x509/x509.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+name:         "x509"
+homepage:     "https://github.com/mirleft/ocaml-x509"
+dev-repo:     "https://github.com/mirleft/ocaml-x509.git"
+bug-reports:  "https://github.com/mirleft/ocaml-x509/issues"
+doc:          "https://mirleft.github.io/ocaml-x509/doc"
+author:       [ "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   [ "Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>" ]
+license:      "BSD2"
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_sexp_conv" {build}
+  "topkg" {build}
+  "result"
+  "cstruct" {>= "1.6.0"}
+  "sexplib"
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "nocrypto" {>= "0.5.3"}
+  "astring"
+  "ounit" {test}
+  "cstruct-unix" {test & >= "3.0.0"}
+]
+
+tags: [ "org:mirage" ]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/x509/x509.0.6.0/url
+++ b/packages/x509/x509.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-x509/releases/download/0.6.0/x509-0.6.0.tbz"
+checksum: "e0bf6b2bed4dea68381978f0ece8eb29"


### PR DESCRIPTION
### `x509.0.6.0`

Public Key Infrastructure purely in OCaml

X.509 is a public key infrastructure used mostly on the Internet.  It consists
of certificates which include public keys and identifiers, signed by an
authority.  Authorities must be exchanged over a second channel to establish the
trust relationship.  This library implements most parts of
[RFC5280](https://tools.ietf.org/html/rfc5280) and
[RFC6125](https://tools.ietf.org/html/rfc6125).

Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).


---
* Homepage: https://github.com/mirleft/ocaml-x509
* Source repo: https://github.com/mirleft/ocaml-x509.git
* Bug tracker: https://github.com/mirleft/ocaml-x509/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
## 0.6.0 (2017-12-13)

* Certificate Revocation List (CRL) support (#99)
* track asn1-combinators 0.2.0 changes (#97)
* provide Extension.subject_alt_names (#95)
* compute length of certificate length, instead of hardcoding 4 (#95)
* enable safe-string (#89)
* use astring instead of custom String_ext.split (#89)
* use topkg instead of oasis (#88, #89)
* provide Encoding.cs_of_distinguished_name (#87 by @reynir)
:camel: Pull-request generated by opam-publish v0.3.5