### PR TITLE
Current version of ppx_tools works for OCaml 4.07

### DIFF
--- a/packages/ppx_tools/ppx_tools.5.1+4.06.0/opam
+++ b/packages/ppx_tools/ppx_tools.5.1+4.06.0/opam
@@ -12,4 +12,4 @@ remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: [
   "ocamlfind" {>= "1.5.0"}
 ]
-available: [ ocaml-version >= "4.06.0" & ocaml-version < "4.07" ]
+available: [ ocaml-version >= "4.06.0" & ocaml-version < "4.08" ]


### PR DESCRIPTION
Bumping upper bound to OCaml 4.08 since the latest version of ppx_tools seems to work fine with OCaml 4.07.