### PR TITLE
caqti-driver-mariadb needs mariadb < 1.1.0.

### DIFF
--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.0/opam
@@ -12,5 +12,5 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "caqti" {= "0.10.0"}
   "jbuilder" {build}
-  "mariadb" {>= "0.10"}
+  "mariadb" {>= "0.10" & < "1.1.0"}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.1/opam
@@ -12,5 +12,5 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "caqti" {= "0.10.1"}
   "jbuilder" {build}
-  "mariadb" {>= "0.10"}
+  "mariadb" {>= "0.10" & < "1.1.0"}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.2/opam
@@ -13,5 +13,5 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "caqti" {= "0.10.2"}
   "jbuilder" {build & >= "1.0+beta19"}
-  "mariadb" {>= "0.10"}
+  "mariadb" {>= "0.10" & < "1.1.0"}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.11.0/opam
@@ -13,5 +13,5 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "caqti" {= "0.11.0"}
   "jbuilder" {build & >= "1.0+beta19"}
-  "mariadb" {>= "0.10"}
+  "mariadb" {>= "0.10" & < "1.1.0"}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
@@ -12,5 +12,5 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "caqti" {= "0.9.0"}
   "jbuilder" {build}
-  "mariadb" {>= "0.10"}
+  "mariadb" {>= "0.10" & < "1.1.0"}
 ]


### PR DESCRIPTION
I need this version constraint for the Caqti MariaDB driver, since I managed to break revdep of my own package with andrenth/ocaml-mariadb#22.  (According to `opam search --depends-on mariadb` this is the only package which needs the constraint.)