### PR TITLE
flowtype.0.27.0: restrict to os != linux

### DIFF
--- a/packages/flowtype/flowtype.0.27.0/opam
+++ b/packages/flowtype/flowtype.0.27.0/opam
@@ -18,7 +18,10 @@ depends: [
   "base-bytes"
   "ocamlbuild" {build}
 ]
-available: [ocaml-version >= "4.01.0" & ocaml-version < "4.04.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.04.0" & os != "linux" ]
+# os restriction is only for this version due to an infinite loop in CI builds
+# that was fixed in later versions. It seems to work fine on OSX, just not Linux.
+
 build: [ [ make ] ]
 depexts: [
  [ ["debian"] ["libelf-dev"] ]


### PR DESCRIPTION
In bulk builds, this particular (historical) version of Flow
causes a timeout in builds as it seems to be in an infinite loop
in a Makefile.  The problem is fixed in later versions, so it is
just this one version affected, and is only happening on Linux
toolchains.

This PR just disables Linux support, which will allow the old
version to be built by disabling that constraint, but also unblocks
CI resources in the short term.

cc @gabelevi 