### PR TITLE
gmap.0.2.0 release

### DIFF
--- a/packages/gmap/gmap.0.2.0/descr
+++ b/packages/gmap/gmap.0.2.0/descr
@@ -1,0 +1,55 @@
+Heterogenous maps over a GADT
+
+
+Gmap exposes the functor `Make` which takes a key type (a
+[GADT](https://en.wikipedia.org/wiki/Generalized_algebraic_data_type) 'a key)
+and outputs a type-safe Map where each 'a key is associated with a 'a value.
+This removes the need for additional packing.  It uses OCaml's stdlib
+[Map](http://caml.inria.fr/pub/docs/manual-ocaml/libref/Map.html) data
+structure.
+
+```OCaml
+type _ k =
+  | A : int k
+  | B : string k
+
+module K = struct
+  type 'a t = 'a k
+
+  let compare : type a b. a t -> b t -> (a, b) Gmap.Order.t = fun t t' ->
+    let open Gmap.Order in
+    match t, t' with
+    | A, A -> Eq | A, _ -> Lt | _, A -> Gt
+    | B, B -> Eq
+
+  let pp : type a. Format.formatter -> a t -> a -> unit = fun ppf t v ->
+    match t, v with
+    | A, x -> Fmt.pf ppf "A %d" x
+    | B, s -> Fmt.pf ppf "B %s" s
+end
+
+module M = Gmap.Make(K)
+
+
+let () =
+  let m = M.empty in
+  ...
+  match M.find A m with
+  | Some x -> Printf.printf "got %d\n" x
+  | None -> Printf.printf "found nothing\n"
+```
+
+This is already an exhaustive pattern match: there is no need for another case
+(for the constructor `B`) since the type system knows that looking for `A` will
+result in an `int`.
+
+Motivation came from parsing of protocols which usually specify optional values
+and extensions via a tag-length-value (TLV) mechanism: for a given tag the
+structure of value is different - see for example IP options, TCP options, DNS
+resource records, TLS hello extensions, etc.
+
+Discussing this problem with Justus Matthiesen during summer 2017, we came up
+with this design. Its main difference to Daniel C. Bünzli's
+[hmap](http://erratique.ch/software/hmap) is that in gmap the key-value GADT
+type must be provided when instantiating the functor.  In hmap, keys are created
+dynamically.

--- a/packages/gmap/gmap.0.2.0/opam
+++ b/packages/gmap/gmap.0.2.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/gmap"
+doc: "https://hannesm.github.io/gmap/doc"
+dev-repo: "https://github.com/hannesm/gmap.git"
+bug-reports: "https://github.com/hannesm/gmap/issues"
+license: "ISC"
+available: [ ocaml-version >= "4.04.2"]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "fmt"
+]
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+]
+

--- a/packages/gmap/gmap.0.2.0/url
+++ b/packages/gmap/gmap.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hannesm/gmap/releases/download/0.2.0/gmap-0.2.0.tbz"
+checksum: "fbf9d1d5a38c2c86ef2f122e22359896"


### PR DESCRIPTION
Gmap - heterogenous maps over a GADT
- New function `update` (`'a key -> ('a option -> 'a option) -> t -> t`)
- New function `add_unless_bound` (`'a key -> 'a -> t -> t option`) and `addb_unless_bound` (`b -> t -> t option`).
- Replace `type v = V : 'a key * 'a -> v` by `type b = B : 'a key * 'a -> b`.
- Renamed functions ending with `v` to `b`

https://github.com/hannesm/gmap