### PR TITLE
lbfgs: not available on 4.06 (safe-string) and fix the version of oas…

### DIFF
--- a/packages/lbfgs/lbfgs.0.8.3/opam
+++ b/packages/lbfgs/lbfgs.0.8.3/opam
@@ -15,7 +15,7 @@ remove: [["ocamlfind" "remove" "lbfgs"]]
 depends: [
   "camlp4" {build}
   "ocamlfind"
-  "oasis" {>= "0.4.6"}
+  "oasis" {= "0.4.6"}
   "ocamlbuild" {build}
 ]
 depopts: ["lacaml"]
@@ -30,3 +30,4 @@ depexts: [
   [["osx" "homebrew"] ["gcc"]]
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/lbfgs/lbfgs.0.8.6/opam
+++ b/packages/lbfgs/lbfgs.0.8.6/opam
@@ -32,3 +32,4 @@ depexts: [
   [["osx" "homebrew"] ["gcc"]]
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/lbfgs/lbfgs.0.8.7/opam
+++ b/packages/lbfgs/lbfgs.0.8.7/opam
@@ -39,3 +39,4 @@ depexts: [
   [["cygwin"] ["mingw64-x86_64-gcc-fortran"]]
   [["osx" "homebrew"] ["gcc"]]
 ]
+available: [ocaml-version < "4.06.0"]

--- a/packages/lbfgs/lbfgs.0.8.8/opam
+++ b/packages/lbfgs/lbfgs.0.8.8/opam
@@ -37,3 +37,4 @@ depexts: [
   [["cygwin"] ["mingw64-x86_64-gcc-fortran"]]
   [["osx" "homebrew"] ["gcc"]]
 ]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
…is to use

/cc @Chris00 