### PR TITLE
re >1.3.0: remove build-test and test dependency (does not work on 4.06+)

### DIFF
--- a/packages/re/re.1.3.0/opam
+++ b/packages/re/re.1.3.0/opam
@@ -14,16 +14,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "ounit" {test}
   "ocamlbuild" {build}
 ]

--- a/packages/re/re.1.3.1/opam
+++ b/packages/re/re.1.3.1/opam
@@ -14,16 +14,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "ounit" {test}
   "ocamlbuild" {build}
 ]

--- a/packages/re/re.1.3.2/opam
+++ b/packages/re/re.1.3.2/opam
@@ -14,16 +14,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "ounit" {test}
   "ocamlbuild" {build}
 ]

--- a/packages/re/re.1.4.0/opam
+++ b/packages/re/re.1.4.0/opam
@@ -14,16 +14,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "ounit" {test}
   "ocamlbuild" {build}
 ]

--- a/packages/re/re.1.4.1/opam
+++ b/packages/re/re.1.4.1/opam
@@ -14,16 +14,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "base-bytes"
-  "ounit" {test}
   "ocamlbuild" {build}
 ]

--- a/packages/re/re.1.5.0/opam
+++ b/packages/re/re.1.5.0/opam
@@ -10,16 +10,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"
-  "ounit" {test}
 ]

--- a/packages/re/re.1.6.0/opam
+++ b/packages/re/re.1.6.0/opam
@@ -10,16 +10,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"
-  "ounit" {test}
 ]

--- a/packages/re/re.1.6.1/opam
+++ b/packages/re/re.1.6.1/opam
@@ -10,16 +10,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"
-  "ounit" {test}
 ]

--- a/packages/re/re.1.7.0/opam
+++ b/packages/re/re.1.7.0/opam
@@ -10,16 +10,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"
-  "ounit" {test}
 ]

--- a/packages/re/re.1.7.1/opam
+++ b/packages/re/re.1.7.1/opam
@@ -10,16 +10,10 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: ["ocaml" "setup.ml" "-doc"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"
-  "ounit" {test}
 ]


### PR DESCRIPTION
re works fine with -safe-string, but the test do not.  I could see two optons:
- restrict re to <4.06.0
- remove the build-test rules from opam files

I chose the latter since it is less disruptive.  I reported the actual issue upstream https://github.com/ocaml/ocaml-re/issues/153