### PR TITLE
Package ocamlformat_support.0.3

### DIFF
--- a/packages/ocamlformat_support/ocamlformat_support.0.3/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.3/opam
@@ -7,6 +7,6 @@ license: "LGPL-2 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]
 available: [ocaml-version >= "4.04.0"]

--- a/packages/ocamlformat_support/ocamlformat_support.0.3/url
+++ b/packages/ocamlformat_support/ocamlformat_support.0.3/url
@@ -1,2 +1,2 @@
 http: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.3.tar.gz"
-checksum: "554634716e42d1ff9c16ce32857bc510"
+checksum: "10e796bd265d454aef604cc5a6500b7d"


### PR DESCRIPTION
### `ocamlformat_support.0.3`

Support package for OCamlFormat

Consists of a patched version of the OCaml standard library Format module.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat/tree/support
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git#support
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5