### PR TITLE
Package benchmark.1.5

### DIFF
--- a/packages/benchmark/benchmark.1.5/descr
+++ b/packages/benchmark/benchmark.1.5/descr
@@ -1,0 +1,5 @@
+Benchmark running times of code
+
+This module provides a set of tools to measure the running times of
+your functions and to easily compare the results.  A statistical test
+is used to determine whether the results truly differ.

--- a/packages/benchmark/benchmark.1.5/opam
+++ b/packages/benchmark/benchmark.1.5/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+          "Doug Bagley"]
+tags: ["benchmark"]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-benchmark"
+dev-repo: "https://github.com/Chris00/ocaml-benchmark.git"
+bug-reports: "https://github.com/Chris00/ocaml-benchmark/issues"
+doc: "https://Chris00.github.io/ocaml-benchmark/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "base-unix"
+  "base-bigarray" {test}
+  "pcre" {test}
+]
+available: [ ocaml-version >= "3.12.0" ]

--- a/packages/benchmark/benchmark.1.5/url
+++ b/packages/benchmark/benchmark.1.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-benchmark/releases/download/1.5/benchmark-1.5.tbz"
+checksum: "af4bef4028866b21496c583f83a86c7f"


### PR DESCRIPTION
### `benchmark.1.5`

Benchmark running times of code

This module provides a set of tools to measure the running times of
your functions and to easily compare the results.  A statistical test
is used to determine whether the results truly differ.



---
* Homepage: https://github.com/Chris00/ocaml-benchmark
* Source repo: https://github.com/Chris00/ocaml-benchmark.git
* Bug tracker: https://github.com/Chris00/ocaml-benchmark/issues

---


---
1.5 2018-05-17
--------------

- Port to Dune/Jbuilder and Topkg.
- Add option `--all` to the `Tree.arg`.
- Fix uncaught exception in `Tree.run_global`.
:camel: Pull-request generated by opam-publish v0.3.5