### PR TITLE
[Travis script] Don't test dependencies

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -110,6 +110,9 @@ function build_one {
     depext=$(opam depext -ls $pkg --no-sources)
     opam depext $pkg
     echo
+    echo "====== Installing dependencies ======"
+    opam install --deps-only $pkg
+    echo
     echo "====== Installing package ======"
     opam install -t $pkg
     opam remove -a ${pkg%%.*}


### PR DESCRIPTION
Since https://github.com/ocaml/opam-repository/pull/11436 Travis also run tests.
Now, there are a lot of packages where the tests are broken and I feel there are too much to fix in a reasonable amount of time.

This PR then just run tests from the packages that are actually added and now for their dependencies. 