### PR TITLE
Fix a race condition between jbuilder, dune and ocaml-migrate-parsetree

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
@@ -26,3 +26,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta2"}
 ]
 available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
@@ -26,3 +26,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta2"}
 ]
 available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
@@ -16,3 +16,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta7"}
 ]
 available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
 ]
 available: ocaml-version >= "4.02.0"
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
@@ -15,6 +15,6 @@ build: [
 depends: [
   "result"
   "ocamlfind" {build}
-  "jbuilder" {build & >= "1.0+beta18.1"}
+  "dune" {build}
 ]
 available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.6/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.6/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 available: [ ocaml-version >= "4.02.0" & ocaml-version < "4.06.0" ]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.7/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.7/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 available: [ocaml-version >= "4.02.0" & ocaml-version < "4.07.0"]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
 ]
 available: [ocaml-version >= "4.02.0" & ocaml-version < "4.07.0"]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.9/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.9/opam
@@ -18,3 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
 ]
 available: [ocaml-version >= "4.02.0" & ocaml-version < "4.07.0"]
+conflicts: [ "dune" ]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
@@ -26,3 +26,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta7"}
 ]
 available: [ocaml-version >= "4.02.0" & ocaml-version < "4.06.0"]
+conflicts: [ "dune" ]

--- a/packages/ppxlib/ppxlib.0.2.1/opam
+++ b/packages/ppxlib/ppxlib.0.2.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "base"                    {>= "v0.11.0"}
-  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "dune"                    {build}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.0.9"}
   "ppx_derivers"            {>= "1.0"}

--- a/packages/ppxlib/ppxlib.0.3.0/opam
+++ b/packages/ppxlib/ppxlib.0.3.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "base"                    {>= "v0.11.0"}
-  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "dune"                    {build}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.0.9"}
   "ppx_derivers"            {>= "1.0"}


### PR DESCRIPTION
Fix the issue described [here](https://discuss.ocaml.org/t/is-it-currently-possible-to-use-ppx-deriving-in-a-jbuilder-project/426/11). In summary, when ocaml-migrate-parsetree is built and installed by dune, it will copy one more information to the installation directory compared to when it is built and installed by jbuilder. This is not an issue for existing jbuilder projects but it is for newer pure dune projects. A few users have been bitten by this issue.

To avoid this issue, this PR makes `dune` an explicit dependency of ocaml-migrate-parsetree. This should ensure that omp is always built and installed with dune. Given that all versions of omp are fully backward compatible and that some older packages might depend on omp and have a upper bound on jbuilder, I only made this change for the latest version of omp and marked older versions as conflicting with dune.

I did the same for ppxlib which has the same issue but made both 0.2.1 and 0.3.0 depend on dune since 0.3.0 has breaking changes compared to 0.2.1.