### PR TITLE
js_of_ocaml-compiler: add bound on ocaml version

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.1/opam
@@ -25,4 +25,4 @@ conflicts: [
   "js_of_ocaml" {< "3.0"}
 ]
 
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.07.0" ]

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.2/opam
@@ -25,4 +25,4 @@ conflicts: [
   "js_of_ocaml" {< "3.0"}
 ]
 
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.07.0" ]

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.1.0/opam
@@ -25,4 +25,4 @@ conflicts: [
   "js_of_ocaml" {< "3.0"}
 ]
 
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.07.0" ]


### PR DESCRIPTION
Doesn't compile with 4.07 because of the change to `Env.summary`.
