### PR TITLE
Package qcheck.0.8

### DIFF
--- a/packages/qcheck/qcheck.0.8/descr
+++ b/packages/qcheck/qcheck.0.8/descr
@@ -1,0 +1,6 @@
+QuickCheck inspired property-based testing for OCaml.
+
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them.
+

--- a/packages/qcheck/qcheck.0.8/opam
+++ b/packages/qcheck/qcheck.0.8/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+homepage: "https://github.com/c-cube/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+doc: "http://c-cube.github.io/qcheck/"
+tags: ["test" "property" "quickcheck"]
+dev-repo: "https://github.com/c-cube/qcheck.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest"]
+build-doc: ["jbuilder" "build" "@doc"]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+  "ounit"
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/qcheck/qcheck.0.8/url
+++ b/packages/qcheck/qcheck.0.8/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/qcheck/archive/0.8.tar.gz"
+checksum: "061005847a32c4b4252d449e26f6c8f9"


### PR DESCRIPTION
### `qcheck.0.8`

QuickCheck inspired property-based testing for OCaml.

This module allows to check invariants (properties of some types) over
randomly generated instances of the type. It provides combinators for
generating instances and printing them.




---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---

:camel: Pull-request generated by opam-publish v0.3.5