### PR TITLE
Package uucd.11.0.0

### DIFF
--- a/packages/uucd/uucd.11.0.0/descr
+++ b/packages/uucd/uucd.11.0.0/descr
@@ -1,0 +1,13 @@
+Unicode character database decoder for OCaml
+
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[xmlm]: http://erratique.ch/software/xmlm 

--- a/packages/uucd/uucd.11.0.0/opam
+++ b/packages/uucd/uucd.11.0.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uucd"
+dev-repo: "http://erratique.ch/repos/uucd.git"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+doc: "http://erratique.ch/software/uucd/doc/Uucd"
+tags: [ "unicode" "database" "decoder" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "xmlm" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]

--- a/packages/uucd/uucd.11.0.0/url
+++ b/packages/uucd/uucd.11.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uucd/releases/uucd-11.0.0.tbz"
+checksum: "4bd7b0ad64b054422b412d29b06aa843"


### PR DESCRIPTION
### `uucd.11.0.0`

Unicode character database decoder for OCaml

Uucd is an OCaml module to decode the data of the [Unicode character 
database][1] from its XML [representation][2]. It provides high-level 
(but not necessarily efficient) access to the data so that efficient 
representations can be extracted.

Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
under the ISC license.

[1]: http://www.unicode.org/reports/tr44/
[2]: http://www.unicode.org/reports/tr42/
[xmlm]: http://erratique.ch/software/xmlm 



---
* Homepage: http://erratique.ch/software/uucd
* Source repo: http://erratique.ch/repos/uucd.git
* Bug tracker: https://github.com/dbuenzli/uucd/issues

---


---
v11.0.0 2017-06-06 Lausanne
---------------------------

- Support for Unicode 11.0.0
:camel: Pull-request generated by opam-publish v0.3.5