### PR TITLE
Add the statmemprof compiler backported to 4.04.2

### DIFF
--- a/compilers/4.04.2/4.04.2+statistical-memprof/4.04.2+statistical-memprof.comp
+++ b/compilers/4.04.2/4.04.2+statistical-memprof/4.04.2+statistical-memprof.comp
@@ -1,0 +1,23 @@
+opam-version: "1"
+version: "4.04.2"
+src: "https://github.com/chambart/ocaml-1/archive/jhj_memprof_4.04.2.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "--statmemprof"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+    "--statmemprof"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.04.2/4.04.2+statistical-memprof/4.04.2+statistical-memprof.descr
+++ b/compilers/4.04.2/4.04.2+statistical-memprof/4.04.2+statistical-memprof.descr
@@ -1,0 +1,1 @@
+OCaml 4.04.2 plus statistical memory profiling, see <http://ocaml.org/meetings/ocaml/2016/Jourdan-statistically_profiling_memory_in_OCaml.pdf>

--- a/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/opam
+++ b/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/jhjourdan/statmemprof-emacs.git"
 bug-reports: "https://github.com/jhjourdan/statmemprof-emacs/issues"
 tags: []
 available: [ compiler = "4.03.0+statistical-memprof"
-           | compiler = "4.04.0+statistical-memprof"
+           | compiler = "4.04.2+statistical-memprof"
            | compiler = "4.05.0+statistical-memprof"
            | compiler = "4.06.0+statistical-memprof" ]
 depends:

--- a/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/opam
+++ b/packages/statmemprof-emacs/statmemprof-emacs.0.1.0/opam
@@ -9,6 +9,7 @@ dev-repo: "https://github.com/jhjourdan/statmemprof-emacs.git"
 bug-reports: "https://github.com/jhjourdan/statmemprof-emacs/issues"
 tags: []
 available: [ compiler = "4.03.0+statistical-memprof"
+           | compiler = "4.04.0+statistical-memprof"
            | compiler = "4.05.0+statistical-memprof"
            | compiler = "4.06.0+statistical-memprof" ]
 depends:


### PR DESCRIPTION
I backported the current state of the PR to 4.04.2 (the version of OCaml used by tezos). Here it is.
Ping to make @jhjourdan aware of it. 