### PR TITLE
Package freetds.0.5.2

### DIFF
--- a/packages/freetds/freetds.0.5.2/descr
+++ b/packages/freetds/freetds.0.5.2/descr
@@ -1,0 +1,5 @@
+Binding to the FreeTDS library
+
+FreeTDS is a set of libraries for Unix and Linux that allows your
+programs to natively talk to Microsoft SQL Server and Sybase
+databases.

--- a/packages/freetds/freetds.0.5.2/opam
+++ b/packages/freetds/freetds.0.5.2/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Kenn Knowles <kenn.knowles@gmail.com>" ]
+maintainer: "Christophe.Troestler@umons.ac.be"
+homepage: "https://github.com/kennknowles/ocaml-freetds"
+dev-repo: "https://github.com/kennknowles/ocaml-freetds.git"
+bug-reports: "https://github.com/kennknowles/ocaml-freetds/issues"
+doc: "https://kennknowles.github.io/ocaml-freetds/doc"
+license: "LGPL-2.1"
+
+tags: [
+  "clib:ct"
+  "clib:sybdb"
+]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta19.1"}
+  "ounit" {test & >= "2.0.0"}
+]
+depexts: [
+  [["alpine"] ["freetds-dev"]]
+  [["centos"] ["freetds-devel"]]
+  [["debian"] ["freetds-dev"]]
+  [["fedora"] ["freetds-devel"]]
+  [["ubuntu"] ["freetds-dev"]]
+  [["osx" "homebrew"] ["freetds"]]
+]
+
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/freetds/freetds.0.5.2/url
+++ b/packages/freetds/freetds.0.5.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/kennknowles/ocaml-freetds/releases/download/0.5.2/freetds-0.5.2.tbz"
+checksum: "061df4b808d84f40ae3e2a344e091406"


### PR DESCRIPTION
### `freetds.0.5.2`

Binding to the FreeTDS library

FreeTDS is a set of libraries for Unix and Linux that allows your
programs to natively talk to Microsoft SQL Server and Sybase
databases.



---
* Homepage: https://github.com/kennknowles/ocaml-freetds
* Source repo: https://github.com/kennknowles/ocaml-freetds.git
* Bug tracker: https://github.com/kennknowles/ocaml-freetds/issues

---


---
0.5.2 2018-04-15
----------------

- Better error messages (commits #94134f7 and #bdc2c99)
- Port to Jbuilder/Dune (Brendan Long) and topkg
- Add basic unit tests (Brendan Long)
- Fix all build warnings
- Improve Travis CI scripts
:camel: Pull-request generated by opam-publish v0.3.5