### PR TITLE
Package pure-splitmix.0.1

### DIFF
--- a/packages/pure-splitmix/pure-splitmix.0.1/descr
+++ b/packages/pure-splitmix/pure-splitmix.0.1/descr
@@ -1,0 +1,1 @@
+Purely functional splittable PRNG

--- a/packages/pure-splitmix/pure-splitmix.0.1/files/pure-splitmix.install
+++ b/packages/pure-splitmix/pure-splitmix.0.1/files/pure-splitmix.install
@@ -1,0 +1,8 @@
+lib: [
+  "META"
+  "_build/src/pureSplitMix.cmi"
+  "_build/src/pureSplitMix.cmx"
+  "_build/src/pureSplitMix.cma"
+  "_build/src/pureSplitMix.cmxa"
+  "_build/src/pureSplitMix.a"
+]

--- a/packages/pure-splitmix/pure-splitmix.0.1/opam
+++ b/packages/pure-splitmix/pure-splitmix.0.1/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Li-yao Xia <lysxia@gmail.com>"
+authors: "Li-yao Xia"
+homepage: "https://github.com/Lysxia/pure-splitmix"
+bug-reports: "https://github.com/Lysxia/pure-splitmix/issues"
+license: "MIT"
+dev-repo: "https://github.com/Lysxia/pure-splitmix.git"
+build: [make "build"]
+build-test: [make "test"]
+depends: [
+  "ocamlbuild" {build & >= "0.9.0"}
+]

--- a/packages/pure-splitmix/pure-splitmix.0.1/url
+++ b/packages/pure-splitmix/pure-splitmix.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Lysxia/pure-splitmix/archive/0.1.tar.gz"
+checksum: "5d8dedb233756272ec55a83501f2a139"


### PR DESCRIPTION
### `pure-splitmix.0.1`

Purely functional splittable PRNG



---
* Homepage: https://github.com/Lysxia/pure-splitmix
* Source repo: 
* Bug tracker: 

---
### opam-lint failures
- **WARNING** 37 Missing field 'dev-repo'
- **WARNING** 36 Missing field 'bug-reports'
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5