### PR TITLE
Actually opam-lib.1.3.1 seems to work for 4.06

### DIFF
--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -27,4 +27,3 @@ depends: [
   "ocamlfind" {build}
   "jsonm"
 ]
-available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
This partially reverts #10988 @minishrink do you remember why this constraint was needed?