### PR TITLE
release ppx_deriving_crowbar 0.1.1

### DIFF
--- a/packages/ppx_deriving_crowbar/ppx_deriving_crowbar.0.1.1/descr
+++ b/packages/ppx_deriving_crowbar/ppx_deriving_crowbar.0.1.1/descr
@@ -1,0 +1,1 @@
+ppx_deriving plugin for crowbar generators

--- a/packages/ppx_deriving_crowbar/ppx_deriving_crowbar.0.1.1/opam
+++ b/packages/ppx_deriving_crowbar/ppx_deriving_crowbar.0.1.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "maintenance@identity-function.com"
+authors: ["Mindy Preston"]
+homepage: "https://github.com/yomimono/ppx_deriving_crowbar"
+bug-reports: "https://github.com/yomimono/ppx_deriving_crowbar/issues"
+dev-repo: "https://github.com/yomimono/ppx_deriving_crowbar.git"
+license: "MIT"
+build: [[ "%{make}%" ]]
+build-test: [["%{make}%" "test"]]
+available: [ ocaml-version >= "4.06.0" ]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ppx_deriving" {>= "4.1.5" }
+  "ppx_tools"
+  "crowbar"
+]

--- a/packages/ppx_deriving_crowbar/ppx_deriving_crowbar.0.1.1/url
+++ b/packages/ppx_deriving_crowbar/ppx_deriving_crowbar.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/yomimono/ppx_deriving_crowbar/archive/0.1.1.tar.gz"
+checksum: "259d96c464f56c2dbea22746f0125f79"


### PR DESCRIPTION
ppx_deriving_crowbar 0.1.1 fixes linking so ppx_deriving_crowbar can be used in driverized workflows, like those used by an increasingly popular, recently-renamed sandy build system.