### PR TITLE
fat-filesystem.0.12.1: mark unavailable (doesn't include fat binary)

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.12.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.1/opam
@@ -32,4 +32,4 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: false


### PR DESCRIPTION
to unbreak https://github.com/mirage/mirage-www/pull/604