### PR TITLE
ppx_type_conv 0.9.0 also conflicts with ppx_deriving 4.2.1

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
@@ -19,6 +19,6 @@ depopts: [
   "ppx_deriving"
 ]
 conflicts: [
-  "ppx_deriving" {< "4.1" & = "4.02.0"}
+  "ppx_deriving" {< "4.1" & = "4.02.0" & = "4.02.1"}
 ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/11086 for previous
version -- too restrictive -- of the conflict clause.