### PR TITLE
Fix ipaddr.2.7.x constraints

### DIFF
--- a/packages/ipaddr/ipaddr.2.7.0/opam
+++ b/packages/ipaddr/ipaddr.2.7.0/opam
@@ -33,8 +33,8 @@ depends: [
   "ocamlbuild" {build}
   "base-bytes"
   "sexplib"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.10.0"}
+  "ppx_deriving" {build & >= "4.2"}
+  "ppx_sexp_conv" {build}
   "ounit" {test}
 ]
 available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.04.0" ]

--- a/packages/ipaddr/ipaddr.2.7.1/opam
+++ b/packages/ipaddr/ipaddr.2.7.1/opam
@@ -30,8 +30,8 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "sexplib"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.10.0"}
+  "ppx_deriving" {build & >= "4.2"}
+  "ppx_sexp_conv" {build}
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]

--- a/packages/ipaddr/ipaddr.2.7.2/opam
+++ b/packages/ipaddr/ipaddr.2.7.2/opam
@@ -30,8 +30,8 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "sexplib"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.10.0"}
+  "ppx_deriving" {build & >= "4.2"}
+  "ppx_sexp_conv" {build}
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]


### PR DESCRIPTION
Turns out I was wrong in #11543
So here seems a good fix. Is there anybody around who would know a broader fix to that ? (with a constraint or something). Something tells me it's not the only package with this problem :/

Fixing failures discovered in #11609 and #11541