### PR TITLE
extlib: blacklist 1.7.4 on 32-bit archs (broken)

### DIFF
--- a/packages/extlib/extlib.1.7.4/opam
+++ b/packages/extlib/extlib.1.7.4/opam
@@ -33,3 +33,5 @@ depends: [
   "cppo" {build}
   "base-bytes" {build}
 ]
+# 1.7.3 broke 32-bit builds
+available: [ arch != "i386" & arch != "armv7l" ]


### PR DESCRIPTION
ref https://github.com/ygrek/ocaml-extlib/issues/46