### PR TITLE
fix typo in url for lablgtk.8.06.5

### DIFF
--- a/packages/labltk/labltk.8.06.5/url
+++ b/packages/labltk/labltk.8.06.5/url
@@ -1,2 +1,2 @@
-archive: "https://forge.ocamlcore.org/frs/download.php/1784/labltk-8.06.5.tar.gz"
+archive: "https://forge.ocamlcore.org/frs/download.php/1764/labltk-8.06.5.tar.gz"
 checksum: "a2741cebd8d59565ac35814074ca3002"


### PR DESCRIPTION
Since this is a 4.07 only package, the checks didn't run on the previous PR.
This fixes the url. The md5 is correct too.