### PR TITLE
bisect 1.3.1 (OCaml 4.06 compatibility release)

### DIFF
--- a/packages/bisect/bisect.1.3.1/descr
+++ b/packages/bisect/bisect.1.3.1/descr
@@ -1,0 +1,6 @@
+Code coverage tool for the OCaml language
+Bisect is a code coverage tool for the OCaml language. It is a
+camlp4-based tool that allows to instrument your application before
+running tests. After application execution, it is possible to generate
+a report in HTML format that is the replica of the application source
+code annotated with code coverage information.

--- a/packages/bisect/bisect.1.3.1/files/bisect.install
+++ b/packages/bisect/bisect.1.3.1/files/bisect.install
@@ -1,0 +1,4 @@
+bin: [
+  "_build/src/report/report.native" {"bisect-report.opt"}
+  "_build/src/report/report.byte" {"bisect-report"}
+]

--- a/packages/bisect/bisect.1.3.1/opam
+++ b/packages/bisect/bisect.1.3.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "bisect"
+maintainer: "gabriel.scherer@gmail.com"
+authors: ["Xavier Clerc"]
+homepage: "http://bisect.x9c.fr/"
+bug-reports: "https://github.com/gasche/bisect/issues"
+dev-repo: "https://github.com/gasche/bisect.git"
+license: "GPL v3"
+build: [
+  ["sh" "configure" "-ocaml-prefix" prefix "-ocamlfind" "%{bin}%/ocamlfind"]
+  [make "all"]
+]
+install: [make "install"]
+remove: [["ocamlfind" "remove" "bisect"]]
+depends: [
+  "ocamlfind"
+  "camlp4"
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/bisect/bisect.1.3.1/url
+++ b/packages/bisect/bisect.1.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gasche/bisect/archive/1.3.1.tar.gz"
+checksum: "fd0c2d163e4847df075d87fa9bb42b00"


### PR DESCRIPTION
cc @xclerc : I created a github mirror ( https://github.com/gasche/bisect/ ), merged the opam-distributed patches ( https://github.com/gasche/bisect/commit/d16ff9bec48309438685285c733ac8f1b28ba79d , https://github.com/gasche/bisect/commit/a108caad4541cef19ccf66f5b128a2e1c27870ee ), and made the two-lines change for Bytes/String support ( https://github.com/gasche/bisect/commit/0cea6b05cb6696baad8805a51884f0bdeb609db7 ).