### PR TITLE
centos needs epel-release

### DIFF
--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   [["ubuntu"] ["r-base-core"]]
   [["opensuse"] ["R-core"]]
   [["alpine"] ["R"]]
-  [["centos"] ["R"]]
+  [["centos"] ["epel-release" "R"]]
   [["fedora"] ["R"]]
   [["nixpkgs"] ["R"]]
 ]


### PR DESCRIPTION
in order to be able to install the R package