### PR TITLE
Add genlet.a to the genlet.install file.

### DIFF
--- a/packages/genlet/genlet.201406/files/genlet.install
+++ b/packages/genlet/genlet.201406/files/genlet.install
@@ -1,4 +1,5 @@
 lib: [
+  "genlet.a"
   "genlet.cma"
   "gengenlet.cmi"
   "genlet.cmxa"


### PR DESCRIPTION
Add a file that was missing from the installation instructions in the `genlet` package.