### PR TITLE
BAP 1.4 Release

### DIFF
--- a/packages/bap-abi/bap-abi.1.4.0/descr
+++ b/packages/bap-abi/bap-abi.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP ABI integration subsystem

--- a/packages/bap-abi/bap-abi.1.4.0/opam
+++ b/packages/bap-abi/bap-abi.1.4.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+name: "bap-abi"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-abi"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-abi"]
+         ["ocamlfind" "remove" "bap-abi"]
+         ["bapbundle" "remove" "abi.plugin"]
+         ]
+depends: ["bap-std" "cmdliner"]

--- a/packages/bap-abi/bap-abi.1.4.0/url
+++ b/packages/bap-abi/bap-abi.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-api/bap-api.1.4.0/descr
+++ b/packages/bap-api/bap-api.1.4.0/descr
@@ -1,0 +1,1 @@
+A pass that adds parameters to subroutines based on known API

--- a/packages/bap-api/bap-api.1.4.0/opam
+++ b/packages/bap-api/bap-api.1.4.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "bap-api"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-api"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-api"]
+         ["ocamlfind" "remove" "bap-api"]
+         ["bapbundle" "remove" "api.plugin"]
+         ["rm" "-rf" "%{prefix}%/share/bap-api/c"]
+         ]
+depends: ["bap-std" "cmdliner"]

--- a/packages/bap-api/bap-api.1.4.0/url
+++ b/packages/bap-api/bap-api.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-arm/bap-arm.1.4.0/descr
+++ b/packages/bap-arm/bap-arm.1.4.0/descr
@@ -1,0 +1,5 @@
+BAP ARM lifter and disassembler
+
+
+Provides semantics for ARM instructions, disassembler, and partial
+support for the gnueabi ABI

--- a/packages/bap-arm/bap-arm.1.4.0/opam
+++ b/packages/bap-arm/bap-arm.1.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "bap-arm"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-arm"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-arm"]
+        ["ocamlfind" "remove" "bap-plugin-arm"]
+        ["bapbundle"   "remove" "arm.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "bap-llvm"
+    "bap-abi"
+    "bap-c"
+]

--- a/packages/bap-arm/bap-arm.1.4.0/url
+++ b/packages/bap-arm/bap-arm.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-beagle/bap-beagle.1.4.0/descr
+++ b/packages/bap-beagle/bap-beagle.1.4.0/descr
@@ -1,0 +1,4 @@
+BAP obfuscated string solver
+
+Like strings on steroids - finds strings encoded in binaries,
+even if they are not truly static.

--- a/packages/bap-beagle/bap-beagle.1.4.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.4.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "bap-beagle"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-beagle"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
+         ["ocamlfind" "remove" "bap-beagle-prey"]
+         ["ocamlfind" "remove" "bap-plugin-strings"]
+         ["bapbundle" "remove" "beagle.plugin"]
+         ["bapbundle" "remove" "strings.plugin"]
+         ]
+depends: ["bap-std" "cmdliner" "bap-microx" "bap-primus" ]

--- a/packages/bap-beagle/bap-beagle.1.4.0/url
+++ b/packages/bap-beagle/bap-beagle.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/descr
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/descr
@@ -1,0 +1,4 @@
+BAP Toolkit for training and controlling Byteweight algorithm
+
+A command line interface to the byteweight system that can train,
+test, download, and upload binary signatures.

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-byteweight-frontend"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight-frontend"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+    "bap-std"
+    "bap-byteweight"
+    "cmdliner"
+    "ocurl"
+    "fileutils"
+    "re"
+]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/url
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-byteweight/bap-byteweight.1.4.0/descr
+++ b/packages/bap-byteweight/bap-byteweight.1.4.0/descr
@@ -1,0 +1,4 @@
+BAP facility for indentifying code entry points
+
+Provides a library and a plugin that uses the Byteweigh algorithm for
+finding entry points (function strats) in stripped code.

--- a/packages/bap-byteweight/bap-byteweight.1.4.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "bap-byteweight"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-byteweight"]
+        ["ocamlfind" "remove" "bap-plugin-byteweight"]
+        [ "bapbundle" "remove" "byteweight.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "bap-signatures"
+]

--- a/packages/bap-byteweight/bap-byteweight.1.4.0/url
+++ b/packages/bap-byteweight/bap-byteweight.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-c/bap-c.1.4.0/descr
+++ b/packages/bap-c/bap-c.1.4.0/descr
@@ -1,0 +1,1 @@
+A C language support library for BAP

--- a/packages/bap-c/bap-c.1.4.0/opam
+++ b/packages/bap-c/bap-c.1.4.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "bap-c"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-c"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-c"]]
+depends: ["bap-std" "bap-api"]

--- a/packages/bap-c/bap-c.1.4.0/url
+++ b/packages/bap-c/bap-c.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-cache/bap-cache.1.4.0/descr
+++ b/packages/bap-cache/bap-cache.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP caching service

--- a/packages/bap-cache/bap-cache.1.4.0/opam
+++ b/packages/bap-cache/bap-cache.1.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-cache"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-cache"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cache"]
+        [ "bapbundle" "remove" "cache.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-cache/bap-cache.1.4.0/url
+++ b/packages/bap-cache/bap-cache.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-callsites/bap-callsites.1.4.0/descr
+++ b/packages/bap-callsites/bap-callsites.1.4.0/descr
@@ -1,0 +1,1 @@
+Inject data definition terms at callsites

--- a/packages/bap-callsites/bap-callsites.1.4.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "bap-callsites"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-callsites"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-callsites"]
+        [ "bapbundle" "remove" "callsites.plugin"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-callsites/bap-callsites.1.4.0/url
+++ b/packages/bap-callsites/bap-callsites.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/descr
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/descr
@@ -1,0 +1,1 @@
+A demangler that relies on a c++filt utility

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "bap-cxxfilt"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-cxxfilt"
+                 "--cxxfilt-targets=%{conf-binutils:targets}%"
+                 "--cxxfilt-path=%{conf-binutils:cxxfilt}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cxxfilt"]
+        ["bapbundle" "remove" "cxxfilt.plugin"]
+]
+depends: [
+         "bap-std"
+         "bap-demangle"
+         "conf-binutils" {>= "0.2"}
+]

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/url
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-dead-code-elimination/bap-dead-code-elimination.1.4.0/descr
+++ b/packages/bap-dead-code-elimination/bap-dead-code-elimination.1.4.0/descr
@@ -1,0 +1,7 @@
+A BAP plugin that removes dead IR code
+
+An pass that conservatively removes dead code in the generated IR. The
+removed dead code is usually produced by a lifter, though it might be
+possible that a binary indeed contains a dead code. The algorithm
+doesn't remove variables that are stored in memory, only registers are
+considered.

--- a/packages/bap-dead-code-elimination/bap-dead-code-elimination.1.4.0/opam
+++ b/packages/bap-dead-code-elimination/bap-dead-code-elimination.1.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "bap-dead-code-elimination"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dead-code-elimination"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-dead_code_elimination"]
+         ["bapbundle" "remove" "dead_code_elimination.plugin"]]
+depends: ["bap-std"]

--- a/packages/bap-dead-code-elimination/bap-dead-code-elimination.1.4.0/url
+++ b/packages/bap-dead-code-elimination/bap-dead-code-elimination.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-demangle/bap-demangle.1.4.0/descr
+++ b/packages/bap-demangle/bap-demangle.1.4.0/descr
@@ -1,0 +1,1 @@
+Library for name demangling

--- a/packages/bap-demangle/bap-demangle.1.4.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "bap-demangle"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-demangle"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-demangle"]
+        ["ocamlfind" "remove" "bap-plugin-demangle"]
+        ["bapbundle"   "remove" "demangle.plugin"]
+        ]
+
+depends: [
+    "core_kernel"       {>= "113.24.00"}
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-demangle/bap-demangle.1.4.0/url
+++ b/packages/bap-demangle/bap-demangle.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.4.0/descr
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP plugin that dumps symbols information from a binary

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.4.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-dump-symbols"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dump-symbols"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-dump_symbols"]
+        ["bapbundle" "remove" "dump_symbols.plugin"]
+]
+
+depends: [
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.4.0/url
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-dwarf/bap-dwarf.1.4.0/descr
+++ b/packages/bap-dwarf/bap-dwarf.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP DWARF parsing library

--- a/packages/bap-dwarf/bap-dwarf.1.4.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.1.4.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "bap-dwarf"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dwarf"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-dwarf"]]
+depends: ["bap-std"]

--- a/packages/bap-dwarf/bap-dwarf.1.4.0/url
+++ b/packages/bap-dwarf/bap-dwarf.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-elf/bap-elf.1.0.0/opam
+++ b/packages/bap-elf/bap-elf.1.0.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring" {< "3.0.0"}
+    "bitstring"
 ]

--- a/packages/bap-elf/bap-elf.1.1.0/opam
+++ b/packages/bap-elf/bap-elf.1.1.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring" {< "3.0.0"}
+    "bitstring"
 ]

--- a/packages/bap-elf/bap-elf.1.2.0/opam
+++ b/packages/bap-elf/bap-elf.1.2.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring" {< "3.0.0"}
+    "bitstring"
 ]

--- a/packages/bap-elf/bap-elf.1.3.0/opam
+++ b/packages/bap-elf/bap-elf.1.3.0/opam
@@ -24,5 +24,5 @@ depends: [
     "bap-std"
     "bap-dwarf"
     "camlp4"
-    "bitstring" {< "3.0.0"}
+    "bitstring"
 ]

--- a/packages/bap-frames/bap-frames.1.4.0/descr
+++ b/packages/bap-frames/bap-frames.1.4.0/descr
@@ -1,0 +1,1 @@
+A data format for storing execution traces.

--- a/packages/bap-frames/bap-frames.1.4.0/opam
+++ b/packages/bap-frames/bap-frames.1.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "1.2"
+name: "bap-frames"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-frames"]
+        [ "ocamlfind" "remove" "bap-frames"]
+        [ "ocamlfind" "remove" "bfd"]
+        [ "bapbundle" "remove" "frames.plugin"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/*.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/exceptionframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/frame.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/keyframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/metaframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/modloadframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/stdframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/syscallframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/taintintroframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/types.piqi"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "bap-traces"
+    "cmdliner"
+    "piqi" {>= "0.7.4"}
+]

--- a/packages/bap-frames/bap-frames.1.4.0/url
+++ b/packages/bap-frames/bap-frames.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-frames/bap-frames.2.1.1/descr
+++ b/packages/bap-frames/bap-frames.2.1.1/descr
@@ -1,0 +1,1 @@
+A data format for storing execution traces.

--- a/packages/bap-frames/bap-frames.2.1.1/opam
+++ b/packages/bap-frames/bap-frames.2.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "1.2"
+name: "bap-frames"
+version: "2.1.1"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-frames"]
+        [ "ocamlfind" "remove" "bap-frames"]
+        [ "ocamlfind" "remove" "bfd"]
+        [ "bapbundle" "remove" "frames.plugin"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/*.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/exceptionframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/frame.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/keyframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/metaframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/modloadframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/stdframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/syscallframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/taintintroframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/types.piqi"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "bap-traces"
+    "cmdliner"
+    "piqi" {>= "0.7.4"}
+]

--- a/packages/bap-frames/bap-frames.2.1.1/url
+++ b/packages/bap-frames/bap-frames.2.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap-frames/archive/v2.1.1.tar.gz"
+checksum: "1c9d805875230c84b8ba131be1cb8486"

--- a/packages/bap-frontc/bap-frontc.1.4.0/descr
+++ b/packages/bap-frontc/bap-frontc.1.4.0/descr
@@ -1,0 +1,1 @@
+A C language frontend for based on FrontC library.

--- a/packages/bap-frontc/bap-frontc.1.4.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "bap-frontc"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-frontc-parser"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
+        ["bapbundle" "remove" "frontc_parser.plugin"]]
+depends: ["bap-std" "bap-c" "FrontC"]

--- a/packages/bap-frontc/bap-frontc.1.4.0/url
+++ b/packages/bap-frontc/bap-frontc.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-frontend/bap-frontend.1.4.0/descr
+++ b/packages/bap-frontend/bap-frontend.1.4.0/descr
@@ -1,0 +1,3 @@
+BAP frontend
+
+The command-line interface to the Binary Analysis Platform.

--- a/packages/bap-frontend/bap-frontend.1.4.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "bap-frontend"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-frontend"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap"]
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+    "parsexp"
+]

--- a/packages/bap-frontend/bap-frontend.1.4.0/url
+++ b/packages/bap-frontend/bap-frontend.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/descr
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP function start identification benchmark game

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-fsi-benchmark"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-fsi-benchmark"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+    "bap-std"
+    "bap-ida"
+    "bap-byteweight-frontend"
+    "cmdliner"
+    "fileutils"
+    "re"
+]

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/url
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-future/bap-future.1.4.0/descr
+++ b/packages/bap-future/bap-future.1.4.0/descr
@@ -1,0 +1,4 @@
+A library for asynchronous values
+
+A library for reasoning about state based dynamic systems. This can
+be seen as a common denominator between Lwt and Async libraries.

--- a/packages/bap-future/bap-future.1.4.0/opam
+++ b/packages/bap-future/bap-future.1.4.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "bap-future"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-future"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-future"]]
+
+depends: [
+    "core_kernel"       {>= "v0.9.0" & < "v0.10"}
+    "oasis"             {build & >= "0.4.7"}
+    "monads"
+]

--- a/packages/bap-future/bap-future.1.4.0/url
+++ b/packages/bap-future/bap-future.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/descr
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/descr
@@ -1,0 +1,1 @@
+Plugins for IDA and BAP integration

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "bap-ida-plugin"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ida-plugin"]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-emit_ida_script"]
+        [ "bapbundle" "remove" "emit_ida_script.plugin"]
+
+]
+depends: ["bap" "cmdliner"]

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/url
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-ida/bap-ida.1.4.0/descr
+++ b/packages/bap-ida/bap-ida.1.4.0/descr
@@ -1,0 +1,1 @@
+An IDA Pro integration library

--- a/packages/bap-ida/bap-ida.1.4.0/opam
+++ b/packages/bap-ida/bap-ida.1.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "bap-ida"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+     "--prefix=%{prefix}%"
+     "--enable-ida"
+     "--ida-path=%{conf-ida:path}%"
+     "--ida-headless=%{conf-ida:headless}%"
+]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-ida"]
+        ["ocamlfind" "remove" "bap-plugin-ida"]
+        ["bapbundle" "remove" "ida.plugin"]
+]
+depends: [
+         "conf-ida"
+         "bap-ida-python"
+         "core_kernel"       {>= "113.24.00"}
+         "oasis"             {build & = "0.4.7"}
+         "ppx_jane"          {>= "113.24.01"}
+         "fileutils"
+         "re"
+         "bap-ida-plugin"
+]

--- a/packages/bap-ida/bap-ida.1.4.0/url
+++ b/packages/bap-ida/bap-ida.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-llvm/bap-llvm.1.4.0/descr
+++ b/packages/bap-llvm/bap-llvm.1.4.0/descr
@@ -1,0 +1,3 @@
+BAP LLVM backend
+
+Provides a loader and a disassembler, based on LLVM-MC library.

--- a/packages/bap-llvm/bap-llvm.1.4.0/files/detect.travis
+++ b/packages/bap-llvm/bap-llvm.1.4.0/files/detect.travis
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > bap-llvm.config <<EOF
+ travis : ${TRAVIS:-false}
+EOF

--- a/packages/bap-llvm/bap-llvm.1.4.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+name: "bap-llvm"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+  "--prefix=%{prefix}%"
+  "--with-cxx=`which clang++`"
+  "--with-llvm-version=%{conf-bap-llvm:package-version}%"
+  "--with-llvm-config=%{conf-bap-llvm:config}%"
+  "--enable-llvm"]
+  [make]
+  ]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-llvm"]
+  ["ocamlfind" "remove" "bap-llvm"]
+  ["bapbundle" "remove" "llvm.plugin"]
+]
+
+depends: [
+    "bap-std"
+    "cmdliner"
+    "conf-env-travis"
+    "conf-bap-llvm" {>= "1.1"}
+    "ogre"
+    "monads"
+]
+
+depexts: [
+    [["ubuntu"] ["clang"]]
+    [["debian"] ["clang"]]
+]

--- a/packages/bap-llvm/bap-llvm.1.4.0/url
+++ b/packages/bap-llvm/bap-llvm.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-mc/bap-mc.1.4.0/descr
+++ b/packages/bap-mc/bap-mc.1.4.0/descr
@@ -1,0 +1,3 @@
+BAP machine instruction playground
+
+A BAP version of llvm-mc tool.

--- a/packages/bap-mc/bap-mc.1.4.0/opam
+++ b/packages/bap-mc/bap-mc.1.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "bap-mc"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-mc"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap-mc"]
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-mc/bap-mc.1.4.0/url
+++ b/packages/bap-mc/bap-mc.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-microx/bap-microx.1.4.0/descr
+++ b/packages/bap-microx/bap-microx.1.4.0/descr
@@ -1,0 +1,1 @@
+A micro execution framework

--- a/packages/bap-microx/bap-microx.1.4.0/opam
+++ b/packages/bap-microx/bap-microx.1.4.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "bap-microx"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-microx"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-microx"]]
+depends: ["bap-std"]

--- a/packages/bap-microx/bap-microx.1.4.0/url
+++ b/packages/bap-microx/bap-microx.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-mips/bap-mips.1.4.0/descr
+++ b/packages/bap-mips/bap-mips.1.4.0/descr
@@ -1,0 +1,3 @@
+BAP MIPS lifter
+
+Provides lifter for MIPS and MIPS32 architectures

--- a/packages/bap-mips/bap-mips.1.4.0/opam
+++ b/packages/bap-mips/bap-mips.1.4.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name: "bap-mips"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-mips"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-mips"]
+         ["bapbundle" "remove" "mips.plugin"]]
+
+depends: [
+  "bap-std"
+  "bap-abi"
+  "bap-c"
+]

--- a/packages/bap-mips/bap-mips.1.4.0/url
+++ b/packages/bap-mips/bap-mips.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-objdump/bap-objdump.1.4.0/descr
+++ b/packages/bap-objdump/bap-objdump.1.4.0/descr
@@ -1,0 +1,1 @@
+extract symbols from binary, using binutils objdump

--- a/packages/bap-objdump/bap-objdump.1.4.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.4.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "bap-objdump"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-objdump"
+                 "--objdump-targets=%{conf-binutils:targets}%"
+                 "--objdump-path=%{conf-binutils:objdump}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
+	 ["bapbundle" "remove" "objdump.plugin"]
+]
+depends: ["bap-std" "re" "cmdliner" "conf-binutils"]

--- a/packages/bap-objdump/bap-objdump.1.4.0/url
+++ b/packages/bap-objdump/bap-objdump.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-phoenix/bap-phoenix.1.4.0/descr
+++ b/packages/bap-phoenix/bap-phoenix.1.4.0/descr
@@ -1,0 +1,3 @@
+BAP plugin that dumps information in a phoenix decompiler format
+
+Useful for visualization and project exploration

--- a/packages/bap-phoenix/bap-phoenix.1.4.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "bap-phoenix"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-phoenix"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-phoenix"]
+        ["bapbundle" "remove" "phoenix.plugin"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+    "text-tags"
+    "ocamlgraph"
+    "ezjsonm"
+]

--- a/packages/bap-phoenix/bap-phoenix.1.4.0/url
+++ b/packages/bap-phoenix/bap-phoenix.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-piqi/bap-piqi.1.4.0/descr
+++ b/packages/bap-piqi/bap-piqi.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP plugin for serialization based on piqi library

--- a/packages/bap-piqi/bap-piqi.1.4.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+name: "bap-piqi"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-piqi"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-piqi_printers"]
+        [ "ocamlfind" "remove" "bap-piqi"]
+        [ "bapbundle" "remove" "piqi_printers.plugin"]
+        [ "rm" "-f" "%{prefix}%/share/bap/exp.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/ir.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/stmt.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/type.piqi"]
+]
+
+depends: [
+    "oasis"             {build & >= "0.4.7"}
+    "bap-std"
+    "cmdliner"
+    "piqi" {>= "0.7.4"}
+
+]

--- a/packages/bap-piqi/bap-piqi.1.4.0/url
+++ b/packages/bap-piqi/bap-piqi.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-powerpc/bap-powerpc.1.4.0/descr
+++ b/packages/bap-powerpc/bap-powerpc.1.4.0/descr
@@ -1,0 +1,3 @@
+BAP PowerPC lifter
+
+Provides support for PPC and PPC64 architectures.

--- a/packages/bap-powerpc/bap-powerpc.1.4.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-powerpc"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-powerpc"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
+         ["bapbundle" "remove" "powerpc.plugin"]]
+
+depends: [
+    "bap-abi"
+    "bap-c"
+    "bap-primus"
+    "zarith"
+]

--- a/packages/bap-powerpc/bap-powerpc.1.4.0/url
+++ b/packages/bap-powerpc/bap-powerpc.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.1.4.0/descr
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.1.4.0/descr
@@ -1,0 +1,5 @@
+BAP Primus Lisp library that provides dictionaries
+
+Provides a key-value storage for Primus Lisp programs.  Dictionaries
+are represented with symbols and it is a responsibility of user to
+prevent name clashing between different dictionaries.

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.1.4.0/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-primus-dictionary"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-dictionary"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_dictionary"]
+        ["bapbundle" "remove" "primus_dictionary.plugin"]
+        ]
+
+depends: [
+    "bap-std"
+    "bap-primus"
+]

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.1.4.0/url
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-primus-lisp/bap-primus-lisp.1.4.0/descr
+++ b/packages/bap-primus-lisp/bap-primus-lisp.1.4.0/descr
@@ -1,0 +1,5 @@
+BAP Primus Lisp Runtime
+
+The default (and the only one so far) Primus Lisp runtime. The plugin
+provides Lisp primitives for manipulation program state, loads user
+specified libraries, and integrates Primus Lisp with BAP universe.

--- a/packages/bap-primus-lisp/bap-primus-lisp.1.4.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.1.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-primus-lisp"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-lisp"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_lisp"]
+        ["bapbundle" "remove" "primus_lisp.plugin"]
+        ["rm" "-rf" "%{prefix}%/share/primus/site-lisp"]
+        ]
+
+depends: [
+    "bap-std"
+    "bap-primus"
+]

--- a/packages/bap-primus-lisp/bap-primus-lisp.1.4.0/url
+++ b/packages/bap-primus-lisp/bap-primus-lisp.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-primus-region/bap-primus-region.1.4.0/descr
+++ b/packages/bap-primus-region/bap-primus-region.1.4.0/descr
@@ -1,0 +1,1 @@
+Provides a set of operations to store and manipulate interval trees.

--- a/packages/bap-primus-region/bap-primus-region.1.4.0/opam
+++ b/packages/bap-primus-region/bap-primus-region.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-primus-region"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-region"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_region"]
+        ["bapbundle" "remove" "primus_region.plugin"]
+        ]
+
+depends: [
+    "bap-std"
+    "bap-primus"
+]

--- a/packages/bap-primus-region/bap-primus-region.1.4.0/url
+++ b/packages/bap-primus-region/bap-primus-region.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-primus-support/bap-primus-support.1.4.0/descr
+++ b/packages/bap-primus-support/bap-primus-support.1.4.0/descr
@@ -1,0 +1,1 @@
+provides supporting components for Primus

--- a/packages/bap-primus-support/bap-primus-support.1.4.0/opam
+++ b/packages/bap-primus-support/bap-primus-support.1.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "1.2"
+name: "bap-primus-support"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-support"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_exploring"]
+        ["ocamlfind" "remove" "bap-plugin-primus_greedy"]
+        ["ocamlfind" "remove" "bap-plugin-primus_limit"]
+        ["ocamlfind" "remove" "bap-plugin-primus_loader"]
+        ["ocamlfind" "remove" "bap-plugin-primus_mark_visited"]
+        ["ocamlfind" "remove" "bap-plugin-primus_print"]
+        ["ocamlfind" "remove" "bap-plugin-primus_promiscuous"]
+        ["ocamlfind" "remove" "bap-plugin-primus_round_robin"]
+        ["ocamlfind" "remove" "bap-plugin-primus_wandering"]
+        ["bapbundle" "remove" "primus_exploring.plugin"]
+        ["bapbundle" "remove" "primus_greedy.plugin"]
+        ["bapbundle" "remove" "primus_limit.plugin"]
+        ["bapbundle" "remove" "primus_loader.plugin"]
+        ["bapbundle" "remove" "primus_mark_visited.plugin"]
+        ["bapbundle" "remove" "primus_print.plugin"]
+        ["bapbundle" "remove" "primus_promiscuous.plugin"]
+        ["bapbundle" "remove" "primus_round_robin.plugin"]
+        ["bapbundle" "remove" "primus_wandering.plugin"]
+]
+
+depends: [
+    "bap-std"
+    "bap-primus"
+    "bare"
+]

--- a/packages/bap-primus-support/bap-primus-support.1.4.0/url
+++ b/packages/bap-primus-support/bap-primus-support.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-primus-test/bap-primus-test.1.4.0/descr
+++ b/packages/bap-primus-test/bap-primus-test.1.4.0/descr
@@ -1,0 +1,15 @@
+BAP Primus Testing and Program Verification module
+
+With Primus Test Framework program analysis could be implemented as a
+set of simple tests written in Primus Lisp language. The framework
+provides an unified incident reporting facility for generalized
+problem reporting. The framework comes with a couple of analysis on
+board as a showcase.
+
+Memcheck - a memory checker that detects vioalations of memory
+management discipline, such as use-after-free, double free, and
+corrupted free.
+
+Check Returned Value - verifies that a program is addressing all
+possible outcomes of certain API calls, e.g., checks return values,
+error codes, etc.

--- a/packages/bap-primus-test/bap-primus-test.1.4.0/opam
+++ b/packages/bap-primus-test/bap-primus-test.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-primus-test"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-test"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_test"]
+        ["bapbundle" "remove" "primus_test.plugin"]
+        ]
+
+depends: [
+    "bap-std"
+    "bap-primus"
+]

--- a/packages/bap-primus-test/bap-primus-test.1.4.0/url
+++ b/packages/bap-primus-test/bap-primus-test.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-primus-x86/bap-primus-x86.1.4.0/descr
+++ b/packages/bap-primus-x86/bap-primus-x86.1.4.0/descr
@@ -1,0 +1,1 @@
+The x86 CPU support package for BAP Primus CPU emulator

--- a/packages/bap-primus-x86/bap-primus-x86.1.4.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.1.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-primus-x86"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_x86"]
+        ["bapbundle" "remove" "primus_x86.plugin"]
+        ]
+
+depends: [
+    "bap-std"
+    "bap-primus"
+    "bap-x86"
+]

--- a/packages/bap-primus-x86/bap-primus-x86.1.4.0/url
+++ b/packages/bap-primus-x86/bap-primus-x86.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-primus/bap-primus.1.4.0/descr
+++ b/packages/bap-primus/bap-primus.1.4.0/descr
@@ -1,0 +1,11 @@
+The BAP Microexecution Framework
+
+BAP Primus is a Microexecutuin Framework. The Microexecution technique
+was pioneered by Patrice Godefroid from Microsoft Research. The idea
+is to execute a binary from any point, using random inputs for
+undefined values.
+
+The idea of Primus is very similiar. A program is lifted into the
+Intermediate Representation, that is interpreted using the Primus
+interpreter. The Framework allows users to customize the interpreter
+by implementing different machine components.

--- a/packages/bap-primus/bap-primus.1.4.0/opam
+++ b/packages/bap-primus/bap-primus.1.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "bap-primus"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-primus"]]
+
+depends: [
+    "bap-std"
+    "bap-abi"
+    "bap-c"
+    "bap-future"
+    "bap-strings"
+    "monads"
+    "uuidm"
+    "parsexp"
+]

--- a/packages/bap-primus/bap-primus.1.4.0/url
+++ b/packages/bap-primus/bap-primus.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-print/bap-print.1.4.0/descr
+++ b/packages/bap-print/bap-print.1.4.0/descr
@@ -1,0 +1,1 @@
+Print plugin - print project in various formats

--- a/packages/bap-print/bap-print.1.4.0/opam
+++ b/packages/bap-print/bap-print.1.4.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "bap-print"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-print"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-print"]
+        ["bapbundle" "remove" "print.plugin"]
+
+        ]
+
+depends: [
+    "bap-std"
+    "bap-demangle"
+    "text-tags"
+]

--- a/packages/bap-print/bap-print.1.4.0/url
+++ b/packages/bap-print/bap-print.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-relocatable/bap-relocatable.1.4.0/descr
+++ b/packages/bap-relocatable/bap-relocatable.1.4.0/descr
@@ -1,0 +1,1 @@
+Provides a brancher service for BAP that handles certain relocations

--- a/packages/bap-relocatable/bap-relocatable.1.4.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-relocatable"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-relocatable"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-relocatable"]
+        ["bapbundle" "remove" "relocatable.plugin"]
+        ]
+
+depends: [
+    "bap-std"
+    "ogre"
+]

--- a/packages/bap-relocatable/bap-relocatable.1.4.0/url
+++ b/packages/bap-relocatable/bap-relocatable.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-report/bap-report.1.4.0/descr
+++ b/packages/bap-report/bap-report.1.4.0/descr
@@ -1,0 +1,1 @@
+A BAP plugin that reports program status

--- a/packages/bap-report/bap-report.1.4.0/opam
+++ b/packages/bap-report/bap-report.1.4.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "bap-report"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-report"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-report"]
+         ["bapbundle" "remove" "report.plugin"]]
+
+depends: [
+  "bap-std"
+]

--- a/packages/bap-report/bap-report.1.4.0/url
+++ b/packages/bap-report/bap-report.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-run/bap-run.1.4.0/descr
+++ b/packages/bap-run/bap-run.1.4.0/descr
@@ -1,0 +1,3 @@
+A BAP plugin that executes a binary
+
+Uses the Primus Microexecution Framework to execute a binary.

--- a/packages/bap-run/bap-run.1.4.0/opam
+++ b/packages/bap-run/bap-run.1.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "bap-run"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-run"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-run"]
+        ["bapbundle" "remove" "run.plugin"]
+        ]
+
+depends: [
+    "bap-std"
+    "bap-primus"
+]

--- a/packages/bap-run/bap-run.1.4.0/url
+++ b/packages/bap-run/bap-run.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-server/bap-server.0.2.0/descr
+++ b/packages/bap-server/bap-server.0.2.0/descr
@@ -1,0 +1,3 @@
+BAP RPC server
+
+Provides a small subset of BAP functionality via a JSON RPC server.

--- a/packages/bap-server/bap-server.0.2.0/opam
+++ b/packages/bap-server/bap-server.0.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "1.2"
+name: "bap-server"
+version: "0.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-server/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-server/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-server/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap-server"]
+]
+
+depends: [
+    "core-lwt"
+    "regular"
+    "bap"
+    "cohttp" {>= "1.0.0" & < "2.0.0"}
+    "cohttp-lwt" {>= "1.0.0" & < "2.0.0"}
+    "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
+    "core_kernel" {>= "v0.9.0" & < "v0.10.0"}
+    "ezjsonm" {= "0.5.0" }
+    "lwt" {>= "3.0.0" & < "4.0.0"}
+    "oasis" {build & = "0.4.7"}
+    "re"
+    "uri" {>= "1.9.6"}
+]
+
+conflicts: [
+    "tls" {< "0.7.1"}
+    "nocrypto" {< "0.5.3"}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/bap-server/bap-server.0.2.0/url
+++ b/packages/bap-server/bap-server.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap-server/archive/v0.2.0.tar.gz"
+checksum: "4252e66d43802393b89cb93ba68e278f"

--- a/packages/bap-signatures/bap-signatures.1.4.0/descr
+++ b/packages/bap-signatures/bap-signatures.1.4.0/descr
@@ -1,0 +1,4 @@
+A data package with binary signatures for bap
+
+
+A package contains signatures for Byteweight algorithm.

--- a/packages/bap-signatures/bap-signatures.1.4.0/opam
+++ b/packages/bap-signatures/bap-signatures.1.4.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+name: "bap-signatures"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+install: [
+  ["mkdir" "-p" "%{share}%/bap/"]
+  ["cp" "sigs.zip" "%{share}%/bap/sigs.zip"]
+]
+
+remove: [["rm" "%{share}%/bap/sigs.zip"]]

--- a/packages/bap-signatures/bap-signatures.1.4.0/url
+++ b/packages/bap-signatures/bap-signatures.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v1.4.0/sigs.tar.gz"
+checksum: "e46f1494adabb9ea437a775d3842546c"

--- a/packages/bap-ssa/bap-ssa.1.4.0/descr
+++ b/packages/bap-ssa/bap-ssa.1.4.0/descr
@@ -1,0 +1,1 @@
+A BAP plugin, that translates a program into the SSA form

--- a/packages/bap-ssa/bap-ssa.1.4.0/opam
+++ b/packages/bap-ssa/bap-ssa.1.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "bap-ssa"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ssa"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-ssa"]
+         ["bapbundle" "remove" "ssa.plugin"]]
+depends: ["bap-std"]

--- a/packages/bap-ssa/bap-ssa.1.4.0/url
+++ b/packages/bap-ssa/bap-ssa.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-std/bap-std.1.4.0/descr
+++ b/packages/bap-std/bap-std.1.4.0/descr
@@ -1,0 +1,3 @@
+The Binary Analysis Platform Standard Library
+
+Provides the main BAP library.

--- a/packages/bap-std/bap-std.1.4.0/opam
+++ b/packages/bap-std/bap-std.1.4.0/opam
@@ -1,0 +1,71 @@
+opam-version: "1.2"
+name: "bap-std"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--with-cxx=`which clang++`"
+                 "--mandir=%{man}%"
+                 "--enable-bap-std"]
+  [make]
+]
+
+install: [
+  [make "reinstall"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap"]
+  ["ocamlfind" "remove" "bap-build"]
+  ["rm" "-f" "%{bin}%/baptop"]
+  ["rm" "-f" "%{bin}%/ppx-bap"]
+  ["rm" "-f" "%{bin}%/bapbuild"]
+  ["rm" "-f" "%{bin}%/bapbundle"]
+]
+
+depends: [
+  "base-unix"
+  "bap-future"
+  "camlzip" {>= "1.07"}
+  "core_kernel" {>= "v0.9.0" & < "v0.10"}
+  "bin_prot" {>= "v0.9.1" & < "v0.10"}
+  "fileutils"
+  "graphlib"
+  "oasis" {build & = "0.4.7"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ppx_jane" {>= "v0.9.0" & < "v0.10"}
+  "regular"
+  "uri"
+  "utop"     {build & = "1.19.3"}
+  "uuidm"
+  "zarith"
+  "cmdliner" {>= "0.9.8"}
+  "ogre"
+  "monads"
+]
+depexts: [
+    [["ubuntu"] [
+        "libgmp-dev"
+        "libzip-dev"
+        "clang"
+     ]]
+     [["osx" "macports"] [
+        "gmp"
+        "libzip"
+     ]]
+     [["debian"] [
+        "clang"
+     ]]
+]
+
+conflicts: [
+  "fileutils" {= "0.5.0"}
+  "jbuilder" {= "1.0+beta18"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/bap-std/bap-std.1.4.0/url
+++ b/packages/bap-std/bap-std.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-strings/bap-strings.1.4.0/descr
+++ b/packages/bap-strings/bap-strings.1.4.0/descr
@@ -1,0 +1,14 @@
+Text utilities useful in Binary Analysis and Reverse Engineering
+
+
+The library provides several algorithms:
+
+- Detector - that uses a maximum aposteriori likelihood estimator
+  (MAP) to detect code that operates with textual data (aka Bayesian
+  inference).
+
+- Unscrambler - that is capable of finding all possible words, that
+  can be built from a bag of letters in O(1).
+
+- Scanner - a generic algorithm for finding strings of characters (a
+  library variant of strings tool)

--- a/packages/bap-strings/bap-strings.1.4.0/opam
+++ b/packages/bap-strings/bap-strings.1.4.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "bap-strings"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-strings"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-strings"]]
+
+depends: [
+    "core_kernel" {>= "v0.9.0" & < "v0.10"}
+    "oasis"       {build & = "0.4.7"}
+]

--- a/packages/bap-strings/bap-strings.1.4.0/url
+++ b/packages/bap-strings/bap-strings.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.4.0/descr
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP plugin that reads symbol information from files

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.4.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "bap-symbol-reader"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-symbol-reader"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-read_symbols"]
+        [ "bapbundle" "remove" "read_symbols.plugin"]
+
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.4.0/url
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/descr
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP Taint propagation engine using based on microexecution.

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+name: "bap-taint-propagator"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-propagate-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
+         ["bapbundle" "remove" "propagate_taint.plugin"]]
+depends: ["bap-std" "cmdliner" "bap-microx"]

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/url
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-taint/bap-taint.1.4.0/descr
+++ b/packages/bap-taint/bap-taint.1.4.0/descr
@@ -1,0 +1,5 @@
+BAP Taint Analysis Framework
+
+Provides a generic library for handling program taints, and plugins
+that integrate existing and new taint analysis tools with the new
+framework.

--- a/packages/bap-taint/bap-taint.1.4.0/opam
+++ b/packages/bap-taint/bap-taint.1.4.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name: "bap-taint"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-taint"]
+  ["ocamlfind" "remove" "bap-plugin-taint"]
+  ["ocamlfind" "remove" "bap-plugin-primus_propagate_taint"]
+  ["ocamlfind" "remove" "bap-plugin-primus_taint"]
+  ["bapbundle" "remove" "taint.plugin"]
+  ["bapbundle" "remove" "primus_propagate_taint.plugin"]
+  ["bapbundle" "remove" "primus_taint.plugin"]
+]
+
+depends: ["bap-std" "bap-primus" "cmdliner"]

--- a/packages/bap-taint/bap-taint.1.4.0/url
+++ b/packages/bap-taint/bap-taint.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-term-mapper/bap-term-mapper.1.4.0/descr
+++ b/packages/bap-term-mapper/bap-term-mapper.1.4.0/descr
@@ -1,0 +1,1 @@
+A BAP DSL for mapping program terms

--- a/packages/bap-term-mapper/bap-term-mapper.1.4.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "bap-term-mapper"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-map-terms"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
+         [ "ocamlfind" "remove" "bap-bml"]
+         [ "bapbundle" "remove" "map_terms.plugin"]
+]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-term-mapper/bap-term-mapper.1.4.0/url
+++ b/packages/bap-term-mapper/bap-term-mapper.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-trace/bap-trace.1.4.0/descr
+++ b/packages/bap-trace/bap-trace.1.4.0/descr
@@ -1,0 +1,1 @@
+A plugin to load and run program execution traces

--- a/packages/bap-trace/bap-trace.1.4.0/opam
+++ b/packages/bap-trace/bap-trace.1.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "bap-trace"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-trace"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-trace"]
+        ["bapbundle" "remove" "trace.plugin"]
+        ]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "bap-traces"
+    "cmdliner"
+]

--- a/packages/bap-trace/bap-trace.1.4.0/url
+++ b/packages/bap-trace/bap-trace.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-traces/bap-traces.1.4.0/descr
+++ b/packages/bap-traces/bap-traces.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP Library for loading and parsing execution traces

--- a/packages/bap-traces/bap-traces.1.4.0/opam
+++ b/packages/bap-traces/bap-traces.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "bap-traces"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-traces"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-traces"]
+]
+
+depends: [
+    "oasis"             {build & >= "0.4.7"}
+    "bap-std"
+    "uri"               {>= "1.9.0"}
+    "uuidm"
+]

--- a/packages/bap-traces/bap-traces.1.4.0/url
+++ b/packages/bap-traces/bap-traces.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.4.0/descr
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.4.0/descr
@@ -1,0 +1,6 @@
+Eliminates complex conditionals in branches.
+
+Ensures that all branching conditions are either a variable
+or a constant. We call such representation a Trivial Condition Form
+(TCF). During the translation all complex condition expressions are
+hoisted into the assignemnt section of a block.

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.4.0/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.4.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "bap-trivial-condition-form"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-trivial-condition-form"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-trivial_condition_form"]
+         ["bapbundle" "remove" "trivial_condition_form.plugin"]]
+
+depends: [
+  "bap-std"
+]

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.4.0/url
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-veri/bap-veri.0.2.2/descr
+++ b/packages/bap-veri/bap-veri.0.2.2/descr
@@ -1,0 +1,1 @@
+BAP verification tool

--- a/packages/bap-veri/bap-veri.0.2.2/opam
+++ b/packages/bap-veri/bap-veri.0.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+name: "bap-veri"
+version: "0.2.2"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-veri/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-veri/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-veri/"
+license: "MIT"
+
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+  ["ocamlfind" "remove" "bap-veri"]
+  ["rm" "-f" "%{bin}%/bap-veri"]
+]
+
+depends: [
+    "bap-std" { >= "1.3.0" }
+    "bap-traces"
+    "cmdliner"
+    "oasis"       {build}
+    "ounit"
+    "pcre"
+    "textutils"
+    "uri"
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/bap-veri/bap-veri.0.2.2/url
+++ b/packages/bap-veri/bap-veri.0.2.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap-veri/archive/v0.2.2.tar.gz"
+checksum: "370ef26054ee1040351bad9cf6c22a45"

--- a/packages/bap-veri/bap-veri.1.4.0/descr
+++ b/packages/bap-veri/bap-veri.1.4.0/descr
@@ -1,0 +1,5 @@
+BAP Instruction Semantics Verification Tool
+
+Verifies that our understaning of instruction semantics is correct, or
+at least the same as in QEMU by checking if our execution bisimulates
+the QEMU.

--- a/packages/bap-veri/bap-veri.1.4.0/opam
+++ b/packages/bap-veri/bap-veri.1.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+name: "bap-veri"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-veri/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-veri/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-veri/"
+license: "MIT"
+
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+  ["ocamlfind" "remove" "bap-veri"]
+  ["rm" "-f" "%{bin}%/bap-veri"]
+]
+
+depends: [
+    "bap-std"
+    "bap-traces"
+    "cmdliner"
+    "oasis"       {build}
+    "ounit"
+    "pcre"
+    "textutils"
+    "uri"
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/bap-veri/bap-veri.1.4.0/url
+++ b/packages/bap-veri/bap-veri.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-warn-unused/bap-warn-unused.1.4.0/descr
+++ b/packages/bap-warn-unused/bap-warn-unused.1.4.0/descr
@@ -1,0 +1,1 @@
+Emit a warning if an unused result may cause a bug or security issue

--- a/packages/bap-warn-unused/bap-warn-unused.1.4.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "bap-warn-unused"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-warn-unused"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
+        ["bapbundle" "remove" "warn_unused.plugin"]]
+
+depends: [
+    "oasis"             {build & = "0.4.7"}
+    "bap-std"
+    "cmdliner"
+]

--- a/packages/bap-warn-unused/bap-warn-unused.1.4.0/url
+++ b/packages/bap-warn-unused/bap-warn-unused.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap-x86/bap-x86.1.4.0/descr
+++ b/packages/bap-x86/bap-x86.1.4.0/descr
@@ -1,0 +1,1 @@
+BAP x86 lifter

--- a/packages/bap-x86/bap-x86.1.4.0/opam
+++ b/packages/bap-x86/bap-x86.1.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "bap-x86"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-x86-cpu"]
+        ["ocamlfind" "remove" "bap-plugin-x86"]
+        ["bapbundle" "remove" "x86.plugin"]
+
+]
+
+depends: [
+    "bap-std"
+    "bap-abi"
+    "bap-c"
+    "bap-llvm"
+    "cmdliner"
+]

--- a/packages/bap-x86/bap-x86.1.4.0/url
+++ b/packages/bap-x86/bap-x86.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bap/bap.1.4.0/descr
+++ b/packages/bap/bap.1.4.0/descr
@@ -1,0 +1,17 @@
+Binary Analysis Platform.
+
+
+The Carnegie Mellon University Binary Analysis Platform (CMU BAP) is a
+reverse engineering and program analysis platform that works with
+binary code and doesn't require the source code. BAP supports multiple
+architectures: ARM, x86, x86-64, PowerPC, and MIPS. BAP disassembles
+and lifts binary code into the RISC-like BAP Instruction Language
+(BIL). Program analysis is performed using the BIL representation and
+is architecture independent in a sense that it will work equally well
+for all supported architectures. The main purpose of BAP is to provide
+a toolkit for implementing automated program analysis. BAP is written
+in OCaml and it is the preferred language to write analysis, but we
+have bindings to C, Python and Rust. The Primus Framework also provide
+a Lisp-like DSL for writing program analysis tools.
+
+This is a meta package that installs essential parts of BAP.

--- a/packages/bap/bap.1.4.0/opam
+++ b/packages/bap/bap.1.4.0/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+name: "bap"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+
+depends: [
+    "bap-abi" {= "1.4.0"}
+    "bap-api" {= "1.4.0"}
+    "bap-arm" {= "1.4.0"}
+    "bap-beagle" {= "1.4.0"}
+    "bap-byteweight" {= "1.4.0"}
+    "bap-c" {= "1.4.0"}
+    "bap-cache" {= "1.4.0"}
+    "bap-cxxfilt" {= "1.4.0"}
+    "bap-callsites" {= "1.4.0"}
+    "bap-demangle" {= "1.4.0"}
+    "bap-dead-code-elimination" {= "1.4.0"}
+    "bap-dump-symbols" {= "1.4.0"}
+    "bap-frontend" {= "1.4.0"}
+    "bap-frontc" {= "1.4.0"}
+    "bap-llvm" {= "1.4.0"}
+    "bap-mc" {= "1.4.0"}
+    "bap-microx" {= "1.4.0"}
+    "bap-mips" {= "1.4.0"}
+    "bap-objdump" {= "1.4.0"}
+    "bap-powerpc" {= "1.4.0"}
+    "bap-primus" {= "1.4.0"}
+    "bap-primus-dictionary" {= "1.4.0"}
+    "bap-primus-lisp" {= "1.4.0"}
+    "bap-primus-region" {= "1.4.0"}
+    "bap-primus-support" {= "1.4.0"}
+    "bap-primus-test" {= "1.4.0"}
+    "bap-primus-x86" {= "1.4.0"}
+    "bap-print" {= "1.4.0"}
+    "bap-relocatable" {= "1.4.0"}
+    "bap-report" {= "1.4.0"}
+    "bap-run" {= "1.4.0"}
+    "bap-ssa" {= "1.4.0"}
+    "bap-std" {= "1.4.0"}
+    "bap-strings" {= "1.4.0"}
+    "bap-symbol-reader" {= "1.4.0"}
+    "bap-taint" {= "1.4.0"}
+    "bap-taint-propagator" {= "1.4.0"}
+    "bap-term-mapper" {= "1.4.0"}
+    "bap-trace" {= "1.4.0"}
+    "bap-traces" {= "1.4.0"}
+    "bap-trivial-condition-form" {= "1.4.0"}
+    "bap-warn-unused" {= "1.4.0"}
+    "bap-x86" {= "1.4.0"}
+]
+
+available: [ocaml-version >= "4.03.0" ]

--- a/packages/bap/bap.1.4.0/url
+++ b/packages/bap/bap.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/bare/bare.1.4.0/descr
+++ b/packages/bare/bare.1.4.0/descr
@@ -1,0 +1,8 @@
+BAP Rule Engine Library
+
+BARE is a library that provides non-linear pattern matching on streams
+of facts that are represented as s-expressions. We use BARE, in particular,
+to process Primus observations. Since Primus components use observations to
+convey their knowledge downstream it is very convenient to be able to query
+and join observations through the stream. In a sense, BARE could be seen as
+SQL select/join for streams.

--- a/packages/bare/bare.1.4.0/opam
+++ b/packages/bare/bare.1.4.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "bare"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bare"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bare"]]
+
+depends: [
+    "core_kernel" {>="v0.9.0" & < "v0.10"}
+    "parsexp"
+]

--- a/packages/bare/bare.1.4.0/url
+++ b/packages/bare/bare.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.2/files/configure
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.2/files/configure
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# if LLVM_CONFIG variable doesn't explicitly specify which llvm-config
+# we should use, then we will search across all possible llvm-configs
+# that might work for us.  Our search strategy is to try to pick up
+# 3.4, then 3.8, then 4.0.0, and, if neither found, fallback to any
+# llvm-config.
+#
+# Note - suffix `-mp-` stands for macports, and will work on macs
+# if used with macports.
+
+config=${LLVM_CONFIG}
+
+if ! which "$config" ; then
+    config="llvm-config"
+    versions="3.4 3.8 4.0 5.0"
+
+    for version in $versions; do
+
+        if hash brew 2>/dev/null; then
+            brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
+        fi
+
+        configs="llvm-config-$version llvm-config${version//./} llvm-config-mp-$version $brew_llvm_config"
+
+        for llvm_config in $configs; do
+            if which $llvm_config; then
+                llvm_version="`$llvm_config --version`" || true
+                case $llvm_version in
+                    $version*)
+                        config=$llvm_config
+                        break ;;
+                    *)
+                        continue;
+                esac
+            fi
+        done
+    done
+fi
+
+if ! which "$config" ; then
+    exit 1
+else
+    version=`$config --version`
+fi
+
+cat > conf-bap-llvm.config <<EOF
+config: "$config"
+package-version: "$version"
+EOF

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+version: "1.2"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+homepage: "http://llvm.org"
+authors: "The LLVM Team"
+bug-reports: "https://llvm.org/bugs/"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+license: "BSD"
+build: [
+  ["bash" "-ex" "configure"]
+]
+depends: [
+  "conf-which" {build}
+]
+
+depexts: [
+  [["debian"] ["llvm-3.4-dev"]]
+  [["ubuntu"] ["llvm-3.8-dev"]]
+  [["osx" "macports"] ["llvm-3.8"]]
+  [["osx" "homebrew"] ["homebrew/versions/llvm38"]]
+]

--- a/packages/core-lwt/core-lwt.0.2/descr
+++ b/packages/core-lwt/core-lwt.0.2/descr
@@ -1,0 +1,4 @@
+Lwt library wrapper in the Janestreet core style
+
+Provides an interface to Lwt library that follows the Janestreet
+coding standards.

--- a/packages/core-lwt/core-lwt.0.2/opam
+++ b/packages/core-lwt/core-lwt.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "core-lwt"
+version: "0.2"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/core-lwt/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/core-lwt/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/core-lwt/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "core_lwt"]
+]
+
+depends: [
+    "oasis" {build & >= "0.4.0"}
+    "base-unix"
+    "base-threads"
+    "core_kernel" {>= "v0.9.0"}
+    "lwt" { >= "3.0.0" & < "4.0.0"}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/core-lwt/core-lwt.0.2/url
+++ b/packages/core-lwt/core-lwt.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/core-lwt/archive/0.2.tar.gz"
+checksum: "2d7a534c599fe69c233aee23f1ab02bb"

--- a/packages/core-lwt/core-lwt.1.4.0/descr
+++ b/packages/core-lwt/core-lwt.1.4.0/descr
@@ -1,0 +1,4 @@
+Lwt library wrapper in the Janestreet core style
+
+Provides an interface to Lwt library that follows the Janestreet
+coding standards.

--- a/packages/core-lwt/core-lwt.1.4.0/opam
+++ b/packages/core-lwt/core-lwt.1.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "core-lwt"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/core-lwt/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/core-lwt/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/core-lwt/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "core_lwt"]
+]
+
+depends: [
+    "oasis" {build & >= "0.4.0"}
+    "base-unix"
+    "base-threads"
+    "core_kernel" {>= "v0.9.0"}
+    "lwt" { >= "3.0.0" & < "4.0.0"}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/core-lwt/core-lwt.1.4.0/url
+++ b/packages/core-lwt/core-lwt.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/graphlib/graphlib.1.3.0/descr
+++ b/packages/graphlib/graphlib.1.3.0/descr
@@ -1,0 +1,9 @@
+Generic Graph library
+
+Graphlib is a generic library that extends a well known OCamlGraph
+library. Graphlib uses its own, more reach, Graph interface that
+is isomorphic to OCamlGraph's `Sigs.P` signature for persistant
+graphs. Two functors witness the isomorphism of the interfaces:
+`Graphlib.To_ocamlgraph` and `Graphlib.Of_ocamlgraph`. Thanks to
+these functors, any algorithm written for OCamlGraph can be used on
+`Graphlibs` graph and vice verse.

--- a/packages/graphlib/graphlib.1.3.0/opam
+++ b/packages/graphlib/graphlib.1.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+name: "graphlib"
+version: "1.3.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-graphlib"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "graphlib"]
+]
+
+depends: [
+    "core_kernel"       {>= "v0.9.0" & < "v0.10"}
+    "oasis"             {build & >= "0.4.7"}
+    "ppx_jane"          {>= "v0.9.0" & < "v0.10"}
+    "ocamlgraph"
+    "regular"
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/graphlib/graphlib.1.3.0/url
+++ b/packages/graphlib/graphlib.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"

--- a/packages/monads/monads.1.1/descr
+++ b/packages/monads/monads.1.1/descr
@@ -1,0 +1,3 @@
+A missing monad library
+
+Provides monad transformers for most (if not all) common monads.

--- a/packages/monads/monads.1.1/opam
+++ b/packages/monads/monads.1.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "monads"
+version: "1.1"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-monads"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "monads"]]
+
+depends: [
+         "core_kernel" {>="v0.9.0" & < "v0.10"}
+         "oasis"       {build & = "0.4.7"}
+]

--- a/packages/monads/monads.1.1/url
+++ b/packages/monads/monads.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"

--- a/packages/ogre/ogre.1.1/descr
+++ b/packages/ogre/ogre.1.1/descr
@@ -1,0 +1,6 @@
+Open Generic REpresentation NoSQL Database
+
+
+OGRE is a NoSQL document-style database, that uses s-exp for data
+representation and provides a type safe monadic interface for quering
+and updating documents.

--- a/packages/ogre/ogre.1.1/opam
+++ b/packages/ogre/ogre.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "ogre"
+version: "1.1"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ogre"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "ogre"]]
+
+depends: [
+    "core_kernel" {>="v0.9.0" & < "v0.10"}
+    "oasis"       {build & = "0.4.7"}
+    "monads"
+]

--- a/packages/ogre/ogre.1.1/url
+++ b/packages/ogre/ogre.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"

--- a/packages/regular/regular.1.4.0/descr
+++ b/packages/regular/regular.1.4.0/descr
@@ -1,0 +1,13 @@
+Library for regular data types
+
+Provides functors and typeclasses implementing functionality expected
+for a regular data type, like i/o, containers, printing, etc.
+
+In particular, the library includes:
+
+- module Data that adds generic i/o routines for each regular data type.
+- module Cache that adds caching service for data types
+- module Regular that glues everything together
+- module Opaque for regular but opaque data types
+- module Seq that extends Core_kernel's sequence module
+- module Bytes that provides a rich core-like interface for Bytes data type.

--- a/packages/regular/regular.1.4.0/opam
+++ b/packages/regular/regular.1.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "regular"
+version: "1.4.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-regular"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "regular"]
+]
+
+depends: [
+    "core_kernel"       {>= "v0.9.0" & < "v0.10"}
+    "oasis"             {build & = "0.4.7"}
+    "ppx_jane"          {= "v0.9.0"}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/regular/regular.1.4.0/url
+++ b/packages/regular/regular.1.4.0/url
@@ -1,0 +1,5 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"
+mirrors: [
+         "https://mirrors.aegis.cylab.cmu.edu/bap/1.4.0/v1.4.0.tar.gz"
+]

--- a/packages/text-tags/text-tags.1.3.0/descr
+++ b/packages/text-tags/text-tags.1.3.0/descr
@@ -1,0 +1,1 @@
+A library for rich formatting using semantics tags

--- a/packages/text-tags/text-tags.1.3.0/opam
+++ b/packages/text-tags/text-tags.1.3.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "text-tags"
+version: "1.3.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-text-tags"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "text-tags"]]
+
+depends: [
+    "core_kernel"       {>="v0.9.0" & < "v0.10"}
+    "oasis"             {build & = "0.4.7" }
+]

--- a/packages/text-tags/text-tags.1.3.0/url
+++ b/packages/text-tags/text-tags.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
+checksum: "b7785715c24645e8e69a8091427d090e"


### PR DESCRIPTION
The tests shall not pass and this is expected. There are two reasons:

- HTTP 429 Error. This is a drastic error that Github starts to fire when you're doing, as it thinks, to many requests. Our own CI system also suffers from it.

- Absence of proper LLVM on CI system. BAP works with the assorted selection of LLVM versions, namely 3.4,3.8,4.0, 5.0. Different linux distributions provide different LLVM versions and have different defaults. Unfortunately depext is not always able to pick the right version.

Nevertheless, we are extensively testing BAP using Travis, Docker, and Vagrant. Our testing matrix includes Ubuntu Xenial and Trusty distributions, with 4.03, 4.04, and 4.05 compilers. I will upload freshly built Docker images to the Hub as soon as GitHub will unban me. We also release to [NixOS][1].

P.S. NixOS fails somewhere in ppx/Jane Street stuff on Aarch64, I will report upstream as soon as I will figure out what package is failing. 

[1]: https://github.com/NixOS/nixpkgs/pull/36194

Release Notes
===========

- PR#762 MIPS and MIPS64 lifters
- PR#739 PowerPC and PowerPC64 lifters
- PR#744 LLVM 5.0 compatibility
- PR#734 BARE Binary Analysis Rule Engine
- PR#734 New Taint Analysis Framework
- PR#734 Primus Lisp 2.0 with symbols and methods
- PR#734 Recipes
- PR#734 Primus Test Framework
- PR#734 Dataflow and Abstract Interpretation Framework
- PR#734 Progress Reports and Profilers
- PR#773 New primitives for BML

- PR#782 Incorrect error handling in x86 lifter
- PR#734 Failure to decode ICC binaries
- PR#772 Fixes equiv type in Graphlib
- PR#771 Unhardcodes llvm backed in the linear sweep disassembler
- PR#770 Fixes the memory printer
- PR#761 Fixes handling relocations in reconstructor
- PR#759 Fixes race condition in the source merge procedure
- PR#758 Restores the source-type command line option
- PR#755 Proper handling of tail calls in IR lifter
- PR#754 Fixes segment registers in mov instruction
- PR#746 Fixes xor in the BIL simplfication procedure
- PR#728 Fixes flag calculation in the x86 sub instruction
- PR#727 Fixes numerous missed sign extensions in x86 lifter
- PR#725 Adds modulo operation to x86 rot/rol instructions
- PR#724 Fixes operands order in the x86 xadd instruction
- PR#723 Fixes segment duplication