### PR TITLE
Ppxlib 0.2.1

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.11.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"   {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.11.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.11.0/opam
@@ -15,6 +15,6 @@ depends: [
   "ppx_here"                {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_compare/ppx_compare.v0.11.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.11.0/opam
@@ -13,6 +13,6 @@ depends: [
   "base"                    {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_core/ppx_core.v0.11.0/opam
+++ b/packages/ppx_core/ppx_core.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"   {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.11.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.11.0/opam
@@ -16,6 +16,6 @@ depends: [
   "ppx_fields_conv"         {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_driver/ppx_driver.v0.11.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"   {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_enumerate/ppx_enumerate.v0.11.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.11.0/opam
@@ -13,6 +13,6 @@ depends: [
   "base"                    {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_fun/ppx_fun.0.0.1/opam
+++ b/packages/ppx_fun/ppx_fun.0.0.1/opam
@@ -21,3 +21,4 @@ build: [
 build-test: [
  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
  [ "ocaml" "pkg/pkg.ml" "test" ]]
+conflicts: [ "ppxlib" ]

--- a/packages/ppx_fun/ppx_fun.0.0.2/opam
+++ b/packages/ppx_fun/ppx_fun.0.0.2/opam
@@ -20,3 +20,4 @@ build: [
 build-test: [
  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
  [ "ocaml" "pkg/pkg.ml" "test" ]]
+conflicts: [ "ppxlib" ]

--- a/packages/ppx_fun/ppx_fun.0.0.4/opam
+++ b/packages/ppx_fun/ppx_fun.0.0.4/opam
@@ -22,3 +22,4 @@ build: [
 build-test: [
  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
  [ "ocaml" "pkg/pkg.ml" "test" ]]
+conflicts: [ "ppxlib" ]

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
@@ -23,3 +23,4 @@ depends: [
   "hardcaml"       {>= "1.1.0"}
 ]
 available: ocaml-version >= "4.03"
+conflicts: [ "ppxlib" ]

--- a/packages/ppx_hash/ppx_hash.v0.11.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.11.0/opam
@@ -15,6 +15,6 @@ depends: [
   "ppx_sexp_conv"           {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.2/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.2/opam
@@ -22,3 +22,4 @@ depends: [
   "ocamlbuild"   {build}
 ]
 available: [ ocaml-version >= "4.03.0" ]
+conflicts: [ "ppxlib" ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.3/opam
@@ -22,3 +22,4 @@ depends: [
   "ocamlbuild"   {build}
 ]
 available: [ ocaml-version >= "4.03.0" ]
+conflicts: [ "ppxlib" ]

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.4/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.4.4/opam
@@ -22,3 +22,4 @@ depends: [
   "ocamlbuild"   {build}
 ]
 available: [ ocaml-version >= "4.03.0" ]
+conflicts: [ "ppxlib" ]

--- a/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"   {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.0/opam
@@ -13,6 +13,6 @@ depends: [
   "base"                    {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/opam
@@ -13,7 +13,7 @@ depends: [
   "base"                    {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
   "sexplib0"                {>= "v0.11" & < "v0.12"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
+++ b/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"   {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"   {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
@@ -10,6 +10,6 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib"   {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"   {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.0/opam
@@ -13,6 +13,6 @@ depends: [
   "typerep"                 {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.11.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.11.0/opam
@@ -13,6 +13,6 @@ depends: [
   "variantslib"             {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0" & <= "0.2.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.3.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppxlib/ppxlib.0.1.0/opam
+++ b/packages/ppxlib/ppxlib.0.1.0/opam
@@ -17,3 +17,4 @@ depends: [
   "stdio"                   {>= "v0.11.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]
+conflicts: [ "dune" ]

--- a/packages/ppxlib/ppxlib.0.2.0/opam
+++ b/packages/ppxlib/ppxlib.0.2.0/opam
@@ -17,3 +17,4 @@ depends: [
   "stdio"                   {>= "v0.11.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]
+conflicts: [ "dune" ]

--- a/packages/ppxlib/ppxlib.0.2.1/descr
+++ b/packages/ppxlib/ppxlib.0.2.1/descr
@@ -1,0 +1,9 @@
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.

--- a/packages/ppxlib/ppxlib.0.2.1/opam
+++ b/packages/ppxlib/ppxlib.0.2.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "https://github.com/ocaml-ppx/ppxlib.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.11.0"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.0.9"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ppxlib/ppxlib.0.2.1/url
+++ b/packages/ppxlib/ppxlib.0.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-ppx/ppxlib/releases/download/0.2.1/ppxlib-0.2.1.tbz"
+checksum: "d59ee60d85a374699ae492b7853a090b"


### PR DESCRIPTION
There is a bug in ppxlib 0.1.0 and 0.2.0 that make them incompatible with the upcoming 1.0.0 release of Dune. This PR marks these two packages as incompatible with `dune` and release a 0.2.1 version that fixes the issue.

0.3.0 is not affected but it is not co-installable with ppx_driver v0.11.0, so we need this intermediate version.