### PR TITLE
gmp-freestanding: 6.1.2-1

### DIFF
--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0-1/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0-1/opam
@@ -16,3 +16,6 @@ depends: [
   "ocaml-freestanding"
   "conf-m4" {build}
 ]
+available: [
+  arch = "x86_64" | arch = "amd64"
+]

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
@@ -16,3 +16,6 @@ depends: [
   "ocaml-freestanding"
   "conf-m4" {build}
 ]
+available: [
+  arch = "x86_64" | arch = "amd64"
+]

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/descr
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/descr
@@ -1,0 +1,3 @@
+The GNU Multiple Precision Arithmetic Library
+
+Freestanding build of GNU GMP.

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/files/gmp-freestanding.pc
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/files/gmp-freestanding.pc
@@ -1,0 +1,9 @@
+libdir=${pcfiledir}/../gmp-freestanding
+includedir=${libdir}/include
+
+Name: gmp-freestanding
+Version: 6.1.2
+URL: https://gmplib.org
+Description: The GNU Multiple Precision Arithmetic Library
+Cflags: -I${includedir}
+Libs: -L${libdir} -lgmp-freestanding

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/files/mirage-build.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/files/mirage-build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX="`opam config var prefix`/lib/gmp-freestanding"
+fi
+
+PKG_CONFIG_DEPS="ocaml-freestanding"
+check_deps () {
+  pkg-config --print-errors --exists ${PKG_CONFIG_DEPS}
+}
+
+if ! check_deps 2>/dev/null; then
+  # rely on `opam` if deps are unavailable
+  export PKG_CONFIG_PATH="`opam config var prefix`/lib/pkgconfig"
+fi
+check_deps || exit 1
+
+#
+# ocaml-freestanding does not provide a real cross compiler, so we fake it:
+# 
+# - set CC to stop configure trying to find a host compiler
+# - set CPPFLAGS to ocaml-freestanding CFLAGS, this prevents inclusion of
+#   system headers
+# - manually override tests for missing functions
+# - manually trim the components (SUBDIRS) of libgmp we build to the subset
+#   actually used by zarith-freestanding (our sole dependency)
+# - set -Werror=implicit-function-declaration at *build* time to catch any
+#   undefined symbols
+#
+ac_cv_func_obstack_vprintf=no \
+ac_cv_func_localeconv=no \
+./configure \
+    --host=$(uname -m)-unknown-none --enable-fat --disable-shared --with-pic \
+    CC=cc "CPPFLAGS=$(pkg-config --cflags ${PKG_CONFIG_DEPS})"
+
+make SUBDIRS="mpn mpz mpq mpf" \
+    PRINTF_OBJECTS= SCANF_OBJECTS= \
+    CFLAGS+=-Werror=implicit-function-declaration

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/files/mirage-install.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/files/mirage-install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX=`opam config var prefix`
+fi
+PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+LIBDIR=${PREFIX}/lib/gmp-freestanding
+
+mkdir -p ${PKG_CONFIG_PATH}
+cp gmp-freestanding.pc ${PKG_CONFIG_PATH}
+mkdir -p ${LIBDIR}
+cp .libs/libgmp.a ${LIBDIR}/libgmp-freestanding.a
+touch ${LIBDIR}/META
+mkdir -p ${LIBDIR}/include
+cp gmp.h ${LIBDIR}/include

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/opam
@@ -15,6 +15,3 @@ remove: [
 depends: [
   "ocaml-freestanding" {>= "0.2.3"}
 ]
-available: [
-  arch = "x86_64" | arch = "amd64"
-]

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/url
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/url
@@ -1,0 +1,2 @@
+archive: "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
+checksum: "f58fa8001d60c4c77595fbbb62b63c1d"


### PR DESCRIPTION
Add runes to build on non x86_64 architectures, mark earlier versions
as unavailable on other architectures.