### PR TITLE
datakit-ci.0.12.0: Depend on cohttp-lwt-unix

### DIFF
--- a/packages/datakit-ci/datakit-ci.0.12.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.0/opam
@@ -40,5 +40,6 @@ depends: [
   "datakit" {test & >= "0.12.0"}
   "irmin-unix" {test & >= "1.2.0"}
   "alcotest" {test}
+  "cohttp-lwt-unix" {< "1.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
Same as #11187 but uses explicit dependency instead.
Log: http://obi.ocamllabs.io/logs/d2c399fa31456c661fad50a428eb5901.txt
Related to: https://github.com/moby/datakit/pull/615