### PR TITLE
lazy-trie.1.0 is not compatible with -safe-string

### DIFF
--- a/packages/lazy-trie/lazy-trie.1.0.0/opam
+++ b/packages/lazy-trie/lazy-trie.1.0.0/opam
@@ -16,3 +16,4 @@ depends: [
 ]
 dev-repo: "git://github.com/mirage/ocaml-lazy-trie"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/lazy-trie/lazy-trie.1.0.0/opam
+++ b/packages/lazy-trie/lazy-trie.1.0.0/opam
@@ -1,6 +1,8 @@
 opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
 authors: [ "Louis Gesbert" "Thomas Gazagnaire" ]
+homepage: "https://github.com/mirage/ocaml-lazy-trie"
+bug-reports: "https://github.com/mirage/ocaml-lazy-trie/issues"
 license: "ISC"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]


### PR DESCRIPTION
See http://51.145.134.72/4.06.1/bad/lazy-trie.1.0.0