### PR TITLE
Update opam file of Why3

### DIFF
--- a/packages/why3/why3.0.88.3/opam
+++ b/packages/why3/why3.0.88.3/opam
@@ -27,7 +27,7 @@ depends: [
   "lablgtk"
   "conf-gtksourceview"
   "zarith"
-  "camlzip"
+  "camlzip" { >= "1.06" }
   "ocamlgraph"
 ]
 depopts: [


### PR DESCRIPTION
Without this constraint, why3 does not compile with an already installed `camlzip` package.