### PR TITLE
Remove build-test stanzas from Caqti.

### DIFF
--- a/packages/caqti-async/caqti-async.0.10.0/opam
+++ b/packages/caqti-async/caqti-async.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "async" {>= "v0.10.0"}

--- a/packages/caqti-async/caqti-async.0.9.0/opam
+++ b/packages/caqti-async/caqti-async.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "async" {>= "v0.10.0"}

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti" {= "0.10.0"}

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti" {= "0.10.0"}

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.9.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti" {= "0.10.0"}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.1/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.1/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti" {= "0.10.1"}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.9.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti"

--- a/packages/caqti-dynload/caqti-dynload.0.10.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti" {= "0.10.0"}

--- a/packages/caqti-dynload/caqti-dynload.0.9.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti"

--- a/packages/caqti-lwt/caqti-lwt.0.10.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti" {= "0.10.0"}

--- a/packages/caqti-lwt/caqti-lwt.0.9.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti"

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti" {= "0.10.0"}

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "caqti"

--- a/packages/caqti/caqti.0.10.0/opam
+++ b/packages/caqti/caqti.0.10.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build}

--- a/packages/caqti/caqti.0.10.1/opam
+++ b/packages/caqti/caqti.0.10.1/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build}

--- a/packages/caqti/caqti.0.9.0/opam
+++ b/packages/caqti/caqti.0.9.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build}


### PR DESCRIPTION
Tests don't work from opam yet due to issues with internal dependencies.  The build-test stanzas will be reintroduced in the first caqti release following the next jbuilder release.

See also #11495 and thanks to @mseri and @jdpeplaix for noticing.