### PR TITLE
Add compiler descriptions for OCaml 4.06.1

### DIFF
--- a/compilers/4.06.1/4.06.1+afl/4.06.1+afl.comp
+++ b/compilers/4.06.1/4.06.1+afl/4.06.1+afl.comp
@@ -1,0 +1,22 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-afl-instrument"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1+afl/4.06.1+afl.descr
+++ b/compilers/4.06.1/4.06.1+afl/4.06.1+afl.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release, with afl-fuzz instrumentation

--- a/compilers/4.06.1/4.06.1+default-unsafe-string/4.06.1+default-unsafe-string.comp
+++ b/compilers/4.06.1/4.06.1+default-unsafe-string/4.06.1+default-unsafe-string.comp
@@ -1,0 +1,22 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-default-unsafe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1+default-unsafe-string/4.06.1+default-unsafe-string.descr
+++ b/compilers/4.06.1/4.06.1+default-unsafe-string/4.06.1+default-unsafe-string.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release, without safe strings by default

--- a/compilers/4.06.1/4.06.1+flambda/4.06.1+flambda.comp
+++ b/compilers/4.06.1/4.06.1+flambda/4.06.1+flambda.comp
@@ -1,0 +1,22 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1+flambda/4.06.1+flambda.descr
+++ b/compilers/4.06.1/4.06.1+flambda/4.06.1+flambda.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release, with flambda activated

--- a/compilers/4.06.1/4.06.1+force-safe-string/4.06.1+force-safe-string.comp
+++ b/compilers/4.06.1/4.06.1+force-safe-string/4.06.1+force-safe-string.comp
@@ -1,0 +1,18 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1+force-safe-string/4.06.1+force-safe-string.descr
+++ b/compilers/4.06.1/4.06.1+force-safe-string/4.06.1+force-safe-string.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release, with -force-safe-string enabled.

--- a/compilers/4.06.1/4.06.1+fp+flambda/4.06.1+fp+flambda.comp
+++ b/compilers/4.06.1/4.06.1+fp+flambda/4.06.1+fp+flambda.comp
@@ -1,0 +1,32 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1+fp+flambda/4.06.1+fp+flambda.descr
+++ b/compilers/4.06.1/4.06.1+fp+flambda/4.06.1+fp+flambda.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release, with frame-pointers and flambda activated

--- a/compilers/4.06.1/4.06.1+fp/4.06.1+fp.comp
+++ b/compilers/4.06.1/4.06.1+fp/4.06.1+fp.comp
@@ -1,0 +1,30 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-with-frame-pointers"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1+fp/4.06.1+fp.descr
+++ b/compilers/4.06.1/4.06.1+fp/4.06.1+fp.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release, with frame-pointers

--- a/compilers/4.06.1/4.06.1/4.06.1.comp
+++ b/compilers/4.06.1/4.06.1/4.06.1.comp
@@ -1,0 +1,22 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1/4.06.1.descr
+++ b/compilers/4.06.1/4.06.1/4.06.1.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release


### PR DESCRIPTION
The official release of 4.06.1 is out! Here are the compiler descriptions, this time without mistakes. (I hope)

