### PR TITLE
Package ppx_driver.v0.10.2

### DIFF
--- a/packages/ppx_driver/ppx_driver.v0.10.2/descr
+++ b/packages/ppx_driver/ppx_driver.v0.10.2/descr
@@ -1,0 +1,3 @@
+Feature-full driver for OCaml AST transformers
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_driver/ppx_driver.v0.10.2/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+homepage: "https://github.com/janestreet/ppx_driver"
+bug-reports: "https://github.com/janestreet/ppx_driver/issues"
+license: "Apache-2.0"
+dev-repo: "git+https://github.com/janestreet/ppx_driver.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "ppx_core" {>= "v0.10" & < "v0.11"}
+  "ppx_optcomp" {>= "v0.10" & < "v0.11"}
+  "jbuilder" {build & >= "1.0+beta12"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ocaml-version >= "4.04.1"]

--- a/packages/ppx_driver/ppx_driver.v0.10.2/url
+++ b/packages/ppx_driver/ppx_driver.v0.10.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/ppx_driver/archive/v0.10.2.tar.gz"
+checksum: "80908a5fa700756aa6150cf5bd6d6112"


### PR DESCRIPTION
### `ppx_driver.v0.10.2`

Feature-full driver for OCaml AST transformers

Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_driver
* Source repo: git+https://github.com/janestreet/ppx_driver.git
* Bug tracker: https://github.com/janestreet/ppx_driver/issues

---

:camel: Pull-request generated by opam-publish v0.3.5