### PR TITLE
old versions of fat-filesystem do not work with -safe-string

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.12.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.0/opam
@@ -37,4 +37,4 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.06.0" ]

--- a/packages/fat-filesystem/fat-filesystem.0.12.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.2/opam
@@ -32,4 +32,4 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]


### PR DESCRIPTION
/cc @djs55 