### PR TITLE
Restrict ppx_protocol_conv version for aws-s3

### DIFF
--- a/packages/aws-s3/aws-s3.1.1.0/opam
+++ b/packages/aws-s3/aws-s3.1.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" { build }
-  "core" { >= "0.9" }
+  "core" { >= "v0.9" & < "v0.10" }
   "async"
   "async_extended"
   "ounit"
@@ -17,6 +17,6 @@ depends: [
   "cryptokit"
   "nocrypto"
   "yojson"
-  "ppx_deriving_protocol" { < "2.0.0" }
+  "ppx_deriving_protocol" { = "0.8" }
   "xml-light"
 ]

--- a/packages/aws-s3/aws-s3.1.1.0/opam
+++ b/packages/aws-s3/aws-s3.1.1.0/opam
@@ -17,6 +17,6 @@ depends: [
   "cryptokit"
   "nocrypto"
   "yojson"
-  "ppx_deriving_protocol"
+  "ppx_deriving_protocol" { < "2.0.0" }
   "xml-light"
 ]

--- a/packages/aws-s3/aws-s3.1.1.1/opam
+++ b/packages/aws-s3/aws-s3.1.1.1/opam
@@ -18,5 +18,5 @@ depends: [
   "nocrypto"
   "yojson"
   "xml-light"
-  "ppx_protocol_conv"
+  "ppx_protocol_conv" { < "2.0.0" }
 ]

--- a/packages/aws-s3/aws-s3.1.1.1/opam
+++ b/packages/aws-s3/aws-s3.1.1.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" { build }
-  "core" { >= "v0.9" }
+  "core" { >= "v0.9" & < "v0.10" }
   "async"
   "async_extended"
   "ounit"

--- a/packages/aws-s3/aws-s3.2.0.0/opam
+++ b/packages/aws-s3/aws-s3.2.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "nocrypto"
   "xml-light"
   "yojson"
-  "ppx_protocol_conv"
+  "ppx_protocol_conv" { < "2.0.0" }
 ]
 
 available: [ ocaml-version >= "4.04.0" ]


### PR DESCRIPTION
aws-s3 will not compile with the latest version of ppx_protocol_conv. This PR restricts the version to < 2.0.0