### PR TITLE
Package jbuilder.1.0+beta19.1

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta19.1/descr
+++ b/packages/jbuilder/jbuilder.1.0+beta19.1/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+jbuilder is a build system that was designed to simplify the release
+of Jane Street packages. It reads metadata from "jbuild" files
+following a very simple s-expression syntax.
+
+jbuilder is fast, it has very low-overhead and support parallel builds
+on all platforms. It has no system dependencies, all you need to build
+jbuilder and packages using jbuilder is OCaml. You don't need or make
+or bash as long as the packages themselves don't use bash explicitely.
+
+jbuilder supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/jbuilder/jbuilder.1.0+beta19.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta19.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "Apache-2.0"
+build: [
+  ["ocaml" "configure.ml" "--libdir" lib]
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--subst"] {pinned}
+  ["./boot.exe" "-j" jobs]
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/jbuilder/jbuilder.1.0+beta19.1/url
+++ b/packages/jbuilder/jbuilder.1.0+beta19.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dune/releases/download/1.0+beta19.1/jbuilder-1.0.beta19.1.tbz"
+checksum: "456b4aa804d46d84d132230b3db9ff4a"


### PR DESCRIPTION
### `jbuilder.1.0+beta19.1`

Fast, portable and opinionated build system

jbuilder is a build system that was designed to simplify the release
of Jane Street packages. It reads metadata from "jbuild" files
following a very simple s-expression syntax.

jbuilder is fast, it has very low-overhead and support parallel builds
on all platforms. It has no system dependencies, all you need to build
jbuilder and packages using jbuilder is OCaml. You don't need or make
or bash as long as the packages themselves don't use bash explicitely.

jbuilder supports multi-package development by simply dropping multiple
repositories into the same directory.

It also supports multi-context builds, such as building against
several opam roots/switches simultaneously. This helps maintaining
packages across several versions of OCaml and gives cross-compilation
for free.



---
* Homepage: https://github.com/ocaml/dune
* Source repo: https://github.com/ocaml/dune.git
* Bug tracker: https://github.com/ocaml/dune/issues

---


---
1.0+beta19.1 (21/03/2018)
-------------------------

- Missing asm in ocaml -config on bytecode only architecture is no longer fatal
  (#637 fixed by #639 @rgrinberg)

- Fix regression introduced by beta19 where duplicate environment variables in
  Unix.environ would cause a fatal error. The first defined environment variable
  is now chosen. (#638 fixed by #640)

- Use ';' as the path separator for OCAMLPATH on Cygwin (#630 fixed by #636
  @diml).

- Use the contents of the `OCAMLPATH` environment variable when not relying on
  `ocamlfind` (#642 @diml)
:camel: Pull-request generated by opam-publish v0.3.5