### PR TITLE
debian-formats: require extlib{,-compat} above 1.7.0 for String.trim

### DIFF
--- a/packages/debian-formats/debian-formats.0.1.1/opam
+++ b/packages/debian-formats/debian-formats.0.1.1/opam
@@ -17,7 +17,7 @@ remove: [
 ]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
-  ("extlib" | "extlib-compat")
+  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
   "re"
   "ocamlfind"
   "ounit" {>= "2.0.0"}


### PR DESCRIPTION
debian-formats.0.1.1 uses String.trim:
  https://github.com/gildor478/ocaml-debian-formats/blob/0.1.1/src/DFWatch.ml#L28

It is only re-exported by extlib since 1.7.0:
  https://github.com/ygrek/ocaml-extlib/commit/a0524549c2d8b25e3a321ae7587b50ccb13a9b9e#diff-b661d5707e503cfebfc340d733ac79c7

This issue was spotted throught the CI testing of #11726.