### PR TITLE
Lwt 4.1.0: concurrency library, now under MIT license

### DIFF
--- a/packages/amqp-client/amqp-client.1.0.1/opam
+++ b/packages/amqp-client/amqp-client.1.0.1/opam
@@ -24,4 +24,4 @@ conflicts: [
   "lwt" {< "2.4.6"}
   "async_unix" {>="v0.9"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/amqp-client/amqp-client.1.0.2/opam
+++ b/packages/amqp-client/amqp-client.1.0.2/opam
@@ -24,4 +24,4 @@ conflicts: [
   "lwt" {< "2.4.6"}
   "async" {>="v0.9"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.03.0" & ocaml-version < "4.06.0" ]

--- a/packages/bencode/bencode.0.2/opam
+++ b/packages/bencode/bencode.0.2/opam
@@ -9,5 +9,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/rgrinberg/bencode"
-available: ocaml-version >= "4.00.1"
+available: [ocaml-version >= "4.00.1" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/bencode_rpc/bencode_rpc.0.1/opam
+++ b/packages/bencode_rpc/bencode_rpc.0.1/opam
@@ -12,5 +12,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/c-cube/bencode_rpc"
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/dht/dht.0.1.3/opam
+++ b/packages/dht/dht.0.1.3/opam
@@ -18,5 +18,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/nojb/ocaml-dht"
-available: ocaml-version >= "4.01.0"
+available: [ ocaml-version >= "4.01.0" & ocaml-version < "4.06.0" ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/lwt-binio/lwt-binio.0.2.1/opam
+++ b/packages/lwt-binio/lwt-binio.0.2.1/opam
@@ -15,5 +15,5 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/hcarty/lwt-binio"
-available: ocaml-version >= "4.01.0"
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/lwt/lwt.4.1.0/descr
+++ b/packages/lwt/lwt.4.1.0/descr
@@ -1,0 +1,10 @@
+Promises, concurrency, and parallelized I/O
+
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis.

--- a/packages/lwt/lwt.4.1.0/opam
+++ b/packages/lwt/lwt.4.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "1.2"
+version: "4.1.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "jbuilder" {build & >= "1.0+beta14"}
+  # We are only using ocamlfind during configuration of the Unix binding.
+  # However, ocamlfind also installs the "threads" package, and ocamlfind
+  # 1.7.3-1 is the first one whose threads package does not have incorrect error
+  # lines. See
+  #   https://github.com/ocaml/opam-repository/pull/11071#issuecomment-353131128
+  # If ocamlfind becomes no longer necessary for configuration of Lwt, this
+  # dependency should be converted to a conflict, and package jbuilder should be
+  # constrained such that it also includes the error lines fix.
+  "ocamlfind" {build & >= "1.7.3-1"}
+  # result is needed as long as Lwt still supports OCaml 4.02.
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
+
+messages: [
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
+  "For the Camlp4 syntax, please install package lwt_camlp4"
+    {camlp4:installed & !lwt_camlp4:installed}
+  "For Lwt_log and Lwt_daemon, please install package lwt_log"
+    {!lwt_log:installed}
+]

--- a/packages/lwt/lwt.4.1.0/url
+++ b/packages/lwt/lwt.4.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/4.1.0.tar.gz"
+checksum: "e919bee206f18b3d49250ecf9584fde7"

--- a/packages/lwt_ppx/lwt_ppx.1.2.1/descr
+++ b/packages/lwt_ppx/lwt_ppx.1.2.1/descr
@@ -1,0 +1,1 @@
+PPX syntax for Lwt, providing something similar to async/await from JavaScript

--- a/packages/lwt_ppx/lwt_ppx.1.2.1/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.2.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+version: "1.2.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta14"}
+  "lwt"
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0.1"}
+]
+# The Lwt PPX uses the %reraise primitive, which is available on OCaml >= 4.02.
+# Even though OCaml PPX itself requires 4.02, we add this constraint for
+# thoroughness and safety.
+available: [ocaml-version >= "4.02.0"]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/lwt_ppx/lwt_ppx.1.2.1/url
+++ b/packages/lwt_ppx/lwt_ppx.1.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/4.1.0.tar.gz"
+checksum: "e919bee206f18b3d49250ecf9584fde7"

--- a/packages/ocplib-concur/ocplib-concur.0.1/opam
+++ b/packages/ocplib-concur/ocplib-concur.0.1/opam
@@ -31,4 +31,4 @@ depopts: [
 conflicts: [
     "async" {< "111.25.0" } "async" {>= "v0.10.0" }
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]

--- a/packages/statsd-client/statsd-client.1.0.1/opam
+++ b/packages/statsd-client/statsd-client.1.0.1/opam
@@ -9,5 +9,6 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "statsd-client"]]
 depends: ["ocamlfind" "lwt"]
+available: [ocaml-version < "4.05.0"]
 dev-repo: "git://github.com/mfp/ocaml-statsd-client"
 install: [make "install"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.1/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.1/opam
@@ -28,4 +28,4 @@ depexts: [
   [["archlinux"] ["xenstore"]]
 ]
 
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.3/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.3/opam
@@ -28,4 +28,4 @@ depexts: [
   [["archlinux"] ["xenstore"]]
 ]
 
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.4/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.4/opam
@@ -28,4 +28,4 @@ depexts: [
   [["archlinux"] ["xenstore"]]
 ]
 
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/xen-evtchn/xen-evtchn.1.0.5/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.5/opam
@@ -27,4 +27,4 @@ depexts: [
   [["fedora"] ["xen-devel"]]
   [["archlinux"] ["xenstore"]]
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/xenctrl/xenctrl.0.10.0/opam
+++ b/packages/xenctrl/xenctrl.0.10.0/opam
@@ -48,4 +48,4 @@ depexts: [
   [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
   [["alpine"] ["xen-dev"]]
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/xenctrl/xenctrl.0.9.32/opam
+++ b/packages/xenctrl/xenctrl.0.9.32/opam
@@ -44,4 +44,4 @@ depexts: [
   [["centos"] ["xen-devel"]]
   [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]

--- a/packages/zbar/zbar.0.9/opam
+++ b/packages/zbar/zbar.0.9/opam
@@ -14,5 +14,6 @@ depexts: [
 [ ["ubuntu"] ["libzbar-dev"] ]
 [ ["debian"] ["libzbar-dev"] ]
 ]
+available: [ocaml-version < "4.06.0"]
 dev-repo: "git://github.com/vbmithr/ocaml-zbar"
 install: [make "PREFIX=%{prefix}%" "install"]


### PR DESCRIPTION
The main purpose of this release is that it is the first one under the MIT license.

From the changelog:

> Additions
>
> - Change license to MIT (ocsigen/lwt#560).
> - [`Lwt_fmt`](https://github.com/ocsigen/lwt/blob/33c37b550304b8d18b5dea4818fb1bfbc9a86aaf/src/unix/lwt_fmt.mli), an Lwt-aware version of [`Format`](http://caml.inria.fr/pub/docs/manual-ocaml/libref/Format.html) (ocsigen/lwt#548, Gabriel Radanne).
> - [`Lwt_io.establish_server_with_client_socket`](https://github.com/ocsigen/lwt/blob/33c37b550304b8d18b5dea4818fb1bfbc9a86aaf/src/unix/lwt_io.mli#L533) (ocsigen/lwt#586).
>
> Bugs fixed
>
> - [`Lwt_stream.iter_n`](https://github.com/ocsigen/lwt/blob/33c37b550304b8d18b5dea4818fb1bfbc9a86aaf/src/core/lwt_stream.mli#L314): rename `?max_threads` argument to `?max_concurrency` (ocsigen/lwt#581, Hezekiah Carty).
> - PPX: reject `match` expressions that have only `exception` cases (ocsigen/lwt#597, Raphaël Proust).
>
> Miscellaneous
>
> - Improvements to [`Lwt_pool`](https://github.com/ocsigen/lwt/blob/33c37b550304b8d18b5dea4818fb1bfbc9a86aaf/src/core/lwt_pool.mli) docs (ocsigen/lwt#575, Bobby Priambodo).
> - Restore all PPX tests (ocsigen/lwt#590, Jess Smith).
