### PR TITLE
mirage-fs-unix: old versions need an old version of lwt

### DIFF
--- a/packages/mirage-fs-unix/mirage-fs-unix.1.1.4/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.1.4/opam
@@ -14,10 +14,11 @@ install: [
 remove: ["ocamlfind" "remove" "mirage-fs-unix"]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "lwt" {< "4.0.0"}
   "camlp4"
   "cstruct" {>= "1.4.0"}
   "mirage-types-lwt" {< "3.0.0"}
-  "ocamlbuild" {build}
   "cstruct-lwt"
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
@@ -18,14 +18,15 @@ build-test: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-fs-unix"]
 depends: [
+  "ocamlbuild" {build}
   "ocamlfind" {build}
   "cstruct" {>= "1.4.0"}
+  "cstruct-lwt"
+  "lwt" {< "4.0.0"}
   "mirage-types-lwt" {< "3.0.0"}
   "camlp4"
   "mirage-clock-unix" {test}
   "alcotest" {test}
   "ounit" {test}
-  "ocamlbuild" {build}
-  "cstruct-lwt"
 ]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "lwt" {< "4.0.0"}
   "mirage-types-lwt" {< "3.0.0"}
   "camlp4"
-  "mirage-clock-unix" {test}
+  "mirage-clock-unix" {test & = "1.0.0"}
   "alcotest" {test}
   "ounit" {test}
 ]


### PR DESCRIPTION
Fix http://51.145.134.72/4.05.0/bad/mirage-fs-unix.1.2.0
and http://51.145.134.72/4.05.0/bad/mirage-fs-unix.1.1.4