### PR TITLE
Lwt 4.0.1

### DIFF
--- a/packages/lwt/lwt.4.0.1/descr
+++ b/packages/lwt/lwt.4.0.1/descr
@@ -1,0 +1,10 @@
+Promises, concurrency, and parallelized I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.4.0.1/opam
+++ b/packages/lwt/lwt.4.0.1/opam
@@ -1,0 +1,58 @@
+opam-version: "1.2"
+version: "4.0.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "jbuilder" {build & >= "1.0+beta14"}
+  # We are only using ocamlfind during configuration of the Unix binding.
+  # However, ocamlfind also installs the "threads" package, and ocamlfind
+  # 1.7.3-1 is the first one whose threads package does not have incorrect error
+  # lines. See
+  #   https://github.com/ocaml/opam-repository/pull/11071#issuecomment-353131128
+  # If ocamlfind becomes no longer necessary for configuration of Lwt, this
+  # dependency should be converted to a conflict, and package jbuilder should be
+  # constrained such that it also includes the error lines fix.
+  "ocamlfind" {build & >= "1.7.3-1"}
+  # result is needed as long as Lwt still supports OCaml 4.02.
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+
+messages: [
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
+  "For the Camlp4 syntax, please install package lwt_camlp4"
+    {camlp4:installed & !lwt_camlp4:installed}
+  "For Lwt_log and Lwt_daemon, please install package lwt_log"
+    {!lwt_log:installed}
+]
+post-messages: [
+  "Lwt 4.0.0 has made some breaking changes. See
+  https://github.com/ocsigen/lwt/issues/453"
+]

--- a/packages/lwt/lwt.4.0.1/url
+++ b/packages/lwt/lwt.4.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/4.0.1.tar.gz"
+checksum: "d2d1dacf089d7948fd95d9665259a9b6"


### PR DESCRIPTION
This release mainly fixes two major bugs in `Lwt_unix` that were found by @gabelevi immediately after 4.0.0 was tagged. From the [changelog](https://github.com/ocsigen/lwt/releases/tag/4.0.1):

> Bugs fixed
>
> - Race condition in worker thread management in `Lwt_unix` (ocsigen/lwt#569, diagnosed Gabe Levi).
> - Hang in `Lwt_unix.read` on Windows (ocsigen/lwt#574, ocsigen/lwt#569, 86a6baf, diagnosed Gabe Levi).
> - Docs: note that `Lwt_io.open_file` for writing truncates the file by default (ocsigen/lwt#570, reported Tóth Róbert).
