### PR TITLE
Package pprint.20180528

### DIFF
--- a/packages/pprint/pprint.20180528/descr
+++ b/packages/pprint/pprint.20180528/descr
@@ -1,0 +1,6 @@
+A pretty-printing combinator library and rendering engine.
+
+This library offers a set of combinators for building so-called "documents" as
+well as an efficient engine for converting documents to a textual, fixed-width
+format. The engine takes care of indentation and line breaks, while respecting
+the constraints imposed by the structure of the document and by the text width.

--- a/packages/pprint/pprint.20180528/opam
+++ b/packages/pprint/pprint.20180528/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Nicolas Pouillard <np@nicolaspouillard.fr>"
+]
+homepage: "https://github.com/fpottier/pprint"
+bug-reports: "francois.pottier@inria.fr"
+dev-repo: "git@github.com:fpottier/pprint.git"
+build: [make "all"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/pprint/pprint.20180528/url
+++ b/packages/pprint/pprint.20180528/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fpottier/pprint/archive/20180528.tar.gz"
+checksum: "a75651b51ba6668cd6121799986a1ca2"


### PR DESCRIPTION
### `pprint.20180528`

A pretty-printing combinator library and rendering engine.

This library offers a set of combinators for building so-called "documents" as
well as an efficient engine for converting documents to a textual, fixed-width
format. The engine takes care of indentation and line breaks, while respecting
the constraints imposed by the structure of the document and by the text width.



---
* Homepage: https://github.com/fpottier/pprint
* Source repo: git@github.com:fpottier/pprint.git
* Bug tracker: francois.pottier@inria.fr

---

:camel: Pull-request generated by opam-publish v0.3.5