### PR TITLE
Radare2 bindings v0.0.2 release bump

### DIFF
--- a/packages/radare2/radare2.0.0.2/descr
+++ b/packages/radare2/radare2.0.0.2/descr
@@ -1,0 +1,12 @@
+OCaml interface to r2
+
+Interact with radare2,
+See the mli for documentation, example usage in utop:
+
+#require "radare2";;
+let result = R2.with_command_j ~cmd:"/j chown" "/bin/ls";;
+val result : Yojson.Basic.json =
+`List
+  [`Assoc
+    [("offset", `Int 4294987375); ("id:", `Int 0);
+     ("data", `String "ywritesecuritychownfile_inheritdi")]]"

--- a/packages/radare2/radare2.0.0.2/opam
+++ b/packages/radare2/radare2.0.0.2/opam
@@ -1,0 +1,47 @@
+# -*- conf -*-
+opam-version: "1.2"
+name: "radare2"
+version: "0.0.2"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/fxfactorial/ocaml-radare2"
+dev-repo: "https://github.com/fxfactorial/ocaml-radare2.git"
+bug-reports: "https://github.com/fxfactorial/ocaml-radare2/issues"
+build: [
+	["jbuilder" "subst" "-n" name] {pinned}
+	["jbuilder" "build" "-p" name "-j" jobs]
+]
+depexts: [
+  [["debian"] ["radare2"]]
+  [["ubuntu"] ["radare2"]]
+  [["fedora"] ["radare2"]]
+  [["archlinux"] ["radare2"]]
+  [["gentoo"] ["radare2"]]
+  [["homebrew" "osx"] ["radare2"]]
+]
+depends: [
+  "jbuilder" {build}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "base-unix"
+  ("yojson" {>= "1.3.2"} | "yojson-android" {>= "1.3.2"})
+]
+messages:[
+"You need to have r2 (radare2) installed and in your path"
+"Use `opam depext radare2` to get it installed with your system package manager"
+]
+
+post-messages:[
+"Play with radare2 interactively from within an OCaml repl like utop"
+"Example in utop:"
+""
+"#require \"radare2\";;"
+"let result = R2.with_command_j ~cmd:\"/j chown\" \"/bin/ls\";;
+val result : Yojson.Basic.json =
+`List
+  [`Assoc
+       [(\"offset\", `Int 4294987375); (\"id:\", `Int 0);
+        (\"data\", `String \"ywritesecuritychownfile_inheritdi\")]]"
+{success}]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/radare2/radare2.0.0.2/url
+++ b/packages/radare2/radare2.0.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/fxfactorial/ocaml-radare2/archive/v0.0.2.tar.gz"
+checksum: "63a1a06ffe646acde3a5f38f3c0d5b7e"


### PR DESCRIPTION
New release of radare2 bindings:
 - Switched to the Dune/Jbuilder for building
 - Support for OCaml 4.06 `-safe-string`
 - Minor stability fixes