### PR TITLE
Package jbuilder.1.0+beta17

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta17/descr
+++ b/packages/jbuilder/jbuilder.1.0+beta17/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+jbuilder is a build system that was designed to simplify the release
+of Jane Street packages. It reads metadata from "jbuild" files
+following a very simple s-expression syntax.
+
+jbuilder is fast, it has very low-overhead and support parallel builds
+on all platforms. It has no system dependencies, all you need to build
+jbuilder and packages using jbuilder is OCaml. You don't need or make
+or bash as long as the packages themselves don't use bash explicitely.
+
+jbuilder supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/jbuilder/jbuilder.1.0+beta17/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta17/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "Apache-2.0"
+build: [
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--subst"] {pinned}
+  ["./boot.exe" "-j" jobs]
+]
+build-test: [
+  ["./_build/default/bin/main.exe" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  # ocamlfind is not mandatory to build packages using
+  # jbuilder. However if it is present jbuilder will use it.  Making
+  # it a hard-dependency avoids problems when there is a previous
+  # ocamlfind in the PATH. We make it a "build" depepdency even though
+  # it is only a runtime dependency so that reinstalling ocamlfind
+  # doesn't resintall jbuilder
+  "ocamlfind" {build}
+  "menhir" {test}
+  "reason" {test}
+  "ocaml-migrate-parsetree" {test}
+  "ppx_driver" {test}
+  "odoc" {test}
+  "js_of_ocaml-compiler" {test}
+  "utop" {test}
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/jbuilder/jbuilder.1.0+beta17/url
+++ b/packages/jbuilder/jbuilder.1.0+beta17/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dune/releases/download/1.0+beta17/jbuilder-1.0.beta17.tbz"
+checksum: "03f11f4c6851d799ec7051ff48510ed4"


### PR DESCRIPTION
### `jbuilder.1.0+beta17`

Fast, portable and opinionated build system

jbuilder is a build system that was designed to simplify the release
of Jane Street packages. It reads metadata from "jbuild" files
following a very simple s-expression syntax.

jbuilder is fast, it has very low-overhead and support parallel builds
on all platforms. It has no system dependencies, all you need to build
jbuilder and packages using jbuilder is OCaml. You don't need or make
or bash as long as the packages themselves don't use bash explicitely.

jbuilder supports multi-package development by simply dropping multiple
repositories into the same directory.

It also supports multi-context builds, such as building against
several opam roots/switches simultaneously. This helps maintaining
packages across several versions of OCaml and gives cross-compilation
for free.



---
* Homepage: https://github.com/ocaml/dune
* Source repo: https://github.com/ocaml/dune.git
* Bug tracker: https://github.com/ocaml/dune/issues

---


---
1.0+beta17 (01/02/2018)
-----------------------

- Make jbuilder aware that `num` is an external package in OCaml >= 4.06.0
  (#358)

- `jbuilder exec` will now rebuild the executable before running it if
  necessary. This can be turned off by passing `--no-build` (#345)

- Fix `jbuilder utop` to work in any working directory (#339)

- Fix generation of META synopsis that contains double quotes (#337)

- Add `S .` to .merlin by default (#284)

- Improve `jbuilder exec` to make it possible to execute non public executables.
  `jbuilder exec path/bin` will execute `bin` inside default (or specified)
  context relative to `path`. `jbuilder exec /path` will execute `/path` as
  absolute path but with the context's environment set appropriately. Lastly,
  `jbuilder exec` will change the root as to which paths are relative using the
  `-root` option. (#286)

- Fix `jbuilder rules` printing rules when some binaries are missing (#292)

- Build documentation for non public libraries (#306)

- Fix doc generation when several private libraries have the same name (#369)

- Fix copy# for C/C++ with Microsoft C compiler (#353)

- Add support for cross-compilation. Currently we are supporting the
  opam-cross-x repositories such as
  [opam-cross-windows](https://github.com/whitequark/opam-cross-windows)
  (#355)

- Simplify generated META files: do not generate the transitive
  closure of dependencies in META files (#405)

- Deprecated `${!...}`: the split behavior is now a property of the
  variable. For instance `${CC}`, `${^}`, `${read-lines:...}` all
  expand to lists unless used in the middle of a longer atom (#336)

- Add an `(include ...)` stanza allowing one to include another
  non-generated jbuild file in the current file (#402)

- Add a `(diff <file1> <file2>)` action allowing to diff files and
  promote generated files in case of mismatch (#402, #421)

- Add `jbuilder promote` and `--auto-promote` to promote files (#402,
  #421)

- Report better errors when using `(glob_files ...)` with a directory
  that doesn't exist (#413, Fix #412)

- Jbuilder now properly handles correction files produced by
  ppx_driver. This allows to use `[@@deriving_inline]` in .ml/.mli
  files. This require `ppx_driver >= v0.10.2` to work properly (#415)

- Make jbuilder load rules lazily instead of generating them all
  eagerly. This speeds up the initial startup time of jbuilder on big
  workspaces (#370)

- Now longer generate a `META.pkg.from-jbuilder` file. Now the only
  way to customise the generated `META` file is through
  `META.pkg.template`. This feature was unused and was making the code
  complicated (#370)

- Remove read-only attribute on Windows before unlink (#247)

- Use /Fo instead of -o when invoking the Microsoft C compiler to eliminate
  deprecation warning when compiling C++ sources (#354)

- Add a mode field to `rule` stanzas:
  + `(mode standard)` is the default
  + `(mode fallback)` replaces `(fallback)`
  + `(mode promote)` means that targets are copied to the source tree
  after the rule has completed
  + `(mode promote-until-clean)` is the same as `(mode promote)` except
  that `jbuilder clean` deletes the files copied to the source tree.
  (#437)

- Add a flag `--ignore-promoted-rules` to make jbuilder ignore rules
  with `(mode promote)`. `-p` implies `--ignore-promoted-rules` (#437)

- Display a warning for invalid lines in jbuild-ignore (#389)

- Always build `boot.exe` as a bytecode program. It makes the build of
  jbuilder faster and fix the build on some architectures (#463, fixes #446)

- Fix bad interaction between promotion and incremental builds on OSX
  (#460, fix #456)
:camel: Pull-request generated by opam-publish v0.3.5