### PR TITLE
New release of Earley and Earley-OCaml (version 1.0.1)

### DIFF
--- a/packages/earley-ocaml/earley-ocaml.1.0.0/descr
+++ b/packages/earley-ocaml/earley-ocaml.1.0.0/descr
@@ -1,10 +1,10 @@
-Earley-ocaml extensible parser for OCaml
+Earley-OCaml extensible parser for OCaml (and pa_ocaml preprocessos)
 
-Earley-ocaml is an extensible parser for OCaml, written using the
-Earley library. It provides a preprocessor called pa_ocaml that
-extends the OCaml with a BNF-like syntax for writing parsers inside
-the language.
+Earley-OCaml is an (extensible) parser for OCaml,  written using the
+Earley library. It come with a built-in preprocessor called pa_ocaml
+which handles a natural BNF-like syntax extension for OCaml.  It can
+be used to define Earley parsers inside the language.
 
 Authors:
- - Christophe Raffalli <christophe.raffalli@univ-savoie.fr>
- - Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>
+ - Christophe Raffalli <christophe@raffalli.eu>
+ - Rodolphe Lepigre <rodolphe.lepigre@lepigre.fr>

--- a/packages/earley-ocaml/earley-ocaml.1.0.0/opam
+++ b/packages/earley-ocaml/earley-ocaml.1.0.0/opam
@@ -1,19 +1,14 @@
 opam-version: "1.2"
-available:    [ ocaml-version >= "4.01.0" & ocaml-version <= "4.04.0" ]
-maintainer:   "Christophe Raffalli <christophe.raffalli@univ-savoie.fr>"
-bug-reports:  "https://github.com/rlepigre/ocaml-earley-ocaml/issues"
-authors:
-  [ "Christophe Raffalli <christophe.raffalli@univ-savoie.fr>"
-    "Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>" ]
-homepage: "https://rlepigre.github.io/ocaml-earley-ocaml/"
-license: "LGPL-3.0"
-dev-repo: "https://github.com/rlepigre/ocaml-earley-ocaml.git"
-build: [
-  [make]
-  [make]
-]
-install: [make "install" "BINDIR=%{bin}%" ]
-remove: [make "uninstall"]
-depends:
-  [ "ocamlfind" {build}
-    "earley" ]
+available   : [ ocaml-version >= "4.01.0" & ocaml-version <= "4.04.0" ]
+maintainer  : "Christophe Raffalli <christophe@raffalli.eu>"
+bug-reports : "https://github.com/rlepigre/ocaml-earley-ocaml/issues"
+authors     : [ "Christophe Raffalli <christophe@raffalli.eu>"
+                "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>" ]
+homepage    : "https://rlepigre.github.io/ocaml-earley-ocaml/"
+license     : "CeCILL-B_V1"
+dev-repo    : "https://github.com/rlepigre/ocaml-earley-ocaml.git"
+build       : [ [make] [make] ]
+install     : [make "install" "BINDIR=%{bin}%" ]
+remove      : [make "uninstall"]
+depends     : [ "ocamlfind" {build}
+                "earley" {= "1.0.0"} ]

--- a/packages/earley-ocaml/earley-ocaml.1.0.1/descr
+++ b/packages/earley-ocaml/earley-ocaml.1.0.1/descr
@@ -1,0 +1,10 @@
+Earley-OCaml extensible parser for OCaml (and pa_ocaml preprocessos)
+
+Earley-OCaml is an (extensible) parser for OCaml,  written using the
+Earley library. It come with a built-in preprocessor called pa_ocaml
+which handles a natural BNF-like syntax extension for OCaml.  It can
+be used to define Earley parsers inside the language.
+
+Authors:
+ - Christophe Raffalli <christophe@raffalli.eu>
+ - Rodolphe Lepigre <rodolphe.lepigre@lepigre.fr>

--- a/packages/earley-ocaml/earley-ocaml.1.0.1/opam
+++ b/packages/earley-ocaml/earley-ocaml.1.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+available   : [ ocaml-version >= "4.03.0" ]
+maintainer  : "Christophe Raffalli <christophe@raffalli.eu>"
+bug-reports : "https://github.com/rlepigre/ocaml-earley-ocaml/issues"
+authors     : [ "Christophe Raffalli <christophe@raffalli.eu>"
+                "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>" ]
+homepage    : "https://rlepigre.github.io/ocaml-earley-ocaml/"
+license     : "CeCILL-B_V1"
+dev-repo    : "https://github.com/rlepigre/ocaml-earley-ocaml.git"
+build       : [ [make] [make] ]
+install     : [make "install" "BINDIR=%{bin}%" ]
+remove      : [make "uninstall"]
+depends     : [ "ocamlfind" {build}
+                "ocamlbuild" {build}
+                "earley" {= "1.0.1"} ]

--- a/packages/earley-ocaml/earley-ocaml.1.0.1/url
+++ b/packages/earley-ocaml/earley-ocaml.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/rlepigre/ocaml-earley-ocaml/archive/ocaml-earley-ocaml_1.0.1.tar.gz"
+checksum: "91f16b2d85dd269b61cb5e2ce7ab7733"

--- a/packages/earley/earley.1.0.0/descr
+++ b/packages/earley/earley.1.0.0/descr
@@ -1,10 +1,11 @@
 Earley parser combinator library
 
 Earley is a parser combinator library base on Earley's algorithm. It
-is intended to be used with pa_ocaml,  which is an extensible parser
-for OCaml (distributed separately).  It contains a syntax  extension
-for OCaml, which allows the definition of parsers in the language.
+is intended to be used in conjunction with Earley-OCaml, which is an
+extensible parser for OCaml (distributed separately).  It contains a
+syntax extension for OCaml,  which allows the definition of  parsers
+inside the language.
 
 Authors:
- - Christophe Raffalli <christophe.raffalli@univ-savoie.fr>
- - Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>
+ - Christophe Raffalli <christophe@raffalli.eu>
+ - Rodolphe Lepigre <rodolphe.lepigre@inria.fr>

--- a/packages/earley/earley.1.0.0/opam
+++ b/packages/earley/earley.1.0.0/opam
@@ -1,16 +1,14 @@
 opam-version: "1.2"
-available:    [ ocaml-version >= "4.01.0" ]
-maintainer:   "Christophe Raffalli <christophe.raffalli@univ-savoie.fr>"
-bug-reports:  "https://github.com/rlepigre/ocaml-earley/issues"
-authors:
-  [ "Christophe Raffalli <christophe.raffalli@univ-savoie.fr>"
-    "Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>" ]
-homepage: "https://rlepigre.github.io/ocaml-earley/"
-license: "LGPL-3.0"
-dev-repo: "https://github.com/rlepigre/ocaml-earley.git"
-build: [make]
-install: [make "install"]
-remove: [make "uninstall"]
-depends:
-  [ "ocamlbuild" {build}
-    "ocamlfind" {build} ]
+available   : [ ocaml-version >= "4.01.0" ]
+maintainer  : "Christophe Raffalli <christophe@raffalli.eu>"
+bug-reports : "https://github.com/rlepigre/ocaml-earley/issues"
+authors     : [ "Christophe Raffalli <christophe@raffalli.eu>"
+                "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>" ]
+homepage    : "https://rlepigre.github.io/ocaml-earley/"
+license     : "CeCILL-B_V1"
+dev-repo    : "https://github.com/rlepigre/ocaml-earley.git"
+build       : [make]
+install     : [make "install"]
+remove      : [make "uninstall"]
+depends     : [ "ocamlbuild" {build}
+                "ocamlfind" {build} ]

--- a/packages/earley/earley.1.0.0/opam
+++ b/packages/earley/earley.1.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-available   : [ ocaml-version >= "4.01.0" ]
+available   : [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 maintainer  : "Christophe Raffalli <christophe@raffalli.eu>"
 bug-reports : "https://github.com/rlepigre/ocaml-earley/issues"
 authors     : [ "Christophe Raffalli <christophe@raffalli.eu>"

--- a/packages/earley/earley.1.0.1/descr
+++ b/packages/earley/earley.1.0.1/descr
@@ -1,0 +1,11 @@
+Earley parser combinator library
+
+Earley is a parser combinator library base on Earley's algorithm. It
+is intended to be used in conjunction with Earley-OCaml, which is an
+extensible parser for OCaml (distributed separately).  It contains a
+syntax extension for OCaml,  which allows the definition of  parsers
+inside the language.
+
+Authors:
+ - Christophe Raffalli <christophe@raffalli.eu>
+ - Rodolphe Lepigre <rodolphe.lepigre@inria.fr>

--- a/packages/earley/earley.1.0.1/opam
+++ b/packages/earley/earley.1.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+available   : [ ocaml-version >= "4.03.0" ]
+maintainer  : "Christophe Raffalli <christophe@raffalli.eu>"
+bug-reports : "https://github.com/rlepigre/ocaml-earley/issues"
+authors     : [ "Christophe Raffalli <christophe@raffalli.eu>"
+                "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>" ]
+homepage    : "https://rlepigre.github.io/ocaml-earley/"
+license     : "CeCILL-B_V1"
+dev-repo    : "https://github.com/rlepigre/ocaml-earley.git"
+build       : [make]
+build-test  : [make "tests" "TESTS=--full"]
+install     : [make "install"]
+remove      : [make "uninstall"]
+depends     : [ "ocamlbuild" {build}
+                "ocamlfind" {build} ]

--- a/packages/earley/earley.1.0.1/url
+++ b/packages/earley/earley.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/rlepigre/ocaml-earley/archive/ocaml-earley_1.0.1.tar.gz"
+checksum: "b86117be1161ae3a831b45d7d1087184"


### PR DESCRIPTION
Some of the metadata for earlier versions of the packages have been updated (mainly email addresses). And the previously only available version of Earley-OCaml now requires the previously only available version of Earley (this should have been done from the beginning and cannot break anything).