### PR TITLE
rawlink: fix dependency

### DIFF
--- a/packages/rawlink/rawlink.0.6/opam
+++ b/packages/rawlink/rawlink.0.6/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "cstruct" {>= "3.2.0"}
   "ppx_cstruct"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.11.0"}
 ]
 depexts: [[ ["alpine"] ["linux-headers"] ]]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/rawlink/rawlink.0.7/opam
+++ b/packages/rawlink/rawlink.0.7/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "cstruct" {>= "3.2.0"}
   "ppx_cstruct"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.11.0"}
 ]
 depexts: [[ ["alpine"] ["linux-headers"] ]]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
rawlink needs a recent version of ocamlbuild.

This is probably the same problem as #12175 

cc @haesbaert 
