### PR TITLE
Retrieve MetaOCaml 3.09.1 from GitHub rather than archive.org

### DIFF
--- a/compilers/3.09.1/3.09.1+metaocaml/3.09.1+metaocaml.comp
+++ b/compilers/3.09.1/3.09.1+metaocaml/3.09.1+metaocaml.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.09.1"
-src: "http://web.archive.org/web/20120209151915/www.metaocaml.org/dist/old/MetaOCaml_309_alpha_030.tar.gz"
+src: "https://github.com/metaocaml/metaocaml-archive/blob/master/MetaOCaml_309_alpha_030.tar.gz?raw=true"
 build: [
   ["./configure"
     "-prefix" prefix


### PR DESCRIPTION
Closes #11392.