### PR TITLE
conduit-lwt-unix has depopt on lwt_ssl, not ssl

### DIFF
--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 depopts: [
   "tls"
-  "ssl"
+  "lwt_ssl"
   "launchd"
 ]
 conflicts: [

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 depopts: [
   "tls"
-  "ssl"
+  "lwt_ssl"
   "launchd"
 ]
 conflicts: [

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 depopts: [
   "tls"
-  "ssl"
+  "lwt_ssl"
   "launchd"
 ]
 conflicts: [


### PR DESCRIPTION
While setting up cohttp with @FooB4r, we discovered that if you install `ssl` and then `lwt_ssl`, `conduit-lwt-unix` is not recompiled.

cc @avsm, @rgrinberg, @samoht