### PR TITLE
Package ocp-ocamlres.0.4

### DIFF
--- a/packages/ocp-ocamlres/ocp-ocamlres.0.4/descr
+++ b/packages/ocp-ocamlres/ocp-ocamlres.0.4/descr
@@ -1,0 +1,5 @@
+Manipulation, injection and extraction of embedded resources
+
+A tool ocp-ocamlres to embed files and directories inside OCaml
+executables, with a companion library ocplib-ocamlres to manipulate
+them at run-time.

--- a/packages/ocp-ocamlres/ocp-ocamlres.0.4/opam
+++ b/packages/ocp-ocamlres/ocp-ocamlres.0.4/opam
@@ -18,4 +18,4 @@ remove: [
   [make "DOCDIR=%{doc}%" "uninstall-doc"]
 ]
 depends: ["ocamlfind" "base-unix" "pprint" "astring"]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocp-ocamlres/ocp-ocamlres.0.4/opam
+++ b/packages/ocp-ocamlres/ocp-ocamlres.0.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "benjamin@ocamlpro.com"
+authors: "benjamin@ocamlpro.com"
+homepage: "https://github.com/OCamlPro/ocp-ocamlres"
+bug-reports: "https://github.com/OCamlPro/ocp-ocamlres/issues"
+dev-repo: "git://github.com/OCamlPro/ocp-ocamlres"
+license: "GNU Lesser General Public License version 3"
+build: [
+  [make "all"]
+  [make "doc"]
+]
+install: [
+  [make "BINDIR=%{bin}%" "LIBDIR=%{lib}%" "install"]
+  [make "DOCDIR=%{doc}%" "install-doc"]
+]
+remove: [
+  [make "BINDIR=%{bin}%" "LIBDIR=%{lib}%" "uninstall"]
+  [make "DOCDIR=%{doc}%" "uninstall-doc"]
+]
+depends: ["ocamlfind" "base-unix" "pprint" "astring"]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/ocp-ocamlres/ocp-ocamlres.0.4/url
+++ b/packages/ocp-ocamlres/ocp-ocamlres.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocp-ocamlres/archive/v0.4.tar.gz"
+checksum: "725eb557e659c6febf8dc3044b323bd8"


### PR DESCRIPTION
### `ocp-ocamlres.0.4`

Manipulation, injection and extraction of embedded resources

A tool ocp-ocamlres to embed files and directories inside OCaml
executables, with a companion library ocplib-ocamlres to manipulate
them at run-time.



---
* Homepage: https://github.com/OCamlPro/ocp-ocamlres
* Source repo: git://github.com/OCamlPro/ocp-ocamlres
* Bug tracker: https://github.com/OCamlPro/ocp-ocamlres/issues

---

:camel: Pull-request generated by opam-publish v0.3.5