### PR TITLE
add correct opam file for travis-opam 1.1.0

### DIFF
--- a/packages/travis-opam/travis-opam.1.1.0/opam
+++ b/packages/travis-opam/travis-opam.1.1.0/opam
@@ -7,11 +7,22 @@ authors: [
   "Thomas Gazagnaire"
   "Richard Mortier"
   "David Sheets"
-  "Anil Madhavapeddy"
 ]
 
 depends: [
   "ocamlbuild" {build}
+  "ocamlfind"  {build}
+]
+
+depexts: [
+  [["alpine"] ["jq"]]
+  [["centos"] ["jq"]]
+  [["debian"] ["jq"]]
+  [["fedora"] ["jq"]]
+  [["homebrew" "osx"] ["jq"]]
+  [["opensuse"] ["jq"]]
+  [["oraclelinux"] ["jq"]]
+  [["ubuntu"] ["jq"]]
 ]
 
 build: [make]


### PR DESCRIPTION
The original pull request adding travis-opam 1.1.0 had the opam file from travis-opam 1.0.3.  (Oops.)