### PR TITLE
Add deriving.0.8.1 (OCaml 4.06 compatible)

### DIFF
--- a/packages/deriving/deriving.0.8.1/descr
+++ b/packages/deriving/deriving.0.8.1/descr
@@ -1,0 +1,1 @@
+Extension to OCaml for deriving functions from type declarations

--- a/packages/deriving/deriving.0.8.1/opam
+++ b/packages/deriving/deriving.0.8.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "deriving"
+version: "0.8.1"
+maintainer: "dev@ocsigen.org"
+authors: "Jeremy Yallop <yallop@gmail.com>"
+homepage: "http://github.com/ocsigen/deriving/"
+bug-reports: "https://github.com/ocsigen/deriving/issues/"
+license: "MIT"
+dev-repo: "https://github.com/ocsigen/deriving.git"
+build: [
+  [make "setup.exe"]
+  ["./setup.exe" "-configure" "--prefix" prefix "--%{type_conv:enable}%-tc"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "deriving"]
+depends: [
+  "ocamlfind"
+  "camlp4"
+  "num"
+  "oasis" {build & >= "0.4.4"}
+]
+depopts: "type_conv"
+conflicts: [
+  "type_conv" {< "108.07.00"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/deriving/deriving.0.8.1/url
+++ b/packages/deriving/deriving.0.8.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/deriving/archive/0.8.1.tar.gz"
+checksum: "59558a23583fbc0c7c139f6ed22fbb54"


### PR DESCRIPTION
Follow-up to #11324 with a small build system fix (`num` dependency).