### PR TITLE
ppx_type_conv 0.9.0 conflicts with ppx_deriving 4.02.0

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
@@ -19,6 +19,6 @@ depopts: [
   "ppx_deriving"
 ]
 conflicts: [
-  "ppx_deriving" {< "4.1"}
+  "ppx_deriving" {< "4.1" & = "4.02.0"}
 ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
This is the solution to build problems affecting cohttp proposed in

  https://github.com/mirage/ocaml-cohttp/pull/591

My first attempt at fixing the cohttp issue was https://github.com/ocaml/opam-repository/pull/11085, but it seems to be the wrong approach.

I had to look at other files in the repository to remember whether `&` or `|` should be used for multi-version conflicts, but this seems to be it. (It's not intuitive at all.)