### PR TITLE
Warn if num installed to a broken system compiler

### DIFF
--- a/packages/num/num.1.0/files/installation-warning.patch
+++ b/packages/num/num.1.0/files/installation-warning.patch
@@ -1,0 +1,59 @@
+From db8d748b2cad0adc2698e9fcf28727083a711bae Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Wed, 24 Jan 2018 16:01:56 +0000
+Subject: [PATCH] Warn about installations broken by previous faulty package
+
+---
+ Makefile | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index b40e588..d4dcd70 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,9 +14,42 @@ install:
+ 	$(MAKE) -C src install
+ 	$(MAKE) -C toplevel install
+ 
++OCAMLFIND_DIR:=$(dir $(shell command -v ocamlfind 2>/dev/null))
++OCAMLC_DIR:=$(dir $(shell command -v ocamlc 2>/dev/null))
++NUM_INSTALLED:=$(shell ocamlfind query num 2>/dev/null)
++
++ifeq ($(NUM_INSTALLED),)
++# The num findlib package is not already present - wohoo!
++OUR_FAULT=no
++else
++ifeq ($(OCAMLFIND_DIR),$(OCAMLC_DIR))
++# The num findlib package is present, but ocamlc and ocamlfind are in the
++# same place, which means that either we're looking at a system-installed
++# ocamlfind (which isn't supported), or the user has done something else
++# nefarious and doesn't deserve our sympathy (or, at least, our potentially
++# unhelpful advice)
++OUR_FAULT=no
++else
++# The num findlib package package is present, and ocamlc and ocamlfind reside
++# in different directories, which means that we're almost certainly looking at
++# a system switch which has been damaged by a previous num package installation
++# on an OS which didn't protect the system lib directory.
++OUR_FAULT=probably
++endif
++endif
++
+ findlib-install:
++ifeq ($(OUR_FAULT),no)
+ 	$(MAKE) -C src findlib-install
+ 	$(MAKE) -C toplevel install
++else
++	@echo "\033[0;31m[ERROR]\033[m It appears that the num library was previously installed to your system"
++	@echo "        compiler's lib directory, probably by a faulty opam package."
++	@echo "        You will need to remove arith_flags.*, arith_status.*, big_int.*,"
++	@echo "        int_misc.*, nat.*, num.*, ratio.*, nums.*, libnums.* and"
++	@echo "        stublibs/dllnums.* from $(shell ocamlc -where)."
++	@false
++endif
+ 
+ uninstall:
+ 	$(MAKE) -C src uninstall
+-- 
+2.14.1
+

--- a/packages/num/num.1.0/opam
+++ b/packages/num/num.1.0/opam
@@ -24,4 +24,4 @@ depends: [
 ]
 conflicts: [ "base-num" ]
 available: [ ocaml-version >= "4.06.0" ]
-patches: [ "findlib-install.patch" ]
+patches: [ "findlib-install.patch" "installation-warning.patch" ]

--- a/packages/num/num.1.1/files/installation-warning.patch
+++ b/packages/num/num.1.1/files/installation-warning.patch
@@ -1,0 +1,59 @@
+From db8d748b2cad0adc2698e9fcf28727083a711bae Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Wed, 24 Jan 2018 16:01:56 +0000
+Subject: [PATCH] Warn about installations broken by previous faulty package
+
+---
+ Makefile | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index b40e588..d4dcd70 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,9 +14,42 @@ install:
+ 	$(MAKE) -C src install
+ 	$(MAKE) -C toplevel install
+ 
++OCAMLFIND_DIR:=$(dir $(shell command -v ocamlfind 2>/dev/null))
++OCAMLC_DIR:=$(dir $(shell command -v ocamlc 2>/dev/null))
++NUM_INSTALLED:=$(shell ocamlfind query num 2>/dev/null)
++
++ifeq ($(NUM_INSTALLED),)
++# The num findlib package is not already present - wohoo!
++OUR_FAULT=no
++else
++ifeq ($(OCAMLFIND_DIR),$(OCAMLC_DIR))
++# The num findlib package is present, but ocamlc and ocamlfind are in the
++# same place, which means that either we're looking at a system-installed
++# ocamlfind (which isn't supported), or the user has done something else
++# nefarious and doesn't deserve our sympathy (or, at least, our potentially
++# unhelpful advice)
++OUR_FAULT=no
++else
++# The num findlib package package is present, and ocamlc and ocamlfind reside
++# in different directories, which means that we're almost certainly looking at
++# a system switch which has been damaged by a previous num package installation
++# on an OS which didn't protect the system lib directory.
++OUR_FAULT=probably
++endif
++endif
++
+ findlib-install:
++ifeq ($(OUR_FAULT),no)
+ 	$(MAKE) -C src findlib-install
+ 	$(MAKE) -C toplevel install
++else
++	@echo "\033[0;31m[ERROR]\033[m It appears that the num library was previously installed to your system"
++	@echo "        compiler's lib directory, probably by a faulty opam package."
++	@echo "        You will need to remove arith_flags.*, arith_status.*, big_int.*,"
++	@echo "        int_misc.*, nat.*, num.*, ratio.*, nums.*, libnums.* and"
++	@echo "        stublibs/dllnums.* from $(shell ocamlc -where)."
++	@false
++endif
+ 
+ uninstall:
+ 	$(MAKE) -C src uninstall
+-- 
+2.14.1
+

--- a/packages/num/num.1.1/opam
+++ b/packages/num/num.1.1/opam
@@ -24,4 +24,4 @@ depends: [
 ]
 conflicts: [ "base-num" ]
 available: [ ocaml-version >= "4.06.0" ]
-patches: [ "findlib-install.patch" ]
+patches: [ "findlib-install.patch" "installation-warning.patch" ]


### PR DESCRIPTION
This follows on from #11207.

If the num library was installed in a system switch where the user had write permissions to the system compiler's lib directory before #11207 was merged, then *fresh* installations of the ocamlfind package will detect this "system" installation of num and create a META file for it.

This in turn will cause the num package installation to fail. Annoyingly, this failure only appears once because opam then executes `ocamlfind remove num` so a subsequent attempt to install the num package will appear to have worked (however, in reality the system-installed files will conflict with the ones in the opam directory).

This patch displays a comprehensive error message the first time, strongly suggesting that the user manually delete the files which were incorrectly installed previously.

If you have a system compiler where num has been manually installed to `ocamlc -where` (e.g. by running `sudo make install` from the GitHub sources) and a fresh installation of the ocamlfind package, then you will now see the following if you attempt to install the num package:

```
dra@zesty64:~/num/src$ opam install num
The following actions will be performed:
  ∗  install num 1.1 

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[num.1.1] found in cache

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[ERROR] The installation of num failed at "make findlib-install".
Processing  2/2: [num: make findlib-uninstall]
#=== ERROR while installing num.1.1 ===========================================#
# context      2.0.0~beta6 | linux/x86_64 | ocaml-system.4.06.0 | file:///home/dra/opam-repository
# path         ~/.opam/temp/.opam-switch/build/num.1.1
# command      /usr/bin/make findlib-install
# exit-code    2
# env-file     ~/.opam/log/num-21717-a00279.env
# output-file  ~/.opam/log/num-21717-a00279.out
### output ###
# [ERROR] It appears that the num library was previously installed to your system
#         compiler's lib directory, probably by a faulty opam package.
#         You will need to remove arith_flags.*, arith_status.*, big_int.*,
#         int_misc.*, nat.*, num.*, ratio.*, nums.*, libnums.* and
#         stublibs/dllnums.* from /usr/local/lib/ocaml.
# Makefile:46: recipe for target 'findlib-install' failed
# make: *** [findlib-install] Error 1



=-=- Error report -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
┌─ The following actions failed
│ ∗  install num 1.1
└─ 
╶─ No changes have been performed
```

cc @avsm