### PR TITLE
Package oseq.0.1

### DIFF
--- a/packages/oseq/oseq.0.1/descr
+++ b/packages/oseq/oseq.0.1/descr
@@ -1,0 +1,3 @@
+Simple list of suspensions, as a composable lazy iterator that behaves like a value.
+
+Will be compatible with the new standard library's `Seq` module.

--- a/packages/oseq/oseq.0.1/opam
+++ b/packages/oseq/oseq.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/oseq/"
+bug-reports: "https://github.com/c-cube/oseq/issues"
+license: "BSD-2-clauses"
+doc: "https://c-cube.github.io/oseq/"
+tags: ["sequence" "iterator" "seq" "pure" "list"]
+dev-repo: "https://github.com/c-cube/oseq.git"
+build: [make "build"]
+build-test: [make "test"]
+build-doc: [make "doc"]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "qcheck" {test}
+  "qtest" {test}
+  "gen" {test}
+  "containers" {test}
+  "odoc" {doc}
+  "seq"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/oseq/oseq.0.1/url
+++ b/packages/oseq/oseq.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/oseq/archive/0.1.tar.gz"
+checksum: "bac70c88e5d57d264b4455240a8c5968"


### PR DESCRIPTION
### `oseq.0.1`

Simple list of suspensions, as a composable lazy iterator that behaves like a value.

Will be compatible with the new standard library's `Seq` module.



---
* Homepage: https://github.com/c-cube/oseq/
* Source repo: https://github.com/c-cube/oseq.git
* Bug tracker: https://github.com/c-cube/oseq/issues

---

:camel: Pull-request generated by opam-publish v0.3.5