### PR TITLE
Package omod.0.0.2

### DIFF
--- a/packages/omod/omod.0.0.2/descr
+++ b/packages/omod/omod.0.0.2/descr
@@ -1,0 +1,7 @@
+Lookup and load installed OCaml modules
+
+Omod is a library and command line tool to lookup and load installed OCaml
+modules. It provides a mecanism to load modules and their dependencies
+in the OCaml toplevel system (REPL).
+
+omod is distributed under the ISC license.

--- a/packages/omod/omod.0.0.2/opam
+++ b/packages/omod/omod.0.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The omod programmers"]
+homepage: "http://erratique.ch/software/omod"
+doc: "http://erratique.ch/software/omod/doc"
+license: "ISC"
+dev-repo: "http://erratique.ch/repos/omod.git"
+bug-reports: "https://github.com/dbuenzli/omod/issues"
+tags: [ "org:erratique" "dev" "toplevel" "repl" ]
+available: [ ocaml-version >= "4.03.0"]
+depends:
+[
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.1"}
+  "cmdliner" {>= "1.0.2"}
+]
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--dev-pkg" "%{pinned}%"
+           "--lib-dir" "%{lib}%" ]
+]
+
+# Following is only to deal with
+# https://caml.inria.fr/mantis/view.php?id=7808
+
+install:
+[
+  ["install" "-d" "%{lib}%/ocaml/"]
+  ["install" "src/omod.top" "src/omod.nattop" "%{lib}%/ocaml/"]
+]
+
+remove:
+[[
+  "rm" "-f" "%{lib}%/ocaml/omod.top" "%{lib}%/ocaml/omod.nattop"
+]]

--- a/packages/omod/omod.0.0.2/url
+++ b/packages/omod/omod.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/omod/releases/omod-0.0.2.tbz"
+checksum: "98cb7bc813e9325237929d047cd8408b"


### PR DESCRIPTION
### `omod.0.0.2`

Lookup and load installed OCaml modules

Omod is a library and command line tool to lookup and load installed OCaml
modules. It provides a mecanism to load modules and their dependencies
in the OCaml toplevel system (REPL).

omod is distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/omod
* Source repo: http://erratique.ch/repos/omod.git
* Bug tracker: https://github.com/dbuenzli/omod/issues

---


---
v0.0.2 2018-06-19 Zagreb
------------------------

- Fix `omod` for `opam` system switches. The location of the
  `ocaml` package is determined by `ocamlc -where` rather than
  `$LIBDIR/ocaml` (#1)
- Get rid of shell outs to `opam` for auto-configuration: infer prefix from the
  executable's install path (#4).
- `opam pkg --long` sort cobjs by name.
:camel: Pull-request generated by opam-publish v0.3.5