### PR TITLE
Partial format upgrade (orsvm_e1071.2.0.0)

### DIFF
--- a/packages/orsvm_e1071/orsvm_e1071.2.0.0/opam
+++ b/packages/orsvm_e1071/orsvm_e1071.2.0.0/opam
@@ -28,6 +28,10 @@ The svmpath package allows to efficiently compute the list of cost
 values (lambda = 1/C) that need to be tested in order to find the optimal
 lambda.
 This package really fires up and talks to an R interpreter."""
+extra-files: [
+  ["install_svmpath.r" "md5=5bcfd487963a2558353200750b4bb62f"]
+  ["install_e1071.r" "md5=e4ad6596051f390f3542d9058869c458"]
+]
 url {
   src: "https://github.com/UnixJunkie/orsvm-e1071/archive/v2.0.0.tar.gz"
   checksum: "md5=3ced2f5900780bc786e9da62fb399f90"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/orsvm_e1071/orsvm_e1071.2.0.0/files/install_e1071.r
  - packages/orsvm_e1071/orsvm_e1071.2.0.0/files/install_svmpath.r
  - packages/orsvm_e1071/orsvm_e1071.2.0.0/opam