### PR TITLE
bitv <1.3 does not work with safe-string

### DIFF
--- a/packages/bitv/bitv.1.0/opam
+++ b/packages/bitv/bitv.1.0/opam
@@ -6,3 +6,4 @@ build: [
   ["./configure"]
   [make]
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/bitv/bitv.1.1/opam
+++ b/packages/bitv/bitv.1.1/opam
@@ -10,3 +10,4 @@ build: [
 remove: [["ocamlfind" "remove" "bitv"]]
 depends: ["ocamlfind"]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/bitv/bitv.1.2/opam
+++ b/packages/bitv/bitv.1.2/opam
@@ -17,4 +17,4 @@ depends: [
   "ocamlfind"
   "conf-autoconf" {build}
 ]
-available: [ocaml-version >= "4.00.1"]
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
Related issue: https://github.com/backtracking/bitv/pull/10

```sh-session
$ opam switch show
4.06.0
$ opam install bitv.1.2
The following actions will be performed:
  - install bitv 1.2

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[bitv] Archive in cache

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[ERROR] The compilation of bitv failed at "make".
Processing  1/1: [bitv: ocamlfind remove]
#=== ERROR while installing bitv.1.2 ==========================================#
# opam-version 1.2.2
# os           linux
# command      make
# path         /home/nek/.opam/4.06.0/build/bitv.1.2
# compiler     4.06.0
# exit-code    2
# env-file     /home/nek/.opam/4.06.0/build/bitv.1.2/bitv-9467-6d07ae.env
# stdout-file  /home/nek/.opam/4.06.0/build/bitv.1.2/bitv-9467-6d07ae.out
# stderr-file  /home/nek/.opam/4.06.0/build/bitv.1.2/bitv-9467-6d07ae.err
### stdout ###
# ocamlc.opt -c  bitv.mli
# ocamlc.opt -c  bitv.ml
# Makefile:112: recipe for target 'bitv.cmo' failed
### stderr ###
# File "bitv.ml", line 528, characters 29-74:
# Warning 3: deprecated: String.set
# Use Bytes.set instead.
# File "bitv.ml", line 528, characters 29-30:
# Error: This expression has type string but an expression was expected of type
#          bytes
# make: *** [bitv.cmo] Error 2



=-=- Error report -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
The following actions failed
  - install bitv 1.2
No changes have been performed
$ opam install bitv.1.3
The following actions will be performed:
  ∗  install bitv 1.3

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[bitv] Archive in cache

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
∗  installed bitv.1.3
Done.
```

cc @backtracking 