### PR TITLE
Package mariadb.1.0.1

### DIFF
--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -5,7 +5,7 @@ homepage: "https://mariadb.org/"
 bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
 dev-repo: "https://github.com/MariaDB/server.git"
 license: "GPL2"
-build: [["mysql_config" "--include"]]
+build: [["mariadb_config" "--include"]]
 depexts: [
   [["debian"] ["libmariadb-dev"]]
   [["ubuntu"] ["libmariadb-dev"]]

--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -7,8 +7,8 @@ dev-repo: "https://github.com/MariaDB/server.git"
 license: "GPL2"
 build: [["mysql_config" "--include"]]
 depexts: [
-  [["debian"] ["libmariadbclient-dev"]]
-  [["ubuntu"] ["libmariadbclient-dev"]]
+  [["debian"] ["libmariadb-dev"]]
+  [["ubuntu"] ["libmariadb-dev"]]
   [["centos"] ["mariadb-devel"]]
   [["osx" "homebrew"] ["mariadb-connector-c"]]
   [["alpine"] ["mariadb-dev"]]

--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -5,7 +5,10 @@ homepage: "https://mariadb.org/"
 bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
 dev-repo: "https://github.com/MariaDB/server.git"
 license: "GPL2"
-build: [["mariadb_config" "--include"]]
+build: [
+  ["mariadb_config" "--include"] {os != "alpine"}
+  ["mysql_config" "--include"] {os = "alpine"}
+]
 depexts: [
   [["debian"] ["libmariadb-dev"]]
   [["ubuntu"] ["libmariadb-dev"]]

--- a/packages/mariadb/mariadb.1.0.1/descr
+++ b/packages/mariadb/mariadb.1.0.1/descr
@@ -1,0 +1,4 @@
+OCaml bindings for MariaDB
+
+OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its
+nonblocking API.

--- a/packages/mariadb/mariadb.1.0.1/opam
+++ b/packages/mariadb/mariadb.1.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/ocaml-mariadb"
+bug-reports: "https://github.com/andrenth/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-mariadb.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "mariadb"]
+  ["ocamlfind" "remove" "mariadb_bindings"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ctypes" {>= "0.7.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+depexts: [
+  [["debian"] ["libmariadb-dev"]]
+  [["ubuntu"] ["libmariadb-dev"]]
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/mariadb/mariadb.1.0.1/opam
+++ b/packages/mariadb/mariadb.1.0.1/opam
@@ -18,6 +18,5 @@ depends: [
   "ocamlfind" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
-  "conf-mariadb"
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mariadb/mariadb.1.0.1/opam
+++ b/packages/mariadb/mariadb.1.0.1/opam
@@ -19,8 +19,4 @@ depends: [
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]
-depexts: [
-  [["debian"] ["libmariadb-dev"]]
-  [["ubuntu"] ["libmariadb-dev"]]
-]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mariadb/mariadb.1.0.1/opam
+++ b/packages/mariadb/mariadb.1.0.1/opam
@@ -18,5 +18,6 @@ depends: [
   "ocamlfind" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
+  "conf-mariadb"
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mariadb/mariadb.1.0.1/url
+++ b/packages/mariadb/mariadb.1.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-mariadb/archive/1.0.1.tar.gz"
+checksum: "26cd5c04ad3f8bf107a37919f74b97ef"


### PR DESCRIPTION
### `mariadb.1.0.1`

OCaml bindings for MariaDB

OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its
nonblocking API.



---
* Homepage: https://github.com/andrenth/ocaml-mariadb
* Source repo: https://github.com/andrenth/ocaml-mariadb.git
* Bug tracker: https://github.com/andrenth/ocaml-mariadb/issues

---

:camel: Pull-request generated by opam-publish v0.3.5