### PR TITLE
Package duff.0.1

### DIFF
--- a/packages/duff/duff.0.1/descr
+++ b/packages/duff/duff.0.1/descr
@@ -1,0 +1,7 @@
+LibXdiff implementation in OCaml
+
+Duff is a little library to implement
+[libXdiff](http://www.xmailserver.org/xdiff-lib.html) in OCaml. This library is
+a part of the [ocaml-git](https://github.com/mirage/ocaml-git) project. This
+code is a translation of `diff-delta.c` available on the git project in OCaml.
+So, it respects some git's constraints unlike libXdiff.

--- a/packages/duff/duff.0.1/opam
+++ b/packages/duff/duff.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/duff"
+bug-reports:  "https://github.com/dinosaure/duff/issues"
+dev-repo:     "https://github.com/dinosaure/duff.git"
+doc:          "https://dinosaure.github.io/duff/"
+license:      "MIT"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "fmt"
+  "cstruct"
+  "alcotest" {test}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/duff/duff.0.1/opam
+++ b/packages/duff/duff.0.1/opam
@@ -18,6 +18,10 @@ depends: [
   "fmt"
   "cstruct"
   "cmdliner" {>= "1.0.2"}
+  "logs" {>= "0.6.2"}
+  "fmt" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "fpath" {>= "0.7.0"}
   "alcotest" {test}
 ]
 

--- a/packages/duff/duff.0.1/opam
+++ b/packages/duff/duff.0.1/opam
@@ -17,6 +17,7 @@ depends: [
   "jbuilder" {build & >="1.0+beta9"}
   "fmt"
   "cstruct"
+  "cmdliner" {>= "1.0.2"}
   "alcotest" {test}
 ]
 

--- a/packages/duff/duff.0.1/url
+++ b/packages/duff/duff.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dinosaure/duff/releases/download/v0.1/duff-0.1.tbz"
+checksum: "c42d3fcfd1062a3422012b97ee8f543c"


### PR DESCRIPTION
### `duff.0.1`

LibXdiff implementation in OCaml

Duff is a little library to implement
[libXdiff](http://www.xmailserver.org/xdiff-lib.html) in OCaml. This library is
a part of the [ocaml-git](https://github.com/mirage/ocaml-git) project. This
code is a translation of `diff-delta.c` available on the git project in OCaml.
So, it respects some git's constraints unlike libXdiff.


---
* Homepage: https://github.com/dinosaure/duff
* Source repo: https://github.com/dinosaure/duff.git
* Bug tracker: https://github.com/dinosaure/duff/issues

---


---
v0.1 2018-04-20 Paris (France)
------------------------------------

- First release of duff
:camel: Pull-request generated by opam-publish v0.3.5