### PR TITLE
mirage-protocols: restrict to newer mirage-device and mirage-flow

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.1.3.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.3.0/opam
@@ -15,8 +15,8 @@ build: [
 
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "mirage-device"
-  "mirage-flow"
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
   "fmt"
   "duration"
 ]


### PR DESCRIPTION
mirage-protocols `<=1.2.0` already have these constraints, missing in 1.3.0... also reported upstream to mirage-protocols repository https://github.com/mirage/mirage-protocols/pull/10