### PR TITLE
Package encore.0.1

### DIFF
--- a/packages/encore/encore.0.1/descr
+++ b/packages/encore/encore.0.1/descr
@@ -1,0 +1,8 @@
+Isomorphism between encoder & decoder
+
+Encore is a little library to provide an interface to generate an
+[Angstrom](https://github.com/inhabitedtype/angstrom.git)'s decoder and a
+internal encoder from a shared description. The goal is specifically for
+[ocaml-git](https://github.com/mirage/ocaml-git.git) to ensure isomorphism when
+we decode and encode a Git object - and keep the same hash/identifier.
+

--- a/packages/encore/encore.0.1/opam
+++ b/packages/encore/encore.0.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/encore"
+bug-reports:  "https://github.com/dinosaure/encore/issues"
+dev-repo:     "https://github.com/dinosaure/encore.git"
+doc:          "https://dinosaure.github.io/encore/"
+license:      "MIT"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "angstrom" {>= "0.9.0"}
+  "ocplib-endian"
+  "fmt"
+  "alcotest" {test}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/encore/encore.0.1/url
+++ b/packages/encore/encore.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dinosaure/encore/releases/download/v0.1/encore-0.1.tbz"
+checksum: "79647f73f51e1681cd64790b62d13e59"


### PR DESCRIPTION
### `encore.0.1`

Isomorphism between encoder & decoder

Encore is a little library to provide an interface to generate an
[Angstrom](https://github.com/inhabitedtype/angstrom.git)'s decoder and a
internal encoder from a shared description. The goal is specifically for
[ocaml-git](https://github.com/mirage/ocaml-git.git) to ensure isomorphism when
we decode and encode a Git object - and keep the same hash/identifier.




---
* Homepage: https://github.com/dinosaure/encore
* Source repo: https://github.com/dinosaure/encore.git
* Bug tracker: https://github.com/dinosaure/encore/issues

---


---
v0.1 2018-03-31 Paris (France)
==============================

- First release
:camel: Pull-request generated by opam-publish v0.3.5