### PR TITLE
Package capnp-rpc.0.3.1

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/descr
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/descr
@@ -1,0 +1,3 @@
+Cap'n Proto is a capability-based RPC system with bindings for many languages.
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency.

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer:   "Thomas Leonard <thomas.leonard@docker.com>"
+authors:      "Thomas Leonard <thomas.leonard@docker.com>"
+license:      "Apache"
+homepage:     "https://github.com/mirage/capnp-rpc"
+bug-reports:  "https://github.com/mirage/capnp-rpc/issues"
+dev-repo:     "https://github.com/mirage/capnp-rpc.git"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "conf-capnproto" {build}
+  "capnp" { >= "3.0.0" }
+  "capnp-rpc" { >= "0.3" }
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow-lwt"
+  "tls" { >= "0.8.0" }
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "base64"
+  "uri" { >= "1.6.0" }
+  "ptime"
+  "asn1-combinators" {>= "0.2.0"}
+  "jbuilder" {build & >= "1.0+beta10" }
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/url
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/capnp-rpc/releases/download/0.3.1/capnp-rpc-0.3.1.tbz"
+checksum: "81b6f20193c16a3910c616045d94e1a0"

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/descr
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/descr
@@ -1,0 +1,2 @@
+Cap'n Proto is a capability-based RPC system with bindings for many languages.
+This package provides a version of the Cap'n Proto RPC system for use with MirageOS.

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer:   "Thomas Leonard <thomas.leonard@docker.com>"
+authors:      "Thomas Leonard <thomas.leonard@docker.com>"
+license:      "Apache"
+homepage:     "https://github.com/mirage/capnp-rpc"
+bug-reports:  "https://github.com/mirage/capnp-rpc/issues"
+dev-repo:     "https://github.com/mirage/capnp-rpc.git"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "capnp" { >= "3.1.0" }
+  "capnp-rpc-lwt" { >= "0.3" }
+  "astring"
+  "fmt"
+  "logs"
+  "mirage-dns"
+  "mirage-stack-lwt"
+  "alcotest-lwt" {test}
+  "io-page-unix" {test}
+  "tcpip" {test}
+  "mirage-vnetif" {test}
+  "jbuilder" {build & >= "1.0+beta10" }
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/url
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/capnp-rpc/releases/download/0.3.1/capnp-rpc-0.3.1.tbz"
+checksum: "81b6f20193c16a3910c616045d94e1a0"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/descr
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/descr
@@ -1,0 +1,2 @@
+Cap'n Proto is a capability-based RPC system with bindings for many languages.
+This package contains some helpers for use with traditional (non-Unikernel) operating systems.

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "Thomas Leonard <thomas.leonard@docker.com>"
+authors:      "Thomas Leonard <thomas.leonard@docker.com>"
+license:      "Apache"
+homepage:     "https://github.com/mirage/capnp-rpc"
+bug-reports:  "https://github.com/mirage/capnp-rpc/issues"
+dev-repo:     "https://github.com/mirage/capnp-rpc.git"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "capnp-rpc-lwt" { >= "0.3" }
+  "mirage-flow-unix"
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" { >= "0.8.4" }
+  "logs"
+  "jbuilder" {build & >= "1.0+beta10" }
+  "alcotest-lwt" {test & >= "0.8.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/url
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/capnp-rpc/releases/download/0.3.1/capnp-rpc-0.3.1.tbz"
+checksum: "81b6f20193c16a3910c616045d94e1a0"

--- a/packages/capnp-rpc/capnp-rpc.0.3.1/descr
+++ b/packages/capnp-rpc/capnp-rpc.0.3.1/descr
@@ -1,0 +1,4 @@
+Cap'n Proto is a capability-based RPC system with bindings for many languages.
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly.

--- a/packages/capnp-rpc/capnp-rpc.0.3.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "Thomas Leonard <thomas.leonard@docker.com>"
+authors:      "Thomas Leonard <thomas.leonard@docker.com>"
+license:      "Apache"
+homepage:     "https://github.com/mirage/capnp-rpc"
+bug-reports:  "https://github.com/mirage/capnp-rpc/issues"
+dev-repo:     "https://github.com/mirage/capnp-rpc.git"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "uint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "jbuilder" {build & >= "1.0+beta10" }
+  "alcotest" {test}
+  "afl-persistent" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/capnp-rpc/capnp-rpc.0.3.1/url
+++ b/packages/capnp-rpc/capnp-rpc.0.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/capnp-rpc/releases/download/0.3.1/capnp-rpc-0.3.1.tbz"
+checksum: "81b6f20193c16a3910c616045d94e1a0"


### PR DESCRIPTION
### `capnp-rpc.0.3.1`

Cap'n Proto RPC library

Copyright 2017 Docker, Inc.
See [LICENSE.md](LICENSE.md) for details.

---
* Homepage: https://github.com/mirage/capnp-rpc
* Source repo: https://github.com/mirage/capnp-rpc.git
* Bug tracker: https://github.com/mirage/capnp-rpc/issues

---


---
### 0.3.1

- Updates for new `x509` API and for OCaml 4.06 (#143).

- Add some diagrams to the tutorial (#134).

- Add FAQ: how can I import a sturdy ref that I need to start my vat? (#137)

Build updates:

- Add build dependency on conf-capnproto (#146). Projects using the schema compiler themselves should also now add this dependency instead of relying on `capnp` to pull it in.

- Remove generics from persistent.capnp (#141) so that it compiles on systems with older capnproto compilers (e.g. Ubuntu 14.04).

- `unix/network.ml` uses `Fmt.failwith`, which requires fmt.0.8.4 (#139).

- `capnp-rpc-lwt` requires `Uri.with_userinfo`, which is only in `uri` >= 1.6.0 (#138).

- Move test-lwt to unix module (#133).
:camel: Pull-request generated by opam-publish v0.3.5
  