### PR TITLE
Fix ocaml and ocaml-system packages to take .exe into account

### DIFF
--- a/packages/ocaml-system/ocaml-system.3.07/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.07/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.08.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.08.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.08.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.2/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.08.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.3/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.08.4/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.4/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.09.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.09.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.09.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.2/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.09.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.3/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.10.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.10.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.10.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.10.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.10.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.10.2/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.11.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.11.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.11.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.11.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.11.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.11.2/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.12.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.12.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.3.12.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.12.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.00.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.00.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.00.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.00.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.01.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.01.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.02.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.02.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.02.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.2/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.02.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.3/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.03.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.03.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.04.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.04.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.04.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.04.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.04.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.04.2/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.05.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.05.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.06.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.06.0/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml-system/ocaml-system.4.06.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.06.1/files/gen_ocaml_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/packages/ocaml/ocaml.3.07/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.07/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.08.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.08.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.08.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.08.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.08.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.08.2/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.08.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.08.3/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.08.4/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.08.4/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.09.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.09.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.09.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.09.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.09.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.09.2/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.09.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.09.3/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.10.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.10.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.10.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.10.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.10.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.10.2/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.11.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.11.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.11.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.11.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.11.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.11.2/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.12.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.12.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.3.12.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.12.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.00.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.00.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.00.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.00.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.01.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.01.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.02.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.02.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.02.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.02.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.02.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.02.2/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.02.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.02.3/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.03.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.03.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.04.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.04.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.04.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.04.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.04.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.04.2/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.05.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.05.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.06.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.06.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.06.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.06.1/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.07.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.07.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/packages/ocaml/ocaml.4.08.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.4.08.0/files/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"


### PR DESCRIPTION
This is a manual application of the change to the upgrade process in https://github.com/ocaml/opam/pull/3337 intended to unblock https://github.com/ocaml/opam/issues/3336.

I don't know if this affects Camelus's rewriting as well - I think not, as the ocaml packages are maintained by hand but could opam-repository maintainers wait for @AltGr to review before merging this one.