### PR TITLE
Use a slightly less unstable tarball URL

### DIFF
--- a/packages/scrypt/scrypt.0.2.1/url
+++ b/packages/scrypt/scrypt.0.2.1/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/pacemkr/ocaml-scrypt/tarball/v0.2.1"
+archive: "https://github.com/constfun/ocaml-scrypt/archive/v0.2.1.tar.gz"
 checksum: "24704b12638932a14400f74a354c0617"


### PR DESCRIPTION
Closes #11557.

References the URL mentioned in https://github.com/ocaml/opam/issues/3251