### PR TITLE
Add capnp upper-bound due to base API change

### DIFF
--- a/packages/capnp/capnp.3.0.0/opam
+++ b/packages/capnp/capnp.3.0.0/opam
@@ -19,4 +19,7 @@ depends: [
   "ounit" {test}
   "conf-capnproto" {build}
 ]
+conflicts: [
+  "base" {>= "v0.10.0"}
+]
 available: [ ocaml-version >= "4.02.0" ]

--- a/packages/capnp/capnp.3.1.0/opam
+++ b/packages/capnp/capnp.3.1.0/opam
@@ -20,4 +20,7 @@ depends: [
   "ounit" {test}
   "conf-capnproto" {build}
 ]
+conflicts: [
+  "base" {>= "v0.10.0"}
+]
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
It appears that `Exn.backtrace` was removed from base in v0.9.114.39.
The commit does not say why.