### PR TITLE
Package integration1d.0.5

### DIFF
--- a/packages/integration1d/integration1d.0.5/descr
+++ b/packages/integration1d/integration1d.0.5/descr
@@ -1,0 +1,25 @@
+Integration of functions of one variable
+
+This is a Collection of numerical integration routines inspired by
+QUADPACK but written in pure OCaml.
+
+Installation
+------------
+
+The easiest way of installing this library is to use [opam][]:
+
+    opam install integration1d
+
+If you wish to compile it by hand, install [jbuilder][] and do
+`jbuilder build @install`.
+
+
+Documentation
+-------------
+
+Please see the interface of the
+module [Integration1D](src/integration1D.mli).
+
+
+[OPAM]: https://opam.ocaml.org/
+[jbuilder]: https://github.com/janestreet/jbuilder

--- a/packages/integration1d/integration1d.0.5/opam
+++ b/packages/integration1d/integration1d.0.5/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["science" "numerics"]
+license: "ISC"
+homepage: "https://github.com/Chris00/integration1d"
+dev-repo: "https://github.com/Chris00/integration1d.git"
+bug-reports: "https://github.com/Chris00/integration1d/issues"
+doc: "https://Chris00.github.io/integration1d/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "camlp4"   {build}
+]

--- a/packages/integration1d/integration1d.0.5/url
+++ b/packages/integration1d/integration1d.0.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/integration1d/releases/download/0.5/integration1d-0.5.tbz"
+checksum: "fbdb255fd50f55db1691126e2ddfce92"


### PR DESCRIPTION
### `integration1d.0.5`

Integration of functions of one variable

This is a Collection of numerical integration routines inspired by
QUADPACK but written in pure OCaml.

Installation
------------

The easiest way of installing this library is to use [opam][]:

    opam install integration1d

If you wish to compile it by hand, install [jbuilder][] and do
`jbuilder build @install`.


Documentation
-------------

Please see the interface of the
module [Integration1D](src/integration1D.mli).


[OPAM]: https://opam.ocaml.org/
[jbuilder]: https://github.com/janestreet/jbuilder


---
* Homepage: https://github.com/Chris00/integration1d
* Source repo: https://github.com/Chris00/integration1d.git
* Bug tracker: https://github.com/Chris00/integration1d/issues

---


---
0.5 2018-04-17
--------------

- The exception `Function_not_finite` only takes a single argument
  now and add a custom printer to see for the float argument to be
  printed.
- Improve the documentation
- Use Dune/Jbuilder & topkg
:camel: Pull-request generated by opam-publish v0.3.5