### PR TITLE
Package fstar.0.9.6.0~alpha1 (tweaks)

### DIFF
--- a/packages/fstar/fstar.0.9.6.0~alpha1/opam
+++ b/packages/fstar/fstar.0.9.6.0~alpha1/opam
@@ -5,7 +5,7 @@ authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.c
 homepage: "http://fstar-lang.org"
 license: "Apache"
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "batteries"
   "zarith"
   "stdint"

--- a/packages/fstar/fstar.0.9.6.0~alpha1/opam
+++ b/packages/fstar/fstar.0.9.6.0~alpha1/opam
@@ -34,7 +34,7 @@ remove: [
       "%{prefix}%/lib/fstar"
       "%{prefix}%/doc/fstar"
       "%{prefix}%/etc/fstar"
-      "%{prefix}%/bin/fstar"
+      "%{prefix}%/bin/fstar.exe"
       "%{prefix}%/share/fstar" ]
   [ "ocamlfind" "remove" "fstarlib" ]
   [ "ocamlfind" "remove" "fstar-compiler-lib" ]


### PR DESCRIPTION
- Flag ocamlfind as build dependency
- Make `opam remove fstar` actually remove `fstar.exe` (which is the actual name of the F* binary, not `fstar`)