### PR TITLE
nocrypto.0.5.4: restrict to a single job

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -10,6 +10,7 @@ tags:          [ "org:mirage" ]
 available:     [ ocaml-version >= "4.02.0" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+                "--jobs" "1"
                 "--with-lwt" "%{lwt:installed}%"
                 "--xen" "%{mirage-xen:installed}%"
                 "--freestanding" "%{mirage-solo5:installed}%"]


### PR DESCRIPTION
/cc @pqwy

issue is:
```
�[33m# �[mocamlfind ocamlc -g -ccopt '--std=c99 -Wall -Wextra -O3' -package bytes -package cstruct -c src/native/aes/aesni.c
�[33m# �[mmv aesni.o src/native/aes/aesni.o
�[33m# �[mocamlfind ocamlc -g -ccopt '--std=c99 -Wall -Wextra -O3' -package bytes -package cstruct -c src/native/des/generic.c
�[33m# �[mmv md5.o src/native/hash/md5.o
�[33m# �[mmv sha1.o src/native/hash/sha1.o
�[33m# �[mmv generic.o src/native/aes/generic.o
�[33m# �[mmv generic.o src/native/des/generic.o
�[33m# �[m+ mv generic.o src/native/des/generic.o
�[33m# �[mmv: rename generic.o to src/native/des/generic.o: No such file or directory
�[33m# �[mCommand exited with code 1.
```

log: https://api.travis-ci.org/v3/job/316132313/log.txt
upstream issue: https://github.com/mirleft/ocaml-nocrypto/issues/136
fix as proposed by @dbuenzli: https://github.com/mirleft/ocaml-nocrypto/issues/136#issuecomment-351757775