### PR TITLE
Restrict github-unix to < 4.06.0

### DIFF
--- a/packages/github-unix/github-unix.3.0.0/opam
+++ b/packages/github-unix/github-unix.3.0.0/opam
@@ -36,4 +36,4 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]

--- a/packages/github-unix/github-unix.3.0.1/opam
+++ b/packages/github-unix/github-unix.3.0.1/opam
@@ -36,4 +36,4 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
github-unix doesn't compile with 4.06.0.

Build log: http://obi.ocamllabs.io/logs/234ec4899c528795d05a672d641272ac.txt

Upstream PR: https://github.com/mirage/ocaml-github/pull/212