### PR TITLE
Make ipaddr.2.7.x incompatible with sexplib >= v0.11

### DIFF
--- a/packages/ipaddr/ipaddr.2.7.0/opam
+++ b/packages/ipaddr/ipaddr.2.7.0/opam
@@ -32,9 +32,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"
-  "sexplib"
+  "sexplib" {< "v0.11"}
   "ppx_deriving" {build & >= "4.2"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11"}
   "ounit" {test}
 ]
 available: [ ocaml-version >= "4.02.2" & ocaml-version < "4.04.0" ]

--- a/packages/ipaddr/ipaddr.2.7.1/opam
+++ b/packages/ipaddr/ipaddr.2.7.1/opam
@@ -29,9 +29,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "base-bytes"
-  "sexplib"
+  "sexplib" {< "v0.11"}
   "ppx_deriving" {build & >= "4.2"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11"}
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]

--- a/packages/ipaddr/ipaddr.2.7.2/opam
+++ b/packages/ipaddr/ipaddr.2.7.2/opam
@@ -29,9 +29,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "base-bytes"
-  "sexplib"
+  "sexplib" {< "v0.11"}
   "ppx_deriving" {build & >= "4.2"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11"}
   "ounit" {test}
 ]
 depopts: [ "base-unix" ]


### PR DESCRIPTION
Long term alternative to https://github.com/ocaml/opam-repository/pull/11636

cc @hannesm @diml @trefis 