### PR TITLE
Constrain js_of_ocaml for Lwt 4.0.0

### DIFF
--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta12"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta12"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta17"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.3/opam
@@ -15,6 +15,7 @@ depopts: ["deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving" {< "0.6"}
   "lwt"      {< "2.4"}
+  "lwt"      {>= "4.0.0"}
   "tyxml"    {< "3.2"}
   "tyxml"    {>= "3.6.0"}
   "reactiveData" {>= "0.2"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
@@ -15,6 +15,7 @@ depopts: ["deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving" {< "0.6"}
   "lwt"      {< "2.4"}
+  "lwt"      {>= "4.0.0"}
   "tyxml"    {< "3.2.1"}
   "tyxml"    {>= "3.6.0"}
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4/opam
@@ -15,6 +15,7 @@ depopts: ["deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving" {< "0.6"}
   "lwt"      {< "2.4"}
+  "lwt"      {>= "4.0.0"}
   "tyxml"    {< "3.2.1"}
   "tyxml"    {>= "3.6.0"}
   "reactiveData" {>= "0.2"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.5/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.5/opam
@@ -13,7 +13,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "camlp4"
   "ocamlbuild"

--- a/packages/js_of_ocaml/js_of_ocaml.2.6/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.6/opam
@@ -13,7 +13,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo"
   "camlp4"

--- a/packages/js_of_ocaml/js_of_ocaml.2.7/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.7/opam
@@ -13,7 +13,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo"
   "camlp4"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
@@ -13,7 +13,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
@@ -11,7 +11,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
@@ -11,7 +11,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
@@ -11,7 +11,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8/opam
@@ -13,7 +13,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"


### PR DESCRIPTION
cc @hannesm @hhugo

Constraints are based on looking in the git history of js_of_ocaml. The dependency on `lwt.log` first appeared in 2.3, and seems not to be guarded by its own condition.

EDIT: see https://github.com/ocaml/opam-repository/pull/11708#issuecomment-381119399.