### PR TITLE
ocaml-migrate-parsetree v1.0.11

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta18.1"}
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.0.11/ocaml-migrate-parsetree-1.0.11.tbz"
+checksum: "26bb1b038de81a79d43ed95c282b2b71"


### PR DESCRIPTION
### Changelog:

- Fix handling of `--impl/--intf`. Before the driver would crash if
  the file extension was neither `.ml` nor `.mli`
