### PR TITLE
mirage-entropy: Correct arch availability

### DIFF
--- a/packages/mirage-entropy/mirage-entropy.0.4.0/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.4.0/opam
@@ -32,4 +32,7 @@ conflicts: [
   "mirage-xen" {<"2.2.0"}
 ]
 tags: [ "org:mirage"]
-available: [ ocaml-version >= "4.03.0" ]
+available: [
+  ocaml-version >= "4.03.0" &
+  (arch = "arm" | arch = "i386" | arch = "x86_64" | arch = "amd64")
+]


### PR DESCRIPTION
... based on what's actually supported in `lib/native/entropy_cpu_stubs.c`.