### PR TITLE
ctypes: lwt < 4.0.0 for tests

### DIFF
--- a/packages/ctypes/ctypes.0.10.0/opam
+++ b/packages/ctypes/ctypes.0.10.0/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.10.1/opam
+++ b/packages/ctypes/ctypes.0.10.1/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.10.2/opam
+++ b/packages/ctypes/ctypes.0.10.2/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.10.3/opam
+++ b/packages/ctypes/ctypes.0.10.3/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.10.4/opam
+++ b/packages/ctypes/ctypes.0.10.4/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.10.5/opam
+++ b/packages/ctypes/ctypes.0.10.5/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.11.0/opam
+++ b/packages/ctypes/ctypes.0.11.0/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.11.1/opam
+++ b/packages/ctypes/ctypes.0.11.1/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.11.2/opam
+++ b/packages/ctypes/ctypes.0.11.2/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.11.3/opam
+++ b/packages/ctypes/ctypes.0.11.3/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.11.4/opam
+++ b/packages/ctypes/ctypes.0.11.4/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.11.5/opam
+++ b/packages/ctypes/ctypes.0.11.5/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.12.0/opam
+++ b/packages/ctypes/ctypes.0.12.0/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -26,7 +26,7 @@ depends: [
    "integers"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
    "conf-ncurses" {test}

--- a/packages/ctypes/ctypes.0.12.1/opam
+++ b/packages/ctypes/ctypes.0.12.1/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -26,7 +26,7 @@ depends: [
    "integers"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
    "conf-ncurses" {test}

--- a/packages/ctypes/ctypes.0.13.0/opam
+++ b/packages/ctypes/ctypes.0.13.0/opam
@@ -26,7 +26,7 @@ depends: [
    "integers"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
    "conf-ncurses" {test}

--- a/packages/ctypes/ctypes.0.13.1/opam
+++ b/packages/ctypes/ctypes.0.13.1/opam
@@ -26,7 +26,7 @@ depends: [
    "integers"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
    "conf-ncurses" {test}

--- a/packages/ctypes/ctypes.0.6.0/opam
+++ b/packages/ctypes/ctypes.0.6.0/opam
@@ -22,7 +22,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & < "4.0.0"}
 ]
 depopts: [
    "ctypes-foreign"

--- a/packages/ctypes/ctypes.0.6.1/opam
+++ b/packages/ctypes/ctypes.0.6.1/opam
@@ -22,7 +22,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & < "4.0.0"}
 ]
 depopts: [
    "ctypes-foreign"

--- a/packages/ctypes/ctypes.0.6.2/opam
+++ b/packages/ctypes/ctypes.0.6.2/opam
@@ -22,7 +22,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
 ]
 depopts: [
    "ctypes-foreign"

--- a/packages/ctypes/ctypes.0.6.3/opam
+++ b/packages/ctypes/ctypes.0.6.3/opam
@@ -22,7 +22,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
 ]
 depopts: [
    "ctypes-foreign"

--- a/packages/ctypes/ctypes.0.7.0/opam
+++ b/packages/ctypes/ctypes.0.7.0/opam
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.7.1/opam
+++ b/packages/ctypes/ctypes.0.7.1/opam
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.7.2/opam
+++ b/packages/ctypes/ctypes.0.7.2/opam
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.8.0/opam
+++ b/packages/ctypes/ctypes.0.8.0/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.8.1/opam
+++ b/packages/ctypes/ctypes.0.8.1/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.8.2/opam
+++ b/packages/ctypes/ctypes.0.8.2/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.9.0/opam
+++ b/packages/ctypes/ctypes.0.9.0/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.9.1/opam
+++ b/packages/ctypes/ctypes.0.9.1/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.9.2/opam
+++ b/packages/ctypes/ctypes.0.9.2/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.9.3/opam
+++ b/packages/ctypes/ctypes.0.9.3/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.9.4/opam
+++ b/packages/ctypes/ctypes.0.9.4/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]

--- a/packages/ctypes/ctypes.0.9.5/opam
+++ b/packages/ctypes/ctypes.0.9.5/opam
@@ -13,7 +13,7 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"] {ctypes-foreign:installed}
 ]
 build-test: [
-   [make "test"]
+   [make "test"] {ocaml-version < "4.06.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
@@ -25,7 +25,7 @@ depends: [
    "base-bytes"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & >= "2.4.7" & < "4.0.0"}
    "ounit" {test}
    "ctypes-foreign" {test}
 ]


### PR DESCRIPTION
The test instructions refer to `lwt.preemptive` that is gone now ...
CC @yallop