### PR TITLE
fixes following core suite v0.11

### DIFF
--- a/packages/async_inotify/async_inotify.v0.10.0/opam
+++ b/packages/async_inotify/async_inotify.v0.10.0/opam
@@ -14,7 +14,7 @@ depends: [
   "core"                    {>= "v0.10" & < "v0.11"}
   "ppx_driver"              {>= "v0.10" & < "v0.11"}
   "ppx_jane"                {>= "v0.10" & < "v0.11"}
-  "inotify"
+  "inotify"                 {>= "2.0"}
   "jbuilder"                {build & >= "1.0+beta12"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]

--- a/packages/async_inotify/async_inotify.v0.9.0/opam
+++ b/packages/async_inotify/async_inotify.v0.9.0/opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder"                {build & >= "1.0+beta7"}
   "ppx_driver"              {>= "v0.9" & < "v0.10"}
   "ppx_jane"                {>= "v0.9" & < "v0.10"}
-  "inotify"
+  "inotify"                 {>= "2.0"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/bistro/bistro.0.3.0/opam
+++ b/packages/bistro/bistro.0.3.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/pveber/bistro.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build & >= "1.0+beta8"}
-  "core" {>= "0.9.0"}
+  "core" {>= "v0.9.0" & < "v0.11" }
   "lwt"
   "ocamlgraph" {>= "1.8.7"}
   "rresult"

--- a/packages/bitcoinml/bitcoinml.0.2.4/opam
+++ b/packages/bitcoinml/bitcoinml.0.2.4/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "jbuilder" {build & >= "1.0+beta11"}
-  "base" {build & >= "v0.9.2"}
+  "base" {build & >= "v0.9.2" & < "v0.11"}
   "configurator" {build & >= "v0.9.1"}
   "ppx_jane" {build & >= "v0.9.0"}
   "ppx_bitstring" {build & >= "2.0.0"}

--- a/packages/bitcoinml/bitcoinml.0.2/opam
+++ b/packages/bitcoinml/bitcoinml.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/dakk/bitcoinml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
-  "base" {build & >= "v0.9.2"}
+  "base" {build & >= "v0.9.2" & < "v0.11" }
   "stdio" {build & >= "v0.9.0"}
   "configurator" {build & >= "v0.9.1"}
   "bitstring" {build & >= "2.1.0"}

--- a/packages/bitcoinml/bitcoinml.0.3.0/opam
+++ b/packages/bitcoinml/bitcoinml.0.3.0/opam
@@ -10,7 +10,7 @@ build-test: ["jbuilder" "build" "-p" name "-j" jobs "@runtest" "@doc"]
 build-doc: ["jbuilder" "build" "-p" name "-j" jobs "@doc"]
 depends: [
   "jbuilder" {build & >= "1.0+beta11"}
-  "base" {build & >= "v0.9.2"}
+  "base" {build & >= "v0.9.2" & < "v0.11" }
   "configurator" {build & >= "v0.9.1"}
   "ppx_jane" {build & >= "v0.9.0"}
   "ppx_bitstring" {build & >= "2.0.0"}

--- a/packages/bitcoinml/bitcoinml.0.3.1/opam
+++ b/packages/bitcoinml/bitcoinml.0.3.1/opam
@@ -10,7 +10,7 @@ build-test: ["jbuilder" "build" "-p" name "-j" jobs "@runtest" "@doc"]
 build-doc: ["jbuilder" "build" "-p" name "-j" jobs "@doc"]
 depends: [
   "jbuilder" {build & >= "1.0+beta11"}
-  "base" {build & >= "v0.9.2"}
+  "base" {build & >= "v0.9.2" & < "v0.11" }
   "configurator" {build & >= "v0.9.1"}
   "ppx_jane" {build & >= "v0.9.0"}
   "ppx_bitstring" {build & >= "2.0.0"}

--- a/packages/boomerang/boomerang.1.1.0/opam
+++ b/packages/boomerang/boomerang.1.1.0/opam
@@ -28,4 +28,4 @@ depends: [
   "ppx_deriving"
   "ppx_hash"
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.04" ]

--- a/packages/boomerang/boomerang.1.1.0/opam
+++ b/packages/boomerang/boomerang.1.1.0/opam
@@ -22,7 +22,7 @@ build-test: [
 ]
 depends: [
   "base-unix"
-  "core" {< "v0.11"}
+  "core" {< "v0.10"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ppx_deriving"

--- a/packages/boomerang/boomerang.1.1.0/opam
+++ b/packages/boomerang/boomerang.1.1.0/opam
@@ -22,7 +22,7 @@ build-test: [
 ]
 depends: [
   "base-unix"
-  "core"
+  "core" {< "v0.11"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ppx_deriving"

--- a/packages/capnp/capnp.3.2.0/opam
+++ b/packages/capnp/capnp.3.2.0/opam
@@ -11,7 +11,7 @@ build-test: ["jbuilder" "build" "@runtest" "@src/benchmark/benchmarks"]
 depends: [
   "jbuilder" {build}
   "result"
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.11"}
   "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"

--- a/packages/cfstream/cfstream.1.2.3/opam
+++ b/packages/cfstream/cfstream.1.2.3/opam
@@ -12,7 +12,7 @@ dev-repo: "https://github.com/biocaml/cfstream.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build}
-  "core_kernel" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0" & < "v0.11" }
   "ounit"
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/conduit-async/conduit-async.1.0.3/opam
+++ b/packages/conduit-async/conduit-async.1.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder" {build & >="1.0+beta9"}
   "ppx_sexp_conv" {build}
   "conduit" {>="1.0.0"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.11"}
 ]
 depopts: [ "async_ssl" ]
 conflicts: [

--- a/packages/core-lwt/core-lwt.0.2.0/opam
+++ b/packages/core-lwt/core-lwt.0.2.0/opam
@@ -25,7 +25,7 @@ depends: [
     "oasis" {build & >= "0.4.0"}
     "base-unix"
     "base-threads"
-    "core_kernel" {>= "v0.9.0"}
+    "core_kernel" {>= "v0.9.0" & < "v0.11"}
     "lwt" { >= "3.0.0" & < "4.0.0"}
 ]
 

--- a/packages/frag/frag.0.1.0/opam
+++ b/packages/frag/frag.0.1.0/opam
@@ -8,7 +8,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 depends: [
-  "core" {>= "109.42.00" & < "v0.11"}
+  "core" {>= "109.42.00" & < "v0.10"}
   "mpp"
   "ocamlfind"
   "re"

--- a/packages/frag/frag.0.1.0/opam
+++ b/packages/frag/frag.0.1.0/opam
@@ -8,7 +8,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 depends: [
-  "core" {>= "109.42.00"}
+  "core" {>= "109.42.00" & < "v0.11"}
   "mpp"
   "ocamlfind"
   "re"

--- a/packages/netml/netml.0.1.0/opam
+++ b/packages/netml/netml.0.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_deriving"        {build}
   "ppx_deriving_yojson" {build}
   "bitstring"           {>= "2.1.0"}
-  "core"                {< "v0.11"}
+  "core"                {< "v0.10"}
   "yojson"
 ]
 

--- a/packages/netml/netml.0.1.0/opam
+++ b/packages/netml/netml.0.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_deriving"        {build}
   "ppx_deriving_yojson" {build}
   "bitstring"           {>= "2.1.0"}
-  "core"
+  "core"                {< "v0.11"}
   "yojson"
 ]
 

--- a/packages/osm_xml/osm_xml.0.0.1/opam
+++ b/packages/osm_xml/osm_xml.0.0.1/opam
@@ -12,7 +12,7 @@ remove: [
   ["ocamlfind" "remove" "osm_xml"]
 ]
 depends: [
-  "core"
+  "core" {< "v0.11"}
   "xmlm"
   "ocamlbuild" {build}
 ]

--- a/packages/prettiest/prettiest.0.0.1/opam
+++ b/packages/prettiest/prettiest.0.0.1/opam
@@ -11,7 +11,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "base"
+  "base" {< "v0.11"}
   "ppx_compare"
   "ocaml-migrate-parsetree"
   "jbuilder" {build & >= "1.0+beta12"}

--- a/packages/prettiest/prettiest.0.0.2/opam
+++ b/packages/prettiest/prettiest.0.0.2/opam
@@ -11,7 +11,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "base"
+  "base" {< "v0.11"}
   "ppx_compare"
   "ocaml-migrate-parsetree"
   "jbuilder" {build & >= "1.0+beta12"}

--- a/packages/session-postgresql-async/session-postgresql-async.0.4.0/opam
+++ b/packages/session-postgresql-async/session-postgresql-async.0.4.0/opam
@@ -15,6 +15,6 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "session-postgresql"
-  "async"
+  "async" {< "v0.11"}
   "base-threads"
 ]

--- a/packages/trie/trie.0.1.1/opam
+++ b/packages/trie/trie.0.1.1/opam
@@ -19,5 +19,5 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "core_kernel" {< "v0.11"}
+  "core_kernel" {< "v0.10"}
 ]

--- a/packages/trie/trie.0.1.1/opam
+++ b/packages/trie/trie.0.1.1/opam
@@ -19,5 +19,5 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
-  "core_kernel"
+  "core_kernel" {< "v0.11"}
 ]


### PR DESCRIPTION
I left the following packages broken:
- camlhighlight (a failed build is logged [here](https://ci.ocamllabs.io/log/saved/docker-run-f1fd63e27f717ac46fc3d7494f21a5e4/b2acb1b5f773afe387129ea5fc7b5a5dba83d612))
- nocrypto (a failed build is logged [here](https://ci.ocamllabs.io/log/saved/docker-run-acdc48bd8962eca2ae7b1407977f308c/0b95ffea49bb08e149bff429110fec57fa5951ce))
- yaml

That last one doesn't have any constraint at the moment, looking at the code it opens Sexplib.Conv without depending on sexplib in the opam file: someone else will have to look at it.

For the other two, I'm not sure what's going on. The build fails because some cmi files are not available (because the right -I haven't been passed).
It might be an issue with the content of some of our META files (in which case it's a jbuilder issue I guess), or it might just be that their build system is confused: IDK.