### PR TITLE
fix stog 0.13.0 and stog 0.14.0

### DIFF
--- a/packages/stog/stog.0.13.0/opam
+++ b/packages/stog/stog.0.13.0/opam
@@ -36,5 +36,7 @@ conflicts: [
   "lwt" {< "2.4.5"}
   "websocket" {< "0.8.1"}
   "xmldiff" {< "0.3.0"}
+  "xmlm" {= "1.2.0"}
+  "xmlm" {= "1.3.0"}
 ]
 

--- a/packages/stog/stog.0.13.0/opam
+++ b/packages/stog/stog.0.13.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlnet" {>= "3.6"}
   "higlo" { >= "0.4" }
 ]
-available: [ ocaml-version >= "4.02.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]
 
 depopts: ["js_of_ocaml" "xmldiff" "lwt" "websocket" "cstruct" "crunch"]
 

--- a/packages/stog/stog.0.14.0/opam
+++ b/packages/stog/stog.0.14.0/opam
@@ -37,5 +37,7 @@ conflicts: [
   "ojs-base" {< "0.2"}
   "websocket" {!= "0.8.1"}
   "xmldiff" {< "0.5.0"}
+  "xmlm" {= "1.2.0"}
+  "xmlm" {= "1.3.0"}
 ]
 


### PR DESCRIPTION
- stog 0.13 is not safe-string compatible
- stog 0.13 and 0.14 require xmlm not 1.2.0 or 1.3.0 (which both use a `v` prefix in ocamlfind)