### PR TITLE
Update Ubuntu depexts for conf-neko

### DIFF
--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -8,7 +8,7 @@ license: ["MIT"]
 build: [["neko" "-version"]]
 depexts: [
   [["alpine"] ["neko-dev"]]
-  [["debian"] ["neko-dev"]]
+  [["debian"] ["neko" "neko-dev"]]
   [["ubuntu"] ["neko" "neko-dev"]]
   [["fedora"] ["nekovm-devel"]]
   [["nixpkgs"] ["neko"]]

--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -9,7 +9,7 @@ build: [["neko" "-version"]]
 depexts: [
   [["alpine"] ["neko-dev"]]
   [["debian"] ["neko-dev"]]
-  [["ubuntu"] ["neko-dev"]]
+  [["ubuntu"] ["neko" "neko-dev"]]
   [["fedora"] ["nekovm-devel"]]
   [["nixpkgs"] ["neko"]]
   [["homebrew" "osx"] ["neko"]]


### PR DESCRIPTION
It seems both `neko` and `neko-dev` are needed.

cc @andyli