### PR TITLE
kyotocabinet 0.1: mark jbuilder dep with {build}

### DIFF
--- a/packages/kyotocabinet/kyotocabinet.0.1/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.1/opam
@@ -9,7 +9,7 @@ build: [
   "jbuilder" "build" "--only" "kyotocabinet" "--root" "." "-j" jobs "@install"
 ]
 build-test: [ "jbuilder" "runtest" "-p" name ]
-depends: "jbuilder"
+depends: ["jbuilder" {build}]
 depexts: [
   [[ "ubuntu"] ["libkyotocabinet-dev"]]
   [[ "debian"] ["libkyotocabinet-dev"]]


### PR DESCRIPTION
Upstream PR: https://github.com/didier-wenzek/ocaml-kyotocabinet/pull/1 .