### PR TITLE
add certify version 0.2

### DIFF
--- a/packages/certify/certify.0.2/descr
+++ b/packages/certify/certify.0.2/descr
@@ -1,0 +1,1 @@
+Utility for signing x509 certificates and creating CSRs.

--- a/packages/certify/certify.0.2/opam
+++ b/packages/certify/certify.0.2/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "meetup@yomimono.org"
+homepage:     "https://github.com/yomimono/ocaml-certify"
+dev-repo:     "https://github.com/yomimono/ocaml-certify.git"
+bug-reports:  "https://github.com/yomimono/ocaml-certify/issues"
+authors: [
+  "Mindy Preston"
+]
+tags: ["org:mirage"]
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+  ["test/test.sh"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.6.0"}
+  "cstruct" {>= "3.2.0"}
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "conf-openssl" {test}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/certify/certify.0.2/url
+++ b/packages/certify/certify.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/yomimono/ocaml-certify/releases/download/v0.2/certify-0.2.tbz"
+checksum: "6d2faab47941a748af34eee056907a87"


### PR DESCRIPTION
This is a maintenance release which builds with `-safe-string` enabled and follows breaking API changes in some dependencies.