### PR TITLE
Detect graphics.cmi in ocaml-system compiler

### DIFF
--- a/packages/ocaml-system/ocaml-system.3.07/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.07/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.08.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.08.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.08.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.2/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.08.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.3/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.08.4/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.08.4/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.09.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.09.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.09.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.2/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.09.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.09.3/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.10.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.10.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.10.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.10.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.10.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.10.2/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.11.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.11.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.11.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.11.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.11.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.11.2/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.12.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.12.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.3.12.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.12.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.00.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.00.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.00.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.00.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.01.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.01.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.02.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.02.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.02.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.2/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.02.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.02.3/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.03.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.03.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.04.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.04.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.04.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.04.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.04.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.04.2/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.05.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.05.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.06.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.06.0/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/packages/ocaml-system/ocaml-system.4.06.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.06.1/files/gen_ocaml_config.ml.in
@@ -9,9 +9,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc


### PR DESCRIPTION
** This PR requires opam2 rc2, so shouldn't be merged at least until that's released **

This is a manual application of https://github.com/ocaml/opam/pull/3345 to the `ocaml-system` package. The opam PR includes the full motivation for this change. Earlier releases of opam 2 will insist on rebuild system compilers on every operation *unless* the system compiler has `graphics.cmi`.