### PR TITLE
ocaml-migrate-parsetree.1.0.8 does not work with 4.07.0

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
@@ -17,4 +17,4 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta18.1"}
 ]
-available: [ocaml-version >= "4.02.0" & ocaml-version < "4.08.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.07.0"]


### PR DESCRIPTION
Specifically, when you install ocaml-migrate-parsetree.1.0.8 on ocaml.4.07.0+beta2, then ppx_tools_versioned.5.1 produces preprocessors that output the wrong magic number, which makes lwt.3.1 (and a number of other packages) fail to compile.
