### PR TITLE
[new release] stb_truetype v0.6

### DIFF
--- a/packages/stb_truetype/stb_truetype.0.6/descr
+++ b/packages/stb_truetype/stb_truetype.0.6/descr
@@ -1,0 +1,8 @@
+OCaml bindings to stb_truetype, a public domain font rasterizer
+
+Stb_truetype is an OCaml binding to stb_truetype from Sean Barrett, [Nothings](http://nothings.org/):
+
+  stb_truetype.h: public domain C truetype rasterization library 
+
+The OCaml binding is released under CC-0 license.  It has no dependency beside
+working OCaml and C compilers (stb_truetype is self-contained).

--- a/packages/stb_truetype/stb_truetype.0.6/opam
+++ b/packages/stb_truetype/stb_truetype.0.6/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/stb_truetype"
+bug-reports: "https://github.com/let-def/stb_truetype"
+license: "CC0"
+dev-repo: "https://github.com/let-def/stb_truetype.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "stb_truetype"]
+depends: [
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02"] 

--- a/packages/stb_truetype/stb_truetype.0.6/url
+++ b/packages/stb_truetype/stb_truetype.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/stb_truetype/archive/v0.6.tar.gz"
+checksum: "60010c06922babb1eca899862a46f90b"


### PR DESCRIPTION
Fixes incorrect stubs when compiled in bytecode.