### PR TITLE
Package radis.0.1

### DIFF
--- a/packages/radis/radis.0.1/descr
+++ b/packages/radis/radis.0.1/descr
@@ -1,0 +1,14 @@
+Radix tree implementation
+
+Radis is a little library to provide an implementation of a Radix tree
+(specialized with a scalar key - like a string, bigarray or array). This project
+is a part of ocaml-git to have a fast access to an immutable store. In this way,
+remove operation should be the slowest operation and this data-structure is
+focused on lookup operation when the key is specifically a hash (see
+[digestif](https://github.com/mirage/digestif)).
+
+The idea behind this library is to provide a fast access to an immutable store
+(like git). So, in my mind, if we put a new object in this store, it can not be
+deleted. It's why remove operation should be slow - of course, in a git store,
+it's possible to delete an useless object (see `git gc`), however this
+computation does not appear in this way.

--- a/packages/radis/radis.0.1/opam
+++ b/packages/radis/radis.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/radis"
+bug-reports:  "https://github.com/dinosaure/radis/issues"
+dev-repo:     "https://github.com/dinosaure/radis.git"
+doc:          "https://dinosaure.github.io/radis/"
+license:      "MIT"
+
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "fmt"
+  "alcotest" {test}
+]
+
+available: [ocaml-version >= "4.06.0"]

--- a/packages/radis/radis.0.1/url
+++ b/packages/radis/radis.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dinosaure/radis/releases/download/v0.1/radis-0.1.tbz"
+checksum: "1a8b674f1159f67acb8d03fa46c5d5e7"


### PR DESCRIPTION
### `radis.0.1`

Radix tree implementation

Radis is a little library to provide an implementation of a Radix tree
(specialized with a scalar key - like a string, bigarray or array). This project
is a part of ocaml-git to have a fast access to an immutable store. In this way,
remove operation should be the slowest operation and this data-structure is
focused on lookup operation when the key is specifically a hash (see
[digestif](https://github.com/mirage/digestif)).

The idea behind this library is to provide a fast access to an immutable store
(like git). So, in my mind, if we put a new object in this store, it can not be
deleted. It's why remove operation should be slow - of course, in a git store,
it's possible to delete an useless object (see `git gc`), however this
computation does not appear in this way.


---
* Homepage: https://github.com/dinosaure/radis
* Source repo: https://github.com/dinosaure/radis.git
* Bug tracker: https://github.com/dinosaure/radis/issues

---


---
v0.1 2018-05-07 Paris (France)
----------------------------------------

- First release of `radis`
:camel: Pull-request generated by opam-publish v0.3.5