### PR TITLE
+dockerfile.4.0.0

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.4.0.0/descr
+++ b/packages/dockerfile-cmd/dockerfile-cmd.4.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile-cmd/dockerfile-cmd.4.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.4.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "dockerfile-opam" {>="3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "csv"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile-cmd/dockerfile-cmd.4.0.0/url
+++ b/packages/dockerfile-cmd/dockerfile-cmd.4.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v4.0.0/dockerfile-4.0.0.tbz"
+checksum: "816592094fbe1186573ef727f6af50f2"

--- a/packages/dockerfile-opam/dockerfile-opam.4.0.0/descr
+++ b/packages/dockerfile-opam/dockerfile-opam.4.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile-opam/dockerfile-opam.4.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.4.0.0/opam
@@ -13,6 +13,10 @@ depends: [
   "dockerfile" {>="3.0.0"}
   "ocaml-version"
   "cmdliner"
+  "astring"
+  "sexplib"
+  "fmt"
+  "cmdliner"
 ]
 build: [
   ["jbuilder" "subst" "-p" name "--name" name] {pinned}

--- a/packages/dockerfile-opam/dockerfile-opam.4.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.4.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "dockerfile" {>="3.0.0"}
+  "ocaml-version"
+  "cmdliner"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile-opam/dockerfile-opam.4.0.0/url
+++ b/packages/dockerfile-opam/dockerfile-opam.4.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v4.0.0/dockerfile-4.0.0.tbz"
+checksum: "816592094fbe1186573ef727f6af50f2"

--- a/packages/dockerfile/dockerfile.4.0.0/descr
+++ b/packages/dockerfile/dockerfile.4.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile/dockerfile.4.0.0/opam
+++ b/packages/dockerfile/dockerfile.4.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "sexplib"
+  "base-bytes"
+  "fmt"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile/dockerfile.4.0.0/url
+++ b/packages/dockerfile/dockerfile.4.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v4.0.0/dockerfile-4.0.0.tbz"
+checksum: "816592094fbe1186573ef727f6af50f2"


### PR DESCRIPTION
Major API iteration to:

- switch to multistage container builds for smaller containers
- instead of separate `ocaml` and `opam` containers, just generate
  a single `opam` one which can optionally have the system compiler
  or a locally compiled one.
- explicitly support aliases for distributions, and allow older
  distributions to be marked as deprecated.

Other changes:
* Update OPAM 2 build mechanism to use `make cold`.
* Drop support for opam1 containers; use an older library version for those.
* Also mark OCaml 4.05.0 and 4.06.0 as a mainline release for opam2 as well.