### PR TITLE
Package nunchaku.0.5.1

### DIFF
--- a/packages/nunchaku/nunchaku.0.5.1/descr
+++ b/packages/nunchaku/nunchaku.0.5.1/descr
@@ -1,0 +1,7 @@
+A counter-example finder for higher-order logic.
+
+Nunchaku is a counter-example finder for higher-order logic, designed to be
+used from various proof assistants, and a spiritual successor to Nitpick. It
+relies encodings and external solvers (CVC4, kodkod, paradox, smbc) to find
+models, thanks to its modular architecture.
+

--- a/packages/nunchaku/nunchaku.0.5.1/opam
+++ b/packages/nunchaku/nunchaku.0.5.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Jasmin Blanchette"]
+homepage: "https://github.com/nunchaku-inria/nunchaku/"
+bug-reports: "https://github.com/nunchaku-inria/nunchaku/issues"
+dev-repo: "https://github.com/nunchaku-inria/nunchaku.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["strip" "_build/default/src/main/nunchaku.exe"]
+]
+build-test: ["jbuilder" "runtest" "-j" jobs]
+build-doc: [make "doc"]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "containers" {>= "1.0"}
+  "menhir" {build}
+  "sequence"
+  "base-unix"
+  "base-threads"
+  "num"
+  "qtest" {test}
+  "qcheck" {test}
+  "ounit" {test}
+  "odoc" {doc}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/nunchaku/nunchaku.0.5.1/opam
+++ b/packages/nunchaku/nunchaku.0.5.1/opam
@@ -11,7 +11,6 @@ build: [
 build-test: ["jbuilder" "runtest" "-j" jobs]
 build-doc: [make "doc"]
 depends: [
-  "ocamlfind" {build}
   "jbuilder" {build}
   "containers" {>= "1.0"}
   "menhir" {build}

--- a/packages/nunchaku/nunchaku.0.5.1/url
+++ b/packages/nunchaku/nunchaku.0.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nunchaku-inria/nunchaku/archive/0.5.1.tar.gz"
+checksum: "39f5e6c8b36943062c86b10bb917ea1c"


### PR DESCRIPTION
### `nunchaku.0.5.1`

A counter-example finder for higher-order logic.

Nunchaku is a counter-example finder for higher-order logic, designed to be
used from various proof assistants, and a spiritual successor to Nitpick. It
relies encodings and external solvers (CVC4, kodkod, paradox, smbc) to find
models, thanks to its modular architecture.




---
* Homepage: https://github.com/nunchaku-inria/nunchaku/
* Source repo: https://github.com/nunchaku-inria/nunchaku.git
* Bug tracker: https://github.com/nunchaku-inria/nunchaku/issues

---

:camel: Pull-request generated by opam-publish v0.3.5