### PR TITLE
xenstore_transport: correct metadata for upstream fork

### DIFF
--- a/packages/xenstore_transport/xenstore_transport.1.0.0/opam
+++ b/packages/xenstore_transport/xenstore_transport.1.0.0/opam
@@ -12,9 +12,9 @@ authors: [
   "Vincent Bernardoff"
 ]
 maintainer: "dave@recoil.org"
-homepage:    "http://github.com/djs55/ocaml-xenstore-clients"
-bug-reports: "http://github.com/djs55/ocaml-xenstore-clients/issues"
-dev-repo:    "http://github.com/djs55/ocaml-xenstore-clients.git"
+homepage:    "http://github.com/xapi-project/ocaml-xenstore-clients"
+bug-reports: "http://github.com/xapi-project/ocaml-xenstore-clients/issues"
+dev-repo:    "http://github.com/xapi-project/ocaml-xenstore-clients.git"
 doc:         "http://djs55.github.io/ocaml-xenstore-clients"
 license:     "LGPL"
 


### PR DESCRIPTION
cc @djs55 @mseri