### PR TITLE
Package spf.2.0.0

### DIFF
--- a/packages/spf/spf.2.0.0/descr
+++ b/packages/spf/spf.2.0.0/descr
@@ -1,0 +1,3 @@
+OCaml bindings for libspf2
+
+OCaml-SPF provides C bindings for OCaml programs.

--- a/packages/spf/spf.2.0.0/opam
+++ b/packages/spf/spf.2.0.0/opam
@@ -10,6 +10,16 @@ depends: [
   "jbuilder" {build}
 ]
 depexts: [
-  [["debian"] ["libspf2-dev"]]
-  [["ubuntu"] ["libspf2-dev"]]
+  [["alpine"]    ["libspf2-dev"]]
+  [["archlinux"] ["libspf2"]]
+  [["centos"]    ["libspf2-devel"]]
+  [["debian"]    ["libspf2-dev"]]
+  [["fedora"]    ["libspf2-devel"]]
+  [["freebsd"]   ["libspf2"]]
+  [["gentoo"]    ["libspf2"]]
+  [["mageia"]    ["libspf2-devel"]]
+  [["netbsd"]    ["libspf2"]]
+  [["openbsd"]   ["libspf2"]]
+  [["opensuse"]  ["libspf2-devel"]]
+  [["ubuntu"]    ["libspf2-dev"]]
 ]

--- a/packages/spf/spf.2.0.0/opam
+++ b/packages/spf/spf.2.0.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andre@hostnet.com.br>"
+authors: "Andre Nathan <andre@hostnet.com.br>"
+homepage: "https://github.com/andrenth/ocaml-spf"
+bug-reports: "https://github.com/andrenth/ocaml-spf/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-spf.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+]
+depexts: [
+  [["debian"] ["libspf2-dev"]]
+  [["ubuntu"] ["libspf2-dev"]]
+]

--- a/packages/spf/spf.2.0.0/url
+++ b/packages/spf/spf.2.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-spf/archive/2.0.0.tar.gz"
+checksum: "2898640c8c4b6e1072666835b5db1d22"


### PR DESCRIPTION
### `spf.2.0.0`

OCaml bindings for libspf2

OCaml-SPF provides C bindings for OCaml programs.



---
* Homepage: https://github.com/andrenth/ocaml-spf
* Source repo: https://github.com/andrenth/ocaml-spf.git
* Bug tracker: https://github.com/andrenth/ocaml-spf/issues

---

:camel: Pull-request generated by opam-publish v0.3.5