### PR TITLE
Update md5 of xtmpl 0.17.0 archive

### DIFF
--- a/packages/xtmpl/xtmpl.0.17.0/url
+++ b/packages/xtmpl/xtmpl.0.17.0/url
@@ -1,2 +1,2 @@
 http: "https://framagit.org/zoggy/xtmpl/-/archive/0.17.0/xtmpl-0.17.0.tar.gz"
-checksum: "17b0eff3d8e57cb434e0f61ef767f4c3"
+checksum: "3be7f684566ffdce7a975653fdcaf671"


### PR DESCRIPTION
META file in previous archive contained a bad version number.