### PR TITLE
avoid ppx_sexp_conv v0.11.0 since it comes with a runtime depedency on base

### DIFF
--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ppx_deriving" {build}
   "ppx_cstruct" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_type_conv" {build}
   "cstruct" {>="1.9.0" & <"3.0.0"}
   "cstruct-unix"

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ppx_deriving" {build}
   "ppx_cstruct" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_type_conv" {build}
   "cstruct" {>="1.9.0" & <"3.0.0"}
   "sexplib"

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -24,7 +24,7 @@ depends: [
   "ocamlbuild"    {build}
   "topkg"         {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>="1.9.0" & <"3.0.0"}

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind"     {build}
   "ocamlbuild"    {build}
   "topkg"         {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>= "1.9.0" & <"3.0.0"}

--- a/packages/charrua-core/charrua-core.0.7/opam
+++ b/packages/charrua-core/charrua-core.0.7/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind"     {build}
   "ocamlbuild"    {build}
   "topkg"         {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_tools"     {build}
   "menhir"        {build}
   "cstruct"       {>= "1.9.0" & < "3.0.0"}

--- a/packages/charrua-core/charrua-core.0.8/opam
+++ b/packages/charrua-core/charrua-core.0.8/opam
@@ -21,7 +21,7 @@ build-test: [
 
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_cstruct"   {build}
   "menhir"        {build}
   "cstruct"       {>= "3.0.1"}

--- a/packages/charrua-core/charrua-core.0.9/opam
+++ b/packages/charrua-core/charrua-core.0.9/opam
@@ -21,7 +21,7 @@ build-test: [
 
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_cstruct"   {build}
   "menhir"        {build}
   "cstruct"       {>= "3.0.1"}

--- a/packages/cohttp-lwt/cohttp-lwt.1.0.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.1.0.0/opam
@@ -21,7 +21,7 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "cohttp" {>="1.0.0"}
   "lwt" {>="2.5.0"}
 ]

--- a/packages/cohttp/cohttp.1.0.0/opam
+++ b/packages/cohttp/cohttp.1.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "fieldslib"
   "sexplib"
   "ppx_fields_conv" {build & >="v0.9.0"}
-  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0" & < "v0.11.0"}
   "stringext"
   "base64" {>= "2.0.0"}
   "fmt" {test}

--- a/packages/cohttp/cohttp.1.0.2/opam
+++ b/packages/cohttp/cohttp.1.0.2/opam
@@ -28,7 +28,7 @@ depends: [
   "sexplib"
   "ppx_type_conv" {build & >="v0.9.1"}
   "ppx_fields_conv" {build & >="v0.9.0"}
-  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0" & < "v0.11.0"}
   "stringext"
   "base64" {>= "2.0.0"}
   "fmt" {test}

--- a/packages/cohttp/cohttp.1.1.0/opam
+++ b/packages/cohttp/cohttp.1.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "sexplib"
   "ppx_type_conv" {build & >="v0.9.1"}
   "ppx_fields_conv" {build & >="v0.9.0"}
-  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0" & < "v0.11.0"}
   "stringext"
   "base64" {>= "2.0.0"}
   "fmt" {test}

--- a/packages/conduit-lwt/conduit-lwt.1.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "base-unix"
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "conduit" {>="1.0.0"}
   "lwt" {>="3.0.0"}
 ]

--- a/packages/conduit-lwt/conduit-lwt.1.0.3/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.0.3/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "base-unix"
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "conduit" {>="1.0.0"}
   "lwt" {>="3.0.0"}
 ]

--- a/packages/conduit-lwt/conduit-lwt.1.1.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.1.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "base-unix"
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "conduit"
   "lwt" {>="3.0.0"}
 ]

--- a/packages/conduit/conduit.0.12.0/opam
+++ b/packages/conduit/conduit.0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & <="113.33.04"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.13.0/opam
+++ b/packages/conduit/conduit.0.13.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver"  {build & <="113.33.04"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.0/opam
+++ b/packages/conduit/conduit.0.14.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver"  {build & <="113.33.04"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.1/opam
+++ b/packages/conduit/conduit.0.14.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver"  {build & <="113.33.04"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.2/opam
+++ b/packages/conduit/conduit.0.14.2/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver"  {build & <= "113.33.04"}
   "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.3/opam
+++ b/packages/conduit/conduit.0.14.3/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.4/opam
+++ b/packages/conduit/conduit.0.14.4/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.5/opam
+++ b/packages/conduit/conduit.0.14.5/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.0/opam
+++ b/packages/conduit/conduit.0.15.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.1/opam
+++ b/packages/conduit/conduit.0.15.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.2/opam
+++ b/packages/conduit/conduit.0.15.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.3/opam
+++ b/packages/conduit/conduit.0.15.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.4/opam
+++ b/packages/conduit/conduit.0.15.4/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_driver" {build & < "v0.10.0"}
   "ppx_deriving" {build}
   "ppx_optcomp" {build & >="113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.1.0.0/opam
+++ b/packages/conduit/conduit.1.0.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "uri"
   "result"

--- a/packages/conduit/conduit.1.0.3/opam
+++ b/packages/conduit/conduit.1.0.3/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "astring"
   "uri"

--- a/packages/conduit/conduit.1.1.0/opam
+++ b/packages/conduit/conduit.1.1.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "astring"
   "uri"

--- a/packages/ipaddr/ipaddr.2.8.0/opam
+++ b/packages/ipaddr/ipaddr.2.8.0/opam
@@ -25,7 +25,7 @@ build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
   "base-bytes"
-  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0" & < "v0.11.0"}
   "sexplib"
   "ounit" {test}
 ]

--- a/packages/mirage-conduit/mirage-conduit.1.0.3/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.0.3/opam
@@ -15,7 +15,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "cstruct"          {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt"  {>= "1.2.0"}

--- a/packages/mirage-conduit/mirage-conduit.3.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "jbuilder"         {build & >="1.0+beta10"}
-  "ppx_sexp_conv"    {build}
+  "ppx_sexp_conv"    {build & < "v0.11.0"}
   "cstruct"          {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt"  {>= "1.2.0"}

--- a/packages/mirage-conduit/mirage-conduit.3.0.1/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.1/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "jbuilder"         {build & >="1.0+beta10"}
-  "ppx_sexp_conv"    {build}
+  "ppx_sexp_conv"    {build & < "v0.11.0"}
   "cstruct"          {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt"  {>= "1.2.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "cstruct" {>= "2.1.0"}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/netchannel/netchannel.1.7.1/opam
+++ b/packages/netchannel/netchannel.1.7.1/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder"  {build & >="1.0+beta9"}
   "cstruct" {>= "3.0.0"}
   "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_cstruct" {build}
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/netchannel/netchannel.1.8.0/opam
+++ b/packages/netchannel/netchannel.1.8.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder"  {build & >="1.0+beta9"}
   "cstruct" {>= "3.0.0"}
   "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_cstruct" {build}
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/uri/uri.1.9.2/opam
+++ b/packages/uri/uri.1.9.2/opam
@@ -36,7 +36,7 @@ depends: [
   "re"
   "sexplib" {>= "109.53.00"}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & >= "113.33.01"}
+  "ppx_sexp_conv" {build & >= "113.33.01" & < "v0.11.0"}
   "base-bytes"
   "stringext" {>= "1.4.0"}
   "ounit" {test & >= "1.0.2"}

--- a/packages/uri/uri.1.9.4/opam
+++ b/packages/uri/uri.1.9.4/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >="1.0+beta7"}
   "ounit" {test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.11.0"}
   "re"
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}

--- a/packages/uri/uri.1.9.5/opam
+++ b/packages/uri/uri.1.9.5/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >="1.0+beta7"}
   "ounit" {test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.11.0"}
   "re"
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}

--- a/packages/uri/uri.1.9.6/opam
+++ b/packages/uri/uri.1.9.6/opam
@@ -24,7 +24,7 @@ depends: [
   "base-bytes"
   "jbuilder" {build & >="1.0+beta7"}
   "ounit" {test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.11.0"}
   "re"
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}

--- a/packages/vchan-unix/vchan-unix.3.0.0/opam
+++ b/packages/vchan-unix/vchan-unix.3.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_cstruct" {build}
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}

--- a/packages/vchan-xen/vchan-xen.3.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.3.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ppx_cstruct" {build}
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "io-page"
   "mirage-types-lwt" {< "3.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "io-page"
   "mirage-types-lwt" {< "3.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.3.0.0/opam
+++ b/packages/vchan/vchan.3.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_tools" {build}
-  "ppx_sexp_conv" {build & >="v0.9"} 
+  "ppx_sexp_conv" {build & >="v0.9" & < "v0.11.0"}
   "ppx_cstruct" {build}
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/issues/11852 and the latest mirage call for more reasoning behind this upper bound