### PR TITLE
Partial format upgrade (ocaml-variants.4.07.0+beta2, ocaml-variants.4.07.0+beta2+afl, ocaml-variants.4.07.0+beta2+default-unsafe-string, ocaml-variants.4.07.0+beta2+flambda, ocaml-variants.4.07.0+beta2+fp, ...)

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-afl-instrument"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-default-unsafe-string"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,7 +28,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,7 +23,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -18,7 +18,7 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -30,7 +30,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,7 +28,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-afl-instrument"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,12 +22,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
-  checksum: "md5=23e97673d30fcb2815a69d20bd39636a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
@@ -18,7 +18,7 @@ build: [
     "-with-debug-runtime"
     "-no-force-safe-string"
     "-default-unsafe-string"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -30,12 +30,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
-  checksum: "md5=23e97673d30fcb2815a69d20bd39636a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,12 +23,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
-  checksum: "md5=23e97673d30fcb2815a69d20bd39636a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
@@ -18,7 +18,7 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -30,12 +30,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
-  checksum: "md5=23e97673d30fcb2815a69d20bd39636a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,12 +28,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
-  checksum: "md5=23e97673d30fcb2815a69d20bd39636a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+afl/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-afl-instrument"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,12 +22,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-  checksum: "md5=3257475f890cc37c9d205be0ff901568"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-default-unsafe-string"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,12 +28,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-  checksum: "md5=3257475f890cc37c9d205be0ff901568"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+flambda/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,12 +23,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-  checksum: "md5=3257475f890cc37c9d205be0ff901568"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp+flambda/opam
@@ -18,7 +18,7 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -30,12 +30,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-  checksum: "md5=3257475f890cc37c9d205be0ff901568"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,12 +28,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-  checksum: "md5=3257475f890cc37c9d205be0ff901568"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,12 +22,11 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-  checksum: "md5=3257475f890cc37c9d205be0ff901568"
 }

--- a/packages/ocaml/ocaml.4.08.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.08.0/files/gen_ocaml_config.ml.in
@@ -1,0 +1,43 @@
+let () =
+  let ocaml_version =
+    let v = Sys.ocaml_version in
+    try String.sub v 0 (String.index v '+') with Not_found -> v
+  in
+  if ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "OCaml version mismatch: %%s, expected %{_:version}%"
+       ocaml_version;
+     exit 1)
+  else
+  let oc = open_out "%{_:name}%.config" in
+  let ocaml = Sys.executable_name in
+  let ocamlc = ocaml^"c" in
+  let libdir =
+    let ic = Unix.open_process_in (ocamlc^" -where") in
+    let r = input_line ic in
+    if Unix.close_process_in ic <> Unix.WEXITED 0 then 
+      failwith "Bad return from 'ocamlc -where'";
+    r
+  in
+  let stubsdir =
+    let ic = open_in (Filename.concat libdir "ld.conf") in
+    let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
+    let lines = List.rev (r []) in
+    close_in ic;
+    String.concat ":" lines
+  in
+  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
+  p "opam-version: \"2.0\"";
+  p "variables {";
+  p "  native: %%b"
+    (Sys.file_exists (ocaml^"opt"));
+  p "  native-tools: %%b"
+    (Sys.file_exists (ocamlc^".opt"));
+  p "  native-dynlink: %%b"
+    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+  p "  stubsdir: %%S"
+    stubsdir;
+  p "  preinstalled: %{ocaml-system:installed}%";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
+  p "}";
+  close_out oc

--- a/packages/ocaml/ocaml.4.08.0/opam
+++ b/packages/ocaml/ocaml.4.08.0/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-base-compiler" {= "4.08.0"} |
+  "ocaml-variants" {>= "4.08.0" & < "4.08.1~"} |
+  "ocaml-system" {= "4.08.0"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "unix.cma" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+build-env: CAML_LD_LIBRARY_PATH = ""


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
  - packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam