### PR TITLE
Release pyml.20180530

### DIFF
--- a/packages/pyml/pyml.20180530/descr
+++ b/packages/pyml/pyml.20180530/descr
@@ -1,0 +1,1 @@
+OCaml bindings for Python

--- a/packages/pyml/pyml.20180530/opam
+++ b/packages/pyml/pyml.20180530/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://pyml.gforge.inria.fr"
+bug-reports: "http://pyml.gforge.inria.fr/tracker"
+license: "BSD"
+dev-repo: "https://scm.gforge.inria.fr/anonscm/git/pyml/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "ocamlfind" {build}
+  "stdcompat" {>= "3"}
+  "num"
+]
+depopts: ["utop"]
+available: [ocaml-version >= "3.12.1" & ocaml-version < "4.08.0"]
+version: "20180530"

--- a/packages/pyml/pyml.20180530/url
+++ b/packages/pyml/pyml.20180530/url
@@ -1,0 +1,3 @@
+http: "http://pyml.gforge.inria.fr/pyml-20180530.tar.gz"
+checksum: "c4984df264751168e9017c05bee0d5e6"
+


### PR DESCRIPTION
[*] marks changes that break compatibility with previous versions.

- `Py.import` is an alias for `Py.Import.import_module`.
- Use `*_opt` naming convention for the functions that return an option
  instead of an exception: `Py.import_opt`, `Py.Object.find_opt`,...
- of_seq/to_seq converters
- [*] get_attr/get_attr_string now returns option type
- Indexing operators (for OCaml 4.06.0 and above) defined in Pyops