### PR TITLE
ppx_sexp_conv v0.11.1

### DIFF
--- a/packages/msgpck/msgpck.1.0/opam
+++ b/packages/msgpck/msgpck.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "ocplib-endian"
 ]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.1/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/let-def/topexpect.git"
 build: [make]
 depends: [
   "ocamlfind" {build}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_deriving"
 ]
 available: [ocaml-version >= "4.04.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.1/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.1/opam
@@ -11,4 +11,4 @@ depends: [
   "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_deriving"
 ]
-available: [ocaml-version >= "4.04.0"]
+available: [ocaml-version >= "4.04.0" & ocaml-version < "4.05.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.2/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.2/opam
@@ -6,5 +6,7 @@ bug-reports: "https://github.com/let-def/topexpect"
 license: "MIT"
 dev-repo: "https://github.com/let-def/topexpect.git"
 build: [make]
-depends: ["ocamlfind" "ppx_sexp_conv" "ppx_deriving"]
+depends: ["ocamlfind"
+          "ppx_sexp_conv" {< "v0.11.0"}
+          "ppx_deriving"]
 available: [ocaml-version >= "4.04.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.2/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.2/opam
@@ -9,4 +9,4 @@ build: [make]
 depends: ["ocamlfind"
           "ppx_sexp_conv" {< "v0.11.0"}
           "ppx_deriving"]
-available: [ocaml-version >= "4.04.0"]
+available: [ocaml-version >= "4.04.0" & ocaml-version < "4.05.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
@@ -16,4 +16,4 @@ depends: [
   "jbuilder" {build & >="1.0+beta9"}
   "sexplib"
 ]
-available: [ocaml-version >= "4.04.0"]
+available: [ocaml-version >= "4.04.0" & ocaml-version < "4.05.0"]

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
@@ -11,8 +11,9 @@ dev-repo: "https://github.com/let-def/topexpect.git"
 build: [make]
 depends: [
   "ocamlfind" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "ppx_deriving" {build}
   "jbuilder" {build & >="1.0+beta9"}
+  "sexplib"
 ]
 available: [ocaml-version >= "4.04.0"]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/descr
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/descr
@@ -1,0 +1,3 @@
+Generation of S-expression conversion functions from type definitions
+
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+conflicts: [ "jbuilder" { = "1.0+beta19" } ]
+depends: [
+  "base"                    {>= "v0.11" & < "v0.12"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
+  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "sexplib0"                {>= "v0.11" & < "v0.12"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/url
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/ppx_sexp_conv/releases/download/v0.11.1/ppx_sexp_conv-v0.11.1.tbz"
+checksum: "f834fbbdd9e709e2092923f3b254a534"

--- a/packages/qcow/qcow.0.6.0/opam
+++ b/packages/qcow/qcow.0.6.0/opam
@@ -26,7 +26,7 @@ depends: [
   "topkg" {build}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build &  < "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}

--- a/packages/qcow/qcow.0.6.0/opam
+++ b/packages/qcow/qcow.0.6.0/opam
@@ -22,6 +22,7 @@ depends: [
   "logs"
   "fmt" {>="0.8.2"}
   "io-page"
+  "io-page-unix"
   "ocamlfind" {build}
   "topkg" {build}
   "ppx_tools" {build}

--- a/packages/qcow/qcow.0.7.0/opam
+++ b/packages/qcow/qcow.0.7.0/opam
@@ -26,7 +26,7 @@ depends: [
   "topkg" {build}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build &  < "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}

--- a/packages/qcow/qcow.0.7.0/opam
+++ b/packages/qcow/qcow.0.7.0/opam
@@ -22,6 +22,7 @@ depends: [
   "logs"
   "fmt" {>="0.8.2"}
   "io-page"
+  "io-page-unix"
   "ocamlfind" {build}
   "topkg" {build}
   "ppx_tools" {build}

--- a/packages/qcow/qcow.0.8.1/opam
+++ b/packages/qcow/qcow.0.8.1/opam
@@ -29,7 +29,7 @@ depends: [
   "topkg" {build}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build &  < "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}

--- a/packages/qcow/qcow.0.9.0/opam
+++ b/packages/qcow/qcow.0.9.0/opam
@@ -32,7 +32,7 @@ depends: [
   "topkg" {build}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build &  < "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}

--- a/packages/qcow/qcow.0.9.4/opam
+++ b/packages/qcow/qcow.0.9.4/opam
@@ -30,7 +30,7 @@ depends: [
   "topkg" {build}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build &  < "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}

--- a/packages/qcow/qcow.0.9.5/opam
+++ b/packages/qcow/qcow.0.9.5/opam
@@ -32,7 +32,7 @@ depends: [
   "topkg" {build}
   "ppx_tools" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build &  < "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {test}
   "mirage-block-ramdisk" {test}

--- a/packages/yaml/yaml.0.1.0/opam
+++ b/packages/yaml/yaml.0.1.0/opam
@@ -11,7 +11,7 @@ available: [ ocaml-version >= "4.03.0"]
 depends: [
   "jbuilder" {build & >="1.0+beta10"}
   "ctypes" {>="0.12.0"}
-  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0" & < "v0.11.0"}
   "rresult"
   "fmt"
   "logs"


### PR DESCRIPTION
Remove the dependency from `ppx_sexp_conv.runtime-lib` to base