### PR TITLE
Package cfstream.1.3.0

### DIFF
--- a/packages/cfstream/cfstream.1.3.0/descr
+++ b/packages/cfstream/cfstream.1.3.0/descr
@@ -1,0 +1,1 @@
+Stream operations in the style of Core's API.

--- a/packages/cfstream/cfstream.1.3.0/opam
+++ b/packages/cfstream/cfstream.1.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+homepage: "https://github.com/biocaml/cfstream"
+dev-repo: "https://github.com/biocaml/cfstream.git"
+bug-reports: "https://github.com/biocaml/cfstream/issues"
+license: "LGPL + linking exception"
+maintainer: "Ashish Agarwal <agarwal1975@gmail.com>"
+authors: [
+  "Philippe Veber <philippe.veber@gmail.com>"
+  "Ashish Agarwal <agarwal1975@gmail.com>"
+  "Drup <drupyog@zoho.com>"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build}
+  "core_kernel" {>= "v0.11.0"}
+]
+
+available: [
+  ocaml-version >= "4.04.1"
+]

--- a/packages/cfstream/cfstream.1.3.0/url
+++ b/packages/cfstream/cfstream.1.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/biocaml/cfstream/archive/1.3.0.tar.gz"
+checksum: "c45c74500ac564719511a314f0633b56"


### PR DESCRIPTION
### `cfstream.1.3.0`

Stream operations in the style of Core's API.



---
* Homepage: https://github.com/biocaml/cfstream
* Source repo: https://github.com/biocaml/cfstream.git
* Bug tracker: https://github.com/biocaml/cfstream/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5