### PR TITLE
Patch base.v0.9.3 to work with MetaOCaml

### DIFF
--- a/packages/base/base.v0.9.3/files/metaocaml.patch
+++ b/packages/base/base.v0.9.3/files/metaocaml.patch
@@ -1,0 +1,13 @@
+diff --git a/src/import0.ml b/src/import0.ml
+index 18d8a5c..bae0904 100644
+--- a/src/import0.ml
++++ b/src/import0.ml
+@@ -193,7 +193,7 @@ include Int_replace_polymorphic_compare
+ let ( <.  ) (x : float) y = Poly.( <  ) x y
+ let ( <=. ) (x : float) y = Poly.( <= ) x y
+ let ( =.  ) (x : float) y = Poly.( =  ) x y
+-let ( >.  ) (x : float) y = Poly.( >  ) x y
++let ( >:  ) (x : float) y = Poly.( >  ) x y
+ let ( >=. ) (x : float) y = Poly.( >= ) x y
+ 
+ (* This needs to be defined as an external so that the compiler can specialize it as a

--- a/packages/base/base.v0.9.3/opam
+++ b/packages/base/base.v0.9.3/opam
@@ -11,4 +11,5 @@ depends: [
   "sexplib" {>= "v0.9.1" & < "v0.10"}
 ]
 depopts: "base-native-int63"
+patches: ["metaocaml.patch" {compiler = "4.04.0+BER"}]
 available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
The character sequence `>.`, which base uses for float comparison, is reserved syntax for MetaOCaml.  This tiny patch makes it possible to build `base.v0.9.3` (and the large number of packages that depend on it) with MetaOCaml ([4.04.0+BER](https://github.com/ocaml/opam-repository/tree/master/compilers/4.04.0/4.04.0+BER)).