### PR TITLE
Package alcotest.0.8.3

### DIFF
--- a/packages/alcotest/alcotest.0.8.3/descr
+++ b/packages/alcotest/alcotest.0.8.3/descr
@@ -1,0 +1,11 @@
+Alcotest is a lightweight and colourful test framework.
+
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.

--- a/packages/alcotest/alcotest.0.8.3/opam
+++ b/packages/alcotest/alcotest.0.8.3/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder"  {build & >= "1.0+beta10"}
+  "fmt"       {>= "0.8.0"}
+  "astring"
+  "result"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/alcotest/alcotest.0.8.3/url
+++ b/packages/alcotest/alcotest.0.8.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/alcotest/releases/download/0.8.3/alcotest-0.8.3.tbz"
+checksum: "597e6bb271bd42062f95aa67afdb9185"


### PR DESCRIPTION
### `alcotest.0.8.3`

Alcotest is a lightweight and colourful test framework.

Alcotest exposes simple interface to perform unit tests. It exposes
a simple TESTABLE module type, a check function to assert test
predicates and a run function to perform a list of unit -> unit
test callbacks.

Alcotest provides a quiet and colorful output where only faulty runs
are fully displayed at the end of the run (with the full logs ready to
inspect), with a simple (yet expressive) query language to select the
tests to run.



---
* Homepage: https://github.com/mirage/alcotest/
* Source repo: https://github.com/mirage/alcotest.git
* Bug tracker: https://github.com/mirage/alcotest/issues/

---


---
### 0.8.3 (2018-03-25)

- Show one failure when multiple tests fail (#117, @aantron)
:camel: Pull-request generated by opam-publish v0.3.5