### PR TITLE
Package dune-release.0.1.0

### DIFF
--- a/packages/dune-release/dune-release.0.1.0/descr
+++ b/packages/dune-release/dune-release.0.1.0/descr
@@ -1,0 +1,6 @@
+Release dune packages in opam
+
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports only projects be built
+with [Dune](https://github.com/ocaml/dune) and released on
+[GitHub](https://github.com).

--- a/packages/dune-release/dune-release.0.1.0/opam
+++ b/packages/dune-release/dune-release.0.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire"]
+homepage: "https://github.com/samoht/dune-release"
+license: "ISC"
+dev-repo: "https://github.com/samoht/dune-release.git"
+bug-reports: "https://github.com/samoht/dune-release/issues"
+doc: "https://samoht.github.io/dune-release/"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build}
+  "fmt"
+  "bos"
+  "cmdliner"
+  "webbrowser"
+  "opam-format"
+  "rresult"
+  "logs"
+  "odoc"
+  "opam-publish" {build}
+]
+
+available: [
+  ocaml-version >= "4.06.0"
+]

--- a/packages/dune-release/dune-release.0.1.0/url
+++ b/packages/dune-release/dune-release.0.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/dune-release/releases/download/0.1.0/dune-release-0.1.0.tbz"
+checksum: "94161a71444057bfc1ff70379a169c83"


### PR DESCRIPTION
### `dune-release.0.1.0`

Release dune packages in opam

`dune-release` is a tool to streamline the release of Dune packages in
[opam](https://opam.ocaml.org). It supports only projects be built
with [Dune](https://github.com/ocaml/dune) and released on
[GitHub](https://github.com).


---
* Homepage: https://github.com/samoht/dune-release
* Source repo: https://github.com/samoht/dune-release.git
* Bug tracker: https://github.com/samoht/dune-release/issues

---


---
## 0.1.0 (2018-04-12)

Initial release.

Import some code from [topkg](http://erratique.ch/software/topkg).

- Use of `Astring`, `Logs`, `Fpath` and`Bos` instead of custom
  re-implementations;
- Remove the IPC layer which is used between `topkg` and `topkg-care`;
- Bundle everything as a single binary;
- Assume that the package is built using [dune](https://github.com/ocaml/dune);
- Do not read/neeed a `pkg/pkg.ml` file.
:camel: Pull-request generated by opam-publish v0.3.5