### PR TITLE
Nocrypto freebsd

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -7,7 +7,7 @@ authors:      ["David Kaloper <david@numm.org>"]
 maintainer:   "David Kaloper <david@numm.org>"
 license:      "ISC"
 tags:          [ "org:mirage" ]
-available:     [ ocaml-version >= "4.02.0" ]
+available:     [ ocaml-version >= "4.02.0" & os != "freebsd" & os != "openbsd" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
                 "--jobs" "1"


### PR DESCRIPTION
#12062 added various patches for nocrypto to add another runtime dependency due to ppx_sexp_conv 0.11.0.

using a FreeBSD (or OpenBSD) system, this leads to a patched META file which contains the following line:
`requires = "cstruct zarith sexplib PPX_SEXP_CONV_RUNTIME"`, which lets all dependencies fail to link against nocrypto.

this patch marks nocrypto 0.5.4-1 unavailable on these systems. /cc @copy @mseri @hcarty 

when manually downloading the tarball from opam.ocaml.org and applying the patches, the following output can be seen (with 0005, the one renaming META to META.in) //cc @AltGr (this is opam 1.2.2 - i guess this can't be easily fixed, but maybe for 2.0)) :
```
[20:55 hannes@shell:nocrypto.0.5.4-1] patch -p1 < 0005-Auto-detect-ppx_sexp_conv-runtime-library.patch 
Hmm...  Looks like a unified diff to me...
The text leading up to this was:
--------------------------
|From 25e1206eb1b173acdfc7312d072e0583327c4ac0 Mon Sep 17 00:00:00 2001
|From: Jeremie Dimino <jeremie@dimino.org>
|Date: Fri, 11 May 2018 15:44:47 +0200
|Subject: [PATCH 5/6] Auto-detect ppx_sexp_conv runtime library
|
|---
| myocamlbuild.ml       | 25 ++++++++++++++++++++++---
| pkg/{META => META.in} |  2 +-
| 2 files changed, 23 insertions(+), 4 deletions(-)
| rename pkg/{META => META.in} (95%)
|
|diff --git a/myocamlbuild.ml b/myocamlbuild.ml
|index 2752315..7b29635 100644
|--- a/myocamlbuild.ml
|+++ b/myocamlbuild.ml
--------------------------
Patching file myocamlbuild.ml using Plan A...
Hunk #1 succeeded at 1.
Hmm...  The next patch looks like a unified diff to me...
The text leading up to this was:
--------------------------
|diff --git a/pkg/META b/pkg/META.in
|similarity index 95%
|rename from pkg/META
|rename to pkg/META.in
|index a7929c7..0b263d7 100644
|--- a/pkg/META
|+++ b/pkg/META.in
--------------------------
Patching file pkg/META using Plan A...
Hunk #1 succeeded at 1 with fuzz 1.
Hmm...  Ignoring the trailing garbage.
done

[20:56 hannes@shell:nocrypto.0.5.4-1] ls pkg/
pkg:
META       META.orig  pkg.ml*    

[20:55 hannes@shell:nocrypto.0.5.4-1] less pkg/META
version = "0.5.4"
description = "Simple crypto for the modern age"
requires = "cstruct zarith sexplib PPX_SEXP_CONV_RUNTIME"
archive(byte) = "nocrypto.cma"
archive(native) = "nocrypto.cmxa"
plugin(byte) = "nocrypto.cma"
plugin(native) = "nocrypto.cmxs"
xen_linkopts = "-lnocrypto_stubs+mirage-xen"
freestanding_linkopts = "-lnocrypto_stubs+mirage-freestanding"
exists_if = "nocrypto.cma"
..
```