### PR TITLE
Add version 1.3 of the OByteLib library.

### DIFF
--- a/packages/obytelib/obytelib.1.3/descr
+++ b/packages/obytelib/obytelib.1.3/descr
@@ -1,0 +1,1 @@
+OCaml bytecode library tools to read, write and evaluate OCaml bytecode files.

--- a/packages/obytelib/obytelib.1.3/opam
+++ b/packages/obytelib/obytelib.1.3/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+authors: ["Benoît Vaugon"]
+homepage: "https://github.com/bvaugon/obytelib"
+bug-reports: "https://github.com/bvaugon/obytelib/issues"
+dev-repo: "git@github.com:bvaugon/obytelib.git"
+maintainer: "benoit.vaugon@gmail.com"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "all"]
+]
+remove: [
+  ["./configure" "-prefix" prefix]
+  [make "uninstall"]
+]
+depends: ["ocamlbuild"]
+available: ocaml-version >= "4.04.0"
+install: [make "install"]

--- a/packages/obytelib/obytelib.1.3/opam
+++ b/packages/obytelib/obytelib.1.3/opam
@@ -12,6 +12,6 @@ remove: [
   ["./configure" "-prefix" prefix]
   [make "uninstall"]
 ]
-depends: ["ocamlbuild"]
+depends: ["ocamlbuild" {build}]
 available: ocaml-version >= "4.04.0"
 install: [make "install"]

--- a/packages/obytelib/obytelib.1.3/url
+++ b/packages/obytelib/obytelib.1.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/bvaugon/obytelib/archive/1.3.tar.gz"
+checksum: "2fb61d89b99ec24c53e53ab0829a2111"


### PR DESCRIPTION
This new version of OByteLib simply fix ocamlfind compatibility and expose some useful functions.