### PR TITLE
Fix build failure with ppx_deriving_yojson.3.1 & ppx_deriving.4.2

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
@@ -27,3 +27,6 @@ depends: [
   "ounit"        {test}
   "ppx_import"   {test & >= "1.1"}
 ]
+conflicts: [
+  "ppx_deriving" {= "4.2"}
+]


### PR DESCRIPTION
Spotted here: https://arm64.ci.ocamllabs.io/log/saved/docker-build-42232c66a676dbb042e6d1c0958b088f/f15b0ec933b40635af510546c1ec8c968128e18d

cc @gasche since it seems you are the maintainer.