### PR TITLE
utop: add bound on OCaml version

### DIFF
--- a/packages/utop/utop.2.0.2/opam
+++ b/packages/utop/utop.2.0.2/opam
@@ -22,4 +22,4 @@ depends: [
   "jbuilder"     {build & >= "1.0+beta9"}
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/utop/utop.2.1.0/opam
+++ b/packages/utop/utop.2.1.0/opam
@@ -22,4 +22,4 @@ depends: [
   "jbuilder"     {build & >= "1.0+beta9"}
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.02.3" & ocam-version < "4.07.0"]


### PR DESCRIPTION
`utop` doesn't compile on 4.07.0 because of changes to `Env.summary`.

cc @diml 
