### PR TITLE
rpc: update opam file of v2.0.0 and release v.2.2.0

### DIFF
--- a/packages/rpc/rpc.2.0.0/opam
+++ b/packages/rpc/rpc.2.0.0/opam
@@ -9,7 +9,6 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  [configure]
   [make]
 ]
 install: [
@@ -34,6 +33,8 @@ depends: [
   "lwt"
   "cmdliner"
   "rresult"
-  "async"
+  "async" {< "v0.10.0"}
 ]
 depopts: [ "js_of_ocaml" ]
+available: [ ocamlversion < "4.06.0" ]
+

--- a/packages/rpc/rpc.2.0.0/opam
+++ b/packages/rpc/rpc.2.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "thomas@gazagnaire.org"
+maintainer: "xen-api@list.xen.org"
 authors: "Thomas Gazagnaire, Jon Ludlam"
 homepage: "https://github.com/mirage/ocaml-rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"

--- a/packages/rpc/rpc.2.2.0/descr
+++ b/packages/rpc/rpc.2.2.0/descr
@@ -1,6 +1,6 @@
 A library to deal with RPCs in OCaml
 
-This library provides a PPX and a camlp4 syntax extension to generate functions
+This library provides a PPX and a deprecated camlp4 syntax extension to generate functions
 to convert values of a given type to and from their RPC representations. In
 order to do so, it is sufficient to add `[@@deriving rpc]` (or `with rpc` in
 case of camlp4) to the corresponding type definition.

--- a/packages/rpc/rpc.2.2.0/descr
+++ b/packages/rpc/rpc.2.2.0/descr
@@ -1,0 +1,6 @@
+A library to deal with RPCs in OCaml
+
+This library provides a PPX and a camlp4 syntax extension to generate functions
+to convert values of a given type to and from their RPC representations. In
+order to do so, it is sufficient to add `[@@deriving rpc]` (or `with rpc` in
+case of camlp4) to the corresponding type definition.

--- a/packages/rpc/rpc.2.2.0/opam
+++ b/packages/rpc/rpc.2.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+homepage: "https://github.com/mirage/ocaml-rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "rpclib"]
+  ["ocamlfind" "remove" "ppx_deriving_rpc"]
+]
+build-test: [
+    [make]
+    [make "test"]
+]
+depends: [
+  "oasis" {build}
+  "cppo"  {build}
+  "async" {< "v0.10.0"}
+  "cmdliner"
+  "cow"
+  "lwt"
+  "ocamlfind"
+  "ppx_deriving"
+  "rresult"
+  "type_conv" {>= "108.07.01"}
+  "xmlm"
+  "yojson"
+]
+depopts: [ "js_of_ocaml" ]
+available: [ ocaml-version < "4.06.0"]
+

--- a/packages/rpc/rpc.2.2.0/opam
+++ b/packages/rpc/rpc.2.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "thomas@gazagnaire.org"
+maintainer: "xen-api@list.xen.org"
 authors: "Thomas Gazagnaire, Jon Ludlam"
 homepage: "https://github.com/mirage/ocaml-rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"

--- a/packages/rpc/rpc.2.2.0/url
+++ b/packages/rpc/rpc.2.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-rpc/archive/v2.2.0.tar.gz"
+checksum: "5eb085431917bed5a4f4c3293db774b6"


### PR DESCRIPTION
The new release includes the following changes:

* Remove warnings by extending pattern matches in {cmdliner,markdown}gen
* Redefined  with a safer interface
* Add a way to explicitly mark a tuple list as a dict
* Allow the use ocamldoc tags rather than [@doc ...]
* Add an 'abstract' typ.
* Deprecate xmlrpc from/to char producers
* Deprecate jsonrpc from/to char producers
* Port the jsonrpc module to yojson
* Add defaults for polymorphic variants
