### PR TITLE
restrict OCaml version for older cohttp versions

### DIFF
--- a/packages/cohttp/cohttp.0.20.0/opam
+++ b/packages/cohttp/cohttp.0.20.0/opam
@@ -47,4 +47,4 @@ conflicts: [
   "lwt" {< "2.5.0"}
   "js_of_ocaml" {>="3.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/cohttp/cohttp.0.20.1/opam
+++ b/packages/cohttp/cohttp.0.20.1/opam
@@ -48,4 +48,4 @@ conflicts: [
   "js_of_ocaml" {< "2.6"}
   "js_of_ocaml" {>="3.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/cohttp/cohttp.0.20.2/opam
+++ b/packages/cohttp/cohttp.0.20.2/opam
@@ -49,4 +49,4 @@ conflicts: [
   "js_of_ocaml" {< "2.6"}
   "js_of_ocaml" {>="3.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/cohttp/cohttp.0.21.0/opam
+++ b/packages/cohttp/cohttp.0.21.0/opam
@@ -48,4 +48,4 @@ conflicts: [
   "js_of_ocaml" {< "2.6"}
   "js_of_ocaml" {>= "3.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/cohttp/cohttp.0.21.1/opam
+++ b/packages/cohttp/cohttp.0.21.1/opam
@@ -49,4 +49,4 @@ conflicts: [
   "js_of_ocaml" {< "2.8"}
   "js_of_ocaml" {>= "3.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/cohttp/cohttp.0.22.0/opam
+++ b/packages/cohttp/cohttp.0.22.0/opam
@@ -51,4 +51,4 @@ conflicts: [
   "js_of_ocaml" {< "2.8"}
   "js_of_ocaml" {>= "3.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
CI results from https://github.com/ocaml/opam-repository/pull/11076
seem to indicate that older cohttp versions still get selected by the
dependency solver, and are incompatible with recent OCaml version: the
only thing I know for sure is that 0.20.1 is incompatible with both
4.05 and 4.06. This tentative PR touches a range of cohttp versions
(restrict them to < 4.06, which seems correct given the bound on 0.99)
to check them against OCaml versions -- it may turn out that they are
all incompatible with 4.05 as well, in which case they would all be
restricted.

(I didn't do it on *all* older cohttp version to avoid CI overload.)