### PR TITLE
Packages fstar.0.9.6.0, kremlin.0.9.6.0

### DIFF
--- a/packages/fstar/fstar.0.9.6.0/descr
+++ b/packages/fstar/fstar.0.9.6.0/descr
@@ -1,0 +1,1 @@
+An ML-like language with a type system for program verification.

--- a/packages/fstar/fstar.0.9.6.0/opam
+++ b/packages/fstar/fstar.0.9.6.0/opam
@@ -18,6 +18,7 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson"
   "process"
+  "ocaml-migrate-parsetree"
 ]
 depexts: [
   [ ["osx" "homebrew"] ["coreutils"] ]

--- a/packages/fstar/fstar.0.9.6.0/opam
+++ b/packages/fstar/fstar.0.9.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "1.2"
+version: "0.9.6.0"
+maintainer: "taramana@microsoft.com"
+authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.com>,Tahina Ramananandro <taramana@microsoft.com>"
+homepage: "http://fstar-lang.org"
+license: "Apache"
+depends: [
+  "ocamlfind"
+  "batteries"
+  "zarith"
+  "stdint"
+  "yojson"
+  "ocamlbuild" {build}
+  "fileutils"
+  "menhir" { >= "20161115" }
+  "pprint"
+  "ulex"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "process"
+]
+depexts: [
+  [ ["osx" "homebrew"] ["coreutils"] ]
+]
+build: [
+  [make "PREFIX=%{prefix}%" "-C" "src/ocaml-output"]
+  [make "PREFIX=%{prefix}%" "-C" "ulib" "install-fstarlib"]
+  [make "PREFIX=%{prefix}%" "-C" "ulib" "install-fstar-tactics"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "-C" "src/ocaml-output" "install"]
+]
+remove: [
+  [ "rm" "-rf"
+      "%{prefix}%/lib/fstar"
+      "%{prefix}%/doc/fstar"
+      "%{prefix}%/etc/fstar"
+      "%{prefix}%/bin/fstar.exe"
+      "%{prefix}%/share/fstar" ]
+  [ "ocamlfind" "remove" "fstarlib" ]
+  [ "ocamlfind" "remove" "fstar-compiler-lib" ]
+  [ "ocamlfind" "remove" "fstar-tactics-lib" ]
+]
+available: [ (ocaml-version >= "4.04.0") ]
+dev-repo: "git://github.com/FStarLang/FStar"
+bug-reports: "https://github.com/FStarLang/FStar/issues"

--- a/packages/fstar/fstar.0.9.6.0/url
+++ b/packages/fstar/fstar.0.9.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/FStarLang/FStar/archive/e4dfb79f6b8f236e3c1d93e503c05ca816366884.zip"
+checksum: "b317eb7a393a9e5bc4b3faa9704b3044"

--- a/packages/kremlin/kremlin.0.9.6.0/descr
+++ b/packages/kremlin/kremlin.0.9.6.0/descr
@@ -1,0 +1,1 @@
+A compiler from Low*, a low-level subset of F*, to C.

--- a/packages/kremlin/kremlin.0.9.6.0/opam
+++ b/packages/kremlin/kremlin.0.9.6.0/opam
@@ -16,7 +16,6 @@ depends: [
   "pprint"
   "ulex"
   "process"
-  "unix"
   "fix"
   "wasm"
   "ppx_deriving"

--- a/packages/kremlin/kremlin.0.9.6.0/opam
+++ b/packages/kremlin/kremlin.0.9.6.0/opam
@@ -21,6 +21,7 @@ depends: [
   "wasm"
   "ppx_deriving"
   "ppx_deriving_yojson"
+  "fstar"
 ]
 depexts: [
   [ ["osx" "homebrew"] ["coreutils"] ]

--- a/packages/kremlin/kremlin.0.9.6.0/opam
+++ b/packages/kremlin/kremlin.0.9.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "1.2"
+version: "0.9.6.0"
+maintainer: "protz@microsoft.com"
+authors: "Jonathan Protzenko <jonathan.protzenko@gmail.com>"
+homepage: "https://github.com/fstarlang/kremlin"
+license: "Apache"
+depends: [
+  "ocamlfind" {build}
+  "batteries"
+  "zarith"
+  "stdint"
+  "yojson"
+  "ocamlbuild" {build}
+  "fileutils"
+  "menhir" { >= "20161115" }
+  "pprint"
+  "ulex"
+  "process"
+  "unix"
+  "fix"
+  "wasm"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+]
+depexts: [
+  [ ["osx" "homebrew"] ["coreutils"] ]
+]
+build: [
+  [make "PREFIX=%{prefix}%"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [
+  [ "rm" "-rf"
+      "%{prefix}%/lib/kremlin"
+      "%{prefix}%/include/kremlin"
+      "%{prefix}%/doc/kremlin"
+      "%{prefix}%/bin/krml"
+      "%{prefix}%/share/kremlin" ]
+]
+available: [ (ocaml-version >= "4.04.0" & ocaml-version < "4.07.0") ]
+dev-repo: "git://github.com/FStarLang/kremlin"
+bug-reports: "https://github.com/FStarLang/kremlin/issues"

--- a/packages/kremlin/kremlin.0.9.6.0/opam
+++ b/packages/kremlin/kremlin.0.9.6.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ulex"
   "process"
   "fix"
+  "visitors"
   "wasm"
   "ppx_deriving"
   "ppx_deriving_yojson"

--- a/packages/kremlin/kremlin.0.9.6.0/opam
+++ b/packages/kremlin/kremlin.0.9.6.0/opam
@@ -21,7 +21,7 @@ depends: [
   "wasm"
   "ppx_deriving"
   "ppx_deriving_yojson"
-  "fstar"
+  "fstar" { >= "0.9.6.0" }
 ]
 depexts: [
   [ ["osx" "homebrew"] ["coreutils"] ]

--- a/packages/kremlin/kremlin.0.9.6.0/url
+++ b/packages/kremlin/kremlin.0.9.6.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/FStarLang/kremlin/archive/e9fedcdd446add18a38e1d1bf35c0251713b87a9.zip"
+archive: "https://github.com/FStarLang/kremlin/archive/0.9.6.0.zip"
 checksum: "8b5c5d848a4b041b86df27d824d243a0"

--- a/packages/kremlin/kremlin.0.9.6.0/url
+++ b/packages/kremlin/kremlin.0.9.6.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/FStarLang/kremlin/archive/0.9.6.0.zip"
-checksum: "9c443f454d74055fda11f00b67444b82"
+archive: "https://github.com/FStarLang/kremlin/archive/v0.9.6.0.zip"
+checksum: "6a580d0b470484db5637d593a06811be"

--- a/packages/kremlin/kremlin.0.9.6.0/url
+++ b/packages/kremlin/kremlin.0.9.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/FStarLang/kremlin/archive/867319bdca5060c89fb1a053fc175aed8da78aca.zip"
+checksum: "f7bf731ff62e9b01565c3b1c6e463c0c"

--- a/packages/kremlin/kremlin.0.9.6.0/url
+++ b/packages/kremlin/kremlin.0.9.6.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/FStarLang/kremlin/archive/0.9.6.0.zip"
-checksum: "8b5c5d848a4b041b86df27d824d243a0"
+checksum: "9c443f454d74055fda11f00b67444b82"

--- a/packages/kremlin/kremlin.0.9.6.0/url
+++ b/packages/kremlin/kremlin.0.9.6.0/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/FStarLang/kremlin/archive/867319bdca5060c89fb1a053fc175aed8da78aca.zip"
-checksum: "f7bf731ff62e9b01565c3b1c6e463c0c"
+archive: "https://github.com/FStarLang/kremlin/archive/e9fedcdd446add18a38e1d1bf35c0251713b87a9.zip"
+checksum: "13a75c8ad793bb7d85d1cf59695d859d"

--- a/packages/kremlin/kremlin.0.9.6.0/url
+++ b/packages/kremlin/kremlin.0.9.6.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/FStarLang/kremlin/archive/e9fedcdd446add18a38e1d1bf35c0251713b87a9.zip"
-checksum: "13a75c8ad793bb7d85d1cf59695d859d"
+checksum: "8b5c5d848a4b041b86df27d824d243a0"


### PR DESCRIPTION
# New F* version: 0.9.6.0
F* is a functional programming language with dependent types, refinement types, SMT-based verification, tactics and extraction to OCaml.

Latest changes:
- Meta-F*: A metaprogramming and tactic framework, as described in this [report](https://arxiv.org/abs/1803.06547). Code samples are in examples/tactics, examples/native_tactics and the `FStar.Tactics` and `FStar.Reflection` libraries. Many people contributed a lot to this work, especially Guido Martinez.

- Improved type inference with two-phase typechecking: We now build verification conditions for a program after a first phase of type inference. This improves inference of implicit arguments and reduces our trust in the type inference. Thanks to Aseem Rastogi!

- Caching typechecked modules: F* emits ".checked" files, an on-disk representation of a typechecked module that can be read back later. This significantly reduces the time to load a module's dependences.

- Many other changes. For more info, see https://github.com/FStarLang/FStar/releases/tag/v0.9.6.0

# New package: KreMLin 0.9.6.0
KreMLin is a companion tool for F*, by @msprotz , to extract F* programs to C. To be eligible, such F* programs must fit in Low*, a low-level subset of F* supporting first-order effectful functions with non-recursive data types, while their specifications and proofs can still enjoy all F* features such as dependent types. F* comes with a library of buffers to model the C memory, thus enabling high-level verification for low-level code.

For more information:
- on this KreMLin release: https://github.com/FStarLang/kremlin/releases/tag/v0.9.6.0
- on using KreMLin: https://fstarlang.github.io/lowstar/html/
- on the theory of Low* : https://arxiv.org/abs/1703.00053
 