### PR TITLE
added packages/dokeysto_lz4/dokeysto_lz4.2.0.1

### DIFF
--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/descr
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/descr
@@ -1,0 +1,3 @@
+the dumb OCaml key-value store w/ LZ4 compression
+
+dokeysto with on-the-fly compression/decompression of values via LZ4

--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+name: "dokeysto_lz4"
+authors: "Francois BERENGER"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: [make "test_lz4"]
+depends: [
+  "jbuilder" {build}
+  "dokeysto"
+  "lz4"
+]

--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/url
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/UnixJunkie/dokeysto/archive/v2.0.1.tar.gz"
+checksum: "e2b8fb9e8f13c3746f64e212f45600c6"


### PR DESCRIPTION
Previously, the interface was not constrained to be the same as dokeysto (Dokeysto.Db.RO and
Dokeysto.Db.RW).
This is now enforced.
