### PR TITLE
Package omod.0.0.1

### DIFF
--- a/packages/omod/omod.0.0.1/descr
+++ b/packages/omod/omod.0.0.1/descr
@@ -1,0 +1,7 @@
+Lookup and load installed OCaml modules
+
+Omod is a library and command line to lookup and load installed OCaml
+modules. It provides a mecanism to load modules and their dependencies
+in the OCaml toplevel system (REPL).
+
+omod is distributed under the ISC license.

--- a/packages/omod/omod.0.0.1/opam
+++ b/packages/omod/omod.0.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The omod programmers"]
+homepage: "http://erratique.ch/software/omod"
+doc: "http://erratique.ch/software/omod/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/omod.git"
+bug-reports: "https://github.com/dbuenzli/omod/issues"
+tags: [ "org:erratique" "dev" "toplevel" "repl" ]
+available: [ ocaml-version >= "4.03.0"]
+depends:
+[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.1"}
+  "cmdliner" {>= "1.0.2"}
+]
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--lib-dir" "%{lib}%"
+]]

--- a/packages/omod/omod.0.0.1/url
+++ b/packages/omod/omod.0.0.1/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/omod/releases/omod-0.0.1.tbz"
+checksum: "4473c5d474a0c2ba8715f64bd3d2b800"


### PR DESCRIPTION
### `omod.0.0.1`

Lookup and load installed OCaml modules

Omod is a library and command line to lookup and load installed OCaml
modules. It provides a mecanism to load modules and their dependencies
in the OCaml toplevel system (REPL).

omod is distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/omod
* Source repo: http://erratique.ch/repos/omod.git
* Bug tracker: https://github.com/dbuenzli/omod/issues

---


---
v0.0.1 2018-06-12 Zagreb
------------------------

First release.
:camel: Pull-request generated by opam-publish v0.3.5