### PR TITLE
distwit: work with 4.05 and 4.06

### DIFF
--- a/packages/distwit/distwit.0.1.0/opam
+++ b/packages/distwit/distwit.0.1.0/opam
@@ -11,4 +11,4 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
 ]
-available: [ocaml-version >= "4.03" & ocaml-version < "4.05"]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.07"]


### PR DESCRIPTION
Relax the package constraints, code and version are unchanged.