### PR TITLE
Package capnp.3.2.0

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
@@ -10,6 +10,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
+  "conf-capnproto" {build}
   "capnp" { >= "3.0.0" }
   "capnp-rpc" { >= "0.3" }
   "lwt"

--- a/packages/capnp/capnp.3.2.0/descr
+++ b/packages/capnp/capnp.3.2.0/descr
@@ -1,0 +1,5 @@
+OCaml code generation plugin for the Cap'n Proto serialization framework
+Cap'n Proto is a multi-language code generation framework designed for
+high performance through the use of lazy parsing and arena allocation.
+This package provides a plugin for the Cap'n Proto compiler which enables
+OCaml code generation, as well as corresponding runtime library support.

--- a/packages/capnp/capnp.3.2.0/opam
+++ b/packages/capnp/capnp.3.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+homepage: "https://github.com/capnproto/capnp-ocaml"
+bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
+dev-repo: "https://github.com/capnproto/capnp-ocaml.git"
+author: "Paul Pelzl <pelzlpj@gmail.com>"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "build" "@runtest" "@src/benchmark/benchmarks"]
+
+depends: [
+  "jbuilder" {build}
+  "result"
+  "core_kernel" {>= "v0.10.0"}
+  "extunix"
+  "ocplib-endian" {>= "0.7"}
+  "res"
+  "uint"
+  "core" {test}
+  "ounit" {test}
+  "conf-capnproto" {test}
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/capnp/capnp.3.2.0/url
+++ b/packages/capnp/capnp.3.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/capnproto/capnp-ocaml/releases/download/v3.2.0/capnp-3.2.0.tbz"
+checksum: "e2ad69c6465b960cf8834b42138a1303"


### PR DESCRIPTION
### `capnp.3.2.0`

OCaml code generation plugin for the Cap'n Proto serialization framework
Cap'n Proto is a multi-language code generation framework designed for
high performance through the use of lazy parsing and arena allocation.
This package provides a plugin for the Cap'n Proto compiler which enables
OCaml code generation, as well as corresponding runtime library support.



---
* Homepage: https://github.com/capnproto/capnp-ocaml
* Source repo: https://github.com/capnproto/capnp-ocaml.git
* Bug tracker: https://github.com/capnproto/capnp-ocaml/issues

---


---
== capnp-ocaml 3.2.0

=== Backwards-incompatible changes

* The `capnp` opam package no longer depends on the C++ compiler (#47).
  If your project compiles schema files, you should add
  `"conf-capnproto" {build}` to your opam dependencies.

=== Other changes

* Add support for OCaml 4.06 (#45).

* Update for API changes in Base and Core_kernel (#44).
:camel: Pull-request generated by opam-publish v0.3.5