### PR TITLE
Dokeysto lz4

### DIFF
--- a/packages/dokeysto/dokeysto.2.0.0/descr
+++ b/packages/dokeysto/dokeysto.2.0.0/descr
@@ -1,0 +1,4 @@
+the dumb OCaml key-value store
+
+Persistent hash table (i.e. in a file on disk) for string keys
+and string values.

--- a/packages/dokeysto/dokeysto.2.0.0/opam
+++ b/packages/dokeysto/dokeysto.2.0.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "dokeysto"
+authors: "Francois BERENGER"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: [make "test"]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+  "extunix"
+]

--- a/packages/dokeysto/dokeysto.2.0.0/url
+++ b/packages/dokeysto/dokeysto.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/UnixJunkie/dokeysto/archive/v2.0.0.tar.gz"
+checksum: "949c4c6421514a3087534ced4b05ed25"

--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/descr
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/descr
@@ -1,0 +1,3 @@
+the dumb OCaml key-value store w/ LZ4 compression
+
+dokeysto with on-the-fly compression/decompression of values via LZ4

--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+name: "dokeysto_lz4"
+authors: "Francois BERENGER"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: [make "test_lz4"]
+depends: [
+  "jbuilder" {build}
+  "dokeysto"
+  "lz4"
+]

--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/url
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/UnixJunkie/dokeysto/archive/v2.0.0.tar.gz"
+checksum: "949c4c6421514a3087534ced4b05ed25"


### PR DESCRIPTION
There are two packages in one PR.
I cut my previous dokeysto package in two.
One doesn't depend on lz4, so it will probably install everywhere.
The other depends on lz4, so will install in less environments, unfortunately.
I should create and send a dokeysto_zlib later on (because sometimes you
are not root, and zlib is there but not lz4).
