### PR TITLE
Package jbuilder.1.0+beta19

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta19/descr
+++ b/packages/jbuilder/jbuilder.1.0+beta19/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+jbuilder is a build system that was designed to simplify the release
+of Jane Street packages. It reads metadata from "jbuild" files
+following a very simple s-expression syntax.
+
+jbuilder is fast, it has very low-overhead and support parallel builds
+on all platforms. It has no system dependencies, all you need to build
+jbuilder and packages using jbuilder is OCaml. You don't need or make
+or bash as long as the packages themselves don't use bash explicitely.
+
+jbuilder supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/jbuilder/jbuilder.1.0+beta19/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta19/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "Apache-2.0"
+build: [
+  ["ocaml" "configure.ml" "--libdir" lib]
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--subst"] {pinned}
+  ["./boot.exe" "-j" jobs]
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/jbuilder/jbuilder.1.0+beta19/url
+++ b/packages/jbuilder/jbuilder.1.0+beta19/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dune/releases/download/1.0+beta19/jbuilder-1.0.beta19.tbz"
+checksum: "9b70f0067a460dec936a8f94ad5e4d9a"


### PR DESCRIPTION
### `jbuilder.1.0+beta19`

Fast, portable and opinionated build system

jbuilder is a build system that was designed to simplify the release
of Jane Street packages. It reads metadata from "jbuild" files
following a very simple s-expression syntax.

jbuilder is fast, it has very low-overhead and support parallel builds
on all platforms. It has no system dependencies, all you need to build
jbuilder and packages using jbuilder is OCaml. You don't need or make
or bash as long as the packages themselves don't use bash explicitely.

jbuilder supports multi-package development by simply dropping multiple
repositories into the same directory.

It also supports multi-context builds, such as building against
several opam roots/switches simultaneously. This helps maintaining
packages across several versions of OCaml and gives cross-compilation
for free.



---
* Homepage: https://github.com/ocaml/dune
* Source repo: https://github.com/ocaml/dune.git
* Bug tracker: https://github.com/ocaml/dune/issues

---


---
1.0+beta19 (14/03/2018)
-----------------------

- Ignore errors during the generation of the .merlin (#569, fixes #568 and #51)

- Add a workaround for when a library normally installed by the
  compiler is not installed but still has a META file (#574, fixes
  #563)

- Do not depend on ocamlfind. Instead, hard-code the library path when
  installing from opam (#575)

- Change the default behavior regarding the check for overlaps between
  local and installed libraries. Now even if there is no link time
  conflict, we don't allow an external dependency to overlap with a
  local library, unless the user specifies `allow_overlapping_dependencies`
  in the jbuild file (#587, fixes #562)

- Expose a few more variables in jbuild files: `ext_obj`, `ext_asm`,
  `ext_lib`, `ext_dll` and `ext_exe` as well as `${ocaml-config:XXX}`
  for most variables in the output of `ocamlc -config` (#590)

- Add support for inline and inline expectation tests. The system is
  generic and should support several inline test systems such as
  `ppx_inline_test`, `ppx_expect` or `qtest` (#547)

- Make sure modules in the current directory always have precedence
  over included directories (#597)

- Add support for building executables as object or shared object
  files (#23)

- Add a `best` mode which is native with fallback to byte-code when
  native compilation is not available (#23)

- Fix locations reported in error messages (#609)

- Report error when a public library has a private dependency. Previously, this
  would be silently ignored and install broken artifacts (#607).

- Fix display when output is not a tty (#518)

- Add a `(universe)` special dependency to specify that an action
  depend on everything in the universe. Jbuilder cannot cache the
  result of an action that depend on the universe (#603, fixes #255)
:camel: Pull-request generated by opam-publish v0.3.5