### PR TITLE
[new release] crlibm (0.2)

### DIFF
--- a/packages/crlibm/crlibm.0.2/descr
+++ b/packages/crlibm/crlibm.0.2/descr
@@ -1,0 +1,1 @@
+Binding to CRlibm, a correctly rounded math lib

--- a/packages/crlibm/crlibm.0.2/opam
+++ b/packages/crlibm/crlibm.0.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["libm" "math" "science"]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-crlibm"
+dev-repo: "https://github.com/Chris00/ocaml-crlibm.git"
+bug-reports: "https://github.com/Chris00/ocaml-crlibm/issues"
+doc: "https://Chris00.github.io/ocaml-crlibm/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "jbuilder" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "base-bytes" {build}
+  "benchmark" {test}
+]
+available: [ ocaml-version >= "4.02" ]

--- a/packages/crlibm/crlibm.0.2/url
+++ b/packages/crlibm/crlibm.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-crlibm/releases/download/0.2/crlibm-0.2.tbz"
+checksum: "f7d0a67363df00fab66e3d898621b7b3"


### PR DESCRIPTION
Binding to CRlibm, a correctly rounded math lib

- Project page: <a href="https://github.com/Chris00/ocaml-crlibm">https://github.com/Chris00/ocaml-crlibm</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-crlibm/doc">https://Chris00.github.io/ocaml-crlibm/doc</a>

##### CHANGES:

- Speed improvements.
