### PR TITLE
Add dbm 1.1

### DIFF
--- a/packages/dbm/dbm.1.1/descr
+++ b/packages/dbm/dbm.1.1/descr
@@ -1,0 +1,1 @@
+Binding to the NDBM/GDBM Unix "databases"

--- a/packages/dbm/dbm.1.1/files/include_local_fix.patch
+++ b/packages/dbm/dbm.1.1/files/include_local_fix.patch
@@ -1,0 +1,26 @@
+From 6c11b9255e5fc116714f7ee4fd3d7f9175b262f5 Mon Sep 17 00:00:00 2001
+From: Ion Alberdi <nolaridebi@gmail.com>
+Date: Mon, 8 May 2017 21:23:37 +0200
+Subject: [PATCH] Look for ndbm.h in /usr/local/include too
+
+In macOS 10.12.4
+% brew install gdbm --with-libgdbm-compat
+
+puts ndbm.h in /usr/local/include.
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 7786275..00b763f 100755
+--- a/configure
++++ b/configure
+@@ -42,7 +42,7 @@ dbm_include="not found"
+ dbm_link="not found"
+ dbm_defines=""
+ 
+-for dir in /usr/include /usr/include/db1 /usr/include/gdbm; do
++for dir in /usr/include /usr/include/db1 /usr/include/gdbm /usr/local/include; do
+   if test -f $dir/ndbm.h; then
+     dbm_include=$dir
+     if hasgot $dir ndbm.h; then

--- a/packages/dbm/dbm.1.1/opam
+++ b/packages/dbm/dbm.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Francois Rouaix"]
+homepage: "https://forge.ocamlcore.org/projects/camldbm/"
+license: "LGPL-v2 with OCaml linking exception"
+build: [
+  ["mkdir" "-p" "%{lib}%/dbm"]
+  ["./configure"]
+  [make "all"]
+  [make "test"]
+]
+depends: ["ocamlfind"]
+depexts: [
+  [["debian"] ["libgdbm-dev"]]
+  [["ubuntu"] ["libgdbm-dev"]]
+  [["nixpkgs"] ["gdbm"]]
+  [["centos"] ["gdbm-devel"]]
+  [["rhel"] ["gdbm-devel"]]
+  [["fedora"] ["gdbm-devel"]]
+  [["alpine"] ["gdbm-dev"]]
+  [["osx" "homebrew"] ["gdbm"]]
+]
+patches: [
+  "include_local_fix.patch"
+]
+install: [
+  [make "install" "STUBLIBDIR=%{lib}%/stublibs" "LIBDIR=%{lib}%/dbm"]
+  ["cp" "META" "%{lib}%/dbm"]
+]

--- a/packages/dbm/dbm.1.1/opam
+++ b/packages/dbm/dbm.1.1/opam
@@ -1,7 +1,9 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Francois Rouaix"]
-homepage: "https://forge.ocamlcore.org/projects/camldbm/"
+homepage: "https://github.com/ocaml/dbm"
+bug-reports: "https://github.com/ocaml/dbm/issues"
+dev-repo: "https://github.com/ocaml/dbm.git"
 license: "LGPL-v2 with OCaml linking exception"
 build: [
   ["mkdir" "-p" "%{lib}%/dbm"]
@@ -26,4 +28,8 @@ patches: [
 install: [
   [make "install" "STUBLIBDIR=%{lib}%/stublibs" "LIBDIR=%{lib}%/dbm"]
   ["cp" "META" "%{lib}%/dbm"]
+]
+remove: [
+  ["rm" "-f" "%{lib}%/stublibs/dllcamldbm.so"]
+  ["rm" "-f" "%{lib}%/dbm"]
 ]

--- a/packages/dbm/dbm.1.1/url
+++ b/packages/dbm/dbm.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dbm/archive/camldbm-1.1.tar.gz"
+checksum: "d21a65d7f744677e074600b938195630"


### PR DESCRIPTION
dbm 1.1 incorporates the previous patches from OPAM. Also, a new patch is added (https://github.com/ocaml/dbm/pull/2) that makes it possible to actually build on macOS, by looking into `/usr/local/include`. `/usr/include` is not possible to use on macOS because of SIP, and brew
installs gdbm into `/usr/local/include` anyway.