### PR TITLE
mirage-block-solo5: fix minimal bound on mirage-types

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
@@ -18,6 +18,6 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
-  "mirage-types" {>= "1.1.0" & < "3.0.0"}
+  "mirage-types" {>= "2.3.0" & < "3.0.0"}
   "mirage-solo5"
 ]


### PR DESCRIPTION
Please do not merge if any revdeps are failing.