### PR TITLE
Release Caqti 0.10.2.

### DIFF
--- a/packages/caqti-async/caqti-async.0.10.2/descr
+++ b/packages/caqti-async/caqti-async.0.10.2/descr
@@ -1,0 +1,1 @@
+Async support for Caqti

--- a/packages/caqti-async/caqti-async.0.10.2/opam
+++ b/packages/caqti-async/caqti-async.0.10.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "caqti-dynload"
+name: "caqti-async"
 authors: ["Petter A. Urkedal"]
 maintainer: "paurkedal@gmail.com"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
@@ -8,12 +8,13 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
-  "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
-  "ppx_driver"
+  "async" {>= "v0.11.0"}
+  "caqti" {>= "0.10.2"}
+  "caqti-dynload" {test & >= "0.10.2"}
+  "caqti-driver-sqlite3" {test & >= "0.10.2"}
+  "core"
+  "jbuilder" {build & >= "1.0+beta19"}
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-async/caqti-async.0.10.2/url
+++ b/packages/caqti-async/caqti-async.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/descr
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/descr
@@ -1,0 +1,1 @@
+MariaDB driver for Caqti using C bindings

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "caqti-dynload"
+name: "caqti-driver-mariadb"
 authors: ["Petter A. Urkedal"]
 maintainer: "paurkedal@gmail.com"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
@@ -8,12 +8,10 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
-  "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
-  "ppx_driver"
+  "caqti" {>= "0.10.2"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "mariadb" {>= "0.10"}
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/url
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/descr
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/descr
@@ -1,0 +1,1 @@
+PostgreSQL driver for Caqti based on C bindings

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "caqti-dynload"
+name: "caqti-driver-postgresql"
 authors: ["Petter A. Urkedal"]
 maintainer: "paurkedal@gmail.com"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
@@ -8,12 +8,10 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
-  "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
-  "ppx_driver"
+  "caqti" {>= "0.10.2"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "postgresql"
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/url
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/descr
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/descr
@@ -1,0 +1,1 @@
+Sqlite3 driver for Caqti using C bindings

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "caqti-dynload"
+name: "caqti-driver-sqlite3"
 authors: ["Petter A. Urkedal"]
 maintainer: "paurkedal@gmail.com"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
@@ -8,12 +8,10 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
-  "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
-  "ppx_driver"
+  "caqti" {>= "0.10.2"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "sqlite3"
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/url
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti-dynload/caqti-dynload.0.10.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.0/opam
@@ -13,5 +13,6 @@ depends: [
   "caqti" {= "0.10.0"}
   "jbuilder" {build}
   "ocamlfind"
+  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"
 ]

--- a/packages/caqti-dynload/caqti-dynload.0.10.1/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.1/opam
@@ -13,5 +13,6 @@ depends: [
   "caqti" {= "0.10.1"}
   "jbuilder" {build}
   "ocamlfind"
+  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"
 ]

--- a/packages/caqti-dynload/caqti-dynload.0.10.2/descr
+++ b/packages/caqti-dynload/caqti-dynload.0.10.2/descr
@@ -1,0 +1,10 @@
+Dynamic linking of Caqti drivers using findlib.dynload.
+
+This library registers a dynamic linker which will be called when
+encoutering an unhandled database URI.  It tries to load a findlib package
+named "caqti-driver-<scheme>" where "<scheme>" is the scheme of the URI,
+which is expected register a driver for the scheme.
+
+This is a separate package to avoid the dependency on the findlib.dynload
+for architectures, like MirageOS, where dynamic linking may be unavailable.
+The alternative is to link drivers directly into the application.

--- a/packages/caqti-dynload/caqti-dynload.0.10.2/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.2/opam
@@ -8,12 +8,12 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
+  "caqti" {>= "0.10.2"}
+  "jbuilder" {build & >= "1.0+beta19"}
   "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"
 ]
-conflicts: ["caqti" {<"0.6.0"}]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/caqti-dynload/caqti-dynload.0.10.2/url
+++ b/packages/caqti-dynload/caqti-dynload.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti-lwt/caqti-lwt.0.10.2/descr
+++ b/packages/caqti-lwt/caqti-lwt.0.10.2/descr
@@ -1,0 +1,1 @@
+Lwt support for Caqti

--- a/packages/caqti-lwt/caqti-lwt.0.10.2/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.10.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "caqti-dynload"
+name: "caqti-lwt"
 authors: ["Petter A. Urkedal"]
 maintainer: "paurkedal@gmail.com"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
@@ -8,12 +8,12 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
-  "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
-  "ppx_driver"
+  "caqti" {>= "0.10.2"}
+  "caqti-dynload" {test & >= "0.10.2"}
+  "caqti-driver-sqlite3" {test & >= "0.10.2"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "lwt" {< "4.0.0"}
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-lwt/caqti-lwt.0.10.2/url
+++ b/packages/caqti-lwt/caqti-lwt.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/descr
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/descr
@@ -1,0 +1,1 @@
+Date and time field types using the calendar library.

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "caqti-dynload"
+name: "caqti-type-calendar"
 authors: ["Petter A. Urkedal"]
 maintainer: "paurkedal@gmail.com"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
@@ -8,12 +8,10 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
-  "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
-  "ppx_driver"
+  "caqti" {>= "0.10.2"}
+  "calendar"
+  "jbuilder" {build & >= "1.0+beta19"}
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/url
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti/caqti.0.10.0/opam
+++ b/packages/caqti/caqti.0.10.0/opam
@@ -13,7 +13,6 @@ depends: [
   "jbuilder" {build}
   "calendar"
   "ocamlfind" {build}
-  "ppx_optcomp" {build}
   "ptime"
   "uri" {>= "1.9.0"}
 ]

--- a/packages/caqti/caqti.0.10.1/opam
+++ b/packages/caqti/caqti.0.10.1/opam
@@ -13,7 +13,6 @@ depends: [
   "jbuilder" {build}
   "calendar"
   "ocamlfind" {build}
-  "ppx_optcomp" {build}
   "ptime"
   "uri" {>= "1.9.0"}
 ]

--- a/packages/caqti/caqti.0.10.2/descr
+++ b/packages/caqti/caqti.0.10.2/descr
@@ -1,0 +1,17 @@
+Unified interface to relational database libraries
+
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators.

--- a/packages/caqti/caqti.0.10.2/opam
+++ b/packages/caqti/caqti.0.10.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "caqti-dynload"
+name: "caqti"
 authors: ["Petter A. Urkedal"]
 maintainer: "paurkedal@gmail.com"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
@@ -8,12 +8,13 @@ dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
-  "jbuilder" {build}
-  "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
-  "ppx_driver"
+  "jbuilder" {build & >= "1.0+beta19"}
+  "calendar"
+  "ocamlfind" {build}
+  "ptime"
+  "uri" {>= "1.9.0"}
 ]
-conflicts: ["caqti" {<"0.6.0"}]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/caqti/caqti.0.10.2/url
+++ b/packages/caqti/caqti.0.10.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.10.2/caqti-0.10.2.tbz"
+checksum: "d18745a703da336054c0d27e78f8be8a"

--- a/packages/caqti/caqti.0.9.0/opam
+++ b/packages/caqti/caqti.0.9.0/opam
@@ -13,7 +13,6 @@ depends: [
   "jbuilder" {build}
   "calendar"
   "ocamlfind" {build}
-  "ppx_optcomp" {build}
   "ptime"
   "uri" {>= "1.9.0"}
 ]


### PR DESCRIPTION
Most importantly this fixes incompatibility with ppx_optcomp.v0.11.0.  (It also re-enables testing during opam builds, which was disabled after issues discovered during the previous release, and fully deprecates an old API.)