### PR TITLE
Prepend v to core kernel constraint of biocaml

### DIFF
--- a/packages/biocaml/biocaml.0.8.0/opam
+++ b/packages/biocaml/biocaml.0.8.0/opam
@@ -19,7 +19,7 @@ depends: [
   "base64"
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta8"}
-  "core_kernel" {>= "0.9.1"}
+  "core_kernel" {>= "v0.9.1"}
   "sexplib"
   "camlzip" {>= "1.05"}
   "xmlm"

--- a/packages/biocaml/biocaml.0.8.0/opam
+++ b/packages/biocaml/biocaml.0.8.0/opam
@@ -31,4 +31,4 @@ depends: [
   "uri"
 ]
 depopts: ["async" "core" "lwt"]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
... otherwise it doesn't work correctly.