### PR TITLE
Package ppx_gen_rec.1.0.0

### DIFF
--- a/packages/ppx_gen_rec/ppx_gen_rec.1.0.0/descr
+++ b/packages/ppx_gen_rec/ppx_gen_rec.1.0.0/descr
@@ -1,0 +1,1 @@
+A ppx rewriter that transforms a recursive module expression into a `struct`.

--- a/packages/ppx_gen_rec/ppx_gen_rec.1.0.0/opam
+++ b/packages/ppx_gen_rec/ppx_gen_rec.1.0.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Marshall Roch <mroch@fb.com>"
+authors: ["Marshall Roch <mroch@fb.com>"]
+homepage: "https://github.com/flowtype/ocaml-ppx_gen_rec"
+doc: "https://github.com/flowtype/ocaml-ppx_gen_rec"
+license: "MIT"
+dev-repo: "https://github.com/flowtype/ocaml-ppx_gen_rec.git"
+bug-reports: "https://github.com/flowtype/ocaml-ppx_gen_rec/issues"
+depends:
+[
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ocaml-migrate-parsetree"
+]
+build: [["jbuilder" "build" "-p" name "-j" jobs]]

--- a/packages/ppx_gen_rec/ppx_gen_rec.1.0.0/url
+++ b/packages/ppx_gen_rec/ppx_gen_rec.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/flowtype/ocaml-ppx_gen_rec/releases/download/v1.0.0/ppx_gen_rec-1.0.0.tbz"
+checksum: "e4cdce94fd2c264f7d74fdb7146dda99"


### PR DESCRIPTION
### `ppx_gen_rec.1.0.0`

A ppx rewriter that transforms a recursive module expression into a `struct`.



---
* Homepage: https://github.com/flowtype/ocaml-ppx_gen_rec
* Source repo: https://github.com/flowtype/ocaml-ppx_gen_rec.git
* Bug tracker: https://github.com/flowtype/ocaml-ppx_gen_rec/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---


---
v1.0.0 2018-07-06
-----------------

Initial release.
:camel: Pull-request generated by opam-publish v0.3.5