### PR TITLE
Package ocamlformat.0.3

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.3/descr
+++ b/packages/ocamlformat/ocamlformat.0.3/descr
@@ -1,0 +1,3 @@
+Auto-formatter for OCaml code
+
+OCamlFormat is a tool to automatically format OCaml code in a uniform style.

--- a/packages/ocamlformat/ocamlformat.0.3/opam
+++ b/packages/ocamlformat/ocamlformat.0.3/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["tools/gen_version.sh" "src/Version.ml" version] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base" {>= "v0.10.0"}
+  "base-unix"
+  "cmdliner"
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocamlformat_support" {= "0.2"}
+  "stdio"
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ocamlformat/ocamlformat.0.3/url
+++ b/packages/ocamlformat/ocamlformat.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/0.3.tar.gz"
+checksum: "9e6f34a8680b2fc978fb09c222050efb"

--- a/packages/ocamlformat/ocamlformat.v0.2/opam
+++ b/packages/ocamlformat/ocamlformat.v0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "cmdliner"
   "jbuilder" {build}
   "ocaml-migrate-parsetree" {>= "1.0.5"}
-  "ocamlformat_support"
+  "ocamlformat_support" {= "0.1"}
   "stdio"
 ]
 available: [ocaml-version >= "4.04.0"]

--- a/packages/ocamlformat/ocamlformat.v0.2/url
+++ b/packages/ocamlformat/ocamlformat.v0.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/ocaml-ppx/ocamlformat/archive/v0.2.tar.gz"
-checksum: "751e95e26bff698bbafe0cb38b031c24"
+checksum: "0da94dc86b60ade10c2d3c1824ffabc4"

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/descr
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/descr
@@ -1,0 +1,3 @@
+Support package for OCamlFormat
+
+Consists of a patched version of the OCaml standard library Format module.

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Pierre Weis"
+homepage: "https://github.com/ocaml-ppx/ocamlformat/tree/support"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/url
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.2.tar.gz"
+checksum: "162086e6ef309a7ea98943c189dc3a6d"


### PR DESCRIPTION
### `ocamlformat.0.3`

Auto-formatter for OCaml code

OCamlFormat is a tool to automatically format OCaml code in a uniform style.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5