### PR TITLE
opam-core.2.0.0~beta5 is incompatible with jbuilder >= 1.0+beta18

### DIFF
--- a/packages/opam-core/opam-core.2.0.0~beta5/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta5/opam
@@ -22,6 +22,6 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "jbuilder" {build & >= "1.0+beta12"}
+  "jbuilder" {build & >= "1.0+beta12" & < "1.0+beta19"}
 ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
As discovered [here](https://github.com/ocaml/opam-repository/pull/11756#issuecomment-380799708)