### PR TITLE
mirage-solo5 v0.3.0

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.1.1/opam
@@ -19,5 +19,5 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-types" {>= "2.3.0" & < "3.0.0"}
-  "mirage-solo5"
+  "mirage-solo5" {< "0.3.0"}
 ]

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.1.1/opam
@@ -13,7 +13,7 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-bootvar"]
 depends: [
-  "mirage-solo5"
+  "mirage-solo5" {< "0.3.0"}
   "mirage-types" {< "3.0.0"}
   "astring"
 ]

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.1.1/opam
@@ -17,6 +17,6 @@ depends: [
   "ocamlfind" {build}
   "mirage-console"   {< "2.2.0"}
   "mirage-types-lwt" {< "3.0.0"}
-  "mirage-solo5"
+  "mirage-solo5"     {< "0.3.0"}
   "cstruct-lwt"
 ]

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.1.1/opam
@@ -24,6 +24,6 @@ depends: [
   "io-page" {>= "1.0.0"}
   "ipaddr" {>= "1.0.0"}
   "mirage-profile" {>= "0.3"}
-  "mirage-solo5"
+  "mirage-solo5" {< "0.3.0"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-solo5/mirage-solo5.0.3.0/descr
+++ b/packages/mirage-solo5/mirage-solo5.0.3.0/descr
@@ -1,0 +1,14 @@
+Solo5 core platform libraries for MirageOS
+
+This package provides the MirageOS `OS` library for
+[Solo5][1] targets, which handles the main loop and timers. It also provides
+the low level C startup code and C stubs required by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding][2] package.
+
+[1]: https://github.com/Solo5/solo5
+[2]: https://github.com/mirage/ocaml-freestanding

--- a/packages/mirage-solo5/mirage-solo5.0.3.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ] { os != "openbsd" }
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "false" ] { os = "openbsd" }
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.7.6"}
+  "ocb-stubblr" {build}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "ocaml-freestanding" {>= "0.3.0"}
+  "logs"
+  ("solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} | "solo5-kernel-muen" {>= "0.3.0"})
+]
+conflicts: [ "io-page" {< "2.0.0"} ]
+available: [ ocaml-version >= "4.04.2" ]

--- a/packages/mirage-solo5/mirage-solo5.0.3.0/url
+++ b/packages/mirage-solo5/mirage-solo5.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-solo5/releases/download/v0.3.0/mirage-solo5-0.3.0.tbz"
+checksum: "9ba8e7360a0572383dcabcbfba330c30"


### PR DESCRIPTION
Continuing up the stack from #12202, #12206.

(this time with the correct release artifact run through topkg)