### PR TITLE
add bound on ocaml version

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.4/opam
@@ -61,5 +61,6 @@ depopts: [
 available: [ ocaml-version >= "4.00.0"
            & compiler != "4.04.0+flambda"
            & compiler != "4.04.1+flambda"
-           & compiler != "4.04.2+flambda" ]
+           & compiler != "4.04.2+flambda"
+           & ocaml-version < "4.07.0" ]
 install: [make "install"]

--- a/packages/ocamlnet/ocamlnet.4.1.5/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.5/opam
@@ -62,5 +62,6 @@ patches: [ "netgzip.patch" ]
 available: [ ocaml-version >= "4.00.0"
            & compiler != "4.04.0+flambda"
            & compiler != "4.04.1+flambda"
-           & compiler != "4.04.2+flambda" ]
+           & compiler != "4.04.2+flambda"
+           & ocaml-version < "4.07.0" ]
 install: [make "install"]


### PR DESCRIPTION
`ocamlnet` embeds an old version of cppo that doesn't work on 4.07 because the parsing of `# line` directives has changed. Patch sent upstream: https://gitlab.camlcity.org/gerd/lib-ocamlnet3/merge_requests/4/diffs

cc @gerdstolpmann 
