### PR TITLE
mirage-*-solo5: Release v0.3.0

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/descr
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/descr
@@ -1,0 +1,3 @@
+Solo5 implementation of MirageOS block interface
+
+This library implements the MirageOS block interface for Solo5 targets.

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+authors:      "Dan Williams <djwllia@us.ibm.com>"
+tags: [
+  "org:mirage"
+]
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.1"}
+  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-solo5" {>= "0.3.0"}
+  "fmt"
+]
+available: [ ocaml-version >= "4.04.2" ]

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/url
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-block-solo5/releases/download/v0.3.0/mirage-block-solo5-0.3.0.tbz"
+checksum: "fd5cb3f654d2ea8398201ff27fff8573"

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/descr
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/descr
@@ -1,0 +1,14 @@
+Solo5 implementation of MirageOS Bootvar interface
+
+Library for passing boot parameters from Solo5 to MirageOS.
+
+## Install
+
+Bootvar can be installed with `opam`:
+
+```
+opam install mirage-bootvar-solo5
+```
+
+## License
+Bootvar is published under the ISC license. See [LICENSE.md](LICENSE.md) for details.

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name:         "mirage-bootvar-solo5"
+maintainer:   "Martin Lucina <martin@lucina.net>"
+homepage:     "https://github.com/mirage/mirage-bootvar-solo5"
+bug-reports:  "https://github.com/mirage/mirage-bootvar-solo5/issues/"
+dev-repo:     "https://github.com/mirage/mirage-bootvar-solo5.git"
+license:      "ISC"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-solo5" {>= "0.3.0"}
+  "lwt"
+  "parse-argv"
+]
+available: [ ocaml-version >= "4.04.2" ]

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/url
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-bootvar-solo5/releases/download/v0.3.0/mirage-bootvar-solo5-0.3.0.tbz"
+checksum: "be303f63ee0b8f070dc77d97d844a260"

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/descr
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/descr
@@ -1,0 +1,3 @@
+Solo5 implementation of MirageOS console interface
+
+This library implements the MirageOS console interface for Solo5 targets.

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-console-solo5"
+bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo:      "https://github.com/mirage/mirage-console-solo5.git"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "mirage-solo5" {>= "0.3.0"}
+  "cstruct"
+  "lwt"
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/url
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-console-solo5/releases/download/v0.3.0/mirage-console-solo5-0.3.0.tbz"
+checksum: "d813eca6738353dd013023d63e737aba"

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/descr
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/descr
@@ -1,0 +1,3 @@
+Solo5 implementation of MirageOS network interface
+
+This library implements the MirageOS network interface for Solo5 targets.

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "https://github.com/mirage/mirage-net-solo5.git"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "1.0.0"}
+  "mirage-solo5" {>= "0.3.0"}
+  "logs" {>= "0.6.0"}
+  "fmt"
+]
+available: [ ocaml-version >= "4.04.2" ]

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/url
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-net-solo5/releases/download/v0.3.0/mirage-net-solo5-0.3.0.tbz"
+checksum: "93fb953d76b6b183fc572d31ce4b8009"


### PR DESCRIPTION
Leaf packages for Mirage updates to Solo5 v0.3.0