### PR TITLE
Package uunf.11.0.0

### DIFF
--- a/packages/uunf/uunf.11.0.0/descr
+++ b/packages/uunf/uunf.11.0.0/descr
@@ -1,0 +1,13 @@
+Unicode text normalization for OCaml
+
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms][nf]. The library is independent from any
+IO mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf has no dependency. It may optionally depend on [Uutf][uutf] for
+support on OCaml UTF-X encoded strings. It is distributed under the
+ISC license.
+
+[nf]: http://www.unicode.org/reports/tr15/
+[uutf]: http://erratique.ch/software/uutf

--- a/packages/uunf/uunf.11.0.0/opam
+++ b/packages/uunf/uunf.11.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uunf"
+doc: "http://erratique.ch/software/uunf/doc/Uunf"
+dev-repo: "http://erratique.ch/repos/uunf.git"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+tags: [ "unicode" "text" "normalization" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uchar"
+]
+depopts: [ "uutf" "cmdliner" ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]

--- a/packages/uunf/uunf.11.0.0/url
+++ b/packages/uunf/uunf.11.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uunf/releases/uunf-11.0.0.tbz"
+checksum: "b94a5fd9da5395f475a0aff1dbe2e18f"


### PR DESCRIPTION
### `uunf.11.0.0`

Unicode text normalization for OCaml

Uunf is an OCaml library for normalizing Unicode text. It supports all
Unicode [normalization forms][nf]. The library is independent from any
IO mechanism or Unicode text data structure and it can process text
without a complete in-memory representation.

Uunf has no dependency. It may optionally depend on [Uutf][uutf] for
support on OCaml UTF-X encoded strings. It is distributed under the
ISC license.

[nf]: http://www.unicode.org/reports/tr15/
[uutf]: http://erratique.ch/software/uutf



---
* Homepage: http://erratique.ch/software/uunf
* Source repo: http://erratique.ch/repos/uunf.git
* Bug tracker: https://github.com/dbuenzli/uunf/issues

---


---
v11.0.0 2018-06-06 Lausanne
---------------------------

- Unicode 11.0.0 support.
- Fix bug when normalizer flushes at the end of stream: a spurious
  `Await` was returned before the final `End`.
:camel: Pull-request generated by opam-publish v0.3.5