### PR TITLE
Package lacaml.11.0.0

### DIFF
--- a/packages/lacaml/lacaml.11.0.0/descr
+++ b/packages/lacaml/lacaml.11.0.0/descr
@@ -1,0 +1,5 @@
+Lacaml - OCaml-bindings to BLAS and LAPACK
+
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices.

--- a/packages/lacaml/lacaml.11.0.0/opam
+++ b/packages/lacaml/lacaml.11.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "http://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+dev-repo: "https://github.com/mmottl/lacaml.git"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+tags: [ "clib:lapack" "clib:blas" ]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta13"}
+  "base-bytes"
+  "base-bigarray"
+]
+
+available: [ ocaml-version >= "4.04" ]

--- a/packages/lacaml/lacaml.11.0.0/url
+++ b/packages/lacaml/lacaml.11.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/lacaml/releases/download/11.0.0/lacaml-11.0.0.tbz"
+checksum: "c5ec1c0bb635def40cf6f87846ea314e"


### PR DESCRIPTION
### `lacaml.11.0.0`

Lacaml - OCaml-bindings to BLAS and LAPACK

Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
LAPACK-library (Linear Algebra routines).  It also contains many additional
convenience functions for vectors and matrices.



---
* Homepage: http://mmottl.github.io/lacaml
* Source repo: https://github.com/mmottl/lacaml.git
* Bug tracker: https://github.com/mmottl/lacaml/issues

---


---
### 11.0.0 (2018-02-28)

  _WARNINIG_ _WARNING_ _WARNING_

  * User code changes in existing code required!  User code may still compile,
    but can behave differently!

    The following functions are affected:

      * `potrf`
      * `potri`
      * `potrs`

    The above functions now do not support the `jitter` argument anymore.
    Users should remove the flag from calls to the above functions and
    call the new `Mat.add_const_diag` function if they need to add jitter.
    This call should happen right before the (now required) call to `potrf`.

    More importantly, `potri` and `potrs` now do not support the `factorize`
    flag anymore, which would call `potrf` automatically beforehand.  This was
    the (ill-conceived) default, which makes it harder to port LAPACK code
    to Lacaml.  In order to upgrade your code, please do the following:

      * If `potri` or `potrs` were passed `~factorize:false`, just remove
        the flag.

      * If `potri` or `potrs` were passed `~factorize:true` _or were called
        without the `factorize` flag_, remove the flag if necessary and call
        `potrf` with the exactly corresponding arguments before.

    Luckily, these functions are typically used rarely, and the changes
    are trivial.  Apologies anyway for the churn!

  * New functions

      * `Mat.add_const_diag` for adding a constant to the diagonal of a
        (sub-)matrix.

  * `orgqr` now detects if `m < n` and raises an exception instead of printing
    a Fortran error message and continuing.

  * Eigenvalue offsets should now work correctly.

  * Improved documentation.
:camel: Pull-request generated by opam-publish v0.3.5