### PR TITLE
old versions of irmin need an old version of re

### DIFF
--- a/packages/irmin/irmin.0.10.0/opam
+++ b/packages/irmin/irmin.0.10.0/opam
@@ -33,7 +33,7 @@ depends: [
   "uri" {>= "1.3.12"}
   "stringext" {>= "1.1.0"}
   "hex"
-  "re"
+  "re" {< "1.7.2"}
   "cmdliner"
   "crunch"
   "base-unix" {test}

--- a/packages/irmin/irmin.0.10.1/opam
+++ b/packages/irmin/irmin.0.10.1/opam
@@ -33,7 +33,7 @@ depends: [
   "uri" {>= "1.3.12"}
   "stringext" {>= "1.1.0"}
   "hex"
-  "re"
+  "re" {< "1.7.2"}
   "cmdliner"
   "crunch"
   "base-unix" {test}

--- a/packages/irmin/irmin.0.11.0/opam
+++ b/packages/irmin/irmin.0.11.0/opam
@@ -36,7 +36,7 @@ depends: [
   "uri" {>= "1.3.12"}
   "stringext" {>= "1.1.0"}
   "hex"
-  "re"
+  "re" {< "1.7.2"}
   "cmdliner"
   "crunch"
   "base-unix" {test}

--- a/packages/irmin/irmin.0.11.1/opam
+++ b/packages/irmin/irmin.0.11.1/opam
@@ -32,7 +32,7 @@ depends: [
   "uri" {>= "1.3.12"}
   "stringext" {>= "1.1.0"}
   "hex"
-  "re"
+  "re" {< "1.7.2"}
   "cmdliner"
   "crunch"
 ]

--- a/packages/irmin/irmin.0.12.0/opam
+++ b/packages/irmin/irmin.0.12.0/opam
@@ -39,7 +39,7 @@ depends: [
   "uri" {>= "1.3.12"}
   "astring"
   "hex"
-  "re"
+  "re" {< "1.7.2"}
   "cmdliner"
   "crunch"
   "mtime"         {test}


### PR DESCRIPTION
Fix http://51.145.134.72/4.05.0/bad/irmin-unix.0.9.9