### PR TITLE
Package multipart-form-data.0.2.0

### DIFF
--- a/packages/multipart-form-data/multipart-form-data.0.2.0/descr
+++ b/packages/multipart-form-data/multipart-form-data.0.2.0/descr
@@ -1,0 +1,11 @@
+Parser for ocaml [![Build Status](https://travis-ci.org/cryptosense/multipart-form-data.svg)](https://travis-ci.org/cryptosense/multipart-form-data)
+
+This is a parser for structured form data based on `Lwt_stream` in order to use
+it with [cohttp](https://github.com/mirage/ocaml-cohttp/). You can use it to
+send POST parameters.
+
+There are two APIs:
+
+- a high-level one: `parse_stream` and `get_parts`. It works for strings, but
+  has some problems with files.
+- a low-level one: `parse`. It works for well for both strings and files.

--- a/packages/multipart-form-data/multipart-form-data.0.2.0/opam
+++ b/packages/multipart-form-data/multipart-form-data.0.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/multipart-form-data"
+bug-reports: "https://github.com/cryptosense/multipart-form-data/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/multipart-form-data.git"
+doc: "https://cryptosense.github.io/multipart-form-data/doc"
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree" {build}
+  "alcotest" {test}
+  "stringext"
+  "lwt"
+  "lwt_ppx"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/multipart-form-data/multipart-form-data.0.2.0/url
+++ b/packages/multipart-form-data/multipart-form-data.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/multipart-form-data/releases/download/v0.2.0/multipart-form-data-0.2.0.tbz"
+checksum: "7e6276ba4b19d6289cc4129fc45ab1f2"


### PR DESCRIPTION
### `multipart-form-data.0.2.0`

Parser for ocaml [![Build Status](https://travis-ci.org/cryptosense/multipart-form-data.svg)](https://travis-ci.org/cryptosense/multipart-form-data)

This is a parser for structured form data based on `Lwt_stream` in order to use
it with [cohttp](https://github.com/mirage/ocaml-cohttp/). You can use it to
send POST parameters.

There are two APIs:

- a high-level one: `parse_stream` and `get_parts`. It works for strings, but
  has some problems with files.
- a low-level one: `parse`. It works for well for both strings and files.


---
* Homepage: https://github.com/cryptosense/multipart-form-data
* Source repo: https://github.com/cryptosense/multipart-form-data.git
* Bug tracker: https://github.com/cryptosense/multipart-form-data/issues

---


---
v0.2.0 2018-04-11
=================

Compatibility:

- Use the standalone `lwt_ppx` for compatibility with `lwt >= 4.0.0` (#20).

Packaging:

- Port to jbuilder. (#18)
- CI improvements: (#19)
  + use travis-docker
  + add 4.05 + 4.06 builds
:camel: Pull-request generated by opam-publish v0.3.5