### PR TITLE
mirage-net-lwt.1.0.0: Avoid inconsistance with mirage-net.1.1.0

### DIFF
--- a/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build & >= "0.8.0"}
-  "mirage-net" {>= "1.0.0"}
+  "mirage-net" {= "1.0.0"}
   "lwt"
   "ipaddr" {>= "1.0.0"}
   "cstruct" "io-page"


### PR DESCRIPTION
Noticed in #11426
This seems fair to remove broken packages.