### PR TITLE
tcpip>=3.2.0 uses ppx_cstruct

### DIFF
--- a/packages/tcpip/tcpip.3.2.0/opam
+++ b/packages/tcpip/tcpip.3.2.0/opam
@@ -22,6 +22,7 @@ build-test: [
 depends: [
   "jbuilder" {build & >= "1.0+beta9" & < "1.0+beta18"}
   "configurator" {build}
+  "ppx_cstruct"
   "rresult"
   "cstruct" {>= "3.0.2"}
   "cstruct-lwt"

--- a/packages/tcpip/tcpip.3.3.0/opam
+++ b/packages/tcpip/tcpip.3.3.0/opam
@@ -22,6 +22,7 @@ build-test: [
 depends: [
   "jbuilder"     {build & >="1.0+beta10" & < "1.0+beta18"}
   "configurator" {build}
+  "ppx_cstruct"
   "rresult"
   "cstruct" {>= "3.0.2"}
   "cstruct-lwt"

--- a/packages/tcpip/tcpip.3.3.1/opam
+++ b/packages/tcpip/tcpip.3.3.1/opam
@@ -22,6 +22,7 @@ build-test: [
 depends: [
   "jbuilder"     {build & >="1.0+beta10" & < "1.0+beta18"}
   "configurator" {build}
+  "ppx_cstruct"
   "rresult"
   "cstruct" {>= "3.0.2"}
   "cstruct-lwt"

--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -22,6 +22,7 @@ build-test: [
 depends: [
   "jbuilder"     {build & >="1.0+beta10" & < "1.0+beta18"}
   "configurator" {build}
+  "ppx_cstruct"
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.0.2"}
   "cstruct-lwt"

--- a/packages/tcpip/tcpip.3.4.1/opam
+++ b/packages/tcpip/tcpip.3.4.1/opam
@@ -22,6 +22,7 @@ build-test: [
 depends: [
   "jbuilder"     {build & >="1.0+beta10"}
   "configurator" {build}
+  "ppx_cstruct"
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.0.2"}
   "cstruct-lwt"


### PR DESCRIPTION
Following the discussion on #12013 I haven't added `build` to the ppx dependency. No idea is that's the right thing to do, but ppx experts seem to say so, so let's trust them :-)