### PR TITLE
netchannel.1.8.0: require shared-memory-ring >= 3.0.0 for Ring.Rpc.of…

### DIFF
--- a/packages/netchannel/netchannel.1.8.0/opam
+++ b/packages/netchannel/netchannel.1.8.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0"}
   "mirage-profile" {>="0.3"}
-  "shared-memory-ring" {>="1.1.1"}
+  "shared-memory-ring" {>="3.0.0"}
   "sexplib" {>= "113.01.00"}
   "result"
   "logs" {>= "0.5.0"}


### PR DESCRIPTION
…_buf_no_init

discovered in https://ci.ocamllabs.io/log/saved/docker-run-abe87000db602c649dfdaf84c7d49f4d/032035818aac9f7c0c83dbaca3b2556d6e13ac92 via #11575

reported upstream as https://github.com/mirage/mirage-net-xen/pull/75