### PR TITLE
Fix camlp4 on non-natdynlink systems

### DIFF
--- a/packages/camlp4/camlp4.4.02+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.02+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.02+1/opam
+++ b/packages/camlp4/camlp4.4.02+1/opam
@@ -5,8 +5,8 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlfind"
@@ -25,6 +25,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.02") & (ocaml-version < "4.03") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.02+2/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.02+2/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.02+2/opam
+++ b/packages/camlp4/camlp4.4.02+2/opam
@@ -5,8 +5,8 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlfind"
@@ -25,6 +25,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.02") & (ocaml-version < "4.03") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.02+3/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.02+3/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.02+3/opam
+++ b/packages/camlp4/camlp4.4.02+3/opam
@@ -5,8 +5,8 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlfind"
@@ -25,6 +25,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.02") & (ocaml-version < "4.03") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.02+4/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.02+4/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.02+4/opam
+++ b/packages/camlp4/camlp4.4.02+4/opam
@@ -5,8 +5,8 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlfind"
@@ -25,6 +25,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.02") & (ocaml-version < "4.03") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.02+6/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.02+6/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.02+6/opam
+++ b/packages/camlp4/camlp4.4.02+6/opam
@@ -5,8 +5,8 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlbuild" {build}
@@ -24,6 +24,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.02") & (ocaml-version < "4.03") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.02+7/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.02+7/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.02+7/opam
+++ b/packages/camlp4/camlp4.4.02+7/opam
@@ -5,8 +5,8 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "conf-which" {build}
@@ -24,7 +24,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.02") & (ocaml-version < "4.03") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.03+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.03+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.03+1/opam
+++ b/packages/camlp4/camlp4.4.03+1/opam
@@ -5,8 +5,8 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlbuild" {build}
@@ -24,7 +24,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.03") & (ocaml-version < "4.04") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.04+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.04+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.04+1/opam
+++ b/packages/camlp4/camlp4.4.04+1/opam
@@ -6,8 +6,8 @@ license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
   [make "clean"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlbuild" {build}
@@ -24,7 +24,7 @@ remove: [
              "%{bin}%/camlp4prof"]
 ]
 
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.04") & (ocaml-version < "4.05") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"

--- a/packages/camlp4/camlp4.4.05+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.05+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.05+1/opam
+++ b/packages/camlp4/camlp4.4.05+1/opam
@@ -5,12 +5,13 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 patches: [
   "safe-string.patch"
+  "f0ea53725465260556832398096cef8d3f20b49d.patch"
 ]
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
   [make "clean"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlbuild" {build}

--- a/packages/camlp4/camlp4.4.06+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
+++ b/packages/camlp4/camlp4.4.06+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
@@ -1,0 +1,28 @@
+From f0ea53725465260556832398096cef8d3f20b49d Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Mon, 8 Jan 2018 12:59:08 +0000
+Subject: [PATCH] Fix make byte for systems with no natdynlink
+
+2a31a83 builds a native-code preprocessor if ocamlbuild supports native
+code. However, it's possible to have systems which support native code but
+don't have natdynlink (e.g. Cygwin without flexdll support) and in this
+case the build fails.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7264df134..ecaac916f 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -76,7 +76,7 @@ let () =
+       else
+         let exe =
+           "camlp4boot" ^
+-          if !Options.native_plugin then
++          if C.ocamlnat then
+             (* If we are using a native plugin, we might as well use a native
+                preprocessor. *)
+             ".native"

--- a/packages/camlp4/camlp4.4.06+1/opam
+++ b/packages/camlp4/camlp4.4.06+1/opam
@@ -6,8 +6,8 @@ license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
   [make "clean"]
-  [make "all"] {ocaml-native}
-  [make "byte"] {!ocaml-native}
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 depends: [
   "ocamlbuild" {build}
@@ -23,7 +23,7 @@ remove: [
              "%{bin}%/camlp4o" "%{bin}%/camlp4of"   "%{bin}%/camlp4oof"
              "%{bin}%/camlp4prof"]
 ]
-
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 available: [ (!preinstalled) & (ocaml-version >= "4.06") & (ocaml-version < "4.07") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"


### PR DESCRIPTION
camlp4's all target depends on ocaml-native-dynlink, not just ocaml-native. This in particular affects Cygwin when the flexdll package has not been installed (which has ocamlopt but does not have natdynlink).

I don't know how the rewriter for opam 2.0 is working, but the patch could be referenced as an extra-sources link to https://github.com/ocaml/camlp4/commit/f0ea53725465260556832398096cef8d3f20b49d.patch

Fixes https://github.com/ocaml/opam/issues/2276