### PR TITLE
Constrain packages not available on ARM64

### DIFF
--- a/packages/core/core.v0.10.0/opam
+++ b/packages/core/core.v0.10.0/opam
@@ -22,4 +22,4 @@ depends: [
   "jbuilder"                {build & >= "1.0+beta12"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.04.1" & arch != "aarch64" ]

--- a/packages/core/core.v0.11.0/opam
+++ b/packages/core/core.v0.11.0/opam
@@ -23,4 +23,4 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.0"}
   "ppxlib"                  {>= "0.1.0"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.04.1" & arch != "aarch64" ]

--- a/packages/core/core.v0.9.0/opam
+++ b/packages/core/core.v0.9.0/opam
@@ -22,4 +22,4 @@ depends: [
   "base-threads"
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.05.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.05.0" & arch != "aarch64" ]

--- a/packages/core/core.v0.9.1/opam
+++ b/packages/core/core.v0.9.1/opam
@@ -22,4 +22,4 @@ depends: [
   "base-threads"
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" & arch != "aarch64" ]

--- a/packages/core/core.v0.9.2/opam
+++ b/packages/core/core.v0.9.2/opam
@@ -22,4 +22,4 @@ depends: [
   "base-threads"
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & arch != "aarch64" ]

--- a/packages/core_kernel/core_kernel.v0.9.0/opam
+++ b/packages/core_kernel/core_kernel.v0.9.0/opam
@@ -30,4 +30,4 @@ depends: [
   "ocaml-migrate-parsetree" {>= "0.4"}
   "num"
 ]
-available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" & arch != "aarch64" ]

--- a/packages/core_kernel/core_kernel.v0.9.1/opam
+++ b/packages/core_kernel/core_kernel.v0.9.1/opam
@@ -29,4 +29,4 @@ depends: [
   "variantslib"             {>= "v0.9" & < "v0.10"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & arch != "aarch64" ]


### PR DESCRIPTION
Reported here for ```core```: https://github.com/janestreet/core/issues/110
Reported upstream for ```ocaml-freestanding```: https://github.com/mirage/ocaml-freestanding/pull/36