### PR TITLE
travis-opam.1.1.0: Remove the ocamlfind dep

### DIFF
--- a/packages/travis-opam/travis-opam.1.1.0/opam
+++ b/packages/travis-opam/travis-opam.1.1.0/opam
@@ -11,7 +11,6 @@ authors: [
 
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
 ]
 
 depexts: [


### PR DESCRIPTION
This fixes numerous build failures with Alpine.
It seems like travis-opam didn't need ocamlfind to compile.

I'm going to merge this right away to avoid further problems. Feel free to revert it if this is wrong.

cc @yomimono 