### PR TITLE
mirage-block-lwt, mirage-channel-lwt, mirage-clock-lwt, mirage-console-lwt, mirage-flow-lwt, mirage-fs-lwt, mirage-kv-lwt, mirage-stack-lwt, mirage-time-lwt

### DIFF
--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "io-page"
   "lwt"
   "logs"
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {= "1.0.0"}
   "result"
 ]
 

--- a/packages/mirage-channel-lwt/mirage-channel-lwt.3.0.0/opam
+++ b/packages/mirage-channel-lwt/mirage-channel-lwt.3.0.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build & >= "0.8.0"}
-  "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-flow-lwt" {= "1.2.0"}
+  "mirage-channel" {= "3.0.0"}
   "io-page"
   "result"
   "lwt" {>= "2.4.7"}

--- a/packages/mirage-clock-lwt/mirage-clock-lwt.1.2.0/opam
+++ b/packages/mirage-clock-lwt/mirage-clock-lwt.1.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build & >= "0.8.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {= "1.2.0"}
   "lwt"
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.2.0/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-console" {= "2.2.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
@@ -19,6 +19,6 @@ depends: [
   "lwt"
   "cstruct" {>= "2.0.0"}
   "cstruct-lwt"
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-clock" {= "1.2.0"}
+  "mirage-flow" {= "1.2.0"}
 ]

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.0.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.0.0/opam
@@ -14,8 +14,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-fs" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-fs" {= "1.0.0"}
+  "mirage-kv-lwt" {= "1.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-kv-lwt/mirage-kv-lwt.1.0.0/opam
+++ b/packages/mirage-kv-lwt/mirage-kv-lwt.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {= "1.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.0.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-stack" {>= "1.0.0"}
+  "mirage-stack" {= "1.0.0"}
   "ipaddr"
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/mirage-time-lwt/mirage-time-lwt.1.0.0/opam
+++ b/packages/mirage-time-lwt/mirage-time-lwt.1.0.0/opam
@@ -17,6 +17,6 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-time" {= "1.0.0"}
   "lwt"
 ]


### PR DESCRIPTION
depend topkg'ed lwt libs to topkg'ed non-lwt libs (see #11490)

see #11579 for CI failures which should be fixed after this PR