### PR TITLE
Package jbuild-create-templates.v0.1.0

### DIFF
--- a/packages/jbuild-create-templates/jbuild-create-templates.v0.1.0/descr
+++ b/packages/jbuild-create-templates/jbuild-create-templates.v0.1.0/descr
@@ -1,0 +1,5 @@
+Package that provides templates for jbuild-create
+
+Package that provides templates for jbuild-create.
+This is useless on its own and is just a dependency for
+jbuild-create. You should install that package instead.

--- a/packages/jbuild-create-templates/jbuild-create-templates.v0.1.0/opam
+++ b/packages/jbuild-create-templates/jbuild-create-templates.v0.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Sam Thomas <sgpthomas@gmail.com>"
+authors: "Sam Thomas <sgpthomas@gmail.com>"
+homepage: "https://github.com/sgpthomas/jbuild-create-templates"
+bug-reports: "https://github.com/sgpthomas/jbuild-create-templates"
+dev-repo: "git@github.com:sgpthomas/jbuild-create-templates.git"
+
+install: [make]
+remove: [
+  ["ocamlfind" "remove" "jbuild-create-templates"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/jbuild-create-templates/jbuild-create-templates.v0.1.0/url
+++ b/packages/jbuild-create-templates/jbuild-create-templates.v0.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/sgpthomas/jbuild-create-templates/archive/v0.1.0.tar.gz"
+checksum: "261f2960a216a411645c24335f254f28"


### PR DESCRIPTION
### `jbuild-create-templates.v0.1.0`

Package that provides templates for jbuild-create

Package that provides templates for jbuild-create.
This is useless on its own and is just a dependency for
jbuild-create. You should install that package instead.



---
* Homepage: https://github.com/sgpthomas/jbuild-create-templates
* Source repo: git@github.com:sgpthomas/jbuild-create-templates.git
* Bug tracker: https://github.com/sgpthomas/jbuild-create-templates

---

:camel: Pull-request generated by opam-publish v0.3.5