### PR TITLE
Add pgx, pgx_async, pgx_lwt and pgx_unix packages

### DIFF
--- a/packages/pgx/pgx.0.1/descr
+++ b/packages/pgx/pgx.0.1/descr
@@ -1,0 +1,21 @@
+A pure OCaml PostgreSQL client library
+
+PGX is a pure-OCaml PostgreSQL client library. The following packages support
+synchronous or asynchronous implementations:
+
+* `Pgx_lwt` uses the [Lwt](https://ocsigen.org/lwt/) library.
+
+* `Pgx_async` uses the
+  [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+
+* `Pgx_unix` uses [Unix
+  bindings](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html). This
+  implementation is synchronous.
+
+Important: trying to run multiple queries at the same time will work properly,
+but with no performance benefit. The current implementation doesn't send queries
+in parallel.
+
+Other targets can be implemented easily. Check out the `IO` signature in
+`pgx/src/pgx.mli` and implement that in the desired backend.

--- a/packages/pgx/pgx.0.1/opam
+++ b/packages/pgx/pgx.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "silver-snakes@arena.io"
+authors: ["Brendan Long" "Jeremy Wei" "Richard W.M. Jones" "Rudi Grinberg"]
+homepage: "https://github.com/arenadotio/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+dev-repo: "https://github.com/arenadotio/pgx.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "ppx_jane"
+  "uuidm"
+  "re"
+  "sexplib" {>= "v0.10"}
+  "bisect_ppx" {build & >= "1.3.1"}
+  "jbuilder" {build & >= "1.0+beta14"}
+  "base64" {test}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/pgx/pgx.0.1/url
+++ b/packages/pgx/pgx.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "9d0ab8cde00c0cca351689a98b532f6c"
+checksum: "8bdc12ce829b66c62183491b954e0356"

--- a/packages/pgx/pgx.0.1/url
+++ b/packages/pgx/pgx.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "8bdc12ce829b66c62183491b954e0356"
+checksum: "8b51cb28052380f03704e2049a16f115"

--- a/packages/pgx/pgx.0.1/url
+++ b/packages/pgx/pgx.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
+checksum: "9d0ab8cde00c0cca351689a98b532f6c"

--- a/packages/pgx_async/pgx_async.0.1/descr
+++ b/packages/pgx_async/pgx_async.0.1/descr
@@ -1,0 +1,21 @@
+A pure OCaml PostgreSQL client library
+
+PGX is a pure-OCaml PostgreSQL client library. The following packages support
+synchronous or asynchronous implementations:
+
+* `Pgx_lwt` uses the [Lwt](https://ocsigen.org/lwt/) library.
+
+* `Pgx_async` uses the
+  [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+
+* `Pgx_unix` uses [Unix
+  bindings](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html). This
+  implementation is synchronous.
+
+Important: trying to run multiple queries at the same time will work properly,
+but with no performance benefit. The current implementation doesn't send queries
+in parallel.
+
+Other targets can be implemented easily. Check out the `IO` signature in
+`pgx/src/pgx.mli` and implement that in the desired backend.

--- a/packages/pgx_async/pgx_async.0.1/opam
+++ b/packages/pgx_async/pgx_async.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "silver-snakes@arena.io"
+authors: ["Brendan Long" "Jeremy Wei" "Richard W.M. Jones" "Rudi Grinberg"]
+homepage: "https://github.com/arenadotio/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+dev-repo: "https://github.com/arenadotio/pgx.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "async" {>= "v0.10.0"}
+  "pgx"
+  "ppx_jane"
+  "base64" {test}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/pgx_async/pgx_async.0.1/url
+++ b/packages/pgx_async/pgx_async.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "9d0ab8cde00c0cca351689a98b532f6c"
+checksum: "8bdc12ce829b66c62183491b954e0356"

--- a/packages/pgx_async/pgx_async.0.1/url
+++ b/packages/pgx_async/pgx_async.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "8bdc12ce829b66c62183491b954e0356"
+checksum: "8b51cb28052380f03704e2049a16f115"

--- a/packages/pgx_async/pgx_async.0.1/url
+++ b/packages/pgx_async/pgx_async.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
+checksum: "9d0ab8cde00c0cca351689a98b532f6c"

--- a/packages/pgx_lwt/pgx_lwt.0.1/descr
+++ b/packages/pgx_lwt/pgx_lwt.0.1/descr
@@ -1,0 +1,21 @@
+A pure OCaml PostgreSQL client library
+
+PGX is a pure-OCaml PostgreSQL client library. The following packages support
+synchronous or asynchronous implementations:
+
+* `Pgx_lwt` uses the [Lwt](https://ocsigen.org/lwt/) library.
+
+* `Pgx_async` uses the
+  [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+
+* `Pgx_unix` uses [Unix
+  bindings](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html). This
+  implementation is synchronous.
+
+Important: trying to run multiple queries at the same time will work properly,
+but with no performance benefit. The current implementation doesn't send queries
+in parallel.
+
+Other targets can be implemented easily. Check out the `IO` signature in
+`pgx/src/pgx.mli` and implement that in the desired backend.

--- a/packages/pgx_lwt/pgx_lwt.0.1/opam
+++ b/packages/pgx_lwt/pgx_lwt.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "silver-snakes@arena.io"
+authors: ["Brendan Long" "Jeremy Wei" "Richard W.M. Jones" "Rudi Grinberg"]
+homepage: "https://github.com/arenadotio/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+dev-repo: "https://github.com/arenadotio/pgx.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "pgx"
+  "ppx_jane"
+  "lwt"
+  "base64" {test}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/pgx_lwt/pgx_lwt.0.1/url
+++ b/packages/pgx_lwt/pgx_lwt.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "9d0ab8cde00c0cca351689a98b532f6c"
+checksum: "8bdc12ce829b66c62183491b954e0356"

--- a/packages/pgx_lwt/pgx_lwt.0.1/url
+++ b/packages/pgx_lwt/pgx_lwt.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "8bdc12ce829b66c62183491b954e0356"
+checksum: "8b51cb28052380f03704e2049a16f115"

--- a/packages/pgx_lwt/pgx_lwt.0.1/url
+++ b/packages/pgx_lwt/pgx_lwt.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
+checksum: "9d0ab8cde00c0cca351689a98b532f6c"

--- a/packages/pgx_unix/pgx_unix.0.1/descr
+++ b/packages/pgx_unix/pgx_unix.0.1/descr
@@ -1,0 +1,21 @@
+A pure OCaml PostgreSQL client library
+
+PGX is a pure-OCaml PostgreSQL client library. The following packages support
+synchronous or asynchronous implementations:
+
+* `Pgx_lwt` uses the [Lwt](https://ocsigen.org/lwt/) library.
+
+* `Pgx_async` uses the
+  [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+
+* `Pgx_unix` uses [Unix
+  bindings](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html). This
+  implementation is synchronous.
+
+Important: trying to run multiple queries at the same time will work properly,
+but with no performance benefit. The current implementation doesn't send queries
+in parallel.
+
+Other targets can be implemented easily. Check out the `IO` signature in
+`pgx/src/pgx.mli` and implement that in the desired backend.

--- a/packages/pgx_unix/pgx_unix.0.1/opam
+++ b/packages/pgx_unix/pgx_unix.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "silver-snakes@arena.io"
+authors: ["Brendan Long" "Jeremy Wei" "Richard W.M. Jones" "Rudi Grinberg"]
+homepage: "https://github.com/arenadotio/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+dev-repo: "https://github.com/arenadotio/pgx.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "pgx"
+  "ppx_jane"
+  "base64" {test}
+  "ounit" {test}
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/pgx_unix/pgx_unix.0.1/url
+++ b/packages/pgx_unix/pgx_unix.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "9d0ab8cde00c0cca351689a98b532f6c"
+checksum: "8bdc12ce829b66c62183491b954e0356"

--- a/packages/pgx_unix/pgx_unix.0.1/url
+++ b/packages/pgx_unix/pgx_unix.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
-checksum: "8bdc12ce829b66c62183491b954e0356"
+checksum: "8b51cb28052380f03704e2049a16f115"

--- a/packages/pgx_unix/pgx_unix.0.1/url
+++ b/packages/pgx_unix/pgx_unix.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/arenadotio/pgx/archive/v0.1.tar.gz"
+checksum: "9d0ab8cde00c0cca351689a98b532f6c"


### PR DESCRIPTION
Pgx is a pure-OCaml PostgreSQL client library.

It's currently maintained by [Arena](https://www.arena.io/).