### PR TITLE
Package ppxlib.0.2.0

### DIFF
--- a/packages/ppxlib/ppxlib.0.2.0/descr
+++ b/packages/ppxlib/ppxlib.0.2.0/descr
@@ -1,0 +1,9 @@
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.

--- a/packages/ppxlib/ppxlib.0.2.0/opam
+++ b/packages/ppxlib/ppxlib.0.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "https://github.com/ocaml-ppx/ppxlib.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.11.0"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.0.9"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppxlib/ppxlib.0.2.0/url
+++ b/packages/ppxlib/ppxlib.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-ppx/ppxlib/releases/download/0.2.0/ppxlib-0.2.0.tbz"
+checksum: "f01c8af982e96c73513745727ee6d04e"


### PR DESCRIPTION
### `ppxlib.0.2.0`

A comprehensive toolbox for ppx development. It features:
- a OCaml AST / parser / pretty-printer snapshot,to create a full
   frontend independent of the version of OCaml;
- a library for library for ppx rewriters in general, and type-driven
  code generators in particular;
- a feature-full driver for OCaml AST transformers;
- a quotation mechanism allowing  to write values representing the
   OCaml AST in the OCaml syntax;
- a generator of open recursion classes from type definitions.



---
* Homepage: https://github.com/ocaml-ppx/ppxlib
* Source repo: https://github.com/ocaml-ppx/ppxlib.git
* Bug tracker: https://github.com/ocaml-ppx/ppxlib/issues

---


---
0.2.0
-----

- Make sure to import command line arguments registered with
  ocaml-migrate-parsetree

- Fix an issue where cookies set from the command line sometimes
  disappeared
:camel: Pull-request generated by opam-publish v0.3.5