### PR TITLE
Partial format upgrade (coq.8.7.2)

### DIFF
--- a/packages/coq/coq.8.7.2/opam
+++ b/packages/coq/coq.8.7.2/opam
@@ -57,6 +57,7 @@ remove: [
 ]
 synopsis: "Formal proof management system."
 flags: light-uninstall
+extra-files: ["coq.install" "md5=b85e0eb533d6836c15581f0e5cb0ebc2"]
 url {
   src: "https://github.com/coq/coq/archive/V8.7.2.tar.gz"
   checksum: "md5=470c8f2bd74a085e1f71d5e4770e64e7"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/coq/coq.8.7.2/files/coq.install
  - packages/coq/coq.8.7.2/opam