### PR TITLE
Markup.ml 0.7.6 – standards-compliant HTML5 parser

### DIFF
--- a/packages/markup/markup.0.7.6/descr
+++ b/packages/markup/markup.0.7.6/descr
@@ -1,0 +1,20 @@
+Error-recovering functional HTML5 and XML parsers and writers
+
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8.

--- a/packages/markup/markup.0.7.6/opam
+++ b/packages/markup/markup.0.7.6/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+version: "0.7.6"
+
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "https://github.com/aantron/markup.ml.git"
+license: "BSD"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta17"}
+  "ounit" {test}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+]
+depopts: [
+  "lwt"
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of
+# Jbuilder. Without that, Markup.ml implicitly requires OCaml 4.01.0, as this is
+# a constraint of Uutf. Without *that*, Markup.ml works on OCaml 3.11 or
+# earlier.
+
+build: [
+  ["ocaml" "src/configure.ml"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]

--- a/packages/markup/markup.0.7.6/url
+++ b/packages/markup/markup.0.7.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/aantron/markup.ml/archive/0.7.6.tar.gz"
+checksum: "866dd2cdb3e304787b26fe8ed53f1f67"


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/markup.ml/releases/tag/0.7.6):

> - Port to Jbuilder (aantron/markup.ml#21).
> - ISO/IEC 8859-15 encoding support (aantron/markup.ml#27, Vladimir Silyaev).
> - Correct handling of stray closing </html> and </body> tags (aantron/markup.ml#28, reported and helped by Vladimir Silyaev).

cc @rgrinberg