### PR TITLE
Package jupyter-kernel.0.1

### DIFF
--- a/packages/jupyter-kernel/jupyter-kernel.0.1/descr
+++ b/packages/jupyter-kernel/jupyter-kernel.0.1/descr
@@ -1,0 +1,2 @@
+A library for writing [Jupyter](https://jupyter.org) kernels in OCaml
+

--- a/packages/jupyter-kernel/jupyter-kernel.0.1/opam
+++ b/packages/jupyter-kernel/jupyter-kernel.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Andrew Ray"]
+homepage: "https://github.com/ocaml-jupyter/jupyter-kernel"
+bug-reports: "https://github.com/ocaml-jupyter/jupyter-kernel/issues"
+tags: ["jupyter" "ipython"]
+dev-repo: "https://github.com/ocaml-jupyter/jupyter-kernel.git"
+build: [make "build"]
+build-doc: ["jbuilder" "doc"]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "result"
+  "base-unix"
+  "zmq"
+  "atdgen"
+  "yojson"
+  "uuidm"
+  "lwt"
+  "lwt-zmq"
+  "nocrypto"
+  "hex"
+  "ISO8601"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/jupyter-kernel/jupyter-kernel.0.1/url
+++ b/packages/jupyter-kernel/jupyter-kernel.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-jupyter/jupyter-kernel/archive/0.1.tar.gz"
+checksum: "32fbe3c0d117cc920d8f3872b5c68967"


### PR DESCRIPTION
### `jupyter-kernel.0.1`

A library for writing [Jupyter](https://jupyter.org) kernels in OCaml




---
* Homepage: https://github.com/ocaml-jupyter/jupyter-kernel
* Source repo: https://github.com/ocaml-jupyter/jupyter-kernel.git
* Bug tracker: https://github.com/ocaml-jupyter/jupyter-kernel/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5