### PR TITLE
added packages/conf-r-mathlib/conf-r-mathlib.1

### DIFF
--- a/packages/conf-r-mathlib/conf-r-mathlib.1/descr
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on a system installation of R Standalone Mathlib
+This package can only install if R Standalone Mathlib is installed on the system.

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Philippe Veber <philippe.veber@gmail.com>"
+author: "https://www.r-project.org/contributors.html"
+homepage: "https://www.r-project.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+license: "GPL"
+build: [["pkg-config" "libRmath"]]
+depends: ["conf-pkg-config"]
+depexts: [
+  [["debian"] ["r-mathlib"]]
+  [["mageia"] ["libRmath-devel"]]
+  [["ubuntu"] ["r-mathlib"]]
+  [["centos"] ["libRmath-devel"]]
+  [["fedora"] ["libRmath-devel"]]
+  [["rhel"] ["libRmath-devel"]]
+  [["alpine"] ["R-mathlib"]]
+  [["opensuse"] ["R-base"]]
+  [["freebsd"] ["libRmath"]]
+  [["osx" "homebrew"] ["r"]]
+  [["archlinux"] ["r"]]
+]


### PR DESCRIPTION
R comes generally in two components: the actual R interpreter and libraries (handled in #11455), and a standalone math library, which is the focus of this conf package. Note that in some distributions the two components come in a single package, but when there are two packages, you can install one without the other, hence the present PR.
