### PR TITLE
Package notty_async.0.1

### DIFF
--- a/packages/notty_async/notty_async.0.1/opam
+++ b/packages/notty_async/notty_async.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "yminsky@gmail.com"
+authors: ["Yaron Minsky"]
+homepage: "https://github.com/yminsky/notty_async"
+bug-reports: "https://github.com/yminsky/notty_async/issues"
+dev-repo: "git+https://github.com/yminsky/notty_async.git"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" "notty" "async" "base"
+]
+url {
+  src: "https://github.com/yminsky/notty_async/archive/0.1.tar.gz"
+  checksum: [
+    "md5=8821833d6bad64499eeb269981d8277c"
+    "sha512=5e2b4e7b4d3b1a9c9b1275d56b792965b267e80f341a4a7e56c522d73209e683819666fc9776491df8fe7f32c336f115f30234b84ceb8e73674b4b1844614cc8"
+  ]
+}

--- a/packages/notty_async/notty_async.0.1/opam
+++ b/packages/notty_async/notty_async.0.1/opam
@@ -1,4 +1,4 @@
-opam-version: "2.0"
+opam-version: "1.2"
 maintainer: "yminsky@gmail.com"
 authors: ["Yaron Minsky"]
 homepage: "https://github.com/yminsky/notty_async"


### PR DESCRIPTION
### `notty_async.0.1`



---
* Homepage: https://github.com/yminsky/notty_async
* Source repo: git+https://github.com/yminsky/notty_async.git
* Bug tracker: https://github.com/yminsky/notty_async/issues

---
:camel: Pull-request generated by opam-publish v2.0.0~beta