### PR TITLE
Package interval.1.4

### DIFF
--- a/packages/interval/interval.1.4/descr
+++ b/packages/interval/interval.1.4/descr
@@ -1,0 +1,8 @@
+An interval library for OCaml
+
+This library uses assembly code to compute all operations with proper
+roundings, and currently ONLY works on intel processors.  It supports
+Linux, Windows and MacOs, with gcc and clang.
+
+More information is given in the paper presented in the OCaml meeting
+2012: http://www.alliot.fr/papers/oud2012.pdf

--- a/packages/interval/interval.1.4/opam
+++ b/packages/interval/interval.1.4/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0"
+tags: ["interval" "science"]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-doc: [[ "jbuilder" "build" "@doc"]]
+depends: [
+  "jbuilder" {build}
+]
+

--- a/packages/interval/interval.1.4/url
+++ b/packages/interval/interval.1.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-interval/releases/download/1.4/interval-1.4.tbz"
+checksum: "fe92e35e8a9cc693e250452f225f42ac"


### PR DESCRIPTION
### `interval.1.4`

An interval library for OCaml

This library uses assembly code to compute all operations with proper
roundings, and currently ONLY works on intel processors.  It supports
Linux, Windows and MacOs, with gcc and clang.

More information is given in the paper presented in the OCaml meeting
2012: http://www.alliot.fr/papers/oud2012.pdf



---
* Homepage: https://github.com/Chris00/ocaml-interval
* Source repo: https://github.com/Chris00/ocaml-interval.git
* Bug tracker: https://github.com/Chris00/ocaml-interval/issues

---


---
1.4 2018-03-01
--------------

- Improved interface for the `Interval` library by using sub-modules
  and standard mathematical names.  In particular, all operations —
  including infix operators — are in a sub-module `I` which can
  conveniently be used to introduce local scopes after issuing `open
  Interval`.

- Improved pretty-printing functions allowing to pass the format of
  the interval bounds.

- The library functions now signal errors by exceptions
  `Division_by_zero` and `Domain_error` that are *local* to
  `Interval`.

- The `Fpu` module has been redesigned: the rounding up or down of
  functions is controlled by the sub-module (`Low` or `High`) to which
  they belong.  This allows for natural expressions such as
  `Low.(x**2. +. 2. *. x +. 1.)`.

- Jbuilder/dune is used to compile and install the library.

- TravisCI and AppVeyor continuous integration ensure the library
  works on a variety of OCaml versions and platforms.
:camel: Pull-request generated by opam-publish v0.3.5