### PR TITLE
Package ocp-index.1.1.6 and 2 others

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.1.6/descr
+++ b/packages/ocp-browser/ocp-browser.1.1.6/descr
@@ -1,0 +1,4 @@
+Console browser for the documentation of installed OCaml libraries
+
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules.

--- a/packages/ocp-browser/ocp-browser.1.1.6/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.6/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: ["Louis Gesbert" "Gabriel Radanne"]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "https://github.com/OCamlPro/ocp-index.git"
+build: ["jbuilder" "build" "-p" name]
+depends: [
+  "ocp-pp"
+  "jbuilder"
+  "ocp-index" {= "1.1.6"}
+  "cmdliner"
+  "lambda-term"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/ocp-browser/ocp-browser.1.1.6/url
+++ b/packages/ocp-browser/ocp-browser.1.1.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocp-index/archive/1.1.6.tar.gz"
+checksum: "9c062e99f3c3c3c334c97df2f78e1082"

--- a/packages/ocp-index/ocp-index.1.1.6/descr
+++ b/packages/ocp-index/ocp-index.1.1.6/descr
@@ -1,0 +1,8 @@
+Lightweight completion and documentation browsing for OCaml libraries
+
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`.

--- a/packages/ocp-index/ocp-index.1.1.6/opam
+++ b/packages/ocp-index/ocp-index.1.1.6/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: ["Louis Gesbert" "Gabriel Radanne"]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "https://github.com/OCamlPro/ocp-index.git"
+build: ["jbuilder" "build" "-p" name]
+depends: [
+  "ocp-pp"
+  "jbuilder"
+  "ocp-indent" {>= "1.4.2"}
+  "re"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages: [
+  "
+This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{prefix}%/share/emacs/site-lisp\")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim
+  "
+    {success & !user-setup:installed}
+]

--- a/packages/ocp-index/ocp-index.1.1.6/url
+++ b/packages/ocp-index/ocp-index.1.1.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocp-index/archive/1.1.6.tar.gz"
+checksum: "9c062e99f3c3c3c334c97df2f78e1082"


### PR DESCRIPTION
This pull-request concerns:
-`ocp-index.1.1.6`: Lightweight completion and documentation browsing for OCaml libraries
-`ocp-browser.1.1.6`: Console browser for the documentation of installed OCaml libraries
-`ocp-index.1.1.6`: Lightweight completion and documentation browsing for OCaml libraries



---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them: "user-setup"
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them: "user-setup"

---

:camel: Pull-request generated by opam-publish v0.3.5