### PR TITLE
Package emile.0.1

### DIFF
--- a/packages/emile/emile.0.1/descr
+++ b/packages/emile/emile.0.1/descr
@@ -1,0 +1,52 @@
+[Images](https://youtube.com/watch?v=S70NaQqAfaw))
+
+Emile is a library to parse an e-mail address in OCaml. This project is an
+extraction of [MrMime](https://github.com/oklm-wsh/MrMime.git) - but we use
+[Angstrom](https://github.com/inhabitedtype/angstrom.git) instead an internal
+decoder.
+
+This implementation follow some RFCs:
+- RFC 822
+- RFC 2822
+- RFC 5321 (domain part)
+- RFC 5322
+- RFC 6532
+
+We handle UTF-8 (RFC 6532), domain defined on the SMTP protocol (RFC 5321), and
+general e-mail address purpose (RFC 822, RFC 2822, RFC 5322) including
+_folding-whitespace_.
+
+The last means we can parse something like:
+
+```
+A Group(Some people)
+   :Chris Jones <c@(Chris's host.)public.example>,
+     joe@example.org,
+ John <jdoe@one.test> (my dear friend); (the end of the group)"
+```
+
+For a general purpose, it's not needed and is close e-mail purpose.
+
+Then, for domain part (explained on RFC 6532 - SMTP protocol), we handle this
+kind of domain:
+
+```
+first.last@[12.34.56.78]
+first.last@[IPv6:1111:2222:3333::4444:12.34.56.78]
+```
+
+The parser of IPv* is done by [Ipaddr](https://github.com/mirage/ipaddr.git).
+As a old specification, we handle multiple-domains like:
+ 
+```
+<@a.com,b.com:john@doe.com>
+```
+
+Obviously, we handle (nested) comments:
+
+```
+a(a(b(c)d(e(f))g)h(i)j)@iana.org
+```
+
+All parsers are binded with a comment which explain where you can find the ABNF
+description and some notes about implementation. All was check by hand.

--- a/packages/emile/emile.0.1/opam
+++ b/packages/emile/emile.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "angstrom" {> "0.6.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "uutf"
+  "fmt"
+  "alcotest" {test}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/emile/emile.0.1/url
+++ b/packages/emile/emile.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dinosaure/emile/releases/download/v0.1/emile-0.1.tbz"
+checksum: "c3204197ca89707b03933b24ffe6d861"


### PR DESCRIPTION
### `emile.0.1`

[Images](https://youtube.com/watch?v=S70NaQqAfaw))

Emile is a library to parse an e-mail address in OCaml. This project is an
extraction of [MrMime](https://github.com/oklm-wsh/MrMime.git) - but we use
[Angstrom](https://github.com/inhabitedtype/angstrom.git) instead an internal
decoder.

This implementation follow some RFCs:
- RFC 822
- RFC 2822
- RFC 5321 (domain part)
- RFC 5322
- RFC 6532

We handle UTF-8 (RFC 6532), domain defined on the SMTP protocol (RFC 5321), and
general e-mail address purpose (RFC 822, RFC 2822, RFC 5322) including
_folding-whitespace_.

The last means we can parse something like:

```
A Group(Some people)
   :Chris Jones <c@(Chris's host.)public.example>,
     joe@example.org,
 John <jdoe@one.test> (my dear friend); (the end of the group)"
```

For a general purpose, it's not needed and is close e-mail purpose.

Then, for domain part (explained on RFC 6532 - SMTP protocol), we handle this
kind of domain:

```
first.last@[12.34.56.78]
first.last@[IPv6:1111:2222:3333::4444:12.34.56.78]
```

The parser of IPv* is done by [Ipaddr](https://github.com/mirage/ipaddr.git).
As a old specification, we handle multiple-domains like:
 
```
<@a.com,b.com:john@doe.com>
```

Obviously, we handle (nested) comments:

```
a(a(b(c)d(e(f))g)h(i)j)@iana.org
```

All parsers are binded with a comment which explain where you can find the ABNF
description and some notes about implementation. All was check by hand.


---
* Homepage: https://github.com/dinosaure/emile
* Source repo: https://github.com/dinosaure/emile.git
* Bug tracker: https://github.com/dinosaure/emile/issues

---


---
v0.1 2018-02-22 Phnom-Penh (Cambodia)
-------------------------------------

- First release
:camel: Pull-request generated by opam-publish v0.3.5