### PR TITLE
Package ppx_blob.0.4.0

### DIFF
--- a/packages/ppx_blob/ppx_blob.0.4.0/descr
+++ b/packages/ppx_blob/ppx_blob.0.4.0/descr
@@ -1,0 +1,3 @@
+Include a file as a string at compile time
+
+ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob "filename"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions. 

--- a/packages/ppx_blob/ppx_blob.0.4.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.4.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree"
+  "alcotest" {test}
+]

--- a/packages/ppx_blob/ppx_blob.0.4.0/url
+++ b/packages/ppx_blob/ppx_blob.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/johnwhitington/ppx_blob/releases/download/0.4.0/ppx_blob-0.4.0.tbz"
+checksum: "b952544785ab6236bb099740d522cc3d"


### PR DESCRIPTION
### `ppx_blob.0.4.0`

Include a file as a string at compile time

ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob "filename"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions. 



---
* Homepage: https://github.com/johnwhitington/ppx_blob
* Source repo: https://github.com/johnwhitington/ppx_blob.git
* Bug tracker: https://github.com/johnwhitington/ppx_blob/issues/

---


---
0.4 2018-02-10
---------------------------------

Check if file exists relative to working directory (#9)
:camel: Pull-request generated by opam-publish v0.3.5