### PR TITLE
New bug-fix release of ocaml-git 0.11

### DIFF
--- a/packages/git-unix/git-unix.1.11.5/descr
+++ b/packages/git-unix/git-unix.1.11.5/descr
@@ -1,0 +1,5 @@
+Unix backend for the Git protocol(s)
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git-unix/git-unix.1.11.5/opam
+++ b/packages/git-unix/git-unix.1.11.5/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "logs"
+  "git-http" {>= "1.11.0"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "cohttp-lwt-unix"  {>= "0.99.0"}
+  "nocrypto" {>= "0.2.0"}
+  "mtime"    {>= "1.0.0"}
+  "base-unix"
+  "alcotest" {test}
+  "io-page"  {test & >= "1.6.1"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-unix/git-unix.1.11.5/url
+++ b/packages/git-unix/git-unix.1.11.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.5/git-1.11.5.tbz"
+checksum: "86090621429b346357604e157274387a"

--- a/packages/git/git.1.11.5/descr
+++ b/packages/git/git.1.11.5/descr
@@ -1,0 +1,13 @@
+Git format and protocol in pure OCaml
+
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects. For instance, it is
+possible to make a pack file position independent (as the Zlib
+compression might change the relative offsets between the packed
+objects), to generate pack indexes from pack files, or to expand
+the filesystem of a given commit.

--- a/packages/git/git.1.11.5/opam
+++ b/packages/git/git.1.11.5/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "build" "-p" name]
+
+depends: [
+  "jbuilder"   {build}
+  "mstruct"    {>= "1.3.1"}
+  "ocamlgraph"
+  "uri"        {>= "1.3.12"}
+  "lwt"        {>= "2.4.7"}
+  "logs"
+  "fmt"
+  "hex"
+  "astring"
+  "ocplib-endian"
+  "decompress" {>= "0.6"}
+  "alcotest" {test}
+  "nocrypto" {test}
+  "mtime"    {test & >= "1.0.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.11.5/url
+++ b/packages/git/git.1.11.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.11.5/git-1.11.5.tbz"
+checksum: "86090621429b346357604e157274387a"


### PR DESCRIPTION
Changes:

- git: make `Git.FS.test_and_set_references` work better with packed
  references (mirage/ocaml-git#291, @samoht. Fixes moby/datakit#633)
- git-unix: ignore trailing newlines when doing 'test and set' on
  reference files (backport of moby/datakit#611, @samoht. Fixes moby/datakit#610)
- git-mirage: fix linking of tests (@samoht)