### PR TITLE
Lwt_ssl 1.1.2 – concurrent OpenSSL binding

### DIFF
--- a/packages/lwt_ssl/lwt_ssl.1.1.2/descr
+++ b/packages/lwt_ssl/lwt_ssl.1.1.2/descr
@@ -1,0 +1,1 @@
+OpenSSL binding with concurrent I/O

--- a/packages/lwt_ssl/lwt_ssl.1.1.2/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.2/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+
+version: "1.1.2"
+homepage: "https://github.com/aantron/lwt_ssl"
+doc: "https://github.com/aantron/lwt_ssl/blob/master/src/lwt_ssl.mli"
+bug-reports: "https://github.com/aantron/lwt_ssl/issues"
+license: "LGPL with OpenSSL linking exception"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "https://github.com/aantron/lwt_ssl.git"
+
+depends: [
+  "base-unix"
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "3.0.0"}
+  "ssl" {>= "0.5.0"}
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_ssl/lwt_ssl.1.1.2/url
+++ b/packages/lwt_ssl/lwt_ssl.1.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/aantron/lwt_ssl/archive/1.1.2.tar.gz"
+checksum: "d239353b1e7c6e3fd4192c71a3b25ce2"


### PR DESCRIPTION
Lwt_ssl is a concurrent, Lwt-friendly wrapper around OCaml-SSL (package `ssl`), itself a binding to the famous OpenSSL.

This release contains one [bugfix](https://github.com/aantron/lwt_ssl/releases/tag/1.1.2):

> - Actually put sockets into non-blocking mode on recent Lwt (ocsigen/lwt#530, reported Romain Slootmaekers).

It is also the first release from Lwt_ssl's new home at [aantron/lwt_ssl](https://github.com/aantron/lwt_ssl).

cc @toolslive