### PR TITLE
ocaml-freestanding 0.3.0

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.1.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
   "mirage-profile" {>= "0.3"}
-  "ocaml-freestanding"
+  "ocaml-freestanding" {< "0.3.0"}
 ]
 conflicts: [ "io-page" {>= "2.0.0"} ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-solo5/mirage-solo5.0.2.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocb-stubblr" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "ocaml-freestanding"
+  "ocaml-freestanding" {< "0.3.0"}
   "logs"
 ]
 conflicts: [ "io-page" {>= "2.0.0"} ]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/descr
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/descr
@@ -1,0 +1,3 @@
+Freestanding OCaml runtime
+
+This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer.

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "https://github.com/mirage/ocaml-freestanding.git"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind"
+  "ocaml-src"
+  ("solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} | "solo5-kernel-muen" {>= "0.3.0"})
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+]
+available: [
+  ocaml-version >= "4.04.2" & ocaml-version < "4.07.0" &
+  ((os = "linux" & (arch = "x86_64" | arch = "aarch64") |
+   (os = "freebsd" & arch = "amd64") | (os = "openbsd" & arch = "amd64" )))
+]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/url
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-freestanding/archive/v0.3.0.tar.gz"
+checksum: "485d53c352880d3618f0563c96a3f554"


### PR DESCRIPTION
Solo5 v0.3.0 is now merged in #12202, so continuing up the stack with a v0.3.0 release of ocaml-freestanding.