### PR TITLE
Caqti 0.11.0.

### DIFF
--- a/packages/caqti-async/caqti-async.0.10.2/opam
+++ b/packages/caqti-async/caqti-async.0.10.2/opam
@@ -12,9 +12,9 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "async" {>= "v0.11.0"}
-  "caqti" {>= "0.10.2"}
-  "caqti-dynload" {test & >= "0.10.2"}
-  "caqti-driver-sqlite3" {test & >= "0.10.2"}
+  "caqti" {= "0.10.2"}
+  "caqti-dynload" {test & = "0.10.2"}
+  "caqti-driver-sqlite3" {test & = "0.10.2"}
   "core"
   "jbuilder" {build & >= "1.0+beta19"}
 ]

--- a/packages/caqti-async/caqti-async.0.11.0/descr
+++ b/packages/caqti-async/caqti-async.0.11.0/descr
@@ -1,0 +1,1 @@
+Async support for Caqti

--- a/packages/caqti-async/caqti-async.0.11.0/opam
+++ b/packages/caqti-async/caqti-async.0.11.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
-name: "caqti-type-calendar"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti-async"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
@@ -11,7 +11,10 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.10.2"}
-  "calendar"
+  "async" {>= "v0.11.0"}
+  "caqti" {= "0.11.0"}
+  "caqti-dynload" {test & = "0.11.0"}
+  "caqti-driver-sqlite3" {test & = "0.11.0"}
+  "core"
   "jbuilder" {build & >= "1.0+beta19"}
 ]

--- a/packages/caqti-async/caqti-async.0.11.0/url
+++ b/packages/caqti-async/caqti-async.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"

--- a/packages/caqti-async/caqti-async.0.9.0/opam
+++ b/packages/caqti-async/caqti-async.0.9.0/opam
@@ -12,7 +12,6 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "async" {>= "v0.10.0"}
   "core"
-  "caqti"
+  "caqti" {= "0.9.0"}
   "jbuilder" {build}
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {>= "0.10.2"}
+  "caqti" {= "0.10.2"}
   "jbuilder" {build & >= "1.0+beta19"}
   "mariadb" {>= "0.10"}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/descr
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/descr
@@ -1,0 +1,1 @@
+MariaDB driver for Caqti using C bindings

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/opam
@@ -1,16 +1,17 @@
 opam-version: "1.2"
-name: "caqti-lwt"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti-driver-mariadb"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.9.0"}
-  "jbuilder" {build}
-  "lwt" {< "4.0.0"}
+  "caqti" {= "0.11.0"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "mariadb" {>= "0.10"}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/url
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
@@ -10,8 +10,7 @@ license: "LGPL-3 with OCaml linking exception"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
+  "caqti" {= "0.9.0"}
   "jbuilder" {build}
   "mariadb" {>= "0.10"}
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.2/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {>= "0.10.2"}
+  "caqti" {= "0.10.2"}
   "jbuilder" {build & >= "1.0+beta19"}
   "postgresql"
 ]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.11.0/descr
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.11.0/descr
@@ -1,0 +1,1 @@
+PostgreSQL driver for Caqti based on C bindings

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.11.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.11.0/opam
@@ -1,16 +1,17 @@
 opam-version: "1.2"
-name: "caqti-lwt"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti-driver-postgresql"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.9.0"}
-  "jbuilder" {build}
-  "lwt" {< "4.0.0"}
+  "caqti" {= "0.11.0"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "postgresql"
 ]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.11.0/url
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.9.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.9.0/opam
@@ -10,8 +10,7 @@ license: "LGPL-3 with OCaml linking exception"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
+  "caqti" {= "0.9.0"}
   "jbuilder" {build}
   "postgresql"
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.2/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {>= "0.10.2"}
+  "caqti" {= "0.10.2"}
   "jbuilder" {build & >= "1.0+beta19"}
   "sqlite3"
 ]

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.11.0/descr
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.11.0/descr
@@ -1,0 +1,1 @@
+Sqlite3 driver for Caqti using C bindings

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.11.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.11.0/opam
@@ -1,16 +1,17 @@
 opam-version: "1.2"
-name: "caqti-lwt"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti-driver-sqlite3"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.9.0"}
-  "jbuilder" {build}
-  "lwt" {< "4.0.0"}
+  "caqti" {= "0.11.0"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "sqlite3"
 ]

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.11.0/url
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.9.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.9.0/opam
@@ -10,8 +10,7 @@ license: "LGPL-3 with OCaml linking exception"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
+  "caqti" {= "0.9.0"}
   "jbuilder" {build}
   "sqlite3"
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-dynload/caqti-dynload.0.10.2/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.2/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {>= "0.10.2"}
+  "caqti" {= "0.10.2"}
   "jbuilder" {build & >= "1.0+beta19"}
   "ocamlfind"
   "ppx_driver"

--- a/packages/caqti-dynload/caqti-dynload.0.11.0/descr
+++ b/packages/caqti-dynload/caqti-dynload.0.11.0/descr
@@ -1,0 +1,10 @@
+Dynamic linking of Caqti drivers using findlib.dynload.
+
+This library registers a dynamic linker which will be called when
+encoutering an unhandled database URI.  It tries to load a findlib package
+named "caqti-driver-<scheme>" where "<scheme>" is the scheme of the URI,
+which is expected register a driver for the scheme.
+
+This is a separate package to avoid the dependency on the findlib.dynload
+for architectures, like MirageOS, where dynamic linking may be unavailable.
+The alternative is to link drivers directly into the application.

--- a/packages/caqti-dynload/caqti-dynload.0.11.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.11.0/opam
@@ -1,16 +1,18 @@
 opam-version: "1.2"
-name: "caqti-lwt"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti-dynload"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.9.0"}
-  "jbuilder" {build}
-  "lwt" {< "4.0.0"}
+  "caqti" {= "0.11.0"}
+  "jbuilder" {build & >= "1.0+beta19"}
+  "ocamlfind"
 ]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/caqti-dynload/caqti-dynload.0.11.0/url
+++ b/packages/caqti-dynload/caqti-dynload.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"

--- a/packages/caqti-dynload/caqti-dynload.0.9.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.9.0/opam
@@ -10,10 +10,9 @@ license: "LGPL-3 with OCaml linking exception"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
+  "caqti" {= "0.9.0"}
   "jbuilder" {build}
   "ocamlfind"
   "ppx_optcomp" { >= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"
 ]
-conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/caqti-lwt/caqti-lwt.0.10.2/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.10.2/opam
@@ -11,9 +11,9 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {>= "0.10.2"}
-  "caqti-dynload" {test & >= "0.10.2"}
-  "caqti-driver-sqlite3" {test & >= "0.10.2"}
+  "caqti" {= "0.10.2"}
+  "caqti-dynload" {test & = "0.10.2"}
+  "caqti-driver-sqlite3" {test & = "0.10.2"}
   "jbuilder" {build & >= "1.0+beta19"}
   "lwt" {< "4.0.0"}
 ]

--- a/packages/caqti-lwt/caqti-lwt.0.11.0/descr
+++ b/packages/caqti-lwt/caqti-lwt.0.11.0/descr
@@ -1,0 +1,1 @@
+Lwt support for Caqti

--- a/packages/caqti-lwt/caqti-lwt.0.11.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.11.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
-name: "caqti-type-calendar"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti-lwt"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
@@ -11,7 +11,10 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.10.2"}
-  "calendar"
+  "caqti" {= "0.11.0"}
+  "caqti-dynload" {test & = "0.11.0"}
+  "caqti-driver-sqlite3" {test & = "0.11.0"}
   "jbuilder" {build & >= "1.0+beta19"}
+  "logs"
+  "lwt" {>= "3.2.0"}
 ]

--- a/packages/caqti-lwt/caqti-lwt.0.11.0/url
+++ b/packages/caqti-lwt/caqti-lwt.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/descr
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/descr
@@ -1,0 +1,1 @@
+Date and time field types using the calendar library.

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/opam
@@ -1,16 +1,17 @@
 opam-version: "1.2"
-name: "caqti-lwt"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti-type-calendar"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
 license: "LGPL-3 with OCaml linking exception"
 
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.9.0"}
-  "jbuilder" {build}
-  "lwt" {< "4.0.0"}
+  "caqti" {= "0.11.0"}
+  "calendar"
+  "jbuilder" {build & >= "1.0+beta19"}
 ]

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/url
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
@@ -10,7 +10,7 @@ license: "LGPL-3 with OCaml linking exception"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti"
+  "caqti" {= "0.9.0"}
   "calendar"
   "jbuilder" {build}
 ]

--- a/packages/caqti/caqti.0.11.0/descr
+++ b/packages/caqti/caqti.0.11.0/descr
@@ -1,0 +1,17 @@
+Unified interface to relational database libraries
+
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators.

--- a/packages/caqti/caqti.0.11.0/opam
+++ b/packages/caqti/caqti.0.11.0/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
-name: "caqti-type-calendar"
-authors: ["Petter A. Urkedal"]
-maintainer: "paurkedal@gmail.com"
+name: "caqti"
+author: "Petter A. Urkedal <paurkedal@gmail.com>"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 dev-repo: "https://github.com/paurkedal/ocaml-caqti.git"
@@ -11,7 +11,10 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "caqti" {= "0.10.2"}
-  "calendar"
   "jbuilder" {build & >= "1.0+beta19"}
+  "logs"
+  "ocamlfind" {build}
+  "ptime"
+  "uri" {>= "1.9.0"}
 ]
+available: [ocaml-version >= "4.04.0"]

--- a/packages/caqti/caqti.0.11.0/url
+++ b/packages/caqti/caqti.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ocaml-caqti/releases/download/v0.11.0/caqti-0.11.0.tbz"
+checksum: "f749fd41e5c20d20a315f257f6ec7128"


### PR DESCRIPTION
## Change Log for 0.11.0

Added and improved:

- Compliance with Lwt 4.0 contributed by Brendan Long.
- Switched to the logs library for logging.
- Strengthen detection of concurrent use of connection.
- Support microsecond precision for timestamps for PostgreSQL and
  millisecond for Sqlite3.
- Use float for time spans in Sqlite3.
- Map the `octets` type to BLOBs for MariaDB and Sqlite3.
- Log recoverable errors for MariaDB and Sqlite3.

Removed:

- The v1 API is now removed.

Ecosystem:

- CI setup contributed by Brendan Long.
- Various documentation updates.
