### PR TITLE
atdgen: fix deps

### DIFF
--- a/packages/atdgen/atdgen.1.10.2/opam
+++ b/packages/atdgen/atdgen.1.10.2/opam
@@ -16,7 +16,7 @@ build-test: [
 
 depends: [
   "jbuilder" {build}
-  "atd" {>= "1.1.0" & < "1.13.0"}
+  "atd" {>= "1.2.0" & < "1.13.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1" }
 ]

--- a/packages/atdgen/atdgen.1.12.0/opam
+++ b/packages/atdgen/atdgen.1.12.0/opam
@@ -16,7 +16,7 @@ build-test: [
 
 depends: [
   "jbuilder" {build}
-  "atd" {>= "1.1.0" & < "1.13.0"}
+  "atd" {>= "1.2.0" & < "1.13.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1" }
 ]


### PR DESCRIPTION
Newer versions of `atdgen` need `atd` >= 1.2.0.
