### PR TITLE
Tyxml 4.02

### DIFF
--- a/packages/tyxml-ppx/tyxml-ppx.4.2.0/descr
+++ b/packages/tyxml-ppx/tyxml-ppx.4.2.0/descr
@@ -1,0 +1,1 @@
+Virtual package for tyxml's ppx

--- a/packages/tyxml-ppx/tyxml-ppx.4.2.0/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.2.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "dev@ocsigen.org"
+author: "The ocsigen team"
+homepage: "https://ocsigen.org/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+build: ["ocamlfind" "query" "tyxml.ppx"]
+depends: [
+  "tyxml" {>= "4.2.0"}
+  "markup" {>= "0.7.2"}
+  "ppx_tools"
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/tyxml/tyxml.4.2.0/descr
+++ b/packages/tyxml/tyxml.4.2.0/descr
@@ -1,0 +1,6 @@
+TyXML is a library for building statically correct HTML5 and SVG documents
+
+TyXML allows you to build HTML5 and SVG trees whose validity is ensured by the typechecker.
+It provides a printer for said XML trees, along with a ppx syntax extension.
+Finally it also provides a functorial interface to choose your XML datastructure.
+It's part of the ocsigen project and is used in js_of_ocaml and eliom.

--- a/packages/tyxml/tyxml.4.2.0/files/tyxml.install
+++ b/packages/tyxml/tyxml.4.2.0/files/tyxml.install
@@ -1,0 +1,6 @@
+lib: "tyxml.opam" { "opam" }
+doc: [
+  "README.md"
+  "CHANGES"
+  "COPYING" { "LICENSE" }
+]

--- a/packages/tyxml/tyxml.4.2.0/opam
+++ b/packages/tyxml/tyxml.4.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+
+maintainer: "dev@ocsigen.org"
+author: "The ocsigen team"
+homepage: "https://ocsigen.org/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "https://github.com/ocsigen/tyxml.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--%{markup+ppx_tools_versioned:enable}%-ppx"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+build-test: [
+  ["ocaml" "setup.ml" "-configure"
+      "--%{camlp4:enable}%-syntax"
+      "--%{markup+ppx_tools_versioned:enable}%-ppx"
+      "--enable-tests"
+      "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tyxml"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+  "base-bytes"
+  "re" {>= "1.5.0"}
+  "alcotest" {test}
+]
+depopts: [
+  "camlp4"
+  "markup"
+  "ppx_tools_versioned"
+]
+available: [ocaml-version >= "4.02"]
+messages: [
+  "For tyxml's ppx, please install tyxml-ppx."
+  {!markup:installed | !ppx_tools_versioned:installed}
+  "Tyxml's camlp4-based libraries (tyxml.syntax and tyxml.parser) are now deprecated and will be removed in the next major version."
+  {camlp4:installed}
+]

--- a/packages/tyxml/tyxml.4.2.0/url
+++ b/packages/tyxml/tyxml.4.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/tyxml/archive/4.2.0.tar.gz"
+checksum: "c802f3c7036adcea3fc00398c23d1b2b"


### PR DESCRIPTION
Announce: https://github.com/ocsigen/tyxml/releases/tag/4.2.0
As usual, one package, and one virtual -ppx package. Main packaging changes are migration to omp and deprecation of camlp4.

------------------

* Compatibility with OCaml 4.6.0.
* The ppx should now be compatible with driver-based workflows. In particular, jbuilder.
* Future breakage:
  * The two camlp4-based packages (tyxml.syntax and tyxml.parser) are now deprecated and will be removed in the next major version.
  * Introduction of the tyxml-ppx ocamlfind package. Usage of the tyxml.ppx package is discouraged, and it will be removed in the next major version.
* Various fixes in the Html_sigs.T module (contribution by Fabian Pijcke):
  * Fixed the map element function signature.
  * The elements functions now (almost) all make use of the types defined in `Html_types`, rather than redefining them.
  * `Html_sigs.T.fieldset` now takes `[< legend] elt wrap` as optional argument rather than `legend elt wrap`.
* Add basic support for `aria-*` attributes (contribution by Armaël Guéneau)
  (see https://www.w3.org/TR/wai-aria-1.1/#states_and_properties)
* Add support for the `role` attribute (contribution by Armaël Guéneau)
  (see https://www.w3.org/TR/role-attribute/)
* Add support for the `minlength` form attribute (contribution by Armaël Guéneau)
  (See https://www.w3.org/TR/html5/forms.html#attr-input-minlength)