### PR TITLE
datakit-bridge-github.0.12.0: Fix compatibility with jbuilder > 1.0+beta18

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/files/fmt.tty-is-used-by-datakit-log.patch
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/files/fmt.tty-is-used-by-datakit-log.patch
@@ -1,0 +1,22 @@
+From 9a7ec63d4993856ec4cf862f02fb5b051dd073c4 Mon Sep 17 00:00:00 2001
+From: Rudi Grinberg <rudi.grinberg@gmail.com>
+Date: Tue, 27 Feb 2018 02:52:58 +0700
+Subject: [PATCH] fmt.tty is used by datakit-log
+
+---
+ src/datakit-log/jbuild | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/datakit-log/jbuild b/src/datakit-log/jbuild
+index 86ed620..3a8465b 100644
+--- a/src/datakit-log/jbuild
++++ b/src/datakit-log/jbuild
+@@ -4,4 +4,4 @@
+  ((name        datakit_log)
+   (wrapped     false)
+   (libraries   (cmdliner fmt logs.cli prometheus-app.unix mtime mtime.clock.os
+-                win-eventlog asl logs.fmt))))
++                win-eventlog asl logs.fmt fmt.tty))))
+-- 
+2.16.3
+

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/opam
@@ -32,3 +32,7 @@ depends: [
   "alcotest" {test}
   "datakit"  {test & >= "0.12.0"}
 ]
+
+patches: [
+  "fmt.tty-is-used-by-datakit-log.patch"
+]


### PR DESCRIPTION
Applying https://github.com/moby/datakit/pull/617

Failing build log: https://ci.ocamllabs.io/log/saved/docker-run-60bec387a3960421f40ce4b67696756d/fdea8960aeb6fe25e661612db001d0bbc1673f36