### PR TITLE
Partial format upgrade (amf.0.1.0, ansi-parse.0.3.0, arp.0.1.1, arp.0.2.0, arp.0.2.1, ...)

### DIFF
--- a/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build}
   "js_of_ocaml-compiler" {build & >= "3.0" & < "4.0"}
-  "js_of_ocaml-ppx" {build & >= "3.0" & < "4.0"}
+  "js_of_ocaml-ppx" {>= "3.0" & < "4.0"}
   "js_of_ocaml" {>= "3.0" & < "4.0"}
   "cairo2"
 ]

--- a/packages/JsOfOCairo/JsOfOCairo.1.1.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta17"}
   "js_of_ocaml-compiler" {build & >= "3.0" & < "4.0"}
-  "js_of_ocaml-ppx" {build & >= "3.0" & < "4.0"}
+  "js_of_ocaml-ppx" {>= "3.0" & < "4.0"}
   "js_of_ocaml" {>= "3.0" & < "4.0"}
   "General" {with-test & >= "0.5.0"}
   "cairo2" {with-test & >= "0.5"}

--- a/packages/amf/amf.0.1.0/opam
+++ b/packages/amf/amf.0.1.0/opam
@@ -22,14 +22,14 @@ install: [
 remove: ["ocamlfind" "remove" "amf"]
 depends: [
   "ocaml" {>= "4.01" & < "4.06"}
-  ("oasis" {build} | "oasis-mirage" {build})
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "oasis" {build} | "oasis-mirage" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "base-threads"
-  ("core" {>= "v0.9.1"})
+  "core" {>= "v0.9.1"}
   "stdint"
   "sexplib"
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "bisect_ppx-ocamlbuild" {build}
   "ounit" {build}
 ]

--- a/packages/ansi-parse/ansi-parse.0.3.0/opam
+++ b/packages/ansi-parse/ansi-parse.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "angstrom" {< "0.2.0"}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "tyxml" {>= "4.0"}
 ]
 doc: "https://jdjakub.github.io/ansi-parse/doc"

--- a/packages/arp/arp.0.1.1/opam
+++ b/packages/arp/arp.0.1.1/opam
@@ -11,10 +11,10 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "result"
   "cstruct" {>= "2.2.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ipaddr" {>= "2.2.0"}
   "logs"
   "alcotest" {with-test}

--- a/packages/arp/arp.0.2.0/opam
+++ b/packages/arp/arp.0.2.0/opam
@@ -11,10 +11,10 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "result"
   "cstruct" {>= "2.2.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ipaddr" {>= "2.2.0"}
   "logs"
   "alcotest" {with-test}

--- a/packages/arp/arp.0.2.1/opam
+++ b/packages/arp/arp.0.2.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "cstruct" {>= "2.2.0"}
   "ipaddr" {>= "2.2.0"}
   "logs"

--- a/packages/async-zmq/async-zmq.0.3.0/opam
+++ b/packages/async-zmq/async-zmq.0.3.0/opam
@@ -18,8 +18,8 @@ depends: [
   "omake" {build}
   "core"
   "async" {< "v0.10"}
-  "ppx_sexp_conv" {build}
-  "ppx_deriving" {build}
+  "ppx_sexp_conv"
+  "ppx_deriving"
   "sexplib"
   "zmq" {< "5.0.0"}
 ]

--- a/packages/biocaml/biocaml.0.4.0/opam
+++ b/packages/biocaml/biocaml.0.4.0/opam
@@ -34,7 +34,7 @@ depends: [
   "cfstream"
   "future"
   "ppx_compare"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "re"
   "uri"

--- a/packages/biocaml/biocaml.0.5.0/opam
+++ b/packages/biocaml/biocaml.0.5.0/opam
@@ -31,7 +31,7 @@ depends: [
   "xmlm"
   "cfstream"
   "ppx_compare"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "re"
   "rresult"

--- a/packages/biocaml/biocaml.0.6.0/opam
+++ b/packages/biocaml/biocaml.0.6.0/opam
@@ -30,7 +30,7 @@ depends: [
   "xmlm"
   "cfstream"
   "ppx_compare"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "re"
   "rresult"

--- a/packages/bisect_ppx/bisect_ppx.0.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.1/opam
@@ -15,7 +15,7 @@ remove: [ "ocamlfind" "remove" "bisect_ppx" ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind"
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
 ]
 synopsis: "Bisect code coverage instrumentation via ppx."

--- a/packages/bisect_ppx/bisect_ppx.0.2.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.2/opam
@@ -15,7 +15,7 @@ remove: [ "ocamlfind" "remove" "bisect_ppx" ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind"
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
 ]
 synopsis: "Bisect code coverage instrumentation via ppx."

--- a/packages/bisect_ppx/bisect_ppx.0.2.3/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.3/opam
@@ -15,7 +15,7 @@ remove: [ "ocamlfind" "remove" "bisect_ppx" ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind"
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
 ]
 synopsis: "Bisect code coverage instrumentation via ppx."

--- a/packages/bisect_ppx/bisect_ppx.0.2.4/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.4/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind"
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
 ]
 synopsis: "Bisect code coverage instrumentation via ppx."

--- a/packages/bisect_ppx/bisect_ppx.0.2.5/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.5/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind"
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
 ]
 synopsis: "Bisect code coverage instrumentation via ppx."

--- a/packages/bisect_ppx/bisect_ppx.0.2.6/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2.6/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
 ]
 synopsis: "Bisect code coverage instrumentation via ppx."

--- a/packages/bisect_ppx/bisect_ppx.0.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.0.2/opam
@@ -15,7 +15,7 @@ remove: [ "ocamlfind" "remove" "bisect_ppx" ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind"
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
 ]
 synopsis: "Bisect code coverage instrumentation via ppx."

--- a/packages/bisect_ppx/bisect_ppx.1.0.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.0.0/opam
@@ -20,7 +20,7 @@ remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
   "ounit" {with-test}
 ]

--- a/packages/bisect_ppx/bisect_ppx.1.0.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.0.1/opam
@@ -20,7 +20,7 @@ remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.03"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ocamlbuild" {build}
   "ounit" {with-test}
 ]

--- a/packages/bisect_ppx/bisect_ppx.1.1.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.1.0/opam
@@ -20,7 +20,7 @@ remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.04.0"}
   "ocamlfind" {build}
-  "ppx_tools" {build & >= "4.02.3"}
+  "ppx_tools" {>= "4.02.3"}
   "ocamlbuild" {build}
   "ounit" {with-test}
 ]

--- a/packages/bisect_ppx/bisect_ppx.1.2.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.2.0/opam
@@ -20,7 +20,7 @@ remove: ["ocamlfind" "remove" "bisect_ppx"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
-  "ppx_tools" {build & >= "4.02.3"}
+  "ppx_tools" {>= "4.02.3"}
   "ocamlbuild" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}

--- a/packages/bitcoinml/bitcoinml.0.2.4/opam
+++ b/packages/bitcoinml/bitcoinml.0.2.4/opam
@@ -17,8 +17,8 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "base" {build & >= "v0.9.2" & < "v0.11"}
   "configurator" {build & >= "v0.9.1"}
-  "ppx_jane" {build & >= "v0.9.0"}
-  "ppx_bitstring" {build & >= "2.0.0"}
+  "ppx_jane" {>= "v0.9.0"}
+  "ppx_bitstring" {>= "2.0.0"}
   "bitstring" {>= "2.1.0"}
   "stdio" {>= "v0.9.0"}
   "bignum" {>= "v0.9.0"}

--- a/packages/bitcoinml/bitcoinml.0.2/opam
+++ b/packages/bitcoinml/bitcoinml.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "stdio" {build & >= "v0.9.0"}
   "configurator" {build & >= "v0.9.1"}
   "bitstring" {build & >= "2.1.0"}
-  "ppx_bitstring" {build & >= "2.0.0"}
+  "ppx_bitstring" {>= "2.0.0"}
   "bignum" {build & >= "v0.9.0"}
   "cryptokit" {build & >= "1.11"}
   "stdint" {build & >= "0.3.0-0"}

--- a/packages/bitcoinml/bitcoinml.0.3.0/opam
+++ b/packages/bitcoinml/bitcoinml.0.3.0/opam
@@ -15,8 +15,8 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "base" {build & >= "v0.9.2" & < "v0.11"}
   "configurator" {build & >= "v0.9.1"}
-  "ppx_jane" {build & >= "v0.9.0"}
-  "ppx_bitstring" {build & >= "2.0.0"}
+  "ppx_jane" {>= "v0.9.0"}
+  "ppx_bitstring" {>= "2.0.0"}
   "bitstring" {>= "2.1.0"}
   "stdio" {>= "v0.9.0"}
   "bignum" {>= "v0.9.0"}

--- a/packages/bitcoinml/bitcoinml.0.3.1/opam
+++ b/packages/bitcoinml/bitcoinml.0.3.1/opam
@@ -15,8 +15,8 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "base" {build & >= "v0.9.2" & < "v0.11"}
   "configurator" {build & >= "v0.9.1"}
-  "ppx_jane" {build & >= "v0.9.0"}
-  "ppx_bitstring" {build & >= "2.0.0"}
+  "ppx_jane" {>= "v0.9.0"}
+  "ppx_bitstring" {>= "2.0.0"}
   "bitstring" {>= "2.1.0"}
   "stdio" {>= "v0.9.0"}
   "bignum" {>= "v0.9.0"}

--- a/packages/bitstring/bitstring.3.0.0/opam
+++ b/packages/bitstring/bitstring.3.0.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {build & >= "1.0.5"}
   "ounit" {with-test}
 ]

--- a/packages/bookaml/bookaml.3.1/opam
+++ b/packages/bookaml/bookaml.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"
   "ocamlnet" {>= "4"}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
   "tyxml" {>= "3.4" & < "3.6"}

--- a/packages/bookaml/bookaml.4.0/opam
+++ b/packages/bookaml/bookaml.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"
   "ocamlnet" {>= "4"}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
   "tyxml"

--- a/packages/camlhighlight/camlhighlight.4.0/opam
+++ b/packages/camlhighlight/camlhighlight.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"
   "batteries" {>= "2"}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
   "tyxml" {>= "3.2" & < "3.6"}

--- a/packages/camlhighlight/camlhighlight.5.0/opam
+++ b/packages/camlhighlight/camlhighlight.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "batteries" {>= "2"}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
   "tyxml" {>= "3.6" & < "4.0"}

--- a/packages/caqti-dynload/caqti-dynload.0.10.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.0/opam
@@ -14,7 +14,7 @@ depends: [
   "caqti" {= "0.10.0"}
   "jbuilder" {build}
   "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
+  "ppx_optcomp" {>= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"
 ]
 synopsis: "Dynamic linking of Caqti drivers using findlib.dynload."

--- a/packages/caqti-dynload/caqti-dynload.0.10.1/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.1/opam
@@ -14,7 +14,7 @@ depends: [
   "caqti" {= "0.10.1"}
   "jbuilder" {build}
   "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
+  "ppx_optcomp" {>= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"
 ]
 synopsis: "Dynamic linking of Caqti drivers using findlib.dynload."

--- a/packages/caqti-dynload/caqti-dynload.0.9.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.9.0/opam
@@ -14,7 +14,7 @@ depends: [
   "caqti"
   "jbuilder" {build}
   "ocamlfind"
-  "ppx_optcomp" {build & >= "v0.9.0" & < "v0.11.0"}
+  "ppx_optcomp" {>= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"
 ]
 conflicts: ["caqti" {<"0.6.0"}]

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -14,9 +14,9 @@ build: [
 depends: [
   "ocaml" {>= "4.01"}
   "ocamlfind" {build}
-  "ppx_deriving" {build}
-  "ppx_cstruct" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_cstruct"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "cstruct-unix"

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -13,9 +13,9 @@ build: [
 depends: [
   "ocaml" {>= "4.01"}
   "ocamlfind" {build}
-  "ppx_deriving" {build}
-  "ppx_cstruct" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_cstruct"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "sexplib"

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -20,12 +20,12 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppx_tools"
   "menhir" {build}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "sexplib"
   "ipaddr" {>= "2.5.0"}
   "tcpip" {>= "3.1.0" & < "3.2.0"}

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -20,11 +20,11 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_sexp_conv"
+  "ppx_tools"
   "menhir" {build}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "sexplib"
   "ipaddr" {>= "2.5.0"}
   "tcpip" {>= "3.1.0" & < "3.2.0"}

--- a/packages/charrua-core/charrua-core.0.7/opam
+++ b/packages/charrua-core/charrua-core.0.7/opam
@@ -20,11 +20,11 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_sexp_conv"
+  "ppx_tools"
   "menhir" {build}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "sexplib"
   "ipaddr" {>= "2.5.0"}
   "tcpip" {>= "3.1.0" & < "3.2.0"}

--- a/packages/charrua-core/charrua-core.0.8/opam
+++ b/packages/charrua-core/charrua-core.0.8/opam
@@ -17,8 +17,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "jbuilder" {build & >= "1.0+beta7"}
-  "ppx_sexp_conv" {build}
-  "ppx_cstruct" {build}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
   "menhir" {build}
   "cstruct" {>= "3.0.1"}
   "sexplib"

--- a/packages/charrua-core/charrua-core.0.9/opam
+++ b/packages/charrua-core/charrua-core.0.9/opam
@@ -17,8 +17,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "jbuilder" {build & >= "1.0+beta7"}
-  "ppx_sexp_conv" {build}
-  "ppx_cstruct" {build}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
   "menhir" {build}
   "cstruct" {>= "3.0.1"}
   "sexplib"

--- a/packages/cohttp-lwt/cohttp-lwt.1.0.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.1.0.0/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "cohttp" {>= "1.0.0"}
   "lwt" {>= "2.5.0"}
 ]

--- a/packages/cohttp/cohttp.0.20.1/opam
+++ b/packages/cohttp/cohttp.0.20.1/opam
@@ -35,7 +35,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.11.0" & < "0.16.0"}
   "ppx_fields_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.20.2/opam
+++ b/packages/cohttp/cohttp.0.20.2/opam
@@ -36,7 +36,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.11.0" & < "0.16.0"}
   "ppx_fields_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.21.0/opam
+++ b/packages/cohttp/cohttp.0.21.0/opam
@@ -35,7 +35,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.11.0" & < "0.16.0"}
   "ppx_fields_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.21.1/opam
+++ b/packages/cohttp/cohttp.0.21.1/opam
@@ -36,7 +36,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.14.0" & < "0.16.0"}
   "ppx_fields_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.0.22.0/opam
+++ b/packages/cohttp/cohttp.0.22.0/opam
@@ -36,7 +36,7 @@ depends: [
   "sexplib"
   "conduit" {>= "0.14.0" & < "0.16.0"}
   "ppx_fields_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "stringext"
   "base64" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.1.0.0/opam
+++ b/packages/cohttp/cohttp.1.0.0/opam
@@ -27,8 +27,8 @@ depends: [
   "uri" {>= "1.9.0"}
   "fieldslib"
   "sexplib"
-  "ppx_fields_conv" {build & >= "v0.9.0"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "stringext"
   "base64" {>= "2.0.0"}
   "fmt" {with-test}

--- a/packages/cohttp/cohttp.1.0.2/opam
+++ b/packages/cohttp/cohttp.1.0.2/opam
@@ -28,8 +28,8 @@ depends: [
   "fieldslib"
   "sexplib"
   "ppx_type_conv" {build & >= "v0.9.1"}
-  "ppx_fields_conv" {build & >= "v0.9.0"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "stringext"
   "base64" {>= "2.0.0"}
   "fmt" {with-test}

--- a/packages/cohttp/cohttp.1.1.0/opam
+++ b/packages/cohttp/cohttp.1.1.0/opam
@@ -27,8 +27,8 @@ depends: [
   "fieldslib"
   "sexplib"
   "ppx_type_conv" {build & >= "v0.9.1"}
-  "ppx_fields_conv" {build & >= "v0.9.0"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "stringext"
   "base64" {>= "2.0.0"}
   "fmt" {with-test}

--- a/packages/conduit-async/conduit-async.1.0.0/opam
+++ b/packages/conduit-async/conduit-async.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit" {>= "1.0.0"}
   "async" {>= "v0.9.0" & < "v0.10"}
 ]

--- a/packages/conduit-async/conduit-async.1.0.3/opam
+++ b/packages/conduit-async/conduit-async.1.0.3/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit" {>= "1.0.0"}
   "async" {>= "v0.10.0" & < "v0.11"}
 ]

--- a/packages/conduit-async/conduit-async.1.1.0/opam
+++ b/packages/conduit-async/conduit-async.1.1.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit"
   "async" {>= "v0.10.0"}
 ]

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit-lwt" {>= "1.0.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit-lwt" {>= "1.0.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit-lwt" {>= "1.1.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}

--- a/packages/conduit-lwt/conduit-lwt.1.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit" {>= "1.0.0"}
   "lwt" {>= "3.0.0"}
 ]

--- a/packages/conduit-lwt/conduit-lwt.1.0.3/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit" {>= "1.0.0"}
   "lwt" {>= "3.0.0"}
 ]

--- a/packages/conduit-lwt/conduit-lwt.1.1.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "conduit" {>= "1.1.0"}
   "lwt" {>= "3.0.0"}
 ]

--- a/packages/conduit/conduit.0.12.0/opam
+++ b/packages/conduit/conduit.0.12.0/opam
@@ -16,8 +16,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & <= "113.33.04"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.13.0/opam
+++ b/packages/conduit/conduit.0.13.0/opam
@@ -16,8 +16,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & <= "113.33.04"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.0/opam
+++ b/packages/conduit/conduit.0.14.0/opam
@@ -19,8 +19,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & <= "113.33.04"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.1/opam
+++ b/packages/conduit/conduit.0.14.1/opam
@@ -19,8 +19,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & <= "113.33.04"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.2/opam
+++ b/packages/conduit/conduit.0.14.2/opam
@@ -20,8 +20,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & <= "113.33.04"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.3/opam
+++ b/packages/conduit/conduit.0.14.3/opam
@@ -20,8 +20,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.4/opam
+++ b/packages/conduit/conduit.0.14.4/opam
@@ -20,8 +20,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.14.5/opam
+++ b/packages/conduit/conduit.0.14.5/opam
@@ -20,8 +20,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.0/opam
+++ b/packages/conduit/conduit.0.15.0/opam
@@ -19,8 +19,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.1/opam
+++ b/packages/conduit/conduit.0.15.1/opam
@@ -19,8 +19,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.2/opam
+++ b/packages/conduit/conduit.0.15.2/opam
@@ -19,8 +19,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.3/opam
+++ b/packages/conduit/conduit.0.15.3/opam
@@ -19,8 +19,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & < "v0.10.0"}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.0.15.4/opam
+++ b/packages/conduit/conduit.0.15.4/opam
@@ -19,9 +19,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_driver" {build & >= "v0.9.1" & < "v0.10.0"}
-  "ppx_deriving" {build}
-  "ppx_optcomp" {build & >= "113.24.00"}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_optcomp" {>= "113.24.00"}
+  "ppx_sexp_conv"
   "sexplib"
   "stringext"
   "uri"

--- a/packages/conduit/conduit.1.0.0/opam
+++ b/packages/conduit/conduit.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "sexplib"
   "uri"
   "result"

--- a/packages/conduit/conduit.1.0.3/opam
+++ b/packages/conduit/conduit.1.0.3/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "sexplib"
   "astring"
   "uri"

--- a/packages/conduit/conduit.1.1.0/opam
+++ b/packages/conduit/conduit.1.1.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "sexplib"
   "astring"
   "uri"

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
@@ -13,12 +13,12 @@ depends: [
   "camlp5"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {build & >= "1.4"}
-  "ppx_deriving" {build & >= "4.2.1"}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
   "cmdliner"
   "sexplib"
   "ppx_driver" {build & >= "v0.10.1"}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:   [ make "-j%{jobs}%" "TARGET=native" ]
 install: [ "cp" "sertop.native" "%{bin}%/sertop" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
@@ -15,10 +15,10 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {build & >= "1.4"}
-  "ppx_deriving" {build & >= "4.2.1"}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
   "ppx_driver" {build & >= "v0.10.1"}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:    [ make "-j%{jobs}%" "TARGET=native" ]
 install: [[ "cp" "sertop.native"  "%{bin}%/sertop" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
@@ -15,10 +15,10 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {build & >= "1.4"}
-  "ppx_deriving" {build & >= "4.2.1"}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
   "ppx_driver" {build & >= "v0.10.1"}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:   [ make "-j%{jobs}%" "TARGET=native" ]
 install: [ "cp" "sertop.native" "%{bin}%/sertop" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
@@ -15,10 +15,10 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {build & >= "1.4"}
-  "ppx_deriving" {build & >= "4.2.1"}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
   "ppx_driver" {build & >= "v0.10.1"}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:    [ make "-j%{jobs}%" "TARGET=native" ]
 install: [[ "cp" "sertop.native"  "%{bin}%/sertop" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
@@ -13,12 +13,12 @@ depends: [
   "camlp5"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {build & >= "1.4"}
-  "ppx_deriving" {build & >= "4.2.1"}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
   "cmdliner"
   "sexplib"
   "ppx_driver" {build & >= "v0.10.1"}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:   [ make "-j%{jobs}%" "TARGET=native" ]
 install: [ "cp" "sertop.native" "%{bin}%/sertop" ]

--- a/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
@@ -15,8 +15,8 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {build & >= "1.4"}
-  "ppx_deriving" {build & >= "4.2.1"}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0"}
 ]
 build:    [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.1/opam
@@ -15,8 +15,8 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {build & >= "1.4"}
-  "ppx_deriving" {build & >= "4.2.1"}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0"}
 ]
 build:    [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/datakit-ci/datakit-ci.0.10.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.10.0/opam
@@ -35,7 +35,7 @@ depends: [
   "github-unix"
   "prometheus-app"
   "lwt" {>= "2.7.1"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "crunch" {build}
   "datakit" {with-test & >= "0.10.0" & < "0.11.0"}
   "irmin-unix" {with-test & >= "1.1.0"}

--- a/packages/datakit-ci/datakit-ci.0.10.1/opam
+++ b/packages/datakit-ci/datakit-ci.0.10.1/opam
@@ -35,7 +35,7 @@ depends: [
   "github-unix"
   "prometheus-app"
   "lwt" {>= "3.0.0"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "crunch" {build}
   "datakit" {with-test & >= "0.10.0" & < "0.11.0"}
   "irmin-unix" {with-test & >= "1.1.0"}

--- a/packages/datakit-ci/datakit-ci.0.11.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.11.0/opam
@@ -36,7 +36,7 @@ depends: [
   "github-unix"
   "prometheus-app"
   "lwt" {>= "3.0.0"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "crunch" {build}
   "datakit" {with-test & >= "0.11.0"}
   "irmin-unix" {with-test & >= "1.2.0"}

--- a/packages/datakit-ci/datakit-ci.0.12.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.0/opam
@@ -37,7 +37,7 @@ depends: [
   "github-unix" {>= "3.0.0"}
   "prometheus-app"
   "lwt" {>= "3.0.0"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "crunch" {build}
   "datakit" {with-test & >= "0.12.0"}
   "irmin-unix" {with-test & >= "1.2.0"}

--- a/packages/datakit-ci/datakit-ci.0.12.1/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.1/opam
@@ -37,7 +37,7 @@ depends: [
   "github-unix" {>= "3.0.0"}
   "prometheus-app"
   "lwt" {>= "3.0.0"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "crunch" {build}
   "datakit" {with-test & >= "0.12.0"}
   "irmin-unix" {with-test & >= "1.2.0"}

--- a/packages/datakit-ci/datakit-ci.0.9.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.9.0/opam
@@ -57,8 +57,8 @@ depends: [
   "github-unix"
   "prometheus-app"
   "lwt" {>= "2.7.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "crunch" {build}
   "datakit" {with-test & < "0.10.0"}
   "irmin-unix" {with-test & = "0.12.0"}

--- a/packages/dns-forward/dns-forward.0.10.0/opam
+++ b/packages/dns-forward/dns-forward.0.10.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "cstruct" {>= "3.0.0"}
   "logs" {>= "0.5.0"}
   "lwt" {>= "2.7.0"}

--- a/packages/dns-forward/dns-forward.0.7.2/opam
+++ b/packages/dns-forward/dns-forward.0.7.2/opam
@@ -17,9 +17,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_cstruct"
+  "ppx_sexp_conv"
   "cmdliner"
   "mirage-flow" {= "1.1.0"}
   "channel"

--- a/packages/dns-forward/dns-forward.0.9.0/opam
+++ b/packages/dns-forward/dns-forward.0.9.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "cstruct" {>= "3.0.0"}
   "logs" {>= "0.5.0"}
   "lwt" {>= "2.7.0"}

--- a/packages/dns/dns.0.18.0/opam
+++ b/packages/dns/dns.0.18.0/opam
@@ -52,7 +52,7 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0" & < "2.8.0"}

--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -35,7 +35,7 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0" & < "2.8.0"}

--- a/packages/dns/dns.0.19.0/opam
+++ b/packages/dns/dns.0.19.0/opam
@@ -52,8 +52,8 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct" {>= "2.0.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
-  "ppx_tools" {build}
+  "ppx_cstruct"
+  "ppx_tools"
   "re"
   "cmdliner"
   "ipaddr" {>= "2.6.0" & < "2.8.0"}

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -44,8 +44,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "ppx_cstruct" {build}
-  "ppx_deriving" {build}
+  "ppx_cstruct"
+  "ppx_deriving"
   "base-bytes"
   "cstruct" {>= "2.0.0" & < "3.0.0"}
   "re"

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -44,10 +44,10 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "base-bytes"
   "cstruct" {>= "2.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "re"
   "ipaddr" {>= "2.6.0" & < "2.8.0"}
   "uri" {>= "1.7.0" & < "1.9.4"}

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -46,10 +46,10 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "base-bytes"
   "cstruct" {>= "2.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "re"
   "ipaddr" {>= "2.6.0" & < "2.8.0"}
   "uri" {>= "1.7.0" & < "1.9.4"}

--- a/packages/dns/dns.1.0.0/opam
+++ b/packages/dns/dns.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.0.2"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "re"
   "ipaddr" {>= "2.6.0"}
   "uri" {>= "1.7.0"}

--- a/packages/dns/dns.1.0.1/opam
+++ b/packages/dns/dns.1.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.0.2"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "re"
   "ipaddr" {>= "2.6.0"}
   "uri" {>= "1.7.0"}

--- a/packages/dockerfile/dockerfile.1.3.0/opam
+++ b/packages/dockerfile/dockerfile.1.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
   "cmdliner"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.4.0/opam
+++ b/packages/dockerfile/dockerfile.1.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
   "cmdliner"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.7.0/opam
+++ b/packages/dockerfile/dockerfile.1.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
   "cmdliner"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.7.1/opam
+++ b/packages/dockerfile/dockerfile.1.7.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
   "cmdliner"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "base-bytes"
 ]

--- a/packages/dockerfile/dockerfile.1.7.2/opam
+++ b/packages/dockerfile/dockerfile.1.7.2/opam
@@ -11,8 +11,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "topkg" {build}
   "cmdliner"
   "sexplib"

--- a/packages/dockerfile/dockerfile.2.0.0/opam
+++ b/packages/dockerfile/dockerfile.2.0.0/opam
@@ -12,8 +12,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "topkg" {build}
   "cmdliner"
   "sexplib"

--- a/packages/dockerfile/dockerfile.2.2.0/opam
+++ b/packages/dockerfile/dockerfile.2.2.0/opam
@@ -12,8 +12,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "topkg" {build}
   "cmdliner"
   "sexplib"

--- a/packages/dockerfile/dockerfile.2.2.1/opam
+++ b/packages/dockerfile/dockerfile.2.2.1/opam
@@ -12,8 +12,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "topkg" {build}
   "cmdliner"
   "sexplib"

--- a/packages/dockerfile/dockerfile.2.2.2/opam
+++ b/packages/dockerfile/dockerfile.2.2.2/opam
@@ -12,8 +12,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_deriving" {build}
+  "ppx_sexp_conv"
+  "ppx_deriving"
   "topkg" {build}
   "cmdliner"
   "sexplib"

--- a/packages/dockerfile/dockerfile.2.2.3/opam
+++ b/packages/dockerfile/dockerfile.2.2.3/opam
@@ -12,8 +12,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_deriving" {build}
+  "ppx_sexp_conv"
+  "ppx_deriving"
   "topkg" {build}
   "cmdliner"
   "sexplib"

--- a/packages/dockerfile/dockerfile.3.0.0/opam
+++ b/packages/dockerfile/dockerfile.3.0.0/opam
@@ -10,7 +10,7 @@ tags: ["org:mirage" "org:ocamllabs"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "sexplib"
   "base-bytes"
   "fmt"

--- a/packages/dockerfile/dockerfile.3.1.0/opam
+++ b/packages/dockerfile/dockerfile.3.1.0/opam
@@ -10,7 +10,7 @@ tags: ["org:mirage" "org:ocamllabs"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "base-bytes"
   "fmt"

--- a/packages/dockerfile/dockerfile.4.0.0/opam
+++ b/packages/dockerfile/dockerfile.4.0.0/opam
@@ -10,7 +10,7 @@ tags: ["org:mirage" "org:ocamllabs"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "base-bytes"
   "fmt"

--- a/packages/fat-filesystem/fat-filesystem.0.11.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.11.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "2.0.0"}
-  "ppx_cstruct" {build}
-  "ppx_tools" {build}
+  "ppx_cstruct"
+  "ppx_tools"
   "lwt" {>= "2.4.3" & < "2.6.0"}
   "mirage-types" {>= "2.6.1" & < "3.0.0"}
   "mirage-block-unix" {>= "1.2.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.12.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "cstruct" {>= "2.0.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}
@@ -32,7 +32,7 @@ depends: [
   "cmdliner"
   "astring"
   "alcotest" {with-test}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
 ]
 tags: [
   "org:mirage"

--- a/packages/fat-filesystem/fat-filesystem.0.12.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.1/opam
@@ -14,8 +14,8 @@ depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta7"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_cstruct"
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}

--- a/packages/fat-filesystem/fat-filesystem.0.12.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.2/opam
@@ -14,8 +14,8 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {build & >= "1.0+beta7"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_cstruct"
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}

--- a/packages/fat-filesystem/fat-filesystem.0.12.3/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.3/opam
@@ -14,8 +14,8 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta7"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_cstruct"
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}

--- a/packages/gdb/gdb.0.3/opam
+++ b/packages/gdb/gdb.0.3/opam
@@ -18,10 +18,10 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.03.0"}
   "ocamlfind" {build}
   "menhir"
-  ("extlib" | "extlib-compat")
+  "extlib" | "extlib-compat"
   "lwt" {>= "2.4.6"}
   "ppx_deriving" {>= "1.0"}
-  "ppx_tools" {build & >= "0.99.1"}
+  "ppx_tools" {>= "0.99.1"}
   "oasis" {build & >= "0.4"}
   "cppo" {build}
   "ocamlbuild" {build}

--- a/packages/github-jsoo/github-jsoo.3.0.0/opam
+++ b/packages/github-jsoo/github-jsoo.3.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "cohttp" {>= "0.17.0" & < "0.99"}
-  "js_of_ocaml-ppx" {build}
+  "js_of_ocaml-ppx"
   "js_of_ocaml"
   "github" {>= "3.0.0"}
 ]

--- a/packages/goblint/goblint.1.0.0/opam
+++ b/packages/goblint/goblint.1.0.0/opam
@@ -12,11 +12,11 @@ depends: [
   "goblint-cil" {build}
   "batteries" {build}
   "xml-light" {build}
-  "ppx_distr_guards" {build}
-  "ppx_monadic" {build}
-  "ppx_import" {build}
-  "ppx_deriving" {build}
-  "ppx_deriving_yojson" {build}
+  "ppx_distr_guards"
+  "ppx_monadic"
+  "ppx_import"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
 ]
 synopsis: "Static analysis framework for concurrent C"
 url {

--- a/packages/graphql_ppx/graphql_ppx.0.0.3/opam
+++ b/packages/graphql_ppx/graphql_ppx.0.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-migrate-parsetree" {build}
   "result" {build}
   "yojson" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 synopsis: "GraphQL syntax extension for Bucklescript/ReasonML"
 description: """

--- a/packages/graphql_ppx/graphql_ppx.0.0.4/opam
+++ b/packages/graphql_ppx/graphql_ppx.0.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-migrate-parsetree" {build}
   "result" {build}
   "yojson" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 synopsis: "GraphQL syntax extension for Bucklescript/ReasonML"
 description: """

--- a/packages/ibx/ibx.0.8.1/opam
+++ b/packages/ibx/ibx.0.8.1/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
   "ppx_fields_conv" {>= "113.33.00"}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv" {>= "113.33.00"}
   "textutils" {>= "113.33.00"}
 ]

--- a/packages/ipaddr/ipaddr.2.7.0/opam
+++ b/packages/ipaddr/ipaddr.2.7.0/opam
@@ -38,8 +38,8 @@ depends: [
   "ocamlbuild" {build}
   "base-bytes"
   "sexplib" {< "v0.11"}
-  "ppx_deriving" {build & >= "4.2"}
-  "ppx_sexp_conv" {build & < "v0.11"}
+  "ppx_deriving" {>= "4.2"}
+  "ppx_sexp_conv" {< "v0.11"}
   "ounit" {with-test}
 ]
 conflicts: [ "ppx_sexp_conv" {="113.33.00+4.03"} ]

--- a/packages/ipaddr/ipaddr.2.7.1/opam
+++ b/packages/ipaddr/ipaddr.2.7.1/opam
@@ -37,8 +37,8 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "sexplib" {< "v0.11"}
-  "ppx_deriving" {build & >= "4.2"}
-  "ppx_sexp_conv" {build & < "v0.11"}
+  "ppx_deriving" {>= "4.2"}
+  "ppx_sexp_conv" {< "v0.11"}
   "ounit" {with-test}
 ]
 depopts: [ "base-unix" ]

--- a/packages/ipaddr/ipaddr.2.7.2/opam
+++ b/packages/ipaddr/ipaddr.2.7.2/opam
@@ -37,8 +37,8 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "sexplib" {< "v0.11"}
-  "ppx_deriving" {build & >= "4.2"}
-  "ppx_sexp_conv" {build & < "v0.11"}
+  "ppx_deriving" {>= "4.2"}
+  "ppx_sexp_conv" {< "v0.11"}
   "ounit" {with-test}
 ]
 depopts: [ "base-unix" ]

--- a/packages/ipaddr/ipaddr.2.8.0/opam
+++ b/packages/ipaddr/ipaddr.2.8.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta7"}
   "base-bytes"
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "ounit" {with-test}
 ]

--- a/packages/lens/lens.1.1.0/opam
+++ b/packages/lens/lens.1.1.0/opam
@@ -19,8 +19,8 @@ depends: [
   "ounit" {build}
 ]
 depopts: [
-  "ppx_deriving" { build }
-  "ppx_tools" { build }
+  "ppx_deriving"
+  "ppx_tools"
 ]
 synopsis: "Functional lenses"
 description: """

--- a/packages/lens/lens.1.2.0/opam
+++ b/packages/lens/lens.1.2.0/opam
@@ -19,8 +19,8 @@ depends: [
   "ounit" {build}
 ]
 depopts: [
-  "ppx_deriving" { build }
-  "ppx_tools" { build }
+  "ppx_deriving"
+  "ppx_tools"
 ]
 synopsis: "Functional lenses"
 description: """

--- a/packages/libsvm/libsvm.0.9.3/opam
+++ b/packages/libsvm/libsvm.0.9.3/opam
@@ -28,7 +28,7 @@ depopts: [
   "archimedes"
   "core"
   "gsl"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
 ]
 available: os != "macos"

--- a/packages/mecab/mecab.0.0.0/opam
+++ b/packages/mecab/mecab.0.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "conf-mecab" {>= "0.996"}
   "camomile"
   "sexplib"
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "ocaml-migrate-parsetree" {build}
   "ocamlfind" {build & >= "1.5.0"}
   "jbuilder" {build & >= "1.0+beta7"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.0.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "mirage-types" {>= "2.3.0" & < "3.0.0"}
   "io-page" {>= "1.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "rresult"

--- a/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "rresult"

--- a/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "rresult"

--- a/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "shared-memory-ring" {>= "0.4.1"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.0/opam
@@ -24,7 +24,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "shared-memory-ring" {>= "0.4.1" & < "2.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
@@ -30,7 +30,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
@@ -30,7 +30,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"

--- a/packages/mirage-conduit/mirage-conduit.1.0.3/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.0.3/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "cstruct" {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}

--- a/packages/mirage-conduit/mirage-conduit.3.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "cstruct" {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}

--- a/packages/mirage-conduit/mirage-conduit.3.0.1/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "cstruct" {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}

--- a/packages/mirage-nat/mirage-nat.1.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "rresult"
   "logs"
   "lru"
-  "ppx_deriving" {build & >= "4.2"}
+  "ppx_deriving" {>= "4.2"}
   "jbuilder" {build}
   "tcpip" {>= "3.0.0"}
   "alcotest" {with-test}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
@@ -18,9 +18,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind"
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
@@ -18,9 +18,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind"
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
@@ -14,9 +14,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "cstruct" {>= "2.1.0"}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/mirage-profile/mirage-profile.0.7.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.7.0/opam
@@ -20,8 +20,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.9.0" & < "3.2.0"}
-  "ppx_cstruct" {build}
-  "ppx_tools" {build}
+  "ppx_cstruct"
+  "ppx_tools"
   "ocplib-endian"
   "io-page"
   "lwt"

--- a/packages/mirage-profile/mirage-profile.0.8.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.0.0" & < "3.2.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocplib-endian"
   "lwt"
   "topkg" {build}

--- a/packages/mirage-profile/mirage-profile.0.8.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.0.0" & < "3.2.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocplib-endian"
   "lwt"
 ]

--- a/packages/mirage-profile/mirage-profile.0.8.2/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocplib-endian"
   "lwt"
 ]

--- a/packages/mrt-format/mrt-format.0.2.0/opam
+++ b/packages/mrt-format/mrt-format.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build}
   "alcotest" {with-test}
   "cstruct" {>= "1.0.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
 ]
 synopsis: "MRT parsing library and CLI"
 description:

--- a/packages/mrt-format/mrt-format.0.3.0/opam
+++ b/packages/mrt-format/mrt-format.0.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ipaddr" {>= "2.0.0"}
   "logs"
   "ocamlfind" {build}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "result"
 ]
 synopsis: "MRT parsing library and CLI"

--- a/packages/msgpck/msgpck.1.0/opam
+++ b/packages/msgpck/msgpck.1.0/opam
@@ -10,8 +10,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "sexplib"
   "ocplib-endian"
 ]

--- a/packages/nbd/nbd.2.1.0/opam
+++ b/packages/nbd/nbd.2.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "oasis" {build}
   "ounit" {with-test}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "lwt" {>= "2.4.5" & < "2.6.0"}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "cmdliner"
@@ -34,7 +34,7 @@ depends: [
   "io-page" {< "2.0.0"}
   "mirage" {>= "1.1.0" & < "3.0.0"}
   "uri"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: ["org:mirage" "org:xapi-project"]

--- a/packages/nbd/nbd.2.1.1/opam
+++ b/packages/nbd/nbd.2.1.1/opam
@@ -24,7 +24,7 @@ depends: [
   "oasis" {build}
   "ounit" {with-test}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "lwt"
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "cmdliner"
@@ -33,7 +33,7 @@ depends: [
   "io-page" {< "2.0.0"}
   "mirage" {>= "1.1.0" & < "3.0.0"}
   "uri"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: ["org:mirage" "org:xapi-project"]

--- a/packages/nbd/nbd.2.1.3/opam
+++ b/packages/nbd/nbd.2.1.3/opam
@@ -25,7 +25,7 @@ depends: [
   "oasis" {build}
   "ounit" {with-test}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "lwt" {>= "2.7.0" & < "3.0.0"}
   "cstruct" {>= "1.9.0"}
   "cmdliner"
@@ -35,7 +35,7 @@ depends: [
   "mirage-types-lwt" {= "2.8.0"}
   "mirage-types" {= "2.8.0"}
   "uri"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: [ "org:xapi-project" ]

--- a/packages/nbd/nbd.2.2.0/opam
+++ b/packages/nbd/nbd.2.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
   "ounit" {with-test}
-  "ppx_tools" {build}
+  "ppx_tools"
   "lwt" {>= "2.6.0" & < "3.0.0"}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "cmdliner"
@@ -24,7 +24,7 @@ depends: [
   "mirage-types-lwt" {= "2.8.0"}
   "mirage-types" {= "2.8.0"}
   "uri"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: [ "org:xapi-project" ]

--- a/packages/nbd/nbd.3.0.0/opam
+++ b/packages/nbd/nbd.3.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "oasis" {build}
   "ounit" {with-test}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "lwt"
   "result"
   "rresult"
@@ -39,7 +39,7 @@ depends: [
   "io-page-unix"
   "mirage" {>= "1.1.0"}
   "uri"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv" {!= "113.33.00+4.03"}
 ]
 tags: [ "org:mirage" "org:xapi-project" ]

--- a/packages/netchannel/netchannel.1.7.1/opam
+++ b/packages/netchannel/netchannel.1.7.1/opam
@@ -14,9 +14,9 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
   "io-page" {>= "1.5.0"}

--- a/packages/netchannel/netchannel.1.8.0/opam
+++ b/packages/netchannel/netchannel.1.8.0/opam
@@ -14,9 +14,9 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
   "io-page" {>= "1.5.0"}

--- a/packages/netml/netml.0.1.0/opam
+++ b/packages/netml/netml.0.1.0/opam
@@ -19,9 +19,9 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build & >= "1.3.2"}
   "js-build-tools" {build}
-  "ppx_bitstring" {build & >= "1.3.1"}
-  "ppx_deriving" {build}
-  "ppx_deriving_yojson" {build}
+  "ppx_bitstring" {>= "1.3.1"}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
   "bitstring" {>= "2.1.0"}
   "core" {< "v0.10"}
   "yojson"

--- a/packages/nocrypto/nocrypto.0.5.3/opam
+++ b/packages/nocrypto/nocrypto.0.5.3/opam
@@ -28,8 +28,8 @@ depends: [
   "cstruct" {>= "1.6.0" & < "3.0.0"}
   "zarith"
   "sexplib" {< "v0.11.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & >= "113.33.01" & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {>= "113.33.01" & < "v0.11.0"}
   "mirage-no-xen" | ("mirage-xen" "mirage-entropy-xen" "zarith-xen")
   "ounit" {with-test}
 ]

--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -20,8 +20,8 @@ depends: [
   "topkg" {build}
   "cpuid" {build}
   "ocb-stubblr" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & >= "113.33.01" & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {>= "113.33.01" & < "v0.11.0"}
   "ounit" {with-test}
   "cstruct" {>= "2.4.0"}
   "cstruct-lwt"

--- a/packages/ocaml-logicalform/ocaml-logicalform.v0.6.0/opam
+++ b/packages/ocaml-logicalform/ocaml-logicalform.v0.6.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "odoc" {with-doc}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build & >= "0.9"}
+  "ppx_sexp_conv" {>= "0.9"}
   "base" {>= "0.9"}
 ]
 build: [

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 synopsis: "Lightweight monadic syntax extension."
 description:

--- a/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
+++ b/packages/ocaml-topexpect/ocaml-topexpect.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.05.0"}
   "ocamlfind" {build}
   "ppx_sexp_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "jbuilder" {build & >= "1.0+beta9"}
   "sexplib"
 ]

--- a/packages/oci/oci.0.3/opam
+++ b/packages/oci/oci.0.3/opam
@@ -31,7 +31,7 @@ depends: [
   "fileutils"
   "textutils"
   "ocamlbuild"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "ppx_bin_prot"
   "ppx_here"

--- a/packages/opass/opass.1.0.6/opam
+++ b/packages/opass/opass.1.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "csv"
   "ocamlfind"
   "pds"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
 ]

--- a/packages/opium/opium.0.15.0/opam
+++ b/packages/opium/opium.0.15.0/opam
@@ -30,7 +30,7 @@ depends: [
   "fieldslib"
   "sexplib"
   "ppx_fields_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "re" {>= "1.3.0"}
   "magic-mime"

--- a/packages/opium/opium.0.15.1/opam
+++ b/packages/opium/opium.0.15.1/opam
@@ -30,7 +30,7 @@ depends: [
   "fieldslib"
   "sexplib"
   "ppx_fields_conv"
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "re" {>= "1.3.0"}
   "magic-mime"

--- a/packages/otr/otr.0.3.1/opam
+++ b/packages/otr/otr.0.3.1/opam
@@ -29,12 +29,12 @@ build: [
 depends: [
   "ocaml" {>= "4.02.2" & < "4.03"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "sexplib"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "nocrypto" {>= "0.5.3"}
   "astring"
   "ocamlbuild" {build}

--- a/packages/otr/otr.0.3.2/opam
+++ b/packages/otr/otr.0.3.2/opam
@@ -29,13 +29,13 @@ build: [
 depends: [
   "ocaml" {>= "4.02.2"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "sexplib"
   "result"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "nocrypto" {>= "0.5.3"}
   "astring"
   "ocamlbuild" {build}

--- a/packages/otr/otr.0.3.3/opam
+++ b/packages/otr/otr.0.3.3/opam
@@ -19,9 +19,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
-  "ppx_cstruct" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
+  "ppx_cstruct"
   "cstruct" {>= "1.9.0"}
   "sexplib"
   "result"

--- a/packages/otr/otr.0.3.4/opam
+++ b/packages/otr/otr.0.3.4/opam
@@ -18,9 +18,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
-  "ppx_cstruct" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
+  "ppx_cstruct"
   "cstruct" {>= "1.9.0"}
   "sexplib"
   "nocrypto" {>= "0.5.3"}

--- a/packages/partition_map/partition_map.0.9.0/opam
+++ b/packages/partition_map/partition_map.0.9.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "jbuilder" {build & >= "1.0+beta19"}
-  "bisect_ppx" {build}
+  "bisect_ppx"
 ]
 synopsis: "Partition maps"
 description: """

--- a/packages/passmaker/passmaker.1.0/opam
+++ b/packages/passmaker/passmaker.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "hex" {with-test}
   "jbuilder" {build & >= "1.0+beta17"}
-  "ppx_blob" {build}
+  "ppx_blob"
   "ppx_deriving" {with-test}
   "rresult" {with-test}
 ]

--- a/packages/pcap-format/pcap-format.0.4.0/opam
+++ b/packages/pcap-format/pcap-format.0.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "lwt" {with-test & >= "2.4.0"}
   "ipaddr"
   "ocamlbuild" {build}

--- a/packages/pcap-format/pcap-format.0.5.0/opam
+++ b/packages/pcap-format/pcap-format.0.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ounit" {with-test}
 ]
 synopsis: "Decode and encode PCAP (packet capture) files"

--- a/packages/planck/planck.2.2.0/opam
+++ b/packages/planck/planck.2.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "spotlib" {>= "3.0.0" & < "4.0.0"}
   "ocamlgraph" {>= "1.8.2"}
   "omake" {build & = "0.9.8.6-0.rc1"}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv"
   "camlp4"
   "ppx_monadic"

--- a/packages/ppx_bitstring/ppx_bitstring.1.0.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "core" {build}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "ppx_bitstring"]

--- a/packages/ppx_bitstring/ppx_bitstring.1.0.1/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "core" {build}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "ppx_bitstring"]

--- a/packages/ppx_bitstring/ppx_bitstring.1.1.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "core" {build}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "ppx_bitstring"]

--- a/packages/ppx_bitstring/ppx_bitstring.1.2.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "core" {build}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ounit" {build}
 ]
 synopsis: "PPX extension for the bitstring library."

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "bitstring" {build & < "3.0.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppx_driver" {build & < "v0.9.0"}
   "ppx_core" {build}
   "ounit" {build}

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.1/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build & >= "1.3.2"}
   "js-build-tools" {build}
   "bitstring" {build & >= "2.1.0" & < "3.0.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppx_driver" {build & < "v0.9.0"}
   "ppx_core" {build}
   "ounit" {build}

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.2/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build & >= "1.3.2"}
   "js-build-tools" {build}
   "bitstring" {build & >= "2.1.0" & < "3.0.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppx_driver" {build & < "v0.9.0"}
   "ppx_core" {build}
   "ounit" {build}

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.3/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.3/opam
@@ -21,7 +21,7 @@ depends: [
   "ounit" {build}
   "ppx_core" {build}
   "ppx_driver" {build & < "v0.9.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 synopsis: "PPX extension for the bitstring library."
 url {

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "bitstring" {>= "2.1.0" & < "3.0.0"}
   "jbuilder" {build}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {build}
 ]
 synopsis: "PPX extension for the bitstring library."

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.1/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "bitstring" {>= "2.1.0" & < "3.0.0"}
   "jbuilder" {build}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {build}
 ]
 synopsis: "PPX extension for the bitstring library."

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.2/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.2/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "bitstring" {>= "2.1.0" & < "3.0.0"}
   "jbuilder" {build}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {build & >= "1.0.5"}
 ]
 synopsis: "PPX extension for the bitstring library."

--- a/packages/ppx_blob/ppx_blob.0.2/opam
+++ b/packages/ppx_blob/ppx_blob.0.2/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "ppx_blob"]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build & >= "1.5.2"}
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 synopsis: "Include a file as a string at compile time"
 flags: light-uninstall

--- a/packages/ppx_cstruct/ppx_cstruct.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.0/opam
@@ -11,8 +11,8 @@ tags: [ "org:mirage" "org:ocamllabs" ]
 depends: [
   "ocaml" {>= "4.02.3"}
   "cstruct" {< "3.0.0"}
-  "ppx_deriving" {build & >= "4.0"}
-  "ppx_tools" {build}
+  "ppx_deriving" {>= "4.0"}
+  "ppx_tools"
 ]
 synopsis: "Access C-like structures directly from OCaml"
 description: """

--- a/packages/ppx_cstruct/ppx_cstruct.3.0.1/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {with-test}
   "ppx_tools_versioned" {>= "5.0.1"}
   "ocaml-migrate-parsetree"
-  "ppx_deriving" {build & >= "4.0"}
+  "ppx_deriving" {>= "4.0"}
 ]
 synopsis: "Access C-like structures directly from OCaml"
 description: """

--- a/packages/ppx_dryunit/ppx_dryunit.0.3.1/opam
+++ b/packages/ppx_dryunit/ppx_dryunit.0.3.1/opam
@@ -10,7 +10,7 @@ depends: [
   "jbuilder" {build}
   "cppo" {build}
   "ocaml-migrate-parsetree" {build}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
 ]
 synopsis: "A detection tool for traditional unit testing in OCaml"
 description: """

--- a/packages/ppx_dryunit/ppx_dryunit.0.4.0/opam
+++ b/packages/ppx_dryunit/ppx_dryunit.0.4.0/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder" {build}
   "cppo" {build}
   "ocaml-migrate-parsetree" {build}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
 ]
 synopsis: "A detection tool for traditional unit testing in OCaml"
 description: """

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "oasis" {build & >= "0.4.8"}
   "ocamlfind" {build & >= "1.3.2"}
   "js-build-tools" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppx_driver" {build}
   "ppx_core" {build}
   "ounit" {build}

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.1.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ounit" {with-test}
   "hardcaml" {>= "1.1.0"}
 ]

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.2.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ounit" {with-test}
   "hardcaml" {>= "1.2.0"}
 ]

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.3.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.3.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "jbuilder" {build}
   "ounit" {with-test}
   "hardcaml" {>= "1.2.0"}

--- a/packages/ppx_monoid/ppx_monoid.0.1/opam
+++ b/packages/ppx_monoid/ppx_monoid.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.1"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build & >= "0.99.2"}
+  "ppx_tools" {>= "0.99.2"}
 ]
 synopsis: "A syntax extension for easier building of values of monoids."
 description: """

--- a/packages/ppx_monoid/ppx_monoid.0.2/opam
+++ b/packages/ppx_monoid/ppx_monoid.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.1"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build & >= "0.99.2"}
+  "ppx_tools" {>= "0.99.2"}
 ]
 synopsis: "A syntax extension for easier building of values of monoids."
 description: """

--- a/packages/ppx_netblob/ppx_netblob.1.0/opam
+++ b/packages/ppx_netblob/ppx_netblob.1.0/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "ppx_netblob"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.04.0"}
   "ocamlfind" {build & >= "1.5.2"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cohttp" {build & < "0.99"}
   "lwt" {build}
 ]

--- a/packages/ppx_netblob/ppx_netblob.1.1/opam
+++ b/packages/ppx_netblob/ppx_netblob.1.1/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "ppx_netblob"]
 depends: [
   "ocaml" {> "4.03.0"}
   "ocamlfind" {build & >= "1.5.2"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cohttp" {build & < "0.99"}
   "lwt" {build}
 ]

--- a/packages/ppx_netblob/ppx_netblob.1.2.1/opam
+++ b/packages/ppx_netblob/ppx_netblob.1.2.1/opam
@@ -13,11 +13,11 @@ remove: ["ocamlfind" "remove" "ppx_netblob"]
 depends: [
   "ocaml" {> "4.03.0"}
   "ocamlfind" {build & >= "1.5.2"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cohttp" {build & < "0.99"}
   "lwt" {build}
-  "ppx_deriving" {build}
-  "ppx_deriving_yojson" {build}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
   "extlib" {build}
 ]
 synopsis: "type-driven generation of HTTP calling code"

--- a/packages/ppx_regexp/ppx_regexp.0.2.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder" {build}
   "ocaml-migrate-parsetree"
   "re" {< "1.7.2~"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "topkg-jbuilder" {build}
 ]
 synopsis: "Matching Regular Expressions with OCaml Patterns"

--- a/packages/ppx_regexp/ppx_regexp.0.3.1/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.1/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder" {build}
   "ocaml-migrate-parsetree"
   "re" {< "1.7.2~"}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "topkg-jbuilder" {build}
 ]
 synopsis: "Matching Regular Expressions with OCaml Patterns"

--- a/packages/ppx_regexp/ppx_regexp.0.3.2/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.2/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder" {build}
   "ocaml-migrate-parsetree"
   "re" {>= "1.7.2"}
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
 ]
 synopsis: "Matching Regular Expressions with OCaml Patterns"
 description: """

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
@@ -30,11 +30,11 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "jbuilder" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "Unix clients and servers for the 9P protocol"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.0/opam
@@ -33,11 +33,11 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "jbuilder" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "Unix clients and servers for the 9P protocol"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.1/opam
@@ -33,11 +33,11 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "jbuilder" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "Unix clients and servers for the 9P protocol"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.2/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.2/opam
@@ -34,9 +34,9 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "Unix clients and servers for the 9P protocol"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.3/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.3/opam
@@ -34,9 +34,9 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page-unix" {>= "2.0.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "Unix clients and servers for the 9P protocol"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
@@ -34,8 +34,8 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page-unix" {>= "2.0.0"}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_sexp_conv"
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "Unix clients and servers for the 9P protocol"

--- a/packages/protocol-9p/protocol-9p.0.10.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.10.0/opam
@@ -30,11 +30,11 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "ocamlfind" {build}
   "jbuilder" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]

--- a/packages/protocol-9p/protocol-9p.0.11.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.0/opam
@@ -14,11 +14,11 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & > "1.0+beta7"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_cstruct"
   "base-bytes"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/protocol-9p/protocol-9p.0.11.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.1/opam
@@ -14,10 +14,10 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta7"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_tools"
+  "ppx_cstruct"
   "base-bytes"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/protocol-9p/protocol-9p.0.11.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.2/opam
@@ -31,9 +31,9 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "An implementation of the 9P protocol in pure OCaml"

--- a/packages/protocol-9p/protocol-9p.0.11.3/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.3/opam
@@ -29,9 +29,9 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "An implementation of the 9P protocol in pure OCaml"

--- a/packages/protocol-9p/protocol-9p.0.12.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.12.0/opam
@@ -29,8 +29,8 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_sexp_conv" {build}
-  "ppx_tools" {build}
+  "ppx_sexp_conv"
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "An implementation of the 9P protocol in pure OCaml"

--- a/packages/protocol-9p/protocol-9p.0.6.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.6.0/opam
@@ -26,11 +26,11 @@ depends: [
   "stringext"
   "fmt"
   "logs" {>= "0.5.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]

--- a/packages/protocol-9p/protocol-9p.0.7.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.2/opam
@@ -45,11 +45,11 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page" {< "2.0.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "topkg" {build & >= "0.7.3"}
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"

--- a/packages/protocol-9p/protocol-9p.0.7.3/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.3/opam
@@ -45,11 +45,11 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page" {< "2.0.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "topkg" {build & >= "0.7.3"}
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"

--- a/packages/protocol-9p/protocol-9p.0.7.4/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.4/opam
@@ -45,11 +45,11 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page" {< "2.0.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "topkg" {build & >= "0.7.3"}
   "alcotest" {with-test & >= "0.4.0"}
 ]

--- a/packages/protocol-9p/protocol-9p.0.8.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.8.0/opam
@@ -46,11 +46,11 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page" {< "2.0.0"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "topkg" {build & >= "0.7.3"}
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"

--- a/packages/protocol-9p/protocol-9p.0.9.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.9.0/opam
@@ -50,11 +50,11 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "topkg" {build & >= "0.7.3"}
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"

--- a/packages/qcow-format/qcow-format.0.3/opam
+++ b/packages/qcow-format/qcow-format.0.3/opam
@@ -32,8 +32,8 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "oasis" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-format/qcow-format.0.4.1/opam
+++ b/packages/qcow-format/qcow-format.0.4.1/opam
@@ -35,9 +35,9 @@ depends: [
   "astring"
   "ocamlfind" {build}
   "oasis" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow-format/qcow-format.0.4.2/opam
+++ b/packages/qcow-format/qcow-format.0.4.2/opam
@@ -35,9 +35,9 @@ depends: [
   "astring"
   "ocamlfind" {build}
   "oasis" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow-format/qcow-format.0.4/opam
+++ b/packages/qcow-format/qcow-format.0.4/opam
@@ -35,9 +35,9 @@ depends: [
   "astring"
   "ocamlfind" {build}
   "oasis" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow-format/qcow-format.0.5.0/opam
+++ b/packages/qcow-format/qcow-format.0.5.0/opam
@@ -35,9 +35,9 @@ depends: [
   "astring"
   "ocamlfind" {build}
   "oasis" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.10.0/opam
+++ b/packages/qcow/qcow.0.10.0/opam
@@ -29,8 +29,8 @@ depends: [
   "io-page"
   "ocamlfind" {build}
   "jbuilder" {build}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.10.2/opam
+++ b/packages/qcow/qcow.0.10.2/opam
@@ -33,8 +33,8 @@ depends: [
   "fmt" {>= "0.8.2"}
   "io-page-unix" {>= "2.0.0"}
   "jbuilder" {build}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.10.3/opam
+++ b/packages/qcow/qcow.0.10.3/opam
@@ -33,8 +33,8 @@ depends: [
   "fmt" {>= "0.8.2"}
   "io-page-unix" {>= "2.0.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.10.4/opam
+++ b/packages/qcow/qcow.0.10.4/opam
@@ -33,8 +33,8 @@ depends: [
   "fmt" {>= "0.8.2"}
   "io-page-unix" {>= "2.0.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.6.0/opam
+++ b/packages/qcow/qcow.0.6.0/opam
@@ -26,9 +26,9 @@ depends: [
   "io-page-unix"
   "ocamlfind" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.7.0/opam
+++ b/packages/qcow/qcow.0.7.0/opam
@@ -26,9 +26,9 @@ depends: [
   "io-page-unix"
   "ocamlfind" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.8.1/opam
+++ b/packages/qcow/qcow.0.8.1/opam
@@ -28,9 +28,9 @@ depends: [
   "io-page"
   "ocamlfind" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.9.0/opam
+++ b/packages/qcow/qcow.0.9.0/opam
@@ -31,9 +31,9 @@ depends: [
   "io-page"
   "ocamlfind" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.9.4/opam
+++ b/packages/qcow/qcow.0.9.4/opam
@@ -29,9 +29,9 @@ depends: [
   "io-page"
   "ocamlfind" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/qcow/qcow.0.9.5/opam
+++ b/packages/qcow/qcow.0.9.5/opam
@@ -31,9 +31,9 @@ depends: [
   "io-page"
   "ocamlfind" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "ppx_type_conv" {build}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}

--- a/packages/rawlink/rawlink.0.4/opam
+++ b/packages/rawlink/rawlink.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "cstruct" {>= "1.9"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocamlbuild" {build}
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/rawlink/rawlink.0.5/opam
+++ b/packages/rawlink/rawlink.0.5/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build}
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "cstruct" {>= "1.9"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocamlbuild" {build}
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/rawlink/rawlink.0.6/opam
+++ b/packages/rawlink/rawlink.0.6/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build}
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "cstruct" {>= "3.2.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocamlbuild" {build}
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/rawlink/rawlink.0.7/opam
+++ b/packages/rawlink/rawlink.0.7/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build}
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "cstruct" {>= "3.2.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocamlbuild" {build}
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/shared-block-ring/shared-block-ring.2.3.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.3.0/opam
@@ -17,10 +17,10 @@ remove: [["ocamlfind" "remove" "shared-block-ring"]]
 depends: [
   "ocaml" {< "4.06.0"}
   "cstruct" {>= "2.4.0"}
-  "ppx_cstruct" {build}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_deriving" {build}
+  "ppx_cstruct"
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_deriving"
   "lwt" {< "4.0.0"}
   "ocamlfind"
   "ounit"

--- a/packages/shared-block-ring/shared-block-ring.2.4.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.4.0/opam
@@ -17,10 +17,10 @@ remove: [["ocamlfind" "remove" "shared-block-ring"]]
 depends: [
   "ocaml" {< "4.06.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_cstruct" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_cstruct"
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "lwt" {< "4.0.0"}
   "ocamlfind"
   "ounit"

--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.0.0/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "2.4.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "shared-memory-ring" {= "3.0.0"}
   "lwt"
   "mirage-profile"

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "2.4.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "mirage-profile"
   "ounit" {with-test}
 ]

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "2.4.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "mirage-profile"
   "ounit" {with-test}
 ]

--- a/packages/shared-memory-ring/shared-memory-ring.3.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.3.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "2.4.1"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "mirage-profile"
   "ounit" {with-test}
 ]

--- a/packages/sqlexpr/sqlexpr.0.9.0/opam
+++ b/packages/sqlexpr/sqlexpr.0.9.0/opam
@@ -13,7 +13,7 @@ depends: [
   "jbuilder" {build}
   "csv"
   "lwt" {>= "2.2.0"}
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "sqlite3" {>= "2.0.4"} | "sqlite3" {= "2.0.3"}
   "base-unix"
   "ppx_sqlexpr"

--- a/packages/sslconf/sslconf.0.8.3/opam
+++ b/packages/sslconf/sslconf.0.8.3/opam
@@ -11,7 +11,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "sexplib"
   "astring"
   "rresult"

--- a/packages/systemverilog/systemverilog.0.0.1/opam
+++ b/packages/systemverilog/systemverilog.0.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}
   "astring" {build & >= "0.8.3"}
-  "ppx_import" {build & >= "1.2"}
+  "ppx_import" {>= "1.2"}
   "menhir" {build & >= "20170418"}
 ]
 build:

--- a/packages/tar-format/tar-format.0.5.0/opam
+++ b/packages/tar-format/tar-format.0.5.0/opam
@@ -33,7 +33,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind"
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "cstruct-lwt"
   "re"
   "cmdliner"

--- a/packages/tar-format/tar-format.0.5.1/opam
+++ b/packages/tar-format/tar-format.0.5.1/opam
@@ -33,7 +33,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind"
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "cstruct-lwt"
   "re"
   "cmdliner"

--- a/packages/tar-format/tar-format.0.6.0/opam
+++ b/packages/tar-format/tar-format.0.6.0/opam
@@ -33,9 +33,9 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cstruct-lwt" {build}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "re"
   "result"
   "cmdliner"

--- a/packages/tar-format/tar-format.0.6.1/opam
+++ b/packages/tar-format/tar-format.0.6.1/opam
@@ -33,7 +33,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind"
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "cstruct-lwt"
   "re"
   "result"

--- a/packages/tar-format/tar-format.0.7.1/opam
+++ b/packages/tar-format/tar-format.0.7.1/opam
@@ -40,7 +40,7 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build & >= "0.8.0"}
   "cstruct" {>= "1.9.0" & < "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "cstruct-lwt" {build}
   "re"
   "result"

--- a/packages/tar/tar.0.8.0/opam
+++ b/packages/tar/tar.0.8.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "jbuilder" {build}
   "ocamlfind" {build}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_cstruct"
   "cstruct" {>= "1.9.0"}
   "re"
   "result"

--- a/packages/tar/tar.0.9.0/opam
+++ b/packages/tar/tar.0.9.0/opam
@@ -15,8 +15,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta7"}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_cstruct"
   "cstruct" {>= "1.9.0"}
   "re"
   "result"

--- a/packages/tcpip/tcpip.2.7.0/opam
+++ b/packages/tcpip/tcpip.2.7.0/opam
@@ -44,7 +44,7 @@ remove: ["ocamlfind" "remove" "tcpip"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"
   "channel"

--- a/packages/tcpip/tcpip.2.8.0/opam
+++ b/packages/tcpip/tcpip.2.8.0/opam
@@ -44,7 +44,7 @@ remove: ["ocamlfind" "remove" "tcpip"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "result"
   "cstruct" {>= "1.9.0"}
   "channel"

--- a/packages/tcpip/tcpip.2.8.1/opam
+++ b/packages/tcpip/tcpip.2.8.1/opam
@@ -44,7 +44,7 @@ remove: ["ocamlfind" "remove" "tcpip"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "result"
   "cstruct" {>= "1.9.0"}
   "channel"

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -42,7 +42,7 @@ depends: [
   "result"
   "rresult"
   "cstruct" {>= "2.1.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-clock" {>= "1.2.0"}

--- a/packages/tcpip/tcpip.3.1.0/opam
+++ b/packages/tcpip/tcpip.3.1.0/opam
@@ -42,7 +42,7 @@ depends: [
   "result"
   "rresult"
   "cstruct" {>= "2.2.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-clock" {>= "1.2.0"}

--- a/packages/tcpip/tcpip.3.1.1/opam
+++ b/packages/tcpip/tcpip.3.1.1/opam
@@ -42,7 +42,7 @@ depends: [
   "result"
   "rresult"
   "cstruct" {>= "2.2.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-clock" {>= "1.2.0"}

--- a/packages/tcpip/tcpip.3.1.2/opam
+++ b/packages/tcpip/tcpip.3.1.2/opam
@@ -42,7 +42,7 @@ depends: [
   "result"
   "rresult"
   "cstruct" {>= "2.2.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-clock" {>= "1.2.0"}

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -42,7 +42,7 @@ depends: [
   "result"
   "rresult"
   "cstruct" {>= "2.2.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-clock" {>= "1.2.0"}

--- a/packages/tcpip/tcpip.3.1.4/opam
+++ b/packages/tcpip/tcpip.3.1.4/opam
@@ -43,7 +43,7 @@ depends: [
   "rresult"
   "cstruct" {>= "2.4.0"}
   "cstruct-lwt"
-  "ppx_tools" {build}
+  "ppx_tools"
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-clock" {>= "1.2.0"}

--- a/packages/tls/tls.0.7.1/opam
+++ b/packages/tls/tls.0.7.1/opam
@@ -28,11 +28,11 @@ depends: [
   "oasis" {build}
   "ocamlbuild" {build}
   "result"
-  "ppx_tools" {build}
+  "ppx_tools"
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_cstruct"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "sexplib"
   "nocrypto" {>= "0.5.3"}
   "x509" {>= "0.5.0" & < "0.6.0"}

--- a/packages/tls/tls.0.8.0/opam
+++ b/packages/tls/tls.0.8.0/opam
@@ -41,11 +41,11 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "result"
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "cstruct" {>= "1.9.0"}
   "sexplib"
   "nocrypto" {>= "0.5.4"}

--- a/packages/tls/tls.0.9.0/opam
+++ b/packages/tls/tls.0.9.0/opam
@@ -41,9 +41,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
-  "ppx_deriving" {build}
-  "ppx_cstruct" {build & >= "3.0.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
+  "ppx_deriving"
+  "ppx_cstruct" {>= "3.0.0"}
   "result"
   "cstruct" {>= "3.0.0"}
   "sexplib"

--- a/packages/tls/tls.0.9.1/opam
+++ b/packages/tls/tls.0.9.1/opam
@@ -41,9 +41,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
-  "ppx_deriving" {build}
-  "ppx_cstruct" {build & >= "3.0.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
+  "ppx_deriving"
+  "ppx_cstruct" {>= "3.0.0"}
   "result"
   "cstruct" {>= "3.0.0"}
   "sexplib"

--- a/packages/unmagic/unmagic.0.9.0/opam
+++ b/packages/unmagic/unmagic.0.9.0/opam
@@ -22,7 +22,7 @@ depends: [
   "omake" {build & < "0.10.1"}
   "spotlib"
   "typerep"
-  "ppx_typerep_conv" {build}
+  "ppx_typerep_conv"
   "ppx_deriving"
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"

--- a/packages/unmagic/unmagic.1.0.0/opam
+++ b/packages/unmagic/unmagic.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "omake" {build & < "0.10"}
   "spotlib"
   "typerep"
-  "ppx_typerep_conv" {build}
+  "ppx_typerep_conv"
   "ppx_deriving"
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"

--- a/packages/unmagic/unmagic.1.0.1/opam
+++ b/packages/unmagic/unmagic.1.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "omake" {build & < "0.10"}
   "spotlib"
   "typerep"
-  "ppx_typerep_conv" {build}
+  "ppx_typerep_conv"
   "ppx_deriving"
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"

--- a/packages/unmagic/unmagic.1.0.2/opam
+++ b/packages/unmagic/unmagic.1.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "omake" {build & < "0.10"}
   "spotlib"
   "typerep"
-  "ppx_typerep_conv" {build}
+  "ppx_typerep_conv"
   "ppx_deriving" {<= "4.1"}
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"

--- a/packages/unmagic/unmagic.1.0.3/opam
+++ b/packages/unmagic/unmagic.1.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "omake" {build & < "0.10"}
   "spotlib"
   "typerep" {>= "v0.10.0"}
-  "ppx_typerep_conv" {build}
+  "ppx_typerep_conv"
   "ppx_deriving"
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"

--- a/packages/unmagic/unmagic.1.0.4/opam
+++ b/packages/unmagic/unmagic.1.0.4/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder" {build}
   "spotlib"
   "typerep" {>= "v0.10.0"}
-  "ppx_typerep_conv" {build}
+  "ppx_typerep_conv"
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"
 description: """

--- a/packages/uri/uri.1.9.2/opam
+++ b/packages/uri/uri.1.9.2/opam
@@ -39,8 +39,8 @@ depends: [
   "ocamlfind" {build}
   "re"
   "sexplib" {>= "109.53.00"}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & >= "113.33.01"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {>= "113.33.01"}
   "base-bytes"
   "stringext" {>= "1.4.0"}
   "ounit" {with-test & >= "1.0.2"}

--- a/packages/uri/uri.1.9.4/opam
+++ b/packages/uri/uri.1.9.4/opam
@@ -26,7 +26,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta7"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "re"
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}

--- a/packages/uri/uri.1.9.5/opam
+++ b/packages/uri/uri.1.9.5/opam
@@ -26,7 +26,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta7"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "re"
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}

--- a/packages/uri/uri.1.9.6/opam
+++ b/packages/uri/uri.1.9.6/opam
@@ -25,7 +25,7 @@ depends: [
   "base-bytes"
   "jbuilder" {build & >= "1.0+beta7"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "re"
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}

--- a/packages/utop/utop.1.19.1/opam
+++ b/packages/utop/utop.1.19.1/opam
@@ -26,7 +26,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cppo_ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/utop/utop.1.19.2/opam
+++ b/packages/utop/utop.1.19.2/opam
@@ -36,7 +36,7 @@ depends: [
 ]
 depopts: [
   "camlp4"
-  "ppx_tools" {build}
+  "ppx_tools"
 ]
 synopsis: "Universal toplevel for OCaml"
 description: """

--- a/packages/utop/utop.1.19/opam
+++ b/packages/utop/utop.1.19/opam
@@ -26,7 +26,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cppo_ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/vchan-unix/vchan-unix.3.0.0/opam
+++ b/packages/vchan-unix/vchan-unix.3.0.0/opam
@@ -23,9 +23,9 @@ depends: [
   "vchan" {= "3.0.0"}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan-xen/vchan-xen.3.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.3.0.0/opam
@@ -23,9 +23,9 @@ depends: [
   "vchan" {= "3.0.0"}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -23,9 +23,9 @@ depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "io-page"
   "mirage-types-lwt" {< "3.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -27,9 +27,9 @@ depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "io-page"
   "mirage-types-lwt" {< "3.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -32,9 +32,9 @@ depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -32,9 +32,9 @@ depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan/vchan.3.0.0/opam
+++ b/packages/vchan/vchan.3.0.0/opam
@@ -22,9 +22,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build & >= "v0.9"}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv" {>= "v0.9"}
+  "ppx_cstruct"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vhd-format/vhd-format.0.8.0/opam
+++ b/packages/vhd-format/vhd-format.0.8.0/opam
@@ -12,8 +12,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_cstruct"
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.9"}
   "cstruct-lwt"

--- a/packages/vhd-format/vhd-format.0.9.1/opam
+++ b/packages/vhd-format/vhd-format.0.9.1/opam
@@ -16,7 +16,7 @@ depends: [
   "io-page"
   "rresult"
   "uuidm"
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 available: os = "linux" | os = "macos"

--- a/packages/vhd-format/vhd-format.0.9.2/opam
+++ b/packages/vhd-format/vhd-format.0.9.2/opam
@@ -16,7 +16,7 @@ depends: [
   "io-page"
   "rresult"
   "uuidm"
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 available: os = "linux" | os = "macos"

--- a/packages/vmnet/vmnet.1.1.0/opam
+++ b/packages/vmnet/vmnet.1.1.0/opam
@@ -16,10 +16,10 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_tools" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
   "sexplib" {>= "113.24.00"}
   "ipaddr" {>= "1.4.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/vmnet/vmnet.1.2.0/opam
+++ b/packages/vmnet/vmnet.1.2.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
   "sexplib" {>= "113.24.00"}
   "ipaddr" {>= "1.4.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/vmnet/vmnet.1.3.0/opam
+++ b/packages/vmnet/vmnet.1.3.0/opam
@@ -18,8 +18,8 @@ build: [
 depends: [
   "ocaml" {< "4.6.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
   "ocaml-migrate-parsetree" {build}
   "sexplib" {>= "113.24.00"}
   "ipaddr" {>= "1.4.0"}

--- a/packages/vmnet/vmnet.1.3.1/opam
+++ b/packages/vmnet/vmnet.1.3.1/opam
@@ -17,8 +17,8 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv"
   "ocaml-migrate-parsetree" {build}
   "sexplib" {>= "113.24.00"}
   "ipaddr" {>= "1.4.0"}

--- a/packages/wamp/wamp.1.0/opam
+++ b/packages/wamp/wamp.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "result"
   "uri"
   "ppx_deriving"

--- a/packages/x509/x509.0.5.1/opam
+++ b/packages/x509/x509.0.5.1/opam
@@ -21,8 +21,8 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ocamlbuild" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "cstruct" {>= "1.6.0"}
   "sexplib"
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.5.2/opam
+++ b/packages/x509/x509.0.5.2/opam
@@ -21,8 +21,8 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ocamlbuild" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "cstruct" {>= "1.6.0"}
   "sexplib"
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.5.3/opam
+++ b/packages/x509/x509.0.5.3/opam
@@ -21,8 +21,8 @@ depends: [
   "ocamlfind" {build}
   "oasis" {build}
   "ocamlbuild" {build}
-  "ppx_deriving" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.11.0"}
   "cstruct" {>= "1.6.0"}
   "sexplib"
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.6.0/opam
+++ b/packages/x509/x509.0.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.2"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
   "topkg" {build}
   "result"
   "cstruct" {>= "1.6.0"}

--- a/packages/x509/x509.0.6.1/opam
+++ b/packages/x509/x509.0.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.2"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv" {< "v0.11.0"}
   "topkg" {build}
   "result"
   "cstruct" {>= "1.6.0"}

--- a/packages/xenstore/xenstore.1.3.0/opam
+++ b/packages/xenstore/xenstore.1.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
   "cstruct" {>= "2.4.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ppx_tools"
   "lwt"
   "ounit" {build}

--- a/packages/xenstore/xenstore.1.4.0/opam
+++ b/packages/xenstore/xenstore.1.4.0/opam
@@ -22,8 +22,8 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "2.4.0"}
-  "ppx_cstruct" {build}
-  "ppx_tools" {build}
+  "ppx_cstruct"
+  "ppx_tools"
   "lwt"
   "ounit" {build}
 ]

--- a/packages/xenstore/xenstore.2.0.0/opam
+++ b/packages/xenstore/xenstore.2.0.0/opam
@@ -21,8 +21,8 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {build & >= "1.0+beta9"}
   "cstruct" {>= "3.2.0"}
-  "ppx_cstruct" {build}
-  "ppx_tools" {build}
+  "ppx_cstruct"
+  "ppx_tools"
   "lwt"
   "ounit" {with-test}
 ]

--- a/packages/yaml/yaml.0.1.0/opam
+++ b/packages/yaml/yaml.0.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "ctypes" {>= "0.12.0"}
-  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.11.0"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.11.0"}
   "rresult"
   "fmt"
   "logs"


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/amf/amf.0.1.0/opam
  - packages/gdb/gdb.0.3/opam