### PR TITLE
deriving.0.8.1: require num with ocamlfind package

### DIFF
--- a/packages/deriving/deriving.0.8.1/opam
+++ b/packages/deriving/deriving.0.8.1/opam
@@ -17,7 +17,7 @@ remove: ["ocamlfind" "remove" "deriving"]
 depends: [
   "ocamlfind"
   "camlp4"
-  "num"
+  "num" { >= "1.0" }
   "oasis" {build & >= "0.4.4"}
 ]
 depopts: "type_conv"


### PR DESCRIPTION
As build system expects to find num ocamlfind package, and it is not provided by base-num.
This effectively limits to ocaml-version >= 4.06.0