### PR TITLE
Package vlq.0.2.0

### DIFF
--- a/packages/vlq/vlq.0.2.0/descr
+++ b/packages/vlq/vlq.0.2.0/descr
@@ -1,0 +1,1 @@
+A simple library for encoding variable-length quantities.

--- a/packages/vlq/vlq.0.2.0/opam
+++ b/packages/vlq/vlq.0.2.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Marshall Roch <mroch@fb.com>"
+authors: ["Marshall Roch <mroch@fb.com>"]
+homepage: "https://github.com/flowtype/ocaml-vlq"
+doc: "https://github.com/flowtype/ocaml-vlq"
+license: "MIT"
+dev-repo: "https://github.com/flowtype/ocaml-vlq.git"
+bug-reports: "https://github.com/flowtype/ocaml-vlq/issues"
+depends:
+[
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ounit" {test & >= "2.0.0"}
+]
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/vlq/vlq.0.2.0/url
+++ b/packages/vlq/vlq.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/flowtype/ocaml-vlq/releases/download/v0.2.0/vlq-0.2.0.tbz"
+checksum: "919d71bd8644dd4290749810e96fb443"


### PR DESCRIPTION
### `vlq.0.2.0`

A simple library for encoding variable-length quantities.



---
* Homepage: https://github.com/flowtype/ocaml-vlq
* Source repo: https://github.com/flowtype/ocaml-vlq.git
* Bug tracker: https://github.com/flowtype/ocaml-vlq/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v0.2.0 2018-03-23
-----------------

Added support for decoding base64 VLQs
:camel: Pull-request generated by opam-publish v0.3.5