### PR TITLE
Package pure-splitmix.0.2

### DIFF
--- a/packages/pure-splitmix/pure-splitmix.0.2/descr
+++ b/packages/pure-splitmix/pure-splitmix.0.2/descr
@@ -1,0 +1,1 @@
+Purely functional splittable PRNG

--- a/packages/pure-splitmix/pure-splitmix.0.2/files/pure-splitmix.install
+++ b/packages/pure-splitmix/pure-splitmix.0.2/files/pure-splitmix.install
@@ -1,0 +1,8 @@
+lib: [
+  "META"
+  "_build/src/pureSplitMix.cmi"
+  "_build/src/pureSplitMix.cmx"
+  "_build/src/pureSplitMix.cma"
+  "_build/src/pureSplitMix.cmxa"
+  "_build/src/pureSplitMix.a"
+]

--- a/packages/pure-splitmix/pure-splitmix.0.2/opam
+++ b/packages/pure-splitmix/pure-splitmix.0.2/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Li-yao Xia <lysxia@gmail.com>"
+authors: "Li-yao Xia"
+homepage: "https://github.com/Lysxia/pure-splitmix"
+bug-reports: "https://github.com/Lysxia/pure-splitmix/issues"
+license: "MIT"
+dev-repo: "https://github.com/Lysxia/pure-splitmix.git"
+build: [make "build"]
+build-test: [make "test"]
+depends: [
+  "ocamlbuild" {build & >= "0.9.0"}
+]

--- a/packages/pure-splitmix/pure-splitmix.0.2/url
+++ b/packages/pure-splitmix/pure-splitmix.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Lysxia/pure-splitmix/archive/0.2.tar.gz"
+checksum: "ceb412a5aec34d00fb6141bf0c28504b"


### PR DESCRIPTION
### `pure-splitmix.0.2`

Purely functional splittable PRNG



---
* Homepage: https://github.com/Lysxia/pure-splitmix
* Source repo: https://github.com/Lysxia/pure-splitmix.git
* Bug tracker: https://github.com/Lysxia/pure-splitmix/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5