### PR TITLE
constrain tcpip.3.4.0 to jbuilder < 18

### DIFF
--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -20,7 +20,7 @@ build-test: [
 ]
 
 depends: [
-  "jbuilder"     {build & >="1.0+beta10"}
+  "jbuilder"     {build & >="1.0+beta10" & < "1.0+beta18"}
   "configurator" {build}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.0.2"}


### PR DESCRIPTION
rgrinberg's fix for this issue in trunk [didn't make it into tcpip 3.4.0](https://github.com/mirage/mirage-tcpip/compare/v3.4.0...master), so the constraint is needed here in addition to in the older packages 3.2.0, 3.3.0, and 3.3.1 where it's already present.