### PR TITLE
nocrypto: restrict to <v0.11.0 core release

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.3/opam
+++ b/packages/nocrypto/nocrypto.0.5.3/opam
@@ -21,9 +21,9 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "1.6.0" & <"3.0.0"}
   "zarith"
-  "sexplib"
+  "sexplib" {< "v0.11.0"}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy-xen" & "zarith-xen"))
   "ounit" {test}
 ]

--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -22,13 +22,13 @@ depends: [
   "cpuid" {build}
   "ocb-stubblr" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ounit" {test}
   "cstruct" {>="2.4.0"}
   "cstruct-lwt"
   "zarith"
   "lwt"
-  "sexplib"
+  "sexplib" {< "v0.11.0"}
   ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy" & "zarith-xen"))
   ("mirage-no-solo5" | ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding"))
 ]


### PR DESCRIPTION
//cc @pqwy 

since #11616 got merged, `nocrypto` is uninstallable.  This PR sets some upper bounds on sexplib and ppx_sexp_conv to enable users to install nocrypto via opam.