### PR TITLE
[new release] docker-api (0.2)

### DIFF
--- a/packages/docker-api/docker-api.0.2/descr
+++ b/packages/docker-api/docker-api.0.2/descr
@@ -1,0 +1,4 @@
+Binding to the Docker Remote API
+
+Control Docker <https://www.docker.com/> containers using the remote API.
+

--- a/packages/docker-api/docker-api.0.2/opam
+++ b/packages/docker-api/docker-api.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+license: "ISC"
+homepage: "https://github.com/Chris00/ocaml-docker"
+dev-repo: "https://github.com/Chris00/ocaml-docker.git"
+bug-reports: "https://github.com/Chris00/ocaml-docker/issues"
+doc: "https://Chris00.github.io/ocaml-docker/doc"
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+  "yojson"
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/docker-api/docker-api.0.2/url
+++ b/packages/docker-api/docker-api.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-docker/releases/download/0.2/docker-api-0.2.tbz"
+checksum: "ebc188226b86c01554fd430dd1c9dbca"


### PR DESCRIPTION
Binding to the Docker Remote API

- Project page: <a href="https://github.com/Chris00/ocaml-docker">https://github.com/Chris00/ocaml-docker</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-docker/doc">https://Chris00.github.io/ocaml-docker/doc</a>

##### CHANGES:

- Upgrade to API v1.29.
- New signature of `Container.create`.
- Add functions `Container.wait` and `Container.changes`.
- Handle errors `409 Conflict`.
- New exceptions `Docker.Failure` and `Docker.No_such_container`.
- New tests `ls` and `ps`.
- Use [Dune](https://github.com/ocaml/dune) and
  [dune-release](https://github.com/samoht/dune-release).
