### PR TITLE
Package tls.0.9.0

### DIFF
--- a/packages/tls/tls.0.9.0/descr
+++ b/packages/tls/tls.0.9.0/descr
@@ -1,0 +1,15 @@
+Transport Layer Security purely in OCaml
+
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).

--- a/packages/tls/tls.0.9.0/opam
+++ b/packages/tls/tls.0.9.0/opam
@@ -1,0 +1,55 @@
+opam-version: "1.2"
+name:         "tls"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+author:       ["David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD2"
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+    "--with-lwt" "%{lwt+ptime:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+    "--with-lwt" "%{lwt+ptime+astring:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_deriving" {build}
+  "ppx_cstruct" {build & >= "3.0.0"}
+  "result"
+  "cstruct" {>= "3.0.0"}
+  "sexplib"
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.6.1"}
+  "cstruct-unix" {test & >= "3.0.0"}
+  "ounit" {test}
+]
+depopts: [
+  "lwt"
+  "mirage-flow-lwt"
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "ptime"
+  "astring" {test}
+]
+conflicts: [
+  "lwt" {<"2.4.8"}
+  "mirage-net-xen" {<"1.3.0"}
+  "mirage-types" {<"3.0.0"}
+  "sexplib" {= "v0.9.0"}
+  "ptime" {< "0.8.1"}
+]
+
+tags: [ "org:mirage"]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/tls/tls.0.9.0/url
+++ b/packages/tls/tls.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-tls/releases/download/0.9.0/tls-0.9.0.tbz"
+checksum: "aaac6ed2fa734b59b9771a702f5a20ff"


### PR DESCRIPTION
### `tls.0.9.0`

Transport Layer Security purely in OCaml

Transport Layer Security (TLS) is probably the most widely deployed security
protocol on the Internet. It provides communication privacy to prevent
eavesdropping, tampering, and message forgery. Furthermore, it optionally
provides authentication of the involved endpoints. TLS is commonly deployed for
securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
virtual private networks, and wireless networks.

TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
authenticate (using X.509) either or both endpoints. It provides algorithmic
agility, which means that the key exchange method, symmetric encryption
algorithm, and hash algorithm are negotiated.

Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).


---
* Homepage: https://github.com/mirleft/ocaml-tls
* Source repo: https://github.com/mirleft/ocaml-tls.git
* Bug tracker: https://github.com/mirleft/ocaml-tls/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---


---
## 0.9.0 (2017-12-23)

* renegotiation semantics (#375)
   allow acceptable_ca, authenticator, and own_cert to be updated (Config.with_x)
   semantics of reneg is blocking
   `{Tls_lwt.Unix|Tls_mirage}.reneg ~drop:bool` drops data of earlier epoch
* implement acceptable_ca (#332, @reynir)
* fix client renegotiation with ExtendedMasterSecret (#373, broken since 0.7.0)
* Config.client can get ~peer_name (#373)
* Asn.Time.t is Ptime.t now (asn1-combinators.0.2.0, x509.0.6.0, #372)
* cleanups (#360, #363, #369, @rgrinberg)
* remove 3DES CBC SHA from default ciphers (#359)
:camel: Pull-request generated by opam-publish v0.3.5