### PR TITLE
Package weberizer.0.7.8

### DIFF
--- a/packages/weberizer/weberizer.0.7.8/descr
+++ b/packages/weberizer/weberizer.0.7.8/descr
@@ -1,0 +1,9 @@
+Compile HTML templates into OCaml modules
+
+Weberizer is a simple templating engine for OCaml.  It compiles the
+template to an OCaml module, providing an easy way to set the
+variables and render the template.  String values are automatically
+escaped according to the context of the template in which they appear.
+You can add you own functions to the generated module — for example to
+set several related variables at once (you can also hide those
+variables from the interface if desired).

--- a/packages/weberizer/weberizer.0.7.8/opam
+++ b/packages/weberizer/weberizer.0.7.8/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+tags: [ "web" "template" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/weberizer"
+dev-repo: "https://github.com/Chris00/weberizer.git"
+bug-reports: "https://github.com/Chris00/weberizer/issues"
+doc: "https://Chris00.github.io/weberizer/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "ocamlnet"
+]
+available: [ ocaml-version >= "4.03" ]

--- a/packages/weberizer/weberizer.0.7.8/url
+++ b/packages/weberizer/weberizer.0.7.8/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/weberizer/releases/download/0.7.8/weberizer-0.7.8.tbz"
+checksum: "00404cfa89d106f5d527ad46e2b3fdea"


### PR DESCRIPTION
### `weberizer.0.7.8`

Compile HTML templates into OCaml modules

Weberizer is a simple templating engine for OCaml.  It compiles the
template to an OCaml module, providing an easy way to set the
variables and render the template.  String values are automatically
escaped according to the context of the template in which they appear.
You can add you own functions to the generated module — for example to
set several related variables at once (you can also hide those
variables from the interface if desired).



---
* Homepage: https://github.com/Chris00/weberizer
* Source repo: https://github.com/Chris00/weberizer.git
* Bug tracker: https://github.com/Chris00/weberizer/issues

---


---
0.7.8 2018-06-01
----------------

- Compile with Dune/Jbuilder.
- Fix all compilation warnings with `--dev`.
:camel: Pull-request generated by opam-publish v0.3.5