### PR TITLE
aws-s3.3.0.0

### DIFF
--- a/packages/aws-s3-async/aws-s3-async.3.0.0/descr
+++ b/packages/aws-s3-async/aws-s3-async.3.0.0/descr
@@ -1,0 +1,10 @@
+Ocaml library for accessing Amazon S3 - Async version
+
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* Fetching credentials (though IAM)
+
+This library uses async for concurrency

--- a/packages/aws-s3-async/aws-s3-async.3.0.0/opam
+++ b/packages/aws-s3-async/aws-s3-async.3.0.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" { build }
+  "aws-s3" { = "3.0.0" }
+  "async_kernel" { >= "v0.9.0" }
+  "core_kernel" { >= "v0.9.0" }
+  "cohttp-async"
+]
+
+available: [ ocaml-version >= "4.04.0" ]

--- a/packages/aws-s3-async/aws-s3-async.3.0.0/url
+++ b/packages/aws-s3-async/aws-s3-async.3.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/git@github.com:andersfugmann/aws-s3/archive/3.0.0.tar.gz"
+checksum: "9d1ead73e678fa2f51a70a933b0bf017"

--- a/packages/aws-s3-async/aws-s3-async.3.0.0/url
+++ b/packages/aws-s3-async/aws-s3-async.3.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/git@github.com:andersfugmann/aws-s3/archive/3.0.0.tar.gz"
-checksum: "9d1ead73e678fa2f51a70a933b0bf017"
+http: "https://github.com/andersfugmann/aws-s3/archive/3.0.0.tar.gz"
+checksum: "c857576898b2fc54515be0dc4a6a141f"

--- a/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/descr
+++ b/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/descr
@@ -1,0 +1,11 @@
+Ocaml library for accessing Amazon S3 - Lwt version.
+
+
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* Fetching credentials (though IAM)
+
+This library uses lwt for concurrency

--- a/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" { build }
+  "aws-s3" { = "3.0.0" }
+  "lwt"
+  "cohttp-lwt-unix"
+]
+
+available: [ ocaml-version >= "4.04.0" ]

--- a/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/url
+++ b/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/git@github.com:andersfugmann/aws-s3/archive/3.0.0.tar.gz"
+checksum: "9d1ead73e678fa2f51a70a933b0bf017"

--- a/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/url
+++ b/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/git@github.com:andersfugmann/aws-s3/archive/3.0.0.tar.gz"
-checksum: "9d1ead73e678fa2f51a70a933b0bf017"
+http: "https://github.com/andersfugmann/aws-s3/archive/3.0.0.tar.gz"
+checksum: "c857576898b2fc54515be0dc4a6a141f"

--- a/packages/aws-s3/aws-s3.3.0.0/descr
+++ b/packages/aws-s3/aws-s3.3.0.0/descr
@@ -1,0 +1,12 @@
+Ocaml library for accessing Amazon S3
+
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* Fetching credentials (though IAM)
+
+The library supports both lwt and async concurrency models.
+* For lwt, please install `aws-s3-lwt` package
+* For Async, please install `aws-s3-async` package

--- a/packages/aws-s3/aws-s3.3.0.0/opam
+++ b/packages/aws-s3/aws-s3.3.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" { build }
+  "core" {>= "v0.9.0"}
+  "ounit"
+  "cohttp"
+  "ocaml-inifiles"
+  "digestif"
+  "xml-light"
+  "yojson"
+  "ppx_protocol_conv_xml_light"
+  "ppx_protocol_conv_json"
+  "cmdliner"
+]
+
+available: [ ocaml-version >= "4.04.0" ]

--- a/packages/aws-s3/aws-s3.3.0.0/url
+++ b/packages/aws-s3/aws-s3.3.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/git@github.com:andersfugmann/aws-s3/archive/3.0.0.tar.gz"
+checksum: "9d1ead73e678fa2f51a70a933b0bf017"

--- a/packages/aws-s3/aws-s3.3.0.0/url
+++ b/packages/aws-s3/aws-s3.3.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/git@github.com:andersfugmann/aws-s3/archive/3.0.0.tar.gz"
-checksum: "9d1ead73e678fa2f51a70a933b0bf017"
+http: "https://github.com/andersfugmann/aws-s3/archive/3.0.0.tar.gz"
+checksum: "c857576898b2fc54515be0dc4a6a141f"


### PR DESCRIPTION
* Add parameter to specify scheme(http|https)
* Fix IAM handling for lwt version.
* Always use http when accessing s3.
* Support copying s3 -> s3
* Support multipart upload
* Support permanent/temporary redirect error code
* Return an error indicating the redirect to successive calls
* Switch to use Digistif 
* Remove support for gzip (Users are encurraged to set the encoding and use ezgzip instead)
* Compatibility with base.v0.11.0

