### PR TITLE
Package tube.4.3.0

### DIFF
--- a/packages/tube/tube.4.3.0/descr
+++ b/packages/tube/tube.4.3.0/descr
@@ -1,0 +1,4 @@
+Typesafe abstraction on top of Lwt_io channels
+
+A typesafe abstraction on top of Lwt_io channels in order to avoid things like unsafe operations
+(i.e. https://github.com/ocsigen/lwt/issues/345 ) when running in practice.

--- a/packages/tube/tube.4.3.0/opam
+++ b/packages/tube/tube.4.3.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "alin.popa@gmail.com"
+authors: "Alin Popa"
+homepage: "https://github.com/alinpopa/tube"
+bug-reports: "https://github.com/alinpopa/tube/issues"
+license: "LGPL-3 with OCaml linking exception"
+dev-repo: "https://github.com/alinpopa/tube.git"
+build: ["jbuilder" "build" "-p" "tube"]
+depends: [
+  "jbuilder" {build & >= "1.0+beta15"}
+  "lwt"
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/tube/tube.4.3.0/url
+++ b/packages/tube/tube.4.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/alinpopa/tube/archive/4.3.0.zip"
+checksum: "117a21a572b19aeb41008a8d000c7d09"


### PR DESCRIPTION
### `tube.4.3.0`

Typesafe abstraction on top of Lwt_io channels

A typesafe abstraction on top of Lwt_io channels in order to avoid things like unsafe operations
(i.e. https://github.com/ocsigen/lwt/issues/345 ) when running in practice.



---
* Homepage: https://github.com/alinpopa/tube
* Source repo: https://github.com/alinpopa/tube.git
* Bug tracker: https://github.com/alinpopa/tube/issues

---

:camel: Pull-request generated by opam-publish v0.3.5