### PR TITLE
fixed link error

### DIFF
--- a/packages/lymp/lymp.0.2.4/url
+++ b/packages/lymp/lymp.0.2.4/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/dbousque/lymp/archive/0.2.4.tar.gz"
-checksum: "52b19106aa2bbe1c9c59f80c2a86bc46"
+checksum: "c7ff7a403434a193135f8085d14c8bc5"


### PR DESCRIPTION
Lymp 0.2.4 on opam is currently broken, due to a link error, a fix was made for this release, and so the checksum changed.