### PR TITLE
Package obandit.0.3-2-g16ba7ac

### DIFF
--- a/packages/obandit/obandit.0.3-2-g16ba7ac/descr
+++ b/packages/obandit/obandit.0.3-2-g16ba7ac/descr
@@ -1,0 +1,10 @@
+Ocaml Multi-Armed Bandits
+
+![release](https://img.shields.io/github/release/freuk/obandit.svg)
+![downloads](https://img.shields.io/github/downloads/freuk/obandit/latest/total.svg)
+![web](https://img.shields.io/website-up-down-green-red/http/freux.fr.svg)
+
+Obandit is an OCaml module for basic multi-armed bandits. It supports the
+EXP3, UCB1 and Epsilon-greedy algorithms.
+
+Obandit is distributed under the ISC license.

--- a/packages/obandit/obandit.0.3-2-g16ba7ac/opam
+++ b/packages/obandit/obandit.0.3-2-g16ba7ac/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Valentin Reis <fre@freux.fr>"
+authors: ["Valentin Reis <fre@freux.fr>"]
+homepage: "https://freuk.github.io/obandit/"
+doc: "https://freuk.github.io/obandit/api.docdir"
+license: "ISC"
+dev-repo: "https://github.com/freuk/obandit.git"
+bug-reports: "https://github.com/freuk/obandit/issues"
+tags: []
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cmdliner"
+  "batteries" ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%" ]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]]

--- a/packages/obandit/obandit.0.3-2-g16ba7ac/url
+++ b/packages/obandit/obandit.0.3-2-g16ba7ac/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/freuk/obandit/releases/download/v0.3-2-g16ba7ac/obandit-0.3-2-g16ba7ac.tbz"
+checksum: "0204b793605033591606dac622440794"


### PR DESCRIPTION
### `obandit.0.3-2-g16ba7ac`

Ocaml Multi-Armed Bandits

![release](https://img.shields.io/github/release/freuk/obandit.svg)
![downloads](https://img.shields.io/github/downloads/freuk/obandit/latest/total.svg)
![web](https://img.shields.io/website-up-down-green-red/http/freux.fr.svg)

Obandit is an OCaml module for basic multi-armed bandits. It supports the
EXP3, UCB1 and Epsilon-greedy algorithms.

Obandit is distributed under the ISC license.



---
* Homepage: https://freuk.github.io/obandit/
* Source repo: https://github.com/freuk/obandit.git
* Bug tracker: https://github.com/freuk/obandit/issues

---


---
v0.3 2018-03-14 Grenoble
--------------------------

* bugfix in exp3 reward ranges
* added cli interface
* added validation suite
:camel: Pull-request generated by opam-publish v0.3.5