### PR TITLE
OCaml 4.06.0 support for delimcc

### DIFF
--- a/packages/delimcc/delimcc.2018.02.27/descr
+++ b/packages/delimcc/delimcc.2018.02.27/descr
@@ -1,0 +1,1 @@
+Oleg's delimited continuations library for byte-code and native OCaml

--- a/packages/delimcc/delimcc.2018.02.27/opam
+++ b/packages/delimcc/delimcc.2018.02.27/opam
@@ -10,4 +10,4 @@ build: [
 remove: [["ocamlfind" "remove" "delimcc"]]
 depends: ["ocamlfind"]
 install: [make "findlib-install"]
-available: [ ocaml-version >= "4.04.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.06.0"  ]

--- a/packages/delimcc/delimcc.2018.02.27/url
+++ b/packages/delimcc/delimcc.2018.02.27/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/zinid/delimcc/archive/2018.02.27.zip"
+checksum: "0aed318eca4839c2eb04642be2ea5853"


### PR DESCRIPTION
This is just a new version of delimcc package to support OCaml 4.06.0
The related issue is tracked at https://github.com/zinid/delimcc/issues/2