### PR TITLE
Package gen.0.5.1

### DIFF
--- a/packages/gen/gen.0.5.1/descr
+++ b/packages/gen/gen.0.5.1/descr
@@ -1,0 +1,4 @@
+Simple and efficient iterators (modules Gen and GenLabels).
+
+Now provides additional modules GenClone and GenMList for lower-level control
+over persistency and duplication of iterators.

--- a/packages/gen/gen.0.5.1/opam
+++ b/packages/gen/gen.0.5.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/gen/"
+bug-reports: "https://github.com/c-cube/gen/issues"
+doc: "http://cedeela.fr/~simon/software/gen/"
+tags: ["gen" "iterator" "iter" "fold"]
+dev-repo: "https://github.com/c-cube/gen.git"
+build: ["jbuilder" "build" "@install"]
+build-test: ["jbuilder" "runtest"]
+build-doc: ["jbuilder" "build" "@doc"]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "odoc" {doc}
+  "qtest" {test}
+  "qcheck" {test}
+]

--- a/packages/gen/gen.0.5.1/url
+++ b/packages/gen/gen.0.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/gen/archive/0.5.1.tar.gz"
+checksum: "4fb545ddde26dd084f01210681df4c14"


### PR DESCRIPTION
### `gen.0.5.1`

Simple and efficient iterators (modules Gen and GenLabels).

Now provides additional modules GenClone and GenMList for lower-level control
over persistency and duplication of iterators.



---
* Homepage: https://github.com/c-cube/gen/
* Source repo: https://github.com/c-cube/gen.git
* Bug tracker: https://github.com/c-cube/gen/issues

---

:camel: Pull-request generated by opam-publish v0.3.5