### PR TITLE
bibtex2html 1.99

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.99/descr
+++ b/packages/bibtex2html/bibtex2html.1.99/descr
@@ -1,0 +1,1 @@
+BibTeX to HTML translator

--- a/packages/bibtex2html/bibtex2html.1.99/opam
+++ b/packages/bibtex2html/bibtex2html.1.99/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "filliatr@lri.fr"
+authors: [
+  "Jean-Christophe Filliâtre"
+  "Claude Marché"
+]
+license: "GNU General Public License version 2"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+depends: [
+  "hevea"
+]
+install: [make "install"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/bibtex2html/bibtex2html.1.99/opam
+++ b/packages/bibtex2html/bibtex2html.1.99/opam
@@ -5,7 +5,7 @@ authors: [
   "Claude Marché"
 ]
 homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
-dev-repo: "https://github.com/backtracking/bibtex2html"
+dev-repo: "https://github.com/backtracking/bibtex2html.git"
 bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GNU General Public License version 2"
 build: [

--- a/packages/bibtex2html/bibtex2html.1.99/opam
+++ b/packages/bibtex2html/bibtex2html.1.99/opam
@@ -1,9 +1,12 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "filliatr@lri.fr"
 authors: [
   "Jean-Christophe Filliâtre"
   "Claude Marché"
 ]
+homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
+dev-repo: "https://github.com/backtracking/bibtex2html"
+bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GNU General Public License version 2"
 build: [
   ["./configure" "--prefix=%{prefix}%"]

--- a/packages/bibtex2html/bibtex2html.1.99/url
+++ b/packages/bibtex2html/bibtex2html.1.99/url
@@ -1,0 +1,2 @@
+archive: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.99.tar.gz"
+checksum: "85f8d617b13d34a552261b3fbb406a0f"


### PR DESCRIPTION
fixed compilation with OCaml 4.06
now requires OCaml >= 4.03.0