### PR TITLE
ppx_tools_versioned: Fix lower-bound to ocaml-migrate-parsetree

### DIFF
--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.1/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.1/opam
@@ -14,6 +14,6 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "ppx_tools_versioned"]
 depends: [
   "ocamlfind" {>= "1.5.0"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
+  "ocaml-migrate-parsetree" {>= "1.0.7"}
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
Fix proposed by @let-def over IRC

Failing build log: https://ci.ocamllabs.io/log/saved/docker-run-e817741de7e4fb9b4d7f628701f8ec9b/fcabd786ea4343662bba8341d317e2d378935ebd