### PR TITLE
Package git-mirage.1.11.4

### DIFF
--- a/packages/git-mirage/git-mirage.1.11.4/descr
+++ b/packages/git-mirage/git-mirage.1.11.4/descr
@@ -1,0 +1,1 @@
+MirageOS backend for the Git protocol(s)

--- a/packages/git-mirage/git-mirage.1.11.4/opam
+++ b/packages/git-mirage/git-mirage.1.11.4/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "test/git-mirage"]
+
+depends: [
+  "jbuilder" {build}
+  "cohttp-mirage" {>= "1.0.1"}
+  "mirage-flow-lwt"
+  "mirage-channel-lwt"
+  "mirage-fs-lwt"
+  "mirage-conduit" {>= "3.0.0"}
+  "result"
+  "git-http" {>= "1.11.0"}
+  "git"      {>= "1.11.0"}
+  "alcotest"       {test}
+  "mtime"          {test & >= "1.0.0"}
+  "mirage-fs-unix" {test & >= "1.3.0"}
+  "nocrypto"       {test & >= "0.5.4"}
+  "io-page"        {test & >= "1.6.1"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-mirage/git-mirage.1.11.4/url
+++ b/packages/git-mirage/git-mirage.1.11.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.4/git-1.11.4.tbz"
+checksum: "8996056ecacbc5bbdd226a3708f11232"


### PR DESCRIPTION
### `git-mirage.1.11.4`

MirageOS backend for the Git protocol(s)



---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
### 1.11.4 (2018-01-03)

- support cohttp 1.0 (#249, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5