### PR TITLE
angstrom < 0.6.0 are not safe-string safe

### DIFF
--- a/packages/angstrom/angstrom.0.1.0/opam
+++ b/packages/angstrom/angstrom.0.1.0/opam
@@ -34,4 +34,4 @@ depopts: [
   "lwt"
 ]
 conflicts: [ "lwt" {< "2.4.7"} ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.1.0/opam
+++ b/packages/angstrom/angstrom.0.1.0/opam
@@ -23,7 +23,7 @@ build-test: [
 ]
 depends: [
   "alcotest" {test & >= "0.4.1" & < "0.8.0"}
-  "cstruct" {>= "0.7.0"}
+  "cstruct" {>= "0.7.0" & < "3.2.0"}
   "ocamlfind" {build}
   "result"
   "ocplib-endian" {>= "0.6"}

--- a/packages/angstrom/angstrom.0.1.0/opam
+++ b/packages/angstrom/angstrom.0.1.0/opam
@@ -34,4 +34,4 @@ depopts: [
   "lwt"
 ]
 conflicts: [ "lwt" {< "2.4.7"} ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.1.1/opam
+++ b/packages/angstrom/angstrom.0.1.1/opam
@@ -34,4 +34,4 @@ depopts: [
   "lwt"
 ]
 conflicts: [ "lwt" {< "2.4.7"} ]
-available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.1.1/opam
+++ b/packages/angstrom/angstrom.0.1.1/opam
@@ -23,7 +23,7 @@ build-test: [
 ]
 depends: [
   "alcotest" {test & >= "0.4.1" & < "0.8.0"}
-  "cstruct" {>= "0.7.0"}
+  "cstruct" {>= "0.7.0" & < "3.2.0"}
   "ocamlfind" {build}
   "result"
   "ocplib-endian" {>= "0.6"}

--- a/packages/angstrom/angstrom.0.1.1/opam
+++ b/packages/angstrom/angstrom.0.1.1/opam
@@ -34,4 +34,4 @@ depopts: [
   "lwt"
 ]
 conflicts: [ "lwt" {< "2.4.7"} ]
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.2.0/opam
+++ b/packages/angstrom/angstrom.0.2.0/opam
@@ -22,7 +22,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}

--- a/packages/angstrom/angstrom.0.2.0/opam
+++ b/packages/angstrom/angstrom.0.2.0/opam
@@ -33,4 +33,4 @@ depopts: [
   "base-unix"
   "lwt"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.2.0/opam
+++ b/packages/angstrom/angstrom.0.2.0/opam
@@ -33,4 +33,4 @@ depopts: [
   "base-unix"
   "lwt"
 ]
-available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.3.0/opam
+++ b/packages/angstrom/angstrom.0.3.0/opam
@@ -23,7 +23,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}

--- a/packages/angstrom/angstrom.0.3.0/opam
+++ b/packages/angstrom/angstrom.0.3.0/opam
@@ -34,4 +34,4 @@ depopts: [
   "base-unix"
   "lwt"
 ]
-available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.3.0/opam
+++ b/packages/angstrom/angstrom.0.3.0/opam
@@ -34,4 +34,4 @@ depopts: [
   "base-unix"
   "lwt"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.4.0/opam
+++ b/packages/angstrom/angstrom.0.4.0/opam
@@ -23,7 +23,7 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}

--- a/packages/angstrom/angstrom.0.4.0/opam
+++ b/packages/angstrom/angstrom.0.4.0/opam
@@ -34,4 +34,4 @@ depopts: [
   "base-unix"
   "lwt"
 ]
-available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.4.0/opam
+++ b/packages/angstrom/angstrom.0.4.0/opam
@@ -34,4 +34,4 @@ depopts: [
   "base-unix"
   "lwt"
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.5.0/opam
+++ b/packages/angstrom/angstrom.0.5.0/opam
@@ -33,4 +33,4 @@ depends: [
   "result"
 ]
 depopts: ["async" "base-unix" "lwt"]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.5.0/opam
+++ b/packages/angstrom/angstrom.0.5.0/opam
@@ -26,7 +26,7 @@ build-test: [
 ]
 remove: ["ocamlfind" "remove" "angstrom"]
 depends: [
-  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}

--- a/packages/angstrom/angstrom.0.5.1/opam
+++ b/packages/angstrom/angstrom.0.5.1/opam
@@ -33,4 +33,4 @@ depends: [
   "result"
 ]
 depopts: ["async" "base-unix" "lwt"]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.03.0" & ocaml-version < "4.06.0"]

--- a/packages/angstrom/angstrom.0.5.1/opam
+++ b/packages/angstrom/angstrom.0.5.1/opam
@@ -26,7 +26,7 @@ build-test: [
 ]
 remove: ["ocamlfind" "remove" "angstrom"]
 depends: [
-  "alcotest" {test & >= "0.4.1" & < "0.8.0"}
+  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "ocamlfind" {build}


### PR DESCRIPTION
/cc @seliopou (but newer releases play fine with 4.06.0)

/cc @andreas discovered while browsing through CI issues in #11712