### PR TITLE
Add ezgzip 0.2.0

### DIFF
--- a/packages/ezgzip/ezgzip.0.2.0/descr
+++ b/packages/ezgzip/ezgzip.0.2.0/descr
@@ -1,0 +1,14 @@
+# ezgzip - Simple gzip (de)compression library
+
+Documentation is available
+[here](https://hcarty.github.io/ezgzip/ezgzip/index.html).
+
+```ocaml
+open Rresult
+
+let () =
+  let original = "Hello world" in
+  let compressed = Ezgzip.compress original in
+  let decompressed = R.get_ok (Ezgzip.decompress compressed) in
+  assert (original = decompressed)
+```

--- a/packages/ezgzip/ezgzip.0.2.0/descr
+++ b/packages/ezgzip/ezgzip.0.2.0/descr
@@ -1,8 +1,12 @@
 # ezgzip - Simple gzip (de)compression library
 
+ezgzip is a simple interface focused on `string -> string` zlib and gzip
+(de)compression.
+
 Documentation is available
 [here](https://hcarty.github.io/ezgzip/ezgzip/index.html).
 
+An example illustrating how to gzip compress and then decompress a string:
 ```ocaml
 open Rresult
 
@@ -12,3 +16,8 @@ let () =
   let decompressed = R.get_ok (Ezgzip.decompress compressed) in
   assert (original = decompressed)
 ```
+
+This library currently uses the zlib bindings provided by
+[camlzip](https://github.com/xavierleroy/camlzip).  The gzip header/footer code
+is based on the
+[upstream specification](http://www.gzip.org/zlib/rfc-gzip.html#specification).

--- a/packages/ezgzip/ezgzip.0.2.0/opam
+++ b/packages/ezgzip/ezgzip.0.2.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Hezekiah M. Carty <hez@0ok.org>"
+authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
+license: "MIT"
+homepage: "https://github.com/hcarty/ezgzip"
+dev-repo: "https://github.com/hcarty/ezgzip.git"
+bug-reports: "https://github.com/hcarty/ezgzip/issues"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+build-doc: [ "jbuilder" "build" "@doc" "-p" name]
+depends: [
+  "alcotest" {test & >= "0.8.1"}
+  "astring"
+  "benchmark" {test & >= "1.4"}
+  "jbuilder" {build & >= "1.0+beta13"}
+  "ocplib-endian"
+  "odoc" {doc & >= "1.1.1"}
+  "qcheck" {test & >= "0.7"}
+  "rresult"
+  "camlzip"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ezgzip/ezgzip.0.2.0/url
+++ b/packages/ezgzip/ezgzip.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hcarty/ezgzip/archive/v0.2.0.tar.gz"
+checksum: "22057f2528e282a1af961b36f61d5271"


### PR DESCRIPTION
First release to opam

# ezgzip - Simple gzip (de)compression library

Documentation is available [here](https://hcarty.github.io/ezgzip/ezgzip/index.html).

```ocaml
open Rresult

let () =
  let original = "Hello world" in
  let compressed = Ezgzip.compress original in
  let decompressed = R.get_ok (Ezgzip.decompress compressed) in
  assert (original = decompressed)
```