### PR TITLE
Package conduit-lwt.1.1.0

### DIFF
--- a/packages/conduit-lwt/conduit-lwt.1.1.0/descr
+++ b/packages/conduit-lwt/conduit-lwt.1.1.0/descr
@@ -1,0 +1,37 @@
+An OCaml network connection establishment library
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-conduit.svg?branch=master)](https://travis-ci.org/mirage/ocaml-conduit)
+
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The opam packages available are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `mirage-conduit`: the MirageOS compatible implementation
+
+### Debugging
+
+Some of the `Lwt_unix`-based modules use a non-empty `CONDUIT_DEBUG`
+environment variable to output debugging information to standard error.
+Just set this variable when running the program to see what URIs
+are being resolved to.
+
+### Further Informartion
+
+* **API Docs:** http://docs.mirage.io/
+* **WWW:** https://github.com/mirage/ocaml-conduit
+* **E-mail:** <mirageos-devel@lists.xenproject.org>
+* **Bugs:** https://github.com/mirage/ocaml-conduit/issues

--- a/packages/conduit-lwt/conduit-lwt.1.1.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"]
+homepage:     "https://github.com/mirage/ocaml-conduit"
+dev-repo:     "https://github.com/mirage/ocaml-conduit.git"
+bug-reports:  "https://github.com/mirage/ocaml-conduit/issues"
+tags:         "org:mirage"
+license:      "ISC"
+
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base-unix"
+  "jbuilder" {build & >="1.0+beta9"}
+  "ppx_sexp_conv" {build}
+  "conduit"
+  "lwt" {>="3.0.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/conduit-lwt/conduit-lwt.1.1.0/url
+++ b/packages/conduit-lwt/conduit-lwt.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-conduit/releases/download/v1.1.0/conduit-1.1.0.tbz"
+checksum: "eb1d02c80d06ef812d97dc1ab588b597"


### PR DESCRIPTION
### `conduit-lwt.1.1.0`

An OCaml network connection establishment library

[![Build Status](https://travis-ci.org/mirage/ocaml-conduit.svg?branch=master)](https://travis-ci.org/mirage/ocaml-conduit)

The `conduit` library takes care of establishing and listening for 
TCP and SSL/TLS connections for the Lwt and Async libraries.

The reason this library exists is to provide a degree of abstraction
from the precise SSL library used, since there are a variety of ways
to bind to a library (e.g. the C FFI, or the Ctypes library), as well
as well as which library is used (just OpenSSL for now).

By default, OpenSSL is used as the preferred connection library, but
you can force the use of the pure OCaml TLS stack by setting the
environment variable `CONDUIT_TLS=native` when starting your program.

The opam packages available are:

- `conduit`: the main `Conduit` module
- `conduit-lwt`: the portable Lwt implementation
- `conduit-lwt-unix`: the Lwt/Unix implementation
- `conduit-async` the Jane Street Async implementation
- `mirage-conduit`: the MirageOS compatible implementation

### Debugging

Some of the `Lwt_unix`-based modules use a non-empty `CONDUIT_DEBUG`
environment variable to output debugging information to standard error.
Just set this variable when running the program to see what URIs
are being resolved to.

### Further Informartion

* **API Docs:** http://docs.mirage.io/
* **WWW:** https://github.com/mirage/ocaml-conduit
* **E-mail:** <mirageos-devel@lists.xenproject.org>
* **Bugs:** https://github.com/mirage/ocaml-conduit/issues


---
* Homepage: https://github.com/mirage/ocaml-conduit
* Source repo: https://github.com/mirage/ocaml-conduit.git
* Bug tracker: https://github.com/mirage/ocaml-conduit/issues

---


---
## v1.1.0 (2018-03-22)

* Implement SNI (Server Name Indication) for SSL backend (#255 by @vouillon)
* Make hostname optional in `Conduit_lwt_unix_ssl.Client.connect` (#255 by @vouillon)
* Fix file descriptor leakage on `EADDRINUSE` for the Lwt backend (#257 by @rixed)
:camel: Pull-request generated by opam-publish v0.3.5