### PR TITLE
Bisect_ppx 1.3.2

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.1.3.2/descr
+++ b/packages/bisect_ppx/bisect_ppx.1.3.2/descr
@@ -1,0 +1,19 @@
+Code coverage for OCaml
+
+Bisect_ppx helps you test thoroughly. It is a small preprocessor that inserts
+instrumentation at places in your code, such as if-then-else and match
+expressions. After you run tests, Bisect_ppx gives a nice HTML report showing
+which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, then run the
+report tool on the generated visitation files.
+
+This is an advanced fork of the original Bisect coverage tool. It has many
+improvements and updates.
+
+- Much more thorough code instrumentation, so you can find more gaps in your
+  testing.
+- Fast operation by default.
+- More legible and appealing HTML reports.
+- Various bugfixes.
+- No camlp4 dependency.

--- a/packages/bisect_ppx/bisect_ppx.1.3.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.2/opam
@@ -1,0 +1,49 @@
+version: "1.3.2"
+opam-version: "1.2"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "MPL2"
+homepage: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+dev-repo: "https://github.com/aantron/bisect_ppx.git"
+
+depends: [
+  "base-unix"
+  "jbuilder" {build & >= "1.0+beta13"}
+  # This will be removed when bisect_ppx-ocamlbuild is fully factored
+  # out. It is not a build dependency because Ocamlbuild must be present
+  # each time the plugin is used, even after it is built and installed.
+  "ocamlbuild"
+  "ocaml-migrate-parsetree" {>= "1.0.3"}
+  "ounit" {test}
+  "ppx_tools_versioned"
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+# Note that Bisect_ppx effectively requires 4.02.3, because Jbuilder requires
+# it. 4.02.0 is the natural constraint of Bisect_ppx.
+available: ocaml-version >= "4.02.0"
+
+messages: [
+  "For the Ocamlbuild plugin, please install package bisect_ppx-ocamlbuild"
+  {ocamlbuild:installed & !bisect_ppx-ocamlbuild:installed}
+]
+post-messages: [
+  "The future Bisect_ppx 2.0.0 will make breaking changes. See
+  https://github.com/aantron/bisect_ppx/releases/tag/1.3.0"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]

--- a/packages/bisect_ppx/bisect_ppx.1.3.2/url
+++ b/packages/bisect_ppx/bisect_ppx.1.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.3.2.tar.gz"
+checksum: "cb4c59e82a2c59560893fb75e02110b7"


### PR DESCRIPTION
[Bisect_ppx](https://github.com/aantron/bisect_ppx#bisect_ppx----) is OCaml's code coverage tool.

The 1.3.2 release fixes a few bugs. From the [changelog](https://github.com/aantron/bisect_ppx/releases/tag/1.3.2):

> Bugs fixed
>
> - Report names of intermediate files when Bisect_ppx is unable to read them (aantron/bisect_ppx#163, Emilio Jesús Gallego Arias).
> - Don't apply instrumentation to attributes in `.mli` files (aantron/bisect_ppx#164, reported Etienne Millon).
>
> Improvements
>
> - Generate HTML report filenames from source filenames, instead of assigning them numbers (aantron/bisect_ppx#139, Brad Langel).
