### PR TITLE
git-mirage: old versions need an old version of conduit

### DIFF
--- a/packages/git-mirage/git-mirage.1.10.0/opam
+++ b/packages/git-mirage/git-mirage.1.10.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-flow-lwt"
   "mirage-channel-lwt"
   "mirage-fs-lwt"
-  "mirage-conduit" {>= "2.3.0"}
+  "mirage-conduit" {>= "2.3.0" & < "3.0.0"}
   "result"
   "git-http" {>= "1.10.0"}
   "git"      {>= "1.10.0"}

--- a/packages/git-mirage/git-mirage.1.10.0/opam
+++ b/packages/git-mirage/git-mirage.1.10.0/opam
@@ -11,7 +11,7 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests"
 
 build-test: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
-  ["ocaml" "pkg/pkg.ml" "test"]
+  ["ocaml" "pkg/pkg.ml" "test" "-n" name]
 ]
 
 depends: [
@@ -24,6 +24,7 @@ depends: [
   "git-http" {>= "1.10.0"}
   "git"      {>= "1.10.0"}
   "alcotest"       {test}
+  "mtime"          {test & <  "1.0.0"}
   "mirage-fs-unix" {test & >= "1.3.0"}
   "camlzip"        {test & >= "1.07"}
   "nocrypto"       {test & >= "0.5.4"}

--- a/packages/git-mirage/git-mirage.1.11.0/opam
+++ b/packages/git-mirage/git-mirage.1.11.0/opam
@@ -16,7 +16,7 @@ depends: [
   "mirage-flow-lwt"
   "mirage-channel-lwt"
   "mirage-fs-lwt"
-  "mirage-conduit" {>= "2.3.0"}
+  "mirage-conduit" {>= "2.3.0" & < "3.0.0"}
   "result"
   "git-http" {>= "1.11.0"}
   "git"      {>= "1.11.0"}

--- a/packages/git-mirage/git-mirage.1.11.0/opam
+++ b/packages/git-mirage/git-mirage.1.11.0/opam
@@ -18,6 +18,7 @@ depends: [
   "mirage-fs-lwt"
   "mirage-conduit" {>= "2.3.0" & < "3.0.0"}
   "result"
+  "cstruct"  {<  "3.2.0"}
   "git-http" {>= "1.11.0"}
   "git"      {>= "1.11.0"}
   "alcotest"       {test}


### PR DESCRIPTION
Fixes http://51.145.134.72/4.05.0/bad/git-mirage.1.10.0