### PR TITLE
Package vmnet.1.3.1

### DIFF
--- a/packages/vmnet/vmnet.1.3.1/descr
+++ b/packages/vmnet/vmnet.1.3.1/descr
@@ -1,0 +1,20 @@
+MacOS X `vmnet` NAT networking
+
+MacOS X 10.10 (Yosemite) introduced the somewhat undocumented `vmnet`
+framework.  This exposes virtual network interfaces to userland applications.
+There are a number of advantages of this over previous implementations:
+
+- Unlike [tuntaposx](http://tuntaposx.sourceforge.net/), this is builtin
+  to MacOS X now and so is easier to package up and distribute for end users.
+- `vmnet` uses the XPC sandboxing interfaces and should make it easier to
+  drop a hard dependency on running networking applications as `root`.
+- Most significantly, `vmnet` optionally supports NATing network traffic to the
+  outside world, which was previously unsupported.
+
+These OCaml bindings are constructed against the documentation contained
+in the `<vmnet.h>` header file in Yosemite, and may not be correct due to
+the lack of any other example code.  However, they do suffice to run
+[MirageOS](http://openmirage.org) applications that can connect to the
+outside world.
+
+Note the application must be configured to use DHCP: static IPs are not supported.

--- a/packages/vmnet/vmnet.1.3.1/opam
+++ b/packages/vmnet/vmnet.1.3.1/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer:   "Anil Madhavapeddy <anil@recoil.org>"
+authors:      "Anil Madhavapeddy <anil@recoil.org>"
+homepage:     "https://github.com/mirage/ocaml-vmnet"
+bug-reports:  "https://github.com/mirage/ocaml-vmnet/issues"
+dev-repo:     "https://github.com/mirage/ocaml-vmnet.git"
+doc:          "https://mirage.github.io/ocaml-vmnet/"
+license:      "ISC"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+build-test: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "jbuilder" "runtest" ]
+]
+
+depends: [
+  "jbuilder"   {build & >="1.0+beta9"}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "ocaml-migrate-parsetree" {build}
+  "sexplib" {>= "113.24.00"}
+  "ipaddr" {>="1.4.0"}
+  "lwt" {>="2.4.3"}
+  "cstruct" {>="1.9.0"}
+  "cstruct-unix"
+]
+available: [ os = "darwin" ]
+post-messages: [
+  "This package requires the vmnet.framework plus development headers which are present in Yosemite (10.10.*) and later." {failure}
+]

--- a/packages/vmnet/vmnet.1.3.1/url
+++ b/packages/vmnet/vmnet.1.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-vmnet/releases/download/1.3.1/vmnet-1.3.1.tbz"
+checksum: "2d29f60735a4579fcce6dee37bd015fe"


### PR DESCRIPTION
### `vmnet.1.3.1`

MacOS X `vmnet` NAT networking

MacOS X 10.10 (Yosemite) introduced the somewhat undocumented `vmnet`
framework.  This exposes virtual network interfaces to userland applications.
There are a number of advantages of this over previous implementations:

- Unlike [tuntaposx](http://tuntaposx.sourceforge.net/), this is builtin
  to MacOS X now and so is easier to package up and distribute for end users.
- `vmnet` uses the XPC sandboxing interfaces and should make it easier to
  drop a hard dependency on running networking applications as `root`.
- Most significantly, `vmnet` optionally supports NATing network traffic to the
  outside world, which was previously unsupported.

These OCaml bindings are constructed against the documentation contained
in the `<vmnet.h>` header file in Yosemite, and may not be correct due to
the lack of any other example code.  However, they do suffice to run
[MirageOS](http://openmirage.org) applications that can connect to the
outside world.

Note the application must be configured to use DHCP: static IPs are not supported.


---
* Homepage: https://github.com/mirage/ocaml-vmnet
* Source repo: https://github.com/mirage/ocaml-vmnet.git
* Bug tracker: https://github.com/mirage/ocaml-vmnet/issues

---


---
## 1.3.1 (2018-01-23)

* remove `-warn-error` flags in release mode. Fix compilation on 4.06
  (#21, @samoht)
:camel: Pull-request generated by opam-publish v0.3.5