### PR TITLE
Package git-http.1.11.4

### DIFF
--- a/packages/git-http/git-http.1.11.4/descr
+++ b/packages/git-http/git-http.1.11.4/descr
@@ -1,0 +1,1 @@
+Client implementation of the "Smart" HTTP Git protocol in pure OCaml

--- a/packages/git-http/git-http.1.11.4/opam
+++ b/packages/git-http/git-http.1.11.4/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder"   {build}
+  "git"        {>= "1.11.0"}
+  "cohttp-lwt" {>= "1.0.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-http/git-http.1.11.4/url
+++ b/packages/git-http/git-http.1.11.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.4/git-1.11.4.tbz"
+checksum: "8996056ecacbc5bbdd226a3708f11232"


### PR DESCRIPTION
### `git-http.1.11.4`

Client implementation of the "Smart" HTTP Git protocol in pure OCaml



---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
### 1.11.4 (2018-01-03)

- support cohttp 1.0 (#249, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5