### PR TITLE
ppx_regexp: Add re < 1.7.2 constraints.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.2.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.2.0/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
 depends: [
   "jbuilder" {build}
   "ocaml-migrate-parsetree"
-  "re"
+  "re" {< "1.7.2~"}
   "ppx_tools" {build}
   "topkg-jbuilder" {build}
 ]

--- a/packages/ppx_regexp/ppx_regexp.0.3.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.0/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
 depends: [
   "jbuilder" {build}
   "ocaml-migrate-parsetree"
-  "re"
+  "re" {< "1.7.2~"}
   "ppx_metaquot" {build}
   "topkg-jbuilder" {build}
 ]

--- a/packages/ppx_regexp/ppx_regexp.0.3.1/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.1/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
 depends: [
   "jbuilder" {build}
   "ocaml-migrate-parsetree"
-  "re"
+  "re" {< "1.7.2~"}
   "ppx_tools_versioned" {build}
   "topkg-jbuilder" {build}
 ]


### PR DESCRIPTION
I need a separate PR to constrain past ppx_regexp releases in order to avoid breaking ppx_regexp builds when re.1.7.2 is merged, and to allow running CI for the upcoming release against the new re.  Optimally the merged order should be:

* This PR.
* #11502.
* #11507 after I rebase.
