### PR TITLE
Lwt_ppx 1.0.1, concurrently Lwt 3.2.1

### DIFF
--- a/packages/lwt/lwt.3.2.1/descr
+++ b/packages/lwt/lwt.3.2.1/descr
@@ -1,0 +1,10 @@
+Promises, concurrency, and parallelized I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.3.2.1/opam
+++ b/packages/lwt/lwt.3.2.1/opam
@@ -1,0 +1,64 @@
+opam-version: "1.2"
+version: "3.2.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%"
+                                    "-use-camlp4" "%{camlp4:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "ocaml" "src/util/install_filter.ml" ]
+]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "jbuilder" {build & >= "1.0+beta13"}
+  # We are only using ocamlfind during configuration of the Unix binding.
+  # However, ocamlfind also installs the "threads" package, and ocamlfind
+  # 1.7.3-1 is the first one whose threads package does not have incorrect error
+  # lines. See
+  #   https://github.com/ocaml/opam-repository/pull/11071#issuecomment-353131128
+  # If ocamlfind becomes no longer necessary for configuration of Lwt, this
+  # dependency should be converted to a conflict, and package jbuilder should be
+  # constrained such that it also includes the error lines fix.
+  "ocamlfind" {build & >= "1.7.3-1"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+  # result is needed as long as Lwt still supports OCaml 4.02.
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "camlp4"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+
+messages: [
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
+  "For the Camlp4 syntax, please install package lwt_camlp4"
+    {camlp4:installed & !lwt_camlp4:installed}
+  "For Lwt_log and Lwt_daemon, please install package lwt_log"
+    {!lwt_log:installed}
+]
+post-messages: [
+  "Lwt 4.0.0 will make some breaking changes in March 2018. See
+  https://github.com/ocsigen/lwt/issues/453"
+]

--- a/packages/lwt/lwt.3.2.1/url
+++ b/packages/lwt/lwt.3.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.2.1.tar.gz"
+checksum: "13613bbf6b27d198bafcbd9b253a0076"

--- a/packages/lwt_ppx/lwt_ppx.1.0.1/descr
+++ b/packages/lwt_ppx/lwt_ppx.1.0.1/descr
@@ -1,0 +1,1 @@
+PPX syntax for Lwt, providing something similar to async/await from JavaScript

--- a/packages/lwt_ppx/lwt_ppx.1.0.1/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.0.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+version: "1.0.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta12"}
+  "lwt"
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_ppx/lwt_ppx.1.0.1/url
+++ b/packages/lwt_ppx/lwt_ppx.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.2.1.tar.gz"
+checksum: "13613bbf6b27d198bafcbd9b253a0076"


### PR DESCRIPTION
This release is mainly about adding some deprecation messages to the PPX; see the [changelog](https://github.com/ocsigen/lwt/releases/tag/3.2.1). Lwt is being released to include the same messages as `lwt_ppx`, only because it still contains `lwt.ppx`, and people are likely to still be using that.

<br/>

> *Lwt 3.2.1 is released because it still packages `lwt.ppx`, a deprecated copy of package `lwt_ppx`, and the two packages should be kept in sync.*
>
> Deprecations
>
> - All PPX options are deprecated and should not be used (ocsigen/lwt#534).
> - The `[%lwt ...]` [PPX syntax](https://ocsigen.org/lwt/api/Ppx_lwt) should be replaced by [`Lwt.catch`](https://ocsigen.org/lwt/api/Lwt#VALcatch) (ocsigen/lwt#534).
>
> Fixes
>
> - Clean up PPX `-help` usage message output (ocsigen/lwt#525, Zan Doye).
>
> Miscellaneous
>
> - More thorough testing (ocsigen/lwt#512, ocsigen/lwt#535, Joseph Thomas).
> - Clarification of the C binding (ocsigen/lwt#521, @cedlemo).
