### PR TITLE
Update lwt_glib metadata

### DIFF
--- a/packages/lwt_glib/lwt_glib.1.1.0/opam
+++ b/packages/lwt_glib/lwt_glib.1.1.0/opam
@@ -8,10 +8,10 @@ maintainer: [
 authors: [
   "Jérémie Dimino"
 ]
-homepage: "https://github.com/ocsigen/lwt"
-doc: "https://ocsigen.org/lwt/manual/"
-dev-repo: "https://github.com/ocsigen/lwt.git"
-bug-reports: "https://github.com/ocsigen/lwt/issues"
+homepage: "https://github.com/aantron/lwt_glib"
+doc: "https://github.com/aantron/lwt_glib/blob/master/src/lwt_glib.mli"
+dev-repo: "https://github.com/aantron/lwt_glib.git"
+bug-reports: "https://github.com/aantron/lwt_glib/issues"
 license: "LGPL with OpenSSL linking exception"
 
 build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]


### PR DESCRIPTION
Lwt_glib was factored out of the Lwt repo in https://github.com/ocsigen/lwt/pull/524, and now lives in [aantron/lwt_glib](https://github.com/aantron/lwt_glib).

This commit updates the `dev-repo`, `doc`, etc., links in the most recent release of package `lwt_glib` to point to the new repo. The links now match the current content of [`lwt_glib.opam`](https://github.com/aantron/lwt_glib/blob/master/lwt_glib.opam).

By the way, if anyone needs access to the new repo, or the new repo should be transferred to any other user or organization, please let me know.