### PR TITLE
mirage.3.x.y calls out to ocamlbuild -use-ocamlfind, and thus needs o…

### DIFF
--- a/packages/mirage/mirage.3.0.0/opam
+++ b/packages/mirage/mirage.3.0.0/opam
@@ -12,8 +12,8 @@ doc:          "https://mirage.github.io/mirage/"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocamlbuild" {build}
-  "ocamlfind"  {build}
+  "ocamlbuild"
+  "ocamlfind"
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.0.0" & < "2.2.0"}

--- a/packages/mirage/mirage.3.0.1/opam
+++ b/packages/mirage/mirage.3.0.1/opam
@@ -12,8 +12,8 @@ doc:          "https://mirage.github.io/mirage/"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocamlbuild" {build}
-  "ocamlfind"  {build}
+  "ocamlbuild"
+  "ocamlfind"
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.0.0" & <"2.2.0"}

--- a/packages/mirage/mirage.3.0.2/opam
+++ b/packages/mirage/mirage.3.0.2/opam
@@ -12,8 +12,8 @@ doc:          "https://mirage.github.io/mirage/"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocamlbuild" {build}
-  "ocamlfind"  {build}
+  "ocamlbuild"
+  "ocamlfind"
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.0.0" & < "2.2.0"}

--- a/packages/mirage/mirage.3.0.4/opam
+++ b/packages/mirage/mirage.3.0.4/opam
@@ -12,8 +12,8 @@ doc:          "https://mirage.github.io/mirage/"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocamlbuild" {build}
-  "ocamlfind"  {build}
+  "ocamlbuild"
+  "ocamlfind"
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.0.0" & <"2.2.0"}

--- a/packages/mirage/mirage.3.0.5/opam
+++ b/packages/mirage/mirage.3.0.5/opam
@@ -15,6 +15,8 @@ build: [
 ]
 
 depends: [
+  "ocamlbuild"
+  "ocamlfind"
   "jbuilder"   {build & >= "1.0+beta10"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.2.0"}

--- a/packages/mirage/mirage.3.0.7/opam
+++ b/packages/mirage/mirage.3.0.7/opam
@@ -15,6 +15,8 @@ build: [
 ]
 
 depends: [
+  "ocamlbuild"
+  "ocamlfind"
   "jbuilder"   {build & >= "1.0+beta10"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.2.0"}

--- a/packages/mirage/mirage.3.0.8/opam
+++ b/packages/mirage/mirage.3.0.8/opam
@@ -15,6 +15,8 @@ build: [
 ]
 
 depends: [
+  "ocamlbuild"
+  "ocamlfind"
   "jbuilder"   {build & >= "1.0+beta10"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.2.0"}


### PR DESCRIPTION
…camlfind and ocamlbuild at runtime

upstream PR at https://github.com/mirage/mirage/pull/897