### PR TITLE
+Mesh 0.9.3 & related packages

### DIFF
--- a/packages/mesh-easymesh/mesh-easymesh.0.9.3/descr
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.3/descr
@@ -1,0 +1,7 @@
+Triangular mesh generation with EasyMesh
+
+[EasyMesh][] is a two-dimensional quality mesh generator developed by
+Bojan Niceno and available from MIT.  This module provides an
+interface calling the program EasyMesh to perform the mesh generation.
+
+[EasyMesh]: http://web.mit.edu/easymesh_v1.4/www/easymesh.html

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.3/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.3/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+tags: [ "Mesh" "Triangulation" "PDE" ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+  "base-bigarray"
+  "base-bytes"
+  "mesh" {= "0.9.3"}
+  "lacaml"    {test}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.3/url
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.9.3/mesh-0.9.3.tbz"
+checksum: "c2e57e4287b3ac3bca78a2a25154811a"

--- a/packages/mesh-graphics/mesh-graphics.0.9.3/descr
+++ b/packages/mesh-graphics/mesh-graphics.0.9.3/descr
@@ -1,0 +1,1 @@
+Triangular mesh representation using the graphics module

--- a/packages/mesh-graphics/mesh-graphics.0.9.3/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.3/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+tags: []
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "mesh" {= "0.9.3"}
+  "graphics"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mesh-graphics/mesh-graphics.0.9.3/url
+++ b/packages/mesh-graphics/mesh-graphics.0.9.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.9.3/mesh-0.9.3.tbz"
+checksum: "c2e57e4287b3ac3bca78a2a25154811a"

--- a/packages/mesh-triangle/mesh-triangle.0.9.3/descr
+++ b/packages/mesh-triangle/mesh-triangle.0.9.3/descr
@@ -1,0 +1,8 @@
+Binding to the triangle mesh generator
+
+This module is a binding to the [Triangle][] library which was awarded
+the James Hardy Wilkinson Prize in Numerical Software in 2003.  If
+libtriangle-dev is not installed on your system, it will install a
+local copy for this library.
+
+[Triangle]: http://www.cs.cmu.edu/~quake/triangle.html

--- a/packages/mesh-triangle/mesh-triangle.0.9.3/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.9.3/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+tags: [ "clib:triangle"  ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+  "configurator" {build}
+  "base"  {build}
+  "stdio" {build}
+  "base-bigarray"
+  "base-bytes"
+  "mesh" {= "0.9.3"}
+  "lacaml"    {test}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mesh-triangle/mesh-triangle.0.9.3/url
+++ b/packages/mesh-triangle/mesh-triangle.0.9.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.9.3/mesh-0.9.3.tbz"
+checksum: "c2e57e4287b3ac3bca78a2a25154811a"

--- a/packages/mesh/mesh.0.9.3/descr
+++ b/packages/mesh/mesh.0.9.3/descr
@@ -1,0 +1,6 @@
+Triangular mesh generation and manipulation
+
+This is an interface to various mesh generators, in particular
+triangle. It also provides functions to optimize the numbering of mesh
+points and to export meshes and piecewise linear functions defined on
+them to TikZ, Scilab, Matlab, and Mathematica formats.

--- a/packages/mesh/mesh.0.9.3/opam
+++ b/packages/mesh/mesh.0.9.3/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/mesh"
+dev-repo: "https://github.com/Chris00/mesh.git"
+bug-reports: "https://github.com/Chris00/mesh/issues"
+#doc: ""
+tags: [ "Mesh" "Triangulation" "PDE" ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder"  {build & >="1.0+beta9"}
+  "base-bigarray"
+  "base-bytes"
+  "lacaml"    {test}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mesh/mesh.0.9.3/url
+++ b/packages/mesh/mesh.0.9.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/mesh/releases/download/0.9.3/mesh-0.9.3.tbz"
+checksum: "c2e57e4287b3ac3bca78a2a25154811a"


### PR DESCRIPTION
- Refine dependencies.
- Remove `build-test` which is deprecated with OPAM 2.