### PR TITLE
Root 'jbuilder subst' calls

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/Chris00/ANSITerminal/issues"
 doc: "https://Chris00.github.io/ANSITerminal/doc"
 tags: [ "terminal"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/acgtk/acgtk.1.3.2/opam
+++ b/packages/acgtk/acgtk.1.3.2/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "sylvain.pogodalla@inria.fr"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/acgtk/acgtk.1.3.3/opam
+++ b/packages/acgtk/acgtk.1.3.3/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "sylvain.pogodalla@inria.fr"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/aifad/aifad.2.1.0/opam
+++ b/packages/aifad/aifad.2.1.0/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/mmottl/aifad.git"
 bug-reports: "https://github.com/mmottl/aifad/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/alcotest-async/alcotest-async.0.8.2/opam
+++ b/packages/alcotest-async/alcotest-async.0.8.2/opam
@@ -8,7 +8,7 @@ license:     "ISC"
 doc:         "https://mirage.github.io/alcotest/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/alcotest-lwt/alcotest-lwt.0.8.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.0.8.0/opam
@@ -8,7 +8,7 @@ license:     "ISC"
 doc:         "https://mirage.github.io/alcotest/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/alcotest/alcotest.0.8.0/opam
+++ b/packages/alcotest/alcotest.0.8.0/opam
@@ -8,7 +8,7 @@ license:     "ISC"
 doc:         "https://mirage.github.io/alcotest/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/alcotest/alcotest.0.8.1/opam
+++ b/packages/alcotest/alcotest.0.8.1/opam
@@ -8,7 +8,7 @@ license:     "ISC"
 doc:         "https://mirage.github.io/alcotest/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/alcotest/alcotest.0.8.3/opam
+++ b/packages/alcotest/alcotest.0.8.3/opam
@@ -8,7 +8,7 @@ license:     "ISC"
 doc:         "https://mirage.github.io/alcotest/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/angstrom-async/angstrom-async.0.10.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.10.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-async/angstrom-async.0.6.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.6.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-async/angstrom-async.0.7.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.7.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-async/angstrom-async.0.8.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.8.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-async/angstrom-async.0.8.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.8.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-async/angstrom-async.0.9.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.9.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.10.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.10.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.6.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.7.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.7.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.1/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.9.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.9.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-unix/angstrom-unix.0.10.0/opam
+++ b/packages/angstrom-unix/angstrom-unix.0.10.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-unix/angstrom-unix.0.6.0/opam
+++ b/packages/angstrom-unix/angstrom-unix.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-unix/angstrom-unix.0.7.0/opam
+++ b/packages/angstrom-unix/angstrom-unix.0.7.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-unix/angstrom-unix.0.8.0/opam
+++ b/packages/angstrom-unix/angstrom-unix.0.8.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-unix/angstrom-unix.0.8.1/opam
+++ b/packages/angstrom-unix/angstrom-unix.0.8.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom-unix/angstrom-unix.0.9.0/opam
+++ b/packages/angstrom-unix/angstrom-unix.0.9.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom/angstrom.0.10.0/opam
+++ b/packages/angstrom/angstrom.0.10.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom/angstrom.0.6.0/opam
+++ b/packages/angstrom/angstrom.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom/angstrom.0.7.0/opam
+++ b/packages/angstrom/angstrom.0.7.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom/angstrom.0.8.0/opam
+++ b/packages/angstrom/angstrom.0.8.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom/angstrom.0.8.1/opam
+++ b/packages/angstrom/angstrom.0.8.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/angstrom/angstrom.0.9.0/opam
+++ b/packages/angstrom/angstrom.0.9.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/anycache-async/anycache-async.0.7.4/opam
+++ b/packages/anycache-async/anycache-async.0.7.4/opam
@@ -18,7 +18,7 @@ depends: [
   "async_unix"
 ]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/anycache-lwt/anycache-lwt.0.7.4/opam
+++ b/packages/anycache-lwt/anycache-lwt.0.7.4/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt"
 ]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/anycache/anycache.0.7.4/opam
+++ b/packages/anycache/anycache.0.7.4/opam
@@ -16,7 +16,7 @@ depends: [
   "lru"
 ]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/asl/asl.0.11/opam
+++ b/packages/asl/asl.0.11/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/ocaml-asl/issues"
 doc: "https://mirage.github.io/ocaml-vmnet/"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/atd/atd.1.13.0/opam
+++ b/packages/atd/atd.1.13.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "https://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/atd/atd.2.0.0/opam
+++ b/packages/atd/atd.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "git://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/atdgen-runtime/atdgen-runtime.1.13.0/opam
+++ b/packages/atdgen-runtime/atdgen-runtime.1.13.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "https://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/atdgen-runtime/atdgen-runtime.2.0.0/opam
+++ b/packages/atdgen-runtime/atdgen-runtime.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "git://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/atdgen/atdgen.1.13.0/opam
+++ b/packages/atdgen/atdgen.1.13.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "https://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/atdgen/atdgen.2.0.0/opam
+++ b/packages/atdgen/atdgen.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "git://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/atdj/atdj.1.13.0/opam
+++ b/packages/atdj/atdj.1.13.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "https://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/atdj/atdj.2.0.0/opam
+++ b/packages/atdj/atdj.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "git://github.com/mjambon/atd.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/base64/base64.2.2.0/opam
+++ b/packages/base64/base64.2.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "alcotest" {test & >= "0.4.0"}
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/benchmark/benchmark.1.5/opam
+++ b/packages/benchmark/benchmark.1.5/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/Chris00/ocaml-benchmark.git"
 bug-reports: "https://github.com/Chris00/ocaml-benchmark/issues"
 doc: "https://Chris00.github.io/ocaml-benchmark/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/bigstringaf/bigstringaf.0.1.0/opam
+++ b/packages/bigstringaf/bigstringaf.0.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/bigstringaf"
 bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
 dev-repo: "https://github.com/inhabitedtype/bigstringaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/bigstringaf/bigstringaf.0.2.0/opam
+++ b/packages/bigstringaf/bigstringaf.0.2.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/bigstringaf"
 bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
 dev-repo: "https://github.com/inhabitedtype/bigstringaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/camomile/camomile.1.0.0/opam
+++ b/packages/camomile/camomile.1.0.0/opam
@@ -7,7 +7,7 @@ license: "LGPL-2+ with OCaml linking exception"
 dev-repo: "https://github.com/yoriyuki/Camomile.git"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/camomile/camomile.1.0.1/opam
+++ b/packages/camomile/camomile.1.0.1/opam
@@ -7,7 +7,7 @@ license: "LGPL-2+ with OCaml linking exception"
 dev-repo: "https://github.com/yoriyuki/Camomile.git"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/cfg/cfg.2.1.0/opam
+++ b/packages/cfg/cfg.2.1.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/cfg.git"
 bug-reports: "https://github.com/mmottl/cfg/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
@@ -9,7 +9,7 @@ tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.9/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.9/opam
@@ -9,7 +9,7 @@ tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/charrua-client/charrua-client.0.9/opam
+++ b/packages/charrua-client/charrua-client.0.9/opam
@@ -9,7 +9,7 @@ tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/charrua-core/charrua-core.0.9/opam
+++ b/packages/charrua-core/charrua-core.0.9/opam
@@ -11,7 +11,7 @@ doc: "https://mirage.github.io/charrua-core/api"
 available: [ocaml-version >= "4.03" & opam-version >= "1.2"]
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/charrua-unix/charrua-unix.0.9/opam
+++ b/packages/charrua-unix/charrua-unix.0.9/opam
@@ -8,7 +8,7 @@ license: "ISC"
 dev-repo: "https://github.com/haesbaert/charrua-unix.git"
 available: [ocaml-version >= "4.03" & ocaml-version < "4.06.0"]
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
+++ b/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
@@ -19,7 +19,7 @@ depends: [
   "cmdtui"
 ]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cmdtui/cmdtui.0.4.3/opam
+++ b/packages/cmdtui/cmdtui.0.4.3/opam
@@ -14,6 +14,6 @@ depends: [
   "astring" { >= "0.8.3" }
 ]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/cohttp-async/cohttp-async.0.99.0/opam
+++ b/packages/cohttp-async/cohttp-async.0.99.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-async/cohttp-async.1.0.0/opam
+++ b/packages/cohttp-async/cohttp-async.1.0.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-async/cohttp-async.1.0.2/opam
+++ b/packages/cohttp-async/cohttp-async.1.0.2/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.0.99.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.0.99.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.0.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.0.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.0.2/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.0.2/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.0.99.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.0.99.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.2/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.2/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/cohttp-lwt/cohttp-lwt.0.99.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.0.99.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt/cohttp-lwt.1.0.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.1.0.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-lwt/cohttp-lwt.1.0.2/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.1.0.2/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.0/opam
@@ -10,7 +10,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
@@ -10,7 +10,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.2/opam
@@ -10,7 +10,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-mirage/cohttp-mirage.1.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.0/opam
@@ -10,7 +10,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-top/cohttp-top.0.99.0/opam
+++ b/packages/cohttp-top/cohttp-top.0.99.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-top/cohttp-top.1.0.0/opam
+++ b/packages/cohttp-top/cohttp-top.1.0.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-top/cohttp-top.1.0.2/opam
+++ b/packages/cohttp-top/cohttp-top.1.0.2/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp-top/cohttp-top.1.1.0/opam
+++ b/packages/cohttp-top/cohttp-top.1.1.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp/cohttp.0.99.0/opam
+++ b/packages/cohttp/cohttp.0.99.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp/cohttp.1.0.0/opam
+++ b/packages/cohttp/cohttp.1.0.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp/cohttp.1.0.2/opam
+++ b/packages/cohttp/cohttp.1.0.2/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cohttp/cohttp.1.1.0/opam
+++ b/packages/cohttp/cohttp.1.1.0/opam
@@ -15,7 +15,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cow/cow.2.3.0/opam
+++ b/packages/cow/cow.2.3.0/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/cppo/cppo.1.6.0/opam
+++ b/packages/cppo/cppo.1.6.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/cppo/cppo.1.6.1/opam
+++ b/packages/cppo/cppo.1.6.1/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/cppo/cppo.1.6.2/opam
+++ b/packages/cppo/cppo.1.6.2/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/cppo/cppo.1.6.4/opam
+++ b/packages/cppo/cppo.1.6.4/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.0/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mjambon/cppo/issues"
 license: "BSD-3-Clause"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/crlibm/crlibm.0.1/opam
+++ b/packages/crlibm/crlibm.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/ocaml-crlibm.git"
 bug-reports: "https://github.com/Chris00/ocaml-crlibm/issues"
 doc: "https://Chris00.github.io/ocaml-crlibm/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/crlibm/crlibm.0.2/opam
+++ b/packages/crlibm/crlibm.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/ocaml-crlibm.git"
 bug-reports: "https://github.com/Chris00/ocaml-crlibm/issues"
 doc: "https://Chris00.github.io/ocaml-crlibm/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/crunch/crunch.2.1.0/opam
+++ b/packages/crunch/crunch.2.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "io-page-unix" {test}
 ]
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/csv-lwt/csv-lwt.2.0/opam
+++ b/packages/csv-lwt/csv-lwt.2.0/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/Chris00/ocaml-csv.git"
 bug-reports: "https://github.com/Chris00/ocaml-csv/issues"
 doc: "https://Chris00.github.io/ocaml-csv/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/csv/csv.2.0/opam
+++ b/packages/csv/csv.2.0/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/Chris00/ocaml-csv.git"
 bug-reports: "https://github.com/Chris00/ocaml-csv/issues"
 doc: "https://Chris00.github.io/ocaml-csv/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/cuid/cuid.0.1/opam
+++ b/packages/cuid/cuid.0.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/marcoonroad/ocaml-cuid/issues"
 license: "MIT"
 dev-repo: "git://github.com/marcoonroad/ocaml-cuid.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]

--- a/packages/depyt/depyt.0.2.0/opam
+++ b/packages/depyt/depyt.0.2.0/opam
@@ -9,7 +9,7 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"]
+  ["jbuilder" "subst" "-p" name]
   ["jbuilder" "build" "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-j" jobs]

--- a/packages/diet/diet.0.1/opam
+++ b/packages/diet/diet.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/djs55/ocaml-diet/issues"
 doc: "https://djs55.github.io/ocaml-diet"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dispatch-js/dispatch-js.0.4.0/opam
+++ b/packages/dispatch-js/dispatch-js.0.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/ocaml-dispatch"
 dev-repo: "https://github.com/inhabitedtype/ocaml-dispatch.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-dispatch/issues"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/dispatch/dispatch.0.4.0/opam
+++ b/packages/dispatch/dispatch.0.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/ocaml-dispatch"
 dev-repo: "https://github.com/inhabitedtype/ocaml-dispatch.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-dispatch/issues"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [ [ "jbuilder" "runtest" "-p" name "-j" jobs ] ]

--- a/packages/distributed-lwt/distributed-lwt.0.1.0/opam
+++ b/packages/distributed-lwt/distributed-lwt.0.1.0/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/essdotteedot/distributed.git"
 bug-reports: "https://github.com/essdotteedot/distributed/issues"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/distributed-uwt/distributed-uwt.0.1.0/opam
+++ b/packages/distributed-uwt/distributed-uwt.0.1.0/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/essdotteedot/distributed.git"
 bug-reports: "https://github.com/essdotteedot/distributed/issues"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/distributed/distributed.0.5.0/opam
+++ b/packages/distributed/distributed.0.5.0/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/essdotteedot/distributed.git"
 bug-reports: "https://github.com/essdotteedot/distributed/issues"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns-async/dns-async.1.0.0/opam
+++ b/packages/dns-async/dns-async.1.0.0/opam
@@ -10,7 +10,7 @@ authors: [ "Anil Madhavapeddy" "Tim Deegan" "Richard Mortier" "Haris Rotsos"
 tags: [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns-async/dns-async.1.0.1/opam
+++ b/packages/dns-async/dns-async.1.0.1/opam
@@ -10,7 +10,7 @@ authors: [ "Anil Madhavapeddy" "Tim Deegan" "Richard Mortier" "Haris Rotsos"
 tags: [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
+++ b/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-dns-forward.git"
 doc:          "https://mirage.github.io/ocaml-dns-forward/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/dns-forward/dns-forward.0.10.0/opam
+++ b/packages/dns-forward/dns-forward.0.10.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-dns-forward.git"
 doc:          "https://mirage.github.io/ocaml-dns-forward/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/dns-forward/dns-forward.0.9.0/opam
+++ b/packages/dns-forward/dns-forward.0.9.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-dns-forward.git"
 doc:          "https://mirage.github.io/ocaml-dns-forward/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.0.0/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.0.0/opam
@@ -11,7 +11,7 @@ authors: [
   "David Sheets" "Thomas Gazagnaire" "Luke Dunstan" "David Scott" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.0.1/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.0.1/opam
@@ -11,7 +11,7 @@ authors: [
   "David Sheets" "Thomas Gazagnaire" "Luke Dunstan" "David Scott" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns-lwt/dns-lwt.1.0.0/opam
+++ b/packages/dns-lwt/dns-lwt.1.0.0/opam
@@ -12,7 +12,7 @@ authors: [
 license: "ISC"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns-lwt/dns-lwt.1.0.1/opam
+++ b/packages/dns-lwt/dns-lwt.1.0.1/opam
@@ -12,7 +12,7 @@ authors: [
 license: "ISC"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns/dns.1.0.0/opam
+++ b/packages/dns/dns.1.0.0/opam
@@ -13,7 +13,7 @@ license: "ISC"
 tags: [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dns/dns.1.0.1/opam
+++ b/packages/dns/dns.1.0.1/opam
@@ -13,7 +13,7 @@ license: "ISC"
 tags: [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dnssd/dnssd.0.5.0/opam
+++ b/packages/dnssd/dnssd.0.5.0/opam
@@ -11,7 +11,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-j" jobs]
 ]
 

--- a/packages/doc-ock-html/doc-ock-html.1.1.0/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.1.0/opam
@@ -18,6 +18,6 @@ depends: [
   "xmlm" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock-html/doc-ock-html.1.1.1/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.1.1/opam
@@ -17,6 +17,6 @@ depends: [
   "xmlm" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock-html/doc-ock-html.1.2.0/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.2.0/opam
@@ -18,6 +18,6 @@ depends: [
   "xmlm" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock-html/doc-ock-html.1.2.1/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.2.1/opam
@@ -18,6 +18,6 @@ depends: [
   "xmlm" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock-xml/doc-ock-xml.1.1.0/opam
+++ b/packages/doc-ock-xml/doc-ock-xml.1.1.0/opam
@@ -20,6 +20,6 @@ depends: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock-xml/doc-ock-xml.1.2.0/opam
+++ b/packages/doc-ock-xml/doc-ock-xml.1.2.0/opam
@@ -19,6 +19,6 @@ depends: [
   "doc-ock" {>= "1.2.0" & < "1.2.1"} ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock-xml/doc-ock-xml.1.2.1/opam
+++ b/packages/doc-ock-xml/doc-ock-xml.1.2.1/opam
@@ -19,6 +19,6 @@ depends: [
   "doc-ock" {>= "1.2.1" } ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock/doc-ock.1.1.0/opam
+++ b/packages/doc-ock/doc-ock.1.1.0/opam
@@ -19,6 +19,6 @@ depends: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock/doc-ock.1.1.1/opam
+++ b/packages/doc-ock/doc-ock.1.1.1/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock/doc-ock.1.2.0/opam
+++ b/packages/doc-ock/doc-ock.1.2.0/opam
@@ -19,6 +19,6 @@ depends: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/doc-ock/doc-ock.1.2.1/opam
+++ b/packages/doc-ock/doc-ock.1.2.1/opam
@@ -19,6 +19,6 @@ depends: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/dryunit/dryunit.0.3.1/opam
+++ b/packages/dryunit/dryunit.0.3.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/gersonmoraes/dryunit"
 bug-reports: "https://github.com/gersonmoraes/dryunit"
 dev-repo: "https://github.com/gersonmoraes/dryunit.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/dryunit/dryunit.0.4.0/opam
+++ b/packages/dryunit/dryunit.0.4.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/gersonmoraes/dryunit"
 bug-reports: "https://github.com/gersonmoraes/dryunit"
 dev-repo: "https://github.com/gersonmoraes/dryunit.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/dryunit/dryunit.0.4.1/opam
+++ b/packages/dryunit/dryunit.0.4.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/gersonmoraes/dryunit"
 bug-reports: "https://github.com/gersonmoraes/dryunit"
 dev-repo: "https://github.com/gersonmoraes/dryunit.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dryunit/dryunit.0.5.0/opam
+++ b/packages/dryunit/dryunit.0.5.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/gersonmoraes/dryunit"
 bug-reports: "https://github.com/gersonmoraes/dryunit"
 dev-repo: "https://github.com/gersonmoraes/dryunit.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/duff/duff.0.1/opam
+++ b/packages/duff/duff.0.1/opam
@@ -8,7 +8,7 @@ doc:          "https://dinosaure.github.io/duff/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/dune-release/dune-release.0.1.0/opam
+++ b/packages/dune-release/dune-release.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/samoht/dune-release/issues"
 doc: "https://samoht.github.io/dune-release/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/dune-release/dune-release.0.2.0/opam
+++ b/packages/dune-release/dune-release.0.2.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/samoht/dune-release/issues"
 doc: "https://samoht.github.io/dune-release/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/emile/emile.0.1/opam
+++ b/packages/emile/emile.0.1/opam
@@ -8,7 +8,7 @@ doc:          "https://dinosaure.github.io/emile/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/emile/emile.0.2/opam
+++ b/packages/emile/emile.0.2/opam
@@ -8,7 +8,7 @@ doc:          "https://dinosaure.github.io/emile/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/emile/emile.0.3/opam
+++ b/packages/emile/emile.0.3/opam
@@ -9,7 +9,7 @@ doc:          "https://dinosaure.github.io/emile/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/encore/encore.0.1/opam
+++ b/packages/encore/encore.0.1/opam
@@ -8,7 +8,7 @@ doc:          "https://dinosaure.github.io/encore/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.0.5.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.0.5.0/opam
@@ -12,7 +12,7 @@ tags: [
 ]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/ezjsonm/ezjsonm.0.5.0/opam
+++ b/packages/ezjsonm/ezjsonm.0.5.0/opam
@@ -12,7 +12,7 @@ tags: [
 ]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/ezjsonm/ezjsonm.0.6.0/opam
+++ b/packages/ezjsonm/ezjsonm.0.6.0/opam
@@ -12,7 +12,7 @@ tags: [
 ]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/ezxmlm/ezxmlm.1.0.2/opam
+++ b/packages/ezxmlm/ezxmlm.1.0.2/opam
@@ -4,7 +4,7 @@ authors: [ "Anil Madhavapeddy" ]
 license: "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/facile/facile.1.1.4/opam
+++ b/packages/facile/facile.1.1.4/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/Emmanuel-PLF/facile/issues"
 dev-repo: "https://github.com/Emmanuel-PLF/facile.git"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-async/faraday-async.0.3.0/opam
+++ b/packages/faraday-async/faraday-async.0.3.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-async/faraday-async.0.4.0/opam
+++ b/packages/faraday-async/faraday-async.0.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-async/faraday-async.0.5.0/opam
+++ b/packages/faraday-async/faraday-async.0.5.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-async/faraday-async.0.5.1/opam
+++ b/packages/faraday-async/faraday-async.0.5.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-async/faraday-async.0.6.0/opam
+++ b/packages/faraday-async/faraday-async.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.3.0/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.3.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.4.0/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.5.0/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.5.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.5.1/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.5.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.6.0/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt/faraday-lwt.0.3.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.3.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt/faraday-lwt.0.4.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt/faraday-lwt.0.5.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.5.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt/faraday-lwt.0.5.1/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.5.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday-lwt/faraday-lwt.0.6.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday/faraday.0.3.0/opam
+++ b/packages/faraday/faraday.0.3.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday/faraday.0.4.0/opam
+++ b/packages/faraday/faraday.0.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday/faraday.0.5.0/opam
+++ b/packages/faraday/faraday.0.5.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday/faraday.0.5.1/opam
+++ b/packages/faraday/faraday.0.5.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/faraday/faraday.0.6.0/opam
+++ b/packages/faraday/faraday.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/faraday"
 bug-reports: "https://github.com/inhabitedtype/faraday/issues"
 dev-repo: "https://github.com/inhabitedtype/faraday.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/fftw3/fftw3.0.8.1/opam
+++ b/packages/fftw3/fftw3.0.8.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/fftw-ocaml/issues"
 doc: "https://Chris00.github.io/fftw-ocaml/doc"
 tags: ["FFT"]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ] { os != "darwin" }
   [ "env" "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
     "jbuilder" "build" "-p" name "-j" jobs ] { os = "darwin" }

--- a/packages/fftw3/fftw3.0.8/opam
+++ b/packages/fftw3/fftw3.0.8/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/fftw-ocaml/issues"
 doc: "https://Chris00.github.io/fftw-ocaml/doc"
 tags: ["FFT"]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ] { os != "darwin" }
   [ "env" "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
     "jbuilder" "build" "-p" name "-j" jobs ] { os = "darwin" }

--- a/packages/freetds/freetds.0.5.2/opam
+++ b/packages/freetds/freetds.0.5.2/opam
@@ -14,7 +14,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]

--- a/packages/freetds/freetds.0.6/opam
+++ b/packages/freetds/freetds.0.6/opam
@@ -14,7 +14,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]

--- a/packages/functoria-runtime/functoria-runtime.2.1.0/opam
+++ b/packages/functoria-runtime/functoria-runtime.2.1.0/opam
@@ -13,7 +13,7 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/functoria-runtime/functoria-runtime.2.2.0/opam
+++ b/packages/functoria-runtime/functoria-runtime.2.2.0/opam
@@ -13,7 +13,7 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/functoria/functoria.2.1.0/opam
+++ b/packages/functoria/functoria.2.1.0/opam
@@ -13,7 +13,7 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/functoria/functoria.2.2.0/opam
+++ b/packages/functoria/functoria.2.2.0/opam
@@ -13,7 +13,7 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]

--- a/packages/gammu/gammu.0.9.4/opam
+++ b/packages/gammu/gammu.0.9.4/opam
@@ -10,7 +10,7 @@ dev-repo: "https://github.com/Chris00/ocaml-gammu.git"
 bug-reports: "https://github.com/Chris00/ocaml-gammu/issues"
 doc: "https://Chris00.github.io/ocaml-gammu/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/git-unix/git-unix.1.11.1/opam
+++ b/packages/git-unix/git-unix.1.11.1/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/git-unix/git-unix.1.11.2/opam
+++ b/packages/git-unix/git-unix.1.11.2/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "test/git-unix"]

--- a/packages/git-unix/git-unix.1.11.4/opam
+++ b/packages/git-unix/git-unix.1.11.4/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "test/git-unix"]

--- a/packages/git-unix/git-unix.1.11.5/opam
+++ b/packages/git-unix/git-unix.1.11.5/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/git/git.1.11.0/opam
+++ b/packages/git/git.1.11.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "test/git"]

--- a/packages/git/git.1.11.2/opam
+++ b/packages/git/git.1.11.2/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "test/git"]

--- a/packages/git/git.1.11.3/opam
+++ b/packages/git/git.1.11.3/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "test/git"]

--- a/packages/git/git.1.11.5/opam
+++ b/packages/git/git.1.11.5/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "build" "-p" name]

--- a/packages/github-hooks-unix/github-hooks-unix.0.2.0/opam
+++ b/packages/github-hooks-unix/github-hooks-unix.0.2.0/opam
@@ -15,7 +15,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/github-hooks/github-hooks.0.2.0/opam
+++ b/packages/github-hooks/github-hooks.0.2.0/opam
@@ -15,7 +15,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/github-hooks/github-hooks.0.3.0/opam
+++ b/packages/github-hooks/github-hooks.0.3.0/opam
@@ -15,7 +15,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/github-jsoo/github-jsoo.3.0.0/opam
+++ b/packages/github-jsoo/github-jsoo.3.0.0/opam
@@ -20,7 +20,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github-jsoo/github-jsoo.3.0.1/opam
+++ b/packages/github-jsoo/github-jsoo.3.0.1/opam
@@ -20,7 +20,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github-jsoo/github-jsoo.3.1.0/opam
+++ b/packages/github-jsoo/github-jsoo.3.1.0/opam
@@ -22,7 +22,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github-unix/github-unix.3.0.0/opam
+++ b/packages/github-unix/github-unix.3.0.0/opam
@@ -20,7 +20,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github-unix/github-unix.3.0.1/opam
+++ b/packages/github-unix/github-unix.3.0.1/opam
@@ -20,7 +20,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github-unix/github-unix.3.1.0/opam
+++ b/packages/github-unix/github-unix.3.1.0/opam
@@ -22,7 +22,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github/github.3.0.0/opam
+++ b/packages/github/github.3.0.0/opam
@@ -20,7 +20,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github/github.3.0.1/opam
+++ b/packages/github/github.3.0.1/opam
@@ -20,7 +20,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/github/github.3.1.0/opam
+++ b/packages/github/github.3.1.0/opam
@@ -22,7 +22,7 @@ tags: [
   "git"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/gpr/gpr.1.3.0/opam
+++ b/packages/gpr/gpr.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/gpr.git"
 bug-reports: "https://github.com/mmottl/gpr/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/gpr/gpr.1.3.1/opam
+++ b/packages/gpr/gpr.1.3.1/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/gpr.git"
 bug-reports: "https://github.com/mmottl/gpr/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/gsl/gsl.1.20.0/opam
+++ b/packages/gsl/gsl.1.20.0/opam
@@ -11,7 +11,7 @@ dev-repo: "https://github.com/mmottl/gsl-ocaml.git"
 bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/gsl/gsl.1.20.2/opam
+++ b/packages/gsl/gsl.1.20.2/opam
@@ -11,7 +11,7 @@ dev-repo: "https://github.com/mmottl/gsl-ocaml.git"
 bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/gsl/gsl.1.21.0/opam
+++ b/packages/gsl/gsl.1.21.0/opam
@@ -11,7 +11,7 @@ dev-repo: "https://github.com/mmottl/gsl-ocaml.git"
 bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/gsl/gsl.1.22.0/opam
+++ b/packages/gsl/gsl.1.22.0/opam
@@ -11,7 +11,7 @@ dev-repo: "https://github.com/mmottl/gsl-ocaml.git"
 bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/hex/hex.1.1.1/opam
+++ b/packages/hex/hex.1.1.1/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/ocaml-hex/issues"
 dev-repo:     "https://github.com/mirage/ocaml-hex.git"
 license:      "ISC"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [ [ "jbuilder" "runtest" ] ]

--- a/packages/hex/hex.1.2.0/opam
+++ b/packages/hex/hex.1.2.0/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/ocaml-hex/issues"
 dev-repo:     "https://github.com/mirage/ocaml-hex.git"
 license:      "ISC"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [ [ "jbuilder" "runtest" ] ]

--- a/packages/httpaf-async/httpaf-async.0.1.0/opam
+++ b/packages/httpaf-async/httpaf-async.0.1.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/httpaf"
 bug-reports: "https://github.com/inhabitedtype/httpaf/issues"
 dev-repo: "https://github.com/inhabitedtype/httpaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/httpaf-async/httpaf-async.0.2.0/opam
+++ b/packages/httpaf-async/httpaf-async.0.2.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/inhabitedtype/httpaf"
 bug-reports: "https://github.com/inhabitedtype/httpaf/issues"
 dev-repo: "https://github.com/inhabitedtype/httpaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/httpaf/httpaf.0.1.0/opam
+++ b/packages/httpaf/httpaf.0.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/httpaf"
 bug-reports: "https://github.com/inhabitedtype/httpaf/issues"
 dev-repo: "https://github.com/inhabitedtype/httpaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/httpaf/httpaf.0.2.0/opam
+++ b/packages/httpaf/httpaf.0.2.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/httpaf"
 bug-reports: "https://github.com/inhabitedtype/httpaf/issues"
 dev-repo: "https://github.com/inhabitedtype/httpaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/hvsock/hvsock.1.0.0/opam
+++ b/packages/hvsock/hvsock.1.0.0/opam
@@ -8,12 +8,12 @@ bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
 doc: "https://mirage.github.io/ocaml-hvsock"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 build-test:[
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 ]
 

--- a/packages/hvsock/hvsock.1.0.1/opam
+++ b/packages/hvsock/hvsock.1.0.1/opam
@@ -8,12 +8,12 @@ bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
 doc: "https://mirage.github.io/ocaml-hvsock"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 build-test:[
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 ]
 

--- a/packages/hvsock/hvsock.1.0.2/opam
+++ b/packages/hvsock/hvsock.1.0.2/opam
@@ -8,12 +8,12 @@ bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
 doc: "https://mirage.github.io/ocaml-hvsock"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 build-test:[
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 ]
 

--- a/packages/integration1d/integration1d.0.5/opam
+++ b/packages/integration1d/integration1d.0.5/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/integration1d.git"
 bug-reports: "https://github.com/Chris00/integration1d/issues"
 doc: "https://Chris00.github.io/integration1d/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/interval/interval.1.4/opam
+++ b/packages/interval/interval.1.4/opam
@@ -10,7 +10,7 @@ doc: "https://Chris00.github.io/ocaml-interval/doc"
 license: "LGPL-3.0"
 tags: ["interval" "science"]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-doc: [[ "jbuilder" "build" "@doc"]]

--- a/packages/io-page-unix/io-page-unix.2.0.0/opam
+++ b/packages/io-page-unix/io-page-unix.2.0.0/opam
@@ -11,7 +11,7 @@ authors: [
 ]
 tags: ["org:mirage"]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/io-page-unix/io-page-unix.2.0.1/opam
+++ b/packages/io-page-unix/io-page-unix.2.0.1/opam
@@ -11,7 +11,7 @@ authors: [
 ]
 tags: ["org:mirage"]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/io-page/io-page.2.0.0/opam
+++ b/packages/io-page/io-page.2.0.0/opam
@@ -11,7 +11,7 @@ authors: [
 ]
 tags: ["org:mirage"]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/io-page/io-page.2.0.1/opam
+++ b/packages/io-page/io-page.2.0.1/opam
@@ -11,7 +11,7 @@ authors: [
 ]
 tags: ["org:mirage"]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/ipaddr/ipaddr.2.8.0/opam
+++ b/packages/ipaddr/ipaddr.2.8.0/opam
@@ -17,7 +17,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]

--- a/packages/irmin-chunk/irmin-chunk.1.3.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.1.3.0/opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "https://github.com/mirage/irmin.git"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/irmin-fs/irmin-fs.1.3.0/opam
+++ b/packages/irmin-fs/irmin-fs.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/irmin-git/irmin-git.1.3.0/opam
+++ b/packages/irmin-git/irmin-git.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-http/irmin-http.1.3.0/opam
+++ b/packages/irmin-http/irmin-http.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/irmin-http/irmin-http.1.3.1/opam
+++ b/packages/irmin-http/irmin-http.1.3.1/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-http/irmin-http.1.3.3/opam
+++ b/packages/irmin-http/irmin-http.1.3.3/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-mem/irmin-mem.1.3.0/opam
+++ b/packages/irmin-mem/irmin-mem.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/irmin-mirage/irmin-mirage.1.3.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.3.0/opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "https://github.com/mirage/irmin.git"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-unix/irmin-unix.1.3.0/opam
+++ b/packages/irmin-unix/irmin-unix.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/irmin-unix/irmin-unix.1.3.3/opam
+++ b/packages/irmin-unix/irmin-unix.1.3.3/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/irmin-watcher/irmin-watcher.0.3.0/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.3.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/irmin-watcher/issues"
 license:      "ISC"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/irmin/irmin.1.3.0/opam
+++ b/packages/irmin/irmin.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin/irmin.1.3.2/opam
+++ b/packages/irmin/irmin.1.3.2/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin/irmin.1.4.0/opam
+++ b/packages/irmin/irmin.1.4.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["jbuilder" "subst"] {pinned}
+ ["jbuilder" "subst" "-p" name] {pinned}
  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/json-derivers/json-derivers.1.0.0/opam
+++ b/packages/json-derivers/json-derivers.1.0.0/opam
@@ -7,7 +7,7 @@ dev-repo: "https://github.com/rgrinberg/json-derivers.git"
 license: "ISC"
 tags: ["deriving" "json"]
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/junit/junit.1.0/opam
+++ b/packages/junit/junit.1.0/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 available: [ocaml-version >= "4.02.3"]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/junit/junit.2.0/opam
+++ b/packages/junit/junit.2.0/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 available: [ocaml-version >= "4.02.3"]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/junit_alcotest/junit_alcotest.2.0/opam
+++ b/packages/junit_alcotest/junit_alcotest.2.0/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 available: [ocaml-version >= "4.02.3"]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-doc: [["jbuilder" "build" "@doc" "-p" name "-j" jobs]]

--- a/packages/junit_ounit/junit_ounit.2.0/opam
+++ b/packages/junit_ounit/junit_ounit.2.0/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 available: [ocaml-version >= "4.02.3"]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-doc: [["jbuilder" "build" "@doc" "-p" name "-j" jobs]]

--- a/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/opam
+++ b/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/opam
@@ -12,7 +12,7 @@ dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
 
 available: [ ocaml-version >= "4.02.0" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/jupyter/jupyter.2.0.0/opam
+++ b/packages/jupyter/jupyter.2.0.0/opam
@@ -13,7 +13,7 @@ dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
 
 available: [ ocaml-version >= "4.02.0" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 install: [

--- a/packages/jupyter/jupyter.2.1.0/opam
+++ b/packages/jupyter/jupyter.2.1.0/opam
@@ -13,7 +13,7 @@ dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
 
 available: [ ocaml-version >= "4.02.0" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/jupyter/jupyter.2.2.0/opam
+++ b/packages/jupyter/jupyter.2.2.0/opam
@@ -13,7 +13,7 @@ dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
 
 available: [ ocaml-version >= "4.02.0" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/jupyter/jupyter.2.2.1/opam
+++ b/packages/jupyter/jupyter.2.2.1/opam
@@ -13,7 +13,7 @@ dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
 
 available: [ ocaml-version >= "4.02.0" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/jupyter/jupyter.2.2.2/opam
+++ b/packages/jupyter/jupyter.2.2.2/opam
@@ -13,7 +13,7 @@ dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
 
 available: [ ocaml-version >= "4.02.0" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/jupyter/jupyter.2.3.0/opam
+++ b/packages/jupyter/jupyter.2.3.0/opam
@@ -12,7 +12,7 @@ dev-repo: "https://github.com/akabe/ocaml-jupyter.git"
 
 available: [ ocaml-version >= "4.02.0" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/kicadsch/kicadsch.0.2.0/opam
+++ b/packages/kicadsch/kicadsch.0.2.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
 license: "ISC"
 dev-repo: "https://github.com/jnavila/plotkicadsch.git"
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/kicadsch/kicadsch.0.3.0/opam
+++ b/packages/kicadsch/kicadsch.0.3.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
 license: "ISC"
 dev-repo: "https://github.com/jnavila/plotkicadsch.git"
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/lacaml/lacaml.10.0.1/opam
+++ b/packages/lacaml/lacaml.10.0.1/opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/mmottl/lacaml/issues"
 tags: [ "clib:lapack" "clib:blas" ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/lacaml/lacaml.10.0.2/opam
+++ b/packages/lacaml/lacaml.10.0.2/opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/mmottl/lacaml/issues"
 tags: [ "clib:lapack" "clib:blas" ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/lacaml/lacaml.11.0.0/opam
+++ b/packages/lacaml/lacaml.11.0.0/opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/mmottl/lacaml/issues"
 tags: [ "clib:lapack" "clib:blas" ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/lacaml/lacaml.11.0.1/opam
+++ b/packages/lacaml/lacaml.11.0.1/opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/mmottl/lacaml/issues"
 tags: [ "clib:lapack" "clib:blas" ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/lambda-term/lambda-term.1.12.0/opam
+++ b/packages/lambda-term/lambda-term.1.12.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/diml/lambda-term/issues"
 dev-repo: "git://github.com/diml/lambda-term.git"
 license: "BSD3"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/lambda-term/lambda-term.1.13/opam
+++ b/packages/lambda-term/lambda-term.1.13/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/diml/lambda-term/issues"
 dev-repo: "git://github.com/diml/lambda-term.git"
 license: "BSD3"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/lbfgs/lbfgs.0.9/opam
+++ b/packages/lbfgs/lbfgs.0.9/opam
@@ -9,7 +9,7 @@ doc: "https://Chris00.github.io/L-BFGS-ocaml/doc"
 tags: [ "science" "numerics" "optimization" "minimization" "maximization"
         "bound-constrained" "large-scale" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-doc: [ "jbuilder" "build" "@doc" ]

--- a/packages/lens/lens.1.2.1/opam
+++ b/packages/lens/lens.1.2.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/pdonadeo/ocaml-lens"
 dev-repo: "https://github.com/pdonadeo/ocaml-lens.git"
 bug-reports: "https://github.com/pdonadeo/ocaml-lens/issues"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/links-postgresql/links-postgresql.0.7.3/opam
+++ b/packages/links-postgresql/links-postgresql.0.7.3/opam
@@ -11,7 +11,7 @@ available: [
 ]
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/links/links.0.7.2/opam
+++ b/packages/links/links.0.7.2/opam
@@ -11,7 +11,7 @@ available: [
 ]
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/links/links.0.7.3/opam
+++ b/packages/links/links.0.7.3/opam
@@ -11,7 +11,7 @@ available: [
 ]
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/magic-mime/magic-mime.1.0.1/opam
+++ b/packages/magic-mime/magic-mime.1.0.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-magic-mime"
 license: "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/magic-mime/magic-mime.1.1.0/opam
+++ b/packages/magic-mime/magic-mime.1.1.0/opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-magic-mime"
 license: "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mesh-display/mesh-display.0.8.9/opam
+++ b/packages/mesh-display/mesh-display.0.8.9/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/mesh.git"
 bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/mesh-easymesh/mesh-easymesh.0.8.9/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.8.9/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.0/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.1/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.2/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.3/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.3/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.4/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.4/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mesh-graphics/mesh-graphics.0.9.0/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/mesh.git"
 bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/mesh-graphics/mesh-graphics.0.9.1/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.1/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/mesh.git"
 bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/mesh-graphics/mesh-graphics.0.9.2/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.2/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/mesh.git"
 bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/mesh-graphics/mesh-graphics.0.9.3/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.3/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/mesh.git"
 bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mesh-graphics/mesh-graphics.0.9.4/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.4/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/mesh.git"
 bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mesh-triangle/mesh-triangle.0.8.9/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.8.9/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "clib:triangle"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-triangle/mesh-triangle.0.9.0/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.9.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "clib:triangle"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-triangle/mesh-triangle.0.9.1/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.9.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "clib:triangle"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-triangle/mesh-triangle.0.9.2/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.9.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "clib:triangle"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh-triangle/mesh-triangle.0.9.3/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.9.3/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "clib:triangle"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mesh-triangle/mesh-triangle.0.9.4/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.9.4/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "clib:triangle"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mesh/mesh.0.8.9/opam
+++ b/packages/mesh/mesh.0.8.9/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh/mesh.0.9.0/opam
+++ b/packages/mesh/mesh.0.9.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh/mesh.0.9.1/opam
+++ b/packages/mesh/mesh.0.9.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh/mesh.0.9.2/opam
+++ b/packages/mesh/mesh.0.9.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/mesh/mesh.0.9.3/opam
+++ b/packages/mesh/mesh.0.9.3/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mesh/mesh.0.9.4/opam
+++ b/packages/mesh/mesh.0.9.4/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 #doc: ""
 tags: [ "Mesh" "Triangulation" "PDE" ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/mirage-block/issues"
 doc: "https://mirage.gitub.io/mirage-block/"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
@@ -8,7 +8,7 @@ tags:         "org:mirage"
 license:      "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.3/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.3/opam
@@ -8,7 +8,7 @@ tags:         "org:mirage"
 license:      "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
@@ -8,7 +8,7 @@ tags:         "org:mirage"
 license:      "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
@@ -8,7 +8,7 @@ tags:         "org:mirage"
 license:      "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
@@ -17,7 +17,7 @@ tags: [
 ]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
@@ -17,7 +17,7 @@ tags: [
 ]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-block/mirage-block.1.1.0/opam
+++ b/packages/mirage-block/mirage-block.1.1.0/opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/mirage-block/"
 
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.5.0/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.5.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mirage/mirage-bootvar-xen.git"
 license: "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-channel-lwt/mirage-channel-lwt.3.1.0/opam
+++ b/packages/mirage-channel-lwt/mirage-channel-lwt.3.1.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-channel/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [

--- a/packages/mirage-channel/mirage-channel.3.1.0/opam
+++ b/packages/mirage-channel/mirage-channel.3.1.0/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage"]
 available: [ ocaml-version >= "4.02.3"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.3.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.3.0/opam
@@ -13,6 +13,6 @@ depends: [
   "lwt"
 ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/mirage-clock-lwt/mirage-clock-lwt.1.3.0/opam
+++ b/packages/mirage-clock-lwt/mirage-clock-lwt.1.3.0/opam
@@ -14,6 +14,6 @@ depends: [
   "lwt"
 ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.3.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.3.0/opam
@@ -17,6 +17,6 @@ depends: [
   "configurator" {build}
 ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "configurator" {build}
 ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/mirage-clock/mirage-clock.1.3.0/opam
+++ b/packages/mirage-clock/mirage-clock.1.3.0/opam
@@ -12,6 +12,6 @@ depends: [
   "mirage-device" {>= "1.0.0"}
 ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.2/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.2/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.3/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.3/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.4/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.4/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.5/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.5/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-unix/mirage-console-unix.2.3.2/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.3.2/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-unix/mirage-console-unix.2.3.3/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.3.3/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-unix/mirage-console-unix.2.3.4/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.3.4/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-unix/mirage-console-unix.2.3.5/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.3.5/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.2/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.2/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.3/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.3/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.4/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.4/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.5/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.3.5/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.2/opam
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.2/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.3/opam
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.3/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.4/opam
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.4/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.5/opam
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.3.5/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.2/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.2/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.3/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.3/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.4/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.4/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.5/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.3.5/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.2/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.2/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.3/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.3/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.4/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.4/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.5/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.5/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console/mirage-console.2.3.2/opam
+++ b/packages/mirage-console/mirage-console.2.3.2/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console/mirage-console.2.3.3/opam
+++ b/packages/mirage-console/mirage-console.2.3.3/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console/mirage-console.2.3.4/opam
+++ b/packages/mirage-console/mirage-console.2.3.4/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-console/mirage-console.2.3.5/opam
+++ b/packages/mirage-console/mirage-console.2.3.5/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage" "org:xapi-project"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-device/mirage-device.1.1.0/opam
+++ b/packages/mirage-device/mirage-device.1.1.0/opam
@@ -10,7 +10,7 @@ authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
 tags:          [ "org:mirage"]
 license:       "ISC"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/mirage-dns/mirage-dns.3.0.0/opam
+++ b/packages/mirage-dns/mirage-dns.3.0.0/opam
@@ -8,7 +8,7 @@ authors: [ "Anil Madhavapeddy" "Tim Deegan" "Richard Mortier" "Haris Rotsos"
   "David Sheets" "Thomas Gazagnaire" "Luke Dunstan" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-dns/mirage-dns.3.0.1/opam
+++ b/packages/mirage-dns/mirage-dns.3.0.1/opam
@@ -8,7 +8,7 @@ authors: [ "Anil Madhavapeddy" "Tim Deegan" "Richard Mortier" "Haris Rotsos"
   "David Sheets" "Thomas Gazagnaire" "Luke Dunstan" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
+++ b/packages/mirage-flow-rawlink/mirage-flow-rawlink.1.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/mirage-flow-rawlink/issues"
 doc: "https://mirage.github.io/mirage-flow-rawlink/"
 
 build: [
-  ["jbuilder" "subst"]
+  ["jbuilder" "subst" "-p" name]
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-flow/mirage-flow.1.3.0/opam
+++ b/packages/mirage-flow/mirage-flow.1.3.0/opam
@@ -9,7 +9,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.1.1/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.1.1/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-fs/issues"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.4.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.4.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
 doc:          "https://mirage.github.io/mirage-fs-unix/"
 tags:         [ "org:mirage" ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/mirage-fs/mirage-fs.1.1.1/opam
+++ b/packages/mirage-fs/mirage-fs.1.1.1/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-fs/issues"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-http/mirage-http.3.2.0/opam
+++ b/packages/mirage-http/mirage-http.3.2.0/opam
@@ -10,7 +10,7 @@ license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/mirage-kv-lwt/mirage-kv-lwt.1.1.0/opam
+++ b/packages/mirage-kv-lwt/mirage-kv-lwt.1.1.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-kv/issues"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-kv/mirage-kv.1.1.1/opam
+++ b/packages/mirage-kv/mirage-kv.1.1.1/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-kv/issues"
 tags:         ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-nat/mirage-nat.1.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/mirage/mirage-nat/issues/"
 dev-repo: "https://github.com/mirage/mirage-nat.git"
 license: "ISC"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/mirage-net-lwt/mirage-net-lwt.1.1.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.1.1.0/opam
@@ -11,7 +11,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-net-unix/mirage-net-unix.2.4.1/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.4.1/opam
@@ -13,7 +13,7 @@ license:     "ISC"
 doc:         "https://mirage.github.io/mirage-net-unix/"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-net-xen/mirage-net-xen.1.7.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.1/opam
@@ -6,7 +6,7 @@ bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
 doc:           "https://mirage.github.io/mirage-net-xen"
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-net/mirage-net.1.1.1/opam
+++ b/packages/mirage-net/mirage-net.1.1.1/opam
@@ -11,7 +11,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-profile-unix/mirage-profile-unix.0.8.0/opam
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.8.0/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile-unix/mirage-profile-unix.0.8.1/opam
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.8.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/opam
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.8.2/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.8.0/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.8.0/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.8.1/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.8.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.8.2/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile/mirage-profile.0.8.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.0/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile/mirage-profile.0.8.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-profile/mirage-profile.0.8.2/opam
+++ b/packages/mirage-profile/mirage-profile.0.8.2/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-profile"
 license: "BSD-2-clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.2.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.2.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-protocols/mirage-protocols.1.2.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.2.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-protocols/mirage-protocols.1.3.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.3.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/mirage-qubes.git"
 doc:          "https://mirage.github.io/mirage-qubes"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-qubes/mirage-qubes.0.5/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.5/opam
@@ -8,7 +8,7 @@ doc:          "https://mirage.github.io/mirage-qubes"
 license:      "BSD-2-Clause"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-random/mirage-random.1.1.0/opam
+++ b/packages/mirage-random/mirage-random.1.1.0/opam
@@ -11,7 +11,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-runtime/mirage-runtime.3.0.5/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.0.5/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-runtime/mirage-runtime.3.0.7/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.0.7/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-runtime/mirage-runtime.3.1.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.1.0/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.1.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.1.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-stack/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-stack/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-stack/mirage-stack.1.1.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.1.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-stack/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-stack/mirage-stack.1.2.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.2.0/opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-stack/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-time-lwt/mirage-time-lwt.1.1.0/opam
+++ b/packages/mirage-time-lwt/mirage-time-lwt.1.1.0/opam
@@ -11,7 +11,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-time-unix/mirage-time-unix.1.2.0/opam
+++ b/packages/mirage-time-unix/mirage-time-unix.1.2.0/opam
@@ -11,7 +11,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-time/mirage-time.1.1.0/opam
+++ b/packages/mirage-time/mirage-time.1.1.0/opam
@@ -11,7 +11,7 @@ tags:          [ "org:mirage"]
 license:       "ISC"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
@@ -8,7 +8,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
@@ -8,7 +8,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
@@ -8,7 +8,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-types/mirage-types.3.0.5/opam
+++ b/packages/mirage-types/mirage-types.3.0.5/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-types/mirage-types.3.0.7/opam
+++ b/packages/mirage-types/mirage-types.3.0.7/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-types/mirage-types.3.1.0/opam
+++ b/packages/mirage-types/mirage-types.3.1.0/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage-vnetif/mirage-vnetif.0.4.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.4.0/opam
@@ -9,7 +9,7 @@ doc: "https://docs.mirage.io/mirage-vnetif"
 license: "ISC"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage/mirage.3.0.5/opam
+++ b/packages/mirage/mirage.3.0.5/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage/mirage.3.0.7/opam
+++ b/packages/mirage/mirage.3.0.7/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage/mirage.3.0.8/opam
+++ b/packages/mirage/mirage.3.0.8/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mirage/mirage.3.1.0/opam
+++ b/packages/mirage/mirage.3.1.0/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/mock-ounit/mock-ounit.0.1.0/opam
+++ b/packages/mock-ounit/mock-ounit.0.1.0/opam
@@ -7,7 +7,7 @@ license: "BSD-2"
 dev-repo: "https://github.com/cryptosense/ocaml-mock.git"
 doc: "https://cryptosense.github.io/ocaml-mock/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mock/mock.0.1.0/opam
+++ b/packages/mock/mock.0.1.0/opam
@@ -7,7 +7,7 @@ license: "BSD-2"
 dev-repo: "https://github.com/cryptosense/ocaml-mock.git"
 doc: "https://cryptosense.github.io/ocaml-mock/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/moss/moss.0.1/opam
+++ b/packages/moss/moss.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/ocaml-moss.git"
 bug-reports: "https://github.com/Chris00/ocaml-moss/issues"
 doc: "https://Chris00.github.io/ocaml-moss/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/mrt-format/mrt-format.0.2.0/opam
+++ b/packages/mrt-format/mrt-format.0.2.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mor1/mrt-format/issues"
 doc: "https://mor1.github.io/mrt-format/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mrt-format/mrt-format.0.3.0/opam
+++ b/packages/mrt-format/mrt-format.0.3.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mor1/mrt-format/issues"
 doc: "https://mor1.github.io/mrt-format/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mstruct/mstruct.1.3.4/opam
+++ b/packages/mstruct/mstruct.1.3.4/opam
@@ -7,7 +7,7 @@ dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mstruct/mstruct.1.4.0/opam
+++ b/packages/mstruct/mstruct.1.4.0/opam
@@ -7,7 +7,7 @@ dev-repo:     "https://github.com/mirage/ocaml-mstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/multipart-form-data/multipart-form-data.0.2.0/opam
+++ b/packages/multipart-form-data/multipart-form-data.0.2.0/opam
@@ -7,7 +7,7 @@ license: "BSD-2"
 dev-repo: "https://github.com/cryptosense/multipart-form-data.git"
 doc: "https://cryptosense.github.io/multipart-form-data/doc"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/mustache/mustache.3.0.2/opam
+++ b/packages/mustache/mustache.3.0.2/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/rgrinberg/ocaml-mustache.git"
 doc: "http://mustache.github.io/mustache.5.html"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/netchannel/netchannel.1.7.1/opam
+++ b/packages/netchannel/netchannel.1.7.1/opam
@@ -6,7 +6,7 @@ bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
 doc:           "https://mirage.github.io/mirage-net-xen"
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/netchannel/netchannel.1.8.0/opam
+++ b/packages/netchannel/netchannel.1.8.0/opam
@@ -6,7 +6,7 @@ bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
 doc:           "https://mirage.github.io/mirage-net-xen"
 build: [
-  [ "jbuilder" "subst" "-n" name] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/notty_async/notty_async.0.1/opam
+++ b/packages/notty_async/notty_async.0.1/opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/yminsky/notty_async/issues"
 dev-repo:     "git+https://github.com/yminsky/notty_async.git"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/ocal/ocal.0.1.3/opam
+++ b/packages/ocal/ocal.0.1.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mor1/ocal/issues"
 doc: "https://mor1.github.io/ocal/"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/ocal/ocal.0.2.0/opam
+++ b/packages/ocal/ocal.0.2.0/opam
@@ -11,7 +11,7 @@ doc: "https://mor1.github.io/ocal/"
 available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.06.0" ]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/ocal/ocal.0.2.1/opam
+++ b/packages/ocal/ocal.0.2.1/opam
@@ -11,7 +11,7 @@ doc: "https://mor1.github.io/ocal/"
 available: [ ocaml-version >= "4.02.3" ]
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/ocaml-basics/ocaml-basics.0.5.0/opam
+++ b/packages/ocaml-basics/ocaml-basics.0.5.0/opam
@@ -6,7 +6,7 @@ bug-reports: "http://github.com/advanced-schema/ocaml-basics/issues"
 license: "MIT"
 dev-repo: "https://github.com/advanced-schema/ocaml-basics.git"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/ocamlformat/ocamlformat.0.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.2/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 license: "MIT"
 dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   [make]
 ]
 depends: [

--- a/packages/octavius/octavius.1.1.0/opam
+++ b/packages/octavius/octavius.1.1.0/opam
@@ -16,6 +16,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta7"} ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/octavius/octavius.1.2.0/opam
+++ b/packages/octavius/octavius.1.2.0/opam
@@ -16,6 +16,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta7"} ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/odoc/odoc.1.1.0/opam
+++ b/packages/odoc/odoc.1.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cmdliner" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["ocaml" "bin/set-etc" "bin/odoc_etc.ml" odoc:etc]
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/odoc/odoc.1.1.1/opam
+++ b/packages/odoc/odoc.1.1.1/opam
@@ -26,7 +26,7 @@ depends: [
   "cmdliner" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["ocaml" "bin/set-etc" "bin/odoc_etc.ml" odoc:etc]
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/odoc/odoc.1.2.0/opam
+++ b/packages/odoc/odoc.1.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cmdliner" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["ocaml" "bin/set-etc" "bin/odoc_etc.ml" odoc:etc]
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/packages/opium/opium.0.16.0/opam
+++ b/packages/opium/opium.0.16.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/rgrinberg/opium/issues"
 dev-repo: "https://github.com/rgrinberg/opium.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/opium_kernel/opium_kernel.0.16.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.16.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/rgrinberg/opium/issues"
 dev-repo: "https://github.com/rgrinberg/opium.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/optimization1d/optimization1d.0.6/opam
+++ b/packages/optimization1d/optimization1d.0.6/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/optimization1d/issues"
 doc: "https://Chris00.github.io/optimization1d/doc"
 tags: ["optimization"]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/optint/optint.0.0.1/opam
+++ b/packages/optint/optint.0.0.1/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/dinosaure/optint.git"
 doc:          "https://dinosaure.github.io/optint/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/owl-base/owl-base.0.3.7/opam
+++ b/packages/owl-base/owl-base.0.3.7/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/owl-base/owl-base.0.3.8/opam
+++ b/packages/owl-base/owl-base.0.3.8/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/owl-top/owl-top.0.3.7/opam
+++ b/packages/owl-top/owl-top.0.3.7/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/owl-top/owl-top.0.3.8/opam
+++ b/packages/owl-top/owl-top.0.3.8/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/owl-zoo/owl-zoo.0.3.7/opam
+++ b/packages/owl-zoo/owl-zoo.0.3.7/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/owl-zoo/owl-zoo.0.3.8/opam
+++ b/packages/owl-zoo/owl-zoo.0.3.8/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/owl/owl.0.3.0/opam
+++ b/packages/owl/owl.0.3.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ryanrhymes/owl/issues"
 doc: "http://www.cl.cam.ac.uk/~lw525/owl/"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/owl/owl.0.3.7/opam
+++ b/packages/owl/owl.0.3.7/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/owl/owl.0.3.8/opam
+++ b/packages/owl/owl.0.3.8/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl/issues"
 doc: "https://owlbarn.github.io/"
 
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/parse-argv/parse-argv.0.1.0/opam
+++ b/packages/parse-argv/parse-argv.0.1.0/opam
@@ -9,7 +9,7 @@ tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [

--- a/packages/partition_map/partition_map.0.9.0/opam
+++ b/packages/partition_map/partition_map.0.9.0/opam
@@ -9,7 +9,7 @@ license: "Apache2"
 available: [ ocaml-version >= "4.06" ]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs "@install"]
 ]
 

--- a/packages/pcap-format/pcap-format.0.5.1/opam
+++ b/packages/pcap-format/pcap-format.0.5.1/opam
@@ -9,12 +9,12 @@ doc:          "https://mirage.github.io/ocaml-pcap/"
 tags:         [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 build-test:[
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 ]
 

--- a/packages/pcre/pcre.7.3.0/opam
+++ b/packages/pcre/pcre.7.3.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
 bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/pcre/pcre.7.3.2/opam
+++ b/packages/pcre/pcre.7.3.2/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
 bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/pcre/pcre.7.3.3/opam
+++ b/packages/pcre/pcre.7.3.3/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
 bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/pcre/pcre.7.3.4/opam
+++ b/packages/pcre/pcre.7.3.4/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/pcre-ocaml.git"
 bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/plotkicadsch/plotkicadsch.0.1.4/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.1.4/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
 license: "ISC"
 dev-repo: "https://github.com/jnavila/plotkicadsch.git"
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/plotkicadsch/plotkicadsch.0.2.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.2.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
 license: "ISC"
 dev-repo: "https://github.com/jnavila/plotkicadsch.git"
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/plotkicadsch/plotkicadsch.0.3.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.3.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
 license: "ISC"
 dev-repo: "https://github.com/jnavila/plotkicadsch.git"
 build: [
-  [ "jbuilder" "subst" "-n" name ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/pomap/pomap.4.0.0/opam
+++ b/packages/pomap/pomap.4.0.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/pomap.git"
 bug-reports: "https://github.com/mmottl/pomap/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/postgresql/postgresql.4.1.0/opam
+++ b/packages/postgresql/postgresql.4.1.0/opam
@@ -12,7 +12,7 @@ dev-repo: "https://github.com/mmottl/postgresql-ocaml.git"
 bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/postgresql/postgresql.4.2.0/opam
+++ b/packages/postgresql/postgresql.4.2.0/opam
@@ -12,7 +12,7 @@ dev-repo: "https://github.com/mmottl/postgresql-ocaml.git"
 bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/postgresql/postgresql.4.2.1/opam
+++ b/packages/postgresql/postgresql.4.2.1/opam
@@ -12,7 +12,7 @@ dev-repo: "https://github.com/mmottl/postgresql-ocaml.git"
 bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/postgresql/postgresql.4.3.0/opam
+++ b/packages/postgresql/postgresql.4.3.0/opam
@@ -12,7 +12,7 @@ dev-repo: "https://github.com/mmottl/postgresql-ocaml.git"
 bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/prof_spacetime/prof_spacetime.0.2.0/opam
+++ b/packages/prof_spacetime/prof_spacetime.0.2.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/lpw25/prof_spacetime/issues"
 license: "MIT"
 dev-repo: "git://github.com/lpw25/prof_spacetime"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]

--- a/packages/prometheus-app/prometheus-app.0.3/opam
+++ b/packages/prometheus-app/prometheus-app.0.3/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/prometheus-app/prometheus-app.0.4/opam
+++ b/packages/prometheus-app/prometheus-app.0.4/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/prometheus-app/prometheus-app.0.5/opam
+++ b/packages/prometheus-app/prometheus-app.0.5/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/prometheus/prometheus.0.3/opam
+++ b/packages/prometheus/prometheus.0.3/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/prometheus/prometheus.0.4/opam
+++ b/packages/prometheus/prometheus.0.4/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/prometheus/prometheus.0.5/opam
+++ b/packages/prometheus/prometheus.0.5/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.11.3/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.11.3/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.12.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.12.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.3/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.3/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p/protocol-9p.0.11.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.2/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p/protocol-9p.0.11.3/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.3/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p/protocol-9p.0.12.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.12.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/protocol-9p/protocol-9p.0.12.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.12.1/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/qcow-tool/qcow-tool.0.10.2/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.2/opam
@@ -10,7 +10,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/qcow-tool/qcow-tool.0.10.3/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.3/opam
@@ -10,7 +10,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/qcow-tool/qcow-tool.0.10.4/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.4/opam
@@ -10,7 +10,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/qcow-tool/qcow-tool.0.10.5/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.5/opam
@@ -10,7 +10,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/qcow/qcow.0.10.2/opam
+++ b/packages/qcow/qcow.0.10.2/opam
@@ -11,7 +11,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/qcow/qcow.0.10.3/opam
+++ b/packages/qcow/qcow.0.10.3/opam
@@ -11,7 +11,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/qcow/qcow.0.10.4/opam
+++ b/packages/qcow/qcow.0.10.4/opam
@@ -11,7 +11,7 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/radare2/radare2.0.0.2/opam
+++ b/packages/radare2/radare2.0.0.2/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/fxfactorial/ocaml-radare2"
 dev-repo: "https://github.com/fxfactorial/ocaml-radare2.git"
 bug-reports: "https://github.com/fxfactorial/ocaml-radare2/issues"
 build: [
-	["jbuilder" "subst" "-n" name] {pinned}
+	["jbuilder" "subst" "-p" name] {pinned}
 	["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depexts: [

--- a/packages/radis/radis.0.1/opam
+++ b/packages/radis/radis.0.1/opam
@@ -8,7 +8,7 @@ doc:          "https://dinosaure.github.io/radis/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/re/re.1.7.2/opam
+++ b/packages/re/re.1.7.2/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 dev-repo: "https://github.com/ocaml/ocaml-re.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/re/re.1.7.3/opam
+++ b/packages/re/re.1.7.3/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 dev-repo: "https://github.com/ocaml/ocaml-re.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/regenerate/regenerate.0.1/opam
+++ b/packages/regenerate/regenerate.0.1/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 available: ocaml-version >= "4.03"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs "@install"]
 ]
 build-test: [

--- a/packages/res/res.5.0.0/opam
+++ b/packages/res/res.5.0.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/mmottl/res.git"
 bug-reports: "https://github.com/mmottl/res/issues"
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/root1d/root1d.0.5/opam
+++ b/packages/root1d/root1d.0.5/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/Chris00/root1d.git"
 bug-reports: "https://github.com/Chris00/root1d/issues"
 doc: "https://Chris00.github.io/root1d/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]

--- a/packages/rope/rope.0.6.1/opam
+++ b/packages/rope/rope.0.6.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/ocaml-rope/issues"
 doc: "https://Chris00.github.io/ocaml-rope/doc"
 tags: [ "datastructure"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/rope/rope.0.6/opam
+++ b/packages/rope/rope.0.6/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/Chris00/ocaml-rope/issues"
 doc: "https://Chris00.github.io/ocaml-rope/doc"
 tags: [ "datastructure"  ]
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/session-cohttp-async/session-cohttp-async.0.4.0/opam
+++ b/packages/session-cohttp-async/session-cohttp-async.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session-cohttp-lwt/session-cohttp-lwt.0.4.0/opam
+++ b/packages/session-cohttp-lwt/session-cohttp-lwt.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session-cohttp/session-cohttp.0.4.0/opam
+++ b/packages/session-cohttp/session-cohttp.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session-postgresql-async/session-postgresql-async.0.4.0/opam
+++ b/packages/session-postgresql-async/session-postgresql-async.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session-postgresql-lwt/session-postgresql-lwt.0.4.0/opam
+++ b/packages/session-postgresql-lwt/session-postgresql-lwt.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session-postgresql/session-postgresql.0.4.0/opam
+++ b/packages/session-postgresql/session-postgresql.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session-redis-lwt/session-redis-lwt.0.4.0/opam
+++ b/packages/session-redis-lwt/session-redis-lwt.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session-webmachine/session-webmachine.0.4.0/opam
+++ b/packages/session-webmachine/session-webmachine.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 

--- a/packages/session/session.0.4.0/opam
+++ b/packages/session/session.0.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/inhabitedtype/ocaml-session.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-session/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name]
 ]
 build-test: ["jbuilder" "runtest" "-p" name]

--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.2.0.0/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.2.0.0/opam
@@ -8,7 +8,7 @@ license:      "ISC"
 tags:         [ "org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.2.0.1/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.2.0.1/opam
@@ -8,7 +8,7 @@ license:      "ISC"
 tags:         [ "org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.0.0/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.0.0/opam
@@ -8,7 +8,7 @@ license:      "ISC"
 tags:         [ "org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
@@ -8,7 +8,7 @@ license:      "ISC"
 tags:         [ "org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
@@ -8,7 +8,7 @@ license:      "ISC"
 tags:         [ "org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/shared-memory-ring/shared-memory-ring.3.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.3.0.0/opam
@@ -8,7 +8,7 @@ license:      "ISC"
 tags:         [ "org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/sqlite3/sqlite3.4.2.0/opam
+++ b/packages/sqlite3/sqlite3.4.2.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
 tags: [ "clib:sqlite3" "clib:pthread"  ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/sqlite3/sqlite3.4.3.0/opam
+++ b/packages/sqlite3/sqlite3.4.3.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
 tags: [ "clib:sqlite3" "clib:pthread"  ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/sqlite3/sqlite3.4.3.1/opam
+++ b/packages/sqlite3/sqlite3.4.3.1/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
 tags: [ "clib:sqlite3" "clib:pthread"  ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/sqlite3/sqlite3.4.3.2/opam
+++ b/packages/sqlite3/sqlite3.4.3.2/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
 tags: [ "clib:sqlite3" "clib:pthread"  ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/sqlite3/sqlite3.4.4.0/opam
+++ b/packages/sqlite3/sqlite3.4.4.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
 tags: [ "clib:sqlite3" "clib:pthread"  ]
 
 build: [
-  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "subst" "-p" name]{pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/sslconf/sslconf.0.8.3/opam
+++ b/packages/sslconf/sslconf.0.8.3/opam
@@ -21,7 +21,7 @@ depends: [
   "odoc" {doc}
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/stringext/stringext.1.5.0/opam
+++ b/packages/stringext/stringext.1.5.0/opam
@@ -7,7 +7,7 @@ license:      "MIT"
 dev-repo:     "https://github.com/rgrinberg/stringext.git"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/sugar/sugar.0.7.3/opam
+++ b/packages/sugar/sugar.0.7.3/opam
@@ -7,7 +7,7 @@ license: "MIT"
 doc: "https://gersonmoraes.github.io/ocaml-sugar/doc"
 dev-repo: "http://github.com/gersonmoraes/ocaml-sugar.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/tcpip/tcpip.3.2.0/opam
+++ b/packages/tcpip/tcpip.3.2.0/opam
@@ -12,7 +12,7 @@ license: "ISC"
 tags: ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/tcpip/tcpip.3.3.0/opam
+++ b/packages/tcpip/tcpip.3.3.0/opam
@@ -12,7 +12,7 @@ license: "ISC"
 tags: ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/tcpip/tcpip.3.3.1/opam
+++ b/packages/tcpip/tcpip.3.3.1/opam
@@ -12,7 +12,7 @@ license: "ISC"
 tags: ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -12,7 +12,7 @@ license: "ISC"
 tags: ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/tcpip/tcpip.3.4.1/opam
+++ b/packages/tcpip/tcpip.3.4.1/opam
@@ -12,7 +12,7 @@ license: "ISC"
 tags: ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/tcpip/tcpip.3.4.2/opam
+++ b/packages/tcpip/tcpip.3.4.2/opam
@@ -12,7 +12,7 @@ license: "ISC"
 tags: ["org:mirage"]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/opam
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/diml/topkg-jbuilder"
 bug-reports: "https://github.com/diml/utop/topkg-jbuilder"
 dev-repo: "git://github.com/diml/topkg-jbuilder.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/opam
+++ b/packages/topkg-jbuilder/topkg-jbuilder.0.2.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/samoht/topkg-jbuilder.git"
 doc:          "https://samoht.github.io/topkg-jbuilder/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/touist/touist.3.5.0/opam
+++ b/packages/touist/touist.3.5.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/touist/touist/issues"
 license: "MIT"
 dev-repo: "https://github.com/touist/touist.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 install: ["jbuilder" "install"]

--- a/packages/travis-opam/travis-opam.1.2.0/opam
+++ b/packages/travis-opam/travis-opam.1.2.0/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/tuntap/tuntap.1.5.0/opam
+++ b/packages/tuntap/tuntap.1.5.0/opam
@@ -10,7 +10,7 @@ doc:          "https://mirage.github.io/ocaml-tuntap/"
 tags:         [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/tuntap/tuntap.1.6.0/opam
+++ b/packages/tuntap/tuntap.1.6.0/opam
@@ -10,7 +10,7 @@ doc:          "https://mirage.github.io/ocaml-tuntap/"
 tags:         [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/tuntap/tuntap.1.6.1/opam
+++ b/packages/tuntap/tuntap.1.6.1/opam
@@ -10,7 +10,7 @@ doc:          "https://mirage.github.io/ocaml-tuntap/"
 tags:         [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/typebeat/typebeat.0.2/opam
+++ b/packages/typebeat/typebeat.0.2/opam
@@ -8,7 +8,7 @@ doc:          "https://mirage.github.io/typebeat/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/typebeat/typebeat.0.3/opam
+++ b/packages/typebeat/typebeat.0.3/opam
@@ -8,7 +8,7 @@ doc:          "https://mirage.github.io/typebeat/"
 license:      "MIT"
 
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/uri/uri.1.9.4/opam
+++ b/packages/uri/uri.1.9.4/opam
@@ -16,7 +16,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]

--- a/packages/uri/uri.1.9.5/opam
+++ b/packages/uri/uri.1.9.5/opam
@@ -16,7 +16,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]

--- a/packages/uri/uri.1.9.6/opam
+++ b/packages/uri/uri.1.9.6/opam
@@ -16,7 +16,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]

--- a/packages/uri/uri.1.9.7/opam
+++ b/packages/uri/uri.1.9.7/opam
@@ -16,7 +16,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]

--- a/packages/utop/utop.2.0.0/opam
+++ b/packages/utop/utop.2.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/diml/utop"
 bug-reports: "https://github.com/diml/utop/issues"
 dev-repo: "git://github.com/diml/utop.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/utop/utop.2.0.1/opam
+++ b/packages/utop/utop.2.0.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/diml/utop"
 bug-reports: "https://github.com/diml/utop/issues"
 dev-repo: "git://github.com/diml/utop.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/utop/utop.2.0.2/opam
+++ b/packages/utop/utop.2.0.2/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/diml/utop"
 bug-reports: "https://github.com/diml/utop/issues"
 dev-repo: "git://github.com/diml/utop.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/utop/utop.2.1.0/opam
+++ b/packages/utop/utop.2.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/diml/utop"
 bug-reports: "https://github.com/diml/utop/issues"
 dev-repo: "git://github.com/diml/utop.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/vchan-unix/vchan-unix.3.0.0/opam
+++ b/packages/vchan-unix/vchan-unix.3.0.0/opam
@@ -12,7 +12,7 @@ doc:         "http://mirage.github.io/ocaml-vchan"
 license:     "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/vchan-xen/vchan-xen.3.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.3.0.0/opam
@@ -12,7 +12,7 @@ doc:         "http://mirage.github.io/ocaml-vchan"
 license:     "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/vchan/vchan.3.0.0/opam
+++ b/packages/vchan/vchan.3.0.0/opam
@@ -12,7 +12,7 @@ doc:         "http://mirage.github.io/ocaml-vchan"
 license:     "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/vmnet/vmnet.1.2.0/opam
+++ b/packages/vmnet/vmnet.1.2.0/opam
@@ -9,7 +9,7 @@ doc:          "https://mirage.github.io/ocaml-vmnet/"
 license:      "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/vmnet/vmnet.1.3.0/opam
+++ b/packages/vmnet/vmnet.1.3.0/opam
@@ -9,12 +9,12 @@ doc:          "https://mirage.github.io/ocaml-vmnet/"
 license:      "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 build-test: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
   [ "jbuilder" "runtest" ]
 ]

--- a/packages/vmnet/vmnet.1.3.1/opam
+++ b/packages/vmnet/vmnet.1.3.1/opam
@@ -8,12 +8,12 @@ doc:          "https://mirage.github.io/ocaml-vmnet/"
 license:      "ISC"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 build-test: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
   [ "jbuilder" "runtest" ]
 ]

--- a/packages/vpnkit/vpnkit.0.1.1/opam
+++ b/packages/vpnkit/vpnkit.0.1.1/opam
@@ -18,7 +18,7 @@ dev-repo:     "https://github.com/moby/vpnkit.git"
 doc:          "https://moby.github.io/vpnkit/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/vpnkit/vpnkit.0.2.0/opam
+++ b/packages/vpnkit/vpnkit.0.2.0/opam
@@ -18,7 +18,7 @@ dev-repo:     "https://github.com/moby/vpnkit.git"
 doc:          "https://moby.github.io/vpnkit/"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/weberizer/weberizer.0.7.8/opam
+++ b/packages/weberizer/weberizer.0.7.8/opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/Chris00/weberizer.git"
 bug-reports: "https://github.com/Chris00/weberizer/issues"
 doc: "https://Chris00.github.io/weberizer/doc"
 build: [
-  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "subst" "-p" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/webmachine/webmachine.0.5.0/opam
+++ b/packages/webmachine/webmachine.0.5.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/ocaml-webmachine"
 dev-repo: "https://github.com/inhabitedtype/ocaml-webmachine.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-webmachine/issues"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/webmachine/webmachine.0.6.0/opam
+++ b/packages/webmachine/webmachine.0.6.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/ocaml-webmachine"
 dev-repo: "https://github.com/inhabitedtype/ocaml-webmachine.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-webmachine/issues"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/win-error/win-error.0.3/opam
+++ b/packages/win-error/win-error.0.3/opam
@@ -9,12 +9,12 @@ dev-repo: "https://github.com/djs55/ocaml-win-error.git"
 bug-reports: "https://github.com/djs55/ocaml-win-error/issues"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 build-test:[
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 ]
 

--- a/packages/win-eventlog/win-eventlog.0.2/opam
+++ b/packages/win-eventlog/win-eventlog.0.2/opam
@@ -9,7 +9,7 @@ dev-repo: "https://github.com/mirage/ocaml-win-eventlog.git"
 bug-reports: "https://github.com/mirage/ocaml-win-eventlog/issues"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/mirage/ocaml-evtchn/issues"
 tags:         ["org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xen-evtchn/xen-evtchn.2.0.0/opam
+++ b/packages/xen-evtchn/xen-evtchn.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/mirage/ocaml-evtchn/issues"
 tags:         ["org:mirage" "org:xapi-project"]
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
@@ -6,7 +6,7 @@ bug-reports:   "https://github.com/mirage/ocaml-gnt/issues"
 dev-repo:      "https://github.com/mirage/ocaml-gnt.git"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
@@ -7,7 +7,7 @@ dev-repo:      "https://github.com/mirage/ocaml-gnt.git"
 doc:           "https://mirage.github.io/ocaml-gnt"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xen-gnt/xen-gnt.3.0.0/opam
+++ b/packages/xen-gnt/xen-gnt.3.0.0/opam
@@ -6,7 +6,7 @@ bug-reports:   "https://github.com/mirage/ocaml-gnt/issues"
 dev-repo:      "https://github.com/mirage/ocaml-gnt.git"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xen-gnt/xen-gnt.3.0.1/opam
+++ b/packages/xen-gnt/xen-gnt.3.0.1/opam
@@ -7,7 +7,7 @@ dev-repo:      "https://github.com/mirage/ocaml-gnt.git"
 doc:           "https://mirage.github.com/ocaml-gnt"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xenstore/xenstore.1.4.0/opam
+++ b/packages/xenstore/xenstore.1.4.0/opam
@@ -13,7 +13,7 @@ dev-repo:     "https://github.com/mirage/ocaml-xenstore.git"
 doc:          "https://mirage.github.io/ocaml-xenstore"
 
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xenstore_transport/xenstore_transport.0.9.6/opam
+++ b/packages/xenstore_transport/xenstore_transport.0.9.6/opam
@@ -23,7 +23,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/xenstore_transport/xenstore_transport.1.0.0/opam
+++ b/packages/xenstore_transport/xenstore_transport.1.0.0/opam
@@ -23,7 +23,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-p" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/yaml/yaml.0.2.0/opam
+++ b/packages/yaml/yaml.0.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ezjsonm" {test}
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/yaml/yaml.0.2.1/opam
+++ b/packages/yaml/yaml.0.2.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ezjsonm" {test}
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [

--- a/packages/yara/yara.0.1/opam
+++ b/packages/yara/yara.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/XVilka/yara-ocaml/issues"
 license: "MIT"
 dev-repo: "https://github.com/XVilka/yara-ocaml.git"
 build: [
-	["jbuilder" "subst" "-n" name] {pinned}
+	["jbuilder" "subst" "-p" name] {pinned}
 	["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/zed/zed.1.6/opam
+++ b/packages/zed/zed.1.6/opam
@@ -12,7 +12,7 @@ depends: [
   "react"
 ]
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/zmq-async/zmq-async.5.0.0/opam
+++ b/packages/zmq-async/zmq-async.5.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/issuu/ocaml-zmq"
 dev-repo: "git@github.com/issuu/ocaml-zmq.git"
 bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]

--- a/packages/zmq-lwt/zmq-lwt.5.0.0/opam
+++ b/packages/zmq-lwt/zmq-lwt.5.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/issuu/ocaml-zmq"
 dev-repo: "git@github.com/issuu/ocaml-zmq.git"
 bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]

--- a/packages/zmq/zmq.5.0.0/opam
+++ b/packages/zmq/zmq.5.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/issuu/ocaml-zmq"
 dev-repo: "git@github.com/issuu/ocaml-zmq.git"
 bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]


### PR DESCRIPTION
This ensure that jbuilder doesn't try to escape the build directory.
See https://github.com/ocaml/dune/issues/954 for some context