### PR TITLE
constrain jbuild to < beta12 for ppx_inline_tests v0.9.1

### DIFF
--- a/packages/ppx_inline_test/ppx_inline_test.v0.9.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.9.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "base"                    {>= "v0.9" & < "v0.10"}
-  "jbuilder"                {build & >= "1.0+beta8"}
+  "jbuilder"                {build & >= "1.0+beta8" & < "1.0+beta12"}
   "ppx_core"                {>= "v0.9" & < "v0.10"}
   "ppx_driver"              {>= "v0.9.1" & < "v0.10"}
   "ppx_metaquot"            {>= "v0.9" & < "v0.10"}


### PR DESCRIPTION
jbuilder beta12 deprecated `per-file` in jbuild files.  ppx_inline_tests v0.9.2 has a fix and v0.9.0 is constrained to an earlier version, but v0.9.1 can be coinstalled with a later jbuilder (see https://travis-ci.org/ocaml/opam-repository/jobs/319717212 from https://github.com/ocaml/opam-repository/pull/11089 ), resulting in a build failure.