### PR TITLE
lwt_react: better minimal constraint for jbuilder

### DIFF
--- a/packages/lwt_react/lwt_react.1.1.1/opam
+++ b/packages/lwt_react/lwt_react.1.1.1/opam
@@ -18,7 +18,7 @@ build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]
 build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
 
 depends: [
-  "jbuilder" {build & >= "1.0+beta10"}
+  "jbuilder" {build & >= "1.0+beta14"}
   "lwt" {>= "3.0.0"}
   "react" {>= "1.0.0"}
 ]


### PR DESCRIPTION
lwt_react.1.1.1 uses `copy_files` which is not available in old versions of
jbuilder.

/cc @aantron 