### PR TITLE
Update Travis test matrix to include 4.07.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ matrix:
     osx_image: xcode7.3
     env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2
   - os: linux
-    env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2 INSTALL_LOCAL=1
+    env: OCAML_VERSION=4.07 OPAM_VERSION=1.2.2 INSTALL_LOCAL=1
+  - os: linux
+    env: OCAML_VERSION=4.06 OPAM_VERSION=1.2.2
   - os: linux
     env: OCAML_VERSION=4.05 OPAM_VERSION=1.2.2
   - os: linux


### PR DESCRIPTION
macOS left at 4.06.1 for now.