### PR TITLE
why3-base is not compatible with ocaml 4.07

### DIFF
--- a/packages/why3-base/why3-base.0.88.1/opam
+++ b/packages/why3-base/why3-base.0.88.1/opam
@@ -21,7 +21,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.07.0" ]
 
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [

--- a/packages/why3-base/why3-base.0.88.2/opam
+++ b/packages/why3-base/why3-base.0.88.2/opam
@@ -21,7 +21,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.07.0" ]
 
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [

--- a/packages/why3-base/why3-base.0.88.3/opam
+++ b/packages/why3-base/why3-base.0.88.3/opam
@@ -21,7 +21,7 @@ tags: [
   "automated theorem prover"
   "interactive theorem prover"
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.07.0" ]
 
 # Jessie3 (frama-c plugin) is *disabled* because it is not ready
 build: [


### PR DESCRIPTION
cc @silene 

Build log:
```
#=== ERROR while compiling why3-base.0.88.3 ===================================#
# context              2.0.0~rc | linux/x86_64 | ocaml-variants.4.07.0+trunk | git+file:///home/opam/opam-repository
# path                 ~/.opam/4.07.0+trunk/.opam-switch/build/why3-base.0.88.3
# command              /usr/bin/make -j71 all opt byte
# exit-code            2
# env-file             ~/.opam/log/why3-base-1-58a313.env
# output-file          ~/.opam/log/why3-base-1-58a313.out
### output ###
# [...]
# Ocamlc   lib/ocaml/why3__IntAux.ml
# Ocamlc   src/util/number.ml
# Ocamlc   src/util/loc.ml
# Ocamlc   src/util/debug.ml
# File "compiler internals", line 1:
# Error: Unbound module Stdlib
# Ocamlc   src/session/xml.ml
# Ocamlc   src/util/plugin.mli
# Makefile:1881: recipe for target 'src/util/stdlib.cmi' failed
# make: *** [src/util/stdlib.cmi] Error 2
# make: *** Waiting for unfinished jobs....
# Ocamlopt src/util/cmdline.ml
```