### PR TITLE
Packages bigstring.0.2 and bigstring-unix.0.2

### DIFF
--- a/packages/bigstring-unix/bigstring-unix.0.2/descr
+++ b/packages/bigstring-unix/bigstring-unix.0.2/descr
@@ -1,0 +1,3 @@
+Unix bindings for bigstrings
+
+This includes memory-mapping functions.

--- a/packages/bigstring-unix/bigstring-unix.0.2/opam
+++ b/packages/bigstring-unix/bigstring-unix.0.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+homepage: "https://github.com/c-cube/ocaml-bigstring/"
+bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
+tags: ["bigstring" "bigarray"]
+dev-repo: "git://github.com/c-cube/ocaml-bigstring"
+build: ["jbuilder" "build" "-j" jobs "-p" name "@install"]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta19.1"}
+  "bigstring"
+  "base-bigarray"
+  "base-bytes"
+  "base-unix"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/bigstring-unix/bigstring-unix.0.2/url
+++ b/packages/bigstring-unix/bigstring-unix.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-bigstring/archive/0.2.tar.gz"
+checksum: "5582e995b7d4c9e4a2949214756db7dd"

--- a/packages/bigstring/bigstring.0.2/descr
+++ b/packages/bigstring/bigstring.0.2/descr
@@ -1,0 +1,4 @@
+Bigstring built on top of bigarrays, and convenient functions
+
+Bigstrings are useful for interfacing with C, low level IO,
+memory-mapping, etc.

--- a/packages/bigstring/bigstring.0.2/opam
+++ b/packages/bigstring/bigstring.0.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+homepage: "https://github.com/c-cube/ocaml-bigstring/"
+bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
+tags: ["bigstring" "bigarray"]
+dev-repo: "git://github.com/c-cube/ocaml-bigstring"
+build: ["jbuilder" "build" "-j" jobs "-p" name "@install"]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+depends: [
+  "jbuilder" {build & >= "1.0+beta19.1"}
+  "base-bigarray"
+  "base-bytes"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/bigstring/bigstring.0.2/url
+++ b/packages/bigstring/bigstring.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-bigstring/archive/0.2.tar.gz"
+checksum: "5582e995b7d4c9e4a2949214756db7dd"


### PR DESCRIPTION
This pull-request concerns:
-`bigstring.0.2`: Bigstring built on top of bigarrays, and convenient functions
-`bigstring-unix.0.2`: Unix bindings for bigstrings



---
* Homepage: https://github.com/c-cube/ocaml-bigstring/
* Source repo: git://github.com/c-cube/ocaml-bigstring
* Bug tracker: https://github.com/c-cube/ocaml-bigstring/issues

---

:camel: Pull-request generated by opam-publish v0.3.5