### PR TITLE
Test system switches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: required
 matrix:
   include:
   - os: linux
-    env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2
+    env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2 INSTALL_LOCAL=1
   - os: linux
     env: OCAML_VERSION=4.05 OPAM_VERSION=1.2.2
   - os: linux


### PR DESCRIPTION
This is inspired by the installation failure fixed by #11207. The Travis jobs don't explicitly test system switches - the macOS job indirectly tests a system switch because brew has the latest OCaml, but macOS isn't a good candidate for this because the permissions are weird.

This PR changes the matrix for 4.06.0 on Linux to use the new `INSTALL_LOCAL` option added in https://github.com/ocaml/ocaml-ci-scripts/pull/202 which means that the 4.06.0 test is now a system test as well. This would have rejected the original num packages, as can be seen from https://travis-ci.org/dra27/opam-repository/builds/330338105.

Another option would be test 4.06.0 as **both** system and 4.06.0.

This PR should obviously not be merged with 461fe1f, so it's stalled on the ocaml-ci-scripts PR, however I figured discussions could take place sooner.