### PR TITLE
extlib: add bound on ocaml version

### DIFF
--- a/packages/extlib-compat/extlib-compat.1.7.2/opam
+++ b/packages/extlib-compat/extlib-compat.1.7.2/opam
@@ -34,3 +34,4 @@ depends: [
   "cppo" {build}
   "base-bytes" {build}
 ]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/extlib/extlib.1.7.2/opam
+++ b/packages/extlib/extlib.1.7.2/opam
@@ -33,3 +33,4 @@ depends: [
   "cppo" {build}
   "base-bytes" {build}
 ]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/extlib/extlib.1.7.4/opam
+++ b/packages/extlib/extlib.1.7.4/opam
@@ -34,4 +34,4 @@ depends: [
   "base-bytes" {build}
 ]
 # 1.7.3 broke 32-bit builds
-available: [ arch != "i386" & arch != "armv7l" ]
+available: [ arch != "i386" & arch != "armv7l" & ocaml-version < "4.07.0" ]


### PR DESCRIPTION
`extlib` does not build with OCaml 4.07 because the interface of `Hashtbl` has changed. Search for `@since 4.07` in `hashtbl.mli` to see what needs to be added.
[update: `extlib-compat` fails for the same reason]

cc @ygrek 