### PR TITLE
Package containers.1.5.1

### DIFF
--- a/packages/containers/containers.1.5.1/descr
+++ b/packages/containers/containers.1.5.1/descr
@@ -1,0 +1,12 @@
+A modular, clean and powerful extension of the OCaml standard library.
+
+Containers is an extension of OCaml's standard library (under BSD license)
+focused on data structures, combinators and iterators, without dependencies on
+unix, str or num. Every module is independent and is prefixed with 'CC' in the
+global namespace. Some modules extend the stdlib (e.g. CCList provides safe
+map/fold_right/append, and additional functions on lists).
+Alternatively, `open Containers` will bring enhanced versions of the standard
+modules into scope.
+
+It also features sub-libraries for dealing with threads, S-expressions,
+and the intricacies of unix.

--- a/packages/containers/containers.1.5.1/opam
+++ b/packages/containers/containers.1.5.1/opam
@@ -1,0 +1,44 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes@inria.fr"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+doc: "http://cedeela.fr/~simon/software/containers/"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+dev-repo: "https://github.com/c-cube/ocaml-containers.git"
+build: [
+  [
+    "./configure"
+    "--prefix"
+    prefix
+    "--disable-bench"
+    "--disable-tests"
+    "--%{base-unix:enable}%-unix"
+    "--enable-docs"
+  ]
+  [make "build"]
+]
+install: [make "install"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+remove: ["ocamlfind" "remove" "containers"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "result"
+  "ocamlbuild" {build}
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+  "qtest" {test}
+]
+conflicts: [
+  "sequence" {< "0.5"}
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages:
+  "Release with a few new functions which closes many issues and provides better retro-compatibility with the stdlib.
+
+changelog: https://github.com/c-cube/ocaml-containers/blob/1.5/CHANGELOG.adoc
+  "

--- a/packages/containers/containers.1.5.1/url
+++ b/packages/containers/containers.1.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-containers/archive/1.5.1.tar.gz"
+checksum: "33b76302a84c6def8e050a11d1096fbf"


### PR DESCRIPTION
### `containers.1.5.1`

A modular, clean and powerful extension of the OCaml standard library.

Containers is an extension of OCaml's standard library (under BSD license)
focused on data structures, combinators and iterators, without dependencies on
unix, str or num. Every module is independent and is prefixed with 'CC' in the
global namespace. Some modules extend the stdlib (e.g. CCList provides safe
map/fold_right/append, and additional functions on lists).
Alternatively, `open Containers` will bring enhanced versions of the standard
modules into scope.

It also features sub-libraries for dealing with threads, S-expressions,
and the intricacies of unix.



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---

:camel: Pull-request generated by opam-publish v0.3.5