### PR TITLE
Package crlibm.0.1

### DIFF
--- a/packages/crlibm/crlibm.0.1/descr
+++ b/packages/crlibm/crlibm.0.1/descr
@@ -1,0 +1,1 @@
+Binding to CRlibm, a correctly rounded math lib

--- a/packages/crlibm/crlibm.0.1/opam
+++ b/packages/crlibm/crlibm.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["libm" "math" "science"]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-crlibm"
+dev-repo: "https://github.com/Chris00/ocaml-crlibm.git"
+bug-reports: "https://github.com/Chris00/ocaml-crlibm/issues"
+doc: "https://Chris00.github.io/ocaml-crlibm/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "base-bytes" {build}
+  "benchmark" {test}
+]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/crlibm/crlibm.0.1/url
+++ b/packages/crlibm/crlibm.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-crlibm/releases/download/0.1/crlibm-0.1.tbz"
+checksum: "f5d7975e3afa4ff11e8afd3e0c0a7ca6"


### PR DESCRIPTION
### `crlibm.0.1`

Binding to CRlibm, a correctly rounded math lib



---
* Homepage: https://github.com/Chris00/ocaml-crlibm
* Source repo: https://github.com/Chris00/ocaml-crlibm.git
* Bug tracker: https://github.com/Chris00/ocaml-crlibm/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
0.1 2018-05-14
--------------

- Binding to CRlibm with rounding modes presented as modules.
- Elementary test.
- Speed test (comparison with standard functions).
:camel: Pull-request generated by opam-publish v0.3.5