### PR TITLE
new release of labltk

### DIFF
--- a/packages/labltk/labltk.8.06.5/descr
+++ b/packages/labltk/labltk.8.06.5/descr
@@ -1,0 +1,3 @@
+OCaml interface to Tcl/Tk, including OCaml library explorer OCamlBrowser
+
+For details, see https://forge.ocamlcore.org/projects/labltk/

--- a/packages/labltk/labltk.8.06.5/opam
+++ b/packages/labltk/labltk.8.06.5/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://labltk.forge.ocamlcore.org/"
+bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=343"
+dev-repo: "https://github.com/garrigue/labltk.git"
+license: "LGPL with linking exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all" "opt"]
+]
+install: [
+  [make "install"]
+]
+available: [ ocaml-version >= "4.07" ]
+remove: [["ocamlfind" "remove" "labltk"]]
+depends: ["ocamlfind" "conf-tcl" "conf-tk"]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]

--- a/packages/labltk/labltk.8.06.5/url
+++ b/packages/labltk/labltk.8.06.5/url
@@ -1,0 +1,2 @@
+archive: "https://forge.ocamlcore.org/frs/download.php/1784/labltk-8.06.5.tar.gz"
+checksum: "a2741cebd8d59565ac35814074ca3002"


### PR DESCRIPTION
Due to changes in the compiler, labltk-8.06.5 is required for ocaml-4.07.