### PR TITLE
Partial format upgrade (camlp5.7.05)

### DIFF
--- a/packages/camlp5/camlp5.7.05/opam
+++ b/packages/camlp5/camlp5.7.05/opam
@@ -20,6 +20,7 @@ synopsis: "Preprocessor-pretty-printer of OCaml"
 depends: [
   "ocaml" {>= "4.02" & < "4.06.3"}
 ]
+extra-files: ["camlp5.install" "md5=b16bcaf28bfb364236b2181fb50a6564"]
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel705.tar.gz"
   checksum: "md5=cf9d909191711afb1b634f75acbe1cfe"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/camlp5/camlp5.7.05/files/camlp5.install
  - packages/camlp5/camlp5.7.05/opam