### PR TITLE
Package flow_parser.0.62.0

### DIFF
--- a/packages/flow_parser/flow_parser.0.62.0/descr
+++ b/packages/flow_parser/flow_parser.0.62.0/descr
@@ -1,0 +1,5 @@
+The Flow parser is a JavaScript parser written in OCaml
+
+It produces an AST that conforms to ESTree. The Flow Parser can be compiled to native code or can be compiled to JavaScript using js_of_ocaml.
+
+To find out more about Flow, check out <https://flow.org>.

--- a/packages/flow_parser/flow_parser.0.62.0/opam
+++ b/packages/flow_parser/flow_parser.0.62.0/opam
@@ -19,6 +19,7 @@ remove: ["ocamlfind" "remove" "flow_parser"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "dtoa"
   "sedlex"
   "wtf8"
 ]

--- a/packages/flow_parser/flow_parser.0.62.0/opam
+++ b/packages/flow_parser/flow_parser.0.62.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "gabe@fb.com"
+authors: [
+  "Avik Chaudhuri"
+  "Basil Hosmer"
+  "Gabe Levi"
+  "Jeff Morrison"
+  "Marshall Roch"
+  "Sam Goldman"
+  "James Kyle"
+]
+homepage: "https://github.com/facebook/flow/tree/master/src/parser"
+bug-reports: "https://github.com/facebook/flow/issues"
+license: "MIT"
+
+build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
+
+remove: ["ocamlfind" "remove" "flow_parser"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "sedlex"
+  "wtf8"
+]
+available: [ocaml-version >= "4.03.0"]
+dev-repo: "https://github.com/facebook/flow.git"

--- a/packages/flow_parser/flow_parser.0.62.0/url
+++ b/packages/flow_parser/flow_parser.0.62.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/facebook/flow/archive/v0.62.0.tar.gz"
+checksum: "64cf27ab1e1982e58ca04f2115475aa0"


### PR DESCRIPTION
### `flow_parser.0.62.0`

The Flow parser is a JavaScript parser written in OCaml

It produces an AST that conforms to ESTree. The Flow Parser can be compiled to native code or can be compiled to JavaScript using js_of_ocaml.

To find out more about Flow, check out <https://flow.org>.



---
* Homepage: https://github.com/facebook/flow/tree/master/src/parser
* Source repo: https://github.com/facebook/flow.git
* Bug tracker: https://github.com/facebook/flow/issues

---
### opam-lint failures
- **WARNING** 26 No field 'install', but a field 'remove': install instructions probably part of 'build'. Use the 'install' field or a .install file

---

:camel: Pull-request generated by opam-publish v0.3.5