### PR TITLE
Package calculon.0.2

### DIFF
--- a/packages/calculon/calculon.0.2/descr
+++ b/packages/calculon/calculon.0.2/descr
@@ -1,0 +1,5 @@
+Library for writing IRC bots in OCaml, a collection of plugins, and a dramatic robotic actor.
+
+The core library is called `calculon` and revolves around
+the concept of commands that react to user messages. See the README for a small
+tutorial on how to write your own plugins.

--- a/packages/calculon/calculon.0.2/opam
+++ b/packages/calculon/calculon.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+tags: ["irc" "bot" "factoids"]
+dev-repo: "https://github.com/c-cube/calculon.git"
+build: ["jbuilder" "build" "-p" name]
+build-test: ["jbuilder" "runtest"]
+build-doc: ["jbuilder" "build" "@doc"]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+  "result"
+  "lwt"
+  "irc-client" {>= "0.4.0"}
+  "tls"
+  "yojson"
+  "containers" {>= "1.0"}
+  "ISO8601"
+  "stringext"
+  "re"
+]
+depopts: [
+  "uri"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "atdgen"
+  "lambdasoup"
+  "sequence"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/calculon/calculon.0.2/opam
+++ b/packages/calculon/calculon.0.2/opam
@@ -6,8 +6,8 @@ bug-reports: "https://github.com/c-cube/calculon/issues"
 tags: ["irc" "bot" "factoids"]
 dev-repo: "https://github.com/c-cube/calculon.git"
 build: ["jbuilder" "build" "-p" name]
-build-test: ["jbuilder" "runtest"]
-build-doc: ["jbuilder" "build" "@doc"]
+build-test: ["jbuilder" "runtest" "-p" name]
+build-doc: ["jbuilder" "build" "@doc" "-p" name]
 depends: [
   "jbuilder" {build}
   "base-bytes"

--- a/packages/calculon/calculon.0.2/url
+++ b/packages/calculon/calculon.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/calculon/archive/0.2.tar.gz"
+checksum: "df6692d28d27ae6f87c773739b758fb8"


### PR DESCRIPTION
### `calculon.0.2`

Library for writing IRC bots in OCaml, a collection of plugins, and a dramatic robotic actor.

The core library is called `calculon` and revolves around
the concept of commands that react to user messages. See the README for a small
tutorial on how to write your own plugins.



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---

:camel: Pull-request generated by opam-publish v0.3.5