### PR TITLE
Package cowabloga.0.4.0

### DIFF
--- a/packages/cowabloga/cowabloga.0.4.0/descr
+++ b/packages/cowabloga/cowabloga.0.4.0/descr
@@ -1,0 +1,7 @@
+Simple static blogging support
+
+Helper OCaml libraries for setting up a blog and wiki, using the Zurb
+Foundation CSS/HTML templates.
+
+This is code extracted from the Mirage website, and is still being tidied
+up for general use. See <http://openmirage.org> for more information.

--- a/packages/cowabloga/cowabloga.0.4.0/opam
+++ b/packages/cowabloga/cowabloga.0.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer:   "mort@cantab.net"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"]
+license:      "ISC"
+tags:         "org:mirage"
+dev-repo:     "https://github.com/mirage/cowabloga.git"
+homepage:     "https://github.com/mirage/cowabloga"
+bug-reports:  "https://github.com/mirage/cowabloga/issues"
+doc:          "https://mirage.github.io/cowabloga/"
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "re" {>= "1.7.2"}
+  "cow" {>= "2.3.0"}
+  "omd" {>= "0.8.2"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.1"}
+  "magic-mime"
+  "jbuilder"  {build}
+  "cohttp" {test & >= "0.5.0"}
+  "cohttp-lwt-unix" {test}
+]

--- a/packages/cowabloga/cowabloga.0.4.0/url
+++ b/packages/cowabloga/cowabloga.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/cowabloga/releases/download/0.4.0/cowabloga-0.4.0.tbz"
+checksum: "9c19109d9bdde9e699949a6dbd300c1a"


### PR DESCRIPTION
### `cowabloga.0.4.0`

Simple static blogging support

Helper OCaml libraries for setting up a blog and wiki, using the Zurb
Foundation CSS/HTML templates.

This is code extracted from the Mirage website, and is still being tidied
up for general use. See <http://openmirage.org> for more information.


---
* Homepage: https://github.com/mirage/cowabloga
* Source repo: https://github.com/mirage/cowabloga.git
* Bug tracker: https://github.com/mirage/cowabloga/issues

---


---
## 0.4.0 (2018-05-13)

* support cow 2.3.0 (#34, @samoht)
* support re 1.7.2 (#32, @rgrinberg)
:camel: Pull-request generated by opam-publish v0.3.5