### PR TITLE
omake: patch bugfix from upstream

### DIFF
--- a/packages/omake/omake.0.10.3/files/lib_build_OCaml.om.diff
+++ b/packages/omake/omake.0.10.3/files/lib_build_OCaml.om.diff
@@ -1,0 +1,13 @@
+diff --git a/lib/build/OCaml.om b/lib/build/OCaml.om
+index 8d00490..8fa3a6b 100644
+--- a/lib/build/OCaml.om
++++ b/lib/build/OCaml.om
+@@ -181,7 +181,7 @@ private.get_bytecomp_c_comp() =
+     # Figure out the params for the C compiler
+     #
+     private.c_comp = $(get_c_comp)
+-    if $(equal X$(c_comp)X, XX)
++    if $(equal X$(string $(c_comp))X, XX)
+         private.bytecomp_c_comp = $(get_bytecomp_c_comp)
+         OCAML_CC = $(nth-hd 1, $(bytecomp_c_comp))
+         OCAML_CFLAGS = $(nth-tl 1, $(bytecomp_c_comp))

--- a/packages/omake/omake.0.10.3/opam
+++ b/packages/omake/omake.0.10.3/opam
@@ -12,6 +12,8 @@ dev-repo: "git+https://github.com/ocaml-omake/omake.git"
 homepage: "http://projects.camlcity.org/projects/omake.html"
 bug-reports: "https://github.com/ocaml-omake/issues"
 
+patches: ["lib_build_OCaml.om.diff"]
+
 build: [
   ["./configure" "-prefix" "%{prefix}%"]
   [make]


### PR DESCRIPTION
fix: configuration of C compiler for the case that "ocamlc -config" prints several words for "c_compiler"