### PR TITLE
ocaml-cgi v0.9

### DIFF
--- a/packages/cgi/cgi.0.9/descr
+++ b/packages/cgi/cgi.0.9/descr
@@ -1,0 +1,1 @@
+Library for writing CGIs

--- a/packages/cgi/cgi.0.9/opam
+++ b/packages/cgi/cgi.0.9/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+version: "0.9"
+maintainer: "rixed-opam@happyleptic.org"
+authors: [
+  "Daniel de Rauglaudre"
+  "Jean-Christophe FILLIATRE"
+  "Cedric Cellier" ]
+homepage: "https://www.lri.fr/~filliatr/ftp/ocaml/cgi/"
+bug-reports: "https://github.com/rixed/ocaml-cgi/issues"
+dev-repo: "https://github.com/rixed/ocaml-cgi.git"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [make "install"]
+remove: [["ocamlfind" "remove" "cgi"]]
+depends: ["ocamlfind"]
+available: [ocaml-version > "4.01.0"]

--- a/packages/cgi/cgi.0.9/opam
+++ b/packages/cgi/cgi.0.9/opam
@@ -14,5 +14,5 @@ build: [
 ]
 install: [make "install"]
 remove: [["ocamlfind" "remove" "cgi"]]
-depends: ["ocamlfind"]
+depends: ["ocamlfind" {build}]
 available: [ocaml-version > "4.01.0"]

--- a/packages/cgi/cgi.0.9/url
+++ b/packages/cgi/cgi.0.9/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/rixed/ocaml-cgi/archive/v0.9.tar.gz"
+checksum: "1e1b9e4de0ba12688b4b66523f42125d"


### PR DESCRIPTION
With agreement from JC Filliatre (@backtracking) I pointed the URL to my
github fork of ocaml-cgi, which fixes a few issues and add a couple of
features. In particular, the code is now compatible with latest version
of OCaml compiler.
Also, I tried to improve the opam file.