### PR TITLE
Patch Ocamlnet for co-installability with Camlzip on 4.06

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.5/files/netgzip.patch
+++ b/packages/ocamlnet/ocamlnet.4.1.5/files/netgzip.patch
@@ -1,0 +1,96 @@
+diff --git a/src/netzip/netgzip.ml b/src/netzip/netgzip.ml
+index f696760..1057a4e 100644
+--- a/src/netzip/netgzip.ml
++++ b/src/netzip/netgzip.ml
+@@ -6,8 +6,7 @@ class input_gzip_rec gzip_ch : Netchannels.rec_in_channel =
+ object(self)
+   val mutable closed = false
+ 
+-  method input s p l = 
+-    let s = Bytes.unsafe_to_string s in
++  method input s p l =
+     let n = Gzip.input gzip_ch s p l in
+     if n = 0 then raise End_of_file;
+     n
+@@ -27,7 +26,6 @@ class input_gzip gzip_ch =
+ class output_gzip_rec gzip_ch : Netchannels.rec_out_channel =
+ object(self)
+   method output s p l =
+-    let s = Bytes.unsafe_to_string s in
+     Gzip.output gzip_ch s p l;
+     l
+   method close_out() =
+@@ -156,24 +154,20 @@ let inflating_conv st incoming at_eof outgoing =
+ 		          (fun out_buf out_pos out_len ->
+ 		             let (finished, used_in, used_out) =
+ 			       try
+-                                 let in_buf = Bytes.unsafe_to_string in_buf in
+-                                 let out_buf = Bytes.unsafe_to_string out_buf in
+-			         Zlib.inflate 
+-			           stream 
+-                                   in_buf in_pos in_len out_buf out_pos out_len 
++			         Zlib.inflate
++			           stream
++                                   in_buf in_pos in_len out_buf out_pos out_len
+ 		                   Zlib.Z_SYNC_FLUSH
+ 			       with Zlib.Error(_, _) ->
+-                                 dispose_in_ignore st; 
++                                 dispose_in_ignore st;
+                                  gzip_error "error during decompression" in
+-                             
+-		       
++
++
+                              st.in_size <-
+ 			       Int32.add st.in_size (Int32.of_int used_out);
+ 		             st.in_crc <-
+-                               ( let out_buf = Bytes.unsafe_to_string out_buf in
+-			         Zlib.update_crc st.in_crc out_buf out_pos used_out
+-                               );
+-		       
++			       Zlib.update_crc st.in_crc out_buf out_pos used_out;
++
+ 		             k := !k + used_in;
+ 
+                              if finished then (
+@@ -292,31 +286,27 @@ let deflating_conv st incoming at_eof outgoing =
+ 		  (fun out_buf out_pos out_len ->
+ 		     let (finished, used_in, used_out) =
+ 		       try
+-                         let in_buf = Bytes.unsafe_to_string in_buf in
+-                         let out_buf = Bytes.unsafe_to_string out_buf in
+-			 Zlib.deflate 
+-			   stream in_buf 0 in_len out_buf out_pos out_len 
++			 Zlib.deflate
++			   stream in_buf 0 in_len out_buf out_pos out_len
+ 			   (if at_eof then Zlib.Z_FINISH else Zlib.Z_NO_FLUSH)
+-		       with 
++		       with
+ 			 | Zlib.Error(_, "buffer error") ->
+ 			     (false, 0, 0)
+ 			 |Zlib.Error(_, msg) ->
+ 			    raise (Gzip.Error("error during compression")) in
+-		     
++
+ 		     st.out_size <- Int32.add st.out_size (Int32.of_int used_in);
+-		     st.out_crc <- (
+-                       let in_buf = Bytes.unsafe_to_string in_buf in
+-                       Zlib.update_crc st.out_crc in_buf 0 used_in
+-                     );
+-		     
++		     st.out_crc <-
++                       Zlib.update_crc st.out_crc in_buf 0 used_in;
++
+ 		     Netbuffer.delete incoming 0 used_in;
+-		     
++
+ 		     if at_eof && finished then loop := false;
+ 		     used_out
+ 		  ) in
+ 	      if not at_eof then loop := false
+ 	    done;
+-	    
++
+ 	    if at_eof then (
+ 	      write_int32 outgoing st.out_crc;
+ 	      write_int32 outgoing st.out_size;

--- a/packages/ocamlnet/ocamlnet.4.1.5/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.5/opam
@@ -58,6 +58,7 @@ depopts: [
   "pcre"
   "camlzip"
 ]
+patches: [ "netgzip.patch" ]
 available: [ ocaml-version >= "4.00.0"
            & compiler != "4.04.0+flambda"
            & compiler != "4.04.1+flambda"


### PR DESCRIPTION
The issue has been [reported upstream](https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues/11), but it would be nice to make these co-installable before an upstream release happens.