### PR TITLE
Package ppx_nanocaml.0.1

### DIFF
--- a/packages/ppx_nanocaml/ppx_nanocaml.0.1/descr
+++ b/packages/ppx_nanocaml/ppx_nanocaml.0.1/descr
@@ -1,0 +1,9 @@
+Framework for writing nanopass-style compilers
+
+A PPX-based toolkit that eases compiler writing
+by automatically generating the code needed to
+write a compiler. Nanocaml is designed for the
+nanopass-style of writing compilers, which
+emphasizes the use of many small passes that
+only perform one change to the AST, rather than
+only a few large passes.

--- a/packages/ppx_nanocaml/ppx_nanocaml.0.1/opam
+++ b/packages/ppx_nanocaml/ppx_nanocaml.0.1/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "iitalics, OhadRau"
+authors: ["iitalics" "OhadRau <admin@ohad.space>"]
+homepage: "https://github.com/nanocaml/nanocaml"
+bug-reports: "https://github.com/nanocaml/nanocaml/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/nanocaml/nanocaml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: ["batteries" "jbuilder" { build } "ocaml-migrate-parsetree"]

--- a/packages/ppx_nanocaml/ppx_nanocaml.0.1/url
+++ b/packages/ppx_nanocaml/ppx_nanocaml.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nanocaml/nanocaml/archive/0.1.0.tar.gz"
+checksum: "38877f4878af035303e02b3c9a399e98"


### PR DESCRIPTION
### `ppx_nanocaml.0.1`

Framework for writing nanopass-style compilers

A PPX-based toolkit that eases compiler writing
by automatically generating the code needed to
write a compiler. Nanocaml is designed for the
nanopass-style of writing compilers, which
emphasizes the use of many small passes that
only perform one change to the AST, rather than
only a few large passes.



---
* Homepage: https://github.com/nanocaml/nanocaml
* Source repo: git+https://github.com/nanocaml/nanocaml.git
* Bug tracker: https://github.com/nanocaml/nanocaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5