### PR TITLE
Package sqlite3.4.4.0

### DIFF
--- a/packages/sqlite3/sqlite3.4.4.0/descr
+++ b/packages/sqlite3/sqlite3.4.4.0/descr
@@ -1,0 +1,5 @@
+sqlite3-ocaml - SQLite3 bindings for OCaml
+
+sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
+Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
+database engine with outstanding performance for many use cases.

--- a/packages/sqlite3/sqlite3.4.4.0/opam
+++ b/packages/sqlite3/sqlite3.4.4.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christian Szegedy <csdontspam@metamatix.com>"
+]
+license: "Expat"
+homepage: "http://mmottl.github.io/sqlite3-ocaml"
+doc: "https://mmottl.github.io/sqlite3-ocaml/api"
+dev-repo: "https://github.com/mmottl/sqlite3-ocaml.git"
+bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
+tags: [ "clib:sqlite3" "clib:pthread"  ]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "base" {build}
+  "conf-sqlite3" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.05" ]

--- a/packages/sqlite3/sqlite3.4.4.0/url
+++ b/packages/sqlite3/sqlite3.4.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/sqlite3-ocaml/releases/download/4.4.0/sqlite3-4.4.0.tbz"
+checksum: "73b5e4a0e3a45e0a8690f216d43dceba"


### PR DESCRIPTION
### `sqlite3.4.4.0`

sqlite3-ocaml - SQLite3 bindings for OCaml

sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
database engine with outstanding performance for many use cases.



---
* Homepage: http://mmottl.github.io/sqlite3-ocaml
* Source repo: https://github.com/mmottl/sqlite3-ocaml.git
* Bug tracker: https://github.com/mmottl/sqlite3-ocaml/issues

---


---
### 4.4.0 (2018-04-26)

  * Support for new open flags:

      * uri - for URI filename interpretation
      * memory - for in-memory databases

    Thanks to Raman Varabets for this contribution!

  * Fixed warnings and errors in configuration code due to upstream changes.
:camel: Pull-request generated by opam-publish v0.3.5