### PR TITLE
Fix old ocaml compat

### DIFF
--- a/packages/camomile/camomile.1.0.1/descr
+++ b/packages/camomile/camomile.1.0.1/descr
@@ -1,0 +1,6 @@
+A Unicode library
+
+Camomile is a Unicode library for OCaml. Camomile provides Unicode character
+type, UTF-8, UTF-16, UTF-32 strings, conversion to/from about 200 encodings,
+collation and locale-sensitive case mappings, and more. The library is currently
+designed for Unicode Standard 3.2.

--- a/packages/camomile/camomile.1.0.1/opam
+++ b/packages/camomile/camomile.1.0.1/opam
@@ -13,4 +13,4 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta17"}
 ]
-available: [ocaml-version >= "4.05.0"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/camomile/camomile.1.0.1/url
+++ b/packages/camomile/camomile.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/yoriyuki/Camomile/releases/download/1.0.1/camomile-1.0.1.tbz"
+checksum: "82e016653431353a07f22c259adc6e05"


### PR DESCRIPTION
fix a bug https://github.com/yoriyuki/Camomile/issues/68 in 1.0.0 which prevents build by OCaml <= 4.04.0