### PR TITLE
Added lablqml 0.5.2

### DIFF
--- a/packages/lablqml/lablqml.0.5.2/descr
+++ b/packages/lablqml/lablqml.0.5.2/descr
@@ -1,0 +1,3 @@
+OCamlfind package and PPX extension to interface OCaml and QtQuick.
+
+Versions <= 0.4 are known as `lablqt`, >0.5 -- as `lablqml`.

--- a/packages/lablqml/lablqml.0.5.2/opam
+++ b/packages/lablqml/lablqml.0.5.2/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer:   "kakadu.hafanana@gmail.com"
+authors:      "kakadu.hafanana@gmail.com"
+homepage:     "http://kakadu.github.io/lablqt/"
+bug-reports:  "https://github.com/kakadu/lablqml/issues"
+dev-repo:     "https://github.com/Kakadu/lablqml.git"
+
+tags: [ "gui" "ui" "qt" ]
+
+build: [
+  ["./configure"]
+  [make]
+]
+build-test: [
+  [make "demos"]
+]
+install: [make "opam.install"]
+remove: [
+  ["ocamlfind" "remove" "lablqml"]
+  ["rm" "-f" "%{prefix}%/bin/ppx_qt"]
+]
+flags: [ light-uninstall ]
+depends: [
+  "ocamlfind"
+  "ocamlbuild"  { build }
+  "ocaml-migrate-parsetree"
+  "conf-qt"     { >= "5.2.1"}
+  "lwt"         { test }
+  "cppo"        { test }
+]
+
+available: [ ocaml-version >= "4.03.0" ]
+

--- a/packages/lablqml/lablqml.0.5.2/opam
+++ b/packages/lablqml/lablqml.0.5.2/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 flags: [ light-uninstall ]
 depends: [
-  "ocamlfind"
+  "ocamlfind"   { build }
   "ocamlbuild"  { build }
   "ocaml-migrate-parsetree"
   "conf-qt"     { >= "5.2.1"}

--- a/packages/lablqml/lablqml.0.5.2/opam
+++ b/packages/lablqml/lablqml.0.5.2/opam
@@ -25,6 +25,7 @@ depends: [
   "ocamlbuild"  { build }
   "ocaml-migrate-parsetree"
   "conf-qt"     { >= "5.2.1"}
+  "conf-pkg-config"
   "lwt"         { test }
   "cppo"        { test }
 ]

--- a/packages/lablqml/lablqml.0.5.2/url
+++ b/packages/lablqml/lablqml.0.5.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Kakadu/lablqml/archive/0.5.2.tar.gz"
+checksum: "c060fe40ea5477843cfd6f0336dc7389"

--- a/packages/lablqml/lablqml.0.5.2/url
+++ b/packages/lablqml/lablqml.0.5.2/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/Kakadu/lablqml/archive/0.5.2.tar.gz"
-checksum: "c060fe40ea5477843cfd6f0336dc7389"
+checksum: "9560479e5ed0c47188747b3195fd2712"


### PR DESCRIPTION
New version has fixed Qt version detection and nothing more.