### PR TITLE
Package amf.0.1.2

### DIFF
--- a/packages/amf/amf.0.1.2/descr
+++ b/packages/amf/amf.0.1.2/descr
@@ -1,0 +1,3 @@
+Implementation of Adobe's Action Message Format
+
+AMF is more or less a binary encoding for JSON-esque data. It gets used in a lot of Adobe formats and protocols. There's version 0, which I've implemented here, and version 3, which I'll add when the need arises. Pull requests welcome!

--- a/packages/amf/amf.0.1.2/opam
+++ b/packages/amf/amf.0.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "Brian Caine <brian.d.caine@gmail.com>"
+authors: "Brian Caine <brian.d.caine@gmail.com>"
+dev-repo: "https://github.com/briancaine/ocaml-amf.git"
+homepage: "https://github.com/briancaine/ocaml-amf"
+bug-reports: "https://github.com/briancaine/ocaml-amf/issues"
+license: "LGPL with OCaml linking exception"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+build-doc: [
+  ["oasis" "setup"]
+  [make "doc"]
+]
+install: [
+  ["oasis" "setup"]
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "amf"]
+depends: [
+  "base-threads"
+  ("core" {= "113.00.00"} | "core" {= "112.35.01"} | "core" {= "112.35.00"} | "core" {= "112.24.01"} | "core" {= "112.24.00"} | "core" {= "112.17.00"} | "core" {= "112.06.02"} | "core" {= "112.06.01"} | "core" {= "112.06.00"} | "core" {= "112.01.01"} | "core" {= "112.01.00"} | "core" {= "111.28.01"} | "core" {= "111.28.00"} | "core" {= "111.25.00"} | "core" {= "111.21.00"} | "core" {= "111.17.00"} | "core" {= "111.13.00"} | "core" {= "111.11.01"} | "core" {= "111.11.00"} | "core" {= "111.08.00"} | "core" {= "111.06.00"} | "core" {= "111.03.00"} | "core" {= "110.01.00"} | "core" {= "109.60.00"} | "core" {= "109.58.00"} | "core" {= "109.55.02"} | "core" {= "109.55.00"} | "core" {= "109.53.01"} | "core" {= "109.53.00"} | "core" {= "109.47.00"} | "core" {= "109.45.00"} | "core" {= "109.42.00"} | "core" {= "109.41.00"} | "core" {= "109.40.00"} | "core" {= "109.38.00"} | "core" {= "109.37.00"} | "core" {= "109.36.00"} | "core" {= "109.35.00"} | "core" {= "109.34.00"} | "core" {= "109.32.00"} | "core" {= "109.31.00"} | "core" {= "109.30.00"} | "core" {= "109.28.00"} | "core" {= "109.27.00"} | "core" {= "109.24.00"} | "core" {= "109.23.00"} | "core" {= "109.22.00"} | "core" {= "109.21.00"} | "core" {= "109.20.00"} | "core" {= "109.19.00"} | "core" {= "109.18.00"} | "core" {= "109.17.00"} | "core" {= "109.15.01"} | "core" {= "109.15.00"} | "core" {= "109.14.01"} | "core" {= "109.14.00"} | "core" {= "109.13.00"} | "core" {= "109.12.00"} | "core" {= "109.11.00"} | "core" {= "109.10.00"} | "core" {= "109.09.00"} | "core" {= "109.08.00"} | "core" {= "109.07.00"} | "core" {= "108.08.00"} | "core" {= "108.07.01"} | "core" {= "108.07.00"} | "core" {= "108.00.02"})
+  ("oasis" {build & >= "0.4.7"} | "oasis-mirage" {build & >= "0.4.7"})
+  "bisect_ppx" {build}
+  "bisect_ppx-ocamlbuild" {build}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+  "ppx_deriving"
+  "ppx_fields_conv" {= "113.09.00"}
+  "ppx_sexp_conv" {= "113.09.00"}
+  ("stdint" {>= "0.5.0"} | "stdint" {= "0.4.2"} | "stdint" {= "0.3.0-0"})
+]
+available: [ ocaml-version >= "4.01" ]

--- a/packages/amf/amf.0.1.2/url
+++ b/packages/amf/amf.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/briancaine/ocaml-amf/archive/v0.1.2.tar.gz"
+checksum: "b8b777231c4c600fcaccf18209a2acbd"


### PR DESCRIPTION
### `amf.0.1.2`

Implementation of Adobe's Action Message Format

AMF is more or less a binary encoding for JSON-esque data. It gets used in a lot of Adobe formats and protocols. There's version 0, which I've implemented here, and version 3, which I'll add when the need arises. Pull requests welcome!



---
* Homepage: https://github.com/briancaine/ocaml-amf
* Source repo: https://github.com/briancaine/ocaml-amf.git
* Bug tracker: https://github.com/briancaine/ocaml-amf/issues

---

:camel: Pull-request generated by opam-publish v0.3.5