### PR TITLE
Package fstar.0.9.5.0: add missing package for fstar master

### DIFF
--- a/packages/fstar/fstar.0.9.5.0/opam
+++ b/packages/fstar/fstar.0.9.5.0/opam
@@ -14,6 +14,7 @@ depends: [
   "fileutils"
   "menhir" { >= "20161115" }
   "pprint"
+  "ulex"
 ]
 depexts: [
   [ ["osx" "homebrew"] ["coreutils"] ]

--- a/packages/fstar/fstar.0.9.5.0/opam
+++ b/packages/fstar/fstar.0.9.5.0/opam
@@ -34,6 +34,6 @@ remove: [
       "%{prefix}%/bin/fstar"
       "%{prefix}%/share/fstar" ]
 ]
-available: [ ocaml-version >= "4.02.3" & (ocaml-version < "4.03.0" | ocaml-version >= "4.04.0") ]
+available: [ ocaml-version >= "4.02.3" & (ocaml-version < "4.03.0" | (ocaml-version >= "4.04.0" & ocaml-version < "4.07.0")) ]
 dev-repo: "git://github.com/FStarLang/FStar"
 bug-reports: "https://github.com/FStarLang/FStar/issues"

--- a/packages/fstar/fstar.0.9.5.0/url
+++ b/packages/fstar/fstar.0.9.5.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/FStarLang/FStar/archive/v0.9.5.0-opam.tar.gz"
-checksum: "aeb396184a96dc957f04c28675159170"
+checksum: "bb836bc4b9bb6402afaab671d9df62ce"


### PR DESCRIPTION
This fix is intended for those users who want to pin the F* master branch instead of the stable version 0.9.5.0. It does not impact users of the latter.
See also: FStarLang/FStar#1342
