### PR TITLE
+dockerfile.5.0.0

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.5.0.0/descr
+++ b/packages/dockerfile-cmd/dockerfile-cmd.5.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile-cmd/dockerfile-cmd.5.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.5.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "dockerfile-opam" {>="3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "csv"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile-cmd/dockerfile-cmd.5.0.0/url
+++ b/packages/dockerfile-cmd/dockerfile-cmd.5.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v5.0.0/dockerfile-5.0.0.tbz"
+checksum: "c52b53295067aa207497394251551c6d"

--- a/packages/dockerfile-opam/dockerfile-opam.5.0.0/descr
+++ b/packages/dockerfile-opam/dockerfile-opam.5.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile-opam/dockerfile-opam.5.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.5.0.0/opam
@@ -13,6 +13,7 @@ depends: [
   "dockerfile" {>="3.0.0"}
   "ocaml-version" {>="0.3.0"}
   "cmdliner"
+  "astring"
 ]
 build: [
   ["jbuilder" "subst" "-p" name "--name" name] {pinned}

--- a/packages/dockerfile-opam/dockerfile-opam.5.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.5.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "dockerfile" {>="3.0.0"}
+  "ocaml-version" {>="0.3.0"}
+  "cmdliner"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile-opam/dockerfile-opam.5.0.0/url
+++ b/packages/dockerfile-opam/dockerfile-opam.5.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v5.0.0/dockerfile-5.0.0.tbz"
+checksum: "c52b53295067aa207497394251551c6d"

--- a/packages/dockerfile/dockerfile.5.0.0/descr
+++ b/packages/dockerfile/dockerfile.5.0.0/descr
@@ -1,0 +1,19 @@
+Dockerfile eDSL and distribution support
+
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>

--- a/packages/dockerfile/dockerfile.5.0.0/opam
+++ b/packages/dockerfile/dockerfile.5.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "http://avsm.github.io/avsm/ocaml-dockerfile/doc"
+license: "ISC"
+dev-repo: "https://github.com/avsm/ocaml-dockerfile.git"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+tags: ["org:mirage" "org:ocamllabs"]
+available: [ ocaml-version >= "4.02.3"]
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "sexplib"
+  "base-bytes"
+  "fmt"
+]
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/dockerfile/dockerfile.5.0.0/url
+++ b/packages/dockerfile/dockerfile.5.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/avsm/ocaml-dockerfile/releases/download/v5.0.0/dockerfile-5.0.0.tbz"
+checksum: "c52b53295067aa207497394251551c6d"


### PR DESCRIPTION
```
- Install the Bubblewrap sandboxing tool in all distributions and
  remove the older wrappers for opam2 namespace usage.
- Ensure that X11 is available in the containers so that the
  OCaml Graphics module is available (#8 via @kit-ty-kate)
- Add concept of a "Tier 1" and "Tier 2" distro so that we can
  categorise them more easily for container generation.
- Add support for Alpine 3.7 and Ubuntu 18.04 and Fedora 28.
- Update Ubuntu LTS to 18.04. 
- Deprecate Ubuntu 17.10 and 12.04 (now end-of-life).
- Alter the individual compiler containers to omit the patch version
  from the name. They will always have the latest patch version for CI.
- Allow distro selection to be filtered by OCaml version and architecture.
  This allows combinations like Ubuntu 18.04 (which breaks on earlier
  versions of OCaml due to the shift to PIE) to be expressed.
- Add missing OpenSUSE to the latest distros list.
- Add Ppc64le architecture.
```