### PR TITLE
Patch ppx_fun for ppx_core.v0.11.0+

### DIFF
--- a/packages/ppx_fun/ppx_fun.0.0.4-1/descr
+++ b/packages/ppx_fun/ppx_fun.0.0.4-1/descr
@@ -1,0 +1,1 @@
+ppx_fun is PPX rewriter that provides simplified syntax for anonymous functions via extensions: `[%f ...]` and `[%f_ ...]`.

--- a/packages/ppx_fun/ppx_fun.0.0.4-1/files/tags-file.patch
+++ b/packages/ppx_fun/ppx_fun.0.0.4-1/files/tags-file.patch
@@ -1,0 +1,13 @@
+diff --git a/_tags b/_tags
+index 1a67ce9..cb802d7 100644
+--- a/_tags
++++ b/_tags
+@@ -6,7 +6,7 @@ true: bin_annot, safe_string, debug, warn(-58)
+ <test> : include
+ 
+ <src/*>: warn(@5@8@9@10@11@12@14@15@16@23@24@25@26@27@29@33@40)
+-<src/*>: package(ppx_core), package(ppx_tools.metaquot)
++<src/*>: package(ppx_ast), package(ppx_core), package(ppx_tools.metaquot)
+ 
+ <test/*>:  warn(@5@8@10@11@12@14@23@24@26@29@40)
+ <test/*>:  use_ppx_fun

--- a/packages/ppx_fun/ppx_fun.0.0.4-1/opam
+++ b/packages/ppx_fun/ppx_fun.0.0.4-1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+version: "0.0.4"
+maintainer: "Roma Sokolov <sokolov.r.v@gmail.com>"
+authors: ["Roma Sokolov <sokolov.r.v@gmail.com>"]
+homepage: "https://github.com/little-arhat/ppx_fun"
+doc: "github.com/little-arhat/ppx_fun/doc"
+license: "MIT"
+dev-repo: "https://github.com/little-arhat/ppx_fun.git"
+bug-reports: "https://github.com/little-arhat/ppx_fun/issues"
+patches: [
+  "tags-file.patch"
+]
+tags: []
+available: [ ocaml-version >= "4.03.0"]
+depends: [
+  "ppx_core" {>="v0.9.0"}
+  "ppx_tools"
+  "ppx_ast"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+depopts: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--tests" "true"]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]]

--- a/packages/ppx_fun/ppx_fun.0.0.4-1/url
+++ b/packages/ppx_fun/ppx_fun.0.0.4-1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/little-arhat/ppx_fun/archive/v0.0.4.tar.gz"
+checksum: "651c9cf37123b9b01bf32e19c7d57833"


### PR DESCRIPTION
Before v0.11.0, `ppx_core` depended on `ppx_ast` and was hence
implicitly added to the compilation command-line. This is no longer
the case, so the build has to be patched to explicitly refer to the
`ppx_ast` package.

(Diagnosed while working on https://github.com/ocaml/opam-repository/pull/11608)