### PR TITLE
ppx_type_conv.v0.9.0: use an old version of ppx_core

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "jbuilder"                {build & >= "1.0+beta4"}
-  "ppx_core"                {>= "v0.9" & < "v0.10"}
+  "ppx_core"                {>= "v0.9" & < "v0.9.3"}
   "ppx_driver"              {>= "v0.9" & < "v0.10"}
   "ppx_metaquot"            {>= "v0.9" & < "v0.10"}
   "ocaml-migrate-parsetree" {>= "0.4"}


### PR DESCRIPTION
Otherwise duplicated entries are generated. /cc @diml 

Not too sure about why this bug happens (which is similar to https://github.com/mirage/ocaml-cohttp/issues/573 but with ppx_deriving.4.2.1)

To reproduce it:

```
$ opam install --switch=4.06.0 cohttp.0.20.2 ppx_deriving.4.2.1 ppx_type_conv.v0.9.0 ppx_core.v0.9.3
```