### PR TITLE
Package opam-file-format.2.0.0~rc2

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.0.0~rc2/descr
+++ b/packages/opam-file-format/opam-file-format.2.0.0~rc2/descr
@@ -1,0 +1,1 @@
+Parser and printer for the opam file syntax

--- a/packages/opam-file-format/opam-file-format.2.0.0~rc2/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0~rc2/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+build: [
+  make
+  "byte" {!ocaml-native}
+  "all" {ocaml-native}
+]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: ["rm" "-rf" "%{opam-file-format:lib}%"]

--- a/packages/opam-file-format/opam-file-format.2.0.0~rc2/url
+++ b/packages/opam-file-format/opam-file-format.2.0.0~rc2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam-file-format/archive/2.0.0-rc2.tar.gz"
+checksum: "baa1230ff40a320bebdd980b071cfbf1"


### PR DESCRIPTION
### `opam-file-format.2.0.0~rc2`

Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them: "opam-file-format"
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5