### PR TITLE
Package prepare.0.01

### DIFF
--- a/packages/prepare/prepare.0.01/opam
+++ b/packages/prepare/prepare.0.01/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "Type equivalence for C"
+maintainer: "Jeremy Lacomis <jlacomis@cmu.edu>"
+authors: "Jeremy Lacomis <jlacomis@cmu.edu>"
+license: "MIT"
+homepage: "https://github.com/squaresLab/type-equiv"
+bug-reports: "https://github.com/squaresLab/type-equiv"
+depends: ["cil" "jbuilder"]
+build: ["jbuilder" "build"]
+dev-repo: "git://"
+url {
+  src: "https://github.com/squaresLab/type-recovery/archive/v0.01.tar.gz"
+  checksum: [
+    "md5=894b5619f2e3fc9c77041fb25d663b7f"
+    "sha512=0eefb15491f8bfcd3e2775b7aa5de93c3441138a9371d522403868226576e7da50d335caa17a1fb1fc361b41e194720087e056e4317d76256b5bd073a46fa2b7"
+  ]
+}


### PR DESCRIPTION
### `prepare.0.01`
Type equivalence for C



---
* Homepage: https://github.com/squaresLab/type-equiv
* Source repo: git://
* Bug tracker: https://github.com/squaresLab/type-equiv

---
:camel: Pull-request generated by opam-publish v2.0.0~beta