### PR TITLE
+yaml.0.1.0

### DIFF
--- a/packages/yaml/yaml.0.1.0/descr
+++ b/packages/yaml/yaml.0.1.0/descr
@@ -1,0 +1,7 @@
+Parse and generate YAML 1.1 files
+
+This is an OCaml library to parse and generate the YAML file
+format.  It is intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
+JSON handling library, if the simple common subset of Yaml 
+is used.  Anchors and other advanced Yaml features are not
+implemented in the JSON compatibility layer.

--- a/packages/yaml/yaml.0.1.0/opam
+++ b/packages/yaml/yaml.0.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "http://anil-code.github.io/ocaml-yaml"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-yaml.git"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.03.0"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "ctypes" {>="0.12.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "rresult"
+  "fmt"
+  "logs"
+  "alcotest" {test}
+  "ezjsonm" {test}
+  "bos" {test}
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest"]
+]

--- a/packages/yaml/yaml.0.1.0/url
+++ b/packages/yaml/yaml.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-yaml/releases/download/v0.1.0/yaml-0.1.0.tbz"
+checksum: "2199badcf159e4ac7ca8559493b0cadf"


### PR DESCRIPTION
This is an OCaml library to parse and generate the YAML file format.  It is
intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
JSON handling library, if the simple common subset of Yaml is used.  Anchors
and other advanced Yaml features are not implemented in the JSON compatibility
layer.