### PR TITLE
release netchannel version 1.8.0

### DIFF
--- a/packages/netchannel/netchannel.1.8.0/descr
+++ b/packages/netchannel/netchannel.1.8.0/descr
@@ -1,0 +1,8 @@
+Ethernet network device driver for MirageOS/Xen
+
+This library allows an OCaml application to read and
+write Ethernet frames via the `Netfront` protocol.
+
+* Web: <http://openmirage.org>
+* E-mail: <mirageos-devel@lists.xenproject.org>
+* Issues: <https://github.com/mirage/mirage/issues>

--- a/packages/netchannel/netchannel.1.8.0/opam
+++ b/packages/netchannel/netchannel.1.8.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen"
+build: [
+  [ "jbuilder" "subst" "-n" name] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_cstruct" {build}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "1.1.0"}
+  "ipaddr" {>= "1.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="1.1.1"}
+  "sexplib" {>= "113.01.00"}
+  "result"
+  "logs" {>= "0.5.0"}
+]
+available: [ocaml-version >= "4.03.0"]
+tags: "org:mirage"

--- a/packages/netchannel/netchannel.1.8.0/url
+++ b/packages/netchannel/netchannel.1.8.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/mirage-net-xen/releases/download/v1.8.0/netchannel-1.8.0.tbz"
+checksum: "afa3c1164fcbc6d96d2ebae95484ff17"


### PR DESCRIPTION
* Support client-initiated shutdown (needed for HVM support in QubesOS)
* Improve shared ring handling between Netback and Netfront
* Fix a number of build errors and improve documentation
