### PR TITLE
Package service-registry.0.1.0

### DIFF
--- a/packages/service-registry/service-registry.0.1.0/descr
+++ b/packages/service-registry/service-registry.0.1.0/descr
@@ -1,0 +1,4 @@
+Short
+A simple service registry 
+Long
+A modular and extensible service registry using Irmin for persistence

--- a/packages/service-registry/service-registry.0.1.0/opam
+++ b/packages/service-registry/service-registry.0.1.0/opam
@@ -1,0 +1,22 @@
+version: "0.1.0"
+opam-version: "1.2"
+maintainer: "Samuel Riyad"
+authors: ["Samuel Riyad"]
+tags: []
+license: "MIT"
+homepage: "https://github.com/XnuKernPoll/service-registry"
+dev-repo: "https://github.com/XnuKernPoll/service-registry.git"
+bug-reports: "https://github.com/XnuKernPoll/service-registry/issues"
+             
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "ounit" {test}
+  "irmin-unix"
+  "batteries"
+  "uuidm"
+  "cmdliner"
+]

--- a/packages/service-registry/service-registry.0.1.0/url
+++ b/packages/service-registry/service-registry.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/XnuKernPoll/service-registry/archive/0.1.0.tar.gz"
+checksum: "3d56893c4598d59b51294d7cffa58fb0"


### PR DESCRIPTION
### `service-registry.0.1.0`

Short
A simple service registry 
Long
A modular and extensible service registry using Irmin for persistence



---
* Homepage: https://github.com/XnuKernPoll/service-registry
* Source repo: https://github.com/XnuKernPoll/service-registry.git
* Bug tracker: https://github.com/XnuKernPoll/service-registry/issues

---
### opam-lint failures
- **WARNING** 99 should not contain 'name' or 'version' fields

---

:camel: Pull-request generated by opam-publish v0.3.5