### PR TITLE
Partial format upgrade (extlib.1.7.2, extlib.1.7.4, extlib-compat.1.7.2)

### DIFF
--- a/packages/extlib-compat/extlib-compat.1.7.2/opam
+++ b/packages/extlib-compat/extlib-compat.1.7.2/opam
@@ -30,7 +30,7 @@ remove: [
 ]
 conflicts: ["extlib"]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.07.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}

--- a/packages/extlib/extlib.1.7.2/opam
+++ b/packages/extlib/extlib.1.7.2/opam
@@ -29,7 +29,7 @@ remove: [
   ["ocamlfind" "remove" "extlib"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.07.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}

--- a/packages/extlib/extlib.1.7.4/opam
+++ b/packages/extlib/extlib.1.7.4/opam
@@ -29,12 +29,12 @@ remove: [
   ["ocamlfind" "remove" "extlib"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.07.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}
 ]
-available: [ arch != "i386" & arch != "armv7l" ]
+available: arch != "x86_32" & arch != "arm32"
 synopsis:
   "A complete yet small extension for OCaml standard library (reduced, recommended)"
 description: """


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/extlib/extlib.1.7.4/opam