### PR TITLE
Remove bash-isms in conf-mpi

### DIFF
--- a/packages/conf-mpi/conf-mpi.1/files/configure
+++ b/packages/conf-mpi/conf-mpi.1/files/configure
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 write() {
 cat > conf-mpi.config <<EOF
@@ -13,52 +13,52 @@ if [ ! -z ${MPI_INC_DIR+x} ] \
     && [ ! -z ${MPI_BIN_PATH+x} ]
 then
   write
-elif $(pkg-config --exists ompi)
+elif pkg-config --exists ompi
 then
   MPI_INC_DIR=$(pkg-config --variable=includedir ompi)
   MPI_LIB_DIR=$(pkg-config --variable=libdir ompi)/lib
   MPI_BIN_PATH=$(pkg-config --variable=libdir ompi)/bin/
   write
-elif $(pkg-config --exists mpich)
+elif pkg-config --exists mpich
 then
   MPI_INC_DIR=$(pkg-config --variable=includedir mpich)
   MPI_LIB_DIR=$(pkg-config --variable=libdir mpich)
-  MPIBIPATH=$(pkg-config --variable=libdir mpich)/../bin/
+  MPI_BIN_PATH=$(pkg-config --variable=libdir mpich)/../bin/
   write
 else
   OPENMPI_INCDIR=$(ls -d -1 /usr/include/openmpi* 2>/dev/null | head -n 1)
   MPICH_INCDIR=$(ls -d -1 /usr/include/mpich* 2>/dev/null | head -n 1)
-  if [[ -d ${OPENMPI_INCDIR} ]]
+  if [ -d "${OPENMPI_INCDIR}" ]
   then
     MPI_INC_DIR=${OPENMPI_INCDIR}
     MPI32=/usr/lib/openmpi
     MPI64=/usr/lib64/openmpi
-    if [[ -d ${MPI32} ]]
+    if [ -d ${MPI32} ]
     then
       MPI=${MPI32}
-    elif [[ -d ${MPI64} ]]
+    elif [ -d ${MPI64} ]
     then
       MPI=${MPI64}
     fi
-    if [[ -d "${MPI}" ]]
+    if [ -d "${MPI}" ]
     then
       MPI_LIB_DIR=${MPI}/lib
       MPI_BIN_PATH=${MPI}/bin/
       write
     fi
-  elif [[ -d ${MPICH_INCDIR} ]]
+  elif [ -d "${MPICH_INCDIR}" ]
   then
     MPI_INC_DIR=${MPICH_INCDIR}
     MPI32=/usr/lib/mpich
     MPI64=/usr/lib64/mpich
-    if [[ -d ${MPI32} ]]
+    if [ -d ${MPI32} ]
     then
       MPI=${MPI32}
-    elif [[ -d ${MPI64} ]]
+    elif [ -d "${MPI64}" ]
     then
       MPI=${MPI64}
     fi
-    if [[ -d "${MPI}" ]]
+    if [ -d "${MPI}" ]
     then
       MPI_LIB_DIR=${MPI}/lib
       MPI_BIN_PATH=${MPI}/bin/
@@ -67,18 +67,17 @@ else
   fi
 fi
 
-if [[ ! -f conf-mpi.config ]]
+if [ ! -f conf-mpi.config ]
 then
   echo "Unable to locate a valid MPI installation (openmpi or mpich)."
-  echo "Please install a MPI implementation"
+  echo
   echo "If you have one and it is not detected, you may manually set"
   echo "the following variables and restart this script:"
+  echo "* MPI_INC_DIR: include directory containing 'mpi.h', e.g., /usr/include/openmpi"
+  echo "* MPI_LIB_DIR: library directory containing 'libmpi.{so,dll}', e.g., /usr/lib/openmpi/lib"
+  echo "* MPI_BIN_PATH: path to the 'mpicc' and 'mpirun' binaries, e.g., /usr/lib/openmpi/bin"
   echo
-  echo "- MPI_INC_DIR: the include directly containing 'mpi.h',"
-  echo "  for example /usr/include/openmpi"
-  echo "- MPI_LIB_DIR: the library directory containing 'libmpi.{so,dll}',"
-  echo "  for example /usr/lib/openmpi/lib"
-  echo "- MPI_BIN_PATH: the path to the '${MPI_BIN_PATH}mpicc' and '${MPI_BIN_PATH}mpirun' binaries,"
-  echo "  for example /usr/lib/openmpi/bin/"
+  echo "To install MPI, try: opam depext conf-mpi"
   exit 2
 fi
+

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer: "tim@tbrk.org"
-build: [["sh" "-x" "configure" os]]
+build: [["sh" "configure" os]]
 depends: ["conf-pkg-config"]
 depexts: [
    # these depexts mention openmpi, but mpich is also supported

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -1,5 +1,11 @@
 opam-version: "1.2"
 maintainer: "tim@tbrk.org"
+authors: [
+    "Gabriel Scherer <gabriel.scherer@gmail.com>"
+]
+homepage: "https://www.open-mpi.org"
+bug-reports: "mailto:tim@tbrk.org"
+dev-repo: "git@github.com:tbrk/opam-repository.git"
 build: [["sh" "configure" os]]
 depends: ["conf-pkg-config"]
 depexts: [


### PR DESCRIPTION
Related to #12329. The installation of *conf-mpi* should fail with a useful error message if mpi is not detected, otherwise a subsequent attempt to install mpi (https://github.com/xavierleroy/ocamlmpi) fails in a confusing manner.