### PR TITLE
conf-r: fix build command

### DIFF
--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -5,7 +5,7 @@ authors: "https://www.r-project.org/contributors.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2+"
-build: ["R" "--vanilla" "--slave" "check.r"]
+build: ["R" "--vanilla" "--slave" "<" "check.r"]
 depexts: [
   [["osx" "homebrew"] ["r"]]
   [["archlinux"] ["r"]]


### PR DESCRIPTION
In its current form, the build command doesn't actually use the file `check.r`, as can be seen by running
```sh
$R --vanilla --slave rien.r 
ARGUMENT 'rien.r' __ignored__
```
@UnixJunkie do you confirm the fix is correct?