### PR TITLE
Ppx_driver v0.10.3, Ppx_inline_test v0.10.1, Ppx_expect v0.10.1

### DIFF
--- a/packages/mlt_parser/mlt_parser.v0.10.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.10.0/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "core_kernel"             {>= "v0.10" & < "v0.11"}
   "ppx_driver"              {>= "v0.10" & < "v0.11"}
-  "ppx_expect"              {>= "v0.10" & < "v0.11"}
+  "ppx_expect"              {= "v0.10.0"}
   "ppx_jane"                {>= "v0.10" & < "v0.11"}
   "jbuilder"                {build & >= "1.0+beta12"}
   "ocaml-migrate-parsetree" {>= "0.4"}

--- a/packages/ppx_driver/ppx_driver.v0.10.3/descr
+++ b/packages/ppx_driver/ppx_driver.v0.10.3/descr
@@ -1,0 +1,3 @@
+Feature-full driver for OCaml AST transformers
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_driver/ppx_driver.v0.10.3/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_driver"
+bug-reports: "https://github.com/janestreet/ppx_driver/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_driver.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ppx_core"                {>= "v0.10" & < "v0.11"}
+  "ppx_optcomp"             {>= "v0.10" & < "v0.11"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-migrate-parsetree" {>= "1.0.8"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_driver/ppx_driver.v0.10.3/url
+++ b/packages/ppx_driver/ppx_driver.v0.10.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/ppx_driver/archive/v0.10.3.tar.gz"
+checksum: "f1c47250f6831fda1791403e4f02613a"

--- a/packages/ppx_expect/ppx_expect.v0.10.1/descr
+++ b/packages/ppx_expect/ppx_expect.v0.10.1/descr
@@ -1,0 +1,3 @@
+Cram like framework for OCaml
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_expect/ppx_expect.v0.10.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.10.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.10" & < "v0.11"}
+  "ppx_assert"              {>= "v0.10" & < "v0.11"}
+  "ppx_compare"             {>= "v0.10" & < "v0.11"}
+  "ppx_core"                {>= "v0.10" & < "v0.11"}
+  "ppx_custom_printf"       {>= "v0.10" & < "v0.11"}
+  "ppx_driver"              {>= "v0.10.3" & < "v0.11"}
+  "ppx_fields_conv"         {>= "v0.10" & < "v0.11"}
+  "ppx_here"                {>= "v0.10" & < "v0.11"}
+  "ppx_inline_test"         {>= "v0.10.1" & < "v0.11"}
+  "ppx_metaquot"            {>= "v0.10" & < "v0.11"}
+  "ppx_sexp_conv"           {>= "v0.10" & < "v0.11"}
+  "ppx_traverse"            {>= "v0.10" & < "v0.11"}
+  "ppx_variants_conv"       {>= "v0.10" & < "v0.11"}
+  "stdio"                   {>= "v0.10" & < "v0.11"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+  "re"                      {>= "1.5.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_expect/ppx_expect.v0.10.1/url
+++ b/packages/ppx_expect/ppx_expect.v0.10.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/ppx_expect/archive/v0.10.1.tar.gz"
+checksum: "b8f3f98831258cfc4f3c0c62b1dcb78e"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.10.1/descr
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.10.1/descr
@@ -1,0 +1,3 @@
+Syntax extension for writing in-line tests in ocaml code
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_inline_test/ppx_inline_test.v0.10.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.10.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.10" & < "v0.11"}
+  "ppx_core"                {>= "v0.10" & < "v0.11"}
+  "ppx_driver"              {>= "v0.10.3" & < "v0.11"}
+  "ppx_metaquot"            {>= "v0.10" & < "v0.11"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_inline_test/ppx_inline_test.v0.10.1/url
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.10.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/janestreet/ppx_inline_test/archive/v0.10.1.tar.gz"
+checksum: "c8d58bd57cb4d8f31dd037c7626c04bd"


### PR DESCRIPTION
Minor release of a few ppx packages to integrate with the new inline tests support of jbuilder 1.0+beta19.