### PR TITLE
Tighten Ocsigen Start & Toolkit version constraints

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.1.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.0.0/opam
@@ -12,15 +12,14 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass"
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.2"}
-  "ocsigen-toolkit" {>= "0.99"}
+  "eliom" {= "6.2.0"}
+  "ocsigen-toolkit" {>= "0.99" & <= "1.0.0"}
   "yojson"
 ]
 depexts: [
   [["debian"] ["imagemagick"]]
   [["debian"] ["ruby-sass"]]
   [["debian"] ["postgresql"]]
-  [["debian"] ["npm"]]
   [["ubuntu"] ["imagemagick"]]
   [["ubuntu"] ["ruby-sass"]]
   [["ubuntu"] ["postgresql"]]

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/opam
@@ -8,7 +8,7 @@ build: [ make ]
 install: [ make "install" ]
 remove: [ make "uninstall" ]
 depends: [
-  "eliom" {>= "6.0"}
+  "eliom" {>= "6.0.0" & <= "6.2.0"}
   "calendar"
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.1.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.1.0.0/opam
@@ -8,7 +8,7 @@ build: [ make ]
 install: [ make "install" ]
 remove: [ make "uninstall" ]
 depends: [
-  "eliom" {>= "6.0"}
+  "eliom" {>= "6.0.0" & <= "6.2.0"}
   "calendar"
 ]
 available: [ ocaml-version >= "4.02" ]


### PR DESCRIPTION
Also drop problematic npm external dependency.

See discussion in #11380. CC @jpdeplaix.