### PR TITLE
Mark benchmark 1.3.1 available only for OCaml < 4.06.0

### DIFF
--- a/packages/benchmark/benchmark.1.3.1/opam
+++ b/packages/benchmark/benchmark.1.3.1/opam
@@ -24,3 +24,4 @@ depopts: [
   "pcre"
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/benchmark/benchmark.1.3.1/opam
+++ b/packages/benchmark/benchmark.1.3.1/opam
@@ -3,9 +3,10 @@ name: "benchmark"
 version: "1.3.1"
 maintainer: "Christophe.Troestler@umons.ac.be"
 authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
-# license: "LGPL-3.0 with OCaml linking exception"
-# homepage: "http://ocaml-benchmark.forge.ocamlcore.org/"
-# dev-repo: "svn://scm.ocamlcore.org/svn/ocaml-benchmark/trunk"
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-benchmark"
+dev-repo: "https://github.com/Chris00/ocaml-benchmark.git"
+bug-reports: "https://github.com/Chris00/ocaml-benchmark/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/root1d/root1d.0.3/opam
+++ b/packages/root1d/root1d.0.3/opam
@@ -18,3 +18,4 @@ depends: [
 ]
 depopts: ["benchmark"]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/root1d/root1d.0.3/opam
+++ b/packages/root1d/root1d.0.3/opam
@@ -4,8 +4,11 @@ authors: [
   "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
   "Edgar Friendly <thelema314@gmail.com>"
 ]
-homepage: "http://forge.ocamlcore.org/projects/root1d/"
 license: "LGPL-3.0 with OCaml linking exception"
+tags: ["scientfic" "root finding"]
+homepage: "https://github.com/Chris00/root1d"
+dev-repo: "https://github.com/Chris00/root1d.git"
+bug-reports: "https://github.com/Chris00/root1d/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/weberizer/weberizer.0.7.2/opam
+++ b/packages/weberizer/weberizer.0.7.2/opam
@@ -3,6 +3,8 @@ maintainer: "Christophe.Troestler@umons.ac.be"
 authors: [ "Christophe Troestler" ]
 license: "LGPL-3.0 with OCaml linking exception"
 homepage: "https://github.com/Chris00/weberizer"
+dev-repo: "https://github.com/Chris00/weberizer.git"
+bug-reports: "https://github.com/Chris00/weberizer/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/weberizer/weberizer.0.7.2/opam
+++ b/packages/weberizer/weberizer.0.7.2/opam
@@ -17,3 +17,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]
+

--- a/packages/weberizer/weberizer.0.7.7/opam
+++ b/packages/weberizer/weberizer.0.7.7/opam
@@ -18,3 +18,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/weberizer/weberizer.0.7.7/opam
+++ b/packages/weberizer/weberizer.0.7.7/opam
@@ -3,6 +3,8 @@ maintainer: "Christophe.Troestler@umons.ac.be"
 authors: [ "Christophe Troestler" ]
 license: "LGPL-3.0 with OCaml linking exception"
 homepage: "https://github.com/Chris00/weberizer"
+dev-repo: "https://github.com/Chris00/weberizer.git"
+bug-reports: "https://github.com/Chris00/weberizer/issues"
 tags: [ "web"  ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]


### PR DESCRIPTION
There are newer versions of benchmark that support more recent
compilers.