### PR TITLE
old portia versions that are unmaintained won't work with newer compiler

### DIFF
--- a/packages/portia/portia.0.1/opam
+++ b/packages/portia/portia.0.1/opam
@@ -18,4 +18,4 @@ depexts: [
 post-messages: [
   "This package requires asciidoc to build the doc." {failure}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]

--- a/packages/portia/portia.1.0/opam
+++ b/packages/portia/portia.1.0/opam
@@ -18,4 +18,4 @@ depexts: [
 post-messages: [
   "This package requires asciidoc to build the doc." {failure}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]


### PR DESCRIPTION
But to be honest, I see no reason to keep these old unmaintained versions into the archive.
Shall I delete them instead?