### PR TITLE
Update dbm package to upstream version 1.2

### DIFF
--- a/packages/dbm/dbm.1.2/descr
+++ b/packages/dbm/dbm.1.2/descr
@@ -1,0 +1,1 @@
+Binding to the NDBM/GDBM Unix "databases"

--- a/packages/dbm/dbm.1.2/opam
+++ b/packages/dbm/dbm.1.2/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Francois Rouaix"]
+homepage: "https://github.com/ocaml/dbm"
+bug-reports: "https://github.com/ocaml/dbm/issues"
+dev-repo: "https://github.com/ocaml/dbm.git"
+license: "LGPL-v2 with OCaml linking exception"
+build: [
+  ["mkdir" "-p" "%{lib}%/dbm"]
+  ["./configure"]
+  [make "all"]
+  [make "test"]
+]
+depends: ["ocamlfind"]
+depexts: [
+  [["debian"] ["libgdbm-dev"]]
+  [["ubuntu"] ["libgdbm-dev"]]
+  [["nixpkgs"] ["gdbm"]]
+  [["centos"] ["gdbm-devel"]]
+  [["rhel"] ["gdbm-devel"]]
+  [["fedora"] ["gdbm-devel"]]
+  [["alpine"] ["gdbm-dev"]]
+  [["osx" "homebrew"] ["gdbm"]]
+  [["archlinux"] ["gdbm"]]
+]
+install: [
+  [make "install" "STUBLIBDIR=%{lib}%/stublibs" "LIBDIR=%{lib}%/dbm"]
+  ["cp" "META" "%{lib}%/dbm"]
+]
+remove: [
+  ["rm" "-f" "%{lib}%/stublibs/dllcamldbm.so"]
+  ["ocamlfind" "remove" "dbm"]
+]

--- a/packages/dbm/dbm.1.2/url
+++ b/packages/dbm/dbm.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dbm/archive/camldbm-1.2.tar.gz"
+checksum: "180133dd10b0b10dc47bdd8a6ab8feab"


### PR DESCRIPTION
Improves compatibility with recent Debian & Ubuntu, and also with Brew on MacOS.