### PR TITLE
Package opam-publish.2.0.0~beta

### DIFF
--- a/packages/opam-publish/opam-publish.2.0.0~beta/opam
+++ b/packages/opam-publish/opam-publish.2.0.0~beta/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+build: [ "jbuilder" "build" "-p" name ]
+depends: [
+  "opam-core" {build & >= "2.0.0~beta5"}
+  "opam-format" {build & >= "2.0.0~beta5"}
+  "opam-state" {build & >= "2.0.0~beta5"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  ("github" {build & >= "2.0.0" & < "3.0.0"} |
+   "github-unix" {build & >= "3.0.0"})
+]
+tags: [ "flags:plugin" ]
+url {
+  src: "https://github.com/OCamlPro/opam-publish/archive/2.0.0-beta.tar.gz"
+  checksum: [
+    "md5=62adddfb561a2ee1f7389cf28eafc5a1"
+    "sha512=20d09afa2f262d308abff989bdec273a880ff295d8089c36db4be4824e42f6dcd0eaf9af825f62d0469c4df08967f21b4164fa4063bb30f3d1b7f553aaed57a3"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.0.0~beta`



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.0.0~beta