### PR TITLE
Partial format upgrade (base.v0.9.3)

### DIFF
--- a/packages/base/base.v0.9.3/opam
+++ b/packages/base/base.v0.9.3/opam
@@ -25,6 +25,7 @@ features such as I/O are not offered by Base. They are instead
 provided by companion libraries such as stdio:
 
   https://github.com/janestreet/stdio"""
+extra-files: ["metaocaml.patch" "md5=35e4b6516daba35e7633ee95bc2ebe4a"]
 url {
   src: "https://github.com/janestreet/base/archive/v0.9.3.tar.gz"
   checksum: "md5=3edb19585be84ea308323ccd41213e57"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/base/base.v0.9.3/files/metaocaml.patch
  - packages/base/base.v0.9.3/opam