### PR TITLE
Package json_of_jsonm.1.0.0

### DIFF
--- a/packages/json_of_jsonm/json_of_jsonm.1.0.0/descr
+++ b/packages/json_of_jsonm/json_of_jsonm.1.0.0/descr
@@ -1,0 +1,11 @@
+json_of_jsonm_lib is a JSON encoder and decoder library that converts text to and from a
+`json` type. The library has the following features:
+
+* Uses jsonm to do the actual stream encoding and decoding
+* The `json` type is compatible with and a subset of yojson's `json` type
+* Provides both string and channel interfaces by default
+* The Json_string module provides a standard type `t` interface in addition to the
+  `json` type
+* Both `result` and exception functions are provided in most cases
+* The Json_encoder_decoder functor allows additional IO mechanisms, including Async,
+  to be defined easily. 

--- a/packages/json_of_jsonm/json_of_jsonm.1.0.0/opam
+++ b/packages/json_of_jsonm/json_of_jsonm.1.0.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Steve Bleazard <stevebleazard@googlemail.com>"
+authors: "Steve Bleazard <stevebleazard@googlemail.com>"
+homepage: "https://www.github.com/stevebleazard/ocaml-json-of-jsonm"
+bug-reports: "https://www.github.com/stevebleazard/ocaml-json-of-jsonm/issues"
+license: "MIT"
+dev-repo: "https://www.github.com/stevebleazard/ocaml-json-of-jsonm.git"
+doc: "https://stevebleazard.github.io/ocaml-json-of-jsonm/"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs "@install"]
+]
+
+depends: [
+  "jbuilder"  {build}
+  "jsonm"
+]
+
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/json_of_jsonm/json_of_jsonm.1.0.0/url
+++ b/packages/json_of_jsonm/json_of_jsonm.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://www.github.com/stevebleazard/ocaml-json-of-jsonm/releases/download/v1.0.0/json_of_jsonm-1.0.0.tbz"
+checksum: "1503d4bcb108325c723405271f32bc56"


### PR DESCRIPTION
### `json_of_jsonm.1.0.0`

json_of_jsonm_lib is a JSON encoder and decoder library that converts text to and from a
`json` type. The library has the following features:

* Uses jsonm to do the actual stream encoding and decoding
* The `json` type is compatible with and a subset of yojson's `json` type
* Provides both string and channel interfaces by default
* The Json_string module provides a standard type `t` interface in addition to the
  `json` type
* Both `result` and exception functions are provided in most cases
* The Json_encoder_decoder functor allows additional IO mechanisms, including Async,
  to be defined easily. 



---
* Homepage: https://www.github.com/stevebleazard/ocaml-json-of-jsonm
* Source repo: https://www.github.com/stevebleazard/ocaml-json-of-jsonm.git
* Bug tracker: https://www.github.com/stevebleazard/ocaml-json-of-jsonm/issues

---


---
# v1.0.0

- Initial release
:camel: Pull-request generated by opam-publish v0.3.5