### PR TITLE
add afl version 2.52b

### DIFF
--- a/packages/afl/afl.2.52b/descr
+++ b/packages/afl/afl.2.52b/descr
@@ -1,0 +1,1 @@
+American Fuzzy Lop fuzzer by Michal Zalewski, repackaged for convenient use in opam.

--- a/packages/afl/afl.2.52b/files/add-uninstall-target.patch
+++ b/packages/afl/afl.2.52b/files/add-uninstall-target.patch
@@ -1,0 +1,23 @@
+--- a/Makefile	2017-11-05 02:26:11.000000000 +0000
++++ b/Makefile	2017-12-15 19:55:11.644799174 +0000
+@@ -137,6 +137,19 @@
+ 	cp -r testcases/ $${DESTDIR}$(MISC_PATH)
+ 	cp -r dictionaries/ $${DESTDIR}$(MISC_PATH)
+ 
++uninstall:
++	rm -rf $${DESTDIR}$(MISC_PATH)/dictionaries
++	rm -rf $${DESTDIR}$(MISC_PATH)/testcases
++	rm -f $${DESTDIR}$(DOC_PATH)/README $${DESTDIR}$(DOC_PATH)/ChangeLog $${DESTDIR}$(DOC_PATH)/*.txt
++	rm -f $${DESTDIR}$(HELPER_PATH)/as $${DESTDIR}$(HELPER_PATH)/afl-as
++	set -e; for i in afl-g++ afl-clang afl-clang++; do rm -f $${DESTDIR}$(BIN_PATH)/$$i; done
++	rm -f $${DESTDIR}$(HELPER_PATH)/afl-llvm-rt*.o
++	rm -f $${DESTDIR}$(BIN_PATH)/afl-clang-fast $${DESTDIR}$(BIN_PATH)/afl-clang-fast++
++	rm -f $${DESTDIR}$(BIN_PATH)/afl-qemu-trace
++	set -e; for prog in $(PROGS) $(SH_PROGS); do rm -f $${DESTDIR}$(BIN_PATH)/$$prog; done
++	rm -f $${DESTDIR}$(BIN_PATH)/afl-plot.sh
++	
++
+ publish: clean
+ 	test "`basename $$PWD`" = "afl" || exit 1
+ 	test -f ~/www/afl/releases/$(PROGNAME)-$(VERSION).tgz; if [ "$$?" = "0" ]; then echo; echo "Change program version in config.h, mmkay?"; echo; exit 1; fi
+

--- a/packages/afl/afl.2.52b/opam
+++ b/packages/afl/afl.2.52b/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "meetup@yomimono.org"
+homepage: "http://lcamtuf.coredump.cx/afl"
+bug-reports: "https://groups.google.com/forum/#!forum/afl-users"
+author: "Michal Zalewski"
+license: "Apache v2"
+build: [
+  [make]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
+patches: [
+  "add-uninstall-target.patch"
+]

--- a/packages/afl/afl.2.52b/url
+++ b/packages/afl/afl.2.52b/url
@@ -1,0 +1,2 @@
+archive: "http://lcamtuf.coredump.cx/afl/releases/afl-2.52b.tgz"
+checksum: "d4fa778e6c2221aee4f5326f22e1983d"


### PR DESCRIPTION
This is the moral equivalent of a `depext` with a `source` target, except with versioning and clean removal.

The patch is for `make uninstall`, which isn't available in `afl` without modification, and a request to upstream it [has been made on the afl-users mailing list](https://groups.google.com/forum/#!topic/afl-users/oTf3-ONffdM).