### PR TITLE
Package cuid.0.1

### DIFF
--- a/packages/cuid/cuid.0.1/descr
+++ b/packages/cuid/cuid.0.1/descr
@@ -1,0 +1,4 @@
+CUID generator for OCaml.
+
+For further information, please refer to http://usecuid.org
+

--- a/packages/cuid/cuid.0.1/opam
+++ b/packages/cuid/cuid.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Marco Aurélio da Silva <marcoonroad@gmail.com>"
+authors: "Marco Aurélio da Silva <marcoonroad@gmail.com>"
+homepage: "https://github.com/marcoonroad/ocaml-cuid"
+bug-reports: "https://github.com/marcoonroad/ocaml-cuid/issues"
+license: "MIT"
+dev-repo: "git://github.com/marcoonroad/ocaml-cuid.git"
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+install: [make "install"]
+build-test: [make "test"]
+remove: ["ocamlfind" "remove" "cuid"]
+depends: [
+  "alcotest" {test}
+  "re" {test}
+  "jbuilder" {build}
+  "core" {build}
+  "bisect_ppx" {>= "1.3.0"}
+  "ocveralls" {build}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/cuid/cuid.0.1/opam
+++ b/packages/cuid/cuid.0.1/opam
@@ -16,4 +16,4 @@ depends: [
   "jbuilder" {build}
   "core"
 ]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cuid/cuid.0.1/opam
+++ b/packages/cuid/cuid.0.1/opam
@@ -9,15 +9,11 @@ build: [
   ["jbuilder" "subst"] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-install: [make "install"]
-build-test: [make "test"]
-remove: ["ocamlfind" "remove" "cuid"]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 depends: [
   "alcotest" {test}
   "re" {test}
   "jbuilder" {build}
-  "core" {build}
-  "bisect_ppx" {>= "1.3.0"}
-  "ocveralls" {build}
+  "core"
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/cuid/cuid.0.1/url
+++ b/packages/cuid/cuid.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/marcoonroad/ocaml-cuid/archive/v0.1.tar.gz"
-checksum: "abeecdfbe03e2ce7677821f311552a48"
+checksum: "b6480836346716777a885f6fc10f7451"

--- a/packages/cuid/cuid.0.1/url
+++ b/packages/cuid/cuid.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/marcoonroad/ocaml-cuid/archive/v0.1.tar.gz"
-checksum: "68c7f348dc1e27068029a287340b7066"
+checksum: "abeecdfbe03e2ce7677821f311552a48"

--- a/packages/cuid/cuid.0.1/url
+++ b/packages/cuid/cuid.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/marcoonroad/ocaml-cuid/archive/v0.1.tar.gz"
-checksum: "b6480836346716777a885f6fc10f7451"
+checksum: "5becab41f72e763e110a9f57b94a1000"

--- a/packages/cuid/cuid.0.1/url
+++ b/packages/cuid/cuid.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/marcoonroad/ocaml-cuid/archive/v0.1.tar.gz"
+checksum: "68c7f348dc1e27068029a287340b7066"


### PR DESCRIPTION
### `cuid.0.1`

CUID generator for OCaml.

For further information, please refer to http://usecuid.org




---
* Homepage: https://github.com/marcoonroad/ocaml-cuid
* Source repo: git://github.com/marcoonroad/ocaml-cuid.git
* Bug tracker: https://github.com/marcoonroad/ocaml-cuid/issues

---

:camel: Pull-request generated by opam-publish v0.3.5