### PR TITLE
ppx_ast: add bound on OCaml version

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.10.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.10.0/opam
@@ -13,4 +13,4 @@ depends: [
   "jbuilder"                {build & >= "1.0+beta12"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.04.1" & ocaml-version < "4.06.1" ]


### PR DESCRIPTION
ppx_ast.v0.10.0 fails to compile since 4.06.1, apparently because ocaml/ocaml@f6d53cc38f87c67fbf49109f5fb79a0334bab17a changed the type `Warnings.t`.

cc @janestreet
