### PR TITLE
[new release] gsl (1.22.0)

### DIFF
--- a/packages/gsl/gsl.1.22.0/descr
+++ b/packages/gsl/gsl.1.22.0/descr
@@ -1,0 +1,6 @@
+GSL - Bindings to the GNU Scientific Library
+
+gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
+most frequently used functions for scientific computation including algorithms
+for optimization, differential equations, statistics, random number generation,
+linear algebra, etc.

--- a/packages/gsl/gsl.1.22.0/opam
+++ b/packages/gsl/gsl.1.22.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Olivier Andrieu <oandrieu@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+]
+license: "GPL-3+"
+homepage: "https://mmottl.github.io/gsl-ocaml"
+doc: "https://mmottl.github.io/gsl-ocaml/api"
+dev-repo: "https://github.com/mmottl/gsl-ocaml.git"
+bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "conf-gsl" {build}
+  "conf-pkg-config" {build}
+  "base" {build}
+  "stdio" {build}
+  "configurator" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
+]
+
+available: [ ocaml-version >= "4.05" ]

--- a/packages/gsl/gsl.1.22.0/url
+++ b/packages/gsl/gsl.1.22.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mmottl/gsl-ocaml/releases/download/1.22.0/gsl-1.22.0.tbz"
+checksum: "1baff3a8d0fab6ab080b9063ef3a7ac4"


### PR DESCRIPTION
GSL - Bindings to the GNU Scientific Library

- Project page: <a href="https://mmottl.github.io/gsl-ocaml">https://mmottl.github.io/gsl-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/gsl-ocaml/api">https://mmottl.github.io/gsl-ocaml/api</a>

##### CHANGES:

* Fixed warnings and errors in configuration code due to upstream changes.
