### PR TITLE
Constraints decompress to use re.1.7.1

### DIFF
--- a/packages/decompress/decompress.0.3/opam
+++ b/packages/decompress/decompress.0.3/opam
@@ -30,4 +30,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: "base-unix"
-available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"]
+available: [ocaml-version = "4.02.0"]

--- a/packages/decompress/decompress.0.3/opam
+++ b/packages/decompress/decompress.0.3/opam
@@ -24,7 +24,7 @@ depends: [
   "oasis" {build}
   "base-bytes"
   "alcotest" {test}
-  "re" {test}
+  "re" {test & = "1.7.1"}
   "cstruct" {test}
   "camlzip" {test}
   "ocamlbuild" {build}

--- a/packages/decompress/decompress.0.3/opam
+++ b/packages/decompress/decompress.0.3/opam
@@ -30,4 +30,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: "base-unix"
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"]

--- a/packages/decompress/decompress.0.3/url
+++ b/packages/decompress/decompress.0.3/url
@@ -1,2 +1,2 @@
-http: "https://github.com/oklm-wsh/Decompress/archive/0.3.tar.gz"
-checksum: "e35c92aea4b3135e4b07bc75f0afb84c"
+archive: "https://github.com/mirage/decompress/releases/download/0.3/decompress-0.3.tbz"
+checksum: "40ebe32bff2aeba2a4f5ae5a603f8ae8"

--- a/packages/decompress/decompress.0.4/opam
+++ b/packages/decompress/decompress.0.4/opam
@@ -33,7 +33,7 @@ depends: [
   "ocamlfind"      {build}
   "base-bytes"
   "alcotest"       {test}
-  "re"             {test & = "1.7.1}
+  "re"             {test & = "1.7.1"}
   "camlzip"        {test}
   "cmdliner"       {test}
   "ctypes"         {test}

--- a/packages/decompress/decompress.0.4/opam
+++ b/packages/decompress/decompress.0.4/opam
@@ -33,7 +33,7 @@ depends: [
   "ocamlfind"      {build}
   "base-bytes"
   "alcotest"       {test}
-  "re"             {test}
+  "re"             {test & = "1.7.1}
   "camlzip"        {test}
   "cmdliner"       {test}
   "ctypes"         {test}

--- a/packages/decompress/decompress.0.4/opam
+++ b/packages/decompress/decompress.0.4/opam
@@ -44,4 +44,4 @@ depopts: [
   "base-unix"
 ]
 
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.03.0"]

--- a/packages/decompress/decompress.0.4/url
+++ b/packages/decompress/decompress.0.4/url
@@ -1,2 +1,2 @@
-http: "https://github.com/oklm-wsh/Decompress/archive/0.4.tar.gz"
-checksum: "32f4db760f033d1fcd139eb327d70a64"
+archive: "https://github.com/mirage/decompress/releases/download/0.4/decompress-0.4.tbz"
+checksum: "0b28aa7e55f64a245a9c0d8baf546fd2"

--- a/packages/decompress/decompress.0.5/opam
+++ b/packages/decompress/decompress.0.5/opam
@@ -27,4 +27,4 @@ depopts: [
   "cmdliner"
 ]
 
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]

--- a/packages/decompress/decompress.0.5/opam
+++ b/packages/decompress/decompress.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "camlzip" {test}
-  "re" {test}
+  "re" {test & = "1.7.1"}
   "alcotest" {test}
 ]
 

--- a/packages/decompress/decompress.0.5/url
+++ b/packages/decompress/decompress.0.5/url
@@ -1,2 +1,2 @@
-http: "https://github.com/oklm-wsh/Decompress/archive/0.5.tar.gz"
-checksum: "7bc7cd1fc1090f6d15114fdfe11e557d"
+archive: "https://github.com/mirage/decompress/releases/download/0.5/decompress-0.5.tbz"
+checksum: "2bc98341e4d5752c1053d89c370710fb"

--- a/packages/decompress/decompress.0.6/opam
+++ b/packages/decompress/decompress.0.6/opam
@@ -23,7 +23,7 @@ depends: [
   "topkg"          {build}
   "base-bytes"
   "camlzip"        {test}
-  "re"             {test}
+  "re"             {test & = "1.7.1"}
   "alcotest"       {test}
 ]
 

--- a/packages/decompress/decompress.0.6/opam
+++ b/packages/decompress/decompress.0.6/opam
@@ -31,4 +31,4 @@ depopts: [
   "cmdliner"
 ]
 
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]

--- a/packages/decompress/decompress.0.7/opam
+++ b/packages/decompress/decompress.0.7/opam
@@ -23,7 +23,7 @@ depends: [
   "topkg"          {build}
   "base-bytes"
   "camlzip"        {test}
-  "re"             {test}
+  "re"             {test & = "1.7.1"}
   "alcotest"       {test}
 ]
 

--- a/packages/decompress/decompress.0.7/opam
+++ b/packages/decompress/decompress.0.7/opam
@@ -12,19 +12,11 @@ build: [
   "--with-cmdliner" "%{cmdliner:installed}%"
 ]
 
-build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
-]
-
 depends: [
   "ocamlbuild"     {build}
   "ocamlfind"      {build}
   "topkg"          {build}
   "base-bytes"
-  "camlzip"        {test}
-  "re"             {test & = "1.7.1"}
-  "alcotest"       {test}
 ]
 
 depopts: [


### PR DESCRIPTION
It seems than `re` breaks compatibility.