### PR TITLE
Package ocplib-json-typed.0.6

### DIFF
--- a/packages/ocplib-json-typed/ocplib-json-typed.0.6/descr
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.6/descr
@@ -1,0 +1,25 @@
+Type-aware JSON and JSON schema utilities
+
+Can be used with any JSON library.
+
+This library currently contains five modules:
+
+- Json_encoding:
+    Mappings between OCaml types and JSON structures.
+    Encodings are used to produce readers, writers and
+    JSON schemas for format documentation and interoperability.
+- Json_schema:
+    Manual creation and manipulation of JSON schemas.
+- Json_query:
+    Simple manipulations of JSON documents
+    (extraction, injection, merging, etc.).
+- Json_repr:
+    Modular abstraction over JSON representations.
+    Includes Ezjsonm and Yojson representations.
+- Json_repr_bson:
+    Implementation of the JSON compatible subset
+    of BSON, with a Json_repr compatible interface.
+    Built only if ocplib-endian is present.
+- Json_repr_browser:
+    Json_repr interface over JavaScript's objects.
+    Built only if js_of_ocaml is present.

--- a/packages/ocplib-json-typed/ocplib-json-typed.0.6/opam
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.6/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "https://github.com/ocamlpro/ocplib-json-typed.git"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "uri" {>= "1.9.0"}
+]
+depopts: ["js_of_ocaml" "ocplib-endian"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocplib-json-typed/ocplib-json-typed.0.6/url
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.6.tar.gz"
+checksum: "833e7f4cbf796f9b18c4e39d7d8af738"


### PR DESCRIPTION
### `ocplib-json-typed.0.6`

Type-aware JSON and JSON schema utilities

Can be used with any JSON library.

This library currently contains five modules:

- Json_encoding:
    Mappings between OCaml types and JSON structures.
    Encodings are used to produce readers, writers and
    JSON schemas for format documentation and interoperability.
- Json_schema:
    Manual creation and manipulation of JSON schemas.
- Json_query:
    Simple manipulations of JSON documents
    (extraction, injection, merging, etc.).
- Json_repr:
    Modular abstraction over JSON representations.
    Includes Ezjsonm and Yojson representations.
- Json_repr_bson:
    Implementation of the JSON compatible subset
    of BSON, with a Json_repr compatible interface.
    Built only if ocplib-endian is present.
- Json_repr_browser:
    Json_repr interface over JavaScript's objects.
    Built only if js_of_ocaml is present.



---
* Homepage: https://github.com/ocamlpro/ocplib-json-typed
* Source repo: https://github.com/ocamlpro/ocplib-json-typed.git
* Bug tracker: https://github.com/ocamlpro/ocplib-json-typed/issues

---

:camel: Pull-request generated by opam-publish v0.3.5