### PR TITLE
Package travis-opam.1.2.0

### DIFF
--- a/packages/travis-opam/travis-opam.1.2.0/descr
+++ b/packages/travis-opam/travis-opam.1.2.0/descr
@@ -1,0 +1,6 @@
+Scripts for OCaml projects
+
+Supported CI:
+
+- **stable**: [Travis CI](/README-travis.md) Ubuntu, Debian and OSX workers.
+- **experimental**: [Appveyor](/README-appveyor.md) Windows Server 2012 R2 (x64) workers.

--- a/packages/travis-opam/travis-opam.1.2.0/opam
+++ b/packages/travis-opam/travis-opam.1.2.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+homepage:     "https://github.com/ocaml/ocaml-ci-scripts"
+bug-reports:  "https://github.com/ocaml/ocaml-ci-scripts/issues"
+dev-repo:     "https://github.com/ocaml/ocaml-ci-scripts.git"
+doc:          "https://ocaml.github.io/ocaml-ci-scripts/"
+
+authors: [
+  "Thomas Gazagnaire"
+  "Richard Mortier"
+  "David Sheets"
+]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build}
+  "jsonm" {build}
+]

--- a/packages/travis-opam/travis-opam.1.2.0/url
+++ b/packages/travis-opam/travis-opam.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/ocaml-ci-scripts/releases/download/1.2.0/travis-opam-1.2.0.tbz"
+checksum: "73e7bcc6ca14e30bc37c76379ed108d5"


### PR DESCRIPTION
### `travis-opam.1.2.0`

Scripts for OCaml projects

Supported CI:

- **stable**: [Travis CI](/README-travis.md) Ubuntu, Debian and OSX workers.
- **experimental**: [Appveyor](/README-appveyor.md) Windows Server 2012 R2 (x64) workers.


---
* Homepage: https://github.com/ocaml/ocaml-ci-scripts
* Source repo: https://github.com/ocaml/ocaml-ci-scripts.git
* Bug tracker: https://github.com/ocaml/ocaml-ci-scripts/issues

---

:camel: Pull-request generated by opam-publish v0.3.5