### PR TITLE
Update various jbuilder checksums that have become invalid.

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta2/url
+++ b/packages/jbuilder/jbuilder.1.0+beta2/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/janestreet/jbuilder/archive/1.0+beta2.tar.gz"
-checksum: "cb1758018865d5d7ed26960df2a75e5a"
+checksum: "c2ff5459f3f793f08786d346b6bc7fab"

--- a/packages/jbuilder/jbuilder.1.0+beta3/url
+++ b/packages/jbuilder/jbuilder.1.0+beta3/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/janestreet/jbuilder/archive/1.0+beta3.tar.gz"
-checksum: "1fed86b96a5f8006b91e67cf2ea19733"
+checksum: "667a92432a94abf29769c7a64d285b97"

--- a/packages/jbuilder/jbuilder.1.0+beta4/url
+++ b/packages/jbuilder/jbuilder.1.0+beta4/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/janestreet/jbuilder/archive/1.0+beta4.tar.gz"
-checksum: "84b02e41b472fed4ca254cca39330176"
+checksum: "cfce9bc70426485d7c220bb2ff2fef0f"

--- a/packages/jbuilder/jbuilder.1.0+beta5/url
+++ b/packages/jbuilder/jbuilder.1.0+beta5/url
@@ -1,2 +1,2 @@
 src: "https://github.com/janestreet/jbuilder/archive/1.0+beta5.tar.gz"
-checksum: "609a647290e42d1f7af7fcad24b6ce08"
+checksum: "8511c1b079abb04d57654aa84d2f9d78"

--- a/packages/jbuilder/jbuilder.1.0+beta6/url
+++ b/packages/jbuilder/jbuilder.1.0+beta6/url
@@ -1,2 +1,2 @@
 src: "https://github.com/janestreet/jbuilder/archive/1.0+beta6.tar.gz"
-checksum: "01d35dfa93c4ef8eff2c68d81f53a5cc"
+checksum: "b5e098afe7bcea923626dae24f06ee2b"

--- a/packages/jbuilder/jbuilder.1.0+beta7/url
+++ b/packages/jbuilder/jbuilder.1.0+beta7/url
@@ -1,2 +1,2 @@
 src: "https://github.com/janestreet/jbuilder/archive/1.0+beta7.tar.gz"
-checksum: "bc157c4cf75a3a6f3033165233068fbc"
+checksum: "2a8f5277d3c3a7c85e6ec58cb36f5223"

--- a/packages/jbuilder/jbuilder.1.0+beta8/url
+++ b/packages/jbuilder/jbuilder.1.0+beta8/url
@@ -1,2 +1,2 @@
 src: "https://github.com/janestreet/jbuilder/archive/1.0+beta8.tar.gz"
-checksum: "36fec14f5647368502f0a4e3c1207189"
+checksum: "a7f63d68f717b1658f3685cfce058d0a"


### PR DESCRIPTION
e.g.

```
[ERROR] Bad checksum for
        $HOME/.opam/packages.dev/jbuilder.1.0+beta7/1.0+beta7.tar.gz:
          - bc157c4cf75a3a6f3033165233068fbc [expected result]
          - 2a8f5277d3c3a7c85e6ec58cb36f5223 [actual result]
        This may be fixed by running `opam update`.
```

/cc @rgrinberg, @diml 