### PR TITLE
Use https for the compiler archive sources.

### DIFF
--- a/compilers/3.07/3.07+1/3.07+1.comp
+++ b/compilers/3.07/3.07+1/3.07+1.comp
@@ -1,7 +1,7 @@
 opam-version: "1"
 version: "3.07"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
-patches: ["http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"]
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
+patches: ["https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"]
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]

--- a/compilers/3.07/3.07+2/3.07+2.comp
+++ b/compilers/3.07/3.07+2/3.07+2.comp
@@ -1,7 +1,7 @@
 opam-version: "1"
 version: "3.07"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
-patches: ["http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"]
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
+patches: ["https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"]
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]

--- a/compilers/3.07/3.07/3.07.comp
+++ b/compilers/3.07/3.07/3.07.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.07"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]

--- a/compilers/3.08.0/3.08.0/3.08.0.comp
+++ b/compilers/3.08.0/3.08.0/3.08.0.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.08.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.08.1/3.08.1/3.08.1.comp
+++ b/compilers/3.08.1/3.08.1/3.08.1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.08.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.08.2/3.08.2/3.08.2.comp
+++ b/compilers/3.08.2/3.08.2/3.08.2.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.08.2"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.08.3/3.08.3/3.08.3.comp
+++ b/compilers/3.08.3/3.08.3/3.08.3.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.08.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.08.4/3.08.4/3.08.4.comp
+++ b/compilers/3.08.4/3.08.4/3.08.4.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.08.4"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.09.0/3.09.0/3.09.0.comp
+++ b/compilers/3.09.0/3.09.0/3.09.0.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.09.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.09.1/3.09.1/3.09.1.comp
+++ b/compilers/3.09.1/3.09.1/3.09.1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.09.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.09.2/3.09.2/3.09.2.comp
+++ b/compilers/3.09.2/3.09.2/3.09.2.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.09.2"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.09.3/3.09.3/3.09.3.comp
+++ b/compilers/3.09.3/3.09.3/3.09.3.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.09.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.10.0/3.10.0/3.10.0.comp
+++ b/compilers/3.10.0/3.10.0/3.10.0.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.10.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.10.1/3.10.1/3.10.1.comp
+++ b/compilers/3.10.1/3.10.1/3.10.1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.10.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.10.2/3.10.2/3.10.2.comp
+++ b/compilers/3.10.2/3.10.2/3.10.2.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.10.2"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.2.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.2.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.11.0/3.11.0/3.11.0.comp
+++ b/compilers/3.11.0/3.11.0/3.11.0.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.11.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.0.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.11.1/3.11.1/3.11.1.comp
+++ b/compilers/3.11.1/3.11.1/3.11.1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.11.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.11.2/3.11.2/3.11.2.comp
+++ b/compilers/3.11.2/3.11.2/3.11.2.comp
@@ -1,7 +1,7 @@
 opam-version: "1"
 version: "3.11.2"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.2.tar.gz"
-patches: ["http://www.ocamlpro.com/patches/3.11.2_binutils.patch"]
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.2.tar.gz"
+patches: ["https://www.ocamlpro.com/patches/3.11.2_binutils.patch"]
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.12.0/3.12.0/3.12.0.comp
+++ b/compilers/3.12.0/3.12.0/3.12.0.comp
@@ -1,9 +1,9 @@
 opam-version: "1"
 version: "3.12.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.0.tar.gz"
 patches:
   # S. Glondu's patch for binutils >= 2.21 (see bug report #5237)
-  ["http://caml.inria.fr/mantis/file_download.php?file_id=418&type=bug"]
+  ["https://caml.inria.fr/mantis/file_download.php?file_id=418&type=bug"]
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/3.12.1/3.12.1/3.12.1.comp
+++ b/compilers/3.12.1/3.12.1/3.12.1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "3.12.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/4.00.0/4.00.0+debug-runtime/4.00.0+debug-runtime.comp
+++ b/compilers/4.00.0/4.00.0+debug-runtime/4.00.0+debug-runtime.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.00.0/4.00.0+fp/4.00.0+fp.comp
+++ b/compilers/4.00.0/4.00.0+fp/4.00.0+fp.comp
@@ -1,7 +1,7 @@
 opam-version: "1"
 version: "4.00.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.bz2"
-patches: ["http://www.ocamlpro.com/files/omit-frame-pointer-4.00.0.patch"]
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.bz2"
+patches: ["https://www.ocamlpro.com/files/omit-frame-pointer-4.00.0.patch"]
 make: [
   "world"
   "world.opt"

--- a/compilers/4.00.0/4.00.0/4.00.0.comp
+++ b/compilers/4.00.0/4.00.0/4.00.0.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
 make: [
   "world"
   "opt"

--- a/compilers/4.00.1/4.00.1+PIC/4.00.1+PIC.comp
+++ b/compilers/4.00.1/4.00.1+PIC/4.00.1+PIC.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 build: [
   ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]

--- a/compilers/4.00.1/4.00.1+annot/4.00.1+annot.comp
+++ b/compilers/4.00.1/4.00.1+annot/4.00.1+annot.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
 patches: ["https://bitbucket.org/camlspotter/spotinstall/raw/26c014770721e44be11f364f09b149cff54a047f/ocaml-annot-4.00.1.patch"]
 make: [
   "world"

--- a/compilers/4.00.1/4.00.1+debug-runtime/4.00.1+debug-runtime.comp
+++ b/compilers/4.00.1/4.00.1+debug-runtime/4.00.1+debug-runtime.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 patches: ["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure"

--- a/compilers/4.00.1/4.00.1+french/4.00.1+french.comp
+++ b/compilers/4.00.1/4.00.1+french/4.00.1+french.comp
@@ -1,7 +1,7 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
-patches: ["http://www.ocamlpro.com/contribs/ocaml-french/ocaml-4.00.1.fr.patch"]
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
+patches: ["https://www.ocamlpro.com/contribs/ocaml-french/ocaml-4.00.1.fr.patch"]
 make: [
   "world"
   "world.opt"

--- a/compilers/4.00.1/4.00.1+mirage-unix/4.00.1+mirage-unix.comp
+++ b/compilers/4.00.1/4.00.1+mirage-unix/4.00.1+mirage-unix.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/4.00.1/4.00.1+mirage-xen/4.00.1+mirage-xen.comp
+++ b/compilers/4.00.1/4.00.1+mirage-xen/4.00.1+mirage-xen.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix

--- a/compilers/4.00.1/4.00.1+raspberrypi/4.00.1+raspberrypi.comp
+++ b/compilers/4.00.1/4.00.1+raspberrypi/4.00.1+raspberrypi.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.bz2"
 patches: ["https://github.com/avsm/ocaml/commit/dc0776f55108a20dad5a9c06188545dc08dbf462.patch"]
 make: [
   "world"

--- a/compilers/4.00.1/4.00.1/4.00.1.comp
+++ b/compilers/4.00.1/4.00.1/4.00.1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.00.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
 patches: ["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 make: [
   "world"

--- a/compilers/4.01.0/4.01.0+32bit/4.01.0+32bit.comp
+++ b/compilers/4.01.0/4.01.0+32bit/4.01.0+32bit.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -m32" "-as" "as --32" "-aspp" "gcc -m32 -c" "-host" "i386-linux" "-partialld" "ld -r -melf_i386"]

--- a/compilers/4.01.0/4.01.0+BER.comp
+++ b/compilers/4.01.0/4.01.0+BER.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:[
   "http://pim.happyleptic.org/~rixed/metaocaml-opam/ber-101.patch"
   "https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"

--- a/compilers/4.01.0/4.01.0+PIC/4.01.0+PIC.comp
+++ b/compilers/4.01.0/4.01.0+PIC/4.01.0+PIC.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -fPIC" "-aspp" "gcc -c -fPIC"]

--- a/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
+++ b/compilers/4.01.0/4.01.0+armv6-freebsd/4.01.0+armv6-freebsd.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/andrewray/mirage-fpga/releases/download/v0.1/freebsd10-armv6-natdynlink.patch"]
 build: [
   ["./configure"

--- a/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
+++ b/compilers/4.01.0/4.01.0+fp/4.01.0+fp.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure"

--- a/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
+++ b/compilers/4.01.0/4.01.0+lsb/4.01.0+lsb.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 build: [
   ["sed" "-i" "-e" "s/lcurses/lncurses/" "configure"]
   ["sed" "-i" "-e"

--- a/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.comp
+++ b/compilers/4.01.0/4.01.0+musl+static/4.01.0+musl+static.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"
     "-cc" "musl-gcc -Os"

--- a/compilers/4.01.0/4.01.0+musl/4.01.0+musl.comp
+++ b/compilers/4.01.0/4.01.0+musl/4.01.0+musl.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"
     "-cc" "musl-gcc -Os"

--- a/compilers/4.01.0/4.01.0+profile/4.01.0+profile.comp
+++ b/compilers/4.01.0/4.01.0+profile/4.01.0+profile.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure"

--- a/compilers/4.01.0/4.01.0/4.01.0.comp
+++ b/compilers/4.01.0/4.01.0/4.01.0.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.01.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:["https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"]
 build: [
   ["./configure"

--- a/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.comp
+++ b/compilers/4.02.0/4.02.0+PIC/4.02.0+PIC.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
 build: [
   ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]

--- a/compilers/4.02.0/4.02.0+improved-errors/4.02.0+improved-errors.comp
+++ b/compilers/4.02.0/4.02.0+improved-errors/4.02.0+improved-errors.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
 patches: [
   "https://gist.githubusercontent.com/andrewray/1928825fea090e50c0de/raw/e121b5cd176cdf6b882bc402276235b1c0a71b69/improved-error.patch"
 ]

--- a/compilers/4.02.0/4.02.0+rc1/4.02.0+rc1.comp
+++ b/compilers/4.02.0/4.02.0+rc1/4.02.0+rc1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0+rc1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0+rc1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.02.0/4.02.0/4.02.0.comp
+++ b/compilers/4.02.0/4.02.0/4.02.0.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.0"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.02.1/4.02.1+32bit/4.02.1+32bit.comp
+++ b/compilers/4.02.1/4.02.1+32bit/4.02.1+32bit.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -m32" "-as" "as --32" "-aspp" "gcc -m32 -c" "-host" "i386-linux" "-partialld" "ld -r -melf_i386"] {os = "linux"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" "-as" "as -arch i386" "-aspp" "gcc -arch i386 -m32 -c" "-host" "i386-apple-darwin13.2.0"] {os = "darwin"}

--- a/compilers/4.02.1/4.02.1+PIC/4.02.1+PIC.comp
+++ b/compilers/4.02.1/4.02.1+PIC/4.02.1+PIC.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
   ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]

--- a/compilers/4.02.1/4.02.1+fp/4.02.1+fp.comp
+++ b/compilers/4.02.1/4.02.1+fp/4.02.1+fp.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"

--- a/compilers/4.02.1/4.02.1+musl+static/4.02.1+musl+static.comp
+++ b/compilers/4.02.1/4.02.1+musl+static/4.02.1+musl+static.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"
     "-cc" "musl-gcc -Os"

--- a/compilers/4.02.1/4.02.1+musl/4.02.1+musl.comp
+++ b/compilers/4.02.1/4.02.1+musl/4.02.1+musl.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"
     "-cc" "musl-gcc -Os"

--- a/compilers/4.02.1/4.02.1/4.02.1.comp
+++ b/compilers/4.02.1/4.02.1/4.02.1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.1"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.02.2/4.02.2+rc1/4.02.2+rc1.comp
+++ b/compilers/4.02.2/4.02.2+rc1/4.02.2+rc1.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.2"
-src: "http://github.com/ocaml/ocaml/tarball/4.02.2+rc1"
+src: "https://github.com/ocaml/ocaml/tarball/4.02.2+rc1"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.02.2/4.02.2/4.02.2.comp
+++ b/compilers/4.02.2/4.02.2/4.02.2.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.2"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.02.3/4.02.3+32bit/4.02.3+32bit.comp
+++ b/compilers/4.02.3/4.02.3+32bit/4.02.3+32bit.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -m32" "-as" "as --32" "-aspp" "gcc -m32 -c" "-host" "i386-linux" "-partialld" "ld -r -melf_i386"] {os = "linux"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-cc" "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" "-as" "as -arch i386" "-aspp" "gcc -arch i386 -m32 -c" "-host" "i386-apple-darwin13.2.0"] {os = "darwin"}

--- a/compilers/4.02.3/4.02.3+PIC/4.02.3+PIC.comp
+++ b/compilers/4.02.3/4.02.3+PIC/4.02.3+PIC.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
   ["./configure" "-cc" "cc -fPIC" "-aspp" "cc -c -fPIC" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]

--- a/compilers/4.02.3/4.02.3+bytecode-only/4.02.3+bytecode-only.comp
+++ b/compilers/4.02.3/4.02.3+bytecode-only/4.02.3+bytecode-only.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"

--- a/compilers/4.02.3/4.02.3+fp/4.02.3+fp.comp
+++ b/compilers/4.02.3/4.02.3+fp/4.02.3+fp.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"

--- a/compilers/4.02.3/4.02.3+musl+static/4.02.3+musl+static.comp
+++ b/compilers/4.02.3/4.02.3+musl+static/4.02.3+musl+static.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"
     "-cc" "musl-gcc -Os"

--- a/compilers/4.02.3/4.02.3+musl/4.02.3+musl.comp
+++ b/compilers/4.02.3/4.02.3+musl/4.02.3+musl.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"
     "-cc" "musl-gcc -Os"

--- a/compilers/4.02.3/4.02.3/4.02.3.comp
+++ b/compilers/4.02.3/4.02.3/4.02.3.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.3"
-src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+src: "https://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
 build: [
   ["./configure"
     "-prefix" prefix "-with-debug-runtime"


### PR DESCRIPTION
I've verified the updated links still works.

There are 2 remaining links which don't support https:
 * https://github.com/ocaml/opam-repository/blob/21aad325af7a100424609557443620f3164f6433/compilers/4.06.1/4.06.1%2Btermux/4.06.1%2Btermux.comp#L17
 * https://github.com/ocaml/opam-repository/blob/21aad325af7a100424609557443620f3164f6433/compilers/4.01.0/4.01.0%2BBER.comp#L5