### PR TITLE
leveldb.1.0.3: Remove duplicated dev-repo

### DIFF
--- a/packages/leveldb/leveldb.1.0.3/opam
+++ b/packages/leveldb/leveldb.1.0.3/opam
@@ -20,6 +20,5 @@ depends: [
 ]
 patches: [ "fix_snappy_link_issue.patch"
            "warn_error.patch" ]
-dev-repo: "git://github.com/mfp/ocaml-leveldb"
 install: ["omake" "install" "prefix=%{prefix}%"]
 available: [ ocaml-version < "4.02" ]


### PR DESCRIPTION
This was introduced in #11676 and caused opam2's opam1-to-opam2 format converter to fail on updates.

cc @gasche 