### PR TITLE
Regenerate 0.1

### DIFF
--- a/packages/regenerate/regenerate.0.1/descr
+++ b/packages/regenerate/regenerate.0.1/descr
@@ -1,0 +1,7 @@
+Regenerate is a tool to generate test-cases for regular expression engines.
+
+Regenerate takes a regular expression and generates strings that match it.
+It handles most posix extended regular expressions along with
+complement (~a) and intersection (a&b).
+Since it handles complement, it can also generate strings that
+*don't* match a given regular expression.

--- a/packages/regenerate/regenerate.0.1/opam
+++ b/packages/regenerate/regenerate.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Drup <drupyog@zoho.com>"
+authors: "Drup <drupyog@zoho.com>"
+license: "ISC"
+homepage: "https://github.com/Drup/regenerate"
+bug-reports: "https://github.com/Drup/regenerate/issues"
+dev-repo: "git+https://github.com/Drup/regenerate.git"
+doc: "https://drup.github.io/regenerate/doc/0.1/"
+
+depends: [
+  "jbuilder" {build}
+  "cmdliner"
+  "fmt"
+  "containers"
+  "mtime"
+  "oseq"
+  "sequence"
+  "qcheck"
+  "re" {test}
+]
+available: ocaml-version >= "4.03"
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs "@install"]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]

--- a/packages/regenerate/regenerate.0.1/url
+++ b/packages/regenerate/regenerate.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Drup/regenerate/releases/download/0.1/regenerate-0.1.tbz"
+checksum: "536ea1c857d220a2ae0caca62d6c3670"


### PR DESCRIPTION
Regenerate is a tool to generate test-cases for regular expression engines.

Regenerate takes a regular expression and generates strings that match it.
It handles most posix extended regular expressions along with
complement (~a) and intersection (a&b).
Since it handles complement, it can also generate strings that
*don't* match a given regular expression.

- repo: https://github.com/Drup/regenerate
- website: https://drup.github.io/regenerate/
- release: https://github.com/Drup/regenerate/releases/tag/0.1

----

This marked an attempt at releasing with `dune-release`. It was, honestly, mostly unsuccesful (the good point is that I found many issues). I hope the packaging is still correct! :)