### PR TITLE
Revert "Use Lwt 2.4.3 GitHub archive"

### DIFF
--- a/packages/lwt/lwt.2.4.3/url
+++ b/packages/lwt/lwt.2.4.3/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/ocsigen/lwt/archive/2.4.3.tar.gz"
-checksum: "b487fd835d3587d4f198b7a3953ff7dd"
+archive: "http://ocsigen.org/download/lwt-2.4.3.tar.gz"
+checksum: "4a4a22da7da4301c6282f361edd0c241"


### PR DESCRIPTION
Reverts ocaml/opam-repository#11793.

<p>
The Lwt 2.4.3 archive on ocsigen.org is now back online, so I propose we switch back to using it. We were using the Lwt 2.4.3 git tag since #11793. The ocsigen.org archive is a known-working release, while the git tag might have problems due to not generating the OASIS-generated build system correctly, for example.  

<p>
See https://github.com/ocsigen/lwt/issues/589#issuecomment-389113679. I'm also going to download all the ocsigen.org archives, and attach them to the GitHub releases, so that we have a backup.

<p>
cc @hannesm @mseri