### PR TITLE
uutf.0.9.3: fix a typo of constraints

### DIFF
--- a/packages/uutf/uutf.0.9.3/opam
+++ b/packages/uutf/uutf.0.9.3/opam
@@ -18,4 +18,4 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version > "4.06.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
Not `ocaml-version > "4.06.0"`, but `ocaml-version < "4.06.0"`.

See also: https://github.com/ocaml/opam-repository/commit/ae9e9443292e3cfd3d40ba4e9c2ebb2c8ae928a0