### PR TITLE
Fixed hash of qtest.2.4

### DIFF
--- a/packages/qtest/qtest.2.4/url
+++ b/packages/qtest/qtest.2.4/url
@@ -1,2 +1,2 @@
 http: "https://github.com/vincent-hugot/iTeML/archive/v2.4.tar.gz"
-checksum: "3940923409d984e7ffab5b68567cf831"
+checksum: "b6d45ce61486ec6716106bb0d97f0885"


### PR DESCRIPTION
I'm not sure about the process release of `qtest` and I think it's because GitHub regenerate assets (and hash) automatically. In this case, we need to wait a new _fixed_ asset of `qtest.2.4` before to merge this PR.