### PR TITLE
Package kubecaml.0.1.0

### DIFF
--- a/packages/kubecaml/kubecaml.0.1.0/descr
+++ b/packages/kubecaml/kubecaml.0.1.0/descr
@@ -1,0 +1,4 @@
+Kubernetes API client for OCaml
+
+Kubecaml is an auto-generated Kubernetes API client for OCaml,
+built from the Swagger specification using OCaml-Swagger.

--- a/packages/kubecaml/kubecaml.0.1.0/opam
+++ b/packages/kubecaml/kubecaml.0.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Andre Nathan <andre@hostnet.com.br>"
+authors: ["Andre Nathan <andre@hostnet.com.br>"]
+license: "MIT"
+homepage: "https://github.com/andrenth/kubecaml"
+dev-repo: "https://github.com/andrenth/kubecaml.git"
+bug-reports: "https://github.com/andrenth/kubecaml/issues"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder"            {build}
+  "cohttp-lwt-unix"     {>= "1.0.2"}
+  "lwt"                 {>= "3.3.0"}
+  "ppx_deriving_yojson" {>= "3.1"}
+  "re"                  {>= "1.7.3"}
+  "uri"                 {>= "1.9.6"}
+  "yojson"              {>= "1.4.1"}
+]
+available: [ ocaml-version < "4.04.0" ]

--- a/packages/kubecaml/kubecaml.0.1.0/url
+++ b/packages/kubecaml/kubecaml.0.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/andrenth/kubecaml/archive/0.1.0.tar.gz"
+checksum: "1e1b8d6d4cadfb45408c924e7f3ba05f"


### PR DESCRIPTION
### `kubecaml.0.1.0`

Kubernetes API client for OCaml

Kubecaml is an auto-generated Kubernetes API client for OCaml,
built from the Swagger specification using OCaml-Swagger.



---
* Homepage: https://github.com/andrenth/kubecaml
* Source repo: https://github.com/andrenth/kubecaml.git
* Bug tracker: https://github.com/andrenth/kubecaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5