### PR TITLE
Add the force-safe-string variant for 4.07.0

### DIFF
--- a/compilers/4.07.0/4.07.0+beta2+force-safe-string/4.07.0+beta2+force-safe-string.comp
+++ b/compilers/4.07.0/4.07.0+beta2+force-safe-string/4.07.0+beta2+force-safe-string.comp
@@ -1,0 +1,18 @@
+opam-version: "1"
+version: "4.07.0"
+src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.07.0/4.07.0+beta2+force-safe-string/4.07.0+beta2+force-safe-string.descr
+++ b/compilers/4.07.0/4.07.0+beta2+force-safe-string/4.07.0+beta2+force-safe-string.descr
@@ -1,0 +1,1 @@
+Second beta for 4.07.0 with safe strings forced globally

--- a/compilers/4.07.0/4.07.0+rc1+force-safe-string/4.07.0+rc1+force-safe-string.comp
+++ b/compilers/4.07.0/4.07.0+rc1+force-safe-string/4.07.0+rc1+force-safe-string.comp
@@ -1,0 +1,18 @@
+opam-version: "1"
+version: "4.07.0"
+src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-force-safe-string"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.07.0/4.07.0+rc1+force-safe-string/4.07.0+rc1+force-safe-string.descr
+++ b/compilers/4.07.0/4.07.0+rc1+force-safe-string/4.07.0+rc1+force-safe-string.descr
@@ -1,0 +1,1 @@
+First release candidate for 4.07.0 with safe string forced globally


### PR DESCRIPTION
cc @gasche 