### PR TITLE
Fix ipaddr.2.7.x

### DIFF
--- a/packages/ipaddr/ipaddr.2.7.0/opam
+++ b/packages/ipaddr/ipaddr.2.7.0/opam
@@ -34,7 +34,7 @@ depends: [
   "base-bytes"
   "sexplib"
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.10.0"}
   "ounit" {test}
 ]
 available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.04.0" ]

--- a/packages/ipaddr/ipaddr.2.7.1/opam
+++ b/packages/ipaddr/ipaddr.2.7.1/opam
@@ -31,7 +31,7 @@ depends: [
   "base-bytes"
   "sexplib"
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.10.0"}
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]

--- a/packages/ipaddr/ipaddr.2.7.2/opam
+++ b/packages/ipaddr/ipaddr.2.7.2/opam
@@ -31,7 +31,7 @@ depends: [
   "base-bytes"
   "sexplib"
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.10.0"}
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]


### PR DESCRIPTION
I have no clue what the error is but I'm just guessing the fix from the type of error.
```
#=== ERROR while compiling ipaddr.2.7.2 =======================================#
# context              2.0.0~rc | linux/x86_64 | ocaml-base-compiler.4.05.0 | git+file:///home/opam/opam-repository
# path                 ~/.opam/4.05.0/.opam-switch/build/ipaddr.2.7.2
# command              ~/.opam/4.05.0/bin/ocaml pkg/pkg.ml build --pinned false --with-base-unix true
# exit-code            1
# env-file             ~/.opam/log/ipaddr-16-2ed7fd.env
# output-file          ~/.opam/log/ipaddr-16-2ed7fd.out
### output ###
# ocamlfind ocamldep -package 'bytes sexplib ppx_sexp_conv' -modules lib/ipaddr.ml > lib/ipaddr.ml.depends
# + ocamlfind ocamldep -package 'bytes sexplib ppx_sexp_conv' -modules lib/ipaddr.ml > lib/ipaddr.ml.depends
# File "lib/ipaddr.ml", line 30, characters 12-16:
# Error: Cannot locate deriver sexp
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'lib/ipaddr.a' 'lib/ipaddr.cmxs' 'lib/ipaddr.cmxa'
#      'lib/ipaddr.cma' 'lib/macaddr.cmx' 'lib/macaddr.cmi' 'lib/macaddr.mli'
#      'lib/ipaddr.cmx' 'lib/ipaddr.cmi' 'lib/ipaddr.mli' 'lib/ipaddr_unix.a'
#      'lib/ipaddr_unix.cmxs' 'lib/ipaddr_unix.cmxa' 'lib/ipaddr_unix.cma'
#      'lib/ipaddr_unix.cmx' 'lib/ipaddr_unix.cmi' 'lib/ipaddr_unix.mli'
#      'top/ipaddr_top.a' 'top/ipaddr_top.cmxs' 'top/ipaddr_top.cmxa'
#      'top/ipaddr_top.cma' 'top/ipaddr_top.cmx' 'top/ipaddr_top.cmi'
#      'top/ipaddr_top.mli']: exited with 10
```
Does this seems right to you ? @hannesm @djs55 @trefis 