### PR TITLE
Add an upper bound to deprecated ppx packages

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.11.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0"}
+  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_core/ppx_core.v0.11.0/opam
+++ b/packages/ppx_core/ppx_core.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0"}
+  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_driver/ppx_driver.v0.11.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0"}
+  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0"}
+  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
+++ b/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0"}
+  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0"}
+  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0"}
+  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]


### PR DESCRIPTION
Rationale: these package are now thin compatibility wrappers
around ppxlib, but we do not want ppxlib to be tied by retro
compatibility w.r.t. these packages.

@trefis 