### PR TITLE
Package pkcs11.0.15.0

### DIFF
--- a/packages/pkcs11/pkcs11.0.15.0/descr
+++ b/packages/pkcs11/pkcs11.0.15.0/descr
@@ -1,0 +1,6 @@
+Bindings to the PKCS#11 cryptographic API
+
+This library contains ctypes bindings to the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.

--- a/packages/pkcs11/pkcs11.0.15.0/opam
+++ b/packages/pkcs11/pkcs11.0.15.0/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build"
+    "--pinned" "%{pinned}%"
+    "--with-cmdliner" "%{cmdliner:installed}%"
+    "--with-driver" "%{ctypes:installed}%"
+  ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build"
+    "--pinned" "%{pinned}%"
+    "--tests" "true"
+    "--with-cmdliner" "%{cmdliner:installed}%"
+    "--with-driver" "%{ctypes:installed}%"
+  ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "hex" { >= "1.0.0" }
+  "integers"
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "zarith"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+depopts: [
+  "cmdliner"
+  "ctypes"
+  "ctypes-foreign"
+]
+conflicts: [
+  "ctypes" { < "0.12.0" }
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.03.0" & os != "darwin"]

--- a/packages/pkcs11/pkcs11.0.15.0/url
+++ b/packages/pkcs11/pkcs11.0.15.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/pkcs11/releases/download/v0.15.0/pkcs11-0.15.0.tbz"
+checksum: "035076817a2894d16b2957714f41d75e"


### PR DESCRIPTION
### `pkcs11.0.15.0`

Bindings to the PKCS#11 cryptographic API

This library contains ctypes bindings to the PKCS#11 API.

This API is used by smartcards and Hardware Security Modules to perform
cryptographic operations such as signature or encryption.



---
* Homepage: https://github.com/cryptosense/pkcs11
* Source repo: https://github.com/cryptosense/pkcs11.git
* Bug tracker: https://github.com/cryptosense/pkcs11/issues

---


---
v0.15.0 2018-02-19
==================

Bug fix:

- Fix `P11.RV.of_string "CKR_ACTION_PROHIBITED"`. (#97)

Improvements:

- Make it clear CKR are hex encoded in `OK_OR_FAIL`. (#95)
- Derive more `eq`, `ord` and `show` instances. (#96)
:camel: Pull-request generated by opam-publish v0.3.5