### PR TITLE
Package nsq.0.2.4

### DIFF
--- a/packages/nsq/nsq.0.2.4/descr
+++ b/packages/nsq/nsq.0.2.4/descr
@@ -1,0 +1,4 @@
+Client library for the NSQ messaging platform
+
+This package supports publishing and consuming message using the NSQ message platform.
+It uses Lwt for concurrency.

--- a/packages/nsq/nsq.0.2.4/opam
+++ b/packages/nsq/nsq.0.2.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/nsq-ocaml"
+bug-reports: "https://github.com/ryanslade/nsq-ocaml/issues"
+dev-repo: "https://github.com/ryanslade/nsq-ocaml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build}
+  "containers"
+  "lwt"
+  "ocplib-endian"
+  "integers"
+  "cohttp"
+  "cohttp-lwt-unix"
+  "yojson"
+  "ocaml-migrate-parsetree"
+  "ppx_deriving_yojson"
+  "logs"
+]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/nsq/nsq.0.2.4/url
+++ b/packages/nsq/nsq.0.2.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ryanslade/nsq-ocaml/archive/0.2.4.tar.gz"
+checksum: "bf48408f6015193c55cb9456e49f1a84"


### PR DESCRIPTION
### `nsq.0.2.4`

Client library for the NSQ messaging platform

This package supports publishing and consuming message using the NSQ message platform.
It uses Lwt for concurrency.



---
* Homepage: https://github.com/ryanslade/nsq-ocaml
* Source repo: https://github.com/ryanslade/nsq-ocaml.git
* Bug tracker: https://github.com/ryanslade/nsq-ocaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5