### PR TITLE
Partial format upgrade (bibtex2html.1.97, bibtex2html.1.98, bibtex2html.1.99)

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.97/files/make-uninstall.patch
+++ b/packages/bibtex2html/bibtex2html.1.97/files/make-uninstall.patch
@@ -1,0 +1,29 @@
+From 44baaf74783974ac002b9f77a52a748450652afe Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Filliatre <Jean-Christophe.Filliatre@lri.fr>
+Date: Fri, 23 Mar 2018 13:38:46 +0100
+Subject: [PATCH] make uninstall
+
+---
+ CHANGES     | 2 ++
+ Makefile.in | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/Makefile.in b/Makefile.in
+index f62b61d..dfeb55a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -95,6 +95,11 @@ install: install-indep
+ 		cp bib2bib.byte $(BINDIR)/bib2bib ; \
+ 	fi
+ 
++uninstall:
++	rm -f $(BINDIR)/aux2bib $(BINDIR)/bibtex2html $(BINDIR)/bib2bib
++	rm -f $(MANDIR)/man1/aux2bib.1 $(MANDIR)/man1/bibtex2html.1 \
++	  $(MANDIR)/man1/bib2bib.1
++
+ install-byte: install-indep
+ 	cp bibtex2html.byte $(BINDIR)/bibtex2html
+ 	cp bib2bib.byte $(BINDIR)/bib2bib
+-- 
+2.16.2
+

--- a/packages/bibtex2html/bibtex2html.1.97/opam
+++ b/packages/bibtex2html/bibtex2html.1.97/opam
@@ -4,6 +4,9 @@ authors: [
   "Jean-Christophe Filliâtre"
   "Claude Marché"
 ]
+homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
+dev-repo: "git+https://github.com/backtracking/bibtex2html.git"
+bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GNU General Public License version 2"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -11,7 +14,12 @@ build: [
 ]
 depends: ["ocaml" "hevea"]
 install: [make "install"]
+remove: [make "uninstall"]
+patches: [
+  "make-uninstall.patch"
+]
 synopsis: "BibTeX to HTML translator"
+extra-files: ["make-uninstall.patch" "md5=9b4962f579a48817413af55901dc1db1"]
 url {
   src: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.97.tar.gz"
   checksum: "md5=d20d0d607be3f6aa770554f3eee0dde1"

--- a/packages/bibtex2html/bibtex2html.1.98/files/make-uninstall.patch
+++ b/packages/bibtex2html/bibtex2html.1.98/files/make-uninstall.patch
@@ -1,0 +1,29 @@
+From 44baaf74783974ac002b9f77a52a748450652afe Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Filliatre <Jean-Christophe.Filliatre@lri.fr>
+Date: Fri, 23 Mar 2018 13:38:46 +0100
+Subject: [PATCH] make uninstall
+
+---
+ CHANGES     | 2 ++
+ Makefile.in | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/Makefile.in b/Makefile.in
+index f62b61d..dfeb55a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -95,6 +95,11 @@ install: install-indep
+ 		cp bib2bib.byte $(BINDIR)/bib2bib ; \
+ 	fi
+ 
++uninstall:
++	rm -f $(BINDIR)/aux2bib $(BINDIR)/bibtex2html $(BINDIR)/bib2bib
++	rm -f $(MANDIR)/man1/aux2bib.1 $(MANDIR)/man1/bibtex2html.1 \
++	  $(MANDIR)/man1/bib2bib.1
++
+ install-byte: install-indep
+ 	cp bibtex2html.byte $(BINDIR)/bibtex2html
+ 	cp bib2bib.byte $(BINDIR)/bib2bib
+-- 
+2.16.2
+

--- a/packages/bibtex2html/bibtex2html.1.98/opam
+++ b/packages/bibtex2html/bibtex2html.1.98/opam
@@ -4,6 +4,9 @@ authors: [
   "Jean-Christophe Filliâtre"
   "Claude Marché"
 ]
+homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
+dev-repo: "git+https://github.com/backtracking/bibtex2html.git"
+bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GNU General Public License version 2"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -11,7 +14,12 @@ build: [
 ]
 depends: ["ocaml" "hevea"]
 install: [make "install"]
+remove: [make "uninstall"]
+patches: [
+  "make-uninstall.patch"
+]
 synopsis: "BibTeX to HTML translator"
+extra-files: ["make-uninstall.patch" "md5=9b4962f579a48817413af55901dc1db1"]
 url {
   src: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.98.tar.gz"
   checksum: "md5=33a96d32d6ca870163855573253aa720"

--- a/packages/bibtex2html/bibtex2html.1.99/files/0001-make-uninstall.patch
+++ b/packages/bibtex2html/bibtex2html.1.99/files/0001-make-uninstall.patch
@@ -1,0 +1,29 @@
+From 44baaf74783974ac002b9f77a52a748450652afe Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Filliatre <Jean-Christophe.Filliatre@lri.fr>
+Date: Fri, 23 Mar 2018 13:38:46 +0100
+Subject: [PATCH] make uninstall
+
+---
+ CHANGES     | 2 ++
+ Makefile.in | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/Makefile.in b/Makefile.in
+index f62b61d..dfeb55a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -95,6 +95,11 @@ install: install-indep
+ 		cp bib2bib.byte $(BINDIR)/bib2bib ; \
+ 	fi
+ 
++uninstall:
++	rm -f $(BINDIR)/aux2bib $(BINDIR)/bibtex2html $(BINDIR)/bib2bib
++	rm -f $(MANDIR)/man1/aux2bib.1 $(MANDIR)/man1/bibtex2html.1 \
++	  $(MANDIR)/man1/bib2bib.1
++
+ install-byte: install-indep
+ 	cp bibtex2html.byte $(BINDIR)/bibtex2html
+ 	cp bib2bib.byte $(BINDIR)/bib2bib
+-- 
+2.16.2
+

--- a/packages/bibtex2html/bibtex2html.1.99/files/make-uninstall.patch
+++ b/packages/bibtex2html/bibtex2html.1.99/files/make-uninstall.patch
@@ -1,0 +1,29 @@
+From 44baaf74783974ac002b9f77a52a748450652afe Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Filliatre <Jean-Christophe.Filliatre@lri.fr>
+Date: Fri, 23 Mar 2018 13:38:46 +0100
+Subject: [PATCH] make uninstall
+
+---
+ CHANGES     | 2 ++
+ Makefile.in | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/Makefile.in b/Makefile.in
+index f62b61d..dfeb55a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -95,6 +95,11 @@ install: install-indep
+ 		cp bib2bib.byte $(BINDIR)/bib2bib ; \
+ 	fi
+ 
++uninstall:
++	rm -f $(BINDIR)/aux2bib $(BINDIR)/bibtex2html $(BINDIR)/bib2bib
++	rm -f $(MANDIR)/man1/aux2bib.1 $(MANDIR)/man1/bibtex2html.1 \
++	  $(MANDIR)/man1/bib2bib.1
++
+ install-byte: install-indep
+ 	cp bibtex2html.byte $(BINDIR)/bibtex2html
+ 	cp bib2bib.byte $(BINDIR)/bib2bib
+-- 
+2.16.2
+

--- a/packages/bibtex2html/bibtex2html.1.99/opam
+++ b/packages/bibtex2html/bibtex2html.1.99/opam
@@ -17,7 +17,15 @@ depends: [
   "hevea"
 ]
 install: [make "install"]
+remove: [make "uninstall"]
+patches: [
+  "make-uninstall.patch"
+]
 synopsis: "BibTeX to HTML translator"
+extra-files: [
+  ["make-uninstall.patch" "md5=9b4962f579a48817413af55901dc1db1"]
+  ["0001-make-uninstall.patch" "md5=9b4962f579a48817413af55901dc1db1"]
+]
 url {
   src: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.99.tar.gz"
   checksum: "md5=85f8d617b13d34a552261b3fbb406a0f"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/bibtex2html/bibtex2html.1.97/files/make-uninstall.patch
  - packages/bibtex2html/bibtex2html.1.98/files/make-uninstall.patch
  - packages/bibtex2html/bibtex2html.1.99/files/0001-make-uninstall.patch
  - packages/bibtex2html/bibtex2html.1.99/files/make-uninstall.patch