### PR TITLE
ppx_regexp 0.3.2

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.3.2/descr
+++ b/packages/ppx_regexp/ppx_regexp.0.3.2/descr
@@ -1,0 +1,16 @@
+Matching Regular Expressions with OCaml Patterns
+
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations to the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, except groups can be bound to
+variables using the syntax `(?<var>...)`.  The type of `var` will be
+`string` if a match is of the groups is guaranteed given a match of the
+whole pattern, and `string option` if the variable is bound to or nested
+below an optionally matched group.

--- a/packages/ppx_regexp/ppx_regexp.0.3.2/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "paurkedal@gmail.com"
+authors: ["Petter A. Urkedal <paurkedal@gmail.com>"]
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+dev-repo: "https://github.com/paurkedal/ppx_regexp.git"
+license: "LGPL-3 with OCaml linking exception"
+build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+depends: [
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree"
+  "re" {>= "1.7.2"}
+  "ppx_tools_versioned" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/ppx_regexp/ppx_regexp.0.3.2/url
+++ b/packages/ppx_regexp/ppx_regexp.0.3.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ppx_regexp/releases/download/v0.3.2/ppx_regexp-0.3.2.tbz"
+checksum: "e98e79d9e72803f69c81282cceabdaaa"


### PR DESCRIPTION
This is a minor update to make ppx_regexp compatible with re 1.7.2 (cf. #11502).