### PR TITLE
Fix installation of num for system switches

### DIFF
--- a/packages/num/num.1.0/files/findlib-install.patch
+++ b/packages/num/num.1.0/files/findlib-install.patch
@@ -1,0 +1,129 @@
+From 1a75e61a92fbd79ac4231a4cd62dc4717a4e7cfd Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Wed, 10 Jan 2018 15:20:46 +0000
+Subject: [PATCH] Provide findlib-install target
+
+Allows installing the entire library using ocamlfind.
+---
+ Makefile     | 10 +++++++++-
+ src/META     | 17 -----------------
+ src/META.in  | 19 +++++++++++++++++++
+ src/Makefile | 17 +++++++++++++++--
+ 4 files changed, 43 insertions(+), 20 deletions(-)
+ delete mode 100644 src/META
+ create mode 100644 src/META.in
+
+diff --git a/Makefile b/Makefile
+index 6a5d08f..b40e588 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,8 +14,16 @@ install:
+ 	$(MAKE) -C src install
+ 	$(MAKE) -C toplevel install
+ 
++findlib-install:
++	$(MAKE) -C src findlib-install
++	$(MAKE) -C toplevel install
++
+ uninstall:
+ 	$(MAKE) -C src uninstall
+ 	$(MAKE) -C toplevel uninstall
+ 
+-.PHONY: all test clean install uninstall
++findlib-uninstall:
++	$(MAKE) -C src findlib-uninstall
++	$(MAKE) -C toplevel uninstall
++
++.PHONY: all test clean install uninstall findlib-install findlib-uninstall
+diff --git a/src/META b/src/META
+deleted file mode 100644
+index 66ac170..0000000
+--- a/src/META
++++ /dev/null
+@@ -1,17 +0,0 @@
+-# This META is the one provided by findlib when the "num" library was
+-# part of the core OCaml distribution.  For backward compatibility,
+-# it installs into OCaml's standard library directory, not in a subdirectory
+-
+-requires = "num.core"
+-requires(toploop) = "num.core,num-top"
+-version = "1.0"
+-description = "Arbitrary-precision rational arithmetic"
+-package "core" (
+-  directory = "^"
+-  version = "1.0"
+-  browse_interfaces = ""
+-  archive(byte) = "nums.cma"
+-  archive(native) = "nums.cmxa"
+-  plugin(byte) = "nums.cma"
+-  plugin(native) = "nums.cmxs"
+-)
+diff --git a/src/META.in b/src/META.in
+new file mode 100644
+index 0000000..b5678b7
+--- /dev/null
++++ b/src/META.in
+@@ -0,0 +1,19 @@
++# This META is the one provided by findlib when the "num" library was
++# part of the core OCaml distribution.  For backward compatibility,
++# it is installed into OCaml's standard library directory. If the
++# directory line below is removed, then it's installed in a
++# subdirectory, as normal for a findlib package.
++
++requires = "num.core"
++requires(toploop) = "num.core,num-top"
++version = "1.0"
++description = "Arbitrary-precision rational arithmetic"
++package "core" (
++  directory = "^"
++  version = "1.0"
++  browse_interfaces = ""
++  archive(byte) = "nums.cma"
++  archive(native) = "nums.cmxa"
++  plugin(byte) = "nums.cma"
++  plugin(native) = "nums.cmxs"
++)
+diff --git a/src/Makefile b/src/Makefile
+index ab6a5b6..a9f39ca 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -79,21 +79,34 @@ endif
+ ifeq "$(NATDYNLINK)" "true"
+ TOINSTALL+=nums.cmxs
+ endif
++ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+ TOINSTALL_STUBS=dllnums.$(SO)
++else
++TOINSTALL_STUBS=
++endif
+ 
+ install:
++	cp META.in META
+ 	$(OCAMLFIND) install num META
++	rm -f META
+ 	$(INSTALL) $(TOINSTALL) $(STDLIBDIR)
+ ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+ 	$(INSTALL) $(TOINSTALL_STUBS) $(STDLIBDIR)/stublibs
+ endif
+ 
+-uninstall:
++findlib-install:
++	grep -Fv '^' META.in > META
++	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_STUBS)
++	rm -f META
++
++findlib-uninstall:
++	$(OCAMLFIND) remove num
++
++uninstall: findlib-uninstall
+ 	cd $(STDLIBDIR) && rm -f $(TOINSTALL)
+ ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+ 	cd $(STDLIBDIR)/stublibs && rm -f $(TOINSTALL_STUBS) 
+ endif
+-	$(OCAMLFIND) remove num
+ 
+ clean:
+ 	rm -f *.cm[ioxta] *.cmx[as] *.cmti *.$(O) *.$(A) *.$(SO)
+-- 
+2.14.1
+

--- a/packages/num/num.1.0/opam
+++ b/packages/num/num.1.0/opam
@@ -16,12 +16,12 @@ dev-repo: "https://github.com/ocaml/num.git"
 build: [
   [make]
 ]
-install: [make "install"]
-remove: [make "uninstall"]
+install: [make "install" {!preinstalled} "findlib-install" {preinstalled} ]
+remove: [make "uninstall" {!preinstalled} "findlib-uninstall" {preinstalled} ]
 
 depends: [
   "ocamlfind" {build & >= "1.7.3"}
 ]
 conflicts: [ "base-num" ]
 available: [ ocaml-version >= "4.06.0" ]
-
+patches: [ "findlib-install.patch" ]

--- a/packages/num/num.1.1/files/findlib-install.patch
+++ b/packages/num/num.1.1/files/findlib-install.patch
@@ -1,0 +1,129 @@
+From 7688bb4fea24463c92e9c4870acc08495a4c77cb Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Wed, 10 Jan 2018 15:20:46 +0000
+Subject: [PATCH] Provide findlib-install target
+
+Allows installing the entire library using ocamlfind.
+---
+ Makefile     | 10 +++++++++-
+ src/META     | 17 -----------------
+ src/META.in  | 19 +++++++++++++++++++
+ src/Makefile | 17 +++++++++++++++--
+ 4 files changed, 43 insertions(+), 20 deletions(-)
+ delete mode 100644 src/META
+ create mode 100644 src/META.in
+
+diff --git a/Makefile b/Makefile
+index 6a5d08f..b40e588 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,8 +14,16 @@ install:
+ 	$(MAKE) -C src install
+ 	$(MAKE) -C toplevel install
+ 
++findlib-install:
++	$(MAKE) -C src findlib-install
++	$(MAKE) -C toplevel install
++
+ uninstall:
+ 	$(MAKE) -C src uninstall
+ 	$(MAKE) -C toplevel uninstall
+ 
+-.PHONY: all test clean install uninstall
++findlib-uninstall:
++	$(MAKE) -C src findlib-uninstall
++	$(MAKE) -C toplevel uninstall
++
++.PHONY: all test clean install uninstall findlib-install findlib-uninstall
+diff --git a/src/META b/src/META
+deleted file mode 100644
+index 66ac170..0000000
+--- a/src/META
++++ /dev/null
+@@ -1,17 +0,0 @@
+-# This META is the one provided by findlib when the "num" library was
+-# part of the core OCaml distribution.  For backward compatibility,
+-# it installs into OCaml's standard library directory, not in a subdirectory
+-
+-requires = "num.core"
+-requires(toploop) = "num.core,num-top"
+-version = "1.0"
+-description = "Arbitrary-precision rational arithmetic"
+-package "core" (
+-  directory = "^"
+-  version = "1.0"
+-  browse_interfaces = ""
+-  archive(byte) = "nums.cma"
+-  archive(native) = "nums.cmxa"
+-  plugin(byte) = "nums.cma"
+-  plugin(native) = "nums.cmxs"
+-)
+diff --git a/src/META.in b/src/META.in
+new file mode 100644
+index 0000000..b5678b7
+--- /dev/null
++++ b/src/META.in
+@@ -0,0 +1,19 @@
++# This META is the one provided by findlib when the "num" library was
++# part of the core OCaml distribution.  For backward compatibility,
++# it is installed into OCaml's standard library directory. If the
++# directory line below is removed, then it's installed in a
++# subdirectory, as normal for a findlib package.
++
++requires = "num.core"
++requires(toploop) = "num.core,num-top"
++version = "1.0"
++description = "Arbitrary-precision rational arithmetic"
++package "core" (
++  directory = "^"
++  version = "1.0"
++  browse_interfaces = ""
++  archive(byte) = "nums.cma"
++  archive(native) = "nums.cmxa"
++  plugin(byte) = "nums.cma"
++  plugin(native) = "nums.cmxs"
++)
+diff --git a/src/Makefile b/src/Makefile
+index 97dc074..ff271fe 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -80,21 +80,34 @@ endif
+ ifeq "$(NATDYNLINK)" "true"
+ TOINSTALL+=nums.cmxs
+ endif
++ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+ TOINSTALL_STUBS=dllnums.$(SO)
++else
++TOINSTALL_STUBS=
++endif
+ 
+ install:
++	cp META.in META
+ 	$(OCAMLFIND) install num META
++	rm -f META
+ 	$(INSTALL_DATA) $(TOINSTALL) $(STDLIBDIR)
+ ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+ 	$(INSTALL_DLL) $(TOINSTALL_STUBS) $(STDLIBDIR)/stublibs
+ endif
+ 
+-uninstall:
++findlib-install:
++	grep -Fv '^' META.in > META
++	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_STUBS)
++	rm -f META
++
++findlib-uninstall:
++	$(OCAMLFIND) remove num
++
++uninstall: findlib-uninstall
+ 	cd $(STDLIBDIR) && rm -f $(TOINSTALL)
+ ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+ 	cd $(STDLIBDIR)/stublibs && rm -f $(TOINSTALL_STUBS) 
+ endif
+-	$(OCAMLFIND) remove num
+ 
+ clean:
+ 	rm -f *.cm[ioxta] *.cmx[as] *.cmti *.$(O) *.$(A) *.$(SO)
+-- 
+2.14.1
+

--- a/packages/num/num.1.1/opam
+++ b/packages/num/num.1.1/opam
@@ -16,12 +16,12 @@ dev-repo: "https://github.com/ocaml/num.git"
 build: [
   [make]
 ]
-install: [make "install"]
-remove: [make "uninstall"]
+install: [make "install" {!preinstalled} "findlib-install" {preinstalled} ]
+remove: [make "uninstall" {!preinstalled} "findlib-uninstall" {preinstalled} ]
 
 depends: [
   "ocamlfind" {build & >= "1.7.3"}
 ]
 conflicts: [ "base-num" ]
 available: [ ocaml-version >= "4.06.0" ]
-
+patches: [ "findlib-install.patch" ]


### PR DESCRIPTION
See also https://github.com/ocaml/opam-repository/issues/10857

The fixes to ocamlfind don't address the fact that the package was still attempting to write to the system's lib directory.

I've proposed the addition of a `findlib-install` target upstream, the patch for which is included in this PR.
