### PR TITLE
Constrain datakit 0.12.0

### DIFF
--- a/packages/datakit/datakit.0.12.0/opam
+++ b/packages/datakit/datakit.0.12.0/opam
@@ -15,7 +15,7 @@ build-test: [
 ]
 
 depends: [
-  "jbuilder" {build & >= "1.0+beta10"}
+  "jbuilder" {build & >= "1.0+beta10" & < "1.0+beta18"}
   "cmdliner"
   "rresult" "astring" "fmt" "asetmap"
   "git"         {>= "1.11.0" & < "1.12.0"}


### PR DESCRIPTION
It doesn't work with jbuilder beta 18 because of sloppy dependency
specification.

cc @jpdeplaix 

A fix upstream has also been sent.