### PR TITLE
Add ezgzip 0.2.1

### DIFF
--- a/packages/ezgzip/ezgzip.0.2.1/descr
+++ b/packages/ezgzip/ezgzip.0.2.1/descr
@@ -1,0 +1,23 @@
+# ezgzip - Simple gzip (de)compression library
+
+ezgzip is a simple interface focused on `string -> string` zlib and gzip
+(de)compression.
+
+Documentation is available
+[here](https://hcarty.github.io/ezgzip/ezgzip/index.html).
+
+An example illustrating how to gzip compress and then decompress a string:
+```ocaml
+open Rresult
+
+let () =
+  let original = "Hello world" in
+  let compressed = Ezgzip.compress original in
+  let decompressed = R.get_ok (Ezgzip.decompress compressed) in
+  assert (original = decompressed)
+```
+
+This library currently uses the zlib bindings provided by
+[camlzip](https://github.com/xavierleroy/camlzip).  The gzip header/footer code
+is based on the
+[upstream specification](http://www.gzip.org/zlib/rfc-gzip.html#specification).

--- a/packages/ezgzip/ezgzip.0.2.1/opam
+++ b/packages/ezgzip/ezgzip.0.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Hezekiah M. Carty <hez@0ok.org>"
+authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
+license: "MIT"
+homepage: "https://github.com/hcarty/ezgzip"
+dev-repo: "https://github.com/hcarty/ezgzip.git"
+bug-reports: "https://github.com/hcarty/ezgzip/issues"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+build-doc: [ "jbuilder" "build" "@doc" "-p" name]
+depends: [
+  "alcotest" {test & >= "0.8.1"}
+  "astring"
+  "benchmark" {test & >= "1.4"}
+  "jbuilder" {build & >= "1.0+beta13"}
+  "ocplib-endian"
+  "odoc" {doc & >= "1.1.1"}
+  "qcheck" {test & >= "0.7"}
+  "rresult"
+  "camlzip"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ezgzip/ezgzip.0.2.1/url
+++ b/packages/ezgzip/ezgzip.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hcarty/ezgzip/archive/v0.2.1.tar.gz"
+checksum: "6a0f8aa64541a32691f9884f0ef8737f"


### PR DESCRIPTION
0.2.0 had an incorrect zlib header flag set, breaking compatibility with
gzip/gunzip.  This release fixes that issue.