### PR TITLE
camlp4 patches missing in 2.0.0 branch

### DIFF
--- a/packages/camlp4/camlp4.4.02+1/opam
+++ b/packages/camlp4/camlp4.4.02+1/opam
@@ -49,6 +49,7 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
+patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+2/opam
+++ b/packages/camlp4/camlp4.4.02+2/opam
@@ -49,6 +49,7 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
+patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+3/opam
+++ b/packages/camlp4/camlp4.4.02+3/opam
@@ -49,6 +49,7 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
+patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+4/opam
+++ b/packages/camlp4/camlp4.4.02+4/opam
@@ -49,6 +49,7 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
+patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+6/opam
+++ b/packages/camlp4/camlp4.4.02+6/opam
@@ -48,6 +48,7 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
+patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+7/opam
+++ b/packages/camlp4/camlp4.4.02+7/opam
@@ -30,7 +30,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:

--- a/packages/camlp4/camlp4.4.03+1/opam
+++ b/packages/camlp4/camlp4.4.03+1/opam
@@ -30,7 +30,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:

--- a/packages/camlp4/camlp4.4.04+1/opam
+++ b/packages/camlp4/camlp4.4.04+1/opam
@@ -30,7 +30,7 @@ remove: [
              "%{bin}%/camlp4prof"]
 ]
 
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:

--- a/packages/camlp4/camlp4.4.05+1/opam
+++ b/packages/camlp4/camlp4.4.05+1/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 patches: [
   "safe-string.patch"
+  "f0ea53725465260556832398096cef8d3f20b49d.patch"
 ]
 build: [
   [

--- a/packages/camlp4/camlp4.4.06+1/opam
+++ b/packages/camlp4/camlp4.4.06+1/opam
@@ -45,6 +45,7 @@ Since then it has been replaced by a simpler system which is easier to maintain
 and to learn: ppx rewriters and extension points."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
+patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=4e15b0fb960be4be48b154bfafbb9a16"


### PR DESCRIPTION
#11331 added the missing `extra-files` from #11199, but didn't add them to the `patches` list which is done here.

/cc @AltGr in case there's anything relevant about that to Camulus.

This is worth merging before #11545, just to torture the Camelus rewrite code a bit.
