### PR TITLE
Package datakit-ci.0.12.1

### DIFF
--- a/packages/datakit-ci/datakit-ci.0.12.1/descr
+++ b/packages/datakit-ci/datakit-ci.0.12.1/descr
@@ -1,0 +1,7 @@
+Continuous Integration service using DataKit
+
+DataKitCI is a continuous integration service that monitors your
+GitHub project and tests each branch, tag and pull request. It
+displays the test results as status indicators in the GitHub UI. It
+keeps all of its state and logs in DataKit, rather than a traditional
+relational database, allowing review with the usual Git tools.

--- a/packages/datakit-ci/datakit-ci.0.12.1/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.1/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas© Leonard" "Anil Madhavapeddy"
+               "Dave Tucker" "Thomas Gazagnaire" ]
+license:      "Apache"
+homepage:     "https://github.com/moby/datakit"
+bug-reports:  "https://github.com/moby/datakit/issues"
+dev-repo:     "https://github.com/moby/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "ci/tests"]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "multipart-form-data"
+  "datakit-client" {>= "0.12.0"}
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-github" {>= "0.12.0"}
+  "protocol-9p-unix" {>= "0.11.0"}
+  "astring"
+  "cmdliner"
+  "fmt"
+  "logs"
+  "tyxml" {>= "4.0.0"}
+  "tls" {>= "0.9.0"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "io-page"
+  "pbkdf"
+  "webmachine" {>= "0.4.0"}
+  "session-redis-lwt" {>= "0.4.0"}
+  "session-webmachine" {>= "0.4.0"}
+  "redis-lwt"
+  "asetmap"
+  "github-unix" {>= "3.0.0"}
+  "prometheus-app"
+  "lwt" {>= "3.0.0"}
+  "ppx_sexp_conv" {build}
+  "crunch" {build}
+  "datakit" {test & >= "0.12.0"}
+  "irmin-unix" {test & >= "1.2.0"}
+  "alcotest" {test}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/datakit-ci/datakit-ci.0.12.1/url
+++ b/packages/datakit-ci/datakit-ci.0.12.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/moby/datakit/releases/download/0.12.1/datakit-0.12.1.tbz"
+checksum: "968b20a89937b9510501fb77f08f2ad8"


### PR DESCRIPTION
### `datakit-ci.0.12.1`

Continuous Integration service using DataKit

DataKitCI is a continuous integration service that monitors your
GitHub project and tests each branch, tag and pull request. It
displays the test results as status indicators in the GitHub UI. It
keeps all of its state and logs in DataKit, rather than a traditional
relational database, allowing review with the usual Git tools.



---
* Homepage: https://github.com/moby/datakit
* Source repo: https://github.com/moby/datakit.git
* Bug tracker: https://github.com/moby/datakit/issues

---


---
### 0.12.1 (2018-01-23)

- Upgrade to Tls >= 0.9.0 and Cohttp-lwt-unix >= 1.0.0 (#615, @jpdeplaix)
:camel: Pull-request generated by opam-publish v0.3.5