### PR TITLE
Package ocamlformat.0.6

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.6/descr
+++ b/packages/ocamlformat/ocamlformat.0.6/descr
@@ -1,0 +1,3 @@
+Auto-formatter for OCaml code
+
+OCamlFormat is a tool to automatically format OCaml code in a uniform style.

--- a/packages/ocamlformat/ocamlformat.0.6/opam
+++ b/packages/ocamlformat/ocamlformat.0.6/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["tools/gen_version.sh" "src/Version.ml" version] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "jbuilder" {build & >= "1.0+beta20"}
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocamlformat_support" {>= "0.4" & < "0.5"}
+  "stdio"
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ocamlformat/ocamlformat.0.6/url
+++ b/packages/ocamlformat/ocamlformat.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/0.6.tar.gz"
+checksum: "73b1dea352fa121f5656d1fd651ad10d"


### PR DESCRIPTION
### `ocamlformat.0.6`

Auto-formatter for OCaml code

OCamlFormat is a tool to automatically format OCaml code in a uniform style.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5