### PR TITLE
Package ocamlformat.0.4

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.4/descr
+++ b/packages/ocamlformat/ocamlformat.0.4/descr
@@ -1,0 +1,3 @@
+Auto-formatter for OCaml code
+
+OCamlFormat is a tool to automatically format OCaml code in a uniform style.

--- a/packages/ocamlformat/ocamlformat.0.4/opam
+++ b/packages/ocamlformat/ocamlformat.0.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["tools/gen_version.sh" "src/Version.ml" version] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base" {>= "v0.10.0"}
+  "base-unix"
+  "cmdliner"
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocamlformat_support" {= "0.3"}
+  "stdio"
+]
+available: [ocaml-version >= "4.04.1"]

--- a/packages/ocamlformat/ocamlformat.0.4/url
+++ b/packages/ocamlformat/ocamlformat.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/0.4.tar.gz"
+checksum: "c9c96d3cbb0891c4986205c9a835b0af"


### PR DESCRIPTION
### `ocamlformat.0.4`

Auto-formatter for OCaml code

OCamlFormat is a tool to automatically format OCaml code in a uniform style.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5