### PR TITLE
Partial format upgrade (bap.1.4.0, bap-abi.1.4.0, bap-api.1.4.0, bap-arm.1.4.0, bap-beagle.1.4.0, ...)

### DIFF
--- a/packages/bap-llvm/bap-llvm.1.4.0/files/detect.travis
+++ b/packages/bap-llvm/bap-llvm.1.4.0/files/detect.travis
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > bap-llvm.config <<EOF
+ travis : ${TRAVIS:-false}
+EOF

--- a/packages/bap-llvm/bap-llvm.1.4.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.4.0/opam
@@ -43,6 +43,7 @@ depexts: [
 synopsis: "BAP LLVM backend"
 description:
   "Provides a loader and a disassembler, based on LLVM-MC library."
+extra-files: ["detect.travis" "md5=00e7b28719062d550dcd7813becf7396"]
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.4.0.tar.gz"
   checksum: "md5=b7785715c24645e8e69a8091427d090e"

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
@@ -19,3 +19,4 @@ depexts: [
   ["llvm-3.8"] {os = "macos" & os-distribution = "macports"}
   ["homebrew/versions/llvm38"] {os = "macos" & os-distribution = "homebrew"}
 ]
+extra-files: ["configure" "md5=a033126062cb57df9edae2909302d081"]

--- a/packages/conf-ida/conf-ida.0.1/files/find-ida.sh
+++ b/packages/conf-ida/conf-ida.0.1/files/find-ida.sh
@@ -81,14 +81,13 @@ case $1 in
         [ $IDA_PATH ] || locate_macos
         ;;
     *)
-        echo "unsupported OS"
-        exit 1
+        echo "warning: we don't know how to find programs on $1"
     ;;
 esac
 
 if [ -z $IDA_PATH ]; then
-    echo "failed to locate IDA Pro"
-    exit 1
+    echo "warning: failed to locate IDA Pro"
+    IDA_PATH="undefined"
 fi
 
 cat > conf-ida.config <<EOF

--- a/packages/core-lwt/core-lwt.0.2.0/opam
+++ b/packages/core-lwt/core-lwt.0.2.0/opam
@@ -26,7 +26,7 @@ depends: [
   "oasis" {build & >= "0.4.0"}
   "base-unix"
   "base-threads"
-  "core_kernel" {>= "v0.9.0" & < "v0.11"}
+  "core_kernel" {>= "v0.9.0"}
   "lwt" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Lwt library wrapper in the Janestreet core style"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/bap-abi/bap-abi.1.4.0/opam
  - packages/bap-api/bap-api.1.4.0/opam
  - packages/bap-arm/bap-arm.1.4.0/opam
  - packages/bap-beagle/bap-beagle.1.4.0/opam
  - packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/opam
  - packages/bap-byteweight/bap-byteweight.1.4.0/opam
  - packages/bap-c/bap-c.1.4.0/opam
  - packages/bap-cache/bap-cache.1.4.0/opam
  - packages/bap-callsites/bap-callsites.1.4.0/opam
  - packages/bap-cxxfilt/bap-cxxfilt.1.4.0/opam
  - packages/bap-dead-code-elimination/bap-dead-code-elimination.1.4.0/opam
  - packages/bap-demangle/bap-demangle.1.4.0/opam
  - packages/bap-dump-symbols/bap-dump-symbols.1.4.0/opam
  - packages/bap-dwarf/bap-dwarf.1.4.0/opam
  - packages/bap-frames/bap-frames.2.1.1/opam
  - packages/bap-frontc/bap-frontc.1.4.0/opam
  - packages/bap-frontend/bap-frontend.1.4.0/opam
  - packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/opam
  - packages/bap-future/bap-future.1.4.0/opam
  - packages/bap-ida-plugin/bap-ida-plugin.1.4.0/opam
  - packages/bap-ida/bap-ida.1.4.0/opam
  - packages/bap-llvm/bap-llvm.1.4.0/opam
  - packages/bap-mc/bap-mc.1.4.0/opam
  - packages/bap-microx/bap-microx.1.4.0/opam
  - packages/bap-mips/bap-mips.1.4.0/opam
  - packages/bap-objdump/bap-objdump.1.4.0/opam
  - packages/bap-phoenix/bap-phoenix.1.4.0/opam
  - packages/bap-piqi/bap-piqi.1.4.0/opam
  - packages/bap-powerpc/bap-powerpc.1.4.0/opam
  - packages/bap-primus-dictionary/bap-primus-dictionary.1.4.0/opam
  - packages/bap-primus-lisp/bap-primus-lisp.1.4.0/opam
  - packages/bap-primus-region/bap-primus-region.1.4.0/opam
  - packages/bap-primus-support/bap-primus-support.1.4.0/opam
  - packages/bap-primus-test/bap-primus-test.1.4.0/opam
  - packages/bap-primus-x86/bap-primus-x86.1.4.0/opam
  - packages/bap-primus/bap-primus.1.4.0/opam
  - packages/bap-print/bap-print.1.4.0/opam
  - packages/bap-relocatable/bap-relocatable.1.4.0/opam
  - packages/bap-report/bap-report.1.4.0/opam
  - packages/bap-run/bap-run.1.4.0/opam
  - packages/bap-server/bap-server.0.2.0/opam
  - packages/bap-signatures/bap-signatures.1.4.0/opam
  - packages/bap-ssa/bap-ssa.1.4.0/opam
  - packages/bap-std/bap-std.1.4.0/opam
  - packages/bap-strings/bap-strings.1.4.0/opam
  - packages/bap-symbol-reader/bap-symbol-reader.1.4.0/opam
  - packages/bap-taint-propagator/bap-taint-propagator.1.4.0/opam
  - packages/bap-taint/bap-taint.1.4.0/opam
  - packages/bap-term-mapper/bap-term-mapper.1.4.0/opam
  - packages/bap-trace/bap-trace.1.4.0/opam
  - packages/bap-traces/bap-traces.1.4.0/opam
  - packages/bap-trivial-condition-form/bap-trivial-condition-form.1.4.0/opam
  - packages/bap-veri/bap-veri.0.2.2/opam
  - packages/bap-warn-unused/bap-warn-unused.1.4.0/opam
  - packages/bap-x86/bap-x86.1.4.0/opam
  - packages/bap/bap.1.4.0/opam
  - packages/bare/bare.1.4.0/opam
  - packages/conf-bap-llvm/conf-bap-llvm.1.2/files/configure
  - packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
  - packages/core-lwt/core-lwt.0.2.0/opam
  - packages/graphlib/graphlib.1.4.0/opam
  - packages/monads/monads.1.4.0/opam
  - packages/ogre/ogre.1.4.0/opam
  - packages/regular/regular.1.4.0/opam
  - packages/text-tags/text-tags.1.4.0/opam