### PR TITLE
Nocrypto patches for compatibility with sexplib/ppx_sexp_conv > v0.11.0

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/descr
+++ b/packages/nocrypto/nocrypto.0.5.4-1/descr
@@ -1,0 +1,9 @@
+Simpler crypto
+
+
+nocrypto is a small cryptographic library that puts emphasis on the applicative
+style and ease of use. It includes basic ciphers (AES, 3DES, RC4), hashes (MD5,
+SHA1, SHA2), public-key primitives (RSA, DSA, DH) and a strong RNG (Fortuna).
+
+RSA timing attacks are countered by blinding. AES timing attacks are avoided by
+delegating to AES-NI.

--- a/packages/nocrypto/nocrypto.0.5.4-1/files/0002-add-missing-runtime-dependencies-in-_tags.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-1/files/0002-add-missing-runtime-dependencies-in-_tags.patch
@@ -1,0 +1,47 @@
+From cad7cfe15ae8eca95c4e284f3a679c35842659f2 Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Mon, 26 Mar 2018 16:09:16 +0200
+Subject: [PATCH 2/6] add missing runtime dependencies in _tags
+
+Binaries in <bench/*>, <tests/*> depend on ppx_sexp_conv's runtime
+library within ppx_sexp_conv.
+
+The packed modules <src/nocrypto.cm{x,o}> also depend on the package
+ppx_sexp_conv: its presence at pack-creation time influences the
+generated .cmi interface, see
+
+  https://github.com/ocaml/opam-repository/pull/11628#issuecomment-375697444
+
+Note: the package ppx_sexp_conv.runtime-lib would suffice, but it is
+only available as such under recent ppx_sexp_conv versions, so its
+explicit use would make the build description (needlessly)
+incompatible with older ppx_sexp_conv versions.
+---
+ _tags | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/_tags b/_tags
+index 6d4e7de..c2a6610 100644
+--- a/_tags
++++ b/_tags
+@@ -7,6 +7,7 @@ true: package(bytes), package(cstruct)
+ <src/*.ml{,i}>: package(zarith), package(sexplib), package(ppx_sexp_conv)
+ <src/*.cm{x,o}> and not <src/nocrypto.cmx>: for-pack(Nocrypto)
+ <src/*.cm{,x}a>: link_stubs(src/libnocrypto_stubs)
++<src/nocrypto.cm{x,o}>: package(ppx_sexp_conv)
+ 
+ <unix>: include
+ <unix/*.ml{,i}>: package(unix), package(bytes)
+@@ -19,7 +20,7 @@ true: package(bytes), package(cstruct)
+ 
+ <**/*.c>: ccopt(--std=c99 -Wall -Wextra -O3)
+ 
+-<bench/*>: use_nocrypto, package(zarith), package(cstruct.unix)
+-<tests/*>: use_nocrypto, package(zarith), package(oUnit)
++<bench/*>: use_nocrypto, package(zarith), package(ppx_sexp_conv)
++<tests/*>: use_nocrypto, package(zarith), package(ppx_sexp_conv), package(oUnit)
+ 
+ <rondom>: -traverse
+-- 
+2.17.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-1/files/0004-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-1/files/0004-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch
@@ -1,0 +1,39 @@
+From 55fbc3531afde59ba34cde1c14d99704439756e6 Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Tue, 27 Mar 2018 12:00:23 +0200
+Subject: [PATCH 4/6] add ppx_sexp_conv as a runtime dependency in the
+ packaging metadata
+
+---
+ opam     | 2 +-
+ pkg/META | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/opam b/opam
+index ad1dbc7..c35570b 100644
+--- a/opam
++++ b/opam
+@@ -20,7 +20,7 @@ depends: [
+   "topkg" {build}
+   "cpuid" {build}
+   "ocb-stubblr" {build}
+-  "ppx_sexp_conv" {build}
++  "ppx_sexp_conv"
+   "oUnit" {test}
+   "cstruct"
+   "zarith"
+diff --git a/pkg/META b/pkg/META
+index 242b2bb..a7929c7 100644
+--- a/pkg/META
++++ b/pkg/META
+@@ -1,6 +1,6 @@
+ version = "%%VERSION_NUM%%"
+ description = "Simple crypto for the modern age"
+-requires = "cstruct zarith sexplib"
++requires = "cstruct zarith sexplib ppx_sexp_conv"
+ archive(byte) = "nocrypto.cma"
+ archive(native) = "nocrypto.cmxa"
+ plugin(byte) = "nocrypto.cma"
+-- 
+2.17.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-1/files/0005-Auto-detect-ppx_sexp_conv-runtime-library.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-1/files/0005-Auto-detect-ppx_sexp_conv-runtime-library.patch
@@ -1,0 +1,61 @@
+From 25e1206eb1b173acdfc7312d072e0583327c4ac0 Mon Sep 17 00:00:00 2001
+From: Jeremie Dimino <jeremie@dimino.org>
+Date: Fri, 11 May 2018 15:44:47 +0200
+Subject: [PATCH 5/6] Auto-detect ppx_sexp_conv runtime library
+
+---
+ myocamlbuild.ml       | 25 ++++++++++++++++++++++---
+ pkg/{META => META.in} |  2 +-
+ 2 files changed, 23 insertions(+), 4 deletions(-)
+ rename pkg/{META => META.in} (95%)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 2752315..7b29635 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -1,5 +1,24 @@
+ open Ocamlbuild_plugin
+ 
+-let () = dispatch Ocb_stubblr.(
+-  init & ccopt ~tags:["accelerate"] "-DACCELERATE -msse2 -maes"
+-)
++let runtime_deps_of_ppx ppx =
++  (Findlib.query "ppx_sexp_conv").dependencies
++  |> List.filter_opt (fun { Findlib.name; _ } ->
++      if name = ppx || name = "ppx_deriving" then
++        None
++      else
++        Some name)
++
++let () = dispatch (fun hook ->
++    Ocb_stubblr.(
++      init & ccopt ~tags:["accelerate"] "-DACCELERATE -msse2 -maes"
++    ) hook;
++    match hook with
++    | After_rules ->
++      let meta = "pkg/META" in
++      let meta_in = meta ^ ".in" in
++      rule meta ~dep:meta_in ~prod:meta (fun _ _ ->
++          let deps = String.concat " " (runtime_deps_of_ppx "ppx_sexp_conv") in
++          Echo([String.subst "PPX_SEXP_CONV_RUNTIME" deps
++                  (Pathname.read meta_in)],
++               meta))
++    | _ -> ())
+diff --git a/pkg/META b/pkg/META.in
+similarity index 95%
+rename from pkg/META
+rename to pkg/META.in
+index a7929c7..0b263d7 100644
+--- a/pkg/META
++++ b/pkg/META.in
+@@ -1,6 +1,6 @@
+ version = "%%VERSION_NUM%%"
+ description = "Simple crypto for the modern age"
+-requires = "cstruct zarith sexplib ppx_sexp_conv"
++requires = "cstruct zarith sexplib PPX_SEXP_CONV_RUNTIME"
+ archive(byte) = "nocrypto.cma"
+ archive(native) = "nocrypto.cmxa"
+ plugin(byte) = "nocrypto.cma"
+-- 
+2.17.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-1/files/0006-pack-package-workaround-ocamlbuild-272.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-1/files/0006-pack-package-workaround-ocamlbuild-272.patch
@@ -1,0 +1,38 @@
+From 1befe5d2ab60653d1d44fa734d2b8057cf3410db Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Mon, 26 Mar 2018 16:07:45 +0200
+Subject: [PATCH 6/6] pack+package: workaround ocamlbuild#272
+
+ocamlbuild should pass -package(...) flags to ocamlfind when building
+a -pack-ed file, see
+
+  https://github.com/ocaml/opam-repository/pull/11628#issuecomment-375697444
+---
+ myocamlbuild.ml | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7b29635..7a5cdb6 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -8,9 +8,17 @@ let runtime_deps_of_ppx ppx =
+       else
+         Some name)
+ 
++let ocamlfind_and_pack = function
++  | After_rules ->
++     if !Options.use_ocamlfind then
++       pflag ["ocaml"; "pack"] "package"
++         (fun pkg -> S [A "-package"; A pkg]);
++  | _ -> ()
++
+ let () = dispatch (fun hook ->
+     Ocb_stubblr.(
+       init & ccopt ~tags:["accelerate"] "-DACCELERATE -msse2 -maes"
++      & ocamlfind_and_pack
+     ) hook;
+     match hook with
+     | After_rules ->
+-- 
+2.17.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -1,0 +1,48 @@
+opam-version: "1.2"
+homepage:     "https://github.com/mirleft/ocaml-nocrypto"
+dev-repo:     "https://github.com/mirleft/ocaml-nocrypto.git"
+bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"
+doc:          "https://mirleft.github.io/ocaml-nocrypto/doc"
+authors:      ["David Kaloper <david@numm.org>"]
+maintainer:   "David Kaloper <david@numm.org>"
+license:      "ISC"
+tags:          [ "org:mirage" ]
+available:     [ ocaml-version >= "4.02.0" ]
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+                "--jobs" "1"
+                "--with-lwt" "%{lwt:installed}%"
+                "--xen" "%{mirage-xen:installed}%"
+                "--freestanding" "%{mirage-solo5:installed}%"]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cpuid" {build}
+  "ocb-stubblr" {build}
+  "ppx_deriving" {build}
+  "ppx_sexp_conv" {>= "113.33.01" & != "v0.11.0"}
+  "ounit" {test}
+  "cstruct" {>="2.4.0"}
+  "cstruct-lwt"
+  "zarith"
+  "lwt"
+  "sexplib"
+  ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy" & "zarith-xen"))
+  ("mirage-no-solo5" | ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding"))
+]
+
+conflicts: [
+  "topkg" {<"0.9.1"}
+  "ocb-stubblr" {<"0.1.0"}
+  "mirage-xen" {<"2.2.0"}
+  "sexplib" {="v0.9.0"}
+]
+
+patches: [
+    "0002-add-missing-runtime-dependencies-in-_tags.patch"
+    "0004-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch"
+    "0005-Auto-detect-ppx_sexp_conv-runtime-library.patch"
+    "0006-pack-package-workaround-ocamlbuild-272.patch"
+]

--- a/packages/nocrypto/nocrypto.0.5.4-1/url
+++ b/packages/nocrypto/nocrypto.0.5.4-1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-nocrypto/releases/download/v0.5.4/nocrypto-0.5.4.tbz"
+checksum: "c331a7a4d2a563d1d5ed581aeb849011"


### PR DESCRIPTION
This commit submits @gasche's fixes from https://github.com/mirleft/ocaml-nocrypto/pull/144, as nocrypto's maintainers are not responsive. This fixes https://github.com/mirleft/ocaml-nocrypto/issues/143.

cc @hannesm 