### PR TITLE
Release ppx_compose 0.0.4.

### DIFF
--- a/packages/ppx_compose/ppx_compose.0.0.4/descr
+++ b/packages/ppx_compose/ppx_compose.0.0.4/descr
@@ -1,0 +1,28 @@
+Inlined Function Composition
+
+`ppx_compose` is a simple syntax extension which rewrites code containing
+function compositions into composition-free code, effectively inlining the
+composition operators.  The following two operators are supported
+
+    let (%) g f x = g (f x)
+    let (%>) f g x = g (f x)
+
+Corresponding definitions are not provided, so partial applications of `(%)`
+and `(%>)` will be undefined unless you provide the definitions.
+
+The following rewrites are done:
+
+  * A composition occurring to the left of an application is reduced by
+    applying each term of the composition from right to left to the
+    argument, ignoring associative variations.
+
+  * A composition which is not the left side of an application is first
+    turned into one by η-expansion, then the above rule applies.
+
+  * Any partially applied composition operators are passed though unchanged.
+
+E.g.
+
+    h % g % f ==> (fun x -> h (f (g x)))
+    h % (g % f) ==> (fun x -> h (f (g x)))
+    (g % f) (h % h) ==> g (f (fun x -> h (h x)))

--- a/packages/ppx_compose/ppx_compose.0.0.4/opam
+++ b/packages/ppx_compose/ppx_compose.0.0.4/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "ppx_compose"
+authors: ["Petter A. Urkedal"]
+maintainer: "paurkedal@gmail.com"
+homepage: "https://github.com/paurkedal/ppx_compose/"
+bug-reports: "https://github.com/paurkedal/ppx_compose/issues"
+dev-repo: "https://github.com/paurkedal/ppx_compose.git"
+license: "LGPL-3 with OCaml linking exception"
+
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta7"}
+  "ocaml-migrate-parsetree"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/ppx_compose/ppx_compose.0.0.4/url
+++ b/packages/ppx_compose/ppx_compose.0.0.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ppx_compose/releases/download/v0.0.4/ppx_compose-0.0.4.tbz"
+checksum: "d597c0b1cf29402bbd29d821792c867e"


### PR DESCRIPTION
This is a minor bugfix release to make locations in error messages more
precise.