### PR TITLE
Package orec.1.0

### DIFF
--- a/packages/orec/orec.1.0/descr
+++ b/packages/orec/orec.1.0/descr
@@ -1,0 +1,11 @@
+dynamic open records
+
+Orec's open records make it possible to dynamically create, access,
+update, and assign fields of an "open record" value with a syntax
+somewhat similar to the normal record syntax.
+
+The underlying implementation relies on heterogeneous maps for storing
+the field data and a liberal use of GADTs and extended indexing
+operators to expose a higher-level interface on the top of those
+hetereogeneous maps.
+

--- a/packages/orec/orec.1.0/opam
+++ b/packages/orec/orec.1.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+license: "LGPL-2"
+maintainer: "Florian Angeletti <octa@polychoron.fr>"
+authors: "Florian Angeletti <octa@polychoron.fr>"
+homepage: "https://github.com/Octachron/orec"
+bug-reports: "https://github.com/Octachron/orec/issues"
+dev-repo: "git+https://github.com/Octachron/orec"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-doc: ["jbuilder" "build" "-p" name "-j" jobs "@doc"]
+depends: [
+  "jbuilder" {build}
+]
+available: [ ocaml-version >= "4.06.0" ]

--- a/packages/orec/orec.1.0/url
+++ b/packages/orec/orec.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Octachron/orec/archive/1.0.zip"
+checksum: "a80a5bae704e77d578a415a489c6c507"


### PR DESCRIPTION
### `orec.1.0`

dynamic open records

Orec's open records make it possible to dynamically create, access,
update, and assign fields of an "open record" value with a syntax
somewhat similar to the normal record syntax.

The underlying implementation relies on heterogeneous maps for storing
the field data and a liberal use of GADTs and extended indexing
operators to expose a higher-level interface on the top of those
hetereogeneous maps.




---
* Homepage: https://github.com/Octachron/orec
* Source repo: https://github.com/Octachron/orec
* Bug tracker: https://github.com/Octachron/orec/issues

---

:camel: Pull-request generated by opam-publish v0.3.5