### PR TITLE
modify 4.07 compilers to point to the newly created 4.07 branch

### DIFF
--- a/compilers/4.07.0/4.07.0+trunk+afl/4.07.0+trunk+afl.comp
+++ b/compilers/4.07.0/4.07.0+trunk+afl/4.07.0+trunk+afl.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.07.0"
-src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-afl-instrument"

--- a/compilers/4.07.0/4.07.0+trunk+flambda/4.07.0+trunk+flambda.comp
+++ b/compilers/4.07.0/4.07.0+trunk+flambda/4.07.0+trunk+flambda.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.07.0"
-src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime" "-flambda"

--- a/compilers/4.07.0/4.07.0+trunk+fp+flambda/4.07.0+trunk+fp+flambda.comp
+++ b/compilers/4.07.0/4.07.0+trunk+fp+flambda/4.07.0+trunk+fp+flambda.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.07.0"
-src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 build: [
   [
     "./configure"

--- a/compilers/4.07.0/4.07.0+trunk+fp/4.07.0+trunk+fp.comp
+++ b/compilers/4.07.0/4.07.0+trunk+fp/4.07.0+trunk+fp.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.07.0"
-src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 build: [
   [
     "./configure"

--- a/compilers/4.07.0/4.07.0+trunk+unsafe-string/4.07.0+trunk+unsafe-string.comp
+++ b/compilers/4.07.0/4.07.0+trunk+unsafe-string/4.07.0+trunk+unsafe-string.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.07.0"
-src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime" "-unsafe-string"

--- a/compilers/4.07.0/4.07.0+trunk/4.07.0+trunk.comp
+++ b/compilers/4.07.0/4.07.0+trunk/4.07.0+trunk.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.07.0"
-src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.07.0/4.07.0+trunk/4.07.0+trunk.descr
+++ b/compilers/4.07.0/4.07.0+trunk/4.07.0+trunk.descr
@@ -1,1 +1,1 @@
-latest trunk snapshot
+latest 4.07 development snapshot


### PR DESCRIPTION
This fixes these packages as trunk is now 4.08
cc @damiendoligez 