### PR TITLE
delimcc.2018.03.16

### DIFF
--- a/packages/delimcc/delimcc.2018.03.16/descr
+++ b/packages/delimcc/delimcc.2018.03.16/descr
@@ -1,0 +1,1 @@
+Oleg's delimited continuations library for byte-code and native OCaml

--- a/packages/delimcc/delimcc.2018.03.16/opam
+++ b/packages/delimcc/delimcc.2018.03.16/opam
@@ -10,4 +10,4 @@ build: [
 remove: [["ocamlfind" "remove" "delimcc"]]
 depends: ["ocamlfind" {build}]
 install: [make "findlib-install"]
-available: [ ocaml-version >= "4.04.0" ]
+available: [ ocaml-version >= "4.04.0" & !preinstalled ]

--- a/packages/delimcc/delimcc.2018.03.16/opam
+++ b/packages/delimcc/delimcc.2018.03.16/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "gabriel.scherer@gmail.com"
+authors: ["Oleg Kiselyov"]
+homepage: "http://okmij.org/ftp/continuations/implementations.html#caml-shift"
+license: "MIT"
+build: [
+  [make "all"]
+  [make "opt"]
+]
+remove: [["ocamlfind" "remove" "delimcc"]]
+depends: ["ocamlfind" {build}]
+install: [make "findlib-install"]
+available: [ ocaml-version >= "4.04.0" ]

--- a/packages/delimcc/delimcc.2018.03.16/url
+++ b/packages/delimcc/delimcc.2018.03.16/url
@@ -1,0 +1,2 @@
+archive: "http://okmij.org/ftp/continuations/caml-shift-20180316.tar.gz"
+checksum: "dce59255992c35305d4940e7a2da1d3a"


### PR DESCRIPTION
This somewhat-newly released version of the Delimcc library fixes a compilation failure under GCC 7.x, which affects previous delimcc versions under all OCaml versions.