### PR TITLE
Package mccs.1.1+6

### DIFF
--- a/packages/mccs/mccs.1.1+6/descr
+++ b/packages/mccs/mccs.1.1+6/descr
@@ -1,0 +1,6 @@
+Multi Criteria CUDF Solver with OCaml bindings
+
+This is a stripped-down version of the mccs solver (written in C++), including
+OCaml bindings based on the cudf library, and the GLPK backend (in C). Note that
+it also includes some correction fixes, and a few changes not present in the
+upstream yet.

--- a/packages/mccs/mccs.1.1+6/opam
+++ b/packages/mccs/mccs.1.1+6/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Claude Michel <claude.michel@unice.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+homepage: "http://www.i3s.unice.fr/~cpjm/misc/"
+bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
+license: "LGPL-2.1 with OCaml linking exception, BSD-3-clause, GPL-3.0"
+dev-repo: "https://github.com/AltGr/ocaml-mccs.git"
+build: ["jbuilder" "build" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "cudf" {>= "0.7"}
+]

--- a/packages/mccs/mccs.1.1+6/url
+++ b/packages/mccs/mccs.1.1+6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/ocaml-mccs/archive/1.1+6.tar.gz"
+checksum: "864333066431caf9ebe3a3e1dc4fb22e"


### PR DESCRIPTION
### `mccs.1.1+6`

Multi Criteria CUDF Solver with OCaml bindings

This is a stripped-down version of the mccs solver (written in C++), including
OCaml bindings based on the cudf library, and the GLPK backend (in C). Note that
it also includes some correction fixes, and a few changes not present in the
upstream yet.



---
* Homepage: http://www.i3s.unice.fr/~cpjm/misc/
* Source repo: https://github.com/AltGr/ocaml-mccs.git
* Bug tracker: https://github.com/AltGr/ocaml-mccs/issues

---

:camel: Pull-request generated by opam-publish v0.3.5