### PR TITLE
[new release] dune-release (0.3.0)

### DIFF
--- a/packages/dune-release/dune-release.0.3.0/descr
+++ b/packages/dune-release/dune-release.0.3.0/descr
@@ -1,0 +1,6 @@
+Release dune packages in opam
+
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports only projects be built
+with [Dune](https://github.com/ocaml/dune) and released on
+[GitHub](https://github.com).

--- a/packages/dune-release/dune-release.0.3.0/opam
+++ b/packages/dune-release/dune-release.0.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire"]
+homepage: "https://github.com/samoht/dune-release"
+license: "ISC"
+dev-repo: "https://github.com/samoht/dune-release.git"
+bug-reports: "https://github.com/samoht/dune-release/issues"
+doc: "https://samoht.github.io/dune-release/"
+
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build}
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "opam-format"
+  "rresult"
+  "logs"
+  "odoc"
+]
+
+available: [
+  ocaml-version >= "4.06.0"
+]

--- a/packages/dune-release/dune-release.0.3.0/url
+++ b/packages/dune-release/dune-release.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/samoht/dune-release/releases/download/0.3.0/dune-release-0.3.0.tbz"
+checksum: "312440d610fef22c8508ecf67b0a710b"


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/samoht/dune-release">https://github.com/samoht/dune-release</a>
- Documentation: <a href="https://samoht.github.io/dune-release/">https://samoht.github.io/dune-release/</a>

##### CHANGES:

- Store config files in `~/.config/dune/` instead of `~/.dune`
  to match what `dune` is doing (samoht/dune-release#27, @samoht)
- Support opam 1.2.2 when linting (samoht/dune-release#29, @samoht)
- Use `-p <pkg>` instead of `-n <pkg>` to follow dune convention
  (samoht/dune-release#30, samoht/dune-release#42, @samoht)
- Default to `nano` if the EDITOR environment variable is not set. (samoht/dune-release#32, @avsm)
- Fix location of documentation when `odoc` creates an `_html` subdirectory
  (samoht/dune-release#34, @samoht)
- Remove the browse command (samoht/dune-release#36, @samoht)
- Re-add the publish delegatation mechanism to allow non-GitHub users to
  publish packages (see `dune-release help delegate`) (samoht/dune-release#37, @samoht)
- Fix dropping of `v` at the beginning of version numbers in `dune-release opam`
  (samoht/dune-release#40, @let-def)
- Add basic token validation (samoht/dune-release#40, @let-def)
