### PR TITLE
Package gamepad.0.2.0

### DIFF
--- a/packages/gamepad/gamepad.0.2.0/descr
+++ b/packages/gamepad/gamepad.0.2.0/descr
@@ -1,0 +1,3 @@
+Bindings for the JS Gamepad API
+
+Using this and js_of_ocaml, you can use gamepads with OCaml in your browser.

--- a/packages/gamepad/gamepad.0.2.0/opam
+++ b/packages/gamepad/gamepad.0.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <me@emillon.org>"
+authors: "Etienne Millon <me@emillon.org>"
+homepage: "https://github.com/emillon/gamepad_of_ocaml"
+bug-reports: "https://github.com/emillon/gamepad_of_ocaml/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/emillon/gamepad_of_ocaml.git"
+doc: "https://emillon.github.io/gamepad_of_ocaml/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "lwt"
+  "lwt_ppx"
+  "js_of_ocaml-lwt" {>= "3.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+]

--- a/packages/gamepad/gamepad.0.2.0/url
+++ b/packages/gamepad/gamepad.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/emillon/gamepad_of_ocaml/releases/download/v0.2.0/gamepad-0.2.0.tbz"
+checksum: "48df2644612a86a24f84e54090c68dd7"


### PR DESCRIPTION
### `gamepad.0.2.0`

Bindings for the JS Gamepad API

Using this and js_of_ocaml, you can use gamepads with OCaml in your browser.



---
* Homepage: https://github.com/emillon/gamepad_of_ocaml
* Source repo: https://github.com/emillon/gamepad_of_ocaml.git
* Bug tracker: https://github.com/emillon/gamepad_of_ocaml/issues

---


---
## v0.2.0

*2018-01-07*

Build system / dependencies:

  - Use new split packages for `lwt` and `js_of_ocaml`. (#9)
  - Add builds for 4.05.0 and 4.06.0. (#10)
:camel: Pull-request generated by opam-publish v0.3.5