### PR TITLE
dbm.1.1: Fix uninstall script.

### DIFF
--- a/packages/dbm/dbm.1.1/opam
+++ b/packages/dbm/dbm.1.1/opam
@@ -32,5 +32,5 @@ install: [
 ]
 remove: [
   ["rm" "-f" "%{lib}%/stublibs/dllcamldbm.so"]
-  ["rm" "-f" "%{lib}%/dbm"]
+  ["ocamlfind" "remove" "dbm"]
 ]


### PR DESCRIPTION
Uninstall dbm 1.1 was failed. The error log is the following:
```
$ opam remove dbm
The following actions will be performed:
  ⊘  remove dbm 1.1

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫 
[dbm] Archive in cache

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫 
[WARNING] failure in package uninstall script, some files may remain:
          # opam-version 1.2.2
          # os           darwin
          # command      rm -f /Users/tyabu/.opam/4.06.0/lib/dbm
          # path         /Users/tyabu/.opam/4.06.0/build/dbm.1.1
          # compiler     4.06.0
          # exit-code    1
          # env-file     /Users/tyabu/.opam/4.06.0/build/dbm.1.1/dbm-11738-d2d111.env
          # stdout-file  /Users/tyabu/.opam/4.06.0/build/dbm.1.1/dbm-11738-d2d111.out
          # stderr-file  /Users/tyabu/.opam/4.06.0/build/dbm.1.1/dbm-11738-d2d111.err
          ### stderr ###
          # rm: /Users/tyabu/.opam/4.06.0/lib/dbm: is a directory

[WARNING] Directory /Users/tyabu/.opam/4.06.0/lib/dbm is not empty, not removing
⊘  removed   dbm.1.1
Done.
```

This PR fixes this.