### PR TITLE
Package opam-lock.0.1

### DIFF
--- a/packages/opam-lock/opam-lock.0.1/opam
+++ b/packages/opam-lock/opam-lock.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Locking of development package definition dependency versions"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/AltGr/opam-lock"
+bug-reports: "https://github.com/AltGr/opam-lock/issues"
+dev-repo: "git+https://github.com/AltGr/opam-lock.git"
+depends: [
+  "cmdliner" {>= "1.0"}
+  "opam-solver" {>= "2.0.0~beta5"}
+  "opam-state" {>= "2.0.0~beta5"}
+]
+build: ["jbuilder" "build" "-p" name]
+flags: plugin
+url {
+  src: "https://github.com/AltGr/opam-lock/archive/0.1.tar.gz"
+  checksum: [
+    "md5=1bf7274b168efe282b001d9d9c542f98"
+    "sha512=512550885e6084f6083f624be87be1cb7c81194cdeb8780991b633766980b024cffa3fcd45102d879a19237fe4db51ee7320e7a39fec984e80ded87e095615e0"
+  ]
+}


### PR DESCRIPTION
### `opam-lock.0.1`
Locking of development package definition dependency versions



---
* Homepage: https://github.com/AltGr/opam-lock
* Source repo: git+https://github.com/AltGr/opam-lock.git
* Bug tracker: https://github.com/AltGr/opam-lock/issues

---
:camel: Pull-request generated by opam-publish v2.0.0~beta