### PR TITLE
ppx_derivers: set repositories to ppx_deriving org

### DIFF
--- a/packages/ppx_derivers/ppx_derivers.1.0/opam
+++ b/packages/ppx_derivers/ppx_derivers.1.0/opam
@@ -2,9 +2,9 @@ opam-version: "1.2"
 maintainer: "jeremie@dimino.org"
 authors: ["Jérémie Dimino"]
 license: "BSD3"
-homepage: "https://github.com/diml/ppx_derivers"
-bug-reports: "https://github.com/diml/ppx_derivers/issues"
-dev-repo: "git://github.com/diml/ppx_derivers.git"
+homepage: "https://github.com/ocaml-ppx/ppx_derivers"
+bug-reports: "https://github.com/ocaml-ppx/ppx_derivers/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_derivers.git"
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/ppx_derivers/ppx_derivers.1.0/url
+++ b/packages/ppx_derivers/ppx_derivers.1.0/url
@@ -1,2 +1,2 @@
-src: "https://github.com/diml/ppx_derivers/archive/1.0.tar.gz"
+src: "https://github.com/ocaml-ppx/ppx_derivers/archive/1.0.tar.gz"
 checksum: "4ddce8f43fdb9b0ef0ab6a7cbfebc3e3"


### PR DESCRIPTION
this avoids a redirect in the github apis from @diml's page