### PR TITLE
afl: set AFL_NO_X86=1 for build/install

### DIFF
--- a/packages/afl/afl.2.52b/opam
+++ b/packages/afl/afl.2.52b/opam
@@ -8,7 +8,7 @@ build: [
   [make]
 ]
 install: [
-  [make "PREFIX=%{prefix}%" "install"]
+  [make "AFL_NO_X86=1" "PREFIX=%{prefix}%" "install"]
 ]
 remove: [
   [make "PREFIX=%{prefix}%" "uninstall"]


### PR DESCRIPTION
AFL_NO_X86 allows afl's build to skip a test for X86 that's relevant for
testing whether `afl-gcc` works on that architecture, but not for the
workflow most likely for OCaml users (where instrumentation is generated
by `ocamlopt` and more closely resembles the "llvm mode" in AFL's
documentation).  This test fails on non-x86 architectures, so set
AFL_NO_X86 to disable it.

For more information, see `docs/INSTALL` in afl's source tree.

Thanks to @kit-ty-kate for bringing this to my attention :)