### PR TITLE
2 packages from c-cube/calculon at 0.3

### DIFF
--- a/packages/calculon-web/calculon-web.0.3/opam
+++ b/packages/calculon-web/calculon-web.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+tags: ["irc" "bot" "factoids"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+depends: [
+  "jbuilder" {build}
+  "calculon"
+  "re" {>= "1.7.2"}
+  "uri"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "atdgen"
+  "lambdasoup"
+  "sequence"
+  "odoc" {doc}
+]
+available: ocaml-version >= "4.02.0"
+build: ["jbuilder" "build" "-p" name]
+run-test: ["jbuilder" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+build-doc: ["jbuilder" "build" "@doc" "-p" name]
+url {
+  src: "https://github.com/c-cube/calculon/archive/0.3.tar.gz"
+  checksum: [
+    "md5=825ae13052d2e9bb4ed437080a0682bc"
+    "sha512=b830781915c337bff3a2c5c5a57e4f919bd887f3dd387563447f34b17e97dab9ee8b26fa82a288ab5c055b4a07fbcd658f2560c6e9fc3b60cac8832e6f7ffd45"
+  ]
+}

--- a/packages/calculon/calculon.0.3/opam
+++ b/packages/calculon/calculon.0.3/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+tags: ["irc" "bot" "factoids"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+  "result"
+  "lwt"
+  "irc-client" {>= "0.6.0"}
+  "irc-client-lwt"
+  "irc-client-tls"
+  "tls"
+  "yojson"
+  "containers" {>= "1.0"}
+  "ISO8601"
+  "stringext"
+  "re" {>= "1.7.2"}
+  "odoc" {doc}
+]
+available: ocaml-version >= "4.02.0"
+build: ["jbuilder" "build" "-p" name]
+run-test: ["jbuilder" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+build-doc: ["jbuilder" "build" "@doc" "-p" name]
+url {
+  src: "https://github.com/c-cube/calculon/archive/0.3.tar.gz"
+  checksum: [
+    "md5=825ae13052d2e9bb4ed437080a0682bc"
+    "sha512=b830781915c337bff3a2c5c5a57e4f919bd887f3dd387563447f34b17e97dab9ee8b26fa82a288ab5c055b4a07fbcd658f2560c6e9fc3b60cac8832e6f7ffd45"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.3`
-`calculon-web.0.3`



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: git+https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---
:camel: Pull-request generated by opam-publish v2.0.0~beta