### PR TITLE
fix amqp-client constraints on async

### DIFF
--- a/packages/amqp-client/amqp-client.1.0.5/opam
+++ b/packages/amqp-client/amqp-client.1.0.5/opam
@@ -22,6 +22,6 @@ depopts: [
 ]
 conflicts: [
   "lwt" {< "2.4.6"}
-  "async" {<"v0.9" & > "v0.10"}
+  "async" {<"v0.9" & >= "v0.10"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/amqp-client/amqp-client.1.0.6/opam
+++ b/packages/amqp-client/amqp-client.1.0.6/opam
@@ -22,6 +22,6 @@ depopts: [
 ]
 conflicts: [
   "lwt" {< "2.4.6"}
-  "async" {<"v0.9" & > "v0.10"}
+  "async" {<"v0.9" & >= "v0.10"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/amqp-client/amqp-client.1.1.0/opam
+++ b/packages/amqp-client/amqp-client.1.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder" {build}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
-  "async" {test & < "v0.10"}
+  "async" {test}
   "lwt" {test}
 ]
 depopts: [
@@ -20,6 +20,7 @@ depopts: [
   "lwt"
 ]
 conflicts: [
+  "async" {>= "v0.10" }
   "lwt" {< "2.4.6"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/amqp-client/amqp-client.1.1.1/opam
+++ b/packages/amqp-client/amqp-client.1.1.1/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder" {build}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
-  "async" {test & < "v0.10"}
+  "async" {test}
   "lwt" {test}
 ]
 depopts: [
@@ -20,6 +20,7 @@ depopts: [
   "lwt"
 ]
 conflicts: [
+  "async" {>= "v0.10" }
   "lwt" {< "2.4.6"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/amqp-client/amqp-client.1.1.2/opam
+++ b/packages/amqp-client/amqp-client.1.1.2/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder" {build}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
-  "async" {test & < "v0.10"}
+  "async" {test}
   "lwt" {test}
 ]
 depopts: [
@@ -20,6 +20,7 @@ depopts: [
   "lwt"
 ]
 conflicts: [
+  "async" {>= "v0.10" }
   "lwt" {< "2.4.6"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/amqp-client/amqp-client.1.1.3/opam
+++ b/packages/amqp-client/amqp-client.1.1.3/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder" {build}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
-  "async" {test & < "v0.10" }
+  "async" {test}
   "lwt" {test}
 ]
 depopts: [
@@ -20,6 +20,7 @@ depopts: [
   "lwt"
 ]
 conflicts: [
+  "async" {>= "v0.10" }
   "lwt" {< "2.4.6"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/amqp-client/amqp-client.1.1.4/opam
+++ b/packages/amqp-client/amqp-client.1.1.4/opam
@@ -11,11 +11,12 @@ depends: [
   "jbuilder" {build}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
-  "async" {test & < "v0.10" }
+  "async" {test}
   "lwt" {test}
 ]
 depopts: ["async" "lwt"]
 conflicts: [
+  "async" {>= "v0.10" }
   "lwt" {< "2.4.6"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
@jpdeplaix said:
> There is still a problem on amqp-client (the constraint is not set for the depopt, it should go to the constraints field)

Should now be OK.

(PS: I don't really understand the pattern where a dep is both in depends and depots and then the constraints are in conflict and bllbblblbl...)