### PR TITLE
Package amf.0.1.1

### DIFF
--- a/packages/amf/amf.0.1.1/descr
+++ b/packages/amf/amf.0.1.1/descr
@@ -1,0 +1,3 @@
+Implementation of Adobe's Action Message Format
+
+Implementation of Adobe's Action Message Format

--- a/packages/amf/amf.0.1.1/opam
+++ b/packages/amf/amf.0.1.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Brian Caine <brian.d.caine@gmail.com>"
+authors: "Brian Caine <brian.d.caine@gmail.com>"
+homepage: "https://github.com/briancaine/ocaml-amf"
+bug-reports: "https://github.com/briancaine/ocaml-amf/issues"
+license: "LGPL with OCaml linking exception"
+dev-repo: "http://github.com/briancaine/ocaml-amf.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "amf"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/amf/amf.0.1.1/url
+++ b/packages/amf/amf.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/briancaine/ocaml-amf/archive/v0.1.1.tar.gz"
+checksum: "00bb6fb4fe2134fc8994a25d779d520f"


### PR DESCRIPTION
### `amf.0.1.1`

Implementation of Adobe's Action Message Format

Implementation of Adobe's Action Message Format



---
* Homepage: https://github.com/briancaine/ocaml-amf
* Source repo: http://github.com/briancaine/ocaml-amf.git
* Bug tracker: https://github.com/briancaine/ocaml-amf/issues

---

:camel: Pull-request generated by opam-publish v0.3.5