### PR TITLE
Use Lwt 2.4.3 GitHub archive

### DIFF
--- a/packages/lwt/lwt.2.4.3/url
+++ b/packages/lwt/lwt.2.4.3/url
@@ -1,2 +1,2 @@
-archive: "http://ocsigen.org/download/lwt-2.4.3.tar.gz"
-checksum: "4a4a22da7da4301c6282f361edd0c241"
+archive: "https://github.com/ocsigen/lwt/archive/2.4.3.tar.gz"
+checksum: "b487fd835d3587d4f198b7a3953ff7dd"


### PR DESCRIPTION
`http://ocsigen.org/download/lwt-2.4.3.tar.gz` seems to no longer be available (@hannesm in https://github.com/ocaml/opam-repository/pull/11788#issuecomment-381311848).

Please don't merge this right away. We should probably try to get `ocsigen.org` to restore the archive first. cc @Drup, @balat.