### PR TITLE
Package haxe 3.4.7

### DIFF
--- a/packages/haxe/haxe.3.4.7/descr
+++ b/packages/haxe/haxe.3.4.7/descr
@@ -1,0 +1,6 @@
+Multi-target universal programming language
+
+Haxe is an open source toolkit based on a modern,
+high level, static-typed programming language, a cross-compiler,
+a complete cross-platform standard library and ways to access each
+platform's native capabilities.

--- a/packages/haxe/haxe.3.4.7/opam
+++ b/packages/haxe/haxe.3.4.7/opam
@@ -23,6 +23,8 @@ remove: [
 depends: [
   "ocamlfind" {build}
   "camlp4" {build}
+  "conf-libpcre"
+  "conf-zlib"
   "conf-neko"
 ]
 available: [ocaml-version >= "4.02"]

--- a/packages/haxe/haxe.3.4.7/opam
+++ b/packages/haxe/haxe.3.4.7/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: [
+  "Haxe Foundation <contact@haxe.org>" "Andy Li <andy@onthewings.net>"
+]
+authors: "Haxe Foundation <contact@haxe.org>"
+homepage: "https://haxe.org/"
+bug-reports: "https://github.com/HaxeFoundation/haxe/issues"
+license: ["GPL2+" "MIT"]
+dev-repo: "https://github.com/HaxeFoundation/haxe.git"
+build: [
+  ["git" "submodule" "update" "--init" "--recursive"]
+  ["env" "OCAMLPARAM=safe-string=0,_" make]
+]
+install: [
+  ["cp" "haxe" "haxelib" "%{bin}%"]
+  ["mkdir" "-p" "%{share}%/haxe"]
+  ["cp" "-r" "std" "%{share}%/haxe/std"]
+]
+remove: [
+  ["rm" "%{bin}%/haxe" "%{bin}%/haxelib"]
+  ["rm" "-r" "%{share}%/haxe"]
+]
+depends: [
+  "ocamlfind" {build}
+  "camlp4" {build}
+  "conf-neko"
+]
+available: [ocaml-version > "4.02"]

--- a/packages/haxe/haxe.3.4.7/opam
+++ b/packages/haxe/haxe.3.4.7/opam
@@ -8,7 +8,6 @@ bug-reports: "https://github.com/HaxeFoundation/haxe/issues"
 license: ["GPL2+" "MIT"]
 dev-repo: "https://github.com/HaxeFoundation/haxe.git"
 build: [
-  ["git" "submodule" "update" "--init" "--recursive"]
   ["env" "OCAMLPARAM=safe-string=0,_" make]
 ]
 install: [

--- a/packages/haxe/haxe.3.4.7/opam
+++ b/packages/haxe/haxe.3.4.7/opam
@@ -25,4 +25,4 @@ depends: [
   "camlp4" {build}
   "conf-neko"
 ]
-available: [ocaml-version > "4.02"]
+available: [ocaml-version >= "4.02"]

--- a/packages/haxe/haxe.3.4.7/url
+++ b/packages/haxe/haxe.3.4.7/url
@@ -1,1 +1,2 @@
-git: "git://github.com/HaxeFoundation/haxe.git#3.4.7"
+archive: "https://github.com/HaxeFoundation/haxe-debian/archive/upstream/3.4.7.tar.gz"
+checksum: "8b121500d39c1871513b003f9785da0b"

--- a/packages/haxe/haxe.3.4.7/url
+++ b/packages/haxe/haxe.3.4.7/url
@@ -1,0 +1,1 @@
+git: "git://github.com/HaxeFoundation/haxe.git#3.4.7"


### PR DESCRIPTION
Initial packaging of Haxe.
It is built as a native binary so most dependencies are build only.
The use of `git:` in `url` is because there are git submodules which are not included in the Github archive.

