### PR TITLE
mariadb: ocamlbuild is a build dependency

### DIFF
--- a/packages/mariadb/mariadb.0.10.0/opam
+++ b/packages/mariadb/mariadb.0.10.0/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.0.5.0/opam
+++ b/packages/mariadb/mariadb.0.5.0/opam
@@ -13,6 +13,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mariadb"]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "async"

--- a/packages/mariadb/mariadb.0.5.1/opam
+++ b/packages/mariadb/mariadb.0.5.1/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.0.6.0/opam
+++ b/packages/mariadb/mariadb.0.6.0/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.0.7.0/opam
+++ b/packages/mariadb/mariadb.0.7.0/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.0.8.0/opam
+++ b/packages/mariadb/mariadb.0.8.0/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.0.8.1/opam
+++ b/packages/mariadb/mariadb.0.8.1/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.0.8.2/opam
+++ b/packages/mariadb/mariadb.0.8.2/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.0.9.0/opam
+++ b/packages/mariadb/mariadb.0.9.0/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.1.0.0/opam
+++ b/packages/mariadb/mariadb.1.0.0/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]

--- a/packages/mariadb/mariadb.1.0.1/opam
+++ b/packages/mariadb/mariadb.1.0.1/opam
@@ -16,6 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]


### PR DESCRIPTION
spotted here: https://github.com/ocaml/opam-repository/pull/11754
reported upstream: https://github.com/andrenth/ocaml-mariadb/pull/21