### PR TITLE
Solo5: Add solo5-kernel-* for v0.3.0

### DIFF
--- a/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/descr
+++ b/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/descr
@@ -1,0 +1,11 @@
+Solo5 sandboxed execution environment (muen target)
+
+Solo5 is a sandboxed execution environment primarily intended for, but not
+limited to, running applications built using various unikernels (a.k.a.
+library operating systems).
+
+This package provides the Solo5 components needed to build MirageOS unikernels
+on the "muen" target. The resulting unikernels can then be deployed directly on
+a host running the Muen Separation Kernel.
+
+Building this target is supported on 64-bit Linux, FreeBSD and OpenBSD systems.

--- a/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/opam
+++ b/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "https://github.com/solo5/solo5.git"
+build: [make "muen"]
+install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
+remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
+depends: "conf-pkg-config"
+conflicts: [
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+]
+available: [
+  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]

--- a/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/url
+++ b/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Solo5/solo5/archive/v0.3.0.tar.gz"
+checksum: "1085edafe0c69d2af2dfd75b0e3349de"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/descr
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/descr
@@ -1,0 +1,13 @@
+Solo5 sandboxed execution environment (ukvm target)
+
+Solo5 is a sandboxed execution environment primarily intended for, but not
+limited to, running applications built using various unikernels (a.k.a.
+library operating systems).
+
+This package provides the Solo5 components needed to build and run MirageOS
+unikernels on the "ukvm" target, including the "ukvm" monitor source code, and
+"ukvm-configure" script used to specialize the monitor at MirageOS unikernel
+build time.
+
+This target is supported on 64-bit Linux, FreeBSD and OpenBSD systems with
+hardware virtualization.

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "https://github.com/solo5/solo5.git"
+build: [make "ukvm"]
+install: [make "opam-ukvm-install" "PREFIX=%{prefix}%"]
+remove: [make "opam-ukvm-uninstall" "PREFIX=%{prefix}%"]
+depends: "conf-pkg-config"
+depexts: [
+  [["alpine"] ["linux-headers"]]
+  [["debian"] ["linux-libc-dev"]]
+  [["fedora"] ["kernel-headers"]]
+  [["rhel"] ["kernel-headers"]]
+  [["ubuntu"] ["linux-libc-dev"]]
+]
+conflicts: [
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64" | arch = "aarch64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/url
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Solo5/solo5/archive/v0.3.0.tar.gz"
+checksum: "1085edafe0c69d2af2dfd75b0e3349de"

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/descr
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/descr
@@ -1,0 +1,16 @@
+Solo5 sandboxed execution environment (virtio target)
+
+Solo5 is a sandboxed execution environment primarily intended for, but not
+limited to, running applications built using various unikernels (a.k.a.
+library operating systems).
+
+This package provides the Solo5 components needed to build MirageOS unikernels
+using the "virtio" target.
+
+The "virtio" target is supported on 64-bit Linux and FreeBSD systems with
+hardware virtualization, and produces unikernels suitable for running on any
+virtio-compliant hypervisor.
+
+Note that the "virtio" target provides limited support for current and future
+Solo5 features and abstractions, we recommend that you use the "ukvm" target
+instead.

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "https://github.com/solo5/solo5.git"
+build: [make "virtio"]
+install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
+remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
+depends: "conf-pkg-config"
+conflicts: [
+  "solo5-kernel-ukvm"
+  "solo5-kernel-muen"
+]
+available: [
+  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64") &
+  os != "darwin"
+]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/url
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Solo5/solo5/archive/v0.3.0.tar.gz"
+checksum: "1085edafe0c69d2af2dfd75b0e3349de"


### PR DESCRIPTION
Solo5 v0.3.0 was released today, so starting from the bottom up for the
relevant MirageOS packages.