### PR TITLE
[new release] dune-release (0.2.0)

### DIFF
--- a/packages/dune-release/dune-release.0.2.0/descr
+++ b/packages/dune-release/dune-release.0.2.0/descr
@@ -1,0 +1,6 @@
+Release dune packages in opam
+
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports only projects be built
+with [Dune](https://github.com/ocaml/dune) and released on
+[GitHub](https://github.com).

--- a/packages/dune-release/dune-release.0.2.0/opam
+++ b/packages/dune-release/dune-release.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire"]
+homepage: "https://github.com/samoht/dune-release"
+license: "ISC"
+dev-repo: "https://github.com/samoht/dune-release.git"
+bug-reports: "https://github.com/samoht/dune-release/issues"
+doc: "https://samoht.github.io/dune-release/"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build}
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "webbrowser"
+  "opam-format"
+  "rresult"
+  "logs"
+  "odoc"
+]
+
+available: [
+  ocaml-version >= "4.06.0"
+]

--- a/packages/dune-release/dune-release.0.2.0/url
+++ b/packages/dune-release/dune-release.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/dune-release/releases/download/0.2.0/dune-release-0.2.0.tbz"
+checksum: "4ac74d05e38d255a86c012e149e13793"


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/samoht/dune-release">https://github.com/samoht/dune-release</a>
- Documentation: <a href="https://samoht.github.io/dune-release/">https://samoht.github.io/dune-release/</a>

##### CHANGES:

- Remove opam lint warnings for 1.2 files (samoht/dune-release#2, @samoht)
- Add a `--keep-v` option to not drop `v` at the beginning of version
  numbers (samoht/dune-release#6, @samoht)
- Pass `-p <package>` to jbuilder (samoht/dune-release#8, @diml)
- Fix a bug in `Distrib.write_subst` which could cause an infinite loop
  (samoht/dune-release#10, @diml)
- Add a `--dry-run` option to avoid side-effects for all commands (@samoht)
- Rewrite issues numbers in changelog to point to the right repository
  (samoht/dune-release#13, @samoht)
- Stop force pushing tags to `origin`. Instead, just force push the release
  tag directly to the `dev-repo` repository (@samoht)
- Fix publishing distribution when the the tag to publish is not the repository
  HEAD (samoht/dune-release#4, @samoht)
- Do not depend on `opam-publish` anymore. Use configuration files stored
  in `~/.dune` to parametrise the publishing workflow. (@samoht)
