### PR TITLE
codept 0.10.2: support for OCaml 4.07

### DIFF
--- a/packages/codept/codept.0.10.2/descr
+++ b/packages/codept/codept.0.10.2/descr
@@ -1,0 +1,12 @@
+alternative ocaml dependency analyzer
+
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+   when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis.

--- a/packages/codept/codept.0.10.2/opam
+++ b/packages/codept/codept.0.10.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "codept"
+version: "0.10.2"
+author: "octachron <octa@polychoron.fr>"
+maintainer: "octachron <octa@polychoron.fr>"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+license: "gpl-3"
+dev-repo: "https://github.com/Octachron/codept.git"
+build: [
+  ["./configure" "--%{ocamlbuild:enable}%-ocamlbuild"]
+  [make "all"]
+]
+build-test: [
+  [make "alt2-tests"]
+]
+build-doc: [
+  [make "alt2-docs"]
+]
+depopts:["ocamlbuild"]
+depends: ["base-unix"]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/codept/codept.0.10.2/url
+++ b/packages/codept/codept.0.10.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Octachron/codept/archive/0.10.2.tar.gz"
+checksum: "cded6752fea4095af4706e7daf5d4d24"


### PR DESCRIPTION
# codept − alternative ocaml dependency analyzer

Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep.
This new release updates the supported compiler version to 4.07 by supporting the new prefixed
standard library and the abstract compiler's Ident.t type.

## Changes in 0.10.2

### Features

  * Improved priority order for module resolution: local files, user libraries, standard library
  * support for ocaml script syntax,  `#open` and `#require` are not taken in account yet.

### OCaml version support:

  * OCaml 4.07: prefixed standard library

### Bug fixes:

  * graphviz output: escape graphviz keywords