### PR TITLE
Package sanddb.0.1

### DIFF
--- a/packages/sanddb/sanddb.0.1/descr
+++ b/packages/sanddb/sanddb.0.1/descr
@@ -1,0 +1,13 @@
+A simple immutable database for the masses
+
+A simple immutable database for the masses
+
+SandDB is:
+ - Simple: It only does one thing, which is persisting data in a file.
+ - Easy to use: SandDB's API is extremely small, so you only need to know few functions to use it.
+ - Type safe: Every common dangerous operation (like parsing) is covered by the Result type, so you will know where to expect errors.
+ - Immutable: Database is based on the immutable stack idea, where you can only push onto the stack.
+ - Crud capable: Even though the database is immutable you still can update and delete records, by shadowing them.
+ - Version keeping: Every update and delete operation will produce a new version of the affected record, without modifying the original, so you will have all versions of your data.
+ - Concurrent: SandDB is based on lwt, so every database operation is asynchronous.
+ - Supports multiple serializers: SandDB supports both json and biniou serialization format thanks to the atdgen library.

--- a/packages/sanddb/sanddb.0.1/opam
+++ b/packages/sanddb/sanddb.0.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Robert Toth <kkdstryker@gmail.com>"
+authors: "Robert Toth"
+homepage: "https://github.com/StrykerKKD/SandDB"
+bug-reports: "https://github.com/StrykerKKD/SandDB/issues"
+license: "MIT"
+dev-repo: "http://github.com/StrykerKKD/SandDB.git"
+build: [
+  "jbuilder" "build" "--only" "sanddb" "--root" "." "-j" jobs "@install"
+]
+depends: [
+  "jbuilder" {build}
+  "atdgen" {>= "1.12.0"}
+  "lwt" {>= "3.3.0"}
+  "uuidm" {>= "0.9.6"}
+  "base" {>= "v0.11.0"}
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/sanddb/sanddb.0.1/url
+++ b/packages/sanddb/sanddb.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/StrykerKKD/SandDB/archive/0.1.tar.gz"
+checksum: "e25df6a9d609eb11f1208098d1cdfc70"


### PR DESCRIPTION
### `sanddb.0.1`

A simple immutable database for the masses

A simple immutable database for the masses

SandDB is:
 - Simple: It only does one thing, which is persisting data in a file.
 - Easy to use: SandDB's API is extremely small, so you only need to know few functions to use it.
 - Type safe: Every common dangerous operation (like parsing) is covered by the Result type, so you will know where to expect errors.
 - Immutable: Database is based on the immutable stack idea, where you can only push onto the stack.
 - Crud capable: Even though the database is immutable you still can update and delete records, by shadowing them.
 - Version keeping: Every update and delete operation will produce a new version of the affected record, without modifying the original, so you will have all versions of your data.
 - Concurrent: SandDB is based on lwt, so every database operation is asynchronous.
 - Supports multiple serializers: SandDB supports both json and biniou serialization format thanks to the atdgen library.



---
* Homepage: https://github.com/StrykerKKD/SandDB
* Source repo: http://github.com/StrykerKKD/SandDB.git
* Bug tracker: https://github.com/StrykerKKD/SandDB/issues

---

:camel: Pull-request generated by opam-publish v0.3.5