### PR TITLE
Add async_graphics 0.6.0

### DIFF
--- a/packages/async_graphics/async_graphics.0.5.1/opam
+++ b/packages/async_graphics/async_graphics.0.5.1/opam
@@ -11,7 +11,7 @@ tags: [
 ]
 remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "graphics"
   "async" {>= "109.09.00" & < "113.00.00"}
   "ocamlbuild" {build}

--- a/packages/async_graphics/async_graphics.0.5/opam
+++ b/packages/async_graphics/async_graphics.0.5/opam
@@ -13,7 +13,7 @@ remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
   "ocamlfind"
   "graphics"
-  "async" {>= "109.09.00" & < "v0.10"}
+  "async" {>= "109.09.00" & < "113.00.00"}
   "ocamlbuild" {build}
 ]
 install: "./install.sh"

--- a/packages/async_graphics/async_graphics.0.5/opam
+++ b/packages/async_graphics/async_graphics.0.5/opam
@@ -11,7 +11,7 @@ tags: [
 ]
 remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "graphics"
   "async" {>= "109.09.00" & < "113.00.00"}
   "ocamlbuild" {build}

--- a/packages/async_graphics/async_graphics.0.6.0/descr
+++ b/packages/async_graphics/async_graphics.0.6.0/descr
@@ -1,0 +1,1 @@
+Async wrapper for the OCaml Graphics library

--- a/packages/async_graphics/async_graphics.0.6.0/opam
+++ b/packages/async_graphics/async_graphics.0.6.0/opam
@@ -13,7 +13,7 @@ remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
   "ocamlfind"
   "graphics"
-  "async" {>= "109.09.00" & < "113.00.00"}
+  "async" {>= "113.00.00"}
   "ocamlbuild" {build}
 ]
 install: "./install.sh"

--- a/packages/async_graphics/async_graphics.0.6.0/opam
+++ b/packages/async_graphics/async_graphics.0.6.0/opam
@@ -13,7 +13,7 @@ remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
   "ocamlfind" {build}
   "graphics"
-  "async" {>= "113.00.00"}
+  "async" {>= "v0.9"}
   "ocamlbuild" {build}
 ]
 install: "./install.sh"

--- a/packages/async_graphics/async_graphics.0.6.0/opam
+++ b/packages/async_graphics/async_graphics.0.6.0/opam
@@ -11,7 +11,7 @@ tags: [
 ]
 remove: [["ocamlfind" "remove" "async_graphics"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "graphics"
   "async" {>= "113.00.00"}
   "ocamlbuild" {build}

--- a/packages/async_graphics/async_graphics.0.6.0/url
+++ b/packages/async_graphics/async_graphics.0.6.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/lpw25/async_graphics/archive/0.6.0.tar.gz"
+checksum: "da23174fe7a60956afa514178ce6cea3"


### PR DESCRIPTION
Adds async_graphics version 0.6.0. This updates async_graphics to work with recent versions of async. This PR also fixes the constraints on the earlier versions of async_graphics to stop them being used with some versions of async that they won't work with.