### PR TITLE
[new release] irmin (1.4.0)

### DIFF
--- a/packages/irmin/irmin.1.4.0/descr
+++ b/packages/irmin/irmin.1.4.0/descr
@@ -1,0 +1,7 @@
+Irmin, a distributed database that follows the same design principles as Git
+
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.

--- a/packages/irmin/irmin.1.4.0/opam
+++ b/packages/irmin/irmin.1.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "result"
+  "fmt" {>= "0.8.0"}
+  "uri" {>= "1.3.12"}
+  "cstruct" {>= "1.6.0"}
+  "jsonm" {>= "1.0.0"}
+  "lwt" {>= "2.4.7"}
+  "ocamlgraph"
+  "hex" {>= "0.2.0"}
+  "logs" {>= "0.5.0"}
+  "astring"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/irmin/irmin.1.4.0/url
+++ b/packages/irmin/irmin.1.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/irmin/releases/download/1.4.0/irmin-1.4.0.tbz"
+checksum: "e214dd3832bbe7b83df6c77263ac525b"


### PR DESCRIPTION
Irmin, a distributed database that follows the same design principles as Git

- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>
- Documentation: <a href="https://mirage.github.io/irmin/">https://mirage.github.io/irmin/</a>

##### CHANGES:

- Add types for `Contents.hash`, `Tree.hash` and `Commit.hash` (mirage/irmin#512, @samoht)
- `Tree.hash` and `Tree.of_hash` now work on leaf nodes. To do this, `Tree.hash`
  has to return a more complex type (mirage/irmin#512, @samoht)
- support for webmachine 0.6.0 (mirage/irmin#505, @ansiwen)
