### PR TITLE
Package containers.2.1

### DIFF
--- a/packages/containers/containers.2.1/descr
+++ b/packages/containers/containers.2.1/descr
@@ -1,0 +1,12 @@
+A modular, clean and powerful extension of the OCaml standard library.
+
+Containers is an extension of OCaml's standard library (under BSD license)
+focused on data structures, combinators and iterators, without dependencies on
+unix, str or num. Every module is independent and is prefixed with 'CC' in the
+global namespace. Some modules extend the stdlib (e.g. CCList provides safe
+map/fold_right/append, and additional functions on lists).
+Alternatively, `open Containers` will bring enhanced versions of the standard
+modules into scope.
+
+It also features sub-libraries for dealing with threads, S-expressions,
+and the intricacies of unix.

--- a/packages/containers/containers.2.1/opam
+++ b/packages/containers/containers.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+doc: "https://c-cube.github.io/ocaml-containers"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+dev-repo: "https://github.com/c-cube/ocaml-containers.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+build-doc: ["jbuilder" "build" "@doc"]
+depends: [
+  "jbuilder" {build & >= "1.0+beta12"}
+  "result"
+  "uchar"
+  "qtest" {test}
+  "qcheck" {test}
+  "ounit" {test}
+  "sequence" {test}
+  "gen" {test}
+  "uutf" {test}
+  "odoc" {doc}
+]
+depopts: ["base-unix" "base-threads"]
+conflicts: [
+  "sequence" {< "0.5"}
+]
+available: [ocaml-version >= "4.02.0"]
+post-messages:
+  "
+Feature release with many improvements and some new modules.
+
+In particular:
+- new `CCUtf8_string` to deal with UTF8 encoded bytestrings
+- new `CCBijection` module in containers.data, for finite bijections
+- infix operators for most arithmetic types
+
+changelog: https://github.com/c-cube/ocaml-containers/blob/2.1/CHANGELOG.adoc
+  "

--- a/packages/containers/containers.2.1/url
+++ b/packages/containers/containers.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-containers/archive/2.1.tar.gz"
+checksum: "368bf1c69e0008f74d98e1a64b2ac0e4"


### PR DESCRIPTION
### `containers.2.1`

A modular, clean and powerful extension of the OCaml standard library.

Containers is an extension of OCaml's standard library (under BSD license)
focused on data structures, combinators and iterators, without dependencies on
unix, str or num. Every module is independent and is prefixed with 'CC' in the
global namespace. Some modules extend the stdlib (e.g. CCList provides safe
map/fold_right/append, and additional functions on lists).
Alternatively, `open Containers` will bring enhanced versions of the standard
modules into scope.

It also features sub-libraries for dealing with threads, S-expressions,
and the intricacies of unix.



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---

:camel: Pull-request generated by opam-publish v0.3.5