### PR TITLE
Package nsq.0.2.1

### DIFF
--- a/packages/nsq/nsq.0.2.1/descr
+++ b/packages/nsq/nsq.0.2.1/descr
@@ -1,0 +1,4 @@
+Client library for the NSQ messaging platform
+
+This package supports publishing and consuming message using the NSQ message platform.
+It uses Lwt for concurrency.

--- a/packages/nsq/nsq.0.2.1/opam
+++ b/packages/nsq/nsq.0.2.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/nsq-ocaml"
+bug-reports: "https://github.com/ryanslade/nsq-ocaml/issues"
+dev-repo: "https://github.com/ryanslade/nsq-ocaml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+  "containers"
+  "lwt"
+  "ocplib-endian"
+  "integers"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/nsq/nsq.0.2.1/url
+++ b/packages/nsq/nsq.0.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ryanslade/nsq-ocaml/archive/0.2.1.tar.gz"
+checksum: "a941bc638c597b12a6cd7f6a1322353e"


### PR DESCRIPTION
### `nsq.0.2.1`

Client library for the NSQ messaging platform

This package supports publishing and consuming message using the NSQ message platform.
It uses Lwt for concurrency.



---
* Homepage: https://github.com/ryanslade/nsq-ocaml
* Source repo: https://github.com/ryanslade/nsq-ocaml.git
* Bug tracker: https://github.com/ryanslade/nsq-ocaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5