### PR TITLE
Package kyotocabinet.0.2

### DIFF
--- a/packages/kyotocabinet/kyotocabinet.0.2/descr
+++ b/packages/kyotocabinet/kyotocabinet.0.2/descr
@@ -1,0 +1,5 @@
+OCaml bindings for Kyoto Cabinet DBM
+
+Kyoto Cabinet is a key-value store featuring
+both B+ tree and hash databases
+with either in-memory or on-disk persistence.

--- a/packages/kyotocabinet/kyotocabinet.0.2/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Didier Wenzek <didier.wenzek@acidalie.com>"
+authors: "Didier Wenzek <didier.wenzek@acidalie.com>"
+homepage: "https://github.com/didier-wenzek/ocaml-kyotocabinet"
+bug-reports: "https://github.com/didier-wenzek/ocaml-kyotocabinet/issues"
+license: "GPL"
+dev-repo: "https://github.com/didier-wenzek/ocaml-kyotocabinet.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+depends: [
+  "jbuilder" {build}
+]
+depexts: [
+  [["debian"] ["libkyotocabinet-dev"]]
+  [["fedora"] ["kyotocabinet-devel"]]
+  [["homebrew" "osx"] ["kyoto-cabinet"]]
+  [["macports" "osx"] ["kyotocabinet"]]
+  [["ubuntu"] ["libkyotocabinet-dev"]]
+]

--- a/packages/kyotocabinet/kyotocabinet.0.2/url
+++ b/packages/kyotocabinet/kyotocabinet.0.2/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/didier-wenzek/ocaml-kyotocabinet/archive/0.2.tar.gz"
+checksum: "c9521f3e2ce86613eb3cf5814d71b4bc"


### PR DESCRIPTION
### `kyotocabinet.0.2`

OCaml bindings for Kyoto Cabinet DBM

Kyoto Cabinet is a key-value store featuring
both B+ tree and hash databases
with either in-memory or on-disk persistence.



---
* Homepage: https://github.com/didier-wenzek/ocaml-kyotocabinet
* Source repo: https://github.com/didier-wenzek/ocaml-kyotocabinet.git
* Bug tracker: https://github.com/didier-wenzek/ocaml-kyotocabinet/issues

---

:camel: Pull-request generated by opam-publish v0.3.5