### PR TITLE
Package freetds.0.6

### DIFF
--- a/packages/freetds/freetds.0.6/descr
+++ b/packages/freetds/freetds.0.6/descr
@@ -1,0 +1,5 @@
+Binding to the FreeTDS library
+
+FreeTDS is a set of libraries for Unix and Linux that allows your
+programs to natively talk to Microsoft SQL Server and Sybase
+databases.

--- a/packages/freetds/freetds.0.6/opam
+++ b/packages/freetds/freetds.0.6/opam
@@ -29,7 +29,7 @@ depends: [
 ]
 depexts: [
   [["alpine"] ["freetds-dev"]]
-  [["centos"] ["freetds-devel"]]
+  [["centos"] ["epel-release" "freetds-devel"]]
   [["debian"] ["freetds-dev"]]
   [["ubuntu"] ["freetds-dev"]]
   [["alpine"] ["freetds-dev"]]

--- a/packages/freetds/freetds.0.6/opam
+++ b/packages/freetds/freetds.0.6/opam
@@ -1,0 +1,45 @@
+opam-version: "1.2"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Kenn Knowles <kenn.knowles@gmail.com>" ]
+maintainer: "Christophe.Troestler@umons.ac.be"
+homepage: "https://github.com/kennknowles/ocaml-freetds"
+dev-repo: "https://github.com/kennknowles/ocaml-freetds.git"
+bug-reports: "https://github.com/kennknowles/ocaml-freetds/issues"
+doc: "https://kennknowles.github.io/ocaml-freetds/doc"
+license: "LGPL-2.1"
+
+tags: [
+  "clib:ct"
+  "clib:sybdb"
+]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta19.1"}
+  "cppo" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "ounit" {test & >= "2.0.0"}
+]
+depexts: [
+  [["alpine"] ["freetds-dev"]]
+  [["centos"] ["freetds-devel"]]
+  [["debian"] ["freetds-dev"]]
+  [["ubuntu"] ["freetds-dev"]]
+  [["alpine"] ["freetds-dev"]]
+  [["fedora"] ["freetds-devel"]]
+  [["rhel"]   ["freetds-devel"]]
+  [["mageia"] ["libfreetds-devel"]]
+  [["opensuse"] ["freetds-devel"]]
+  [["freebsd"] ["freetds-devel"]]
+  [["osx" "homebrew"] ["freetds"]]
+# [["cygwinports" "x86_64"] ["mingw64-x86_64-freetds"]]
+]
+
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/freetds/freetds.0.6/url
+++ b/packages/freetds/freetds.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/kennknowles/ocaml-freetds/releases/download/0.6/freetds-0.6.tbz"
+checksum: "50222ca934a1f6a8989d3e5b1a6ad583"


### PR DESCRIPTION
### `freetds.0.6`

Binding to the FreeTDS library

FreeTDS is a set of libraries for Unix and Linux that allows your
programs to natively talk to Microsoft SQL Server and Sybase
databases.



---
* Homepage: https://github.com/kennknowles/ocaml-freetds
* Source repo: https://github.com/kennknowles/ocaml-freetds.git
* Bug tracker: https://github.com/kennknowles/ocaml-freetds/issues

---


---
0.6 2018-05-29
--------------

- Add a parameter `version` to `Dblib.connect` to be able to choose
  the protocol version.  Explain how the old protocol versions
  do not allow empty strings which will be returned as `' '`.
- Keep the compatibility with FreeTDS version < 0.91.
- Keep int64 as such on the OCaml side (they used to be transformed
  into strings).
- Document `Dblib.severity`.
- Make error messages more informative by splicing the binding on a
  finer level.  A configure script ensures the synchronization with
  values defined in the C header files.
- Add tests for `Dblib` and `Ct` (checked by AppVeyor on
  Windows/mingw).
- Improve the interface of `Ct.get_messages`.
- Complete the depexts list.
:camel: Pull-request generated by opam-publish v0.3.5