### PR TITLE
More depext for fdk-aac.

### DIFF
--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -16,6 +16,11 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
+  [["alpine"] ["fdk-aac-dev"]]
+  [["archlinux"] ["libfdk-aac"]]
+  [["centos"] ["fdk-aac-devel"]]
+  [["fedora"] ["fdk-aac-devel"]]
+  [["opensuse"] ["fdk-aac-devel"]]
   [["debian"] ["libfdk-aac-dev"]]
   [["ubuntu"] ["libfdk-aac-dev"]]
   [["osx" "homebrew"] ["fdk-aac"]]


### PR DESCRIPTION
Same as #12255, depext for centos isn't in the main distribution but would be very useful to have mentioned for end-user.