### PR TITLE
ppxx: add bound on OCaml version

### DIFF
--- a/packages/ppxx/ppxx.2.1.0/opam
+++ b/packages/ppxx/ppxx.2.1.0/opam
@@ -25,5 +25,5 @@ depends: [
   "ppx_tools_versioned"
 ]
 available: [
-  ocaml-version >= "4.04.0"
+  ocaml-version >= "4.04.0" & ocaml-version < "4.07.0"
 ]

--- a/packages/ppxx/ppxx.2.3.0/opam
+++ b/packages/ppxx/ppxx.2.3.0/opam
@@ -24,5 +24,5 @@ depends: [
   "ocaml-migrate-parsetree"
 ]
 available: [
-  ocaml-version >= "4.04.0"
+  ocaml-version >= "4.04.0" & ocaml-version < "4.07.0"
 ]

--- a/packages/ppxx/ppxx.2.3.1/opam
+++ b/packages/ppxx/ppxx.2.3.1/opam
@@ -14,4 +14,4 @@ depends: [
   "ocaml-compiler-libs"
   "ocaml-migrate-parsetree"
 ]
-available: [ocaml-version >= "4.04.0"]
+available: [ocaml-version >= "4.04.0" & ocaml-version < "4.07.0"]


### PR DESCRIPTION
`ppxx` won't compile on 4.07.0 because `Ident.t` has become abstract.

reported upstream with a patch: https://bitbucket.org/camlspotter/ppxx/issues/3/fix-for-407

cc @camlspotter 
