### PR TITLE
Package qtest.2.9

### DIFF
--- a/packages/qtest/qtest.2.9/descr
+++ b/packages/qtest/qtest.2.9/descr
@@ -1,0 +1,6 @@
+qtest : Inline (Unit) Tests for OCaml.
+
+qtest extracts inline unit tests written using a special
+syntax in comments. Those tests are then run using the oUnit framework
+and the qcheck library.  The possibilities range from trivial tests --
+extremely simple to use -- to sophisticated random generation of test cases.

--- a/packages/qtest/qtest.2.9/opam
+++ b/packages/qtest/qtest.2.9/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org"
+authors: [
+  "Vincent Hugot <vincent.hugot@gmail.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+homepage: "https://github.com/vincent-hugot/qtest"
+bug-reports: "https://github.com/vincent-hugot/qtest/issues"
+doc:
+  "https://github.com/vincent-hugot/qtest/blob/master/README.adoc#introduction"
+tags: ["test" "property" "quickcheck"]
+dev-repo: "git@github.com:vincent-hugot/qtest.git"
+build: ["jbuilder" "build" "-j" jobs "-p" name]
+depends: [
+  "base-bytes"
+  "ounit" {>= "2.0.0"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "qcheck" {>= "0.5"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/qtest/qtest.2.9/url
+++ b/packages/qtest/qtest.2.9/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vincent-hugot/qtest/archive/v2.9.tar.gz"
+checksum: "74b30bf97719726f0fc23e7beb701750"


### PR DESCRIPTION
### `qtest.2.9`

qtest : Inline (Unit) Tests for OCaml.

qtest extracts inline unit tests written using a special
syntax in comments. Those tests are then run using the oUnit framework
and the qcheck library.  The possibilities range from trivial tests --
extremely simple to use -- to sophisticated random generation of test cases.



---
* Homepage: https://github.com/vincent-hugot/qtest
* Source repo: git@github.com:vincent-hugot/qtest.git
* Bug tracker: https://github.com/vincent-hugot/qtest/issues

---

:camel: Pull-request generated by opam-publish v0.3.5