### PR TITLE
redis: Fix ocaml constraints

### DIFF
--- a/packages/redis/redis.0.2.0/opam
+++ b/packages/redis/redis.0.2.0/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "0xffea@gmail.com"
+authors: ["Mike Wells" "David Höppner" "Alexander Dinu"]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
 license: "BSD3"
 build: [
   ["./configure" "--%{lwt:enable}%-lwt"]

--- a/packages/redis/redis.0.2.0/opam
+++ b/packages/redis/redis.0.2.0/opam
@@ -16,5 +16,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/0xffea/ocaml-redis"
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.05.0"]
 install: [make "install"]

--- a/packages/redis/redis.0.2.1/opam
+++ b/packages/redis/redis.0.2.1/opam
@@ -16,5 +16,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/0xffea/ocaml-redis"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.05.0"]
 install: [make "install"]

--- a/packages/redis/redis.0.2.1/opam
+++ b/packages/redis/redis.0.2.1/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "David Höppner <0xffea@gmail.com>"
+authors: ["Mike Wells" "David Höppner" "Alexander Dinu"]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
 license: "BSD3"
 build: [
   ["./configure" "--%{lwt:enable}%-lwt"]

--- a/packages/redis/redis.0.2.2/opam
+++ b/packages/redis/redis.0.2.2/opam
@@ -16,5 +16,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/0xffea/ocaml-redis"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.05.0"]
 install: [make "install"]

--- a/packages/redis/redis.0.2.2/opam
+++ b/packages/redis/redis.0.2.2/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "David Höppner <0xffea@gmail.com>"
+authors: ["Mike Wells" "David Höppner" "Alexander Dinu"]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
 license: "BSD3"
 build: [
   ["./configure" "--%{lwt:enable}%-lwt"]

--- a/packages/redis/redis.0.2.3/opam
+++ b/packages/redis/redis.0.2.3/opam
@@ -16,5 +16,5 @@ depends: [
 ]
 depopts: ["lwt"]
 dev-repo: "git://github.com/0xffea/ocaml-redis"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.05.0"]
 install: [make "install"]

--- a/packages/redis/redis.0.2.3/opam
+++ b/packages/redis/redis.0.2.3/opam
@@ -1,5 +1,8 @@
 opam-version: "1.2"
 maintainer: "David Höppner <0xffea@gmail.com>"
+authors: ["Mike Wells" "David Höppner" "Alexander Dinu"]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
 license: "BSD3"
 build: [
   ["./configure" "--%{lwt:enable}%-lwt"]


### PR DESCRIPTION
That fixes problems with the ```cloexec``` optional parameter added in OCaml 4.05.0.
This also formally makes redis non-installable without OCaml < 4.06.0.

cc @0xffea (again, if you need help to release something, don't hesitate)