### PR TITLE
Package uwt.0.3.1

### DIFF
--- a/packages/uwt/uwt.0.3.1/descr
+++ b/packages/uwt/uwt.0.3.1/descr
@@ -1,0 +1,5 @@
+libuv bindings
+
+uwt provides OCaml bindings for libuv.
+The main loop of libuv is integrated into lwt,
+the light-weight cooperative threads library.

--- a/packages/uwt/uwt.0.3.1/opam
+++ b/packages/uwt/uwt.0.3.1/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "MIT"
+homepage: "https://github.com/fdopen/uwt"
+dev-repo: "https://github.com/fdopen/uwt.git"
+bug-reports: "https://github.com/fdopen/uwt/issues"
+tags: ["clib:libuv"]
+build: ["omake" "-j%{jobs}%" "lib" "BUILD_LIBUV=true" "UWT_BUILD_JOBS=%{jobs}%"]
+install: [
+  ["omake" "opam-install" "PREFIX=%{prefix}%"]
+]
+build-test: [
+  ["omake" "test" ]
+]
+remove: [
+  ["rm" "-rf" "%{prefix}%/lib/uwt/uv"]
+  ["ocamlfind" "remove" "uwt"]
+  ["rm" "-rf" "%{prefix}%/doc/uwt"]
+]
+available: [ocaml-version >= "4.02.1"]
+depends: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+  "base-bytes"
+  "conf-pkg-config" {build}
+  "ocamlfind" {build}
+  "cppo" {build & >= "1.3"}
+  "omake" {build}
+  "result"
+  "lwt" {>= "2.6.0"}
+  "lwt_log" {test}
+  "ounit" {test & >= "2.0"}
+  "ppx_deriving" {test & >= "2.0"}
+  "ppx_import" {test & >= "1.0"}
+]

--- a/packages/uwt/uwt.0.3.1/url
+++ b/packages/uwt/uwt.0.3.1/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/fdopen/uwt/releases/download/0.3.1/uwt-0.3.1.tar.gz"
+checksum: "3375bfc82eeb05cfe8d36ea6d2f789a7"


### PR DESCRIPTION
### `uwt.0.3.1`

libuv bindings

uwt provides OCaml bindings for libuv.
The main loop of libuv is integrated into lwt,
the light-weight cooperative threads library.



---
* Homepage: https://github.com/fdopen/uwt
* Source repo: https://github.com/fdopen/uwt.git
* Bug tracker: https://github.com/fdopen/uwt/issues

---

:camel: Pull-request generated by opam-publish v0.3.5