### PR TITLE
Mark Slacko as potentially compatible with Lwt 4.0

### DIFF
--- a/packages/slacko/slacko.0.13.0/opam
+++ b/packages/slacko/slacko.0.13.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind"
   "cmdliner"
   "yojson"
-  "lwt" {>= "2.4.7" & < "4.0.0"}
+  "lwt" {>= "2.4.7"}
   "tls" | "ssl"
   "cohttp" {>= "0.21.1" & <"0.99"}
   "ppx_deriving_yojson" {>= "3.0"}


### PR DESCRIPTION
According to the nice comment by @aantron in https://github.com/ocaml/opam-repository/pull/11708#issuecomment-380177528 slacko fails because it expects `lwt.log` to exist without depending on the `lwt_log` message.

This came to a surprise to me since Slacko does not do any logging at all, so constraining it does not seem to be useful.

Looking in the CI log
https://ci.ocamllabs.io/log/saved/docker-run-e97b0a51ae9b04229ade4297103e6c79/e87df7e1b52e41541b179ab4024a538bfd0b1484 I can see that the error came from a module in "lwt/cohttp_lwt_unix.ml" which happens when building `cohttp.0.21.1`.

Therefore I would like to correct the dependency here. If any version of `cohttp` < `0.99` would be compatible with Lwt 4 (e.g. if someone does a maintenance release), so would slacko.