### PR TITLE
Recent Lwt requires Jbuilder >= 1.0+beta14

### DIFF
--- a/packages/lwt/lwt.3.2.0/opam
+++ b/packages/lwt/lwt.3.2.0/opam
@@ -25,7 +25,7 @@ build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
 
 depends: [
   "cppo" {build & >= "1.1.0"}
-  "jbuilder" {build & >= "1.0+beta13"}
+  "jbuilder" {build & >= "1.0+beta14"}
   # We are only using ocamlfind during configuration of the Unix binding.
   # However, ocamlfind also installs the "threads" package, and ocamlfind
   # 1.7.3-1 is the first one whose threads package does not have incorrect error

--- a/packages/lwt/lwt.3.2.1/opam
+++ b/packages/lwt/lwt.3.2.1/opam
@@ -25,7 +25,7 @@ build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
 
 depends: [
   "cppo" {build & >= "1.1.0"}
-  "jbuilder" {build & >= "1.0+beta13"}
+  "jbuilder" {build & >= "1.0+beta14"}
   # We are only using ocamlfind during configuration of the Unix binding.
   # However, ocamlfind also installs the "threads" package, and ocamlfind
   # 1.7.3-1 is the first one whose threads package does not have incorrect error


### PR DESCRIPTION
Lwt 3.2.0 and 3.2.1 use the `copy_files` stanza, which was introduced in that version of Jbuilder. See https://github.com/ocaml/dune/blob/master/CHANGES.md#10beta14-11102017.

cc @dra27 