### PR TITLE
`conf-snappy`

### DIFF
--- a/packages/conf-snappy/conf-snappy.1/descr
+++ b/packages/conf-snappy/conf-snappy.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on snappy
+This package can only install if the snappy library is installed on the system.

--- a/packages/conf-snappy/conf-snappy.1/files/test.cpp
+++ b/packages/conf-snappy/conf-snappy.1/files/test.cpp
@@ -1,0 +1,14 @@
+#include <snappy.h>
+#include <iostream>
+using namespace std;
+
+int main() {
+  string input = "Hello World, Hello World, Hello World!";
+  string compressed;
+  snappy::Compress(input.data(), input.size(), &compressed);
+  cout << input.size() << " => " << compressed.size() << endl;
+  string output;
+  snappy::Uncompress(compressed.data(), compressed.size(), &output);
+  cout << output << endl;
+  return 0;
+}

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+author: ["Gabriel Scherer"]
+maintainer: "gabriel.scherer@inria.fr"
+homepage: "https://google.github.io/snappy/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "https://github.com/ocaml/opam-repository.git"
+build: [
+  ["c++" "test.cpp" "-lsnappy"]
+]
+depends: [ "conf-pkg-config" ]
+depexts: [
+  [["debian"] ["libsnappy-dev"]]
+  [["ubuntu"] ["libsnappy-dev"]]
+  [["osx" "homebrew"] ["snappy"]]
+  [["fedora"] ["snappy-devel"]]
+]

--- a/packages/leveldb/leveldb.1.0.2/opam
+++ b/packages/leveldb/leveldb.1.0.2/opam
@@ -18,3 +18,4 @@ depends: [
 patches: [ "link_against_extra_libs.patch" ]
 dev-repo: "git://github.com/mfp/ocaml-leveldb"
 install: ["omake" "install" "prefix=%{prefix}%"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/leveldb/leveldb.1.0.2/opam
+++ b/packages/leveldb/leveldb.1.0.2/opam
@@ -12,11 +12,8 @@ depends: [
   "ocamlfind"
   "omake"
   "conf-leveldb"
+  "conf-snappy"
   "ounit"
-]
-depexts: [
-  [["debian"] ["libsnappy-dev"]]
-  [["ubuntu"] ["libsnappy-dev"]]
 ]
 patches: [ "link_against_extra_libs.patch" ]
 dev-repo: "git://github.com/mfp/ocaml-leveldb"

--- a/packages/leveldb/leveldb.1.0.2/opam
+++ b/packages/leveldb/leveldb.1.0.2/opam
@@ -1,8 +1,11 @@
 opam-version: "1.2"
 maintainer: "mfp@acm.org"
+authors: "mfp@acm.org"
 homepage: "https://github.com/mfp/ocaml-leveldb"
+bug-reports: "https://github.com/mfp/ocaml-leveldb/issues"
 license: "LGPL+static"
-doc: ["https://github.com/mfp/ocaml-leveldb/blob/master/README.md"]
+doc: "https://github.com/mfp/ocaml-leveldb/blob/master/README.md"
+dev-repo: "git://github.com/mfp/ocaml-leveldb"
 build: ["omake" "-j9"]
 build-test: [["omake" "test"] {"%{ounit:installed}"}]
 remove: [
@@ -16,6 +19,5 @@ depends: [
   "ounit"
 ]
 patches: [ "link_against_extra_libs.patch" ]
-dev-repo: "git://github.com/mfp/ocaml-leveldb"
 install: ["omake" "install" "prefix=%{prefix}%"]
 available: [ ocaml-version < "4.06" ]

--- a/packages/leveldb/leveldb.1.0.2/opam
+++ b/packages/leveldb/leveldb.1.0.2/opam
@@ -20,4 +20,4 @@ depends: [
 ]
 patches: [ "link_against_extra_libs.patch" ]
 install: ["omake" "install" "prefix=%{prefix}%"]
-available: [ ocaml-version < "4.06" ]
+available: [ false ]

--- a/packages/leveldb/leveldb.1.0.3/opam
+++ b/packages/leveldb/leveldb.1.0.3/opam
@@ -1,8 +1,11 @@
 opam-version: "1.2"
 maintainer: "mfp@acm.org"
+authors: "mfp@acm.org"
 homepage: "https://github.com/mfp/ocaml-leveldb"
+bug-reports: "https://github.com/mfp/ocaml-leveldb/issues"
 license: "LGPL+static"
-doc: ["https://github.com/mfp/ocaml-leveldb/blob/master/README.md"]
+doc: "https://github.com/mfp/ocaml-leveldb/blob/master/README.md"
+dev-repo: "git://github.com/mfp/ocaml-leveldb"
 build: ["omake" "-j9"]
 build-test: [["omake" "test"] {"%{ounit:installed}"}]
 remove: [

--- a/packages/leveldb/leveldb.1.0.3/opam
+++ b/packages/leveldb/leveldb.1.0.3/opam
@@ -11,12 +11,9 @@ remove: [
 depends: [
   "ocamlfind"
   "omake"
+  "conf-snappy"
   "conf-leveldb"
   "ounit"
-]
-depexts: [
-  [["debian"] ["libsnappy-dev"]]
-  [["ubuntu"] ["libsnappy-dev"]]
 ]
 patches: [ "fix_snappy_link_issue.patch"
            "warn_error.patch" ]

--- a/packages/leveldb/leveldb.1.0.3/opam
+++ b/packages/leveldb/leveldb.1.0.3/opam
@@ -22,3 +22,4 @@ patches: [ "fix_snappy_link_issue.patch"
            "warn_error.patch" ]
 dev-repo: "git://github.com/mfp/ocaml-leveldb"
 install: ["omake" "install" "prefix=%{prefix}%"]
+available: [ ocaml-version < "4.02" ]

--- a/packages/leveldb/leveldb.1.1.0/opam
+++ b/packages/leveldb/leveldb.1.1.0/opam
@@ -18,9 +18,5 @@ depends: [
   "omake" {build}
   "ounit" {build}
   "conf-leveldb"
-]
-
-depexts: [
-  [["debian"] ["libsnappy-dev"]]
-  [["ubuntu"] ["libsnappy-dev"]]
+  "conf-snappy"
 ]

--- a/packages/leveldb/leveldb.1.1.0/opam
+++ b/packages/leveldb/leveldb.1.1.0/opam
@@ -20,3 +20,4 @@ depends: [
   "conf-leveldb"
   "conf-snappy"
 ]
+available: [ocaml-version < "4.06"]

--- a/packages/leveldb/leveldb.1.1.1/opam
+++ b/packages/leveldb/leveldb.1.1.1/opam
@@ -18,9 +18,5 @@ depends: [
   "omake" {build}
   "ounit" {build}
   "conf-leveldb"
-]
-
-depexts: [
-  [["debian"] ["libsnappy-dev"]]
-  [["ubuntu"] ["libsnappy-dev"]]
+  "conf-snappy"
 ]

--- a/packages/leveldb/leveldb.1.1.1/opam
+++ b/packages/leveldb/leveldb.1.1.1/opam
@@ -20,3 +20,4 @@ depends: [
   "conf-leveldb"
   "conf-snappy"
 ]
+available: [ocaml-version < "4.06"]

--- a/packages/leveldb/leveldb.1.1.2/opam
+++ b/packages/leveldb/leveldb.1.1.2/opam
@@ -16,9 +16,6 @@ depends: [
   "ocamlfind" {build}
   "omake" {build}
   "ounit" {test}
+  "conf-snappy"
   "conf-leveldb"
-]
-depexts: [
-  [["debian"] ["libsnappy-dev"]]
-  [["ubuntu"] ["libsnappy-dev"]]
 ]

--- a/packages/leveldb/leveldb.1.1.2/opam
+++ b/packages/leveldb/leveldb.1.1.2/opam
@@ -19,3 +19,4 @@ depends: [
   "conf-snappy"
   "conf-leveldb"
 ]
+available: [ocaml-version < "4.06"]

--- a/packages/snappy/snappy.0.0.1/opam
+++ b/packages/snappy/snappy.0.0.1/opam
@@ -16,3 +16,4 @@ depends: [
   "conf-snappy"
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available:[false]

--- a/packages/snappy/snappy.0.0.1/opam
+++ b/packages/snappy/snappy.0.0.1/opam
@@ -1,7 +1,10 @@
 opam-version: "1.2"
+authors: "ygrek@autistici.org"
 maintainer: "ygrek@autistici.org"
-homepage: "http://snappy.forge.ocamlcore.org"
-doc: ["http://snappy.forge.ocamlcore.org/api/index.html"]
+homepage: "http://ygrek.org.ua/p/ocaml-snappy/"
+doc: ["http://ygrek.org.ua/p/ocaml-snappy/api/index.html"]
+bug-reports: "https://github.com/ygrek/ocaml-snappy/issues"
+dev-repo: "git://github.com/ygrek/ocaml-snappy"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/snappy/snappy.0.0.1/opam
+++ b/packages/snappy/snappy.0.0.1/opam
@@ -10,9 +10,6 @@ remove: [["ocamlfind" "remove" "snappy"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [["debian"] ["libsnappy-dev"]]
-  [["ubuntu"] ["libsnappy-dev"]]
+  "conf-snappy"
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/snappy/snappy.0.1.0/opam
+++ b/packages/snappy/snappy.0.1.0/opam
@@ -12,11 +12,7 @@ remove: [["ocamlfind" "remove" "snappy"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
-]
-depexts: [
-  [["debian"] ["libsnappy-dev"]]
-  [["ubuntu"] ["libsnappy-dev"]]
-  [["osx" "homebrew"] ["snappy"]]
+  "conf-snappy"
 ]
 patches: [ "myocamlbuild.ml.osx.patch" { os = "darwin" } ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/snappy/snappy.0.1.0/opam
+++ b/packages/snappy/snappy.0.1.0/opam
@@ -19,3 +19,4 @@ depends: [
 ]
 patches: [ "myocamlbuild.ml.osx.patch" { os = "darwin" } ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06" ]

--- a/packages/snappy/snappy.0.1.0/opam
+++ b/packages/snappy/snappy.0.1.0/opam
@@ -1,7 +1,10 @@
 opam-version: "1.2"
+authors: "ygrek@autistici.org"
 maintainer: "ygrek@autistici.org"
-homepage: "http://snappy.forge.ocamlcore.org"
-doc: ["http://snappy.forge.ocamlcore.org/api/index.html"]
+homepage: "http://ygrek.org.ua/p/ocaml-snappy/"
+doc: ["http://ygrek.org.ua/p/ocaml-snappy/api/index.html"]
+bug-reports: "https://github.com/ygrek/ocaml-snappy/issues"
+dev-repo: "git://github.com/ygrek/ocaml-snappy"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]


### PR DESCRIPTION
I got caught by the lack of a fedora depext for snappy in leveldb, so here is a conf-package for snappy.