### PR TITLE
Package mccs.1.1+8

### DIFF
--- a/packages/mccs/mccs.1.1+8/descr
+++ b/packages/mccs/mccs.1.1+8/descr
@@ -1,0 +1,6 @@
+Multi Criteria CUDF Solver with OCaml bindings
+
+This is a stripped-down version of the mccs solver (written in C++), including
+OCaml bindings based on the cudf library, and the GLPK backend (in C). Note that
+it also includes some correction fixes, and a few changes not present in the
+upstream yet.

--- a/packages/mccs/mccs.1.1+8/opam
+++ b/packages/mccs/mccs.1.1+8/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Claude Michel <claude.michel@unice.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+homepage: "http://www.i3s.unice.fr/~cpjm/misc/"
+bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
+license: "LGPL-2.1 with OCaml linking exception, BSD-3-clause, GPL-3.0"
+dev-repo: "https://github.com/AltGr/ocaml-mccs.git"
+build: ["jbuilder" "build" "-p" name]
+build-test: [
+  ["sh" "-c" "jbuilder build @settests --auto-promote || true"]
+  ["jbuilder" "runtest"]
+]
+depends: [
+  "jbuilder" {build}
+  "cudf" {>= "0.7"}
+]

--- a/packages/mccs/mccs.1.1+8/url
+++ b/packages/mccs/mccs.1.1+8/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/ocaml-mccs/archive/1.1+8.tar.gz"
+checksum: "987c4970715713f21e6c79b4f3cba430"


### PR DESCRIPTION
### `mccs.1.1+8`

Multi Criteria CUDF Solver with OCaml bindings

This is a stripped-down version of the mccs solver (written in C++), including
OCaml bindings based on the cudf library, and the GLPK backend (in C). Note that
it also includes some correction fixes, and a few changes not present in the
upstream yet.



---
* Homepage: http://www.i3s.unice.fr/~cpjm/misc/
* Source repo: https://github.com/AltGr/ocaml-mccs.git
* Bug tracker: https://github.com/AltGr/ocaml-mccs/issues

---

:camel: Pull-request generated by opam-publish v0.3.5