### PR TITLE
Build and run tests during Travis install

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -111,7 +111,7 @@ function build_one {
     opam depext $pkg
     echo
     echo "====== Installing package ======"
-    opam install $pkg
+    opam install -t $pkg
     opam remove -a ${pkg%%.*}
     if [ "$depext" != "" ]; then
       case $TRAVIS_OS_NAME in


### PR DESCRIPTION
This would probably have caught #11424 before cppo.1.6.1 was merged, for example.