### PR TITLE
Package ocamlformat_support.0.2

### DIFF
--- a/packages/ocamlformat/ocamlformat.v0.2/opam
+++ b/packages/ocamlformat/ocamlformat.v0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "cmdliner"
   "jbuilder" {build}
   "ocaml-migrate-parsetree" {>= "1.0.5"}
-  "ocamlformat_support"
+  "ocamlformat_support" {= "0.1"}
   "stdio"
 ]
 available: [ocaml-version >= "4.04.0"]

--- a/packages/ocamlformat/ocamlformat.v0.2/url
+++ b/packages/ocamlformat/ocamlformat.v0.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/ocaml-ppx/ocamlformat/archive/v0.2.tar.gz"
-checksum: "751e95e26bff698bbafe0cb38b031c24"
+checksum: "0da94dc86b60ade10c2d3c1824ffabc4"

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/descr
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/descr
@@ -1,0 +1,3 @@
+Support package for OCamlFormat
+
+Consists of a patched version of the OCaml standard library Format module.

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/ocaml-ppx/ocamlformat/tree/support"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 license: "LGPL-2 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
-build: [make]
+build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build}
 ]

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Pierre Weis"
+homepage: "https://github.com/ocaml-ppx/ocamlformat/tree/support"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
+build: [make]
+depends: [
+  "jbuilder" {build}
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/url
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.2.tar.gz"
+checksum: "42a759076f326abd2117c9a2e7fc5451"

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/url
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.2.tar.gz"
-checksum: "42a759076f326abd2117c9a2e7fc5451"
+checksum: "162086e6ef309a7ea98943c189dc3a6d"


### PR DESCRIPTION
### `ocamlformat_support.0.2`

Support package for OCamlFormat

Consists of a patched version of the OCaml standard library Format module.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat/tree/support
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git#support
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5