### PR TITLE
fix camlp5 uninstall

### DIFF
--- a/packages/camlp5/camlp5.7.03/opam
+++ b/packages/camlp5/camlp5.7.03/opam
@@ -7,9 +7,13 @@ build: [
   ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
   [make "world.opt"]
 ]
-available: [ocaml-version >= "4.02" & ocaml-version < "4.07"]
+available: [ocaml-version >= "4.02" & ocaml-version < "4.06.1"]
 bug-reports: "https://github.com/camlp5/camlp5/issues"
 dev-repo: "https://github.com/camlp5/camlp5.git"
 doc: "https://camlp5.github.io/doc/html"
 install: [make "install"]
-remove: [make "uninstall"]
+remove: [
+  ["sh" "-ecx" "./configure --prefix '%{prefix}%' -libdir '%{lib}%' -mandir '%{man}%' && %{make}% uninstall"]
+  [ "rm" "-rf" "%{lib}%/camlp5" ]
+  [ "rm" "-f" "%{man}%/man1/camlp5.1" "%{man}%/man1/camlp5o.1" "%{man}%/man1/camlp5o.opt.1" "%{man}%/man1/camlp5r.1" "%{man}%/man1/camlp5r.opt.1" "%{man}%/man1/camlp5sch.1" "%{man}%/man1/mkcamlp5.1" "%{man}%/man1/mkcamlp5.opt.1" "%{man}%/man1/ocpp5.1" ]
+]


### PR DESCRIPTION
See #11440 
I've noticed it, but didn't take it serious. 'rm -rf /' doesn't work with rm of coreutils or any other version of 'rm' I've seen. It will just print a warning. If this is not a universal feature, it's a very serious problem and this PR should be merged very soon.