### PR TITLE
+ott.0.28

### DIFF
--- a/packages/ott/ott.0.28/descr
+++ b/packages/ott/ott.0.28/descr
@@ -1,0 +1,9 @@
+Ott is a tool for writing definitions of programming languages and calculi
+
+It takes as input a definition of a language syntax and semantics, in a concise
+and readable ASCII notation that is close to what one would write in informal
+mathematics. It generates LaTeX to build a typeset version of the definition,
+and Coq, HOL, and Isabelle versions of the definition. Additionally, it can be
+run as a filter, taking a LaTeX/Coq/Isabelle/HOL source file with embedded
+(symbolic) terms of the defined language, parsing them and replacing them by
+target-system terms.

--- a/packages/ott/ott.0.28/files/ott.install
+++ b/packages/ott/ott.0.28/files/ott.install
@@ -1,0 +1,3 @@
+bin: ["src/ott"]
+doc: ["built_doc/top2.pdf" { "doc/ott_manual.pdf" } "built_doc/top2.html" { "doc/ott_manual.html" }]
+share_root: ["emacs/ott-mode.el" {"emacs/site-lisp/ott-mode.el"} "tex/ottlayout.sty" {"tex/ottlayout.sty"}]

--- a/packages/ott/ott.0.28/opam
+++ b/packages/ott/ott.0.28/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens"]
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+available: [ ocaml-version >= "4.00.0" ]
+
+build: [
+  [ make "world" ]
+]

--- a/packages/ott/ott.0.28/url
+++ b/packages/ott/ott.0.28/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ott-lang/ott/archive/0.28.tar.gz"
+checksum: "42c76a821b8ba1528f6b99025cc6f2b0"


### PR DESCRIPTION
- Bugfix: add missing case of Lem auxparam type name hack when it's hom (Brian Campbell)
- copy ocaml_light example sources from svn (rsem/ott/old_pre_github/examples/caml) and partially de-bitrot (Peter Sewell and palmskog for Coq)
- add pointer to VSCode plugin (JoeyEremondi)
- clean opam install of Emacs ott-mode (hannesm, Blaisorblade)