### PR TITLE
Partial format upgrade (ocaml-variants.4.06.1+trunk+force-safe-string, ocaml-variants.4.06.1+trunk+safe-string, ocaml-variants.4.07.0+trunk+default-unsafe-string, ocaml-variants.4.07.0+trunk+unsafe-string)

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+force-safe-string/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,12 +23,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
-  checksum: "md5=d4b7a4b759ab822f019d218217f094d7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
@@ -19,7 +19,7 @@ build: [
     "-with-debug-runtime"
     "-no-force-safe-string"
     "-default-unsafe-string"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -31,12 +31,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
-  checksum: "md5=2f6faeba9cb6d4ebe6d86f2155998dcf"
 }


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/ocaml-variants/ocaml-variants.4.06.1+trunk+safe-string/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+unsafe-string/opam