### PR TITLE
Package dryunit.0.5.0

### DIFF
--- a/packages/dryunit/dryunit.0.5.0/descr
+++ b/packages/dryunit/dryunit.0.5.0/descr
@@ -1,0 +1,27 @@
+A detection tool for traditional and popular testing frameworks
+
+It works with Alcotest or OUnit 2. It's fast. Everything processed
+(with the help of OCaml's parser) is cached - *you can choose where*.
+It's intuitive. You can get started with the command line
+(be that with templates or `--help`).
+
+No bootstrapping is required and you can keep all your tooling when
+writing tests. No compromises on the syntax. *It's as clean as it gets*. You can
+see the generated tests running `dryunit gen --framework alcotest` from the
+test dir.
+
+If you use jbuilder just run:
+
+```sh
+# Setting up a virtual test executable
+mkdir tests
+dryunit init > tests/jbuild
+
+# Adding a test
+echo "let test_dummy () = ()" > tests/dummy_tests.ml
+
+# Running things
+jbuilder build tests/main.exe && _build/default/tests/main.exe
+```
+
+Integration with other building systems should be straightfoward.

--- a/packages/dryunit/dryunit.0.5.0/opam
+++ b/packages/dryunit/dryunit.0.5.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "gerson.xp@gmail.com"
+authors: "Gerson Moraes"
+homepage: "https://github.com/gersonmoraes/dryunit"
+bug-reports: "https://github.com/gersonmoraes/dryunit"
+dev-repo: "https://github.com/gersonmoraes/dryunit.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build}
+  "cppo" {build}
+  "cmdliner" {>= "1.0.2"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/dryunit/dryunit.0.5.0/url
+++ b/packages/dryunit/dryunit.0.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gersonmoraes/dryunit/archive/0.5.0.tar.gz"
+checksum: "7515b76f79bb53a5074c4d37f94f949d"


### PR DESCRIPTION
### `dryunit.0.5.0`

A detection tool for traditional and popular testing frameworks

It works with Alcotest or OUnit 2. It's fast. Everything processed
(with the help of OCaml's parser) is cached - *you can choose where*.
It's intuitive. You can get started with the command line
(be that with templates or `--help`).

No bootstrapping is required and you can keep all your tooling when
writing tests. No compromises on the syntax. *It's as clean as it gets*. You can
see the generated tests running `dryunit gen --framework alcotest` from the
test dir.

If you use jbuilder just run:

```sh
# Setting up a virtual test executable
mkdir tests
dryunit init > tests/jbuild

# Adding a test
echo "let test_dummy () = ()" > tests/dummy_tests.ml

# Running things
jbuilder build tests/main.exe && _build/default/tests/main.exe
```

Integration with other building systems should be straightfoward.



---
* Homepage: https://github.com/gersonmoraes/dryunit
* Source repo: https://github.com/gersonmoraes/dryunit.git
* Bug tracker: https://github.com/gersonmoraes/dryunit

---

:camel: Pull-request generated by opam-publish v0.3.5