### PR TITLE
rpc 2.0.0: fix typo in opam-version

### DIFF
--- a/packages/rpc/rpc.2.0.0/opam
+++ b/packages/rpc/rpc.2.0.0/opam
@@ -36,5 +36,5 @@ depends: [
   "async" {< "v0.10.0"}
 ]
 depopts: [ "js_of_ocaml" ]
-available: [ ocamlversion < "4.06.0" ]
+available: [ ocaml-version < "4.06.0" ]
 


### PR DESCRIPTION
Sorry about this. I am a bit surprised that the linter and the tests didn't notice it.