### PR TITLE
Package milter.1.0.4

### DIFF
--- a/packages/milter/milter.1.0.4/descr
+++ b/packages/milter/milter.1.0.4/descr
@@ -1,0 +1,4 @@
+OCaml libmilter bindings
+
+This package provides OCaml bindings for sendmail's libmilter, allowing
+integration of OCaml programs with compatible MTAs.

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -10,6 +10,16 @@ depends: [
   "jbuilder" {build}
 ]
 depexts: [
-  [["debian"] ["libmilter-dev"]]
-  [["ubuntu"] ["libmilter-dev"]]
+  [["alpine"]    ["libmilter-dev"]]
+  [["archlinux"] ["libmilter"]]
+  [["centos"]    ["sendmail-devel"]]
+  [["fedora"]    ["sendmail-milter-devel"]]
+  [["freebsd"]   ["libmilter"]]
+  [["gentoo"]    ["libmilter"]]
+  [["macports"]  ["libmilter"]]
+  [["debian"]    ["libmilter-dev"]]
+  [["mageia"]    ["sendmail-devel"]]
+  [["opensuse"]  ["sendmail-devel"]]
+  [["netbsd"]    ["libmilter"]]
+  [["ubuntu"]    ["libmilter-dev"]]
 ]

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andre@hostnet.com.br>"
+authors: "Andre Nathan <andre@hostnet.com.br>"
+homepage: "https://github.com/andrenth/ocaml-milter"
+bug-reports: "https://github.com/andrenth/ocaml-milter/issues"
+license: "MIT"
+dev-repo: "https://github.com/andrenth/ocaml-milter.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+]
+depexts: [
+  [["debian"] ["libmilter-dev"]]
+  [["ubuntu"] ["libmilter-dev"]]
+]

--- a/packages/milter/milter.1.0.4/url
+++ b/packages/milter/milter.1.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/ocaml-milter/archive/1.0.4.tar.gz"
+checksum: "c6e206750966d529ad3bdb0cdc317b50"


### PR DESCRIPTION
### `milter.1.0.4`

OCaml libmilter bindings

This package provides OCaml bindings for sendmail's libmilter, allowing
integration of OCaml programs with compatible MTAs.



---
* Homepage: https://github.com/andrenth/ocaml-milter
* Source repo: https://github.com/andrenth/ocaml-milter.git
* Bug tracker: https://github.com/andrenth/ocaml-milter/issues

---

:camel: Pull-request generated by opam-publish v0.3.5