### PR TITLE
ppx_bin_prot and ppx_expect were missing a couple of dependencies

### DIFF
--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.10.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.10.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ppx_driver"              {>= "v0.10" & < "v0.11"}
   "ppx_here"                {>= "v0.10" & < "v0.11"}
   "ppx_metaquot"            {>= "v0.10" & < "v0.11"}
+  "ppx_compare"             {>= "v0.10" & < "v0.11"}
   "ppx_type_conv"           {>= "v0.10" & < "v0.11"}
   "jbuilder"                {build & >= "1.0+beta12"}
   "ocaml-migrate-parsetree" {>= "0.4"}

--- a/packages/ppx_expect/ppx_expect.v0.10.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.10.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ppx_variants_conv"       {>= "v0.10" & < "v0.11"}
   "stdio"                   {>= "v0.10" & < "v0.11"}
   "jbuilder"                {build & >= "1.0+beta12"}
+  "sexplib"                 {>= "v0.10" & < "V0.11"}
   "ocaml-migrate-parsetree" {>= "0.4"}
   "re"                      {>= "1.5.0"}
 ]

--- a/packages/ppx_expect/ppx_expect.v0.10.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.10.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ppx_variants_conv"       {>= "v0.10" & < "v0.11"}
   "stdio"                   {>= "v0.10" & < "v0.11"}
   "jbuilder"                {build & >= "1.0+beta12"}
-  "sexplib"                 {>= "v0.10" & < "V0.11"}
+  "sexplib"                 {>= "v0.9.0" & < "v0.11"}
   "ocaml-migrate-parsetree" {>= "0.4"}
   "re"                      {>= "1.5.0"}
 ]


### PR DESCRIPTION
this shows up during 'opam upgrade' when their recompilation fails.