### PR TITLE
uwt.0.2.4 - via opam-publish

### DIFF
--- a/packages/uwt/uwt.0.2.4/descr
+++ b/packages/uwt/uwt.0.2.4/descr
@@ -1,0 +1,5 @@
+libuv bindings
+
+uwt provides OCaml bindings for libuv.
+The main loop of libuv is integrated into lwt,
+the light-weight cooperative threads library.

--- a/packages/uwt/uwt.0.2.4/opam
+++ b/packages/uwt/uwt.0.2.4/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/fdopen/uwt"
+dev-repo: "https://github.com/fdopen/uwt.git"
+bug-reports: "https://github.com/fdopen/uwt/issues"
+tags: ["clib:libuv"]
+build: ["omake" "-j%{jobs}%" "lib" "BUILD_LIBUV=true" "UWT_BUILD_JOBS=%{jobs}%"]
+install: [
+  ["omake" "opam-install" "PREFIX=%{prefix}%"]
+]
+build-test: [
+  ["omake" "test" ]
+]
+remove: [
+  ["ocamlfind" "remove" "uwt"]
+  ["rm" "-rf" "%{prefix}%/doc/uwt"]
+]
+available: [ocaml-version >= "4.02.1"]
+depends: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+  "base-bytes"
+  "conf-pkg-config" {build}
+  "ocamlfind" {build}
+  "cppo" {build & >= "1.3"}
+  "omake" {build}
+  "result"
+  "lwt" {>= "2.6.0" & < "4.0"}
+  "ounit" {test & >= "2.0"}
+  "ppx_deriving" {test & >= "2.0"}
+  "ppx_import" {test & >= "1.0"}
+]

--- a/packages/uwt/uwt.0.2.4/url
+++ b/packages/uwt/uwt.0.2.4/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/fdopen/uwt/releases/download/0.2.4/uwt-0.2.4.tar.gz"
+checksum: "26b99812f4a40a3d17c2633dcfd9b609"


### PR DESCRIPTION
libuv bindings

uwt provides OCaml bindings for libuv.
The main loop of libuv is integrated into lwt,
the light-weight cooperative threads library.


---
* Homepage: https://github.com/fdopen/uwt
* Source repo: https://github.com/fdopen/uwt.git
* Bug tracker: https://github.com/fdopen/uwt/issues

---

Pull-request generated by opam-publish v0.3.4