### PR TITLE
Package electrod.0.1.3

### DIFF
--- a/packages/electrod/electrod.0.1.3/descr
+++ b/packages/electrod/electrod.0.1.3/descr
@@ -1,0 +1,40 @@
+Formal analysis for the Electrod formal specification language
+
+
+Electrod is a model finder inspired by Kodkod. It takes as input a
+model expressed in a mixture of relational first-order logic (RFOL)
+over bounded domains and linear temporal logic (LTL) over an unbounded
+time horizon.
+
+Then Electrod compiles the model to a problem for a solver (currently
+the NuSMV and nuXmv tools) to produce example or counter-example traces.
+
+Electrod is mainly meant to be used as a backend for the Electrum Analyzer.
+
+See the file [INSTALL.md](INSTALL.md) for building and installation instructions.
+
+[Home page](https://forge.onera.fr/projects/electrod)
+
+## External dependencies
+
+As of now, Electrod relies on NuSMV or nuXmv (default), so you must at least
+install one of them.
+
+## Running
+
+Electrod is primarily aimed at being called by external, more abstract
+tools, such as the [Electrum Analyzer](https://github.com/haslab/Electrum).
+
+However, it can also be run as a standalone tool by calling the
+`electrod` program.
+
+Type `electrod --help` to get some help on options.
+
+
+## Copyright and license
+
+(C) 2016-2018 ONERA
+
+electrod is distributed under the terms of the Mozilla Public License v2.0.
+
+See [LICENSES.md](LICENSES.md) for more information.

--- a/packages/electrod/electrod.0.1.3/opam
+++ b/packages/electrod/electrod.0.1.3/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "David Chemouil <david.chemouil+git@onera.fr>"
+authors: ["David Chemouil" "Julien Brunel"]
+homepage: "https://github.com/grayswandyr/electrod/"
+bug-reports: "https://github.com/grayswandyr/electrod/issues"
+license: "MPL-2.0"
+dev-repo: "https://github.com/grayswandyr/electrod.git"
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build & >="1.0+beta9"}
+  "topkg" {build & >= "0.9.0"} 
+  "cmdliner" 
+  "containers" 
+  "fmt" 
+  "gen" 
+  "hashcons" 
+  "logs" 
+  "menhir" 
+  "mtime" 
+  "ppx_blob"
+  "ppx_deriving" 
+  "printbox"
+  "sequence" 
+  "visitors" 
+]
+available: [ocaml-version >= "4.04"]

--- a/packages/electrod/electrod.0.1.3/url
+++ b/packages/electrod/electrod.0.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/grayswandyr/electrod/releases/download/0.1.3/electrod-0.1.3.tbz"
+checksum: "c3bd71237974ed87c9101f39a11a1cbd"


### PR DESCRIPTION
### `electrod.0.1.3`

Formal analysis for the Electrod formal specification language


Electrod is a model finder inspired by Kodkod. It takes as input a
model expressed in a mixture of relational first-order logic (RFOL)
over bounded domains and linear temporal logic (LTL) over an unbounded
time horizon.

Then Electrod compiles the model to a problem for a solver (currently
the NuSMV and nuXmv tools) to produce example or counter-example traces.

Electrod is mainly meant to be used as a backend for the Electrum Analyzer.

See the file [INSTALL.md](INSTALL.md) for building and installation instructions.

[Home page](https://forge.onera.fr/projects/electrod)

## External dependencies

As of now, Electrod relies on NuSMV or nuXmv (default), so you must at least
install one of them.

## Running

Electrod is primarily aimed at being called by external, more abstract
tools, such as the [Electrum Analyzer](https://github.com/haslab/Electrum).

However, it can also be run as a standalone tool by calling the
`electrod` program.

Type `electrod --help` to get some help on options.


## Copyright and license

(C) 2016-2018 ONERA

electrod is distributed under the terms of the Mozilla Public License v2.0.

See [LICENSES.md](LICENSES.md) for more information.


---
* Homepage: https://github.com/grayswandyr/electrod/
* Source repo: https://github.com/grayswandyr/electrod.git
* Bug tracker: https://github.com/grayswandyr/electrod/issues

---


---
### 0.1.3 (2018-01-24)
- Fix OPAM problem.
:camel: Pull-request generated by opam-publish v0.3.5