### PR TITLE
ezjsonm-lwt: not available on 4.06

### DIFF
--- a/packages/ezjsonm-lwt/ezjsonm-lwt.0.5.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.0.5.0/opam
@@ -26,3 +26,4 @@ depends: [
   "hex"
   "lwt"       {>= "2.5.0"}
 ]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
See http://51.145.134.72/4.06.1/bad/ezjsonm-lwt.0.5.0