### PR TITLE
fix bun dependency on spawn by adding v prefix

### DIFF
--- a/packages/bun/bun.0.3/opam
+++ b/packages/bun/bun.0.3/opam
@@ -14,6 +14,6 @@ depends: [
   "fpath"
   "rresult" {>= "0.3.0" }
   "astring"
-  "spawn" {>= "0.10.1" & < "v0.12"}
+  "spawn" {>= "v0.10.1" & < "v0.12"}
   "afl" {= "2.52b"}
 ]


### PR DESCRIPTION
It's `v0.10.1`, not `0.10.1`, in `packages/spawn`.  Refer to it properly to avoid installing `v0.9.0` and getting link errors on pthread.