### PR TITLE
Package irmin-http.1.3.3

### DIFF
--- a/packages/irmin-http/irmin-http.1.3.3/descr
+++ b/packages/irmin-http/irmin-http.1.3.3/descr
@@ -1,0 +1,1 @@
+HTTP client and server for Irmin

--- a/packages/irmin-http/irmin-http.1.3.3/opam
+++ b/packages/irmin-http/irmin-http.1.3.3/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "crunch"
+  "webmachine" {>= "0.3.2"}
+  "irmin"  {>= "1.3.0"}
+  "cohttp-lwt" {>= "1.0.0"}
+  "irmin-git" {test & >= "1.3.0"}
+  "irmin-mem" {test & >= "1.3.0"}
+  "alcotest"  {test}
+  "mtime"     {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-http/irmin-http.1.3.3/url
+++ b/packages/irmin-http/irmin-http.1.3.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.3/irmin-1.3.3.tbz"
+checksum: "f21fd211aaa5126588e90661c0d7f0b1"


### PR DESCRIPTION
### `irmin-http.1.3.3`

HTTP client and server for Irmin



---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
### 1.3.3 (2018-01-03)

- complete support for OCaml 4.06 (#484, @samoht)
- support cohttp 1.0 (#484, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5