### PR TITLE
Package conf-netsnmp.1.0.0

### DIFF
--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/descr
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/descr
@@ -1,0 +1,5 @@
+Package relying on net-snmp libs
+
+Virtual package relying on net-snmp system libraries installation.
+This package can only install if the net-snmp lib and development packages
+are installed on the system.

--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Steve Bleazard <stevebleazard@googlemail.com>"
+authors: "Steve Bleazard <stevebleazard@googlemail.com>"
+homepage: "https://www.github.com/stevebleazard/ocaml-conf-netsnmp"
+bug-reports: "https://www.github.com/stevebleazard/ocaml-conf-netsnmp/issues"
+license: "MIT"
+dev-repo: "https://www.github.com/stevebleazard/ocaml-conf-netsnmp.git"
+
+depexts: [
+  [["debian"] ["libsnmp-dev"]]
+  [["ubuntu"] ["libsnmp-dev"]]
+  [["centos"] ["net-snmp-libs" "net-snmp-devel"]]
+  [["fedora"] ["net-snmp-libs" "net-snmp-devel"]]
+  [["opensuse"] ["libsnmp30" "net-snmp-devel"]]
+  [["alpine"] ["net-snmp-libs" "net-snmp-dev"]]
+  [["freebsd"] [ ]]
+  [["openbsd"] [ ]]
+]
+
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include files/test.c"]
+]
+
+available: [ os != "darwin" ]

--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/url
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://www.github.com/stevebleazard/ocaml-conf-netsnmp/releases/download/v1.0.0/conf-netsnmp-1.0.0.tbz"
+checksum: "b7182d9bed4e50b2c7fc94b4a1a303d3"


### PR DESCRIPTION
### `conf-netsnmp.1.0.0`

Package relying on net-snmp libs

Virtual package relying on net-snmp system libraries installation.
This package can only install if the net-snmp lib and development packages
are installed on the system.


---
* Homepage: https://www.github.com/stevebleazard/ocaml-conf-netsnmp
* Source repo: https://www.github.com/stevebleazard/ocaml-conf-netsnmp.git
* Bug tracker: https://www.github.com/stevebleazard/ocaml-conf-netsnmp/issues

---


---
# v1.0.0

- Initial release
:camel: Pull-request generated by opam-publish v0.3.5