### PR TITLE
ocamlmod 0.0.3 0.0.4 0.0.7: mark as unavailable with ocaml 4.06.0+

### DIFF
--- a/packages/ocamlmod/ocamlmod.0.0.3/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.3/opam
@@ -10,3 +10,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/ocamlmod/ocamlmod.0.0.4/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.4/opam
@@ -10,3 +10,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/ocamlmod/ocamlmod.0.0.7/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.7/opam
@@ -24,3 +24,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 patches: [ "test01.mod.patch" ]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
0.0.8 includes a custom patch for `-safe-string`, 0.0.9 is working out of the box with `-safe-string`.

discovered via https://github.com/mirage/mirage-skeleton/issues/256#issuecomment-386223775