### PR TITLE
Package phantom-algebra.1.0

### DIFF
--- a/packages/phantom-algebra/phantom-algebra.1.0/descr
+++ b/packages/phantom-algebra/phantom-algebra.1.0/descr
@@ -1,0 +1,7 @@
+A strongly-typed tensor library à la GLSL
+
+Phantom-algebra is a pure OCaml library implementing strongly-typed
+small tensors with dimensions 0 ≤ 4, rank ≤ 2, and limited to square matrices.
+
+It makes it possible to manipulate vector and matrix expressions with an
+uniform notation while still catching non-sensical operations at compile time

--- a/packages/phantom-algebra/phantom-algebra.1.0/opam
+++ b/packages/phantom-algebra/phantom-algebra.1.0/opam
@@ -1,5 +1,5 @@
-name: "phantom-algebra"
 opam-version: "1.2"
+name: "phantom-algebra"
 license: "MIT"
 maintainer: "Florian Angeletti <octa@polychoron.fr>"
 authors: "Florian Angeletti <octa@polychoron.fr>"

--- a/packages/phantom-algebra/phantom-algebra.1.0/opam
+++ b/packages/phantom-algebra/phantom-algebra.1.0/opam
@@ -1,0 +1,24 @@
+name: "phantom-algebra"
+opam-version: "1.2"
+license: "MIT"
+maintainer: "Florian Angeletti <octa@polychoron.fr>"
+authors: "Florian Angeletti <octa@polychoron.fr>"
+dev-repo: "https://github.com/Octachron/phantom_algebra.git"
+doc: "https://Octachron.github.io/phantom_algebra/docs"
+homepage: "https://github.com/Octachron/phantom_algebra"
+bug-reports: "https://github.com/Octachron/phantom_algebra/issues"
+
+build:[
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+build-doc:[
+  [ "jbuilder" "build" "-p" name "-j" jobs "@doc" ]
+]
+
+available: [ ocaml-version >= "4.02.3"]
+
+depends: [
+  "jbuilder" {build}
+  "cppo" {build}
+  ]

--- a/packages/phantom-algebra/phantom-algebra.1.0/url
+++ b/packages/phantom-algebra/phantom-algebra.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Octachron/phantom_algebra/releases/download/1.0/phantom-algebra-1.0.tbz"
+checksum: "b49521d4a6265d10fbdc64504ce438a5"


### PR DESCRIPTION
### `phantom-algebra.1.0` — a strongly-typed tensor library à la GLSL

Phantom-algebra is a pure OCaml library implementing strongly-typed
small tensors with dimensions 0 ≤ 4, rank ≤ 2, and limited to square matrices.

It makes it possible to manipulate vector and matrix expressions with an
uniform notation while still catching non-sensical operations at compile time

---
* Homepage: https://github.com/Octachron/phantom_algebra
* Source repo: git+https://github.com/Octachron/phantom_algebra.git
* Bug tracker: https://github.com/Octachron/phantom_algebra/issues

---
:camel: Pull-request generated by opam-publish v2.0.0~beta