### PR TITLE
Package pkcs11.0.16.0

### DIFF
--- a/packages/pkcs11/pkcs11.0.16.0/descr
+++ b/packages/pkcs11/pkcs11.0.16.0/descr
@@ -1,0 +1,6 @@
+Bindings to the PKCS#11 cryptographic API
+
+This library contains ctypes bindings to the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.

--- a/packages/pkcs11/pkcs11.0.16.0/opam
+++ b/packages/pkcs11/pkcs11.0.16.0/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build"
+    "--pinned" "%{pinned}%"
+    "--with-cmdliner" "%{cmdliner:installed}%"
+    "--with-driver" "%{ctypes:installed}%"
+  ]
+]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build"
+    "--pinned" "%{pinned}%"
+    "--tests" "true"
+    "--with-cmdliner" "%{cmdliner:installed}%"
+    "--with-driver" "%{ctypes:installed}%"
+  ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "hex" { >= "1.0.0" }
+  "integers"
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "zarith"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ounit" {test}
+]
+depopts: [
+  "cmdliner"
+  "ctypes"
+  "ctypes-foreign"
+]
+conflicts: [
+  "ctypes" { < "0.12.0" }
+]
+tags: ["org:cryptosense"]
+available: [ocaml-version >= "4.03.0" & os != "darwin"]

--- a/packages/pkcs11/pkcs11.0.16.0/url
+++ b/packages/pkcs11/pkcs11.0.16.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/pkcs11/releases/download/v0.16.0/pkcs11-0.16.0.tbz"
+checksum: "2cbd89bd4a81aa97a02918f18c09fee7"


### PR DESCRIPTION
### `pkcs11.0.16.0`

Bindings to the PKCS#11 cryptographic API

This library contains ctypes bindings to the PKCS#11 API.

This API is used by smartcards and Hardware Security Modules to perform
cryptographic operations such as signature or encryption.



---
* Homepage: https://github.com/cryptosense/pkcs11
* Source repo: https://github.com/cryptosense/pkcs11.git
* Bug tracker: https://github.com/cryptosense/pkcs11/issues

---


---
v0.16.0 2018-04-05
==================

Breaking changes:

- Encode `CKA_ID` data as an hex encoded JSON string. (#101)

New features:

- Add all 2.40 mechanism types. (#99)

Deprecations:

- Deprecate mechanism kinds, attribute kinds, and `P11_key_attributes`. (#98)
- Deprecate the "stubs" load mode. This corresponds to the `--indirect` command
  line argument. "auto" stays the recommended default. (#100)

Refactoring:

- Rework `P11_attribute` internals to use `repr` from `CK_ATTRIBUTE`. (#102)
:camel: Pull-request generated by opam-publish v0.3.5