### PR TITLE
Add fedora mirror for ocamlfind

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.8.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.0/opam
@@ -60,5 +60,5 @@ extra-files: [
 url {
   src: "http://download.camlcity.org/download/findlib-1.8.0.tar.gz"
   checksum: "md5=a710c559667672077a93d34eb6a42e5b"
-  mirrors: "http://download2.camlcity.org/download/findlib-1.8.0.tar.gz"
+  mirrors: "https://src.fedoraproject.org/lookaside/pkgs/ocaml-findlib/findlib-1.8.0.tar.gz/sha512/a6dbfd172bff20ebf05db8a0a952a9f0dc67f9420b89771dbfc6193a7a2e5fe448c9d3bdcc113591175906644299529ef937652cfb2c17f67ec2c4dbb1d71e48/findlib-1.8.0.tar.gz"
 }


### PR DESCRIPTION
Per #12302, this PR allows a fallback to install ocamlfind 1.8.0. The Fedora project mirrors this package at https://src.fedoraproject.org/lookaside/pkgs/ocaml-findlib/, so if this is acceptable then I can go back and replace the mirrors for the previous versions as well. 