### PR TITLE
ppx_type_conv.v0.9.1 needs a recent version of deriving

### DIFF
--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
@@ -16,4 +16,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "0.4"}
   "ppx_derivers"
 ]
+conflicts: [
+  "ppx_deriving" {< "4.2"}
+]
 available: [ocaml-version > "4.03.0"]


### PR DESCRIPTION
Fixes https://github.com/mirage/irmin/issues/494

To reproduce:

```
$ opam install ppx_deriving.4.1.5 ppx_type_conv.v0.9.1 -y && opam reinstall nocrypto -y -v
...
File "src/hash.ml", line 115, characters 12-16:
Error: Cannot locate deriver sexp
...
```

whereas:

```
$ opam install ppx_deriving.4.2 ppx_type_conv.v0.9.1 -y && opam reinstall nocrypto -y -v
Done.
```
