### PR TITLE
mirrors the FrontC package

### DIFF
--- a/packages/FrontC/FrontC.3.4/url
+++ b/packages/FrontC/FrontC.3.4/url
@@ -1,2 +1,3 @@
 archive: "http://www.irit.fr/recherches/ARCHI/MARCH/frontc/Frontc-3.4.tgz"
 checksum: "953417daaa2647ed8df45dee3d9f19f0"
+mirrors: ["https://mirrors.aegis.cylab.cmu.edu/bap/extra/Frontc-3.4.tgz"] 


### PR DESCRIPTION
The upstream package is no longer available, so as a temporary measure I propose to mirror it (thanks @pmetzger for the archive). We have contacted the upstream author, and if he won't reply or if he will refuse to fix, then we will put the package on a more reliable media (e.g., github).