### PR TITLE
Publish compatibility version of deprecated ppx packages

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.11.0/descr
+++ b/packages/ppx_ast/ppx_ast.v0.11.0/descr
@@ -1,0 +1,1 @@
+Deprecated: use ppxlib instead

--- a/packages/ppx_ast/ppx_ast.v0.11.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.11.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_ast"
+bug-reports: "https://github.com/janestreet/ppx_ast/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_ast.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta18.1"}
+  "ppxlib"   {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_ast/ppx_ast.v0.11.0/url
+++ b/packages/ppx_ast/ppx_ast.v0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ppx_ast-v0.11.0.tar.gz"
+checksum: "d2760af0ea438cf0fc75d106a27fef80"

--- a/packages/ppx_core/ppx_core.v0.11.0/descr
+++ b/packages/ppx_core/ppx_core.v0.11.0/descr
@@ -1,0 +1,1 @@
+Deprecated: use ppxlib instead

--- a/packages/ppx_core/ppx_core.v0.11.0/opam
+++ b/packages/ppx_core/ppx_core.v0.11.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_core"
+bug-reports: "https://github.com/janestreet/ppx_core/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_core.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta18.1"}
+  "ppxlib"   {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_core/ppx_core.v0.11.0/url
+++ b/packages/ppx_core/ppx_core.v0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ppx_core-v0.11.0.tar.gz"
+checksum: "f39ed11235935a4ee31df0b86940e774"

--- a/packages/ppx_driver/ppx_driver.v0.11.0/descr
+++ b/packages/ppx_driver/ppx_driver.v0.11.0/descr
@@ -1,0 +1,1 @@
+Deprecated: use ppxlib instead

--- a/packages/ppx_driver/ppx_driver.v0.11.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.11.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_driver"
+bug-reports: "https://github.com/janestreet/ppx_driver/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_driver.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta18.1"}
+  "ppxlib"   {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_driver/ppx_driver.v0.11.0/url
+++ b/packages/ppx_driver/ppx_driver.v0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ppx_driver-v0.11.0.tar.gz"
+checksum: "706cda8f743dd8b81aaa87f7261af252"

--- a/packages/ppx_metaquot/ppx_metaquot.v0.11.0/descr
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.11.0/descr
@@ -1,0 +1,1 @@
+Deprecated: use ppxlib instead

--- a/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_metaquot"
+bug-reports: "https://github.com/janestreet/ppx_metaquot/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_metaquot.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta18.1"}
+  "ppxlib"   {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_metaquot/ppx_metaquot.v0.11.0/url
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ppx_metaquot-v0.11.0.tar.gz"
+checksum: "5128cd23d665e17541e96af09406d2c5"

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
@@ -14,6 +14,7 @@ depends: [
   "base"
   "ppx_type_conv"
   "ppx_driver"
+  "ppx_core"
   "jbuilder" {build}
   "ppx_metaquot" {build}
 ]

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
@@ -11,7 +11,7 @@ depends: [
   "yojson"
   "xml-light"
   "msgpck"
-  "base"
+  "base" {< "v0.11"}
   "ppx_type_conv"
   "ppx_driver"
   "ppx_core"

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "msgpck"
   "base"
   "ppx_type_conv"
-  "ppx_driver"
+  "ppx_driver" {>= "v0.10.1"}
   "ppx_core"
   "jbuilder" {build}
   "ppx_metaquot" {build}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
@@ -14,6 +14,7 @@ depends: [
   "base"
   "ppx_type_conv"
   "ppx_driver"
+  "ppx_core"
   "jbuilder" {build}
   "ppx_metaquot" {build}
 ]

--- a/packages/ppx_traverse/ppx_traverse.v0.11.0/descr
+++ b/packages/ppx_traverse/ppx_traverse.v0.11.0/descr
@@ -1,0 +1,1 @@
+Deprecated: use ppxlib instead

--- a/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
+++ b/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_traverse"
+bug-reports: "https://github.com/janestreet/ppx_traverse/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_traverse.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta18.1"}
+  "ppxlib"   {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_traverse/ppx_traverse.v0.11.0/url
+++ b/packages/ppx_traverse/ppx_traverse.v0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ppx_traverse-v0.11.0.tar.gz"
+checksum: "a3315cbbac69dd7d11ba4d907b62a979"

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/descr
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/descr
@@ -1,0 +1,1 @@
+Deprecated: use ppxlib instead

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_traverse_builtins"
+bug-reports: "https://github.com/janestreet/ppx_traverse_builtins/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_traverse_builtins.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta18.1"}
+  "ppxlib"   {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/url
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ppx_traverse_builtins-v0.11.0.tar.gz"
+checksum: "e30f33d5078272917750fc48b562ae19"

--- a/packages/ppx_type_conv/ppx_type_conv.v0.11.0/descr
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.11.0/descr
@@ -1,0 +1,1 @@
+Deprecated: use ppxlib instead

--- a/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_type_conv"
+bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta18.1"}
+  "ppxlib"   {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_type_conv/ppx_type_conv.v0.11.0/url
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/v0.11/files/ppx_type_conv-v0.11.0.tar.gz"
+checksum: "34a6339cf7259e114b2946c615fed9b8"


### PR DESCRIPTION
v0.11 release of
- ppx_ast
- ppx_core
- ppx_driver
- ppx_metaquot
- ppx_traverse{_builtins}
- ppx_type_conv

All these are deprecated, and subsumed by ppxlib.
The v0.11 release of Jane Street's ppxs won't depend on these but on ppxlib directly.