### PR TITLE
sequence: add bound on ocaml version

### DIFF
--- a/packages/sequence/sequence.0.10/opam
+++ b/packages/sequence/sequence.0.10/opam
@@ -32,3 +32,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["delimcc" "base-bigarray"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.11/opam
+++ b/packages/sequence/sequence.0.11/opam
@@ -34,3 +34,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["delimcc" "base-bigarray"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.1/opam
+++ b/packages/sequence/sequence.0.3.1/opam
@@ -10,3 +10,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.2/opam
+++ b/packages/sequence/sequence.0.3.2/opam
@@ -10,3 +10,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.3/opam
+++ b/packages/sequence/sequence.0.3.3/opam
@@ -10,3 +10,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.4/opam
+++ b/packages/sequence/sequence.0.3.4/opam
@@ -10,3 +10,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.5/opam
+++ b/packages/sequence/sequence.0.3.5/opam
@@ -10,3 +10,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.6.1/opam
+++ b/packages/sequence/sequence.0.3.6.1/opam
@@ -17,3 +17,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.6/opam
+++ b/packages/sequence/sequence.0.3.6/opam
@@ -17,3 +17,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3.7/opam
+++ b/packages/sequence/sequence.0.3.7/opam
@@ -14,3 +14,4 @@ homepage: "https://github.com/c-cube/sequence/"
 doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.3/opam
+++ b/packages/sequence/sequence.0.3/opam
@@ -10,3 +10,4 @@ depends: [
 ]
 dev-repo: "git://github.com/c-cube/sequence"
 install: [make "install"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.5.4/opam
+++ b/packages/sequence/sequence.0.5.4/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.07.0" ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
 homepage: "https://github.com/c-cube/sequence/"
 depopts: ["delimcc"]

--- a/packages/sequence/sequence.0.5.5/opam
+++ b/packages/sequence/sequence.0.5.5/opam
@@ -17,6 +17,7 @@ depends: [
   "base-bytes"
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.07.0" ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
 homepage: "https://github.com/c-cube/sequence/"
 depopts: ["delimcc" "base-bigarray"]

--- a/packages/sequence/sequence.0.6/opam
+++ b/packages/sequence/sequence.0.6/opam
@@ -17,6 +17,7 @@ depends: [
   "base-bytes"
   "ocamlbuild" {build}
 ]
+available: [ ocaml-version < "4.07.0" ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
 homepage: "https://github.com/c-cube/sequence/"
 depopts: ["delimcc" "base-bigarray"]

--- a/packages/sequence/sequence.0.7/opam
+++ b/packages/sequence/sequence.0.7/opam
@@ -23,3 +23,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["delimcc" "base-bigarray"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.8/opam
+++ b/packages/sequence/sequence.0.8/opam
@@ -24,3 +24,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["delimcc" "base-bigarray"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.0.9/opam
+++ b/packages/sequence/sequence.0.9/opam
@@ -24,3 +24,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["delimcc" "base-bigarray"]
+available: [ ocaml-version < "4.07.0" ]

--- a/packages/sequence/sequence.1.0/opam
+++ b/packages/sequence/sequence.1.0/opam
@@ -18,3 +18,4 @@ depends: [
   "qtest" {test}
 ]
 depopts: "base-bigarray"
+available: [ ocaml-version < "4.07.0" ]


### PR DESCRIPTION
`sequence` doesn't compile on 4.07.0 because we added the stdlib module `Seq`, with new functions in `Set` and `Map`.

A new release was done last week.

cc @c-cube 
