### PR TITLE
[new release] dune (1.0.0)

### DIFF
--- a/packages/dune/dune.1.0.0/descr
+++ b/packages/dune/dune.1.0.0/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/dune/dune.1.0.0/opam
+++ b/packages/dune/dune.1.0.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "MIT"
+build: [
+  ["ocaml" "configure.ml" "--libdir" lib]
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+available: [ ocaml-version >= "4.02.3" ]
+conflicts: [
+  "jbuilder" {!= "transition"}
+]

--- a/packages/dune/dune.1.0.0/url
+++ b/packages/dune/dune.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dune/releases/download/1.0.0/dune-1.0.0.tbz"
+checksum: "e42e1f7e652a467e5037ef6fe94bfa65"

--- a/packages/dune/dune.1.0.0/url
+++ b/packages/dune/dune.1.0.0/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/ocaml/dune/releases/download/1.0.0/dune-1.0.0.tbz"
-checksum: "e42e1f7e652a467e5037ef6fe94bfa65"
+checksum: "7435bc09a3967bf6da01e6cb7d37ccc3"

--- a/packages/jbuilder/jbuilder.transition/descr
+++ b/packages/jbuilder/jbuilder.transition/descr
@@ -1,0 +1,2 @@
+This is a transition package, jbuilder is now named dune. Use the dune
+package instead.

--- a/packages/jbuilder/jbuilder.transition/opam
+++ b/packages/jbuilder/jbuilder.transition/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "MIT"
+build: []
+depends: ["dune"]
+post-messages: [
+  "Jbuilder has been renamed and the jbuilder package is now a transition"
+  "package. Use the dune package instead."
+]

--- a/packages/opam-client/opam-client.2.0.0~rc/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc/opam
@@ -24,3 +24,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]

--- a/packages/opam-core/opam-core.2.0.0~rc/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc/opam
@@ -26,3 +26,6 @@ depends: [
   "cppo" {build}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]

--- a/packages/opam-devel/opam-devel.2.0.0~rc/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc/opam
@@ -24,6 +24,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]
 post-messages: [
   "
 The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with

--- a/packages/opam-format/opam-format.2.0.0~rc/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc/opam
@@ -23,3 +23,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]

--- a/packages/opam-installer/opam-installer.2.0.0~rc/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc/opam
@@ -24,3 +24,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]

--- a/packages/opam-repository/opam-repository.2.0.0~rc/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc/opam
@@ -22,3 +22,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]

--- a/packages/opam-solver/opam-solver.2.0.0~rc/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~rc/opam
@@ -25,3 +25,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]

--- a/packages/opam-state/opam-state.2.0.0~rc/opam
+++ b/packages/opam-state/opam-state.2.0.0~rc/opam
@@ -22,3 +22,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ocaml-version >= "4.02.3"]
+conflicts: [
+  "dune"
+]

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
@@ -15,3 +15,6 @@ depends: [
   "ctypes-foreign"
 ]
 available: [ocaml-version >= "4.06"]
+conflicts: [
+  "dune"
+]

--- a/packages/yaml/yaml.0.1.0/opam
+++ b/packages/yaml/yaml.0.1.0/opam
@@ -26,3 +26,6 @@ build: [
 build-test: [
   ["jbuilder" "runtest"]
 ]
+conflicts: [
+  "dune"
+]


### PR DESCRIPTION
Fast, portable and opinionated build system

- Project page: https://github.com/ocaml/dune
- Documentation: https://dune.readthedocs.org/

CHANGES:

- Do not load the user configuration file when running inside dune
  (ocaml/dune#700 @diml)

- Do not infer ${null} to be a target (ocaml/dune#693 fixes ocaml/dune#694 @rgrinberg)

- Introduce jbuilder.configurator library. This is a revived version of
  janestreet's configurator library with better cross compilation support, a
  versioned API, and no external dependencies. (ocaml/dune#673, ocaml/dune#678 ocaml/dune#692, ocaml/dune#695
  @rgrinberg)

- Register the transitive dependencies of compilation units as the
  compiler might read `.cm*` files recursively (ocaml/dune#666, fixes ocaml/dune#660,
  @emillon)

- Fix a bug causing `jbuilder external-lib-deps` to crash (ocaml/dune#723,
  @diml)

- `-j` now defaults to the number of processing units available rather
  4 (ocaml/dune#726, @diml)

- Fix attaching index.mld to documentation (ocaml/dune#731, fixes ocaml/dune#717 @rgrinberg)

- Scan the file system lazily (ocaml/dune#732, fixes ocaml/dune#718 and ocaml/dune#228, @diml)

- Add support for setting the default ocaml flags and for build
  profiles (ocaml/dune#419, @diml)

- Display a better error messages when writing `(inline_tests)` in an
  executable stanza (ocaml/dune#748, @diml)

- Restore promoted files when they are deleted or changed in the
  source tree (ocaml/dune#760, fix ocaml/dune#759, @diml)

- Fix a crash when using an invalid alias name (ocaml/dune#762, fixes ocaml/dune#761,
  @diml)

- Fix a crash when using c files from another directory (ocaml/dune#758, fixes
  ocaml/dune#734, @diml)

- Add an `ignored_subdirs` stanza to replace `jbuild-ignore` files
  (ocaml/dune#767, @diml)

- Fix a bug where Dune ignored previous occurrences of duplicated
  fields (ocaml/dune#779, @diml)

- Allow setting custom build directories using the `--build-dir` flag or
  `DUNE_BUILD_DIR` environment variable (ocaml/dune#846, fix ocaml/dune#291, @diml @rgrinberg)

- In dune files, remove support for block (`#| ... |#)`) and sexp
  (`#;`) comments. These were very rarely used and complicate the
  language (ocaml/dune#837, @diml)

- In dune files, add support for block strings, allowing to nicely
  format blocks of texts (ocaml/dune#837, @diml)

- Remove hard-coded knowledge of ppx_driver and
  ocaml-migrate-parsetree when using a `dune` file (ocaml/dune#576, @diml)

- Make the output of Dune slightly more deterministic when run from
  inside Dune (ocaml/dune#855, @diml)

- Simplify quoting behavior of variables. All values are now multi-valued and
  whether a multi valued variable is allowed is determined by the quoting and
  substitution context it appears in. (ocaml/dune#849, fix ocaml/dune#701, @rgrinberg)

- Fix documentation generation for private libraries. (ocaml/dune#864, fix ocaml/dune#856,
  @rgrinberg)

- Use `Marshal` to store digest and incremental databases. This improves the
  speed of 0 rebuilds. (ocaml/dune#817, @diml)

* Allow setting environment variables in `findlib.conf` for cross compilation
  contexts. (ocaml/dune#733, @rgrinberg)

- Add a `link_deps` field to executables, to specify link-time dependencies
  like version scripts. (ocaml/dune#879, fix ocaml/dune#852, @emillon)

- Rename `files_recursively_in` to `source_tree` to make it clearer it
  doesn't include generated files (ocaml/dune#899, fix ocaml/dune#843, @diml)

- Present the `menhir` stanza as an extension with its own version
  (ocaml/dune#901, @diml)

- Improve the syntax of flags in `(pps ...)`. Now instead of `(pps
  (ppx1 -arg1 ppx2 (-foo x)))` one should write `(pps ppx1 -arg ppx2
  -- -foo x)` which looks nicer (ocaml/dune#910, @diml)

- Make `(diff a b)` ignore trailing cr on Windows and add `(cmp a b)` for
  comparing binary files (ocaml/dune#904, fix ocaml/dune#844, @diml)

- Make `dev` the default build profile (ocaml/dune#920, @diml)

- Version `dune-workspace` and `~/.config/dune/config` files (ocaml/dune#932, @diml)

- Add the ability to build an alias non-recursively from the command
  line by writing `@@alias` (ocaml/dune#926, @diml)

- Add a special `default` alias that defaults to `(alias_rec install)`
  when not defined by the user and make `@@default` be the default
  target (ocaml/dune#926, @diml)

- Forbid `#require` in `dune` files in OCaml syntax (ocaml/dune#938, @diml)

- Add `%{profile}` variable. (ocaml/dune#938, @rgrinberg)

- Do not require opam-installer anymore (ocaml/dune#941, @diml)

- Add the `lib_root` and `libexec_root` install sections (ocaml/dune#947, @diml)

- Rename `path:file` to `dep:file` (ocaml/dune#944, @emillon)

- Remove `path-no-dep:file` (ocaml/dune#948, @emillon)

- Adapt the behavior of `dune subst` for dune projects (ocaml/dune#960, @diml)

- Add the `lib_root` and `libexec_root` sections to install stanzas
  (ocaml/dune#947, @diml)

- Add a `Configurator.V1.Flags` module that improves the flag reading/writing
  API (ocaml/dune#840, @avsm)

- Add a `tests` stanza that simlpified defining regular and expect tests
  (ocaml/dune#822, @rgrinberg)

- Change the `subst` subcommand to lookup the project name from the
  `dune-project` whenever it's available. (ocaml/dune#960, @diml)

- The `subst` subcommand no longer looks up the root workspace. Previously this
  detection would break the command whenever `-p` wasn't passed. (ocaml/dune#960, @diml)

- Add a `# DUNE_GEN` in META template files. This is done for consistency with
  `# JBUILDER_GEN`. (ocaml/dune#958, @rgrinberg)

- Rename the following variables in dune files:
  `SCOPE_ROOT` to `project_root`
  `@` to `targets`
  `<` to `first-dep`
  `^` to `deps`
  (ocaml/dune#957, @rgrinberg)

- Rename `ROOT` to `workspace_root` in dune files (ocaml/dune#993, @diml)

- Lowercase all built-in %{variables} in dune files (ocaml/dune#956, @rgrinberg)

- New syntax for naming dependencies: `(deps (:x a b) (:y (glob_files *.c*)))`.
  This replaces the use for `${<}` in dune files. (ocaml/dune#950, @diml, @rgrinberg)

- Fix detection of dynamic cycles, which in particular may appear when
  using `(package ..)` dependencies (ocaml/dune#988, @diml)