### PR TITLE
Package graphql_ppx.0.0.4

### DIFF
--- a/packages/graphql_ppx/graphql_ppx.0.0.4/descr
+++ b/packages/graphql_ppx/graphql_ppx.0.0.4/descr
@@ -1,0 +1,6 @@
+GraphQL syntax extension for Bucklescript/ReasonML
+
+This library lets you construct type-safe and validated queries at compile time,
+and generates response validation code for you. If you're writing a Bucklescript
+app that talks to a GraphQL server, this library will cut down on the
+boilerplate you have to write.

--- a/packages/graphql_ppx/graphql_ppx.0.0.4/opam
+++ b/packages/graphql_ppx/graphql_ppx.0.0.4/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Magnus Hallin <mhallin@fastmail.com>"
+authors: "Magnus Hallin <mhallin@fastmail.com>"
+homepage: "https://github.com/mhallin/graphql_ppx"
+bug-reports: "https://github.com/mhallin/graphql_ppx/issues"
+license: "BSD 3-clause"
+tags: ["bucklescript" "reasonml" "ppx" "graphql"]
+dev-repo: "git@github.com:mhallin/graphql_ppx.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ocaml-migrate-parsetree" {build}
+  "result" {build}
+  "yojson" {build}
+  "ppx_tools" {build}
+]
+available: [ocaml-version = "4.02.3"]

--- a/packages/graphql_ppx/graphql_ppx.0.0.4/url
+++ b/packages/graphql_ppx/graphql_ppx.0.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mhallin/graphql_ppx/archive/0.0.4.tar.gz"
+checksum: "ad173333bee6dad221c076239a37c2ce"


### PR DESCRIPTION
### `graphql_ppx.0.0.4`

GraphQL syntax extension for Bucklescript/ReasonML

This library lets you construct type-safe and validated queries at compile time,
and generates response validation code for you. If you're writing a Bucklescript
app that talks to a GraphQL server, this library will cut down on the
boilerplate you have to write.


---
* Homepage: https://github.com/mhallin/graphql_ppx
* Source repo: git@github.com:mhallin/graphql_ppx.git
* Bug tracker: https://github.com/mhallin/graphql_ppx/issues

---

:camel: Pull-request generated by opam-publish v0.3.5