### PR TITLE
conf-qt5: Fixing version comparison

### DIFF
--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -11,7 +11,7 @@ dev-repo:     "https://github.com/Kakadu/lablqml.git"
 
 build: [
     ["sh" "-exc" "echo \"Your Qt version is `PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH qmake -query QT_VERSION`\"" ] 
-    ["sh" "-exc" "min=\"5.2.1\" cur=`PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH qmake -query QT_VERSION`; res=`printf \"$min\\n$cur\\n\" | sort | head -n 1`; [ \"$res\" = \"$min\" ]"
+    ["sh" "-exc" "min=\"5.2.1\" cur=`PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH qmake -query QT_VERSION`; res=`printf \"$min\\n$cur\\n\" | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -n | head -n 1`; [ \"$res\" = \"$min\" ]"
     ]
 ]
 


### PR DESCRIPTION
The bug was reported about wrong comparison between 5.1.0 and 5.10.0
The solution  should be crossplatform but for GNU/Linux it is shorter to
use `sort -V` command