### PR TITLE
conf-pkg-config: Install pkg-config symlink on OpenBSD

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.1.1/descr
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/descr
@@ -1,0 +1,3 @@
+Virtual package relying on pkg-config installation.
+This package can only install if the pkg-config package is installed
+on the system.

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -8,6 +8,15 @@ license: "GPL"
 build: [
   ["pkg-config" "--help"]
 ]
+install: [
+  ["ln" "-s" "/usr/local/bin/pkgconf" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+remove: [
+  ["rm" "-f" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+post-messages: [
+  "conf-pkg-config: A symlink to /usr/local/bin/pkgconf has been installed in the OPAM bin directory (%{bin}%) on your PATH as 'pkg-config'. This is necessary for correct operation." {os = "openbsd"}
+]
 depexts: [
   [["debian"] ["pkg-config"]]
   [["ubuntu"] ["pkg-config"]]
@@ -23,4 +32,3 @@ depexts: [
   [["osx" "homebrew"] ["pkg-config"]]
   [["freebsd"] ["pkgconf"]]
 ]
-available: [ os != "openbsd" ]


### PR DESCRIPTION
I'm submitting this as a version 1.1 of `conf-pkg-config` since that seems like the right thing to do for this "meta" package.

From the commit:

> The /usr/bin/pkg-config provided by OpenBSD does not support ${pcfiledir}, which breaks .pc files used by MirageOS. Unlike FreeBSD, installing devel/pkgconf does not install a binary called "pkg-config", so we add a symlink to it in the OPAM "bin" directory at package installation time.
> 
> We also inform the user, since this will change the pkg-config binary on their PATH.

Tested on OpenBSD current with OPAM 2 (including `opam lint`), all seems to work as expected.

/cc @hannesm @adamsteen Solo5/solo5#226