### PR TITLE
Package msat.0.6.1

### DIFF
--- a/packages/msat/msat.0.6.1/descr
+++ b/packages/msat/msat.0.6.1/descr
@@ -1,0 +1,8 @@
+Modular sat/smt solver
+
+This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
+- proof output
+- push/pop operations
+- CNF transformation tools
+
+This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.

--- a/packages/msat/msat.0.6.1/opam
+++ b/packages/msat/msat.0.6.1/opam
@@ -16,9 +16,9 @@ build: [
   [make "disable_log"]
   [make "lib"]
 ]
-install: [make "DOCDIR=%{msat:doc}%" "install"]
+install: [make "DOCDIR=%{doc}%" "install"]
 build-doc: [make "doc"]
-remove: [make "DOCDIR=%{msat:doc}%" "uninstall"]
+remove: [make "DOCDIR=%{doc}%" "uninstall"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/msat/msat.0.6.1/opam
+++ b/packages/msat/msat.0.6.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes@inria.fr"]
+authors: [
+  "Sylvain Conchon"
+  "Alain Mebsout"
+  "Stephane Lecuyer"
+  "Simon Cruanes"
+  "Guillaume Bury"
+]
+homepage: "https://github.com/Gbury/mSAT"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+license: "Apache"
+tags: ["sat" "smt"]
+dev-repo: "https://github.com/Gbury/mSAT.git"
+build: [
+  [make "disable_log"]
+  [make "lib"]
+]
+install: [make "DOCDIR=%{msat:doc}%" "install"]
+build-doc: [make "doc"]
+remove: [make "DOCDIR=%{msat:doc}%" "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.00.1"]

--- a/packages/msat/msat.0.6.1/url
+++ b/packages/msat/msat.0.6.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gbury/msat/archive/v0.6.1.tar.gz"
+checksum: "1415cd7d2a2ccd04c630900b161199b0"


### PR DESCRIPTION
### `msat.0.6.1`

Modular sat/smt solver

This library provides functor to easily build a SAT, SMT and/or McSAT solver given an implementation of terms. Current features of the solver are:
- proof output
- push/pop operations
- CNF transformation tools

This project derives from [Alt-Ergo Zero](http://cubicle.lri.fr/alt-ergo-zero), but does not provide any built-in theories, it is designed to let the users use their own implementation of terms and theories.



---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them: "msat"

---

:camel: Pull-request generated by opam-publish v0.3.5