### PR TITLE
Package irmin-unix.1.3.3

### DIFF
--- a/packages/irmin-unix/irmin-unix.1.3.3/descr
+++ b/packages/irmin-unix/irmin-unix.1.3.3/descr
@@ -1,0 +1,5 @@
+Unix backends for Irmin
+
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.

--- a/packages/irmin-unix/irmin-unix.1.3.3/opam
+++ b/packages/irmin-unix/irmin-unix.1.3.3/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder"   {build & >= "1.0+beta10"}
+  "irmin"      {>= "1.3.0"}
+  "irmin-mem"  {>= "1.3.0"}
+  "irmin-git"  {>= "1.3.0"}
+  "irmin-http" {>= "1.3.0"}
+  "irmin-fs"   {>= "1.3.0"}
+  "git-unix"   {>= "1.11.4"}
+  "irmin-watcher" {>= "0.2.0"}
+  "alcotest" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-unix/irmin-unix.1.3.3/url
+++ b/packages/irmin-unix/irmin-unix.1.3.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.3.3/irmin-1.3.3.tbz"
+checksum: "f21fd211aaa5126588e90661c0d7f0b1"


### PR DESCRIPTION
### `irmin-unix.1.3.3`

Unix backends for Irmin

`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
stores.


---
* Homepage: https://github.com/mirage/irmin
* Source repo: https://github.com/mirage/irmin.git
* Bug tracker: https://github.com/mirage/irmin/issues

---


---
### 1.3.3 (2018-01-03)

- complete support for OCaml 4.06 (#484, @samoht)
- support cohttp 1.0 (#484, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5