### PR TITLE
opam-fu: Update opam-lib dependency

### DIFF
--- a/packages/opamfu/opamfu.0.1.4/opam
+++ b/packages/opamfu/opamfu.0.1.4/opam
@@ -13,7 +13,7 @@ install: [make "install"]
 remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
-  "opam-lib" { = "1.3.0" }
+  "opam-lib" { >= "1.3.0" }
   "uri" { >= "1.3.11" }
 ]
 depopts: ["cmdliner"]


### PR DESCRIPTION
This is a bottleneck on building the opam.org site, at least on 4.06.0 and above.