### PR TITLE
Package srs.2.0.0

### DIFF
--- a/packages/srs/srs.2.0.0/descr
+++ b/packages/srs/srs.2.0.0/descr
@@ -1,0 +1,3 @@
+OCaml bindings for libsrs2
+
+OCaml-SRS provides C bindings to libsrs2 for OCaml

--- a/packages/srs/srs.2.0.0/opam
+++ b/packages/srs/srs.2.0.0/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andre@hostnet.com.br>"
+authors: "Andre Nathan <andre@hostnet.com.br>"
+homepage: "https://github.com/andrenth/ocaml-srs"
+bug-reports: "https://github.com/andrenth/ocaml-srs/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-srs.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+]

--- a/packages/srs/srs.2.0.0/url
+++ b/packages/srs/srs.2.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-srs/archive/2.0.0.tar.gz"
+checksum: "42a894c2be920674f8cc4d78cc6e0829"


### PR DESCRIPTION
### `srs.2.0.0`

OCaml bindings for libsrs2

OCaml-SRS provides C bindings to libsrs2 for OCaml



---
* Homepage: https://github.com/andrenth/ocaml-srs
* Source repo: https://github.com/andrenth/ocaml-srs.git
* Bug tracker: https://github.com/andrenth/ocaml-srs/issues

---

:camel: Pull-request generated by opam-publish v0.3.5