### PR TITLE
Package uucp.11.0.0

### DIFF
--- a/packages/uucp/uucp.11.0.0/descr
+++ b/packages/uucp/uucp.11.0.0/descr
@@ -1,0 +1,9 @@
+Unicode character properties for OCaml
+
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/

--- a/packages/uucp/uucp.11.0.0/opam
+++ b/packages/uucp/uucp.11.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [
+  "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  "David Kaloper Meršinjak <david@numm.org>"
+]
+homepage: "http://erratique.ch/software/uucp"
+doc: "http://erratique.ch/software/uucp/doc/Uucp"
+dev-repo: "http://erratique.ch/repos/uucp.git"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+tags: [ "unicode" "text" "character" "org:erratique" ]
+license: "ISC"
+depends: [
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "uchar"
+ "uucd" {test} # dev really
+ "uunf" {test}
+ "uutf" {test}
+ ]
+depopts: [ "uunf" "uutf" "cmdliner" ]
+conflicts: [ "uutf" {< "1.0.1"}
+             "cmdliner" {< "1.0.0"} ]
+available: [ ocaml-version >= "4.01.0" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-uutf" "%{uutf:installed}%"
+          "--with-uunf" "%{uunf:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+]]

--- a/packages/uucp/uucp.11.0.0/url
+++ b/packages/uucp/uucp.11.0.0/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/uucp/releases/uucp-11.0.0.tbz"
+checksum: "38565e80bf92f93b4ced73368038baee"


### PR DESCRIPTION
### `uucp.11.0.0`

Unicode character properties for OCaml

Uucp is an OCaml library providing efficient access to a selection of
character properties of the [Unicode character database][1].

Uucp is independent from any Unicode text data structure and has no
dependencies. It is distributed under the ISC license.

[1]: http://www.unicode.org/reports/tr44/



---
* Homepage: http://erratique.ch/software/uucp
* Source repo: http://erratique.ch/repos/uucp.git
* Bug tracker: https://github.com/dbuenzli/uucp/issues

---


---
v11.0.0 2018-06-06 Zürich
-------------------------

- Unicode 11.0.0 support.
- Add support for the Join_Control property (`Uucp.Func.is_join_control`)
  and the Hangul_Syllable_Type property (`Uucp.Hangul.syllable_type`).
:camel: Pull-request generated by opam-publish v0.3.5