### PR TITLE
Package shcaml.0.2.1

### DIFF
--- a/packages/shcaml/shcaml.0.2.1/descr
+++ b/packages/shcaml/shcaml.0.2.1/descr
@@ -1,0 +1,1 @@
+Library for Unix shell programming

--- a/packages/shcaml/shcaml.0.2.1/opam
+++ b/packages/shcaml/shcaml.0.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+authors: "Jesse A. Tov <jesse.tov@gmail.com>"
+maintainer: "Armael <armael@isomorphis.me>"
+homepage: "https://github.com/tov/shcaml"
+dev-repo: "git+https://github.com/tov/shcaml.git"
+bug-reports: "https://github.com/tov/shcaml/issues"
+doc: "https://tov.github.io/shcaml/doc"
+license: "MIT"
+available: [ ocaml-version >= "4.02.0" ]
+depends: [ "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build & >= "0.9.0"}
+           "cppo" {build}
+           "cppo_ocamlbuild" {build}
+           "pcre"
+           "hmap"
+           "stdcompat"
+         ]
+depopts: [ "lwt" "base-unix" ]
+build:
+[
+  [ "ocaml" "pkg/pkg.ml" "build"
+      "--dev-pkg" "%{pinned}%"
+      "--with-lwt" "%{lwt+base-unix:installed}%"
+  ]
+]

--- a/packages/shcaml/shcaml.0.2.1/url
+++ b/packages/shcaml/shcaml.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/tov/shcaml/releases/download/0.2.1/shcaml-0.2.1.tbz"
+checksum: "10015bfebd93cf07f580dc1d77a5b69f"


### PR DESCRIPTION
### `shcaml.0.2.1`

Library for Unix shell programming



---
* Homepage: https://github.com/tov/shcaml
* Source repo: git+https://github.com/tov/shcaml.git
* Bug tracker: https://github.com/tov/shcaml/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
Caml-Shcaml 0.2.1
-----------------

- Add compatibility with -safe-string and therefore OCaml 4.06.0 onwards.

- Remove uses of the deprecated String.lowercase. Backwards compatibility is
  implemented thanks to the Stdcompat library, which is now a dependency of
  Shcaml.
:camel: Pull-request generated by opam-publish v0.3.5