### PR TITLE
Partial format upgrade (coqide.8.7.2)

### DIFF
--- a/packages/coqide/coqide.8.7.2/opam
+++ b/packages/coqide/coqide.8.7.2/opam
@@ -37,6 +37,7 @@ install: [
 remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
+extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
 url {
   src: "https://github.com/coq/coq/archive/V8.7.2.tar.gz"
   checksum: "md5=470c8f2bd74a085e1f71d5e4770e64e7"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/coqide/coqide.8.7.2/files/coqide.install
  - packages/coqide/coqide.8.7.2/opam