### PR TITLE
Require cppo 1.3.0 for stdcompat (support comma in macro arguments)

### DIFF
--- a/packages/stdcompat/stdcompat.4/opam
+++ b/packages/stdcompat/stdcompat.4/opam
@@ -12,6 +12,6 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocamlfind" {build}
-  "cppo" {build & >= "1.1.0"}
+  "cppo" {build & >= "1.3.0"}
 ]
 available: [ocaml-version >= "3.12.0" & ocaml-version < "4.08.0"]


### PR DESCRIPTION
Solve https://github.com/ocaml/opam-repository/pull/12082#issuecomment-393235752 .