### PR TITLE
r2pipe is now deprecated

### DIFF
--- a/packages/r2pipe/r2pipe.0.0.1/opam
+++ b/packages/r2pipe/r2pipe.0.0.1/opam
@@ -12,3 +12,5 @@ depends: [
   "ocamlfind" {build}
   "yojson"
 ]
+messages: "DEPRECATED. This package is outdated, you should consider using radare2 instead"
+tags: ["deprecated"]


### PR DESCRIPTION
r2pipe is now deprecated. we recommend to use `radare2` package instead of `r2pipe`.
