### PR TITLE
Package ocaml-migrate-parsetree.1.0.8

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta18.1"}
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/url
@@ -1,0 +1,2 @@
+archive: "http://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.0.8/ocaml-migrate-parsetree-1.0.8.tbz"
+checksum: "8efae9d741d9e12f72b06f5bc825e042"


### PR DESCRIPTION
### `ocaml-migrate-parsetree.1.0.8`

Convert OCaml parsetrees between different versions 

This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
High-level functions help making PPX rewriters independent of a compiler version.



---
* Homepage: https://github.com/ocaml-ppx/ocaml-migrate-parsetree
* Source repo: git://github.com/ocaml-ppx/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues

---


---
v1.0.8 2018-03-15 London
------------------------

- Add a `--null` argument to suppress the output. This is used to
  write linters
- Use the new generic ppx driver support of jbuilder
:camel: Pull-request generated by opam-publish v0.3.5