### PR TITLE
Packages calculon.0.3 and calculon-web.0.3

### DIFF
--- a/packages/calculon-web/calculon-web.0.3/descr
+++ b/packages/calculon-web/calculon-web.0.3/descr
@@ -1,0 +1,4 @@
+Web based plugins for calculon
+
+Collection of web-based plugins for [calculon](https://github.com/c-cube/calculon),
+including a giphy command, a youtube search, and others.

--- a/packages/calculon-web/calculon-web.0.3/opam
+++ b/packages/calculon-web/calculon-web.0.3/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+tags: ["irc" "bot" "factoids"]
+dev-repo: "https://github.com/c-cube/calculon.git"
+build: ["jbuilder" "build" "-p" name]
+build-test: ["jbuilder" "runtest" "-p" name]
+build-doc: ["jbuilder" "build" "@doc" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "calculon"
+  "re" {>= "1.7.2"}
+  "uri"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "atdgen"
+  "lambdasoup"
+  "sequence"
+  "odoc" {doc}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/calculon-web/calculon-web.0.3/url
+++ b/packages/calculon-web/calculon-web.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/calculon/archive/0.3.tar.gz"
+checksum: "635a554938d42319beeb6d70a85800ff"

--- a/packages/calculon/calculon.0.3/descr
+++ b/packages/calculon/calculon.0.3/descr
@@ -1,0 +1,5 @@
+Library for writing IRC bots in OCaml, a collection of plugins, and a dramatic robotic actor.
+
+The core library is called `calculon` and revolves around
+the concept of commands that react to user messages. See the README for a small
+tutorial on how to write your own plugins.

--- a/packages/calculon/calculon.0.3/opam
+++ b/packages/calculon/calculon.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+tags: ["irc" "bot" "factoids"]
+dev-repo: "https://github.com/c-cube/calculon.git"
+build: ["jbuilder" "build" "-p" name]
+build-test: ["jbuilder" "runtest" "-p" name]
+build-doc: ["jbuilder" "build" "@doc" "-p" name]
+depends: [
+  "jbuilder" {build}
+  "base-bytes"
+  "base-unix"
+  "result"
+  "lwt"
+  "irc-client" {>= "0.6.0"}
+  "irc-client-lwt"
+  "irc-client-tls"
+  "tls"
+  "yojson"
+  "containers" {>= "1.0"}
+  "ISO8601"
+  "stringext"
+  "re" {>= "1.7.2"}
+  "odoc" {doc}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/calculon/calculon.0.3/url
+++ b/packages/calculon/calculon.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/calculon/archive/0.3.tar.gz"
+checksum: "635a554938d42319beeb6d70a85800ff"


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.3`: Library for writing IRC bots in OCaml, a collection of plugins, and a dramatic robotic actor.
-`calculon-web.0.3`: Web based plugins for calculon



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---

:camel: Pull-request generated by opam-publish v0.3.5