### PR TITLE
Disable cppo.1.6.1 tests, which are failing.

### DIFF
--- a/packages/cppo/cppo.1.6.1/opam
+++ b/packages/cppo/cppo.1.6.1/opam
@@ -10,9 +10,6 @@ build: [
   ["jbuilder" "subst"] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-build-test: [
-  ["jbuilder" "runtest" "-p" name]
-]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}


### PR DESCRIPTION
/cc @mjambon 

This showed up in the [build log for a ctypes pr](https://travis-ci.org/ocamllabs/ocaml-ctypes/jobs/341731674#L7145):

```
#=== ERROR while installing cppo.1.6.1 ========================================#
# opam-version 1.2.2
# os           darwin
# command      jbuilder runtest -p cppo
# path         /Users/travis/.opam/4.03.0/build/cppo.1.6.1
# compiler     4.03.0
# exit-code    1
# env-file     /Users/travis/.opam/4.03.0/build/cppo.1.6.1/cppo-15996-910341.env
# stdout-file  /Users/travis/.opam/4.03.0/build/cppo.1.6.1/cppo-15996-910341.out
# stderr-file  /Users/travis/.opam/4.03.0/build/cppo.1.6.1/cppo-15996-910341.err
### stderr ###
# [...]
# +# 9 "unmatched.cppo"
#    b)
#  
# -# 12
# +# 12 "unmatched.cppo"
#   (1 + (2+3)) 
# -# 13
# +# 13 "unmatched.cppo"
#  )
#  (
```