### PR TITLE
Package mock.0.1.0

### DIFF
--- a/packages/mock/mock.0.1.0/descr
+++ b/packages/mock/mock.0.1.0/descr
@@ -1,0 +1,14 @@
+Configurable functions to test impure code
+
+This package provides "mocks", fake functions that can be configured to return
+values or raise exception. It is possible to inspect their arguments after their
+execution. The API is greatly inspired by [unittest.mock] in Python.
+
+There is no magic under the hood, it is "just" a reference to a function, but
+it makes it possible to have pleasant output like this in your tests:
+
+> expected f to be called once, but it was called 3 times
+
+A wrapper for `OUnit2` is available as `mock-ounit`.
+
+[unittest.mock]: https://docs.python.org/3/library/unittest.mock.html

--- a/packages/mock/mock.0.1.0/opam
+++ b/packages/mock/mock.0.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/ocaml-mock"
+bug-reports: "https://github.com/cryptosense/ocaml-mock/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/ocaml-mock.git"
+doc: "https://cryptosense.github.io/ocaml-mock/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+]

--- a/packages/mock/mock.0.1.0/url
+++ b/packages/mock/mock.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/ocaml-mock/releases/download/v0.1.0/mock-0.1.0.tbz"
+checksum: "f5a6529d2df5aa1789846c902028cd1c"


### PR DESCRIPTION
### `mock.0.1.0`

Configurable functions to test impure code

This package provides "mocks", fake functions that can be configured to return
values or raise exception. It is possible to inspect their arguments after their
execution. The API is greatly inspired by [unittest.mock] in Python.

There is no magic under the hood, it is "just" a reference to a function, but
it makes it possible to have pleasant output like this in your tests:

> expected f to be called once, but it was called 3 times

A wrapper for `OUnit2` is available as `mock-ounit`.

[unittest.mock]: https://docs.python.org/3/library/unittest.mock.html


---
* Homepage: https://github.com/cryptosense/ocaml-mock
* Source repo: https://github.com/cryptosense/ocaml-mock.git
* Bug tracker: https://github.com/cryptosense/ocaml-mock/issues

---


---
v0.1.0
======

Initial release.
:camel: Pull-request generated by opam-publish v0.3.5