### PR TITLE
hmap 0.8.0 does not compile on 4.06

### DIFF
--- a/packages/hmap/hmap.0.8.0/opam
+++ b/packages/hmap/hmap.0.8.0/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "http://erratique.ch/repos/hmap.git"
 bug-reports: "http://github.com/dbuenzli/hmap/issues"
 tags: ["data-structure" "org:erratique"]
-available: [ ocaml-version >= "4.02.0"]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
/cc @dbuenzli 