### PR TITLE
Package ppx_deriving_madcast.0.1

### DIFF
--- a/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/descr
+++ b/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/descr
@@ -1,0 +1,10 @@
+Library deriving cast functions based on their types.
+
+This package provides a PPX that allows to derive cast functions based
+on their types. For instance, [%madcast: ('a * string) -> ('a * int)]
+would be replaced by:
+
+    fun (x, y) ->
+      (x,
+       try int_of_string y
+       with Failure _ -> failwith "madcast: string -> int")

--- a/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
+++ b/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
@@ -14,4 +14,5 @@ depends: [
   "ppx_tools"
   "ppxfind" {build}
   "jbuilder" {build}
+  "ocamlfind" {test}
 ]

--- a/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
+++ b/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Niols <niols@niols.fr>"
+authors: ["Niols <niols@niols.fr>" "Kerl <kerl@wkerl.me>"]
+homepage: "https://github.com/Niols/ppx_deriving_madcast"
+bug-reports: "https://github.com/Niols/ppx_deriving_madcast/issues"
+license: "LGPL3"
+tags: "syntax"
+dev-repo: "git://github.com/Niols/ppx_deriving_madcast.git"
+build: [make]
+build-test: [make "test"]
+available: [ocaml-version >= "4.04.0"]
+depends: ["ppx_deriving" "ppx_tools" "ppxfind" "jbuilder"]

--- a/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
+++ b/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
@@ -6,7 +6,12 @@ bug-reports: "https://github.com/Niols/ppx_deriving_madcast/issues"
 license: "LGPL3"
 tags: "syntax"
 dev-repo: "git://github.com/Niols/ppx_deriving_madcast.git"
-build: [make]
+build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: [make "test"]
 available: [ocaml-version >= "4.04.0"]
-depends: ["ppx_deriving" "ppx_tools" "ppxfind" "jbuilder"]
+depends: [
+  "ppx_deriving"
+  "ppx_tools"
+  "ppxfind" {build}
+  "jbuilder" {build}
+]

--- a/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/url
+++ b/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Niols/ppx_deriving_madcast/archive/v0.1.tar.gz"
+checksum: "312d4fcb58029810900c50c7cb9cfe69"


### PR DESCRIPTION
### `ppx_deriving_madcast.0.1`

Library deriving cast functions based on their types.

This package provides a PPX that allows to derive cast functions based
on their types. For instance, [%madcast: ('a * string) -> ('a * int)]
would be replaced by:

    fun (x, y) ->
      (x,
       try int_of_string y
       with Failure _ -> failwith "madcast: string -> int")



---
* Homepage: https://github.com/Niols/ppx_deriving_madcast
* Source repo: git://github.com/Niols/ppx_deriving_madcast.git
* Bug tracker: https://github.com/Niols/ppx_deriving_madcast/issues

---

:camel: Pull-request generated by opam-publish v0.3.5