### PR TITLE
Constrain Mirage/Solo5 universe to Solo5 < 0.3.0

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.2.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}
-  "mirage-solo5"
+  "mirage-solo5" {< "0.3.0"}
   "fmt"
   "result"
 ]

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.2.0/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-solo5"
+  "mirage-solo5" {< "0.3.0"}
   "lwt"
   "parse-argv"
 ]

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.2.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-console-lwt" {>= "2.2.0"}
-  "mirage-solo5"
+  "mirage-solo5" {< "0.3.0"}
   "cstruct"
   "lwt"
 ]

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.2.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-net-lwt" {>= "1.0.0"}
   "io-page" {>= "1.0.0"}
   "ipaddr" {>= "1.0.0"}
-  "mirage-solo5"
+  "mirage-solo5" {< "0.3.0"}
   "logs" {>= "0.6.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-solo5/mirage-solo5.0.2.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.1/opam
@@ -20,8 +20,9 @@ depends: [
   "ocb-stubblr" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "ocaml-freestanding"
+  "ocaml-freestanding" {< "0.3.0"}
   "logs"
+  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} | "solo5-kernel-muen" {< "0.3.0"})
 ]
 conflicts: [ "io-page" {< "2.0.0"} ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
@@ -12,7 +12,7 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
+  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"})
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
+  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"})
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
@@ -13,7 +13,7 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" | "solo5-kernel-virtio" | "solo5-kernel-muen")
+  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} | "solo5-kernel-muen" {< "0.3.0"})
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
@@ -13,7 +13,7 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" | "solo5-kernel-virtio" | "solo5-kernel-muen")
+  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} | "solo5-kernel-muen" {< "0.3.0"})
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}


### PR DESCRIPTION
The next Solo5 release will contain breaking API changes. In preparation
for merging these, constrain the current Mirage/Solo5 package universe
to Solo5 < 0.3.0.

Additionally, add explicit dependencies from mirage-solo5 to
solo5-kernel-*, where we previously relied only on the transitive
dependency via ocaml-freestanding. mirage-solo5 does use the kernel APIs
directly so this is correct.