### PR TITLE
Fix old versions of macaque/monomorphic/ocamldap/syndic on 4.06

### DIFF
--- a/packages/macaque/macaque.0.7.1/opam
+++ b/packages/macaque/macaque.0.7.1/opam
@@ -36,3 +36,4 @@ tags: [
   "database"
   "DB"
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/monomorphic/monomorphic.1.0/opam
+++ b/packages/monomorphic/monomorphic.1.0/opam
@@ -14,3 +14,4 @@ depends: [
 ]
 dev-repo: "git://github.com/jpdeplaix/ocaml-monomorphic"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/monomorphic/monomorphic.1.1/opam
+++ b/packages/monomorphic/monomorphic.1.1/opam
@@ -14,3 +14,4 @@ depends: [
 ]
 dev-repo: "git://github.com/jpdeplaix/ocaml-monomorphic"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/ocamldap/ocamldap.2.2/opam
+++ b/packages/ocamldap/ocamldap.2.2/opam
@@ -12,5 +12,5 @@ depends: [
   "ssl"
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "3.12.1"
+available: [ocaml-version >= "3.12.1" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/syndic/syndic.1.0/opam
+++ b/packages/syndic/syndic.1.0/opam
@@ -12,12 +12,12 @@ remove: [
 ]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlnet" {>= "3.7.3"}
   "uri" {>= "1.3.13"}
   "xmlm" {>= "1.2.0"}
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/Cumulus/Syndic"
-available: ocaml-version >= "4.01"
+available: [ocaml-version >= "4.01" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/syndic/syndic.1.1/opam
+++ b/packages/syndic/syndic.1.1/opam
@@ -12,11 +12,11 @@ remove: [
 ]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "calendar" {>= "2.03.2"}
   "uri" {>= "1.3.13"}
   "xmlm" {>= "1.2.0"}
   "ocamlbuild" {build}
 ]
-available: ocaml-version >= "4.01"
+available: [ocaml-version >= "4.01" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/syndic/syndic.1.2/opam
+++ b/packages/syndic/syndic.1.2/opam
@@ -18,7 +18,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "calendar" {>= "2.03.2"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "uri" {>= "1.3.1"}
   "xmlm" {>= "1.2.0"}
   "ocamlbuild" {build}

--- a/packages/syndic/syndic.1.3.1/opam
+++ b/packages/syndic/syndic.1.3.1/opam
@@ -19,7 +19,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "calendar" {>= "2.03.2"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "uri" {>= "1.3.1"}
   "xmlm" {>= "1.2.0"}
   "ocamlbuild" {build}

--- a/packages/syndic/syndic.1.3/opam
+++ b/packages/syndic/syndic.1.3/opam
@@ -19,7 +19,7 @@ remove: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "calendar" {>= "2.03.2"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "uri" {>= "1.3.1"}
   "xmlm" {>= "1.2.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
Build logs:
* http://obi.ocamllabs.io/logs/5c3d8b33d343d79dd08d2149e2c6a0c9.txt
* http://obi.ocamllabs.io/logs/6b8fde7c60eef7ab5fc167f325c9d409.txt
* http://obi.ocamllabs.io/logs/33148371c4f275b761adb31604536670.txt
* http://obi.ocamllabs.io/logs/dfd1f7bcaf80887629af9a287faffe7c.txt
* http://obi.ocamllabs.io/logs/541a58f1296dad70ef0cd6ee952d64f6.txt
* http://obi.ocamllabs.io/logs/e46673d83eaa0dc74e88c88a114ed6d3.txt