### PR TITLE
Fix camlp4 system compiler for test dependencies

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -138,7 +138,7 @@ build_switch
 INSTALL_CAMLP4=0
 if [[ $OPAM_SWITCH = "system" ]] ; then
   for i in $(cat tobuild.txt) ; do
-    if opam install $i --deps-only --show | grep "\<camlp4\>" > /dev/null 2>&1 ; then
+    if opam install $i --build-test --deps-only --show | grep "\<camlp4\>" > /dev/null 2>&1 ; then
       INSTALL_CAMLP4=1
       break
     fi


### PR DESCRIPTION
#11700 only looked at the dependencies of the package being installed, but the package is then actually installed with tests so it can break if only test dependencies require camlp4 as in https://github.com/ocaml/opam-repository/pull/11835#issuecomment-383900346 (in this case, camlp4 is drawn in because of the buggy behaviour of `-t` in opam 1.2.2, but the same situation could still arise in future with opam 2.0.0)

This commit does fix #11835 - see [this build log](https://travis-ci.org/dra27/opam-repository/builds/371238156)