### PR TITLE
[urgent] Package opam-state.2.0.0~rc and 7 others

### DIFF
--- a/packages/dose3/dose3.5.0.1/files/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch
+++ b/packages/dose3/dose3.5.0.1/files/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch
@@ -1,0 +1,25 @@
+From b94cf24739818e5aff397e0a83b19ea32dc81f42 Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Tue, 6 Feb 2018 10:15:45 +0100
+Subject: [PATCH 3/3] Add "unix" as dependency to dose3.common in META.in
+
+---
+ META.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/META.in b/META.in
+index aa2cd8d..0f9d337 100644
+--- a/META.in
++++ b/META.in
+@@ -8,7 +8,7 @@ package "common" (
+ version = "@PACKAGE_VERSION@"
+ archive(byte) = "common.cma"
+ archive(native) = "common.cmxa"
+-requires = "extlib, re.pcre, cudf, @ZIP@, @BZ2@"
++requires = "extlib, re.pcre, cudf, unix, @ZIP@, @BZ2@"
+ )
+ 
+ package "algo" (
+-- 
+2.11.0
+

--- a/packages/dose3/dose3.5.0.1/opam
+++ b/packages/dose3/dose3.5.0.1/opam
@@ -38,4 +38,5 @@ patches: [
   "0001-Install-mli-cmx-etc.patch"
   "0002-dont-make-printconf.patch"
   "0003-Fix-for-ocaml-4.06.patch" { ocaml-version >= "4.06.0" }
+  "0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch"
  ]

--- a/packages/opam-client/opam-client.2.0.0~rc/descr
+++ b/packages/opam-client/opam-client.2.0.0~rc/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Actions on the opam root, switches, installations, and front-end.

--- a/packages/opam-client/opam-client.2.0.0~rc/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-state" {= "2.0.0~rc"}
+  "opam-solver" {= "2.0.0~rc"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/opam-client/opam-client.2.0.0~rc/url
+++ b/packages/opam-client/opam-client.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"

--- a/packages/opam-core/opam-core.2.0.0~rc/descr
+++ b/packages/opam-core/opam-core.2.0.0~rc/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Small standard library extensions, and generic system interaction modules used
+by opam.

--- a/packages/opam-core/opam-core.2.0.0~rc/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "jbuilder" {build & >= "1.0+beta12"}
+  "cppo" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/opam-core/opam-core.2.0.0~rc/url
+++ b/packages/opam-core/opam-core.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"

--- a/packages/opam-devel/opam-devel.2.0.0~rc/descr
+++ b/packages/opam-devel/opam-devel.2.0.0~rc/descr
@@ -1,0 +1,6 @@
+opam 2.0.0 development version
+
+This package compiles (bootstraps) the development version of opam 2.0.0. For
+consistency and safety of the installation, the binaries are not installed into
+the PATH, but into lib/opam-devel, from where the user can manually install them
+system-wide.

--- a/packages/opam-devel/opam-devel.2.0.0~rc/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+build-test: [make "tests"]
+depends: [
+  "opam-client" {= "2.0.0~rc"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+available: [ocaml-version >= "4.02.3"]
+post-messages: [
+  "
+The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/* /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\"
+  "
+    {success}
+]

--- a/packages/opam-devel/opam-devel.2.0.0~rc/url
+++ b/packages/opam-devel/opam-devel.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"

--- a/packages/opam-format/opam-format.2.0.0~rc/descr
+++ b/packages/opam-format/opam-format.2.0.0~rc/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Definition of opam datastructures and its file interface.

--- a/packages/opam-format/opam-format.2.0.0~rc/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0.0~rc"}
+  "opam-file-format" {>= "2.0.0~beta5"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/opam-format/opam-format.2.0.0~rc/url
+++ b/packages/opam-format/opam-format.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"

--- a/packages/opam-installer/opam-installer.2.0.0~rc/descr
+++ b/packages/opam-installer/opam-installer.2.0.0~rc/descr
@@ -1,0 +1,7 @@
+Installation of files to a prefix, following opam conventions
+
+opam-installer is a small tool that can read *.install files, as defined by
+opam [1], and execute them to install or remove package files without going
+through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install

--- a/packages/opam-installer/opam-installer.2.0.0~rc/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["touch" "src/tools/.merlin-exists"]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-format" {= "2.0.0~rc"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/opam-installer/opam-installer.2.0.0~rc/url
+++ b/packages/opam-installer/opam-installer.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"

--- a/packages/opam-repository/opam-repository.2.0.0~rc/descr
+++ b/packages/opam-repository/opam-repository.2.0.0~rc/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+This library includes repository and remote sources handling, including
+curl/wget, rsync, git, mercurial, darcs backends.

--- a/packages/opam-repository/opam-repository.2.0.0~rc/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-format" {= "2.0.0~rc"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/opam-repository/opam-repository.2.0.0~rc/url
+++ b/packages/opam-repository/opam-repository.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"

--- a/packages/opam-solver/opam-solver.2.0.0~rc/descr
+++ b/packages/opam-solver/opam-solver.2.0.0~rc/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Solver and Cudf interaction. This library is based on the Cudf and Dose
+libraries, and handles calls to the external solver from opam.

--- a/packages/opam-solver/opam-solver.2.0.0~rc/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~rc/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-format" {= "2.0.0~rc"}
+  "mccs" {>= "1.1+4"}
+  "dose3" {>= "5"}
+  "cudf" {>= "0.7"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/opam-solver/opam-solver.2.0.0~rc/url
+++ b/packages/opam-solver/opam-solver.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"

--- a/packages/opam-state/opam-state.2.0.0~rc/descr
+++ b/packages/opam-state/opam-state.2.0.0~rc/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Handling of the ~/.opam hierarchy, repository and switch states.

--- a/packages/opam-state/opam-state.2.0.0~rc/opam
+++ b/packages/opam-state/opam-state.2.0.0~rc/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Anil Madhavapeddy   <anil@recoil.org>"
+  "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+  "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+  "Vincent Bernardoff  <vb@luminar.eu.org>"
+  "Roberto Di Cosmo    <roberto@dicosmo.org>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-repository" {= "2.0.0~rc"}
+  "jbuilder" {build & >= "1.0+beta12"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/opam-state/opam-state.2.0.0~rc/url
+++ b/packages/opam-state/opam-state.2.0.0~rc/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
+checksum: "ae216e3ea0a9388cc9f711a2a9925557"


### PR DESCRIPTION
This pull-request concerns:
-`opam-state.2.0.0~rc`: opam 2.0 development libraries
-`opam-solver.2.0.0~rc`: opam 2.0 development libraries
-`opam-repository.2.0.0~rc`: opam 2.0 development libraries
-`opam-installer.2.0.0~rc`: Installation of files to a prefix, following opam conventions
-`opam-format.2.0.0~rc`: opam 2.0 development libraries
-`opam-devel.2.0.0~rc`: opam 2.0.0 development version
-`opam-core.2.0.0~rc`: opam 2.0 development libraries
-`opam-client.2.0.0~rc`: opam 2.0 development libraries



---
* Homepage: 
  `opam-state.2.0.0~rc`: https://opam.ocaml.org/
  `opam-solver.2.0.0~rc`: https://opam.ocaml.org/
  `opam-repository.2.0.0~rc`: https://opam.ocaml.org/
  `opam-installer.2.0.0~rc`: https://opam.ocaml.org/
  `opam-format.2.0.0~rc`: https://opam.ocaml.org/
  `opam-devel.2.0.0~rc`: https://opam.ocaml.org
  `opam-core.2.0.0~rc`: https://opam.ocaml.org/
  `opam-client.2.0.0~rc`: https://opam.ocaml.org/
* Source repo: https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---

:camel: Pull-request generated by opam-publish v0.3.5