### PR TITLE
Bisect_ppx 1.3.3: code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/descr
+++ b/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/descr
@@ -1,0 +1,1 @@
+Ocamlbuild plugin for Bisect_ppx, the coverage tool

--- a/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/opam
+++ b/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/opam
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 opam-version: "1.2"
 maintainer: [
   "Anton Bachin <antonbachin@yahoo.com>"
@@ -13,9 +13,9 @@ bug-reports: "https://github.com/aantron/bisect_ppx/issues"
 dev-repo: "https://github.com/aantron/bisect_ppx.git"
 
 depends: [
-  # Bisect_ppx pulls in Ocamlbuild.
-  "bisect_ppx" {>= "1.0.0" & < "1.3.3"}
+  "bisect_ppx" {>= "1.0.0"}
   "jbuilder" {build & >= "1.0+beta10"}
+  "ocamlbuild"
 ]
 
 build: [

--- a/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/url
+++ b/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.3.3.tar.gz"
+checksum: "6d57cab32da2b22fa972b4229597e06f"

--- a/packages/bisect_ppx/bisect_ppx.1.3.3/descr
+++ b/packages/bisect_ppx/bisect_ppx.1.3.3/descr
@@ -1,0 +1,19 @@
+Code coverage for OCaml
+
+Bisect_ppx helps you test thoroughly. It is a small preprocessor that inserts
+instrumentation at places in your code, such as if-then-else and match
+expressions. After you run tests, Bisect_ppx gives a nice HTML report showing
+which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, then run the
+report tool on the generated visitation files.
+
+This is an advanced fork of the original Bisect coverage tool. It has many
+improvements and updates.
+
+- Much more thorough code instrumentation, so you can find more gaps in your
+  testing.
+- Fast operation by default.
+- More legible and appealing HTML reports.
+- Various bugfixes.
+- No camlp4 dependency.

--- a/packages/bisect_ppx/bisect_ppx.1.3.3/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.3/opam
@@ -1,0 +1,46 @@
+version: "1.3.3"
+opam-version: "1.2"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "MPL2"
+homepage: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+dev-repo: "https://github.com/aantron/bisect_ppx.git"
+
+depends: [
+  "base-unix"
+  "jbuilder" {build & >= "1.0+beta13"}
+  "ocamlfind" {test}
+  "ocaml-migrate-parsetree" {>= "1.0.3"}
+  "ounit" {test}
+  "ppx_tools_versioned"
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+# Note that Bisect_ppx effectively requires 4.02.3, because Jbuilder requires
+# it. 4.02.0 is the natural constraint of Bisect_ppx.
+available: ocaml-version >= "4.02.0"
+
+messages: [
+  "For the Ocamlbuild plugin, please install package bisect_ppx-ocamlbuild"
+  {ocamlbuild:installed & !bisect_ppx-ocamlbuild:installed}
+]
+post-messages: [
+  "The future Bisect_ppx 2.0.0 will make breaking changes. See
+  https://github.com/aantron/bisect_ppx/releases/tag/1.3.0"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]

--- a/packages/bisect_ppx/bisect_ppx.1.3.3/url
+++ b/packages/bisect_ppx/bisect_ppx.1.3.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.3.3.tar.gz"
+checksum: "6d57cab32da2b22fa972b4229597e06f"


### PR DESCRIPTION
[**Bisect_ppx**](https://github.com/aantron/bisect_ppx) is the OCaml code coverage tool.

<br/>

This release includes a couple of useful bugfixes, and deletes some old packages whose deprecation was announced in 1.3.0 about 9 months ago.

From the changelog:

> Bugs fixed
>
> - Don't try to read `.exclude` file when Bisect_ppx is disabled (aantron/bisect_ppx#169, Gary Trakhman).
> - Refactor how instrumented code registers itself with the Bisect_ppx runtime, to make it easier to use Bisect_ppx with libraries other than stdlib (aantron/bisect_ppx#171, Hugo Heuzard).
>
> Packaging
>
> - The deprecated packages `bisect_ppx.ocamlbuild` and `bisect_ppx.plugin`, which contained the Bisect_ppx Ocamlbuild plugin, have been deleted. The plugin is now available only through `bisect_ppx-ocamlbuild` (aantron/bisect_ppx#143).
> - The deprecated package alias `bisect_ppx.fast` has been deleted (aantron/bisect_ppx#144).
>
> Miscellaneous
>
> - Major refactoring of the instrumenter to make it much easier to work on.

<br/>

cc @gtrak @hhugo 

