### PR TITLE
Make verimag packages incompatible with 4.06

### DIFF
--- a/packages/lutils/lutils.1.8/opam
+++ b/packages/lutils/lutils.1.8/opam
@@ -27,3 +27,4 @@ depends: [
   "ocamlfind" {build}
   "num"
 ]
+available: [ocaml-version < "4.06"]

--- a/packages/lutils/lutils.1.9/opam
+++ b/packages/lutils/lutils.1.9/opam
@@ -27,3 +27,4 @@ depends: [
   "ocamlfind" {build}
   "num"
 ]
+available: [ocaml-version < "4.06"]

--- a/packages/rdbg/rdbg.1.0/opam
+++ b/packages/rdbg/rdbg.1.0/opam
@@ -23,4 +23,4 @@ depends: [
   "ocamlbuild" {build}
   "num"
 ]
-available: [ ocaml-version >= "4.01" ]
+available: [ ocaml-version >= "4.01" & ocaml-version < "4.06"]

--- a/packages/rdbg/rdbg.1.0/opam
+++ b/packages/rdbg/rdbg.1.0/opam
@@ -23,4 +23,4 @@ depends: [
   "ocamlbuild" {build}
   "num"
 ]
-available: [ ocaml-version >= "4.01" & ocaml-version < "4.06"]
+available: [ ocaml-version >= "4.01" & ocaml-version < "4.05"]

--- a/packages/rdbg/rdbg.1.70/opam
+++ b/packages/rdbg/rdbg.1.70/opam
@@ -31,4 +31,4 @@ depends: [
   "ounit" {build & >= "2.0.0"}
   "num"
 ]
-available: [ ocaml-version >= "4.01" & ocaml-version < "4.06" ]
+available: [ ocaml-version >= "4.01" & ocaml-version < "4.05" ] 

--- a/packages/rdbg/rdbg.1.70/opam
+++ b/packages/rdbg/rdbg.1.70/opam
@@ -31,4 +31,4 @@ depends: [
   "ounit" {build & >= "2.0.0"}
   "num"
 ]
-available: [ ocaml-version >= "4.01" ]
+available: [ ocaml-version >= "4.01" & ocaml-version < "4.06" ]


### PR DESCRIPTION
All these packages are broken by safe-string.