### PR TITLE
New minor release of the web programming language Links, version 0.7.3.

### DIFF
--- a/packages/links-postgresql/links-postgresql.0.7.3/descr
+++ b/packages/links-postgresql/links-postgresql.0.7.3/descr
@@ -1,0 +1,43 @@
+Linking Theory to Practice for the Web
+
+[![Build Status](https://travis-ci.org/links-lang/links.svg?branch=master)](https://travis-ci.org/links-lang/links)
+
+Links helps to build modern Ajax-style applications: those with
+significant client- and server-side components.
+
+A typical, modern web program involves many "tiers": part of the
+program runs in the web browser, part runs on a web server, and part
+runs in specialized systems such as a relational database. To create
+such a program, the programmer must master a myriad of languages: the
+logic is written in a mixture of Java, Python, and Perl; the
+presentation in HTML; the GUI behavior in Javascript; and the queries
+are written in SQL or XQuery. There is no easy way to link these: to
+be sure, for example, that an HTML form or an SQL query produces the
+type of data that the Java code expects. This is called the impedance
+mismatch problem.
+
+Links eases the impedance mismatch problem by providing a single
+language for all three tiers. The system is responsible for
+translating the code into suitable languages for each tier: for
+instance, translating some code into Javascript for the browser, some
+into Java for the server, and some into SQL to use the database.
+
+Links incorporates ideas proven in other programming languages:
+database-query support from Kleisli, web-interaction proposals from
+PLT Scheme, and distributed-computing support from Erlang. On top of
+this, it adds some new web-centric features of its own.
+
+FEATURES
+
+ * Allows web programs to be written in a single programming language
+ * Call-by-value functional language
+ * Server / Client annotations
+ * AJAX
+ * Scalability through defunctionalised server continuations.
+ * Statically typed database access a la Kleisli
+ * Concurrent processes on the client and the server
+ * Statically typed Erlang-esque message passing
+ * Polymorphic records and variants
+ * An effect system for supporting abstraction over database queries
+whilst guaranteeing that they can be efficiently compiled to SQL
+ * Handlers for algebraic effects on the server-side and the client-side

--- a/packages/links-postgresql/links-postgresql.0.7.3/opam
+++ b/packages/links-postgresql/links-postgresql.0.7.3/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+
+available: [
+  ocaml-version >= "4.06.0"
+]
+
+build: [
+  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder" {build}
+  "postgresql"
+  "links"
+]

--- a/packages/links-postgresql/links-postgresql.0.7.3/url
+++ b/packages/links-postgresql/links-postgresql.0.7.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/links-lang/links/releases/download/0.7.3/links-0.7.3.tbz"
+checksum: "c81fa629fba096fd881199c3ee6714c5"

--- a/packages/links/links.0.7.3/descr
+++ b/packages/links/links.0.7.3/descr
@@ -1,0 +1,43 @@
+Linking Theory to Practice for the Web
+
+[![Build Status](https://travis-ci.org/links-lang/links.svg?branch=master)](https://travis-ci.org/links-lang/links)
+
+Links helps to build modern Ajax-style applications: those with
+significant client- and server-side components.
+
+A typical, modern web program involves many "tiers": part of the
+program runs in the web browser, part runs on a web server, and part
+runs in specialized systems such as a relational database. To create
+such a program, the programmer must master a myriad of languages: the
+logic is written in a mixture of Java, Python, and Perl; the
+presentation in HTML; the GUI behavior in Javascript; and the queries
+are written in SQL or XQuery. There is no easy way to link these: to
+be sure, for example, that an HTML form or an SQL query produces the
+type of data that the Java code expects. This is called the impedance
+mismatch problem.
+
+Links eases the impedance mismatch problem by providing a single
+language for all three tiers. The system is responsible for
+translating the code into suitable languages for each tier: for
+instance, translating some code into Javascript for the browser, some
+into Java for the server, and some into SQL to use the database.
+
+Links incorporates ideas proven in other programming languages:
+database-query support from Kleisli, web-interaction proposals from
+PLT Scheme, and distributed-computing support from Erlang. On top of
+this, it adds some new web-centric features of its own.
+
+FEATURES
+
+ * Allows web programs to be written in a single programming language
+ * Call-by-value functional language
+ * Server / Client annotations
+ * AJAX
+ * Scalability through defunctionalised server continuations.
+ * Statically typed database access a la Kleisli
+ * Concurrent processes on the client and the server
+ * Statically typed Erlang-esque message passing
+ * Polymorphic records and variants
+ * An effect system for supporting abstraction over database queries
+whilst guaranteeing that they can be efficiently compiled to SQL
+ * Handlers for algebraic effects on the server-side and the client-side

--- a/packages/links/links.0.7.3/opam
+++ b/packages/links/links.0.7.3/opam
@@ -1,0 +1,68 @@
+opam-version: "1.2"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+
+available: [
+  ocaml-version >= "4.06.0"
+]
+
+build: [
+  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+install: [
+# Install documentation
+  [ "mkdir" "-p" "%{links:doc}%"                                      ]
+  [ "cp" "INSTALL" "%{links:doc}%/README"                             ]
+# Copy examples
+  [ "mkdir" "-p" "%{links:share}%/examples"                           ]
+  [ "sh" "-c" "cp -r examples/dbsetup %{links:share}%/examples/dbsetup/" ]
+  [ "sh" "-c" "cp examples/*.links %{links:share}%/examples"          ]
+  [ "sh" "-c" "cp examples/*.jpg %{links:share}%/examples"            ]
+  [ "sh" "-c" "cp examples/*.sql %{links:share}%/examples"            ]
+  [ "sh" "-c" "cp examples/*.html %{links:share}%/examples"           ]
+  [ "sh" "-c" "cp examples/*.css %{links:share}%/examples"            ]
+  [ "sh" "-c" "cp examples/*.js %{links:share}%/examples"             ]
+  [ "sh" "-c" "cp -r examples/dictionary %{links:share}%/examples/"   ]
+  [ "sh" "-c" "cp -r examples/games %{links:share}%/examples/"        ]
+  [ "sh" "-c" "cp -r examples/sessions %{links:share}%/examples/"     ]
+  [ "sh" "-c" "cp -r examples/webserver %{links:share}%/examples/"    ]
+  [ "sh" "-c" "cp -r examples/css %{links:share}%/examples/"          ]
+# Generate and install a config file
+  [ "touch" "config"                                                  ]
+  [ "sh" "-c" "echo jsliburl=/lib/js > config"                          ]
+  [ "sh" "-c" "echo jslibdir=%{links:lib}%/js >> config"               ]
+  [ "sh" "-c" "echo #database_driver=postgresql >> config"             ]
+  [ "sh" "-c" "echo #database_args=localhost:5432:user:pass >> config" ]
+  [ "mkdir" "-p" "%{links:etc}%"                                      ]
+  [ "cp" "config" "%{links:etc}%"                                     ]
+]
+
+remove: [
+  [ "rm" "-f"  "%{links:bin}%/linx" ]
+  [ "rm" "-f"  "%{links:lib}%/prelude.links" ]
+  [ "rm" "-rf" "%{links:lib}%/stdlib" ]
+  [ "rm" "-rf" "%{links:lib}%/js" ]
+  [ "rm" "-rf" "%{links:share}%/examples" ]
+  [ "rm" "-f"  "%{links:etc}%/config" ]
+  [ "rm" "-f"  "%{links:doc}%/README" ]
+]
+
+depends: [
+  "jbuilder" {build}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "3.1.0"}
+  "cohttp"
+  "websocket-lwt"
+  "safepass"
+  "ocamlfind"
+]

--- a/packages/links/links.0.7.3/url
+++ b/packages/links/links.0.7.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/links-lang/links/releases/download/0.7.3/links-0.7.3.tbz"
+checksum: "c81fa629fba096fd881199c3ee6714c5"


### PR DESCRIPTION
The glorious bits

- Improved dynamic loading of available database drivers
- Compatibility with OCaml 4.06+ compiler tool-chain
- Various bug fixes