### PR TITLE
Package ocp-indent-nlfork.1.5.3

### DIFF
--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.3/descr
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.3/descr
@@ -1,0 +1,10 @@
+ocp-indent library, "newline tokens" fork
+
+This is a modified version of the ocp-indent library, which is based on a
+different lexer, using newline tokens and banning multi-line ones, which is more
+convenient for some applications.
+
+The library is exported as `ocp-indent-nlfork`, so as not to interfere with
+canonical ocp-indent installations.
+
+This package does *not* install an ocp-indent binary or related tools.

--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.3/opam
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.3/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "contact@ocamlpro.com"
+authors: [
+  "Grégoire Henry <gregoire.henry@ocamlpro.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "https://github.com/OCamlPro/ocp-indent.git#nlfork"
+build: [
+  ["./configure" "--prefix" prefix]
+  ["ocp-build" "init"]
+  ["ocp-build" "make" "ocp-indent-nlfork.lib" "ocp-indent-nlfork.lib"]
+]
+depends: [
+  "ocp-build" {build & >= "1.99.6-beta"}
+  "cmdliner" {>= "1.0.0"}
+]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.3/url
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocp-indent/archive/nlfork-1.5.3.tar.gz"
+checksum: "64f2261e65f5e182b7595392af0fad48"


### PR DESCRIPTION
### `ocp-indent-nlfork.1.5.3`

ocp-indent library, "newline tokens" fork

This is a modified version of the ocp-indent library, which is based on a
different lexer, using newline tokens and banning multi-line ones, which is more
convenient for some applications.

The library is exported as `ocp-indent-nlfork`, so as not to interfere with
canonical ocp-indent installations.

This package does *not* install an ocp-indent binary or related tools.



---
* Homepage: http://www.typerex.org/ocp-indent.html
* Source repo: https://github.com/OCamlPro/ocp-indent.git#nlfork
* Bug tracker: https://github.com/OCamlPro/ocp-indent/issues

---

:camel: Pull-request generated by opam-publish v0.3.5