### PR TITLE
Package stdint.0.5.1

### DIFF
--- a/packages/i2c/i2c.0.1.2-0/opam
+++ b/packages/i2c/i2c.0.1.2-0/opam
@@ -18,7 +18,7 @@ build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "result"
   "base-unix"
-  "stdint" {>= "0.4.1"}
+  "stdint" {>= "0.4.1" & <= "0.5.0"}
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}
   "conf-linux-libc-dev"

--- a/packages/stdint/stdint.0.5.1/descr
+++ b/packages/stdint/stdint.0.5.1/descr
@@ -1,0 +1,9 @@
+signed and unsigned integer types having specified widths
+The stdint library provides signed and unsigned integer types of various
+fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical),
+conversion to and from buffers in both big endian and little endian byte order.

--- a/packages/stdint/stdint.0.5.1/opam
+++ b/packages/stdint/stdint.0.5.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+  "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+]
+homepage: "https://github.com/andrenth/ocaml-stdint"
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+license: "MIT"
+doc: "http://stdint.forge.ocamlcore.org/doc/"
+dev-repo: "https://github.com/andrenth/ocaml-stdint.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-doc: ["ocaml" "setup.ml" "-doc"]
+remove: ["ocamlfind" "remove" "stdint"]
+depends: [
+  "base-bytes"
+  "ocamlfind" {>= "1.5"}
+  "ocamlbuild" {build}
+]

--- a/packages/stdint/stdint.0.5.1/opam
+++ b/packages/stdint/stdint.0.5.1/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+version: "0.5.1"
 maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
 authors: [
   "Andre Nathan <andre@digirati.com.br>"
@@ -6,20 +7,16 @@ authors: [
   "Markus W. Weissmann <markus.weissmann@in.tum.de>"
   "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
 ]
-homepage: "https://github.com/andrenth/ocaml-stdint"
-bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
 license: "MIT"
+homepage: "https://github.com/andrenth/ocaml-stdint"
 doc: "http://stdint.forge.ocamlcore.org/doc/"
 dev-repo: "https://github.com/andrenth/ocaml-stdint.git"
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
-  ["ocaml" "setup.ml" "-build"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-install: ["ocaml" "setup.ml" "-install"]
-build-doc: ["ocaml" "setup.ml" "-doc"]
-remove: ["ocamlfind" "remove" "stdint"]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "base-bytes"
-  "ocamlfind" {>= "1.5"}
-  "ocamlbuild" {build}
+  "jbuilder" {build}
 ]

--- a/packages/stdint/stdint.0.5.1/url
+++ b/packages/stdint/stdint.0.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-stdint/archive/0.5.1.tar.gz"
+checksum: "02c7da8215cf8e22ffa58405f2a29ea8"


### PR DESCRIPTION
### `stdint.0.5.1`

signed and unsigned integer types having specified widths
The stdint library provides signed and unsigned integer types of various
fixed widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
This interface is similar to Int32 and Int64 from the base library but provides
more functions and constants like arithmetic and bit-wise operations, constants
like maximum and minimum values, infix operators conversion to and from every
other integer type (including int, float and nativeint), parsing from and
conversion to readable strings (binary, octal, decimal, hexademical),
conversion to and from buffers in both big endian and little endian byte order.



---
* Homepage: https://github.com/andrenth/ocaml-stdint
* Source repo: https://github.com/andrenth/ocaml-stdint.git
* Bug tracker: https://github.com/andrenth/ocaml-stdint/issues

---

:camel: Pull-request generated by opam-publish v0.3.5