### PR TITLE
Package re.1.7.3

### DIFF
--- a/packages/re/re.1.7.3/descr
+++ b/packages/re/re.1.7.3/descr
@@ -1,0 +1,8 @@
+RE is a regular expression library for OCaml
+
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)

--- a/packages/re/re.1.7.3/opam
+++ b/packages/re/re.1.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+
+maintainer: "rudi.grinberg@gmail.com"
+authors: [
+  "Jerome Vouillon"
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Rudi Grinberg"
+  "Gabriel Radanne"
+]
+license: "LGPL-2.0 with OCaml linking exception"
+homepage: "https://github.com/ocaml/ocaml-re"
+bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+dev-repo: "https://github.com/ocaml/ocaml-re.git"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "ounit" {test}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/re/re.1.7.3/url
+++ b/packages/re/re.1.7.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/ocaml-re/releases/download/1.7.3/re-1.7.3.tbz"
+checksum: "d2a74ca77216861bce4449600a132de9"


### PR DESCRIPTION
### `re.1.7.3`

RE is a regular expression library for OCaml

Pure OCaml regular expressions with:
* Perl-style regular expressions (module Re.Perl)
* Posix extended regular expressions (module Re.Posix)
* Emacs-style regular expressions (module Re.Emacs)
* Shell-style file globbing (module Re.Glob)
* Compatibility layer for OCaml's built-in Str module (module Re.Str)



---
* Homepage: https://github.com/ocaml/ocaml-re
* Source repo: https://github.com/ocaml/ocaml-re.git
* Bug tracker: https://github.com/ocaml/ocaml-re/issues

---


---
1.7.3 (05-Mar-2018)
-------------------

* Remove dependency on bytes package (#155)
:camel: Pull-request generated by opam-publish v0.3.5