### PR TITLE
ppx_ast: add bound on OCaml version (second attempt)

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.10.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.10.0/opam
@@ -13,4 +13,4 @@ depends: [
   "jbuilder"                {build & >= "1.0+beta12"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.04.1" & ocaml-version < "4.07.0" ]


### PR DESCRIPTION
Follow-up to #12180 .

@samoht the error message is:
```
- File "src/location_helper.ml", line 1, characters 63-99:
- Error: The constructor Ocaml_common.Warnings.Deprecated
-        expects 3 argument(s), but is applied here to 1 argument(s)
-       ocamlc src/.ppx_ast.objs/ppx_ast__Location_helper.{cmi,cmo,cmt} (exit 2)
```
