### PR TITLE
Fix added depredated message into descr and fix opam syntax error

### DIFF
--- a/packages/r2pipe/r2pipe.0.0.1/descr
+++ b/packages/r2pipe/r2pipe.0.0.1/descr
@@ -1,6 +1,1 @@
-OCaml binding of R2Pipe
-
-r2pipe-ocaml is an OCaml binding of R2Pipe which used to 
-automate radare2. 
-It has simple internal. It just spawn a r2 with quiet mode
-and then interact through In/Out channel. 
+Deprecated: use radare2 instead

--- a/packages/r2pipe/r2pipe.0.0.1/opam
+++ b/packages/r2pipe/r2pipe.0.0.1/opam
@@ -12,5 +12,6 @@ depends: [
   "ocamlfind" {build}
   "yojson"
 ]
-messages: "DEPRECATED. This package is outdated, you should consider using radare2 instead"
-tags: ["deprecated"]
+messages: ["DEPRECATED. r2pipe is outdated, you should consider using radare2 instead"]
+
+post-messages: ["DEPRECATED. r2pipe is outdated, you should consider using radare2 instead"]


### PR DESCRIPTION
R2pipe is now deprecated.