### PR TITLE
Package fftw3.0.8.1

### DIFF
--- a/packages/fftw3/fftw3.0.8.1/descr
+++ b/packages/fftw3/fftw3.0.8.1/descr
@@ -1,0 +1,1 @@
+Binding to the famous Fast Fourier Transform library FFTW

--- a/packages/fftw3/fftw3.0.8.1/opam
+++ b/packages/fftw3/fftw3.0.8.1/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+maintainer: "Christophe.Troestler@umons.ac.be"
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/fftw-ocaml"
+dev-repo: "https://github.com/Chris00/fftw-ocaml.git"
+bug-reports: "https://github.com/Chris00/fftw-ocaml/issues"
+doc: "https://Chris00.github.io/fftw-ocaml/doc"
+tags: ["FFT"]
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ] { os != "darwin" }
+  [ "env" "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
+    "jbuilder" "build" "-p" name "-j" jobs ] { os = "darwin" }
+]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+depends: [
+  "jbuilder" {build}
+  "cppo"     {build}
+  "configurator" {build}
+  "base"     {build}
+  "stdio"    {build}
+  "lacaml" {test}
+]
+available: [ ocaml-version >= "4.03.0" ]
+depexts: [
+  [ [ "ubuntu"  ] [ "libfftw3-dev" ] ]
+  [ [ "debian"  ] [ "libfftw3-dev" ] ]
+  [ [ "centos"  ] [ "fftw-devel" ] ]
+  [ [ "alpine"  ] [ "fftw-dev" ] ]
+  [ [ "fedora"  ] [ "fftw-devel" ] ]
+  [ [ "rhel"    ] [ "fftw-devel" ] ]
+  [ [ "mageia"  ] [ "libfftw-devel" ] ]
+  [ [ "opensuse" ] [ "fftw3-devel" ] ]
+  [ [ "freebsd" ] [ "math/fftw3" ] ]
+  [ [ "openbsd" ] [ "math/fftw3" ] ]
+  [ [ "osx" "homebrew" ] [ "fftw" ] ]
+]

--- a/packages/fftw3/fftw3.0.8.1/url
+++ b/packages/fftw3/fftw3.0.8.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/fftw-ocaml/releases/download/0.8.1/fftw3-0.8.1.tbz"
+checksum: "cdf13311128b1514838e803e2725761d"


### PR DESCRIPTION
### `fftw3.0.8.1`

Binding to the famous Fast Fourier Transform library FFTW



---
* Homepage: https://github.com/Chris00/fftw-ocaml
* Source repo: https://github.com/Chris00/fftw-ocaml.git
* Bug tracker: https://github.com/Chris00/fftw-ocaml/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
0.8.1 2018-05-22
----------------

- Fix documentation (issue #11).
- Add bigarray dependency.
:camel: Pull-request generated by opam-publish v0.3.5