### PR TITLE
cppo 1.6.1

### DIFF
--- a/packages/cppo/cppo.1.4.1/opam
+++ b/packages/cppo/cppo.1.4.1/opam
@@ -24,3 +24,4 @@ depends: [
   "ocamlbuild"
   "base-bytes"
 ]
+available: [ocaml-version < "4.07.0"]

--- a/packages/cppo/cppo.1.5.0/opam
+++ b/packages/cppo/cppo.1.5.0/opam
@@ -24,3 +24,4 @@ depends: [
   "ocamlbuild"
   "base-bytes"
 ]
+available: [ocaml-version < "4.07.0"]

--- a/packages/cppo/cppo.1.6.0/opam
+++ b/packages/cppo/cppo.1.6.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "martin@mjambon.com"
 authors: ["Martin Jambon"]
-homepage: "http://mjambon.com/cppo.html"
+homepage: "https://github.com/mjambon/cppo"
 dev-repo: "https://github.com/mjambon/cppo.git"
 bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
@@ -15,6 +15,7 @@ build-test: [
 ]
 
 depends: [
+  "ocaml"    {< "4.07"}
   "jbuilder" {build & >= "1.0+beta10"}
   "base-bytes"
   "base-unix"

--- a/packages/cppo/cppo.1.6.0/opam
+++ b/packages/cppo/cppo.1.6.0/opam
@@ -15,8 +15,8 @@ build-test: [
 ]
 
 depends: [
-  "ocaml"    {< "4.07"}
   "jbuilder" {build & >= "1.0+beta10"}
   "base-bytes"
   "base-unix"
 ]
+available: [ocaml-version < "4.07.0"]

--- a/packages/cppo/cppo.1.6.1/descr
+++ b/packages/cppo/cppo.1.6.1/descr
@@ -1,0 +1,1 @@
+Equivalent of the C preprocessor for OCaml programs

--- a/packages/cppo/cppo.1.6.1/opam
+++ b/packages/cppo/cppo.1.6.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/cppo.html"
+dev-repo: "https://github.com/mjambon/cppo.git"
+bug-reports: "https://github.com/mjambon/cppo/issues"
+license: "BSD-3-Clause"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "base-bytes"
+  "base-unix"
+]

--- a/packages/cppo/cppo.1.6.1/opam
+++ b/packages/cppo/cppo.1.6.1/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "martin@mjambon.com"
 authors: ["Martin Jambon"]
-homepage: "http://mjambon.com/cppo.html"
+homepage: "https://github.com/mjambon/cppo"
 dev-repo: "https://github.com/mjambon/cppo.git"
 bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"

--- a/packages/cppo/cppo.1.6.1/url
+++ b/packages/cppo/cppo.1.6.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mjambon/cppo/archive/v1.6.1.tar.gz"
+checksum: "b376e0f063f82daf5b1530479f5bcc5f"


### PR DESCRIPTION
Adds compatibility with ocaml 4.07.

I don't know a quick way of making a change to all or most `opam` files of previous versions. Ideally we would update the homepage url for all versions prior to 1.6.0, as well as adding the constraint on ocaml < 4.07. Is there a generic and semi-automated way of patching many `opam` files?
