### PR TITLE
functory: new release 0.6

### DIFF
--- a/packages/functory/functory.0.5/opam
+++ b/packages/functory/functory.0.5/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "roberto@dicosmo.org"
 authors: [
   "Jean-Christophe Filliâtre"

--- a/packages/functory/functory.0.6/descr
+++ b/packages/functory/functory.0.6/descr
@@ -1,0 +1,1 @@
+Distributed computing library.

--- a/packages/functory/functory.0.6/opam
+++ b/packages/functory/functory.0.6/opam
@@ -13,4 +13,4 @@ build: [
 remove: [["ocamlfind" "remove" "functory"]]
 depends: ["ocamlfind"]
 install: [make "ocamlfind-install"]
-available: [ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/functory/functory.0.6/opam
+++ b/packages/functory/functory.0.6/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "roberto@dicosmo.org"
 authors: [
   "Jean-Christophe Filliâtre"

--- a/packages/functory/functory.0.6/url
+++ b/packages/functory/functory.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://www.lri.fr/~filliatr/functory/download/functory-0.6.tar.gz"
+checksum: "0dd4a8ce7f2c8f293686a7df5c307477"


### PR DESCRIPTION
fixed compilation with OCaml 4.06
fixed OCaml version for package functory 0.5 as well