### PR TITLE
Partial format upgrade (camlp4.4.02+1, camlp4.4.02+2, camlp4.4.02+3, camlp4.4.02+4, camlp4.4.02+6, ...)

### DIFF
--- a/packages/camlp4/camlp4.4.02+1/opam
+++ b/packages/camlp4/camlp4.4.02+1/opam
@@ -31,6 +31,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:
@@ -49,7 +50,6 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
-patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+2/opam
+++ b/packages/camlp4/camlp4.4.02+2/opam
@@ -31,6 +31,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:
@@ -49,7 +50,6 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
-patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+3/opam
+++ b/packages/camlp4/camlp4.4.02+3/opam
@@ -31,6 +31,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:
@@ -49,7 +50,6 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
-patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+4/opam
+++ b/packages/camlp4/camlp4.4.02+4/opam
@@ -31,6 +31,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:
@@ -49,7 +50,6 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
-patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.02+6/opam
+++ b/packages/camlp4/camlp4.4.02+6/opam
@@ -30,6 +30,7 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:
@@ -48,7 +49,6 @@ This version of Camlp4 installs using the `ocamlfind` packaging utility.  If
 you were using `+I camlp4` to directly locate Camlp4, this will no longer work."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
-patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=720f4136f835473317507945b86a9826"

--- a/packages/camlp4/camlp4.4.06+1/opam
+++ b/packages/camlp4/camlp4.4.06+1/opam
@@ -29,7 +29,7 @@ remove: [
              "%{bin}%/camlp4o" "%{bin}%/camlp4of"   "%{bin}%/camlp4oof"
              "%{bin}%/camlp4prof"]
 ]
-
+patches: [ "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:
@@ -45,7 +45,6 @@ Since then it has been replaced by a simpler system which is easier to maintain
 and to learn: ppx rewriters and extension points."""
 conflicts: ["ocaml-system"]
 flags: light-uninstall
-patches: ["f0ea53725465260556832398096cef8d3f20b49d.patch"]
 extra-files: [
   "f0ea53725465260556832398096cef8d3f20b49d.patch"
   "md5=4e15b0fb960be4be48b154bfafbb9a16"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/camlp4/camlp4.4.02+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.02+1/opam
  - packages/camlp4/camlp4.4.02+2/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.02+2/opam
  - packages/camlp4/camlp4.4.02+3/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.02+3/opam
  - packages/camlp4/camlp4.4.02+4/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.02+4/opam
  - packages/camlp4/camlp4.4.02+6/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.02+6/opam
  - packages/camlp4/camlp4.4.02+7/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.02+7/opam
  - packages/camlp4/camlp4.4.03+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.03+1/opam
  - packages/camlp4/camlp4.4.04+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.04+1/opam
  - packages/camlp4/camlp4.4.05+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.05+1/opam
  - packages/camlp4/camlp4.4.06+1/files/f0ea53725465260556832398096cef8d3f20b49d.patch
  - packages/camlp4/camlp4.4.06+1/opam