### PR TITLE
Package cohttp-mirage.1.0.1

### DIFF
--- a/packages/cohttp-mirage/cohttp-mirage.1.0.1/descr
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.1/descr
@@ -1,0 +1,26 @@
+An OCaml library for HTTP clients and servers
+
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](http://ocsigen.org/lwt) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](http://www.openmirage.org) interface
+  to generate standalone microkernels use the cohttp-mirage subpackage.
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+   calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+   the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value.

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Gazagnaire"
+]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "result"
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
+  "conduit" {>= "0.99"}
+  "mirage-conduit" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp"
+  "cohttp-lwt"
+  "astring"
+  "magic-mime"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.1/url
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cohttp/releases/download/v1.0.1/cohttp-1.0.1.tbz"
+checksum: "19ee89dc3e2b4b648f2c0e732930d3a3"


### PR DESCRIPTION
### `cohttp-mirage.1.0.1`

An OCaml library for HTTP clients and servers

[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

Cohttp is an OCaml library for creating HTTP daemons. It has a portable
HTTP parser, and implementations using various asynchronous programming
libraries:

* `Cohttp_lwt_unix` uses the [Lwt](http://ocsigen.org/lwt) library, and
  specifically the UNIX bindings.
* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
  library.
* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
  by the [Mirage](http://www.openmirage.org) interface
  to generate standalone microkernels use the cohttp-mirage subpackage.
* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
   calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
   the GitHub bindings to JavaScript and still run efficiently.

You can implement other targets using the parser very easily. Look at the `IO`
signature in `lib/s.mli` and implement that in the desired backend.

You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
value, and all requests and responses will be written to stderr.  Further
debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
to any value.


---
* Homepage: https://github.com/mirage/ocaml-cohttp
* Source repo: https://github.com/mirage/ocaml-cohttp.git
* Bug tracker: https://github.com/mirage/ocaml-cohttp/issues

---


---
## v1.0.1 (2018-01-03)

* cohttp-mirage: expose the missing IO module (#594, @samoht)
* cohttp-mirage: catch exceptions when closing channels in mirage client
  (#589, @ansiwen)
:camel: Pull-request generated by opam-publish v0.3.5