### PR TITLE
Package choice.0.3

### DIFF
--- a/packages/choice/choice.0.3/descr
+++ b/packages/choice/choice.0.3/descr
@@ -1,0 +1,6 @@
+Monadic combinators for enumerating alternatives.
+
+The library provides combinators to branch and test through
+alternatives, with fair strategies and restricted pruning of the search
+tree. It is written in a continuation-passing style, from the paper
+at http://www.cs.rutgers.edu/~ccshan/logicprog/LogicT-icfp2005.pdf .

--- a/packages/choice/choice.0.3/opam
+++ b/packages/choice/choice.0.3/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+homepage: "https://github.com/c-cube/choice/"
+bug-reports: "https://github.com/c-cube/choice/issues"
+dev-repo: "git://github.com/c-cube/choice"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]

--- a/packages/choice/choice.0.3/url
+++ b/packages/choice/choice.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/choice/archive/0.3.tar.gz"
+checksum: "022db6b3d1afc27e4bb76e049c852042"


### PR DESCRIPTION
### `choice.0.3`

Monadic combinators for enumerating alternatives.

The library provides combinators to branch and test through
alternatives, with fair strategies and restricted pruning of the search
tree. It is written in a continuation-passing style, from the paper
at http://www.cs.rutgers.edu/~ccshan/logicprog/LogicT-icfp2005.pdf .



---
* Homepage: https://github.com/c-cube/choice/
* Source repo: git://github.com/c-cube/choice
* Bug tracker: https://github.com/c-cube/choice/issues

---

:camel: Pull-request generated by opam-publish v0.3.5