### PR TITLE
ppx_driver v0.9.1: doesn't compile on 4.05.0

### DIFF
--- a/packages/ppx_driver/ppx_driver.v0.9.1/opam
+++ b/packages/ppx_driver/ppx_driver.v0.9.1/opam
@@ -15,4 +15,4 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.0"}
   "ocamlbuild"
 ]
-available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.05.0" ]


### PR DESCRIPTION
File "src/ppx_driver.ml", line 744, characters 46-51:
Error: This expression has type
         [ `Already_displayed | `Ok of Ppx_driver__.Import.Location.Error.t ]
       but an expression was expected of type
         Ppx_driver__.Import.Location.Error.t = Location.error

see report at https://github.com/janestreet/ppx_driver/issues/15 and log at https://api.travis-ci.org/v3/job/317482043/log.txt

/cc @diml (who committed that version) @xclerc (who committed recent versions)