### PR TITLE
Speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ dist: trusty
 sudo: required
 matrix:
   include:
+  - os: osx
+    osx_image: xcode7.3
+    env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2
   - os: linux
     env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2
   - os: linux
@@ -22,9 +25,6 @@ matrix:
     env: OCAML_VERSION=4.00 OPAM_VERSION=1.2.2
   - os: linux
     env: OCAML_VERSION=3.12 OPAM_VERSION=1.2.2
-  - os: osx
-    osx_image: xcode7.3
-    env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2
 notifications:
   email:
   - opam-commits@lists.ocaml.org


### PR DESCRIPTION
This should be a fairly simple change which could have a large impact on Travis' performances.
The OSX build is always started last and have to wait for every images to build but at the same time it is always the one that takes the longest time; so starting it first should in theory drastically increase overall build time.