### PR TITLE
Package nsq.0.2.2

### DIFF
--- a/packages/nsq/nsq.0.2.2/descr
+++ b/packages/nsq/nsq.0.2.2/descr
@@ -1,0 +1,4 @@
+Client library for the NSQ messaging platform
+
+This package supports publishing and consuming message using the NSQ message platform.
+It uses Lwt for concurrency.

--- a/packages/nsq/nsq.0.2.2/opam
+++ b/packages/nsq/nsq.0.2.2/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/nsq-ocaml"
+bug-reports: "https://github.com/ryanslade/nsq-ocaml/issues"
+dev-repo: "https://github.com/ryanslade/nsq-ocaml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+  "containers"
+  "lwt"
+  "ocplib-endian"
+  "integers"
+  "cohttp"
+  "cohttp-lwt-unix"
+  "yojson"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/nsq/nsq.0.2.2/url
+++ b/packages/nsq/nsq.0.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ryanslade/nsq-ocaml/archive/0.2.2.tar.gz"
+checksum: "9db22a8a7b434a56abcfe3953c847f08"


### PR DESCRIPTION
### `nsq.0.2.2`

Client library for the NSQ messaging platform

This package supports publishing and consuming message using the NSQ message platform.
It uses Lwt for concurrency.



---
* Homepage: https://github.com/ryanslade/nsq-ocaml
* Source repo: https://github.com/ryanslade/nsq-ocaml.git
* Bug tracker: https://github.com/ryanslade/nsq-ocaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5