### PR TITLE
Partial format upgrade (gapi-ocaml.0.2, gapi-ocaml.0.2.1, gapi-ocaml.0.2.3, gapi-ocaml.0.2.4, gapi-ocaml.0.2.5, ...)

### DIFF
--- a/packages/gapi-ocaml/gapi-ocaml.0.2.1/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.1/opam
@@ -10,10 +10,11 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "gapi-ocaml"]]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
-  "ocamlfind"
+  "extlib" | "extlib-compat"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet"
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.10/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.10/opam
@@ -18,10 +18,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet" {>= "3.5.1"}
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.13/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.13/opam
@@ -18,10 +18,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet" {>= "3.5.1"}
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.14/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.14/opam
@@ -18,9 +18,9 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ocamlnet" {>= "3.5.1"}

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.3/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.3/opam
@@ -12,10 +12,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
-  "ocamlfind"
+  "extlib" | "extlib-compat"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet"
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.4/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.4/opam
@@ -12,10 +12,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
-  "ocamlfind"
+  "extlib" | "extlib-compat"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet"
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.5/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.5/opam
@@ -12,10 +12,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
-  "ocamlfind"
+  "extlib" | "extlib-compat"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet"
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.6/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.6/opam
@@ -12,10 +12,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
-  "ocamlfind"
+  "extlib" | "extlib-compat"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet"
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.7/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.7/opam
@@ -18,10 +18,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet"
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.8/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.8/opam
@@ -18,10 +18,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet"
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.9/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.9/opam
@@ -18,10 +18,11 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ocamlnet" {>= "3.5.1"}
   "ocurl"
   "xmlm"

--- a/packages/gapi-ocaml/gapi-ocaml.0.2/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2/opam
@@ -6,9 +6,9 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "gapi-ocaml"]]
 depends: [
-  "ocaml"
-  "ocamlfind"
-  ("extlib" | "extlib-compat")
+  "ocaml" {< "4.06.0"}
+  "ocamlfind" {build}
+  "extlib" | "extlib-compat"
   "ocamlnet"
   "ocurl"
   "cryptokit"

--- a/packages/gapi-ocaml/gapi-ocaml.0.3.1/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.3.1/opam
@@ -18,9 +18,9 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ocamlnet" {>= "3.5.1"}

--- a/packages/gapi-ocaml/gapi-ocaml.0.3.2/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.3.2/opam
@@ -18,9 +18,9 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ocamlnet" {>= "3.5.1"}

--- a/packages/gapi-ocaml/gapi-ocaml.0.3.3/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.3.3/opam
@@ -18,9 +18,9 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ocamlnet" {>= "3.5.1"}

--- a/packages/gapi-ocaml/gapi-ocaml.0.3.4/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.3.4/opam
@@ -18,9 +18,9 @@ remove: [
   ["ocamlfind" "remove" "gapi-ocaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "4.06.0"}
   "cryptokit"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ocamlnet" {>= "3.5.1"}


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/gapi-ocaml/gapi-ocaml.0.2.1/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.10/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.13/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.14/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.3/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.4/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.5/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.6/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.7/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.8/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2.9/opam
  - packages/gapi-ocaml/gapi-ocaml.0.2/opam
  - packages/gapi-ocaml/gapi-ocaml.0.3.1/opam
  - packages/gapi-ocaml/gapi-ocaml.0.3.2/opam
  - packages/gapi-ocaml/gapi-ocaml.0.3.3/opam
  - packages/gapi-ocaml/gapi-ocaml.0.3.4/opam