### PR TITLE
Package milter.1.0.3

### DIFF
--- a/packages/milter/milter.1.0.3/descr
+++ b/packages/milter/milter.1.0.3/descr
@@ -1,0 +1,4 @@
+OCaml libmilter bindings
+
+This package provides OCaml bindings for sendmail's libmilter, allowing
+integration of OCaml programs with compatible MTAs.

--- a/packages/milter/milter.1.0.3/opam
+++ b/packages/milter/milter.1.0.3/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andre@hostnet.com.br>"
+authors: "Andre Nathan <andre@hostnet.com.br>"
+homepage: "https://github.com/andrenth/ocaml-milter"
+bug-reports: "https://github.com/andrenth/ocaml-milter/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-milter.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+]
+depexts: [
+  [["debian"] ["libmilter-dev"]]
+  [["ubuntu"] ["libmilter-dev"]]
+]

--- a/packages/milter/milter.1.0.3/url
+++ b/packages/milter/milter.1.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-milter/archive/1.0.3.tar.gz"
+checksum: "0f04b59342e77aba060d8aed0a7c538b"


### PR DESCRIPTION
### `milter.1.0.3`

OCaml libmilter bindings

This package provides OCaml bindings for sendmail's libmilter, allowing
integration of OCaml programs with compatible MTAs.



---
* Homepage: https://github.com/andrenth/ocaml-milter
* Source repo: https://github.com/andrenth/ocaml-milter.git
* Bug tracker: https://github.com/andrenth/ocaml-milter/issues

---

:camel: Pull-request generated by opam-publish v0.3.5