### PR TITLE
osc < 0.1.4 is not compatible with safe-string

### DIFF
--- a/packages/osc/osc.0.1.0/opam
+++ b/packages/osc/osc.0.1.0/opam
@@ -25,3 +25,4 @@ depends: [
   "rresult"
 ]
 depopts: ["lwt"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/osc/osc.0.1.1/opam
+++ b/packages/osc/osc.0.1.1/opam
@@ -25,3 +25,4 @@ depends: [
   "rresult"
 ]
 depopts: ["lwt"]
+available: [ ocaml-version < "4.06.0" ]


### PR DESCRIPTION
discovered by revdeps build in https://github.com/ocaml/opam-repository/pull/12019