### PR TITLE
Package user-setup.0.7

### DIFF
--- a/packages/user-setup/user-setup.0.7/descr
+++ b/packages/user-setup/user-setup.0.7/descr
@@ -1,0 +1,14 @@
+Helper for the configuration of editors for the use of OCaml tools
+
+This tool knows about several editors, and several OCaml editing tools existing
+as opam packages. It automates the configuration of these editors, providing
+base templates when appropriate, and suitably installing the editing tools in
+the editor's configuration.
+
+For example, it will configure your emacs or Vim to indent OCaml files using
+[ocp-indent](http://www.typerex.org/ocp-indent.html) if you have that installed.
+
+Opam-user-setup is designed to be suitable both to beginners not wanting to be
+bothered with configuration files, and to people who manage them carefully.
+
+It's customisable and reversible.

--- a/packages/user-setup/user-setup.0.7/opam
+++ b/packages/user-setup/user-setup.0.7/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/OCamlPro/opam-user-setup"
+bug-reports: "https://github.com/OCamlPro/opam-user-setup/issues"
+license: "ISC"
+tags: ["org:ocamlpro" "flags:plugin"]
+dev-repo: "https://github.com/OCamlPro/opam-user-setup.git"
+build: [make]
+depends: [
+  "ocamlfind" {build}
+  "cmdliner"
+  "re"
+]
+depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]
+available: [ocaml-version >= "3.12.1"]
+post-messages: [
+  "To setup or update your editors, run 'opam user-setup install'." {success}
+]

--- a/packages/user-setup/user-setup.0.7/url
+++ b/packages/user-setup/user-setup.0.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/opam-user-setup/archive/0.7.tar.gz"
+checksum: "ef0fedc240cd6b852ebc143d4115edaf"


### PR DESCRIPTION
### `user-setup.0.7`

Helper for the configuration of editors for the use of OCaml tools

This tool knows about several editors, and several OCaml editing tools existing
as opam packages. It automates the configuration of these editors, providing
base templates when appropriate, and suitably installing the editing tools in
the editor's configuration.

For example, it will configure your emacs or Vim to indent OCaml files using
[ocp-indent](http://www.typerex.org/ocp-indent.html) if you have that installed.

Opam-user-setup is designed to be suitable both to beginners not wanting to be
bothered with configuration files, and to people who manage them carefully.

It's customisable and reversible.



---
* Homepage: https://github.com/OCamlPro/opam-user-setup
* Source repo: https://github.com/OCamlPro/opam-user-setup.git
* Bug tracker: https://github.com/OCamlPro/opam-user-setup/issues

---

:camel: Pull-request generated by opam-publish v0.3.5