### PR TITLE
qtest.2.7: upstream repo has moved, md5 has changed

### DIFF
--- a/packages/qtest/qtest.2.7/url
+++ b/packages/qtest/qtest.2.7/url
@@ -1,2 +1,2 @@
-http: "https://github.com/vincent-hugot/iTeML/archive/v2.7.tar.gz"
-checksum: "ba6bfd86f2fd35773669a706b4cfe704"
+http: "https://github.com/vincent-hugot/qtest/archive/v2.7.tar.gz"
+checksum: "3dd7f95ec92137e0bbd857c52dd8a095"


### PR DESCRIPTION
Unfortunately the md5sum of github generated tarballs tends to change when the repo is moved.

Fixes #11403

Signed-off-by: David Scott <dave@recoil.org>