### PR TITLE
Package reason.3.2.0

### DIFF
--- a/packages/reason/reason.3.2.0/descr
+++ b/packages/reason/reason.3.2.0/descr
@@ -1,0 +1,5 @@
+Reason: Syntax & Toolchain for OCaml
+
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem.

--- a/packages/reason/reason.3.2.0/opam
+++ b/packages/reason/reason.3.2.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/facebook/reason"
+doc: "http://reasonml.github.io/"
+bug-reports: "https://github.com/facebook/reason/issues"
+dev-repo: "git://github.com/facebook/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder"                {build}
+  "ocamlfind"               {build}
+  "menhir"                  {>= "20170418" & <= "20171013"}
+  "merlin-extend"           {>= "0.3"}
+  "result"
+  "ocaml-migrate-parsetree"
+]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.07" ]

--- a/packages/reason/reason.3.2.0/url
+++ b/packages/reason/reason.3.2.0/url
@@ -1,0 +1,2 @@
+http: "https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.2.0.tgz"
+checksum: "e20593cc089e481997376b973f11accb"


### PR DESCRIPTION
### `reason.3.2.0`

Reason: Syntax & Toolchain for OCaml

Reason gives OCaml a new syntax that is remniscient of languages like
JavaScript. It's also the umbrella project for a set of tools for the OCaml &
JavaScript ecosystem.



---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

:camel: Pull-request generated by opam-publish v0.3.5