### PR TITLE
Add llvm.6.0.0

### DIFF
--- a/packages/conf-llvm/conf-llvm.6.0.0/descr
+++ b/packages/conf-llvm/conf-llvm.6.0.0/descr
@@ -1,0 +1,1 @@
+Virtual package relying on llvm library installation.

--- a/packages/conf-llvm/conf-llvm.6.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.6.0.0/files/configure.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+version=${1/%.?/}
+
+if hash brew 2>/dev/null; then
+    brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
+fi
+
+shopt -s nullglob
+for llvm_config in llvm-config-$version llvm-config${version//./} llvm-config-mp-$version $brew_llvm_config llvm-config; do
+    llvm_version="`$llvm_config --version`" || true
+    case $llvm_version in
+    $version*)
+        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "version: \"$llvm_version\"" >> conf-llvm.config
+        exit 0;;
+    *)
+        echo "Note: '$llvm_config' doesn't match the required version. Got '$llvm_version' but required '$version'."
+        continue;;
+    esac
+done
+
+echo "Error: LLVM ${version} is not installed."
+exit 1

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Jacques-Pascal Deplaix <jp.deplaix@gmail.com>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+license: "MIT"
+build: [
+  ["bash" "-ex" "configure.sh" version]
+]
+depexts: [
+  [["homebrew" "osx"] ["llvm@6"]]
+  [["macports" "osx"] ["llvm-6.0"]]
+  [["debian"] ["llvm-6.0-dev"]]
+  [["ubuntu"] ["llvm-6.0-dev"]]
+  [["alpine"] ["llvm6"]]
+  [["opensuse"] ["llvm6"]]
+  [["freebsd"] ["devel/llvm60"]]
+]

--- a/packages/llvm/llvm.6.0.0/descr
+++ b/packages/llvm/llvm.6.0.0/descr
@@ -1,0 +1,3 @@
+The OCaml bindings distributed with LLVM
+
+Note: LLVM should be installed first.

--- a/packages/llvm/llvm.6.0.0/files/META.patch
+++ b/packages/llvm/llvm.6.0.0/files/META.patch
@@ -1,0 +1,186 @@
+diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/bindings/ocaml/backends/META.llvm_backend.in
++++ b/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,8 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte, -llvm.static) = "shared/llvm_@TARGET@.cma"
++archive(native, -llvm.static) = "shared/llvm_@TARGET@.cmxa"
++archive(byte, llvm.static) = "static/llvm_@TARGET@.cma"
++archive(native, llvm.static) = "static/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+index adafd788ebf..0f54ae1e4b0 100644
+--- a/bindings/ocaml/llvm/META.llvm.in
++++ b/bindings/ocaml/llvm/META.llvm.in
+@@ -1,110 +1,138 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte, -llvm.static) = "shared/llvm.cma"
++archive(native, -llvm.static) = "shared/llvm.cmxa"
++archive(byte, llvm.static) = "static/llvm.cma"
++archive(native, llvm.static) = "static/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_analysis.cma"
++    archive(native, -llvm.static) = "shared/llvm_analysis.cmxa"
++    archive(byte, llvm.static) = "static/llvm_analysis.cma"
++    archive(native, llvm.static) = "static/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitreader.cma"
++    archive(native, llvm.static) = "static/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitwriter.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitwriter.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitwriter.cma"
++    archive(native, llvm.static) = "static/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_executionengine.cma"
++    archive(native, -llvm.static) = "shared/llvm_executionengine.cmxa"
++    archive(byte, llvm.static) = "static/llvm_executionengine.cma"
++    archive(native, llvm.static) = "static/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_ipo.cma"
++    archive(native, -llvm.static) = "shared/llvm_ipo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_ipo.cma"
++    archive(native, llvm.static) = "static/llvm_ipo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_irreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_irreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_irreader.cma"
++    archive(native, llvm.static) = "static/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_scalar_opts.cma"
++    archive(native, -llvm.static) = "shared/llvm_scalar_opts.cmxa"
++    archive(byte, llvm.static) = "static/llvm_scalar_opts.cma"
++    archive(native, llvm.static) = "static/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_transform_utils.cma"
++    archive(native, -llvm.static) = "shared/llvm_transform_utils.cmxa"
++    archive(byte, llvm.static) = "static/llvm_transform_utils.cma"
++    archive(native, llvm.static) = "static/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_vectorize.cma"
++    archive(native, -llvm.static) = "shared/llvm_vectorize.cmxa"
++    archive(byte, llvm.static) = "static/llvm_vectorize.cma"
++    archive(native, llvm.static) = "static/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_passmgr_builder.cma"
++    archive(native, -llvm.static) = "shared/llvm_passmgr_builder.cmxa"
++    archive(byte, llvm.static) = "static/llvm_passmgr_builder.cma"
++    archive(native, llvm.static) = "static/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_target.cma"
++    archive(native, -llvm.static) = "shared/llvm_target.cmxa"
++    archive(byte, llvm.static) = "static/llvm_target.cma"
++    archive(native, llvm.static) = "static/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_linker.cma"
++    archive(native, -llvm.static) = "shared/llvm_linker.cmxa"
++    archive(byte, llvm.static) = "static/llvm_linker.cma"
++    archive(native, llvm.static) = "static/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_all_backends.cma"
++    archive(native, -llvm.static) = "shared/llvm_all_backends.cmxa"
++    archive(byte, llvm.static) = "static/llvm_all_backends.cma"
++    archive(native, llvm.static) = "static/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.6.0.0/files/fix-shared.patch
+++ b/packages/llvm/llvm.6.0.0/files/fix-shared.patch
@@ -1,0 +1,25 @@
+diff --git a/cmake/modules/AddOCaml.cmake b/cmake/modules/AddOCaml.cmake
+index 1d8094cc505..ab4b72edc02 100644
+--- a/cmake/modules/AddOCaml.cmake
++++ b/cmake/modules/AddOCaml.cmake
+@@ -67,9 +67,17 @@ function(add_ocaml_library name)
+   endif()
+ 
+   explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+-  foreach( llvm_lib ${llvm_libs} )
+-    list(APPEND ocaml_flags "-l${llvm_lib}" )
+-  endforeach()
++  if( BUILD_SHARED_LIBS )
++    list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}${LLVM_VERSION_SUFFIX}")
++  else()
++    foreach( llvm_lib ${llvm_libs} )
++      list(APPEND ocaml_flags "-l${llvm_lib}" )
++    endforeach()
++  endif()
++
++  if(LLVM_OCAML_OUT_OF_TREE)
++    list(APPEND ocaml_flags "-ccopt" "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
++  endif()
+ 
+   get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+   foreach(system_lib ${system_libs})

--- a/packages/llvm/llvm.6.0.0/files/install.sh
+++ b/packages/llvm/llvm.6.0.0/files/install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+
+llvm_config="$1"
+libdir="$2"
+cmake="$3"
+make="$4"
+
+function filter_experimental_targets {
+    sed 's/AVR//g' | sed 's/Nios2//g' | sed 's/WebAssembly//g' | xargs
+}
+
+function llvm_install {
+    mkdir build
+    cd build
+
+    "$cmake" \
+        -DCMAKE_BUILD_TYPE="`"$llvm_config" --build-mode`" \
+        -DLLVM_TARGETS_TO_BUILD="`"$llvm_config" --targets-built | filter_experimental_targets | sed 's/ /;/g'`" \
+        -DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR="`"$llvm_config" --libdir`" \
+        -DBUILD_SHARED_LIBS=`[ $1 = "shared" ] && echo TRUE || echo FALSE` \
+        -DLLVM_OCAML_OUT_OF_TREE=TRUE \
+        -DLLVM_OCAML_INSTALL_PATH="${libdir}" \
+        ..
+    $make ocaml_all
+    "$cmake" -P bindings/ocaml/cmake_install.cmake
+
+    mkdir "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cma "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cmxa "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/llvm*.a "${libdir}"/llvm/$1
+
+    cd ..
+    rm -rf build
+}
+
+if "$llvm_config" --link-static --libs && "$llvm_config" --link-shared --libs; then
+    patch -p1 < META.patch
+    llvm_install static
+    llvm_install shared
+elif "$llvm_config" --link-static --libs; then
+    sed "s,%%LINKAGE%%,static," link-META.patch | patch -p1
+    llvm_install static
+elif "$llvm_config" --link-shared --libs; then
+    sed "s,%%LINKAGE%%,shared," link-META.patch | patch -p1
+    llvm_install shared
+else
+    echo "WTF..."
+    exit 1
+fi

--- a/packages/llvm/llvm.6.0.0/files/link-META.patch
+++ b/packages/llvm/llvm.6.0.0/files/link-META.patch
@@ -1,0 +1,156 @@
+diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/bindings/ocaml/backends/META.llvm_backend.in
++++ b/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,6 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm_@TARGET@.cma"
++archive(native) = "%%LINKAGE%%/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+index adafd788ebf..01ff313e426 100644
+--- a/bindings/ocaml/llvm/META.llvm.in
++++ b/bindings/ocaml/llvm/META.llvm.in
+@@ -1,110 +1,110 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm.cma"
++archive(native) = "%%LINKAGE%%/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_analysis.cma"
++    archive(native) = "%%LINKAGE%%/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitwriter.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_executionengine.cma"
++    archive(native) = "%%LINKAGE%%/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_ipo.cma"
++    archive(native) = "%%LINKAGE%%/llvm_ipo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_irreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_scalar_opts.cma"
++    archive(native) = "%%LINKAGE%%/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_transform_utils.cma"
++    archive(native) = "%%LINKAGE%%/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_vectorize.cma"
++    archive(native) = "%%LINKAGE%%/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_passmgr_builder.cma"
++    archive(native) = "%%LINKAGE%%/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_target.cma"
++    archive(native) = "%%LINKAGE%%/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_linker.cma"
++    archive(native) = "%%LINKAGE%%/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_all_backends.cma"
++    archive(native) = "%%LINKAGE%%/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.6.0.0/opam
+++ b/packages/llvm/llvm.6.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "Jacques-Pascal Deplaix <jp.deplaix@gmail.com>"
+authors: [
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "MIT"
+doc: "http://llvm.moe/ocaml-6.0"
+bug-reports: "http://llvm.org/bugs/"
+dev-repo: "http://llvm.org/git/llvm.git"
+homepage: "http://llvm.moe"
+install: [
+  ["bash" "-ex" "install.sh" "%{conf-llvm:config}%" lib "%{conf-cmake:cmd}%" make]
+]
+remove: [
+  ["rm" "-rf" "%{lib}%/llvm"]
+  ["sh" "-c" "rm -f %{lib}%/META.llvm*"]
+  ["sh" "-c" "rm -f %{stublibs}%/dllllvm*.so"]
+]
+depends: [
+  "ctypes" {>= "0.4"}
+  "ounit" {test}
+  "ocamlfind" {build}
+  "conf-llvm" {build & = "6.0.0"}
+  "conf-python-2-7" {build}
+  "conf-cmake" {build}
+]
+patches: [
+  "fix-shared.patch"
+]
+available: [ocaml-version >= "4.00.0"]

--- a/packages/llvm/llvm.6.0.0/url
+++ b/packages/llvm/llvm.6.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://releases.llvm.org/6.0.0/llvm-6.0.0.src.tar.xz"
+checksum: "788a11a35fa62eb008019b37187d09d2"


### PR DESCRIPTION
CI will fail (llvm 6.0 is not available in debian stable as usual). I tried to fix the ARM64 CI to use Debian Sid by default but the ```ocaml/opam2:debian-unstable-ocaml-4.0x.y``` docker images are not available on ARM64.

@avsm could you take care of that or tell me if I can do it ?