### PR TITLE
Release ocaml-jupyter kernel v2.2.2

### DIFF
--- a/packages/jupyter/jupyter.2.0.0/opam
+++ b/packages/jupyter/jupyter.2.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.0"}
   "cryptokit" {>= "1.12"}
   "ocamlfind" {build & >= "1.5.0"}
-  "jbuilder" {build & >= "1.0+beta14"}
+  "jbuilder" {build & >= "1.0+beta14" & < "1.0+beta18"}
 ]
 depopts: [
   "merlin"

--- a/packages/jupyter/jupyter.2.1.0/opam
+++ b/packages/jupyter/jupyter.2.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.0"}
   "cryptokit" {>= "1.12"}
   "ocamlfind" {build & >= "1.5.0"}
-  "jbuilder" {build & >= "1.0+beta14"}
+  "jbuilder" {build & >= "1.0+beta14" & < "1.0+beta18"}
 ]
 depopts: [
   "merlin"

--- a/packages/jupyter/jupyter.2.2.0/opam
+++ b/packages/jupyter/jupyter.2.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.0"}
   "cryptokit" {>= "1.12"}
   "ocamlfind" {build & >= "1.5.0"}
-  "jbuilder" {build & >= "1.0+beta14"}
+  "jbuilder" {build & >= "1.0+beta14" & < "1.0+beta18"}
 ]
 depopts: [
   "merlin"

--- a/packages/jupyter/jupyter.2.2.1/opam
+++ b/packages/jupyter/jupyter.2.2.1/opam
@@ -28,7 +28,7 @@ depends: [
   "yojson" {>= "1.3.3"}
   "ppx_deriving_yojson" {>= "3.0"}
   "cryptokit" {>= "1.12"}
-  "jbuilder" {build & >= "1.0+beta14"}
+  "jbuilder" {build & >= "1.0+beta14" & < "1.0+beta18"}
 ]
 depopts: [
   "merlin"

--- a/packages/jupyter/jupyter.2.2.2/descr
+++ b/packages/jupyter/jupyter.2.2.2/descr
@@ -1,0 +1,3 @@
+An OCaml kernel for Jupyter notebook
+
+OCaml Jupyter provides an OCaml REPL on Jupyter (a great interface with markdown/HTML documentation, LaTeX formula by MathJax, and image embedding). This is useful for data analysis in OCaml.

--- a/packages/jupyter/jupyter.2.2.2/opam
+++ b/packages/jupyter/jupyter.2.2.2/opam
@@ -1,0 +1,46 @@
+opam-version: "1.2"
+name: "jupyter"
+maintainer: [
+  "Akinori ABE <aabe.65535@gmail.com>"
+]
+authors: [
+  "Akinori ABE"
+]
+license: "MIT"
+homepage: "https://akabe.github.io/ocaml-jupyter/"
+bug-reports: "https://github.com/akabe/ocaml-jupyter/issues"
+dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
+
+available: [ ocaml-version >= "4.02.0" ]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "base-threads"
+  "base-unix"
+  "uuidm" {>= "0.9.6"}
+  "base64" {>= "2.1.2"}
+  "lwt" {>= "3.0.0" & < "4.0.0"}
+  "stdint" {>= "0.4.2"}
+  "zmq" {>= "4.0-8"}
+  "lwt-zmq" {>= "2.1.0"}
+  "yojson" {>= "1.3.3"}
+  "ppx_deriving_yojson" {>= "3.0"}
+  "cryptokit" {>= "1.12"}
+  "jbuilder" {build & >= "1.0+beta14"}
+]
+depopts: [
+  "merlin"
+]
+conflicts: [
+  "merlin" {< "3.0.0"}
+]
+
+post-messages: [
+  "Please run for registration of ocaml-jupyter kernel:"
+  ""
+  "$ jupyter kernelspec install --name ocaml-jupyter \\"
+  "    %{share}%/jupyter"
+  {success}
+]

--- a/packages/jupyter/jupyter.2.2.2/url
+++ b/packages/jupyter/jupyter.2.2.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/akabe/ocaml-jupyter/releases/download/v2.2.2/jupyter-2.2.2.tbz"
+checksum: "c5f676a4ecc185a0eb290e272c1f4301"


### PR DESCRIPTION
Release note: https://github.com/akabe/ocaml-jupyter/releases/tag/v2.2.2

This is a bug fix release found in PR #11457.