### PR TITLE
Package pilat.1.2

### DIFF
--- a/packages/pilat/pilat.1.2/descr
+++ b/packages/pilat/pilat.1.2/descr
@@ -1,0 +1,5 @@
+A Frama-C polynomial invariant generator 
+
+This tool generates invariants of linear and polynomial loops, with 
+deterministic and non deterministic assignments, as annotations in the initial 
+source code.

--- a/packages/pilat/pilat.1.2/opam
+++ b/packages/pilat/pilat.1.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Steven De Oliveira <de.oliveira.steven@gmail.com>"
+authors: "Steven De Oliveira <de.oliveira.steven@gmail.com>"
+homepage: "https://github.com/Stevendeo/Pilat/"
+license: "LGPLv2.1"
+dev-repo: "https://github.com/Stevendeo/Pilat.git"
+bug-reports: "https://github.com/Stevendeo/Pilat/issues"
+build: ["sh" "make.sh"]
+install: ["sh" "install.sh"]
+remove: ["ocamlfind" "remove" "pilat"]
+depends: [
+	 "ocamlfind" {build} 
+	 "lacaml" 
+	 "zarith" 
+	 "frama-c" {>= "20180501"}]
+available: [ocaml-version > "4.02.3"]

--- a/packages/pilat/pilat.1.2/url
+++ b/packages/pilat/pilat.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Stevendeo/Pilat/archive/stable_1.2.zip"
+checksum: "e14eae3df08778154824564c8a98eadf"


### PR DESCRIPTION
### `pilat.1.2`

A Frama-C polynomial invariant generator 

This tool generates invariants of linear and polynomial loops, with 
deterministic and non deterministic assignments, as annotations in the initial 
source code.


---
* Homepage: https://github.com/Stevendeo/Pilat/
* Source repo: https://github.com/Stevendeo/Pilat.git
* Bug tracker: https://github.com/Stevendeo/Pilat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5