### PR TITLE
Ocamlweb new release : 1.40

### DIFF
--- a/packages/ocamlweb/ocamlweb.1.40/descr
+++ b/packages/ocamlweb/ocamlweb.1.40/descr
@@ -1,0 +1,1 @@
+A literate programming tool for OCaml

--- a/packages/ocamlweb/ocamlweb.1.40/files/ocamlweb.install
+++ b/packages/ocamlweb/ocamlweb.1.40/files/ocamlweb.install
@@ -1,0 +1,1 @@
+bin: ["ocamlweb"]

--- a/packages/ocamlweb/ocamlweb.1.40/opam
+++ b/packages/ocamlweb/ocamlweb.1.40/opam
@@ -1,6 +1,7 @@
-opam-version: "1"
+opam-version: "1.2.2"
 name: "ocamlweb"
 version: "1.40"
+homepage: "https://www.lri.fr/~filliatr/ocamlweb/"
 maintainer: "filliatr@lri.fr"
 authors: ["Jean-Christophe Filliâtre"]
 license: "GNU Library General Public License version 2"

--- a/packages/ocamlweb/ocamlweb.1.40/opam
+++ b/packages/ocamlweb/ocamlweb.1.40/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2.2"
+opam-version: "1.2"
 name: "ocamlweb"
 version: "1.40"
 homepage: "https://www.lri.fr/~filliatr/ocamlweb/"

--- a/packages/ocamlweb/ocamlweb.1.40/opam
+++ b/packages/ocamlweb/ocamlweb.1.40/opam
@@ -20,4 +20,5 @@ build: [
   ]
   [make]
 ]
+available: [ ocaml-version >= "4.02" ]
 install: [make "install" "BASETEXDIR=%{lib}%/ocamlweb/texmf"]

--- a/packages/ocamlweb/ocamlweb.1.40/opam
+++ b/packages/ocamlweb/ocamlweb.1.40/opam
@@ -1,0 +1,22 @@
+opam-version: "1"
+name: "ocamlweb"
+version: "1.40"
+maintainer: "filliatr@lri.fr"
+authors: ["Jean-Christophe Filliâtre"]
+license: "GNU Library General Public License version 2"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--sbindir=%{lib}%/ocamlweb/sbin"
+    "--libexecdir=%{lib}%/ocamlweb/libexec"
+    "--sysconfdir=%{lib}%/ocamlweb/etc"
+    "--sharedstatedir=%{lib}%/ocamlweb/com"
+    "--localstatedir=%{lib}%/ocamlweb/var"
+    "--libdir=%{lib}%/ocamlweb/lib"
+    "--includedir=%{lib}%/ocamlweb/include"
+    "--datarootdir=%{lib}%/ocamlweb/share"
+  ]
+  [make]
+]
+install: [make "install" "BASETEXDIR=%{lib}%/ocamlweb/texmf"]

--- a/packages/ocamlweb/ocamlweb.1.40/url
+++ b/packages/ocamlweb/ocamlweb.1.40/url
@@ -1,0 +1,2 @@
+archive: "https://www.lri.fr/~filliatr/ftp/ocamlweb/ocamlweb-1.40.tar.gz"
+checksum: "95b9e54beb16efe19875aaf948340db3"


### PR DESCRIPTION
This release replaces the deprecated \tt LaTeX command by \texttt in ocamlweb.sty.
Code is now utf8 (ocamlweb --version prints the names of the authors in utf8).
