### PR TITLE
BetterErrors.0.0.1: Add a dependency on ocamlbuild

### DIFF
--- a/packages/BetterErrors/BetterErrors.0.0.1/opam
+++ b/packages/BetterErrors/BetterErrors.0.0.1/opam
@@ -14,6 +14,7 @@ build: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ANSITerminal" {>= "0.6.5"}
   "re" {>= "1.5.0"}
 ]


### PR DESCRIPTION
Build log: https://ci.ocamllabs.io/log/saved/docker-run-17f0f424aa457bcb94af6ca992340b72/4c9281d262e4d116863bac7d03e7cca57c949a9b