### PR TITLE
domain-name.0.1.1

### DIFF
--- a/packages/domain-name/domain-name.0.1.1/descr
+++ b/packages/domain-name/domain-name.0.1.1/descr
@@ -1,0 +1,12 @@
+[RFC 1035](https://tools.ietf.org/html/rfc1035) Internet domain names
+
+
+A domain name is a sequence of labels separated by dots, such as `foo.example`.
+Each label may contain any bytes. The length of each label may not exceed 63
+charactes.  The total length of a domain name is limited to 253 (byte
+representation is 255), but other protocols (such as SMTP) may apply even
+smaller limits.  A domain name label is case preserving, comparison is done in a
+case insensitive manner.
+
+The invariants on the length of domain names are preserved throughout the
+module.

--- a/packages/domain-name/domain-name.0.1.1/opam
+++ b/packages/domain-name/domain-name.0.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/domain-name"
+doc: "https://hannesm.github.io/domain-name/doc"
+dev-repo: "https://github.com/hannesm/domain-name.git"
+bug-reports: "https://github.com/hannesm/domain-name/issues"
+license: "ISC"
+available: [ ocaml-version >= "4.04.2"]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "fmt"
+  "astring"
+  "alcotest" {test}
+]
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+]
+
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
+

--- a/packages/domain-name/domain-name.0.1.1/url
+++ b/packages/domain-name/domain-name.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hannesm/domain-name/releases/download/0.1.1/domain-name-0.1.1.tbz"
+checksum: "31508a8fbc2498b40b8315731bb5e486"


### PR DESCRIPTION
## Domain-name - [RFC 1035](https://tools.ietf.org/html/rfc1035) Internet domain names

A domain name is a sequence of labels separated by dots, such as `foo.example`. Each label may contain any bytes. The length of each label may not exceed 63 charactes.  The total length of a domain name is limited to 253 (byte representation is 255), but other protocols (such as SMTP) may apply even smaller limits.  A domain name label is case preserving, comparison is done in a case insensitive manner.

## Changes in 0.1.1 
* `to_string` and `to_strings` now have an optional labeled `trailing` argument of type bool
* support for FQDN with trailing dot: `of_string "example.com."` now returns `Ok`, and is equal to `of_string "example.com"`
* fix and add tests for `drop_labels` and `drop_labels_exn`, where the semantics of the labeled `back` argument was inversed.