### PR TITLE
cppo 1.6.4

### DIFF
--- a/packages/cppo/cppo.1.6.4/descr
+++ b/packages/cppo/cppo.1.6.4/descr
@@ -1,0 +1,1 @@
+Equivalent of the C preprocessor for OCaml programs

--- a/packages/cppo/cppo.1.6.4/opam
+++ b/packages/cppo/cppo.1.6.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "https://github.com/mjambon/cppo"
+dev-repo: "https://github.com/mjambon/cppo.git"
+bug-reports: "https://github.com/mjambon/cppo/issues"
+license: "BSD-3-Clause"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta17"}
+  "base-bytes"
+  "base-unix"
+]

--- a/packages/cppo/cppo.1.6.4/url
+++ b/packages/cppo/cppo.1.6.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mjambon/cppo/archive/v1.6.4.tar.gz"
+checksum: "f7a4a6a0e83b76562b45db3a93ffd204"


### PR DESCRIPTION
We can skip release [1.6.3](https://github.com/ocaml/opam-repository/pull/11465) if it wasn't merged yet.