### PR TITLE
Release stdcompat.5

### DIFF
--- a/packages/stdcompat/stdcompat.5/descr
+++ b/packages/stdcompat/stdcompat.5/descr
@@ -1,0 +1,1 @@
+Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml.

--- a/packages/stdcompat/stdcompat.5/opam
+++ b/packages/stdcompat/stdcompat.5/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+version: "5"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+license: "BSD"
+dev-repo: "https://github.com/thierry-martinez/stdcompat.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depopts : [ "result" "seq" "uchar" ]
+available: [ocaml-version >= "3.07" & ocaml-version < "4.08.0"]

--- a/packages/stdcompat/stdcompat.5/url
+++ b/packages/stdcompat/stdcompat.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/thierry-martinez/stdcompat/releases/download/5/stdcompat-5.tar.gz"
+checksum: "0bad6f32e369e1761bbb372091205f8b"

--- a/packages/stdcompat/stdcompat.5/url
+++ b/packages/stdcompat/stdcompat.5/url
@@ -1,2 +1,2 @@
 http: "https://github.com/thierry-martinez/stdcompat/releases/download/5/stdcompat-5.tar.gz"
-checksum: "0bad6f32e369e1761bbb372091205f8b"
+checksum: "c7c4dac066ce8108695d3d530319849f"


### PR DESCRIPTION
- Interfaces are auto-generated.

- stdcompat is now free from any required dependency. There are still
  optional dependencies with respect to the packages result, seq and
  uchar: stdcompat takes care of providing types compatible with
  these packages if they are installed.

- Preprocessing is performed by "./configure" script (generated by
  autoconf). cppo and the C preprocessor are no longer used.

- Makefile is generated by automake. ocamlfind is no longer required
  for installation.

- Split implementation into one module for each standard library module
  (suggested by Yotam Barnoy:
   https://github.com/thierry-martinez/stdcompat/issues/4)

- All modules are now exported as sub-modules of Stdlib module
  (as in OCaml 4.07) -- Bigarray is not exported to allow programs not
  to be compiled with this module, this may change in the future.
  (suggested by Yotam Barnoy:
   https://github.com/thierry-martinez/stdcompat/issues/4)

- Compatibility with uchar package
