### PR TITLE
Package cohttp-async.1.1.0

### DIFF
--- a/packages/cohttp-async/cohttp-async.1.1.0/descr
+++ b/packages/cohttp-async/cohttp-async.1.1.0/descr
@@ -1,0 +1,26 @@
+An OCaml library for HTTP clients and servers
+
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value.

--- a/packages/cohttp-async/cohttp-async.1.1.0/opam
+++ b/packages/cohttp-async/cohttp-async.1.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "cohttp"
+  "conduit-async"
+  "magic-mime"
+  "logs"
+  "fmt"
+  "sexplib"
+  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cohttp-async/cohttp-async.1.1.0/url
+++ b/packages/cohttp-async/cohttp-async.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-cohttp/releases/download/v1.1.0/cohttp-1.1.0.tbz"
+checksum: "7624e77774b90112370924f2d21af436"


### PR DESCRIPTION
### `cohttp-async.1.1.0`

An OCaml library for HTTP clients and servers

[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

Cohttp is an OCaml library for creating HTTP daemons. It has a portable
HTTP parser, and implementations using various asynchronous programming
libraries:

* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
  specifically the UNIX bindings.
* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
  library.
* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
  by the [Mirage](https://mirage.io/) interface to generate standalone
  microkernels (use the cohttp-mirage subpackage).
* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
  the GitHub bindings to JavaScript and still run efficiently.

You can implement other targets using the parser very easily. Look at the `IO`
signature in `lib/s.mli` and implement that in the desired backend.

You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
value, and all requests and responses will be written to stderr.  Further
debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
to any value.


---
* Homepage: https://github.com/mirage/ocaml-cohttp
* Source repo: https://github.com/mirage/ocaml-cohttp.git
* Bug tracker: https://github.com/mirage/ocaml-cohttp/issues

---


---
## v1.1.0 (2018-03-28)

* Add an "expert mode" to hand off raw responses to a custom handler,
  which in turns makes protocols like Websockets easier (#488 by @msaffer).
* Set the user-agent by default if one is not provided (#586 by @TheCBaH).
* Fix typo in the `cohttp.js` META file.
* Refresh use of the Re library to the latest version (#602 by @rgrinberg).
* Rearrange the ppx dependencies to be more specific (#596 by @yomimono).
* Explicitly depend on sexplib in the Async backend (#605 by @kevinqiu).
:camel: Pull-request generated by opam-publish v0.3.5