### PR TITLE
Constrain old versions of conduit and ocamlformat for the next release of janestreet packages

### DIFF
--- a/packages/conduit/conduit.0.14.3/opam
+++ b/packages/conduit/conduit.0.14.3/opam
@@ -18,7 +18,7 @@ remove: ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >= "113.24.00"}
   "ppx_sexp_conv" {build}
   "sexplib"

--- a/packages/conduit/conduit.0.14.4/opam
+++ b/packages/conduit/conduit.0.14.4/opam
@@ -18,7 +18,7 @@ remove: ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >= "113.24.00"}
   "ppx_sexp_conv" {build}
   "sexplib"

--- a/packages/conduit/conduit.0.14.5/opam
+++ b/packages/conduit/conduit.0.14.5/opam
@@ -18,7 +18,7 @@ remove: ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >= "113.24.00"}
   "ppx_sexp_conv" {build}
   "sexplib"

--- a/packages/conduit/conduit.0.15.0/opam
+++ b/packages/conduit/conduit.0.15.0/opam
@@ -15,7 +15,7 @@ build-doc: [make "doc"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
   "ppx_sexp_conv" {build}
   "sexplib"

--- a/packages/conduit/conduit.0.15.1/opam
+++ b/packages/conduit/conduit.0.15.1/opam
@@ -15,7 +15,7 @@ build-doc: [make "doc"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
   "ppx_sexp_conv" {build}
   "sexplib"

--- a/packages/conduit/conduit.0.15.2/opam
+++ b/packages/conduit/conduit.0.15.2/opam
@@ -15,7 +15,7 @@ build-doc: [make "doc"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
   "ppx_sexp_conv" {build}
   "sexplib"

--- a/packages/conduit/conduit.0.15.3/opam
+++ b/packages/conduit/conduit.0.15.3/opam
@@ -15,7 +15,7 @@ build-doc: [make "doc"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
   "ppx_sexp_conv" {build}
   "sexplib"

--- a/packages/conduit/conduit.0.15.4/opam
+++ b/packages/conduit/conduit.0.15.4/opam
@@ -15,7 +15,7 @@ build-doc: [make "doc"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build}
+  "ppx_driver" {build & < "v0.10.0"}
   "ppx_deriving" {build}
   "ppx_optcomp" {build & >="113.24.00"}
   "ppx_sexp_conv" {build}

--- a/packages/ocamlformat/ocamlformat.v0.2/opam
+++ b/packages/ocamlformat/ocamlformat.v0.2/opam
@@ -10,7 +10,7 @@ build: [
   [make]
 ]
 depends: [
-  "base"
+  "base" {< "v0.10.0"}
   "base-unix"
   "cmdliner"
   "jbuilder" {build}


### PR DESCRIPTION
To merge before #11009