### PR TITLE
Package calculon-web.0.2

### DIFF
--- a/packages/calculon-web/calculon-web.0.2/descr
+++ b/packages/calculon-web/calculon-web.0.2/descr
@@ -1,0 +1,4 @@
+Web based plugins for calculon
+
+Collection of web-based plugins for [calculon](https://github.com/c-cube/calculon),
+including a giphy command, a youtube search, and others.

--- a/packages/calculon-web/calculon-web.0.2/opam
+++ b/packages/calculon-web/calculon-web.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+tags: ["irc" "bot" "factoids"]
+dev-repo: "https://github.com/c-cube/calculon.git"
+build: ["jbuilder" "build" "-p" name]
+build-test: ["jbuilder" "runtest" "-p" name]
+build-doc: ["jbuilder" "build" "@doc" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "calculon"
+  "re"
+  "uri"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "atdgen"
+  "lambdasoup"
+  "sequence"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/calculon-web/calculon-web.0.2/url
+++ b/packages/calculon-web/calculon-web.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/calculon/archive/0.2.tar.gz"
+checksum: "df6692d28d27ae6f87c773739b758fb8"

--- a/packages/calculon/calculon.0.1/opam
+++ b/packages/calculon/calculon.0.1/opam
@@ -30,7 +30,7 @@ depends: [
   "yojson"
   "containers" {>= "1.0" < "2.0"}
   "ISO8601"
-  "re"
+  "re" {< "1.7.2"}
   "stringext"
 ]
 depopts: [

--- a/packages/calculon/calculon.0.1/opam
+++ b/packages/calculon/calculon.0.1/opam
@@ -35,9 +35,12 @@ depends: [
 ]
 depopts: [
   "uri"
-  "cohttp" {< "1.0.0"}
+  "cohttp"
   "atdgen"
   "lambdasoup"
   "sequence"
+]
+conflicts: [
+  "cohttp" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/calculon/calculon.0.1/opam
+++ b/packages/calculon/calculon.0.1/opam
@@ -33,5 +33,11 @@ depends: [
   "re"
   "stringext"
 ]
-depopts: ["uri" "cohttp" "atdgen" "lambdasoup" "sequence"]
+depopts: [
+  "uri"
+  "cohttp" {< "1.0.0"}
+  "atdgen"
+  "lambdasoup"
+  "sequence"
+]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/calculon/calculon.0.1/opam
+++ b/packages/calculon/calculon.0.1/opam
@@ -30,7 +30,7 @@ depends: [
   "yojson"
   "containers" {>= "1.0" < "2.0"}
   "ISO8601"
-  "re" {< "1.7.2"}
+  "re" {>= "1.5.0" & < "1.7.2"}
   "stringext"
 ]
 depopts: [


### PR DESCRIPTION
### `calculon-web.0.2`

Web based plugins for calculon

Collection of web-based plugins for [calculon](https://github.com/c-cube/calculon),
including a giphy command, a youtube search, and others.



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---

:camel: Pull-request generated by opam-publish v0.3.5