### PR TITLE
Package result.1.3

### DIFF
--- a/packages/result/result.1.3/descr
+++ b/packages/result/result.1.3/descr
@@ -1,0 +1,5 @@
+Compatibility Result module
+
+Projects that want to use the new result type defined in OCaml >= 4.03
+while staying compatible with older version of OCaml should use the
+Result module defined in this library.

--- a/packages/result/result.1.3/opam
+++ b/packages/result/result.1.3/opam
@@ -1,0 +1,9 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/result"
+dev-repo: "https://github.com/janestreet/result.git"
+bug-reports: "https://github.com/janestreet/result/issues"
+license: "BSD3"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+depends: ["jbuilder" {>= "1.0+beta11"}]

--- a/packages/result/result.1.3/url
+++ b/packages/result/result.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/result/releases/download/1.3/result-1.3.tbz"
+checksum: "4beebefd41f7f899b6eeba7414e7ae01"


### PR DESCRIPTION
### `result.1.3`

Compatibility Result module

Projects that want to use the new result type defined in OCaml >= 4.03
while staying compatible with older version of OCaml should use the
Result module defined in this library.



---
* Homepage: https://github.com/janestreet/result
* Source repo: https://github.com/janestreet/result.git
* Bug tracker: https://github.com/janestreet/result/issues

---


---
1.3 (05/02/2018)
----------------

- Switch to jbuilder
:camel: Pull-request generated by opam-publish v0.3.5