### PR TITLE
odoc.1.x.y: Add missing upper-bound to doc-ock-xml

### DIFF
--- a/packages/odoc/odoc.1.0.0/opam
+++ b/packages/odoc/odoc.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "topkg" {build & >= "0.7.5"}
   "doc-ock"
   "doc-ock-html"
-  "doc-ock-xml"
+  "doc-ock-xml" {< "1.2.0"}
   "tyxml" {>= "4.0.0" }
   "bos"
   "fpath"

--- a/packages/odoc/odoc.1.1.0/opam
+++ b/packages/odoc/odoc.1.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {build}
   "doc-ock"
   "doc-ock-html"
-  "doc-ock-xml"
+  "doc-ock-xml" {< "1.2.0"}
   "tyxml" {>= "4.0.0" }
   "bos"
   "fpath"

--- a/packages/odoc/odoc.1.1.1/opam
+++ b/packages/odoc/odoc.1.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {build}
   "doc-ock"
   "doc-ock-html"
-  "doc-ock-xml"
+  "doc-ock-xml" {< "1.2.0"}
   "tyxml" {>= "4.0.0" }
   "bos"
   "fpath"


### PR DESCRIPTION
@trefis do you think it's correct ?

Failing build log: https://ci.ocamllabs.io/log/saved/docker-build-4bbaa89f483375a56f66d7b2ef4ad9ec/d44f4003e0a368af459668b5183036239c4321ad