### PR TITLE
release mirage version 3.0.8

### DIFF
--- a/packages/mirage/mirage.3.0.8/descr
+++ b/packages/mirage/mirage.3.0.8/descr
@@ -1,0 +1,12 @@
+The MirageOS library operating system
+
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.

--- a/packages/mirage/mirage.3.0.8/opam
+++ b/packages/mirage/mirage.3.0.8/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/mirage/mirage.git"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder"   {build & >= "1.0+beta10"}
+  "ipaddr"             {>= "2.6.0"}
+  "functoria"          {>= "2.2.0"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.0.0"}
+]
+conflicts: [
+  "nocrypto" {< "0.4.0"}
+  "cstruct"  {< "1.0.1"}
+  "io-page"  {< "1.4.0"}
+  "crunch"   {< "1.2.2"}
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/mirage/mirage.3.0.8/url
+++ b/packages/mirage/mirage.3.0.8/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage/releases/download/v3.0.8/mirage-3.0.8.tbz"
+checksum: "bc7bc993a5f88ba8644a6e33a6b966a7"


### PR DESCRIPTION
Mirage version 3.0.8: Bugfix for Xen block device naming

* when passing block devices to xen, pass the raw filename rather than trying to infer the xenstore ID
* make homepage in opam files consistent
