### PR TITLE
Package seq.0.1

### DIFF
--- a/packages/seq/seq.0.1/descr
+++ b/packages/seq/seq.0.1/descr
@@ -1,0 +1,1 @@
+Compatibility package for OCaml's standard iterator type starting from 4.07.

--- a/packages/seq/seq.0.1/opam
+++ b/packages/seq/seq.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/seq/"
+bug-reports: "https://github.com/c-cube/seq/issues"
+license: "GPL"
+tags: ["iterator" "seq" "pure" "list" "compatibility" "cascade"]
+dev-repo: "https://github.com/c-cube/seq.git"
+build: [make "build"]
+install: [make "install"]
+remove: [ "ocamlfind" "remove" "seq" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version < "4.07.0"]

--- a/packages/seq/seq.0.1/url
+++ b/packages/seq/seq.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/seq/archive/0.1.tar.gz"
+checksum: "0e87f9709541ed46ecb6f414bc31458c"


### PR DESCRIPTION
### `seq.0.1`

Compatibility package for OCaml's standard iterator type starting from 4.07.



---
* Homepage: https://github.com/c-cube/seq/
* Source repo: https://github.com/c-cube/seq.git
* Bug tracker: https://github.com/c-cube/seq/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5