### PR TITLE
Set minimum omp to 1.0 for driver >= 0.10.0

### DIFF
--- a/packages/ppx_driver/ppx_driver.v0.10.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.0/opam
@@ -12,6 +12,6 @@ depends: [
   "ppx_core"                {>= "v0.10" & < "v0.11"}
   "ppx_optcomp"             {>= "v0.10" & < "v0.11"}
   "jbuilder"                {build & >= "1.0+beta12"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_driver/ppx_driver.v0.10.1/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.1/opam
@@ -10,6 +10,6 @@ depends: [
   "ppx_core" {>= "v0.10" & < "v0.11"}
   "ppx_optcomp" {>= "v0.10" & < "v0.11"}
   "jbuilder" {build & >= "1.0+beta12"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
 ]
 available: [ocaml-version >= "4.04.1"]

--- a/packages/ppx_driver/ppx_driver.v0.10.2/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.2/opam
@@ -10,6 +10,6 @@ depends: [
   "ppx_core" {>= "v0.10" & < "v0.11"}
   "ppx_optcomp" {>= "v0.10" & < "v0.11"}
   "jbuilder" {build & >= "1.0+beta12"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
 ]
 available: [ocaml-version >= "4.04.1"]


### PR DESCRIPTION
Earlier versions of ppx_driver have the correct constraint (>= 1.0) so it's a bit weird that it's wrong in 0.10