### PR TITLE
Partial format upgrade (bisect.1.3.1)

### DIFF
--- a/packages/bisect/bisect.1.3.1/opam
+++ b/packages/bisect/bisect.1.3.1/opam
@@ -26,6 +26,7 @@ running tests. After application execution, it is possible to generate
 a report in HTML format that is the replica of the application source
 code annotated with code coverage information."""
 flags: light-uninstall
+extra-files: ["bisect.install" "md5=2106aa627796b3e457d35f1100295f27"]
 url {
   src: "https://github.com/gasche/bisect/archive/1.3.1.tar.gz"
   checksum: "md5=fd0c2d163e4847df075d87fa9bb42b00"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/bisect/bisect.1.3.1/files/bisect.install
  - packages/bisect/bisect.1.3.1/opam