### PR TITLE
base64: add missing lower bounds for alcotest

### DIFF
--- a/packages/base64/base64.2.1.2/opam
+++ b/packages/base64/base64.2.1.2/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "bos" {test}
   "rresult" {test}
-  "alcotest" {test}
+  "alcotest" {test & >= "0.4.0"}
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [

--- a/packages/base64/base64.2.2.0/opam
+++ b/packages/base64/base64.2.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "bos" {test}
   "rresult" {test}
-  "alcotest" {test}
+  "alcotest" {test & >= "0.4.0"}
 ]
 build: [
   ["jbuilder" "subst"] {pinned}


### PR DESCRIPTION
Alcotest.check only appeared in alcotest.4.0.0