### PR TITLE
Package amf.0.1.0

### DIFF
--- a/packages/amf/amf.0.1.0/descr
+++ b/packages/amf/amf.0.1.0/descr
@@ -1,0 +1,7 @@
+Ocaml implementation of Adobe's Action Message Format
+
+AMF is a binary encoding for JSON-esque data. It's used in a few different Adobe formats and protocols.
+
+This implements AMF V0. V3 is in the works when the needarises.
+
+Pull requests are welcome.

--- a/packages/amf/amf.0.1.0/opam
+++ b/packages/amf/amf.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "Brian Caine <brian.d.caine@gmail.com>"
+authors: "Brian Caine <brian.d.caine@gmail.com>"
+dev-repo: "https://github.com/briancaine/ocaml-amf.git"
+homepage: "https://github.com/briancaine/ocaml-amf"
+bug-reports: "https://github.com/briancaine/ocaml-amf/issues"
+license: "LGPL with OCaml linking exception"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+build-test: [
+  ["oasis" "setup"]
+  ["./configure" "--enable-tests"]
+  [make "test"]
+]
+build-doc: [
+  ["oasis" "setup"]
+  [make "doc"]
+]
+install: [
+  ["oasis" "setup"]
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "amf"]
+depends: [
+  ("oasis" {build} | "oasis-mirage" {build})
+
+  "ppx_deriving" {build}
+  "ppx_sexp_conv" {build}
+  "base-threads"
+  ("core" {>= "v0.9.1"})
+  "stdint"
+  "sexplib"
+  "bisect_ppx" {build}
+  "bisect_ppx-ocamlbuild" {build}
+  "ounit" {build}
+]
+available: [ ocaml-version >= "4.01" ]

--- a/packages/amf/amf.0.1.0/url
+++ b/packages/amf/amf.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/briancaine/ocaml-amf/archive/v0.1.0.tar.gz"
+checksum: "6d866570c511ea0ce9d6891e29673d2a"


### PR DESCRIPTION
### `amf.0.1.0`

Ocaml implementation of Adobe's Action Message Format

AMF is a binary encoding for JSON-esque data. It's used in a few different Adobe formats and protocols.

This implements AMF V0. V3 is in the works when the needarises.

Pull requests are welcome.



---
* Homepage: https://github.com/briancaine/ocaml-amf
* Source repo: https://github.com/briancaine/ocaml-amf.git
* Bug tracker: https://github.com/briancaine/ocaml-amf/issues

---

:camel: Pull-request generated by opam-publish v0.3.5