### PR TITLE
eigen.0.0.5: fix ctypes constraint, and repo move

### DIFF
--- a/packages/eigen/eigen.0.0.5/opam
+++ b/packages/eigen/eigen.0.0.5/opam
@@ -1,10 +1,10 @@
 opam-version: "1.2"
-maintainer: "Liang Wang (ryanrhymes@gmail.com)"
-authors: [ "Liang Wang (ryanrhymes@gmail.com)" ]
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
 license: "MIT"
-homepage: "https://github.com/ryanrhymes/eigen"
-dev-repo: "https://github.com/ryanrhymes/eigen.git"
-bug-reports: "https://github.com/ryanrhymes/eigen/issues"
+homepage: "https://github.com/owlbarn/eigen"
+dev-repo: "https://github.com/owlbarn/eigen.git"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
@@ -22,7 +22,7 @@ build-test: [
 ]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
-  "ctypes"
+  "ctypes" {>= "0.14.0"}
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
Fix to `ctypes` constraint seems needed for some Travis related builds. Let me know if better to issue a new release (but would prefer not to). Can remove the other metadata updates if they will confuse OPAM without a new release.

Signed-off-by: Richard Mortier <mort@cantab.net>