### PR TITLE
Package mirage-fs-unix.1.4.1

### DIFF
--- a/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/descr
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/descr
@@ -1,0 +1,11 @@
+Passthrough filesystem for MirageOS on Unix
+
+This is a pass-through Mirage filesystem to an underlying Unix directory.  The
+interface is intended to support eventual privilege separation (e.g. via the
+Casper daemon in FreeBSD 11).
+
+The current version supports the `Mirage_fs.S` and `Mirage_fs_lwt.S` signatures
+defined in the `mirage-fs` package.
+
+* WWW: <https://mirage.io>
+* E-mail: <mirageos-devel@lists.xenproject.org>

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
+                "Thomas Gazagnaire" ]
+maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org"]
+homepage:     "https://github.com/mirage/mirage-fs-unix"
+dev-repo:     "https://github.com/mirage/mirage-fs-unix.git"
+bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
+doc:          "https://mirage.github.io/mirage-fs-unix/"
+tags:         [ "org:mirage" ]
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta7"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-fs-lwt" {>= "1.0.0"}
+  "lwt"
+  "rresult" {test}
+  "mirage-clock-unix" {test & >= "1.2.0"}
+  "alcotest" {test & >= "0.7.1"}
+  "ptime" {test}
+]
+available: [ ocaml-version >= "4.04.2"]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/url
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-fs-unix/releases/download/v1.4.1/mirage-fs-unix-1.4.1.tbz"
+checksum: "4ac34c69be8e1544af0ffaec9963ab95"


### PR DESCRIPTION
### `mirage-fs-unix.1.4.1`

Passthrough filesystem for MirageOS on Unix

This is a pass-through Mirage filesystem to an underlying Unix directory.  The
interface is intended to support eventual privilege separation (e.g. via the
Casper daemon in FreeBSD 11).

The current version supports the `Mirage_fs.S` and `Mirage_fs_lwt.S` signatures
defined in the `mirage-fs` package.

* WWW: <https://mirage.io>
* E-mail: <mirageos-devel@lists.xenproject.org>


---
* Homepage: https://github.com/mirage/mirage-fs-unix
* Source repo: https://github.com/mirage/mirage-fs-unix.git
* Bug tracker: https://github.com/mirage/mirage-fs-unix/issues

---


---
v1.4.1 2017-12-16
-----------------

* fix compilation with safe-string
:camel: Pull-request generated by opam-publish v0.3.5