### PR TITLE
Package electrod.0.1.7

### DIFF
--- a/packages/electrod/electrod.0.1.7/descr
+++ b/packages/electrod/electrod.0.1.7/descr
@@ -1,0 +1,40 @@
+Formal analysis for the Electrod formal specification language
+
+
+Electrod is a model finder inspired by Kodkod. It takes as input a
+model expressed in a mixture of relational first-order logic (RFOL)
+over bounded domains and linear temporal logic (LTL) over an unbounded
+time horizon.
+
+Then Electrod compiles the model to a problem for a solver (currently
+the NuSMV and nuXmv tools) to produce example or counter-example traces.
+
+Electrod is mainly meant to be used as a backend for the Electrum Analyzer.
+
+See the file [INSTALL.md](INSTALL.md) for building and installation instructions.
+
+[Home page](https://forge.onera.fr/projects/electrod)
+
+## External dependencies
+
+As of now, Electrod relies on NuSMV or nuXmv (default), so you must at least
+install one of them.
+
+## Running
+
+Electrod is primarily aimed at being called by external, more abstract
+tools, such as the [Electrum Analyzer](https://github.com/haslab/Electrum).
+
+However, it can also be run as a standalone tool by calling the
+`electrod` program.
+
+Type `electrod --help` to get some help on options.
+
+
+## Copyright and license
+
+(C) 2016-2018 ONERA
+
+electrod is distributed under the terms of the Mozilla Public License v2.0.
+
+See [LICENSES.md](LICENSES.md) for more information.

--- a/packages/electrod/electrod.0.1.7/opam
+++ b/packages/electrod/electrod.0.1.7/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "David Chemouil <david.chemouil+git@onera.fr>"
+authors: ["David Chemouil" "Julien Brunel"]
+homepage: "https://github.com/grayswandyr/electrod/"
+bug-reports: "https://github.com/grayswandyr/electrod/issues"
+license: "MPL-2.0"
+dev-repo: "https://github.com/grayswandyr/electrod.git"
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >="1.0+beta20"}
+  "ppxfind" {build} 
+  "cmdliner" { >= "1.0.2"  }
+  "containers" { >= "2.0" }
+  "fmt" 
+  "gen" 
+  "hashcons" 
+  "logs" 
+  "menhir" 
+  "mtime" 
+  "ppx_expect"
+  "ppx_inline_test"
+  "printbox"
+  "sequence" 
+  "visitors"  { >= "20180513" }
+]
+available: [ocaml-version >= "4.04"]

--- a/packages/electrod/electrod.0.1.7/url
+++ b/packages/electrod/electrod.0.1.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/grayswandyr/electrod/releases/download/0.1.7/electrod-0.1.7.tbz"
+checksum: "4a88e818d658569b86577905c8e9d97d"


### PR DESCRIPTION
### `electrod.0.1.7`

Formal analysis for the Electrod formal specification language


Electrod is a model finder inspired by Kodkod. It takes as input a
model expressed in a mixture of relational first-order logic (RFOL)
over bounded domains and linear temporal logic (LTL) over an unbounded
time horizon.

Then Electrod compiles the model to a problem for a solver (currently
the NuSMV and nuXmv tools) to produce example or counter-example traces.

Electrod is mainly meant to be used as a backend for the Electrum Analyzer.

See the file [INSTALL.md](INSTALL.md) for building and installation instructions.

[Home page](https://forge.onera.fr/projects/electrod)

## External dependencies

As of now, Electrod relies on NuSMV or nuXmv (default), so you must at least
install one of them.

## Running

Electrod is primarily aimed at being called by external, more abstract
tools, such as the [Electrum Analyzer](https://github.com/haslab/Electrum).

However, it can also be run as a standalone tool by calling the
`electrod` program.

Type `electrod --help` to get some help on options.


## Copyright and license

(C) 2016-2018 ONERA

electrod is distributed under the terms of the Mozilla Public License v2.0.

See [LICENSES.md](LICENSES.md) for more information.


---
* Homepage: https://github.com/grayswandyr/electrod/
* Source repo: https://github.com/grayswandyr/electrod.git
* Bug tracker: https://github.com/grayswandyr/electrod/issues

---


---
### 0.1.7 (2018-05-23)
- remove ocamlfind from dependencies
- handle child termination
:camel: Pull-request generated by opam-publish v0.3.5