### PR TITLE
Lwt 3.3.0, Lwt_ppx 1.1.0 – promises and concurrent I/O

### DIFF
--- a/packages/lwt/lwt.3.3.0/descr
+++ b/packages/lwt/lwt.3.3.0/descr
@@ -1,0 +1,10 @@
+Promises, concurrency, and parallelized I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.3.3.0/opam
+++ b/packages/lwt/lwt.3.3.0/opam
@@ -1,0 +1,64 @@
+opam-version: "1.2"
+version: "3.3.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%"
+                                    "-use-camlp4" "%{camlp4:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "ocaml" "src/util/install_filter.ml" ]
+]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "jbuilder" {build & >= "1.0+beta14"}
+  # We are only using ocamlfind during configuration of the Unix binding.
+  # However, ocamlfind also installs the "threads" package, and ocamlfind
+  # 1.7.3-1 is the first one whose threads package does not have incorrect error
+  # lines. See
+  #   https://github.com/ocaml/opam-repository/pull/11071#issuecomment-353131128
+  # If ocamlfind becomes no longer necessary for configuration of Lwt, this
+  # dependency should be converted to a conflict, and package jbuilder should be
+  # constrained such that it also includes the error lines fix.
+  "ocamlfind" {build & >= "1.7.3-1"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0.1"}
+  # result is needed as long as Lwt still supports OCaml 4.02.
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "camlp4"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+
+messages: [
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
+  "For the Camlp4 syntax, please install package lwt_camlp4"
+    {camlp4:installed & !lwt_camlp4:installed}
+  "For Lwt_log and Lwt_daemon, please install package lwt_log"
+    {!lwt_log:installed}
+]
+post-messages: [
+  "Lwt 4.0.0 will make some breaking changes in March 2018. See
+  https://github.com/ocsigen/lwt/issues/453"
+]

--- a/packages/lwt/lwt.3.3.0/url
+++ b/packages/lwt/lwt.3.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.3.0.tar.gz"
+checksum: "47bdf4b429da94419941ebe4354f505f"

--- a/packages/lwt_ppx/lwt_ppx.1.1.0/descr
+++ b/packages/lwt_ppx/lwt_ppx.1.1.0/descr
@@ -1,0 +1,1 @@
+PPX syntax for Lwt, providing something similar to async/await from JavaScript

--- a/packages/lwt_ppx/lwt_ppx.1.1.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+version: "1.1.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta12"}
+  "lwt"
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0.1"}
+]
+# The Lwt PPX uses the %reraise primitive, which is available on OCaml >= 4.02.
+# Even though OCaml PPX itself requires 4.02, we add this constraint for
+# thoroughness and safety.
+available: [ocaml-version >= "4.02.0"]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_ppx/lwt_ppx.1.1.0/url
+++ b/packages/lwt_ppx/lwt_ppx.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.3.0.tar.gz"
+checksum: "47bdf4b429da94419941ebe4354f505f"


### PR DESCRIPTION
Perhaps the main highlight of the release is that @gabelevi has restored stack trace generation in the PPX, which should be a big help to everyone.

[Full changelog](https://github.com/ocsigen/lwt/releases/tag/3.3.0):

> Bugs fixed
>
> - Restore backtrace support (ocsigen/lwt#554, ocsigen/lwt#556, Gabe Levi).
> - Serious logic error that could cause Lwt to hang or crash (ocsigen/lwt#549, reported @koen-struyve).
> - All `Lwt_list` functions are now tail-recursive (ocsigen/lwt#538, Joseph Thomas).
>
> Additions
>
> - Support `;%lwt` syntax in the PPX (ocsigen/lwt#307, Hezekiah Carty).
> - `Lwt_stream.iter_n` (ocsigen/lwt#312, Hezekiah Carty).
>
> Miscellaneous
>
> - Testing improvements (ocsigen/lwt#536, ocsigen/lwt#541, @cedlemo).
> - Documentation improvements (ocsigen/lwt#544, ocsigen/lwt#546, ocsigen/lwt#547, ocsigen/lwt#553, ocsigen/lwt#559, Daniil Baturin, Jason Evans, Jess Smith, Milo Turner).
