### PR TITLE
Partial format upgrade (async_inotify.v0.9.0, async_inotify.v0.10.0, bistro.0.3.0, bitcoinml.0.2, bitcoinml.0.2.4, ...)

### DIFF
--- a/packages/core-lwt/core-lwt.0.2.0/opam
+++ b/packages/core-lwt/core-lwt.0.2.0/opam
@@ -26,7 +26,7 @@ depends: [
   "oasis" {build & >= "0.4.0"}
   "base-unix"
   "base-threads"
-  "core_kernel" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0" & < "v0.11"}
   "lwt" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Lwt library wrapper in the Janestreet core style"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/async_inotify/async_inotify.v0.10.0/opam
  - packages/async_inotify/async_inotify.v0.9.0/opam
  - packages/bistro/bistro.0.3.0/opam
  - packages/bitcoinml/bitcoinml.0.2.4/opam
  - packages/bitcoinml/bitcoinml.0.2/opam
  - packages/bitcoinml/bitcoinml.0.3.0/opam
  - packages/bitcoinml/bitcoinml.0.3.1/opam
  - packages/boomerang/boomerang.1.1.0/opam
  - packages/capnp/capnp.3.2.0/opam
  - packages/cfstream/cfstream.1.2.3/opam
  - packages/conduit-async/conduit-async.1.0.3/opam
  - packages/frag/frag.0.1.0/opam
  - packages/netml/netml.0.1.0/opam
  - packages/osm_xml/osm_xml.0.0.1/opam
  - packages/prettiest/prettiest.0.0.1/opam
  - packages/prettiest/prettiest.0.0.2/opam
  - packages/session-postgresql-async/session-postgresql-async.0.4.0/opam
  - packages/trie/trie.0.1.1/opam