### PR TITLE
Package pbkdf.0.3.0

### DIFF
--- a/packages/pbkdf/pbkdf.0.3.0/descr
+++ b/packages/pbkdf/pbkdf.0.3.0/descr
@@ -1,0 +1,3 @@
+Password based key derivation functions from PKCS#5, RFC 2898
+
+An implementation of PBKDF 1 and 2 as defined by PKCS#5 (RFC 2898) in OCaml, using nocrypto.

--- a/packages/pbkdf/pbkdf.0.3.0/opam
+++ b/packages/pbkdf/pbkdf.0.3.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+authors: [
+  "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+  "Sonia Meruelo <smeruelo@gmail.com>"
+]
+homepage: "https://github.com/abeaumont/ocaml-pbkdf"
+bug-reports: "https://github.com/abeaumont/ocaml-pbkdf/issues"
+license: "BSD2"
+dev-repo: "https://github.com/abeaumont/ocaml-pbkdf.git"
+build: ["jbuilder" "build" "-j" jobs "-p" name "@install"]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta17"}
+  "nocrypto" {>= "0.5.4"}
+  "alcotest" {test & >= "0.8.1"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/pbkdf/pbkdf.0.3.0/url
+++ b/packages/pbkdf/pbkdf.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/abeaumont/ocaml-pbkdf/archive/0.3.0.tar.gz"
+checksum: "ab34d1027e693e855a06639c7bbb8ced"


### PR DESCRIPTION
### `pbkdf.0.3.0`

Password based key derivation functions from PKCS#5, RFC 2898

An implementation of PBKDF 1 and 2 as defined by PKCS#5 (RFC 2898) in OCaml, using nocrypto.



---
* Homepage: https://github.com/abeaumont/ocaml-pbkdf
* Source repo: https://github.com/abeaumont/ocaml-pbkdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-pbkdf/issues

---

:camel: Pull-request generated by opam-publish v0.3.5