### PR TITLE
Package rtop.3.2.0

### DIFF
--- a/packages/rtop/rtop.3.2.0/descr
+++ b/packages/rtop/rtop.3.2.0/descr
@@ -1,0 +1,3 @@
+rtop: Reason toplevel
+
+rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/diml/utop).

--- a/packages/rtop/rtop.3.2.0/opam
+++ b/packages/rtop/rtop.3.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/facebook/reason"
+doc: "http://reasonml.github.io/"
+bug-reports: "https://github.com/facebook/reason/issues"
+dev-repo: "git://github.com/facebook/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder"                {build}
+  "reason"                  {= "3.2.0"}
+  "utop"                    {>= "1.17"}
+]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.07" ]

--- a/packages/rtop/rtop.3.2.0/url
+++ b/packages/rtop/rtop.3.2.0/url
@@ -1,0 +1,2 @@
+http: "https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.2.0.tgz"
+checksum: "e20593cc089e481997376b973f11accb"


### PR DESCRIPTION
### `rtop.3.2.0`

rtop: Reason toplevel

rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/diml/utop).



---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---

:camel: Pull-request generated by opam-publish v0.3.5