### PR TITLE
Partial format upgrade (js_of_ocaml.2.3, js_of_ocaml.2.4, js_of_ocaml.2.4.1, js_of_ocaml.2.5, js_of_ocaml.2.6, ...)

### DIFF
--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta12"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta12"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta17"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.3/opam
@@ -21,6 +21,7 @@ depopts: ["deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving" {< "0.6"}
   "lwt"      {< "2.4"}
+  "lwt"      {>= "4.0.0"}
   "tyxml"    {< "3.2"}
   "tyxml"    {>= "3.6.0"}
   "reactiveData" {>= "0.2"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4.1/opam
@@ -22,6 +22,7 @@ depopts: ["deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving" {< "0.6"}
   "lwt"      {< "2.4"}
+  "lwt"      {>= "4.0.0"}
   "tyxml"    {< "3.2.1"}
   "tyxml"    {>= "3.6.0"}
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.4/opam
@@ -22,6 +22,7 @@ depopts: ["deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving" {< "0.6"}
   "lwt"      {< "2.4"}
+  "lwt"      {>= "4.0.0"}
   "tyxml"    {< "3.2.1"}
   "tyxml"    {>= "3.6.0"}
   "reactiveData" {>= "0.2"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.5/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.5/opam
@@ -13,7 +13,7 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "camlp4"
   "ocamlbuild"

--- a/packages/js_of_ocaml/js_of_ocaml.2.6/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.6/opam
@@ -13,12 +13,12 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo"
   "camlp4"
   "base64" {>= "2.0.0"}
-  ("base-no-ppx" | "ppx_tools")
+  "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.7/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.7/opam
@@ -13,12 +13,12 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo"
   "camlp4"
   "base64" {>= "2.0.0"}
-  ("base-no-ppx" | "ppx_tools")
+  "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
 ]
 depopts: ["deriving" "ppx_deriving" "tyxml" "reactiveData" ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
@@ -13,12 +13,12 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"
   "base64" {>= "2.0.0"}
-  ("base-no-ppx" | "ppx_tools")
+  "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
 ]
 depopts: ["deriving" "ppx_deriving" "tyxml" "reactiveData" "async_kernel" "ppx_driver" ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
@@ -12,12 +12,12 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"
   "base64" {>= "2.0.0"}
-  ("base-no-ppx" | "ppx_tools")
+  "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
   "uchar"
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
@@ -12,12 +12,12 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"
   "base64" {>= "2.0.0"}
-  ("base-no-ppx" | "ppx_tools")
+  "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
   "uchar"
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
@@ -12,12 +12,12 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"
   "base64" {>= "2.0.0"}
-  ("base-no-ppx" | "ppx_tools")
+  "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
   "uchar"
   "yojson"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8/opam
@@ -13,12 +13,12 @@ depends: [
   "cmdliner"
   "base-unix"
   "ocamlfind" {>= "1.5.1"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "4.0.0"}
   "menhir"
   "cppo" {>= "1.1.0"}
   "camlp4"
   "base64" {>= "2.0.0"}
-  ("base-no-ppx" | "ppx_tools")
+  "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
 ]
 depopts: ["deriving" "ppx_deriving" "tyxml" "reactiveData" "async_kernel" ]


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/js_of_ocaml/js_of_ocaml.2.6/opam
  - packages/js_of_ocaml/js_of_ocaml.2.7/opam
  - packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
  - packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
  - packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
  - packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
  - packages/js_of_ocaml/js_of_ocaml.2.8/opam