### PR TITLE
dns: fix installation of optional sub-packages with `-t`

### DIFF
--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -26,7 +26,10 @@ build: [
     "--with-async" "%{async:installed}%" ]
 ]
 build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+    "--with-lwt" "%{lwt+mirage-profile+cmdliner:installed}%"
+    "--with-mirage" "%{mirage-time-lwt+mirage-stack-lwt+mirage-kv-lwt+lwt+duration+io-page+mirage-profile:installed}%"
+    "--with-async" "%{async:installed}%" ]
   ["ocaml" "pkg/pkg.ml" "test" ]
 ]
 

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -26,7 +26,10 @@ build: [
     "--with-async" "%{async:installed}%" ]
 ]
 build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+    "--with-lwt" "%{lwt+mirage-profile+cmdliner:installed}%"
+    "--with-mirage" "%{mirage-time-lwt+mirage-stack-lwt+mirage-kv-lwt+lwt+duration+mirage-profile:installed}%"
+    "--with-async" "%{async:installed}%" ]
   ["ocaml" "pkg/pkg.ml" "test" ]
 ]
 

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -28,7 +28,10 @@ build: [
     "--with-async" "%{async:installed}%" ]
 ]
 build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+    "--with-lwt" "%{lwt+mirage-profile+cmdliner:installed}%"
+    "--with-mirage" "%{mirage-time-lwt+mirage-stack-lwt+mirage-kv-lwt+lwt+duration+mirage-profile:installed}%"
+    "--with-async" "%{async:installed}%" ]
   ["ocaml" "pkg/pkg.ml" "test" ]
 ]
 


### PR DESCRIPTION
Fix `ocamlfind: Package `dns.mirage' not found` errors