### PR TITLE
Acknowledge that jacquev6's packages support OCaml 4.06.0

### DIFF
--- a/packages/DrawGrammar/DrawGrammar.0.2.1/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/opam
@@ -15,4 +15,4 @@ depends: [
   "cairo2"
   "General" {>= "0.4.0"}
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/DrawGrammar/DrawGrammar.0.2.1/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/opam
@@ -15,4 +15,4 @@ depends: [
   "cairo2"
   "General" {>= "0.4.0"}
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/General/General.0.4.0/opam
+++ b/packages/General/General.0.4.0/opam
@@ -13,4 +13,4 @@ depends: [
   "cppo" {build & >= "1.3.0"}
   "num"
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/General/General.0.4.0/opam
+++ b/packages/General/General.0.4.0/opam
@@ -11,5 +11,6 @@ build-test: ["jbuilder" "runtest" "-p" name]
 depends: [
   "jbuilder" {build}
   "cppo" {build & >= "1.3.0"}
+  "num"
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
@@ -15,4 +15,4 @@ depends: [
   "js_of_ocaml" {>= "3.0" & < "4.0"}
   "cairo2"
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
@@ -15,4 +15,4 @@ depends: [
   "js_of_ocaml" {>= "3.0" & < "4.0"}
   "cairo2"
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/hashids/hashids.1.0.0/opam
+++ b/packages/hashids/hashids.1.0.0/opam
@@ -12,4 +12,4 @@ depends: [
   "jbuilder" {build}
   "General" {>= "0.4.0"}
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/hashids/hashids.1.0.0/opam
+++ b/packages/hashids/hashids.1.0.0/opam
@@ -12,4 +12,4 @@ depends: [
   "jbuilder" {build}
   "General" {>= "0.4.0"}
 ]
-available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]
+available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
This reflects the following commits:
- https://github.com/jacquev6/General/commit/df2a4f9660b97a387b2793592a882b35099a38f2#diff-ce1095cc45339eed28fa39a706eac56a
- https://github.com/jacquev6/JsOfOCairo/commit/3912f733fdc54ab435bf01a66c3d0b00f7672ddc#diff-91a565848e6c3dd4496c366fd0be1393
- https://github.com/jacquev6/hashids-ocaml/commit/78c1cc0374033b72f0a6453272a8156a3929314b#diff-537f3ffa3dd84ab6601fdf4a033a7b1f
- https://github.com/jacquev6/DrawGrammar/commit/e8dc4732457bd931917bd26678499653dab5f37e#diff-16e2f48684fed3e20eecb51788c587d1

No code had to be modified to support of OCaml 4.06.0, so the
existing archives are usable as-is, and modifying the *.opam files
is enough.

My package sphinxcontrib-ocaml will require more work.