### PR TITLE
Package json-derivers.1.0.0

### DIFF
--- a/packages/json-derivers/json-derivers.1.0.0/descr
+++ b/packages/json-derivers/json-derivers.1.0.0/descr
@@ -1,0 +1,5 @@
+Common Derivers for Jsonm/Yjson
+
+This library provides comparison, hashing, and sexp conversion functions for the
+Yojson.Safe.t and Ezjsonm.t types with a minimal amount of dependencies (only
+base)

--- a/packages/json-derivers/json-derivers.1.0.0/opam
+++ b/packages/json-derivers/json-derivers.1.0.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+homepage: "https://github.com/rgrinberg/json-derivers"
+bug-reports: "https://github.com/rgrinberg/json-derivers/issues"
+dev-repo: "https://github.com/rgrinberg/json-derivers.git"
+license: "ISC"
+tags: ["deriving" "json"]
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build & >= "1.0+beta12"}
+  "base"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/json-derivers/json-derivers.1.0.0/url
+++ b/packages/json-derivers/json-derivers.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/rgrinberg/json-derivers/releases/download/1.0.0/json-derivers-1.0.0.tbz"
+checksum: "dfdeececf8d34f5ba64e5c4ab2696f24"


### PR DESCRIPTION
### `json-derivers.1.0.0`

Common Derivers for Jsonm/Yjson

This library provides comparison, hashing, and sexp conversion functions for the
Yojson.Safe.t and Ezjsonm.t types with a minimal amount of dependencies (only
base)


---
* Homepage: https://github.com/rgrinberg/json-derivers
* Source repo: https://github.com/rgrinberg/json-derivers.git
* Bug tracker: https://github.com/rgrinberg/json-derivers/issues

---


---
## 1.0.0 (04/02/2018)

* Initial Release
:camel: Pull-request generated by opam-publish v0.3.5