### PR TITLE
Package ocamlformat.0.5

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.5/descr
+++ b/packages/ocamlformat/ocamlformat.0.5/descr
@@ -1,0 +1,3 @@
+Auto-formatter for OCaml code
+
+OCamlFormat is a tool to automatically format OCaml code in a uniform style.

--- a/packages/ocamlformat/ocamlformat.0.5/opam
+++ b/packages/ocamlformat/ocamlformat.0.5/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["tools/gen_version.sh" "src/Version.ml" version] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "jbuilder" {build & >= "1.0+beta20"}
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocamlformat_support" {>= "0.4" & < "0.5"}
+  "stdio"
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ocamlformat/ocamlformat.0.5/url
+++ b/packages/ocamlformat/ocamlformat.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/0.5.tar.gz"
+checksum: "c46515742f90b04dae649b09e9c4bf53"

--- a/packages/ocamlformat_support/ocamlformat_support.0.4/descr
+++ b/packages/ocamlformat_support/ocamlformat_support.0.4/descr
@@ -1,0 +1,3 @@
+Support package for OCamlFormat
+
+Consists of a patched version of the OCaml standard library Format module.

--- a/packages/ocamlformat_support/ocamlformat_support.0.4/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.4/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Pierre Weis"
+homepage: "https://github.com/ocaml-ppx/ocamlformat/tree/support"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git#support"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/ocamlformat_support/ocamlformat_support.0.4/url
+++ b/packages/ocamlformat_support/ocamlformat_support.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.4.tar.gz"
+checksum: "ec5f96a2727821f55ac50e305095208a"


### PR DESCRIPTION
### `ocamlformat.0.5`

Auto-formatter for OCaml code

OCamlFormat is a tool to automatically format OCaml code in a uniform style.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5