### PR TITLE
Allow installing mirage-net-xen with newer netchannel versions

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.1.7.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.1/opam
@@ -18,7 +18,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen" {>= "1.1.0"}
-  "netchannel" {= "1.7.1"}
+  "netchannel" {>= "1.7.1"}
   "logs" {>= "0.5.0"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
We either need to release netchannel and mirage-net-xen together, or lift this constraint. Since the package is unlikely to change much (it just pulls in some Xen dependencies and applies the netchannel functor), lifting the constraint seems easier.

See: https://github.com/ocaml/opam-repository/pull/11033

/cc @yomimono