### PR TITLE
ppx_tools_versioned: fix lower bound for omp

### DIFF
--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2/opam
@@ -16,6 +16,6 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build & >= "1.0+beta17"}
-  "ocaml-migrate-parsetree" { >= "0.4" }
+  "ocaml-migrate-parsetree" { >= "0.5" }
 ]
 available: ocaml-version >= "4.02.0"


### PR DESCRIPTION
Otherwise the error is:

```
#=== ERROR while installing ppx_tools_versioned.5.2 ===========================#
# opam-version 1.2.2
# os           linux
# command      jbuilder build -p ppx_tools_versioned -j 4
# path         /home/samoht/.opam/4.04.2/build/ppx_tools_versioned.5.2
# compiler     4.04.2
# exit-code    1
# env-file     /home/samoht/.opam/4.04.2/build/ppx_tools_versioned.5.2/ppx_tools_versioned-6331-42ef32.env
# stdout-file  /home/samoht/.opam/4.04.2/build/ppx_tools_versioned.5.2/ppx_tools_versioned-6331-42ef32.out
# stderr-file  /home/samoht/.opam/4.04.2/build/ppx_tools_versioned.5.2/ppx_tools_versioned-6331-42ef32.err
### stderr ###
# [...]
# File "ast_mapper_class_406.ml", line 175, characters 22-30:
# Error: This pattern matches values of type 'a * 'b
#        but a pattern was expected which matches values of type
#          Ast_406.Parsetree.type_declaration
#     ocamlopt .ppx_tools_versioned.objs/ast_mapper_class_406.{cmx,o} (exit 2)
# (cd _build/default && /home/samoht/.opam/4.04.2/bin/ocamlopt.opt -w -40 -w +A-4-17-44-45-105-42 -safe-string -g -I .ppx_tools_versioned.objs -I /home/samoht/.opam/4.04.2/lib/ocaml-migrate-parsetree -I /home/samoht/.opam/4.04.2/lib/ocaml/compiler-libs -I /home/samoht/.opam/4.04.2/lib/result -no-alias-deps -o .ppx_tools_versioned.objs/ast_mapper_class_406.cmx -c -impl ast_mapper_class_406.ml)
# File "ast_mapper_class_406.ml", line 175, characters 22-30:
# Error: This pattern matches values of type 'a * 'b
#        but a pattern was expected which matches values of type
#          Ast_406.Parsetree.type_declaration
```

/cc @let-def 