### PR TITLE
digestif.0.5: needs newer ocamlbuild

### DIFF
--- a/packages/digestif/digestif.0.5/opam
+++ b/packages/digestif/digestif.0.5/opam
@@ -12,7 +12,7 @@ license:      "MIT"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 
 depends: [
-  "ocamlbuild"     {build}
+  "ocamlbuild"     {build & >= "0.11.0"}
   "ocamlfind"      {build}
   "topkg"          {build}
   "base-bytes"


### PR DESCRIPTION
With older `ocamlbuild` I get a mysterious linker error.

cc @Eyyub @dinosaure 
