### PR TITLE
add conflicts between io-page and mirage-solo5:

### DIFF
--- a/packages/mirage-os-shim/mirage-os-shim.3.0.0/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.3.0.0/opam
@@ -27,5 +27,6 @@ depopts: [
 conflicts: [
   "mirage-unix" {<"3.0.0"}
   "mirage-xen" {<"3.0.0"}
+  "mirage-solo5" {<"0.2.0"}
 ]
 available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-solo5/mirage-solo5.0.1.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.1.1/opam
@@ -17,4 +17,5 @@ depends: [
   "mirage-profile" {>= "0.3"}
   "ocaml-freestanding"
 ]
+conflicts: [ "io-page" {>= "2.0.0"} ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-solo5/mirage-solo5.0.2.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.0/opam
@@ -23,4 +23,5 @@ depends: [
   "ocaml-freestanding"
   "logs"
 ]
+conflicts: [ "io-page" {>= "2.0.0"} ]
 available: [ ocaml-version >= "4.02.3" ]

--- a/packages/mirage-solo5/mirage-solo5.0.2.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.1/opam
@@ -23,4 +23,5 @@ depends: [
   "ocaml-freestanding"
   "logs"
 ]
+conflicts: [ "io-page" {< "2.0.0"} ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
since io-page 2.0.0 the C symbols are named mirage_alloc_pages
before it was caml_alloc_pages

upstream issue: https://github.com/mirage/mirage-solo5/pull/24
log of failed compilation (where opam tries to use old io-page with new mirage-solo5): https://api.travis-ci.org/v3/job/317650589/log.txt