### PR TITLE
astring: depends on base-bytes

### DIFF
--- a/packages/astring/astring.0.8.0/opam
+++ b/packages/astring/astring.0.8.0/opam
@@ -9,7 +9,8 @@ tags: [ "string" "org:erratique" ]
 license: "BSD-3-Clause"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [ "ocamlfind" {build}
-           "ocamlbuild" {build} ]
+           "ocamlbuild" {build}
+           "base-bytes" ]
 build:
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/astring/astring.0.8.1/opam
+++ b/packages/astring/astring.0.8.1/opam
@@ -9,7 +9,8 @@ tags: [ "string" "org:erratique" ]
 license: "BSD-3-Clause"
 available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 depends: [ "ocamlfind" {build}
-           "ocamlbuild" {build} ]
+           "ocamlbuild" {build}
+           "base-bytes" ]
 build:
 [
   [ "ocaml" "pkg/git.ml" ]

--- a/packages/astring/astring.0.8.2/opam
+++ b/packages/astring/astring.0.8.2/opam
@@ -11,7 +11,8 @@ available: [ ocaml-version >= "4.01.0"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build} ]
+  "topkg" {build}
+  "base-bytes" ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pinned" "%{pinned}%" ]]

--- a/packages/astring/astring.0.8.3/opam
+++ b/packages/astring/astring.0.8.3/opam
@@ -11,7 +11,8 @@ available: [ ocaml-version >= "4.01.0"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build} ]
+  "topkg" {build}
+  "base-bytes" ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pinned" "%{pinned}%" ]]


### PR DESCRIPTION
Witness
```
$ ocamlfind query astring  -r -format %p
bytes
astring
```

Omission of this dependency causes build failures.