### PR TITLE
[coq-serapi] New release 8.7.2+0.4.13

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
@@ -21,7 +21,7 @@ depends: [
   "cmdliner"
   "sexplib"
   "ppx_driver"   { build & >= "v0.10.1" }
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" { build & <  "v0.11.0" }
 ]
 
 build:   [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_import"    { build & >= "1.4" }
   "ppx_deriving"  { build & >= "4.2.1" }
   "ppx_driver"    { build & >= "v0.10.1" }
-  "ppx_sexp_conv" { build }
+  "ppx_sexp_conv" { build & <  "v0.11.0" }
 ]
 
 build:    [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_import"    { build & >= "1.4" }
   "ppx_deriving"  { build & >= "4.2.1" }
   "ppx_driver"    { build & >= "v0.10.1" }
-  "ppx_sexp_conv" { build }
+  "ppx_sexp_conv" { build & <  "v0.11.0" }
 ]
 
 build:   [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_import"    { build & >= "1.4" }
   "ppx_deriving"  { build & >= "4.2.1" }
   "ppx_driver"    { build & >= "v0.10.1" }
-  "ppx_sexp_conv" { build }
+  "ppx_sexp_conv" { build & <  "v0.11.0" }
 ]
 
 build:    [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
@@ -21,7 +21,7 @@ depends: [
   "cmdliner"
   "sexplib"
   "ppx_driver"   { build & >= "v0.10.1" }
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" { build & <  "v0.11.0" }
 ]
 
 build:   [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/descr
+++ b/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/descr
@@ -1,0 +1,1 @@
+Sexp Protocol for machine-based interaction with the Coq Proof Assistant.

--- a/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer:   "e@x80.org"
+authors:      "Emilio Jesús Gallego Arias"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL 3"
+
+name: "coq-serapi"
+available: [ ocaml-version >= "4.06.0" ]
+
+# ppx depends are so strict due to the issues with ppx_import and
+# ppx_driver integration in the past.
+# ppx_sexp_conv includes a runtime library now, thus it is not a build
+# dep anymore.
+depends: [
+  "coq"           { >= "8.7.2" & < "8.8" }
+  "camlp5"
+  "cmdliner"
+  "sexplib"
+  "ocamlfind"     { build }
+  "ocamlbuild"    { build }
+  "ppx_import"    { build & >= "1.4" }
+  "ppx_deriving"  { build & >= "4.2.1" }
+  "ppx_sexp_conv" { >= "v0.11.0" }
+]
+
+build:    [ make "-j%{jobs}%" "TARGET=native" ]
+install: [[ "cp" "sertop.native"  "%{bin}%/sertop" ]
+          [ "cp" "sercomp.native" "%{bin}%/sercomp"]]
+remove:  [[ "rm" "-f" "%{bin}%/sertop" ]
+          [ "rm" "-f" "%{bin}%/sercomp"]]

--- a/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/url
+++ b/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ejgallego/coq-serapi/archive/8.7.2+0.4.13.tar.gz"
+checksum: "34e3b9d47c0c52294ed1d4c432cfac45"


### PR DESCRIPTION
Fixes build with newer (>= v0.11) ppx_sexp_conv.