### PR TITLE
New release of ocaml-github, compatible with 4.06

### DIFF
--- a/packages/github-jsoo/github-jsoo.3.1.0/descr
+++ b/packages/github-jsoo/github-jsoo.3.1.0/descr
@@ -1,0 +1,23 @@
+GitHub APIv3 OCaml Library
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-github.svg)](https://travis-ci.org/mirage/ocaml-github)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/ocaml-github/)
+
+This library provides an OCaml interface to the [GitHub
+APIv3](https://developer.github.com/v3/) (JSON). It is compatible with
+[MirageOS](https://mirage.io) and also compiles to pure JavaScript via
+[js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+
+It is [not yet complete](#api-support-coverage) but
+[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib/github.atd)
+contains the data types that have been bound so far.
+
+There are several tests and examples in
+[lib_test](https://github.com/mirage/ocaml-github/tree/master/lib_test)
+for small bits of
+functionality. [jar](https://github.com/mirage/ocaml-github/tree/master/jar)
+contains utility programs that use the [git jar](#git-jar) facility for
+stored tokens.
+
+If you are interested in easily using this library to listen for GitHub
+web hook events, you should look at [dsheets/ocaml-github-hooks](https://github.com/dsheets/ocaml-github-hooks).

--- a/packages/github-jsoo/github-jsoo.3.1.0/opam
+++ b/packages/github-jsoo/github-jsoo.3.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+homepage:    "https://github.com/mirage/ocaml-github"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+dev-repo:    "https://github.com/mirage/ocaml-github.git"
+doc:         "https://mirage.github.io/ocaml-github/"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+  "git"
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml"
+  "github"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/github-jsoo/github-jsoo.3.1.0/url
+++ b/packages/github-jsoo/github-jsoo.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-github/releases/download/3.1.0/github-3.1.0.tbz"
+checksum: "111940cd797b1a4c621be2a8077e706f"

--- a/packages/github-unix/github-unix.3.1.0/descr
+++ b/packages/github-unix/github-unix.3.1.0/descr
@@ -1,0 +1,23 @@
+GitHub APIv3 OCaml Library
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-github.svg)](https://travis-ci.org/mirage/ocaml-github)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/ocaml-github/)
+
+This library provides an OCaml interface to the [GitHub
+APIv3](https://developer.github.com/v3/) (JSON). It is compatible with
+[MirageOS](https://mirage.io) and also compiles to pure JavaScript via
+[js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+
+It is [not yet complete](#api-support-coverage) but
+[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib/github.atd)
+contains the data types that have been bound so far.
+
+There are several tests and examples in
+[lib_test](https://github.com/mirage/ocaml-github/tree/master/lib_test)
+for small bits of
+functionality. [jar](https://github.com/mirage/ocaml-github/tree/master/jar)
+contains utility programs that use the [git jar](#git-jar) facility for
+stored tokens.
+
+If you are interested in easily using this library to listen for GitHub
+web hook events, you should look at [dsheets/ocaml-github-hooks](https://github.com/dsheets/ocaml-github-hooks).

--- a/packages/github-unix/github-unix.3.1.0/opam
+++ b/packages/github-unix/github-unix.3.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+homepage:    "https://github.com/mirage/ocaml-github"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+dev-repo:    "https://github.com/mirage/ocaml-github.git"
+doc:         "https://mirage.github.io/ocaml-github/"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+  "git"
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "github"
+  "cohttp-lwt-unix"
+  "stringext"
+  "lambda-term"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/github-unix/github-unix.3.1.0/url
+++ b/packages/github-unix/github-unix.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-github/releases/download/3.1.0/github-3.1.0.tbz"
+checksum: "111940cd797b1a4c621be2a8077e706f"

--- a/packages/github/github.3.1.0/descr
+++ b/packages/github/github.3.1.0/descr
@@ -1,0 +1,23 @@
+GitHub APIv3 OCaml Library
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-github.svg)](https://travis-ci.org/mirage/ocaml-github)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/ocaml-github/)
+
+This library provides an OCaml interface to the [GitHub
+APIv3](https://developer.github.com/v3/) (JSON). It is compatible with
+[MirageOS](https://mirage.io) and also compiles to pure JavaScript via
+[js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+
+It is [not yet complete](#api-support-coverage) but
+[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib/github.atd)
+contains the data types that have been bound so far.
+
+There are several tests and examples in
+[lib_test](https://github.com/mirage/ocaml-github/tree/master/lib_test)
+for small bits of
+functionality. [jar](https://github.com/mirage/ocaml-github/tree/master/jar)
+contains utility programs that use the [git jar](#git-jar) facility for
+stored tokens.
+
+If you are interested in easily using this library to listen for GitHub
+web hook events, you should look at [dsheets/ocaml-github-hooks](https://github.com/dsheets/ocaml-github-hooks).

--- a/packages/github/github.3.1.0/opam
+++ b/packages/github/github.3.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+homepage:    "https://github.com/mirage/ocaml-github"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+dev-repo:    "https://github.com/mirage/ocaml-github.git"
+doc:         "https://mirage.github.io/ocaml-github/"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+  "git"
+]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "1.10.0"}
+  "yojson" {>= "1.2.0"}
+  "stringext"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/github/github.3.1.0/url
+++ b/packages/github/github.3.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-github/releases/download/3.1.0/github-3.1.0.tbz"
+checksum: "111940cd797b1a4c621be2a8077e706f"


### PR DESCRIPTION
- Make contributor stats author field nullable (mirage/ocaml-github#211, @rvantonder)
- Support OCaml 4.06 by enabling `-safe-string` compatibility (mirage/ocaml-github#212, @jpdeplaix)
- Add support for repository issue search (mirage/ocaml-github#196, @avsm and @samoht)
- TLS isn't a hard dependency of githug (mirage/ocaml-github#208, @rgrinberg)