### PR TITLE
add upper bounds on containers and sequence to some packages

### DIFF
--- a/packages/calculon/calculon.0.1/opam
+++ b/packages/calculon/calculon.0.1/opam
@@ -28,7 +28,7 @@ depends: [
   "irc-client" {>= "0.4.0"}
   "tls"
   "yojson"
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" < "2.0"}
   "ISO8601"
   "re"
   "stringext"

--- a/packages/logtk/logtk.0.8.1/opam
+++ b/packages/logtk/logtk.0.8.1/opam
@@ -28,7 +28,7 @@ depends: [
   "base-unix"
   "zarith"
   "containers" {>= "0.22.1" < "1.0"}
-  "sequence" {>= "0.6"}
+  "sequence" {>= "0.6" < "1.0"}
   "base-bytes"
 ]
 depopts: [

--- a/packages/nsq/nsq.0.1.1/opam
+++ b/packages/nsq/nsq.0.1.1/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/ryanslade/nsq-ocaml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build}
-  "containers"
+  "containers" { < "2.0" }
   "lwt"
   "ocplib-endian"
   "integers"

--- a/packages/nsq/nsq.0.1/opam
+++ b/packages/nsq/nsq.0.1/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/ryanslade/nsq-ocaml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build}
-  "containers"
+  "containers" {< "2.0"}
   "lwt"
   "ocplib-endian"
   "integers"

--- a/packages/oth/oth.2.10/opam
+++ b/packages/oth/oth.2.10/opam
@@ -17,7 +17,7 @@ remove: [
 ]
 
 depends: [
-	"containers"
+	"containers" {< "2.0"}
 	"duration"
 	"merlin-of-pds"
 	"ocamlfind"

--- a/packages/smbc/smbc.0.2/opam
+++ b/packages/smbc/smbc.0.2/opam
@@ -11,7 +11,7 @@ remove: ["rm" "%{bin}%/smbc"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "containers" {> "0.16"}
+  "containers" {> "0.16" < "2.0" }
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.6"}
   "tip-parser" {>= "0.3"}

--- a/packages/smbc/smbc.0.2/opam
+++ b/packages/smbc/smbc.0.2/opam
@@ -11,7 +11,7 @@ remove: ["rm" "%{bin}%/smbc"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "containers" {> "0.16" < "2.0" }
+  "containers" {> "0.16" < "1.0" }
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.6"}
   "tip-parser" {>= "0.3"}

--- a/packages/smbc/smbc.0.3.1/opam
+++ b/packages/smbc/smbc.0.3.1/opam
@@ -11,7 +11,7 @@ remove: ["rm" "%{bin}%/smbc"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" < "2.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.7"}
   "tip-parser" {>= "0.3"}

--- a/packages/smbc/smbc.0.4.1/opam
+++ b/packages/smbc/smbc.0.4.1/opam
@@ -11,7 +11,7 @@ remove: ["rm" "%{bin}%/smbc"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" < "2.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.8"}
   "tip-parser" {>= "0.3"}

--- a/packages/smbc/smbc.0.4/opam
+++ b/packages/smbc/smbc.0.4/opam
@@ -11,7 +11,7 @@ remove: ["rm" "%{bin}%/smbc"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" < "2.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.8"}
   "tip-parser" {>= "0.3"}

--- a/packages/snabela/snabela.1.0/opam
+++ b/packages/snabela/snabela.1.0/opam
@@ -18,7 +18,7 @@ remove: [
 
 depends: [
 	"cmdliner"
-	"containers"
+	"containers" {< "2.0"}
 	"merlin-of-pds"
 	"ocamlfind"
 	"oth" { test }

--- a/packages/zipperposition/zipperposition.1.1/opam
+++ b/packages/zipperposition/zipperposition.1.1/opam
@@ -33,8 +33,8 @@ depends: [
   "base-bytes"
   "base-unix"
   "zarith"
-  "containers" {>= "1.0"}
-  "sequence" {>= "0.4"}
+  "containers" {>= "1.0" < "2.0"}
+  "sequence" {>= "0.4" < "1.0"}
   "oclock"
   "msat" {>= "0.5"}
   "menhir" {build}

--- a/packages/zipperposition/zipperposition.1.2/opam
+++ b/packages/zipperposition/zipperposition.1.2/opam
@@ -33,8 +33,8 @@ depends: [
   "base-bytes"
   "base-unix"
   "zarith"
-  "containers" {>= "1.0"}
-  "sequence" {>= "0.4"}
+  "containers" {>= "1.0" < "2.0"}
+  "sequence" {>= "0.4" < "1.0" }
   "msat" {>= "0.5"}
   "menhir" {build}
   "tip-parser"

--- a/packages/zipperposition/zipperposition.1.4/opam
+++ b/packages/zipperposition/zipperposition.1.4/opam
@@ -33,8 +33,8 @@ depends: [
   "base-bytes"
   "base-unix"
   "zarith"
-  "containers" {>= "1.0"}
-  "sequence" {>= "0.4"}
+  "containers" {>= "1.0" < "2.0"}
+  "sequence" {>= "0.4" < "1.0"}
   "msat" {>= "0.5"}
   "menhir" {build}
 ]


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/11262

haven't looked at websocket yet, but it seems the most recent versions don't depend on containers anymore?