### PR TITLE
+ocaml-version.0.1.0

### DIFF
--- a/packages/ocaml-version/ocaml-version.0.1.0/descr
+++ b/packages/ocaml-version/ocaml-version.0.1.0/descr
@@ -1,0 +1,36 @@
+Manipulate, parse and generate OCaml compiler version strings
+
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+Browse the [API documentation](http://docs.mirage.io/ocaml-version) for more
+details.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/avsm/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+
+Contributions are very welcome.  Please see the overall TODO list below, or
+please get in touch with any particular comments you might have.
+
+[![Build Status](https://travis-ci.org/avsm/ocaml-version.svg?branch=master)](https://travis-ci.org/avsm/ocaml-version)
+
+### TODO 
+
+- Complete the architecture set from the officially supported compilers.
+- Add more features to the opam variants list (such as `Since.safe_string`)
+- Generate the core opam compiler package set purely from this library, so that
+  it remains in sync with the library description.

--- a/packages/ocaml-version/ocaml-version.0.1.0/opam
+++ b/packages/ocaml-version/ocaml-version.0.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-version"
+doc: "http://docs.mirage.io/ocaml-version"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-version.git"
+bug-reports: "https://github.com/avsm/ocaml-version/issues"
+tags: ["org:ocamllabs"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/ocaml-version/ocaml-version.0.1.0/url
+++ b/packages/ocaml-version/ocaml-version.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-version/releases/download/v0.1.0/ocaml-version-0.1.0.tbz"
+checksum: "e9356166a4c10e31ca65acad0ccc517f"


### PR DESCRIPTION
This library provides facilities to parse version numbers of the OCaml
compiler, and enumerates the various official OCaml releases and configuration
variants.

OCaml version numbers are of the form `major.minor.patch+extra`, where the
`patch` and `extra` fields are optional.  This library offers the following
functionality:

- Functions to parse and serialise OCaml compiler version numbers.
- Enumeration of official OCaml compiler version releases.
- Test compiler versions for a particular feature (e.g. the `bytes` type)
- [opam](https://opam.ocaml.org) compiler switch enumeration.