### PR TITLE
restrict jbuilder version for amqp_client

### DIFF
--- a/packages/amqp-client/amqp-client.1.1.1/opam
+++ b/packages/amqp-client/amqp-client.1.1.1/opam
@@ -9,7 +9,7 @@ version: "1.1.1"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & <= "1.0+beta17"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {test}
@@ -23,4 +23,4 @@ conflicts: [
   "async" {>= "v0.10" }
   "lwt" {< "2.4.6"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/amqp-client/amqp-client.1.1.1/opam
+++ b/packages/amqp-client/amqp-client.1.1.1/opam
@@ -22,5 +22,6 @@ depopts: [
 conflicts: [
   "async" {>= "v0.10" }
   "lwt" {< "2.4.6"}
+  "lwt" {>= "4.0.0"}
 ]
 available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
Fixes build by restricting jbuilder and compiler version. 