### PR TITLE
+uri.1.9.6

### DIFF
--- a/packages/uri/uri.1.9.6/descr
+++ b/packages/uri/uri.1.9.6/descr
@@ -1,0 +1,4 @@
+An RFC3986 URI/URL parsing library
+
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.

--- a/packages/uri/uri.1.9.6/opam
+++ b/packages/uri/uri.1.9.6/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "https://github.com/mirage/ocaml-uri.git"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: [
+  "url"
+  "uri"
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]
+depends: [
+  "base-bytes"
+  "jbuilder" {build & >="1.0+beta7"}
+  "ounit" {test & >= "1.0.2"}
+  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "re"
+  "sexplib" {>= "v0.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/uri/uri.1.9.6/url
+++ b/packages/uri/uri.1.9.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-uri/releases/download/v1.9.6/uri-1.9.6.tbz"
+checksum: "a6c4fbbe8e3fd84059fac7bd7bc7b3d2"


### PR DESCRIPTION
* Change code generation strategy to avoid big switches in
  the services file; improves build time by 10x (mirage/ocaml-uri#114 by @gasche).
* Remove deprecated function use (`String.lowercase`)
* Add development Makefile with more targets.