### PR TITLE
Add sqlexpr, ppx_sqlexpr and pa_sqlexpr 0.9.0.

### DIFF
--- a/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/descr
+++ b/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/descr
@@ -1,0 +1,19 @@
+Type-safe, convenient SQLite database access - extension for use with sqlexpr.
+sqlexpr provides type-safe, convenient execution of SQL statements. Currently
+compatible with Sqlite3.
+
+Sqlexpr features:
+
+* automated prepared statement caching, param binding, data
+extraction, error checking (including automatic stmt reset to avoid
+BUSY/LOCKED errors in subsequent queries), stmt finalization on db
+close, etc.
+
+* HOFs like iter, fold, transaction
+
+* support for different concurrency models: everything is functorized
+over a THREAD monad, so you can for instance do concurrent folds/iters
+with Lwt
+
+* support for SQL stmt syntax checks and some extra semantic checking
+(column names, etc)

--- a/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/opam
+++ b/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "mfp@acm.org"
+authors: ["Mauricio Fernandez <mfp@acm.org>"]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "http://github.com/mfp/ocaml-sqlexpr"
+dev-repo: "https://github.com/mfp/ocaml-sqlexpr.git"
+bug-reports: "https://github.com/mfp/ocaml-sqlexpr/issues"
+build: [
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "sqlexpr"
+  "estring"
+  "camlp4"
+]

--- a/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/opam
+++ b/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/opam
@@ -5,6 +5,7 @@ license: "LGPL-2.1 with OCaml linking exception"
 homepage: "http://github.com/mfp/ocaml-sqlexpr"
 dev-repo: "https://github.com/mfp/ocaml-sqlexpr.git"
 bug-reports: "https://github.com/mfp/ocaml-sqlexpr/issues"
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]
 build: [
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/url
+++ b/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mfp/ocaml-sqlexpr/releases/download/0.9.0/ocaml-sqlexpr-0.9.0.tar.gz"
+checksum: "edca74c7c1af6f7ebb0c46598f242552"

--- a/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/descr
+++ b/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/descr
@@ -1,0 +1,19 @@
+Type-safe, convenient SQLite database access - extension for use with sqlexpr.
+sqlexpr provides type-safe, convenient execution of SQL statements. Currently
+compatible with Sqlite3.
+
+Sqlexpr features:
+
+* automated prepared statement caching, param binding, data
+extraction, error checking (including automatic stmt reset to avoid
+BUSY/LOCKED errors in subsequent queries), stmt finalization on db
+close, etc.
+
+* HOFs like iter, fold, transaction
+
+* support for different concurrency models: everything is functorized
+over a THREAD monad, so you can for instance do concurrent folds/iters
+with Lwt
+
+* support for SQL stmt syntax checks and some extra semantic checking
+(column names, etc)

--- a/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/opam
+++ b/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "mfp@acm.org"
+authors: ["Mauricio Fernandez <mfp@acm.org>"]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "http://github.com/mfp/ocaml-sqlexpr"
+dev-repo: "https://github.com/mfp/ocaml-sqlexpr.git"
+bug-reports: "https://github.com/mfp/ocaml-sqlexpr/issues"
+doc: "doc"
+build: [
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "ppx_tools_versioned"
+  "ppx_core"
+  "ocaml-migrate-parsetree"
+  "base-unix"
+  "re" {build & >= "1.3.0"}
+  "ounit" {test}
+  "lwt" {test}
+]

--- a/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/url
+++ b/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mfp/ocaml-sqlexpr/releases/download/0.9.0/ocaml-sqlexpr-0.9.0.tar.gz"
+checksum: "edca74c7c1af6f7ebb0c46598f242552"

--- a/packages/sqlexpr/sqlexpr.0.9.0/descr
+++ b/packages/sqlexpr/sqlexpr.0.9.0/descr
@@ -1,0 +1,19 @@
+Type-safe, convenient SQLite database access.
+Minimalistic library and syntax extension for type-safe, convenient
+execution of SQL statements. Currently compatible with Sqlite3.
+
+Sqlexpr features:
+
+* automated prepared statement caching, param binding, data
+extraction, error checking (including automatic stmt reset to avoid
+BUSY/LOCKED errors in subsequent queries), stmt finalization on db
+close, etc.
+
+* HOFs like iter, fold, transaction
+
+* support for different concurrency models: everything is functorized
+over a THREAD monad, so you can for instance do concurrent folds/iters
+with Lwt
+
+* support for SQL stmt syntax checks and some extra semantic checking
+(column names, etc)

--- a/packages/sqlexpr/sqlexpr.0.9.0/opam
+++ b/packages/sqlexpr/sqlexpr.0.9.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "mfp@acm.org"
+authors: ["Mauricio Fernandez <mfp@acm.org>"]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "http://github.com/mfp/ocaml-sqlexpr"
+dev-repo: "https://github.com/mfp/ocaml-sqlexpr.git"
+bug-reports: "https://github.com/mfp/ocaml-sqlexpr/issues"
+available: ocaml-version >= "4.02.0"
+build: [
+  [ "env" "ESTRING=%{estring:enable}%" "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "csv"
+  "lwt" {>= "2.2.0"}
+  "lwt_ppx" {build}
+  ("sqlite3" {>= "2.0.4"} | "sqlite3" {= "2.0.3"})
+  "base-unix"
+  "ppx_sqlexpr"
+]
+depopts: [ "estring" ]
+
+messages: [
+  "For the PPX syntax extension, install package ppx_sqlexpr"
+  {!ppx_sqlexpr:installed}
+  "For the Camlp4 syntax extension, install package pa_sqlexpr"
+  {!pa_sqlexpr:installed}
+]
+post-messages: [
+  "The sqlexpr.ppx and sqlexpr.syntax package aliases will be dropped
+eventually. Switch to ppx_sqlexpr and pa_sqlexpr now."
+  ]

--- a/packages/sqlexpr/sqlexpr.0.9.0/url
+++ b/packages/sqlexpr/sqlexpr.0.9.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mfp/ocaml-sqlexpr/releases/download/0.9.0/ocaml-sqlexpr-0.9.0.tar.gz"
+checksum: "edca74c7c1af6f7ebb0c46598f242552"


### PR DESCRIPTION
Hand-tested on 4.02.3, 4.05.0, 4.06.0.
Not installable on 4.07 because ppx_core isn't either yet.