### PR TITLE
Package traildb.0.1

### DIFF
--- a/packages/traildb/traildb.0.1/descr
+++ b/packages/traildb/traildb.0.1/descr
@@ -1,0 +1,3 @@
+OCaml bindings for TrailDB.
+
+TrailDB is a file format for time-series.

--- a/packages/traildb/traildb.0.1/opam
+++ b/packages/traildb/traildb.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Didier Wenzek <didier.wenzek@acidalie.com>"
+authors: "Didier Wenzek <didier.wenzek@acidalie.com>"
+homepage: "https://github.com/didier-wenzek/ocaml-traildb"
+bug-reports: "https://github.com/didier-wenzek/ocaml-traildb/issues"
+license: "MIT"
+dev-repo: "https://github.com/didier-wenzek/ocaml-traildb.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-j" jobs]
+depends: [
+  "uuidm"
+  "jbuilder" {build}
+  "oUnit" {test}
+]
+depexts: [
+  [["debian"] ["libtraildb-dev"]]
+  [["homebrew"] ["traildb"]]
+  [["ubuntu"] ["libtraildb-dev"]]
+]

--- a/packages/traildb/traildb.0.1/url
+++ b/packages/traildb/traildb.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/didier-wenzek/ocaml-traildb/archive/0.1.tar.gz"
+checksum: "d3de8da2e0b59880a3a1635753c8663b"


### PR DESCRIPTION
### `traildb.0.1`

OCaml bindings for TrailDB.

TrailDB is a file format for time-series.



---
* Homepage: https://github.com/didier-wenzek/ocaml-traildb
* Source repo: https://github.com/didier-wenzek/ocaml-traildb.git
* Bug tracker: https://github.com/didier-wenzek/ocaml-traildb/issues

---

:camel: Pull-request generated by opam-publish v0.3.5