### PR TITLE
Re2 v0.10.1

### DIFF
--- a/packages/re2/re2.v0.10.0/opam
+++ b/packages/re2/re2.v0.10.0/opam
@@ -12,7 +12,7 @@ depends: [
   "core_kernel"             {>= "v0.10" & < "v0.11"}
   "ppx_driver"              {>= "v0.10" & < "v0.11"}
   "ppx_jane"                {>= "v0.10" & < "v0.11"}
-  "jbuilder"                {build & >= "1.0+beta12"}
+  "jbuilder"                {build & >= "1.0+beta12" & < "1.0+beta18"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/re2/re2.v0.10.1/descr
+++ b/packages/re2/re2.v0.10.1/descr
@@ -1,0 +1,1 @@
+OCaml bindings for RE2, Google's regular expression library

--- a/packages/re2/re2.v0.10.1/opam
+++ b/packages/re2/re2.v0.10.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/re2"
+bug-reports: "https://github.com/janestreet/re2/issues"
+dev-repo: "git+https://github.com/janestreet/re2.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "core_kernel"             {>= "v0.10" & < "v0.11"}
+  "ppx_driver"              {>= "v0.10" & < "v0.11"}
+  "ppx_jane"                {>= "v0.10" & < "v0.11"}
+  "jbuilder"                {build & >= "1.0+beta12"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.04.1" ]
+depexts: [
+ [ ["fedora"] ["gcc-c++"] ]
+ [ ["oraclelinux"] ["gcc-c++"] ]
+]

--- a/packages/re2/re2.v0.10.1/url
+++ b/packages/re2/re2.v0.10.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/re2/archive/v0.10.1.tar.gz"
+checksum: "5fe2ccfb52e76e36f293a5496e55ca05"

--- a/packages/re2/re2.v0.9.0/opam
+++ b/packages/re2/re2.v0.9.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "core_kernel"             {>= "v0.9" & < "v0.10"}
-  "jbuilder"                {build & >= "1.0+beta7"}
+  "jbuilder"                {build & >= "1.0+beta7" & < "1.0+beta18"}
   "ppx_driver"              {>= "v0.9" & < "v0.10"}
   "ppx_jane"                {>= "v0.9" & < "v0.10"}
   "ocaml-migrate-parsetree" {>= "0.4"}

--- a/packages/re2/re2.v0.9.1/opam
+++ b/packages/re2/re2.v0.9.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "core_kernel"             {>= "v0.9" & < "v0.10"}
-  "jbuilder"                {build & >= "1.0+beta15"}
+  "jbuilder"                {build & >= "1.0+beta15" & < "1.0+beta18"}
   "ppx_driver"              {>= "v0.9.2" & < "v0.10"}
   "ppx_jane"                {>= "v0.9" & < "v0.10"}
   "ocaml-migrate-parsetree" {>= "0.4"}


### PR DESCRIPTION
- add re2 v0.10.1 which fixes an incompatibility with jbuilder 1.0+beta18
- mark older versions as incompatible with jbuilder 1.0+beta18