### PR TITLE
Package cstruct.3.2.1

### DIFF
--- a/packages/cstruct/cstruct.3.2.1/descr
+++ b/packages/cstruct/cstruct.3.2.1/descr
@@ -1,0 +1,5 @@
+Access C-like structures directly from OCaml
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.

--- a/packages/cstruct/cstruct.3.2.1/opam
+++ b/packages/cstruct/cstruct.3.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "sexplib"
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cstruct/cstruct.3.2.1/url
+++ b/packages/cstruct/cstruct.3.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cstruct/releases/download/v3.2.1/cstruct-3.2.1.tbz"
+checksum: "c1eb6a48f3d3b0b1e358f06a8c92a4c1"


### PR DESCRIPTION
### `cstruct.3.2.1`

Access C-like structures directly from OCaml

Cstruct is a library and syntax extension to make it easier to access C-like
structures directly from OCaml.  It supports both reading and writing to these
structures, and they are accessed via the `Bigarray` module.


---
* Homepage: https://github.com/mirage/ocaml-cstruct
* Source repo: https://github.com/mirage/ocaml-cstruct.git
* Bug tracker: https://github.com/mirage/ocaml-cstruct/issues

---


---
v3.2.1 2017-12-13
-----------------

- improve performance by using primitives instead of C stubs.  the performance
  regression was introduced in #177 in 3.2.0 (#195 by @pqwy)
:camel: Pull-request generated by opam-publish v0.3.5