### PR TITLE
Package git-unix.1.11.4

### DIFF
--- a/packages/git-unix/git-unix.1.11.4/descr
+++ b/packages/git-unix/git-unix.1.11.4/descr
@@ -1,0 +1,5 @@
+Unix backend for the Git protocol(s)
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git-unix/git-unix.1.11.4/opam
+++ b/packages/git-unix/git-unix.1.11.4/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "test/git-unix"]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "logs"
+  "git-http" {>= "1.11.0"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "cohttp-lwt-unix"  {>= "1.0.0"}
+  "nocrypto" {>= "0.2.0"}
+  "mtime"    {>= "1.0.0"}
+  "base-unix"
+  "alcotest" {test}
+  "io-page"  {test & >= "1.6.1"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-unix/git-unix.1.11.4/url
+++ b/packages/git-unix/git-unix.1.11.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.4/git-1.11.4.tbz"
+checksum: "8996056ecacbc5bbdd226a3708f11232"


### PR DESCRIPTION
### `git-unix.1.11.4`

Unix backend for the Git protocol(s)

The library comes with a command-line tool called `ogit` which shares
a similar interface with `git`, but where all operations are mapped to
the API exposed `ocaml-git` (and hence using only OCaml code).



---
* Homepage: https://github.com/mirage/ocaml-git
* Source repo: https://github.com/mirage/ocaml-git.git
* Bug tracker: https://github.com/mirage/ocaml-git/issues

---


---
### 1.11.4 (2018-01-03)

- support cohttp 1.0 (#249, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5