### PR TITLE
Lwt 4.0.0: promises and parallelized I/O

### DIFF
--- a/packages/gdbprofiler/gdbprofiler.0.2/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.2/opam
@@ -11,7 +11,7 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build}
   "menhir" {build}
-  "lwt" {>= "2.4.6"}
+  "lwt" {>= "2.4.6" & < "4.0.0"}
   "containers" {>= "0.20"}
   "yojson"
 ]

--- a/packages/lwt/lwt.4.0.0/descr
+++ b/packages/lwt/lwt.4.0.0/descr
@@ -1,0 +1,10 @@
+Promises, concurrency, and parallelized I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.4.0.0/opam
+++ b/packages/lwt/lwt.4.0.0/opam
@@ -1,0 +1,58 @@
+opam-version: "1.2"
+version: "4.0.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "jbuilder" {build & >= "1.0+beta14"}
+  # We are only using ocamlfind during configuration of the Unix binding.
+  # However, ocamlfind also installs the "threads" package, and ocamlfind
+  # 1.7.3-1 is the first one whose threads package does not have incorrect error
+  # lines. See
+  #   https://github.com/ocaml/opam-repository/pull/11071#issuecomment-353131128
+  # If ocamlfind becomes no longer necessary for configuration of Lwt, this
+  # dependency should be converted to a conflict, and package jbuilder should be
+  # constrained such that it also includes the error lines fix.
+  "ocamlfind" {build & >= "1.7.3-1"}
+  # result is needed as long as Lwt still supports OCaml 4.02.
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+
+messages: [
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
+  "For the Camlp4 syntax, please install package lwt_camlp4"
+    {camlp4:installed & !lwt_camlp4:installed}
+  "For Lwt_log and Lwt_daemon, please install package lwt_log"
+    {!lwt_log:installed}
+]
+post-messages: [
+  "Lwt 4.0.0 has made some breaking changes. See
+  https://github.com/ocsigen/lwt/issues/453"
+]

--- a/packages/lwt/lwt.4.0.0/url
+++ b/packages/lwt/lwt.4.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/4.0.0.tar.gz"
+checksum: "3bbde866884e32cc7a9d9cbd1e52bde3"

--- a/packages/lwt_log/lwt_log.1.0.0/opam
+++ b/packages/lwt_log/lwt_log.1.0.0/opam
@@ -15,9 +15,7 @@ license: "LGPL"
 
 depends: [
   "jbuilder" {build}
-  # This will be constrained with an upper bound once the log library is fully
-  # factored out of package lwt.
-  "lwt"
+  "lwt" {< "4.0.0"}
 ]
 
 build: [

--- a/packages/lwt_log/lwt_log.1.1.0/descr
+++ b/packages/lwt_log/lwt_log.1.1.0/descr
@@ -1,0 +1,1 @@
+Lwt logging library (deprecated)

--- a/packages/lwt_log/lwt_log.1.1.0/opam
+++ b/packages/lwt_log/lwt_log.1.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+
+version: "1.1.0"
+homepage: "https://github.com/aantron/lwt_log"
+doc: "https://github.com/aantron/lwt_log/blob/master/src/core/lwt_log_core.mli"
+bug-reports: "https://github.com/aantron/lwt_log/issues"
+license: "LGPL"
+
+authors: [
+  "Shawn Wagner"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "https://github.com/aantron/lwt_log.git"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "4.0.0"}
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_log/lwt_log.1.1.0/url
+++ b/packages/lwt_log/lwt_log.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/aantron/lwt_log/archive/1.1.0.tar.gz"
+checksum: "92142135d01a4d7e805990cc98653d55"

--- a/packages/lwt_ppx/lwt_ppx.1.2.0/descr
+++ b/packages/lwt_ppx/lwt_ppx.1.2.0/descr
@@ -1,0 +1,1 @@
+PPX syntax for Lwt, providing something similar to async/await from JavaScript

--- a/packages/lwt_ppx/lwt_ppx.1.2.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+version: "1.2.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta12"}
+  "lwt"
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0.1"}
+]
+# The Lwt PPX uses the %reraise primitive, which is available on OCaml >= 4.02.
+# Even though OCaml PPX itself requires 4.02, we add this constraint for
+# thoroughness and safety.
+available: [ocaml-version >= "4.02.0"]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_ppx/lwt_ppx.1.2.0/url
+++ b/packages/lwt_ppx/lwt_ppx.1.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/4.0.0.tar.gz"
+checksum: "3bbde866884e32cc7a9d9cbd1e52bde3"

--- a/packages/lwt_react/lwt_react.1.1.1/descr
+++ b/packages/lwt_react/lwt_react.1.1.1/descr
@@ -1,0 +1,1 @@
+Helpers for using React with Lwt

--- a/packages/lwt_react/lwt_react.1.1.1/opam
+++ b/packages/lwt_react/lwt_react.1.1.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+version: "1.1.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_react"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]
+build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "3.0.0"}
+  "react" {>= "1.0.0"}
+]

--- a/packages/lwt_react/lwt_react.1.1.1/url
+++ b/packages/lwt_react/lwt_react.1.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/4.0.0.tar.gz"
+checksum: "3bbde866884e32cc7a9d9cbd1e52bde3"

--- a/packages/xenstore/xenstore.1.2.0/opam
+++ b/packages/xenstore/xenstore.1.2.0/opam
@@ -22,7 +22,7 @@ remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
   "cstruct" {>= "0.6.0" & <= "1.9.0"}
   "type_conv" {build}
-  "lwt"
+  "lwt" {< "4.0.0"}
   "ounit"
   "ocamlfind"
   "camlp4"


### PR DESCRIPTION
This is a breaking release of Lwt, that mainly cleans up the Lwt packaging.

The Lwt PPX is also released with minor breaking changes. Lwt_react has a bugfix. Lwt_log 1.1.0 is the first release of Lwt_log with independent packaging. The pre-existing Lwt_log 1.0.0 release was a forward-compatibility alias for Lwt. That Lwt_log 1.0.0 release has been constrained to require Lwt < 4.0.0.

<br/>

From the [changelog](https://github.com/ocsigen/lwt/releases/tag/4.0.0):

> Breaking
>
> *These changes were announced in [Lwt 3.1.0](https://github.com/ocsigen/lwt/releases/tag/3.1.0) and [Lwt 3.2.0](https://github.com/ocsigen/lwt/releases/tag/3.2.0). See ocsigen/lwt#453 about smooth upgrade paths.*
>
> - Delete package `lwt.ppx`. The PPX syntax is in package [`lwt_ppx`](http://opam.ocaml.org/packages/lwt_ppx/) since Lwt 3.2.0 (ocsigen/lwt#338).
> - Remove `>>` syntax from the PPX (ocsigen/lwt#495).
> - Delete modules `Lwt_log`, `Lwt_daemon`, `Lwt_log_core`, and package `lwt.log`. These are in package [`lwt_log`](https://github.com/aantron/lwt_log) since Lwt 3.2.0, but it is recommended to use [`Logs_lwt`](http://erratique.ch/software/logs/doc/Logs_lwt.html) from the [logs](http://erratique.ch/software/logs) library instead (ocsigen/lwt#484, initiated Hannes Mehnert).
> - Delete package `lwt.preemptive`. It is an alias for `lwt.unix` since Lwt 3.2.0 (ocsigen/lwt#487).
> - Delete package `lwt.syntax`. The Camlp4 syntax is in package [`lwt_camlp4`](https://github.com/aantron/lwt_camlp4) since Lwt 3.2.0 (ocsigen/lwt#370).
> - Delete module `Lwt_chan`, a predecessor of [`Lwt_io`](https://ocsigen.org/lwt/api/Lwt_io) (ocsigen/lwt#441).
> - Delete package `lwt.simple-top`, a predecessor of [`utop`](https://github.com/diml/utop) (ocsigen/lwt#371).
> - Make resolvers ([`Lwt.u`](https://ocsigen.org/lwt/api/Lwt#TYPEu)) contravariant (ocsigen/lwt#458).
>
> Planned to break in 5.0.0
>
> - [`Lwt.pick`](https://ocsigen.org/lwt/api/Lwt#VALpick) will raise `Invalid_argument` on the empty list, instead of returning a forever-pending promise. Also applies to [`Lwt.choose`](https://ocsigen.org/lwt/api/Lwt#VALchoose), [`Lwt.npick`](https://ocsigen.org/lwt/api/Lwt#VALnpick), [`Lwt.nchoose`](https://ocsigen.org/lwt/api/Lwt#VALnchoose), and [`Lwt.nchoose_split`](https://ocsigen.org/lwt/api/Lwt#VALnchoose_split) (ocsigen/lwt#562, Tim Reinke, prompted Hezekiah Carty).
> - Remove transation of `[%lwt ...]` to `Lwt.catch` from the PPX (ocsigen/lwt#527).
> - Remove `-no-debug` option from the PPX (ocsigen/lwt#528).
> - Remove `Lwt_log` support from the PPX (ocsigen/lwt#520).
>
> Bugs fixed
>
> - [`Lwt_io.file_length`](https://ocsigen.org/lwt/api/Lwt_io#VALfile_length) now fails with `EISDIR` when used on a directory (ocsigen/lwt#563, requested Cedric Cellier).
> - [`Lwt_react.E.limit`](https://ocsigen.org/lwt/api/Lwt_react.E#VALlimit) and [`Lwt_react.S.limit`](https://ocsigen.org/lwt/api/Lwt_react.S#VALlimit) now working more correctly (ocsigen/lwt#566, @Freyr666).
>
> Miscellaneous
>
> - Documentation improvements (ocsigen/lwt#561, Jason Evans).
