### PR TITLE
Lwt 3.2.0

### DIFF
--- a/packages/lwt/lwt.3.2.0/descr
+++ b/packages/lwt/lwt.3.2.0/descr
@@ -1,0 +1,10 @@
+Promises, concurrency, and parallelized I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.3.2.0/opam
+++ b/packages/lwt/lwt.3.2.0/opam
@@ -27,7 +27,14 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "jbuilder" {build & >= "1.0+beta13"}
   # We are only using ocamlfind during configuration of the Unix binding.
-  "ocamlfind" {build & >= "1.5.0"}
+  # However, ocamlfind also installs the "threads" package, and ocamlfind
+  # 1.7.3-1 is the first one whose threads package does not have incorrect error
+  # lines. See
+  #   https://github.com/ocaml/opam-repository/pull/11071#issuecomment-353131128
+  # If ocamlfind becomes no longer necessary for configuration of Lwt, this
+  # dependency should be converted to a conflict, and package jbuilder should be
+  # constrained such that it also includes the error lines fix.
+  "ocamlfind" {build & >= "1.7.3-1"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   # result is needed as long as Lwt still supports OCaml 4.02.

--- a/packages/lwt/lwt.3.2.0/opam
+++ b/packages/lwt/lwt.3.2.0/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+version: "3.2.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%"
+                                    "-use-camlp4" "%{camlp4:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "ocaml" "src/util/install_filter.ml" ]
+]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "jbuilder" {build & >= "1.0+beta13"}
+  # We are only using ocamlfind during configuration of the Unix binding.
+  "ocamlfind" {build & >= "1.5.0"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+  # result is needed as long as Lwt still supports OCaml 4.02.
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "camlp4"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+
+messages: [
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
+  "For the Camlp4 syntax, please install package lwt_camlp4"
+    {camlp4:installed & !lwt_camlp4:installed}
+  "For Lwt_log and Lwt_daemon, please install package lwt_log"
+    {!lwt_log:installed}
+]
+post-messages: [
+  "Lwt 4.0.0 will make some breaking changes in March 2018. See
+  https://github.com/ocsigen/lwt/issues/453"
+]

--- a/packages/lwt/lwt.3.2.0/url
+++ b/packages/lwt/lwt.3.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.2.0.tar.gz"
+checksum: "cf4256845e18c4d0f39afa7b32b3d6fe"

--- a/packages/lwt_camlp4/lwt_camlp4.1.0.0/descr
+++ b/packages/lwt_camlp4/lwt_camlp4.1.0.0/descr
@@ -1,0 +1,1 @@
+Camlp4 syntax extension for Lwt (deprecated)

--- a/packages/lwt_camlp4/lwt_camlp4.1.0.0/opam
+++ b/packages/lwt_camlp4/lwt_camlp4.1.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+version: "1.0.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Pa_lwt"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "camlp4"
+  "jbuilder" {build}
+  "lwt"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_camlp4/lwt_camlp4.1.0.0/url
+++ b/packages/lwt_camlp4/lwt_camlp4.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.2.0.tar.gz"
+checksum: "cf4256845e18c4d0f39afa7b32b3d6fe"

--- a/packages/lwt_log/lwt_log.1.0.0/descr
+++ b/packages/lwt_log/lwt_log.1.0.0/descr
@@ -1,0 +1,1 @@
+Lwt logging library (deprecated)

--- a/packages/lwt_log/lwt_log.1.0.0/opam
+++ b/packages/lwt_log/lwt_log.1.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+version: "1.0.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Shawn Wagner"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_log"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL"
+
+depends: [
+  "jbuilder" {build}
+  # This will be constrained with an upper bound once the log library is fully
+  # factored out of package lwt.
+  "lwt"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_log/lwt_log.1.0.0/url
+++ b/packages/lwt_log/lwt_log.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.2.0.tar.gz"
+checksum: "cf4256845e18c4d0f39afa7b32b3d6fe"

--- a/packages/lwt_ppx/lwt_ppx.1.0.0/descr
+++ b/packages/lwt_ppx/lwt_ppx.1.0.0/descr
@@ -1,0 +1,1 @@
+PPX syntax for Lwt, providing something similar to async/await from JavaScript

--- a/packages/lwt_ppx/lwt_ppx.1.0.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+version: "1.0.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta12"}
+  "lwt"
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_ppx/lwt_ppx.1.0.0/url
+++ b/packages/lwt_ppx/lwt_ppx.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.2.0.tar.gz"
+checksum: "cf4256845e18c4d0f39afa7b32b3d6fe"

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/descr
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/descr
@@ -1,0 +1,6 @@
+A library manager for OCaml
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/files/check-num-in-sitelib.patch
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/files/check-num-in-sitelib.patch
@@ -1,0 +1,39 @@
+From 04a4e29db7d86e56ba7cb3b1ea6a26cdf9e597b2 Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Fri, 20 Oct 2017 16:13:59 +0200
+Subject: [PATCH] don't install an empty 'num' package if a third-party package
+ exists
+
+When reinstalling/updating ocamlfind in an existing OCaml environment,
+ocamlfind is installed in a context where ocamlfind packages may
+already exist. In particular, the `num` package (separated from the
+compiler distribution in 4.06) may exist and own the file
+${ocaml_core_stdlib}/num.cmi. In this case ocamlfind should not
+overwrite it by installing its own num package -- the behaviour
+observed by Jacques-Pascal Deplaix before this patch.
+
+This approach may be generalizable to the other builtin base packages.
+---
+ configure | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 6a4a558..2627f1f 100755
+--- a/configure
++++ b/configure
+@@ -524,7 +524,11 @@ fi
+ 
+ # num?
+ 
+-if [ -f "${ocaml_core_stdlib}/num.cmi" ]; then
++if [ -f "${ocaml_sitelib}/num/META" ]; then
++    echo "num: package already present"
++    lnum=""
++    numtop=""
++elif [ -f "${ocaml_core_stdlib}/num.cmi" ]; then
+     echo "num: found"
+     lnum="num num-top"
+     numtop="num-top"
+-- 
+2.9.5
+

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/files/ocaml-stub
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/files/ocaml-stub
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+BINDIR=$(dirname "$(command -v ocamlc)")
+"$BINDIR/ocaml" -I "$OCAML_TOPLEVEL_PATH" "$@"

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/files/ocamlfind.install
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/files/ocamlfind.install
@@ -1,0 +1,6 @@
+bin: [
+  "src/findlib/ocamlfind" {"ocamlfind"}
+  "?src/findlib/ocamlfind_opt" {"ocamlfind"}
+  "?tools/safe_camlp4"
+]
+toplevel: ["src/findlib/topfind"]

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/files/threads.patch
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/files/threads.patch
@@ -1,0 +1,26 @@
+From 6de006e6f4864a585b085f840660383fa354f9bf Mon Sep 17 00:00:00 2001
+From: Anton Bachin <antonbachin@yahoo.com>
+Date: Wed, 20 Dec 2017 12:17:40 -0600
+Subject: [PATCH] threads: drop explicit check for -thread/-vmthread
+
+---
+ site-lib-src/threads/META.in | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/site-lib-src/threads/META.in b/site-lib-src/threads/META.in
+index b42f3dd..fe2d986 100644
+--- a/site-lib-src/threads/META.in
++++ b/site-lib-src/threads/META.in
+@@ -9,9 +9,6 @@ dnl This file is input of the m4 macro processor.
+ 
+ `browse_interfaces = "'interfaces`"'
+ 
+-`error(-mt) = "Missing -thread or -vmthread switch"'
+-`error(-mt_vm,-mt_posix) = "Missing -thread or -vmthread switch"'
+-
+ `package "vm" ('
+ `  # --- Bytecode-only threads:'
+ `  requires = "unix"'
+-- 
+2.12.2
+

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: [
+  "check-num-in-sitelib.patch"
+  "threads.patch"
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+  [make "opt"] { ocaml-native }
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {preinstalled}
+]
+remove: [
+  ["ocamlfind" "remove" "bytes"]
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
+  [make "uninstall"]
+  ["rm" "-f" "%{bin}%/ocaml"] {preinstalled}
+]
+available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
+depends: [
+  "conf-m4" {build}
+]

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/url
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/url
@@ -1,0 +1,3 @@
+archive: "http://download.camlcity.org/download/findlib-1.7.3.tar.gz"
+checksum: "7d57451218359f7b7dfc969e3684a6da"
+mirrors: [ "http://download2.camlcity.org/download/findlib-1.7.3.tar.gz" ]


### PR DESCRIPTION
Lwt is a promise and concurrency library for OCaml.

Release 3.2.0 continues the ongoing Lwt cleanup, adds some features, and fixes several bugs. It also schedules some breaking changes for Lwt 4.0.0, which is to be released in March 2018. See ocsigen/lwt#453 for a summary of these breaking changes, and help with adapting ahead of time.

<br/>

From the [changelog](https://github.com/ocsigen/lwt/releases/tag/3.2.0):

Additions

- [`Lwt_mvar.take_available`](https://ocsigen.org/lwt/dev/api/Lwt_mvar#VALtake_available), [`Lwt_mvar.is_empty`](https://ocsigen.org/lwt/dev/api/Lwt_mvar#VALis_empty) (ocsigen/lwt#459, Hezekiah Carty).
- [`Lwt_io.open_temp_file`](https://ocsigen.org/lwt/dev/api/Lwt_io#VALopen_temp_file), [`Lwt_io.with_temp_file`](https://ocsigen.org/lwt/dev/api/Lwt_io#VALwith_temp_file) (ocsigen/lwt#467, Joe Thomas).
- New reference documentation for module [`Lwt`](https://ocsigen.org/lwt/dev/api/Lwt) (ocsigen/lwt#469).
- [`Lwt_pool.clear`](https://ocsigen.org/lwt/dev/api/Lwt_pool#VALclear) and `?dispose` argument for [`Lwt_pool.create`](https://ocsigen.org/lwt/dev/api/Lwt_pool#VALcreate) (ocsigen/lwt#483, Hezekiah Carty).
- [`Lwt_pool.wait_queue_length`](https://ocsigen.org/lwt/dev/api/Lwt_pool#VALwait_queue_length) (ocsigen/lwt#493, Jerome Vouillon).

Bugs fixed

- [`Lwt.npick`](https://ocsigen.org/lwt/dev/api/Lwt#VALnpick) never worked (ocsigen/lwt#447, Zack Coker).
- [`Lwt_pool.use`](https://ocsigen.org/lwt/dev/api/Lwt_pool#VALuse) now always calls `?validate` on elements (ocsigen/lwt#461, Joe Thomas).
- Better locations generated by the PPX (ocsigen/lwt#470, Fabian Hemmer).
- Keep worker thread count accurate in [`Lwt_unix`](https://ocsigen.org/lwt/dev/api/Lwt_unix) when `pthread_create` fails (ocsigen/lwt#493, @koen-struyve).
- Leaked exceptions in [`Lwt_list`](https://ocsigen.org/lwt/dev/api/Lwt_list) (ocsigen/lwt#499).
- Memory leak in [`Lwt_unix.getnameinfo`](https://ocsigen.org/lwt/dev/api/Lwt_unix#VALgetnameinfo) (ocsigen/lwt#503, Hannes Mehnert).

Planned to break in 4.0.0

*See ocsigen/lwt#453 for details and instructions about planned breakage in Lwt 4.0.0.*

- The semantics of Lwt will be adjusted for better exception and stack safety (ocsigen/lwt#500).
- The PPX will be factored out into its own opam package, `lwt_ppx`. This package is installable from opam now, as of Lwt 3.2.0 (ocsigen/lwt#338).
- Similarly, the deprecated Camlp4 syntax will be factored out into `lwt_camlp4`, which is installable from opam now (ocsigen/lwt#370).
- Modules [`Lwt_log`](https://ocsigen.org/lwt/dev/api/Lwt_log), [`Lwt_log_core`](https://ocsigen.org/lwt/dev/api/Lwt_log_core), [`Lwt_log_rules`](https://ocsigen.org/lwt/dev/api/Lwt_log_rules), and [`Lwt_daemon`](https://ocsigen.org/lwt/dev/api/Lwt_daemon) are being deprecated and factored out into opam package `lwt_log`, also installable from opam now. Use the [logs](http://erratique.ch/software/logs) library for logging, in particular module [`Logs_lwt`](http://erratique.ch/software/logs/doc/Logs_lwt.html). Direct daemonization is [deprecated on most platforms](https://github.com/ocsigen/lwt/pull/484#issuecomment-338184730) (ocsigen/lwt#484, Hannes Mehnert).
- The [`>>`](https://ocsigen.org/lwt/3.1.0/api/Ppx_lwt#2_Sequence) construct from the PPX will be deleted (ocsigen/lwt#471, Raphaël Proust).
- Package `lwt.preemptive` is being merged into `lwt.unix`. In 3.2.0, `lwt.preemptive` becomes an alias for `lwt.unix`, and the package name `lwt.preemptive` will be deleted in 4.0.0 (ocsigen/lwt#487).

Deprecations

- [`Lwt.waiter_of_wakener`](https://ocsigen.org/lwt/dev/api/Lwt#VALwaiter_of_wakener) should not be used, as it can lead to soundness bugs in future (but not current) Lwt (ocsigen/lwt#458).
- [`Lwt_sequence`](https://ocsigen.org/lwt/dev/api/Lwt_sequence) was deprecated in [Lwt 2.6.0](https://github.com/ocsigen/lwt/releases/tag/2.6.0), but it now has a warning attached, as do [`Lwt.add_task_r`](https://ocsigen.org/lwt/dev/api/Lwt#VALadd_task_r) and [`Lwt.add_task_l`](https://ocsigen.org/lwt/dev/api/Lwt#VALadd_task_l), which use it (ocsigen/lwt#361).
- Use of the following functions is discouraged, but they have not yet received deprecation warnings: [`Lwt.with_value`](https://ocsigen.org/lwt/dev/api/Lwt#VALwith_value), [`Lwt.cancel`](https://ocsigen.org/lwt/dev/api/Lwt#VALcancel), [`Lwt.state`](https://ocsigen.org/lwt/dev/api/Lwt#VALstate), [`Lwt.ignore_result`](https://ocsigen.org/lwt/dev/api/Lwt#VAL) (ocsigen/lwt#359, ocsigen/lwt#469).

Miscellaneous

- Replace references to Camlp4 in the manual with the PPX (ocsigen/lwt#457, Bobby Priambodo).
- More tests for [`Lwt_pool`](https://ocsigen.org/lwt/dev/api/Lwt_pool) (ocsigen/lwt#464, Joe Thomas).
- Expect tests for the PPX (ocsigen/lwt#474, Fabian Hemmer).
