### PR TITLE
Partial format upgrade (ocaml-variants.4.07.0+trunk, ocaml-variants.4.07.0+trunk+afl, ocaml-variants.4.07.0+trunk+flambda, ocaml-variants.4.07.0+trunk+fp, ocaml-variants.4.07.0+trunk+fp+flambda, ...)

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-afl-instrument"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "freebsd" & os != "darwin"}
   [
     "./configure"
     "-prefix"
@@ -22,11 +22,12 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
+  checksum: "md5=2f6faeba9cb6d4ebe6d86f2155998dcf"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "freebsd" & os != "darwin"}
   [
     "./configure"
     "-prefix"
@@ -23,11 +23,12 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
+  checksum: "md5=2f6faeba9cb6d4ebe6d86f2155998dcf"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
@@ -18,7 +18,7 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
   [
     "./configure"
     "-prefix"
@@ -30,11 +30,12 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
+  checksum: "md5=2f6faeba9cb6d4ebe6d86f2155998dcf"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
   [
     "./configure"
     "-prefix"
@@ -28,11 +28,12 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
+  checksum: "md5=2f6faeba9cb6d4ebe6d86f2155998dcf"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+unsafe-string/opam
@@ -13,7 +13,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-unsafe-string"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "freebsd" & os != "darwin"}
   [
     "./configure"
     "-prefix"
@@ -24,11 +24,12 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
+  checksum: "md5=2f6faeba9cb6d4ebe6d86f2155998dcf"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "latest trunk snapshot"
+synopsis: "latest 4.07 development snapshot"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.07.0" & post}
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "freebsd" & os != "darwin"}
   [
     "./configure"
     "-prefix"
@@ -22,11 +22,12 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
+  checksum: "md5=2f6faeba9cb6d4ebe6d86f2155998dcf"
 }


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+unsafe-string/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam