### PR TITLE
Package utop.2.1.0

### DIFF
--- a/packages/utop/utop.2.1.0/descr
+++ b/packages/utop/utop.2.1.0/descr
@@ -1,0 +1,6 @@
+Universal toplevel for OCaml
+
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs.

--- a/packages/utop/utop.2.1.0/opam
+++ b/packages/utop/utop.2.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/utop"
+bug-reports: "https://github.com/diml/utop/issues"
+dev-repo: "git://github.com/diml/utop.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base-unix"
+  "base-threads"
+  "ocamlfind"    {>= "1.7.2"}
+  "lambda-term"  {>= "1.2"}
+  "lwt"
+  "lwt_react"
+  "camomile"
+  "react"        {>= "1.0.0"}
+  "cppo"         {build & >= "1.1.2"}
+  "jbuilder"     {build & >= "1.0+beta9"}
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/utop/utop.2.1.0/url
+++ b/packages/utop/utop.2.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/utop/releases/download/2.1.0/utop-2.1.0.tbz"
+checksum: "6c63a321379069a1b9ecb7899f80087b"


### PR DESCRIPTION
### `utop.2.1.0`

Universal toplevel for OCaml

utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
OCaml.  It can run in a terminal or in Emacs. It supports line
edition, history, real-time and context sensitive completion, colors,
and more.  It integrates with the Tuareg mode in Emacs.



---
* Homepage: https://github.com/diml/utop
* Source repo: git://github.com/diml/utop.git
* Bug tracker: https://github.com/diml/utop/issues

---


---
2.1.0 (2018-02-28)
------------------

* Add support for company-mode based completion in utop.el (#233)
:camel: Pull-request generated by opam-publish v0.3.5