### PR TITLE
add bounds on jbuilder version

### DIFF
--- a/packages/ago/ago.0.4/opam
+++ b/packages/ago/ago.0.4/opam
@@ -10,5 +10,5 @@ bug-reports:    "https://github.com/lindig/ocaml-ago/issues"
 build:          [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test:     [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]

--- a/packages/atd/atd.1.12.0/opam
+++ b/packages/atd/atd.1.12.0/opam
@@ -15,7 +15,7 @@ build-test: [
 ]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "menhir"
   "easy-format"
 ]

--- a/packages/atd/atd.1.2.1/opam
+++ b/packages/atd/atd.1.2.1/opam
@@ -15,7 +15,7 @@ build-test: [
 ]
 
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "menhir"
   "easy-format"
 ]

--- a/packages/biniou/biniou.1.2.0/opam
+++ b/packages/biniou/biniou.1.2.0/opam
@@ -17,7 +17,7 @@ build-test: [
 
 depends: [
   "conf-which" {build}
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "easy-format"
 ]
 

--- a/packages/camlon/camlon.2.0.1/opam
+++ b/packages/camlon/camlon.2.0.1/opam
@@ -8,6 +8,6 @@ bug-reports:
 dev-repo: "hg://https://bitbucket.org/camlspotter/camlon"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/clarity/clarity.0.1.4/opam
+++ b/packages/clarity/clarity.0.1.4/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/IndiscriminateCoding/clarity/issues"
 dev-repo: "https://github.com/IndiscriminateCoding/clarity.git"
 license: "BSD3"
 available: [ ocaml-version >= "4.04.0" ]
-depends: [ "jbuilder" {build} "ocamlfind" {build} ]
+depends: [ "jbuilder" {build & >= "1.0+beta7"} "ocamlfind" {build} ]
 build: [
   [ "jbuilder" "build" ]
 ]

--- a/packages/clarity/clarity.0.2.0/opam
+++ b/packages/clarity/clarity.0.2.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/IndiscriminateCoding/clarity/issues"
 dev-repo: "https://github.com/IndiscriminateCoding/clarity.git"
 license: "BSD3"
 available: [ ocaml-version >= "4.04.0" ]
-depends: [ "jbuilder" {build} "ocamlfind" {build} ]
+depends: [ "jbuilder" {build & >= "1.0+beta7"} "ocamlfind" {build} ]
 build: [
   [ "jbuilder" "build" ]
 ]

--- a/packages/clarity/clarity.0.3.0/opam
+++ b/packages/clarity/clarity.0.3.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/IndiscriminateCoding/clarity/issues"
 dev-repo: "https://github.com/IndiscriminateCoding/clarity.git"
 license: "BSD3"
 available: [ ocaml-version >= "4.04.0" ]
-depends: [ "jbuilder" {build} "ocamlfind" {build} ]
+depends: [ "jbuilder" {build & >= "1.0+beta7"} "ocamlfind" {build} ]
 build: [
   [ "jbuilder" "build" ]
 ]

--- a/packages/containers/containers.2.0/opam
+++ b/packages/containers/containers.2.0/opam
@@ -10,7 +10,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 build-doc: ["jbuilder" "build" "@doc"]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta12"}
   "result"
 ]
 depopts: [

--- a/packages/cryptodbm/cryptodbm.0.84.2/opam
+++ b/packages/cryptodbm/cryptodbm.0.84.2/opam
@@ -5,6 +5,6 @@ homepage: "https://github.com/lebotlan/ocaml-cryptodbm"
 bug-reports: "https://github.com/lebotlan/ocaml-cryptodbm/issues"
 dev-repo: "git://github.com/lebotlan/ocaml-cryptodbm.git"
 license: "MIT License"
-depends: [ "jbuilder" "dbm" "fileutils" "cryptokit" ]
+depends: [ "jbuilder" {>= "1.0+beta7"} "dbm" "fileutils" "cryptokit" ]
 available: [ ocaml-version >= "4.02.3" ]
 build: [["jbuilder" "build" "-p" name "-j" jobs]]

--- a/packages/csv/csv.2.0/opam
+++ b/packages/csv/csv.2.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta9"}
   "base-bytes"
   "base-unix"
 ]

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0/opam
@@ -10,7 +10,7 @@ name: "js_of_ocaml-ocamlbuild"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "jbuilder" {build & >= "1.0+beta7"}
+  "jbuilder" {build & >= "1.0+beta9"}
   "ocamlbuild"
 ]
 

--- a/packages/json_of_jsonm/json_of_jsonm.1.0.0/opam
+++ b/packages/json_of_jsonm/json_of_jsonm.1.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 
 depends: [
-  "jbuilder"  {build}
+  "jbuilder"  {build & >= "1.0+beta7"}
   "jsonm"
 ]
 

--- a/packages/ocamlformat_support/ocamlformat_support.0.1/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.1/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
 license: "LGPL-2 with OCaml linking exception"
 available: [ ocaml-version >= "4.04.0" ]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]
 build: [
   [make]

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/opam
@@ -7,6 +7,6 @@ license: "LGPL-2 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]
 available: [ocaml-version >= "4.04.0"]

--- a/packages/octavius/octavius.1.1.0/opam
+++ b/packages/octavius/octavius.1.1.0/opam
@@ -13,7 +13,7 @@ tags: ["doc" "ocamldoc" "org:ocaml-doc"]
 available: [ ocaml-version >= "4.03.0"]
 depends: [
   "ocamlfind" {build}
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "topkg" {build & >= "0.7.5"} ]
 
 build: [

--- a/packages/octavius/octavius.1.2.0/opam
+++ b/packages/octavius/octavius.1.2.0/opam
@@ -13,7 +13,7 @@ tags: ["doc" "ocamldoc" "org:ocaml-doc"]
 available: [ ocaml-version >= "4.03.0"]
 depends: [
   "ocamlfind" {build}
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "topkg" {build & >= "0.7.5"} ]
 
 build: [

--- a/packages/opaca/opaca.0.1.5/opam
+++ b/packages/opaca/opaca.0.1.5/opam
@@ -9,6 +9,6 @@ license: "MIT License"
 build: ["jbuilder" "build"]
 available: [ocaml-version >= "4.03.0"]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "topkg" {build}
 ]

--- a/packages/rope/rope.0.6.1/opam
+++ b/packages/rope/rope.0.6.1/opam
@@ -14,7 +14,7 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "base-bytes"
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "benchmark" {test}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/rope/rope.0.6/opam
+++ b/packages/rope/rope.0.6/opam
@@ -14,7 +14,7 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "base-bytes"
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "benchmark" {test}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/sequence/sequence.1.0/opam
+++ b/packages/sequence/sequence.1.0/opam
@@ -13,7 +13,7 @@ build-doc: [["jbuilder" "build" "@doc"]]
 depends: [
   "base-bytes"
   "result"
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta12"}
   "qcheck" {test}
   "qtest" {test}
 ]

--- a/packages/smbc/smbc.0.4.2/opam
+++ b/packages/smbc/smbc.0.4.2/opam
@@ -7,7 +7,7 @@ tags: ["logic" "narrowing" "model" "smt"]
 dev-repo: "https://github.com/c-cube/smbc.git"
 build: ["jbuilder" "build" "@install"]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta6"}
   "base-bytes"
   "containers" {>= "1.0"}
   "sequence" {>= "0.4"}

--- a/packages/vcardgen/vcardgen.1.0/opam
+++ b/packages/vcardgen/vcardgen.1.0/opam
@@ -7,5 +7,5 @@ license: "BSD2"
 dev-repo: "https://github.com/vzaliva/vcardgen.git"
 build: ["jbuilder" "build"]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]

--- a/packages/vpt/vpt.3.0.0/opam
+++ b/packages/vpt/vpt.3.0.0/opam
@@ -9,5 +9,5 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]

--- a/packages/vpt/vpt.3.0.1/opam
+++ b/packages/vpt/vpt.3.0.1/opam
@@ -9,5 +9,5 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]

--- a/packages/vpt/vpt.4.0.1/opam
+++ b/packages/vpt/vpt.4.0.1/opam
@@ -9,5 +9,5 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]

--- a/packages/zipperposition/zipperposition.1.5/opam
+++ b/packages/zipperposition/zipperposition.1.5/opam
@@ -14,7 +14,7 @@ depends: [
   "zarith"
   "containers" {>= "1.0"}
   "sequence" {>= "0.4"}
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
   "msat" {>= "0.5" & < "1.0"}
   "menhir" {build}
 ]


### PR DESCRIPTION
`jbuilder` is changing its feature set between beta versions and a number of packages are missing version constraints on `jbuilder`. Here are some of them.
