### PR TITLE
Package ocamlformat_support.0.3

### DIFF
--- a/packages/ocamlformat_support/ocamlformat_support.0.3/descr
+++ b/packages/ocamlformat_support/ocamlformat_support.0.3/descr
@@ -1,0 +1,3 @@
+Support package for OCamlFormat
+
+Consists of a patched version of the OCaml standard library Format module.

--- a/packages/ocamlformat_support/ocamlformat_support.0.3/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.3/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Pierre Weis"
+homepage: "https://github.com/ocaml-ppx/ocamlformat/tree/support"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/ocamlformat_support/ocamlformat_support.0.3/url
+++ b/packages/ocamlformat_support/ocamlformat_support.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.3.tar.gz"
+checksum: "554634716e42d1ff9c16ce32857bc510"


### PR DESCRIPTION
### `ocamlformat_support.0.3`

Support package for OCamlFormat

Consists of a patched version of the OCaml standard library Format module.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat/tree/support
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git#support
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5