### PR TITLE
nocrypto.0.5.4-1 still does not work with BSD patch

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -7,7 +7,7 @@ authors:      ["David Kaloper <david@numm.org>"]
 maintainer:   "David Kaloper <david@numm.org>"
 license:      "ISC"
 tags:          [ "org:mirage" ]
-available:     [ ocaml-version >= "4.02.0" ]
+available:     [ ocaml-version >= "4.02.0" & os != "freebsd" & os != "openbsd" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
                 "--jobs" "1"


### PR DESCRIPTION
At least on my FreeBSD-11 system, patch `0003` results in an empty `META` file which is then installed - leading to an unusable nocrypto.  Would be nice if next time someone "unbreaks" this on Free/OpenBSD, they'd _test_ their changes.

see #12062 #12252 #12253
//cc @copy @hcarty @mseri 