### PR TITLE
bap-elf <= 1.3.0 depends on bitstring < 3.0.0

### DIFF
--- a/packages/bap-elf/bap-elf.1.0.0/opam
+++ b/packages/bap-elf/bap-elf.1.0.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring"
+    "bitstring" {< "3.0.0"}
 ]

--- a/packages/bap-elf/bap-elf.1.1.0/opam
+++ b/packages/bap-elf/bap-elf.1.1.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring"
+    "bitstring" {< "3.0.0"}
 ]

--- a/packages/bap-elf/bap-elf.1.2.0/opam
+++ b/packages/bap-elf/bap-elf.1.2.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring"
+    "bitstring" {< "3.0.0"}
 ]

--- a/packages/bap-elf/bap-elf.1.3.0/opam
+++ b/packages/bap-elf/bap-elf.1.3.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring"
+    "bitstring" {< "3.0.0"}
 ]


### PR DESCRIPTION
bap-elf <= 1.3.0 depends on the camlp4-based bitstring (ocamlfind package bitstring.syntax) which is no longer provided by bitstring 3.0.