### PR TITLE
ocp-index: add bound on jbuilder version

### DIFF
--- a/packages/ocp-index/ocp-index.1.1.6/opam
+++ b/packages/ocp-index/ocp-index.1.1.6/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/OCamlPro/ocp-index.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocp-pp"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta19"}
   "ocp-indent" {>= "1.4.2"}
   "re"
   "cmdliner"


### PR DESCRIPTION
Older versions of jbuilder don't like ocp-index's `jbuild` file when lambda-term is not installed.

cc @AltGr @Drup 
