### PR TITLE
Release of stdcompat.3

### DIFF
--- a/packages/stdcompat/stdcompat.3/descr
+++ b/packages/stdcompat/stdcompat.3/descr
@@ -1,0 +1,1 @@
+Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml.

--- a/packages/stdcompat/stdcompat.3/opam
+++ b/packages/stdcompat/stdcompat.3/opam
@@ -12,6 +12,6 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocamlfind" {build}
-  "cppo" {build}
+  "cppo" {build, >= "1.1.0"}
 ]
 available: [ocaml-version >= "3.12.0" & ocaml-version < "4.08.0"]

--- a/packages/stdcompat/stdcompat.3/opam
+++ b/packages/stdcompat/stdcompat.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+version: "3"
+name: "stdcompat"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+license: "BSD"
+dev-repo: "https://github.com/thierry-martinez/stdcompat.git"
+build: [make "all" "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "ocamlfind" {build}
+  "cppo" {build}
+]
+available: [ocaml-version >= "3.12.0" & ocaml-version < "4.08.0"]

--- a/packages/stdcompat/stdcompat.3/opam
+++ b/packages/stdcompat/stdcompat.3/opam
@@ -12,6 +12,6 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocamlfind" {build}
-  "cppo" {build, >= "1.1.0"}
+  "cppo" {build & >= "1.1.0"}
 ]
 available: [ocaml-version >= "3.12.0" & ocaml-version < "4.08.0"]

--- a/packages/stdcompat/stdcompat.3/url
+++ b/packages/stdcompat/stdcompat.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/thierry-martinez/stdcompat/archive/3.tar.gz"
+checksum: "8ec220ef583b6899f50dc0b365f378c0"


### PR DESCRIPTION
- Missing List.of_seq/List.to_seq
- Remove spurious Float.seeded_hash_param
  (suggested by Hezekiah M. Carty:
   https://github.com/thierry-martinez/stdcompat/pull/2)
- Compatibility with seq and result packages
  (suggested by Hezekiah M. Carty:
   https://github.com/thierry-martinez/stdcompat/issues/1)
- Magic implementations of {Set,Map,Hashtbl,Queue,Stack}.to_seq*,
  Hashtbl.filter_map_inplace, Hashtbl.stats, Stack.fold,
  Set.find*, Set.map.
  Pure implementations are available by building with
  "make USE_MAGIC=false"