### PR TITLE
Remove all ["source" "linux"] depexts

### DIFF
--- a/packages/aacplus/aacplus.0.2.1/opam
+++ b/packages/aacplus/aacplus.0.2.1/opam
@@ -7,5 +7,9 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "aacplus"]]
 depends: ["ocamlfind"]
-depexts: [[["source" "linux"] ["https://gist.githubusercontent.com/avsm/11409198/raw/8a67c518ad9e030725bb67f25119940eb8da2fa4/install-aacplus.sh"]]]
+depexts: [
+  [["archlinux"] ["libaacplus"]]
+  [["gentoo"] ["libaacplus"]]
+  [["freebsd"] ["libaacplus"]]
+]
 install: [make "install"]

--- a/packages/aacplus/aacplus.0.2.2/opam
+++ b/packages/aacplus/aacplus.0.2.2/opam
@@ -11,6 +11,10 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "aacplus"]
 depends: ["ocamlfind"]
-depexts: [[["source" "linux"] ["https://gist.githubusercontent.com/avsm/11409198/raw/8a67c518ad9e030725bb67f25119940eb8da2fa4/install-aacplus.sh"]]]
+depexts: [
+  [["archlinux"] ["libaacplus"]]
+  [["gentoo"] ["libaacplus"]]
+  [["freebsd"] ["libaacplus"]]
+]
 bug-reports: "https://github.com/savonet/ocaml-aacplus/issues"
 dev-repo: "https://github.com/savonet/ocaml-aacplus.git"

--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -11,7 +11,9 @@ depexts: [
   [[ "freebsd" ] [ "efl" ]]
   [[ "gentoo" ] [ "efl" ]]
   [["osx" "homebrew"] [ "efl" ]]
-  [["opensuse" "linux"] [ "elementary" ]]
+  [["opensuse" "linux"] [ "efl" ]]
   [["ubuntu" "linux"] [ "libelementary-dev "]]
+  [["centos"] ["elementary-devel"]]
+  [["mageia"] ["efl"]]
 ]
 

--- a/packages/conf-libsvm/conf-libsvm.3/opam
+++ b/packages/conf-libsvm/conf-libsvm.3/opam
@@ -15,7 +15,6 @@ depexts: [
   [["archlinux"] ["libsvm"]]
   [["gentoo"] ["sci-libs/libsvm"]]
   [["fedora"] ["libsvm-devel"]]
-  [["source" "centos"] ["https://gist.githubusercontent.com/akabe/918c5018809abceb3a3a83bd985c42c8/raw/libsvm.sh"]]
-  [["source" "alpine"] ["https://gist.githubusercontent.com/akabe/918c5018809abceb3a3a83bd985c42c8/raw/libsvm.sh"]]
+  [["centos"] ["libsvm-devel"]]
   [["osx" "homebrew"] ["libsvm"]]
 ]

--- a/packages/conf-libuv/conf-libuv.1/opam
+++ b/packages/conf-libuv/conf-libuv.1/opam
@@ -17,7 +17,6 @@ depexts: [
   [["centos"] ["libuv-devel"]]
   [["rhel"]   ["libuv-devel"]]
   [["fedora"] ["libuv-devel"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/fdopen/cbfb14114f4ec423a1a4/raw/6ba4cef74e94a7307391bddb7ff20db5d8065bfe/install-libuv.sh"]]
 ]
 post-messages: [
   "This package requires libuv 1.x development packages installed on your system" {failure}

--- a/packages/conf-mecab/conf-mecab.0.996/opam
+++ b/packages/conf-mecab/conf-mecab.0.996/opam
@@ -12,7 +12,5 @@ depexts: [
   [["debian"] ["mecab" "libmecab-dev"]]
   [["ubuntu"] ["mecab" "libmecab-dev"]]
   [["fedora"] ["mecab" "mecab-devel"]]
-  [["source" "centos"] ["https://gist.githubusercontent.com/akabe/e649732722c4d0858afc4aaa33900bf1/raw/opam-src-mecab.sh"]]
-  [["source" "alpine"] ["https://gist.githubusercontent.com/akabe/e649732722c4d0858afc4aaa33900bf1/raw/opam-src-mecab.sh"]]
   [["osx" "homebrew"] ["mecab"]]
 ]

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -10,6 +10,6 @@ depexts: [
   [["ubuntu"] ["libzmq3-dev"]]
   [["osx" "homebrew"] ["zeromq"]]
   [["alpine"] ["zeromq-dev"]]
-  [["source" "centos"] ["https://gist.githubusercontent.com/akabe/9352e05d2413ccbefb2b52ea6ae81599/raw/7ad60a2be120849341cd7c5bf14656773cb7d405/centos-zmq.sh"]]
+  [["centos"] ["zeromq-devel"]]
   [["fedora"] ["zeromq-devel"]]
 ]

--- a/packages/efl/efl.1.10.0/opam
+++ b/packages/efl/efl.1.10.0/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/axiles/bc758f21aee286072216/raw/cb89e6b4aef4efb6df531d92e8f32ebef78e24f2/iinstal_efl_10_on_ubuntu.sh"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.10.1/opam
+++ b/packages/efl/efl.1.10.1/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/axiles/bc758f21aee286072216/raw/cb89e6b4aef4efb6df531d92e8f32ebef78e24f2/iinstal_efl_10_on_ubuntu.sh"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.11.0/opam
+++ b/packages/efl/efl.1.11.0/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/axiles/22722d50d4d0b8bebc4f/raw/7138cf496d42738b23db7e7d4488c2c892874c0e/install_efl_1_11_on_ubuntu"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.11.1/opam
+++ b/packages/efl/efl.1.11.1/opam
@@ -10,10 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/axiles/e4339c22046bdb5ceb5c/raw/643495532edc2d0f878d4d610766adf7dbe3e9ce/install_efl_1_11_on_unbuntu_bis"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.12.0/opam
+++ b/packages/efl/efl.1.12.0/opam
@@ -14,7 +14,5 @@ remove: ["ocamlfind" "remove" "efl"]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/7be06b1fac09d99edf9a/raw/e826d3d93753eb0e677e43b4e0b7c066cfc11c4e/install_efl_1_12_on_ubuntu"]]
+  "conf-efl"
 ]

--- a/packages/efl/efl.1.13.0/opam
+++ b/packages/efl/efl.1.13.0/opam
@@ -14,7 +14,5 @@ remove: ["ocamlfind" "remove" "efl"]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/7be06b1fac09d99edf9a/raw/fc8dc050b5f94d91dd49dda2ba29f3c16815c5a8/install_efl_1_13_on_ubuntu"]]
+  "conf-efl"
 ]

--- a/packages/efl/efl.1.17.0/opam
+++ b/packages/efl/efl.1.17.0/opam
@@ -14,8 +14,5 @@ remove: ["ocamlfind" "remove" "efl"]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [["osx" "homebrew"] ["elementary"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/6e0f43192045c5f9b460/raw/f7c0668e063e12ded850f9b67fc4432b31ca1a7b/install_efl_1_17_on_ubuntu"]]
+  "conf-efl"
 ]

--- a/packages/efl/efl.1.18.0/opam
+++ b/packages/efl/efl.1.18.0/opam
@@ -15,8 +15,5 @@ remove: ["ocamlfind" "remove" "efl"]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [["osx" "homebrew"] ["efl"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/axiles/ad30d3b4465bd08bcb4eb117e21d70c8/raw/3367e23cb29e1255cd8588008250ef98d389bbbd/install_efl_1_18_on_ubuntu"]]
+  "conf-efl"
 ]

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -15,9 +15,5 @@ remove: ["ocamlfind" "remove" "efl"]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [["osx" "homebrew"] ["efl"]]
-  [ ["debian"] [ "libelementary-dev"] ]   
-  [ ["ubuntu"] [ "libelementary-dev"] ]
+  "conf-efl"
 ]

--- a/packages/efl/efl.1.8.1/opam
+++ b/packages/efl/efl.1.8.1/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/axiles/9099537/raw"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.8.2/opam
+++ b/packages/efl/efl.1.8.2/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/axiles/9099537/raw"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.8.3/opam
+++ b/packages/efl/efl.1.8.3/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/axiles/9099537/raw"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.8.4/opam
+++ b/packages/efl/efl.1.8.4/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/axiles/9099537/raw"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.9.0/opam
+++ b/packages/efl/efl.1.9.0/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/axiles/9607036/raw/6c2467aff47cfe02c60422d6d214eda80ddeec80/install_efl_on_ubuntu2"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.9.1/opam
+++ b/packages/efl/efl.1.9.1/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/axiles/2856d2b03fa7b05a8ce8/raw/e55eeecb5d57b2c10ee2b427bbc98a202e2c47bf/install_efl_1_9_on_ubuntu.sh"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/efl/efl.1.9.2/opam
+++ b/packages/efl/efl.1.9.2/opam
@@ -10,9 +10,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/axiles/2856d2b03fa7b05a8ce8/raw/e55eeecb5d57b2c10ee2b427bbc98a202e2c47bf/install_efl_1_9_on_ubuntu.sh"] ]
+  "conf-efl"
 ]
 available: ocaml-version >= "3.12"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.0/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.0/opam
@@ -14,9 +14,7 @@ depends: [
   "ocp-index" {>= "1.0.1"}
   "zmq" {= "3.2-2"}
   "ocamlbuild" {build}
-]
-depexts: [
-[ ["source" "linux"] ["https://gist.github.com/andrewray/179832b0ea39481d0f2c/raw"] ]
+  "conf-zmq" {build}
 ]
 ocaml-version: [ >= "4.01.0" & < "4.02.0" ]
 dev-repo: "git://github.com/andrewray/iocaml"

--- a/packages/ivy/ivy.1.2.2/opam
+++ b/packages/ivy/ivy.1.2.2/opam
@@ -6,12 +6,10 @@ remove: [
   ["ocamlfind" "remove" "ivy"]
   ["ocamlfind" "remove" "glibivy"]
 ]
-depends: ["ocamlfind" "conf-tcl"]
-depexts: [
-  [["debian"] ["libpcre3-dev"]]
-  [["ubuntu"] ["libpcre3-dev"]]
-  [["debian"] ["libglib2.0-dev"]]
-  [["ubuntu"] ["libglib2.0-dev"]]
-  [ ["source" "linux"] ["https://gist.github.com/flixr/10003993/raw"] ]
+depends: [
+  "ocamlfind"
+  "conf-tcl"
+  "conf-glib-2"
+  "conf-libpcre"
 ]
 install: [make "install" "COMPAT_SYMLINK_CREATE=no"]

--- a/packages/ivy/ivy.1.3.1/opam
+++ b/packages/ivy/ivy.1.3.1/opam
@@ -14,9 +14,6 @@ remove: [
 depends: [
   "ocamlfind" {build}
   "conf-tk"
-]
-depexts: [
-  [["debian"] ["libpcre3-dev" "libglib2.0-dev"]]
-  [["ubuntu"] ["libpcre3-dev" "libglib2.0-dev"]]
-  [ ["source" "linux"] ["https://gist.github.com/flixr/10003993/raw"] ]
+  "conf-glib-2"
+  "conf-libpcre"
 ]

--- a/packages/llvm/llvm.3.4/opam
+++ b/packages/llvm/llvm.3.4/opam
@@ -16,7 +16,6 @@ remove: [
 ]
 depexts: [
   [["debian"] ["llvm-3.4-dev"]]
-  [["source" "linux"] ["https://gist.github.com/jpdeplaix/11352552/raw"]]
   [["osx" "homebrew"] ["homebrew/versions/llvm34"]]
 ]
 depends: [

--- a/packages/llvm/llvm.3.5/opam
+++ b/packages/llvm/llvm.3.5/opam
@@ -16,7 +16,6 @@ remove: [
 ]
 depexts: [
   [["debian"] ["llvm-3.5-dev"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/jpdeplaix/58db9c49a79813fc1dda/raw"]]
   [["osx" "homebrew"] ["homebrew/versions/llvm35"]]
 ]
 depends: [

--- a/packages/llvm/llvm.3.6/opam
+++ b/packages/llvm/llvm.3.6/opam
@@ -17,7 +17,6 @@ depends: [
 ]
 depexts: [
   [["debian"] ["llvm-3.6-dev"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/whitequark/cc737ffcb8896e4d7b91/raw/ed2ba05691bc3a0500b1cc2dcd7156dd10c5b652/gistfile1.sh"]]
   [["osx" "homebrew"] ["homebrew/versions/llvm36"]]
 ]
 available: ocaml-version >= "4.00.0" & opam-version >= "1.2"

--- a/packages/llvm/llvm.3.7/opam
+++ b/packages/llvm/llvm.3.7/opam
@@ -18,7 +18,6 @@ depends: [
 ]
 depexts: [
   [["debian"] ["llvm-3.7-dev"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/jpdeplaix/f930a62bb00b573e19f4/raw/9515dd708c65d567cf8e366dac61e0933d4b896b/gistfile1.txt"]]
   [["osx" "homebrew"] ["homebrew/versions/llvm37"]]
 ]
 available: [opam-version >= "1.2" & ocaml-version >= "4.00.0"]

--- a/packages/lz4/lz4.1.0.0/opam
+++ b/packages/lz4/lz4.1.0.0/opam
@@ -10,8 +10,7 @@ depends: ["base-bytes"
           "ctypes"     {>= "0.3.2" & < "0.4.0"}]
 depexts: [
   [["debian"] ["liblz4-dev"]]
-  # [["ubuntu"] ["liblz4-dev"]] reenable when CI updates its Ubuntu
-  [["source"] ["https://gist.githubusercontent.com/whitequark/eef074a8daa14602e447/raw/c151d3ab2f35f6cac54c7ef7459e2bbfff852938/install.sh"]]
+  [["ubuntu"] ["liblz4-dev"]]
 ]
 dev-repo: "git://github.com/whitequark/ocaml-lz4"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/lz4/lz4.1.0.1/opam
+++ b/packages/lz4/lz4.1.0.1/opam
@@ -21,6 +21,5 @@ depends: [
 depexts: [
   [["debian"] ["liblz4-dev"]]
   [["ubuntu"] ["liblz4-dev"]]
-  [["source"] ["https://gist.githubusercontent.com/whitequark/eef074a8daa14602e447/raw/c151d3ab2f35f6cac54c7ef7459e2bbfff852938/install.sh"]]
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/orocksdb/orocksdb.0.1.0/opam
+++ b/packages/orocksdb/orocksdb.0.1.0/opam
@@ -20,9 +20,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
-
-depexts:[
-  [[ "debian"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [[ "ubuntu"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [["source" "linux"] ["https://gist.githubusercontent.com/toolslive/56b9fae64b27d3e00971/raw/60bc8b3f2d8980635500d89bac89e092befac5f9/gistfile1.txt"]]
+post-messages: [
+  "
+  This package requires rocksdb library installed in /usr/local/lib.
+  Tentative instructions : https://gist.githubusercontent.com/toolslive/56b9fae64b27d3e00971/raw/60bc8b3f2d8980635500d89bac89e092befac5f9/gistfile1.txt
+  "
+  {failure}
 ]

--- a/packages/orocksdb/orocksdb.0.2.0/opam
+++ b/packages/orocksdb/orocksdb.0.2.0/opam
@@ -20,9 +20,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
-
-depexts:[
-  [[ "debian"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [[ "ubuntu"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [["source" "linux"] ["https://gist.githubusercontent.com/toolslive/22958251b056dcb3131a/raw/14e68d9a0a2480d7be13c31f1fbe126d796c8db3/install.sh"]]
+post-messages: [
+  "
+  This package requires rocksdb library installed in /usr/local/lib.
+  Tentative instructions : https://gist.githubusercontent.com/toolslive/22958251b056dcb3131a/raw/14e68d9a0a2480d7be13c31f1fbe126d796c8db3/install.sh
+  "
+  {failure}
 ]

--- a/packages/orocksdb/orocksdb.0.2.1/opam
+++ b/packages/orocksdb/orocksdb.0.2.1/opam
@@ -18,9 +18,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
-
-depexts:[
-  [[ "debian"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [[ "ubuntu"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [["source" "linux"] ["https://gist.githubusercontent.com/domsj/9a28ba5a523a3420ded8/raw/dc6ebd8768a87dee285e84438dc733dfc58e037f/gistfile1.txt"]]
+post-messages: [
+  "
+  This package requires rocksdb library installed in /usr/local/lib.
+  Tentative instructions : https://gist.githubusercontent.com/domsj/9a28ba5a523a3420ded8/raw/dc6ebd8768a87dee285e84438dc733dfc58e037f/gistfile1.txt
+  "
+  {failure}
 ]

--- a/packages/orocksdb/orocksdb.0.2.2/opam
+++ b/packages/orocksdb/orocksdb.0.2.2/opam
@@ -17,9 +17,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: [ocaml-version >= "4.02.1" & opam-version >= "1.2"]
-
-depexts:[
-  [[ "debian"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [[ "ubuntu"] ["g++-4.8" "libgflags-dev" "libsnappy-dev" "libbz2-dev" ] ]
-  [["source" "linux"] ["https://gist.githubusercontent.com/domsj/9a28ba5a523a3420ded8/raw/dc6ebd8768a87dee285e84438dc733dfc58e037f/gistfile1.txt"]]
+post-messages: [
+  "
+  This package requires rocksdb library installed in /usr/local/lib.
+  Tentative instructions : https://gist.githubusercontent.com/domsj/9a28ba5a523a3420ded8/raw/dc6ebd8768a87dee285e84438dc733dfc58e037f/gistfile1.txt
+  "
+  {failure}
 ]

--- a/packages/orocksdb/orocksdb.0.3.0/opam
+++ b/packages/orocksdb/orocksdb.0.3.0/opam
@@ -14,9 +14,11 @@ depends: [
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]
-depexts: [
-  [["debian"] ["libbz2-dev" "libgflags-dev" "libsnappy-dev"]]
-  [["linux" "source"] [ "https://raw.githubusercontent.com/domsj/orocksdb/0.3.0/install_rocksdb.sh" ]]
-  [["ubuntu"] ["libbz2-dev" "libgflags-dev" "libsnappy-dev"]]
+post-messages: [
+  "
+  This package requires rocksdb library installed in /usr/local/lib.
+  Tentative instructions : https://raw.githubusercontent.com/domsj/orocksdb/0.3.0/install_rocksdb.sh
+  "
+  {failure}
 ]
 available: [ ocaml-version >= "4.02.2" & os = "linux" ]

--- a/packages/qfs/qfs.0.1/opam
+++ b/packages/qfs/qfs.0.1/opam
@@ -13,11 +13,16 @@ depends: [
   "ocamlfind"
   "oasis"
   "ocamlbuild" {build}
+  "conf-boost"
 ]
-depexts: [
-  [["debian"] ["libboost-dev"]]
-  [["ubuntu"] ["libboost-dev"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/ygrek/7bb217d6ab7b25a765b7/raw"]]
+post-messages: [
+  "
+  This package requires QFS development files installed, consult https://quantcast.github.io/qfs/
+  and https://github.com/quantcast/qfs/wiki/Developer-Documentation on how to build manually.
+
+  Tentative instructions for Debian : https://gist.githubusercontent.com/ygrek/7bb217d6ab7b25a765b7/raw
+  "
+  {failure}
 ]
 dev-repo: "git://github.com/ahrefs/ocaml-qfs"
 install: [make "install"]

--- a/packages/qfs/qfs.0.4/opam
+++ b/packages/qfs/qfs.0.4/opam
@@ -21,9 +21,14 @@ depends: [
   "base-unix"
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build}
+  "conf-boost"
 ]
-depexts: [
-  [["debian"] ["libboost-dev"]]
-  [["ubuntu"] ["libboost-dev"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/ygrek/7bb217d6ab7b25a765b7/raw"]]
+post-messages: [
+  "
+  This package requires QFS development files installed, consult https://quantcast.github.io/qfs/
+  and https://github.com/quantcast/qfs/wiki/Developer-Documentation on how to build manually.
+
+  Tentative instructions for Debian : https://gist.githubusercontent.com/ygrek/7bb217d6ab7b25a765b7/raw
+  "
+  {failure}
 ]

--- a/packages/qfs/qfs.0.5/opam
+++ b/packages/qfs/qfs.0.5/opam
@@ -29,10 +29,15 @@ depends: [
   "lwt" {>= "2.4.6"}
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build}
+  "conf-boost"
 ]
 available: [ ocaml-version >= "4.02.0" ]
-depexts: [
-  [["debian"] ["libboost-dev"]]
-  [["ubuntu"] ["libboost-dev"]]
-  [["source" "linux"] ["https://gist.githubusercontent.com/ygrek/7bb217d6ab7b25a765b7/raw"]]
+post-messages: [
+  "
+  This package requires QFS development files installed, consult https://quantcast.github.io/qfs/
+  and https://github.com/quantcast/qfs/wiki/Developer-Documentation on how to build manually.
+
+  Tentative instructions for Debian : https://gist.githubusercontent.com/ygrek/7bb217d6ab7b25a765b7/raw
+  "
+  {failure}
 ]

--- a/packages/qfs/qfs.0.6/opam
+++ b/packages/qfs/qfs.0.6/opam
@@ -27,12 +27,9 @@ depends: [
   "lwt" {>= "2.4.6"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.5"}
+  "conf-boost"
 ]
 available: [ ocaml-version >= "4.02.0" ]
-depexts: [
-  [["debian"] ["libboost-dev"]]
-  [["ubuntu"] ["libboost-dev"]]
-]
 post-messages: [
   "
   This package requires QFS development files installed, consult https://quantcast.github.io/qfs/

--- a/packages/sodium/sodium.0.1.0/opam
+++ b/packages/sodium/sodium.0.1.0/opam
@@ -7,9 +7,7 @@ depends: [
   "base-bigarray"
   "ocamlfind"
   "ctypes" {>= "0.1.1" & < "0.3"}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/avsm/9037146/raw"] ]
+  "conf-libsodium"
 ]
 dev-repo: "git://github.com/dsheets/ocaml-sodium"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/sodium/sodium.0.2.0/opam
+++ b/packages/sodium/sodium.0.2.0/opam
@@ -10,9 +10,7 @@ depends: [
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/avsm/9037146/raw"] ]
+  "conf-libsodium"
 ]
 dev-repo: "git://github.com/dsheets/ocaml-sodium"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/sodium/sodium.0.2.1/opam
+++ b/packages/sodium/sodium.0.2.1/opam
@@ -10,9 +10,7 @@ depends: [
   "ctypes" {>= "0.3.2"}
   "ctypes-foreign"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/avsm/9037146/raw"] ]
+  "conf-libsodium"
 ]
 dev-repo: "git://github.com/dsheets/ocaml-sodium"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/sodium/sodium.0.3.0/opam
+++ b/packages/sodium/sodium.0.3.0/opam
@@ -12,12 +12,7 @@ depends: [
   "ocamlfind"
   "ctypes" {>= "0.3.2" & < "0.4.0"}
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["debian"] ["libsodium-dev"] ]
-  [ ["source" "linux"] ["https://gist.github.com/avsm/9037146/raw"] ]
-  [ ["freebsd"] ["security/libsodium"] ]
-  [ ["osx" "homebrew"] ["libsodium"] ]
+  "conf-libsodium"
 ]
 available: [ocaml-version >= "4.01.0"]
 dev-repo: "git://github.com/dsheets/ocaml-sodium"

--- a/packages/wiringpi/wiringpi.0.0.1/opam
+++ b/packages/wiringpi/wiringpi.0.0.1/opam
@@ -13,8 +13,12 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-depexts: [
-  [["source" "linux"] ["https://gist.github.com/Leonidas-from-XIV/a1a7315ac01f7fbee3f0/raw"]]
+post-messages: [
+  "
+  This package requires WiringPi development files installed.
+  Tentative instructions : https://gist.githubusercontent.com/Leonidas-from-XIV/a1a7315ac01f7fbee3f0/raw
+  "
+  {failure}
 ]
 available: os = "linux"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/zmq/zmq.4.0-1/opam
+++ b/packages/zmq/zmq.4.0-1/opam
@@ -14,9 +14,7 @@ depends: [
   "uint"
   "oasis"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.githubusercontent.com/andersfugmann/11168509/raw"] ]
+  "conf-zmq"
 ]
 conflicts: ["ocaml-zmq"]
 available: [ ocaml-version < "4.03.0" ]

--- a/packages/zmq/zmq.4.0-2/opam
+++ b/packages/zmq/zmq.4.0-2/opam
@@ -14,9 +14,7 @@ depends: [
   "uint"
   "oasis"
   "ocamlbuild" {build}
-]
-depexts: [
-  [ ["source" "linux"] ["https://gist.github.com/hcarty/77e32afdecbf09af0213/raw"] ]
+  "conf-zmq"
 ]
 conflicts: ["ocaml-zmq"]
 available: [ ocaml-version < "4.03.0" ]


### PR DESCRIPTION
OPAM 2.0 doesn't handle ```"source"``` depexts anymore (see https://github.com/ocaml/opam/pull/3074).
This PR removes it from the packages.

Some of the packages seem to rely on locally installed (unpackaged) dependencies:
* orocksdb: @domsj 
* qfs: @ygrek 
* wiringpi: @Leonidas-from-XIV 