### PR TITLE
Package spirv.1.1.2

### DIFF
--- a/packages/spirv/spirv.1.1.2/descr
+++ b/packages/spirv/spirv.1.1.2/descr
@@ -1,0 +1,9 @@
+SPIR-V Compiler Library
+
+This library provides a code-generated SPIR-V compiler for use in OCaml projects.
+
+SpirV operations are specified using label variants (the number of spirv operations exceeds the ocaml type tag size, so a normal type variant won't work). SpirV enumerants are represented as OCaml type variants. For the case of flag types, enumerants are represented as a list of flags. Enumerants that normally specify extended operands wrap the extended operands as a tuple of arguments to the OCaml type constructor. Literal integers are represented with the `int32` type (for `int32` literals, add an `l` at the end; e.g. `10l`). Literal strings are represented with regular OCaml strings.
+
+When specifying literal values to the `OpConstant` instruction, the values are wrapped with the `big_int_or_float` type (there is no check against the return type of `OpConstant` right now). The default op for a `OpSpecConstantOp` instruction is specified using the type `spec_op`. The values of `spec_op` are the valid `OpSpecConstantOp` instructions, except that the result type and result are removed and the `Op` prefix is removed (e.g. ```OpSpecConstantOp (type_id, result_id, `IAdd (constant_a, constant_b))``).
+
+Extended instructions are currently implemented through a function abstraction. The extended instruction and it's operands are specified with a function in `OpExtInst` which has the type signature `unit -> int32 list`. The idea behind this is that extended instructions can be provided through other OCaml libraries which would return the compiled instruction and operands as a list of SpirV words.

--- a/packages/spirv/spirv.1.1.2/opam
+++ b/packages/spirv/spirv.1.1.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Nathan Holland <nholland94@gmail.com>"
+authors: "Nathan Holland <nholland94@gmail.com>"
+homepage: "https://github.com/nholland94/spirv-ocaml"
+bug-reports: "https://github.com/nholland94/spirv-ocaml/issues"
+license: "MIT"
+dev-repo: "https://github.com/nholland94/spirv-ocaml.git"
+build: [
+  [make "SpirV.cmo"] {!ocaml-native}
+  [make "SpirV.cma"] {!ocaml-native}
+  [make "SpirV.cmx"] {ocaml-native}
+  [make "SpirV.cmxa"] {ocaml-native}
+  [make "SpirV.cmxs"] {ocaml-native}
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "batteries" {>= "2.5.0"}
+]

--- a/packages/spirv/spirv.1.1.2/url
+++ b/packages/spirv/spirv.1.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nholland94/spirv-ocaml/archive/1.1.2.tar.gz"
+checksum: "61c0d0a064b4d30e8860d6890ff0aa08"


### PR DESCRIPTION
### `spirv.1.1.2`

SPIR-V Compiler Library

This library provides a code-generated SPIR-V compiler for use in OCaml projects.

SpirV operations are specified using label variants (the number of spirv operations exceeds the ocaml type tag size, so a normal type variant won't work). SpirV enumerants are represented as OCaml type variants. For the case of flag types, enumerants are represented as a list of flags. Enumerants that normally specify extended operands wrap the extended operands as a tuple of arguments to the OCaml type constructor. Literal integers are represented with the `int32` type (for `int32` literals, add an `l` at the end; e.g. `10l`). Literal strings are represented with regular OCaml strings.

When specifying literal values to the `OpConstant` instruction, the values are wrapped with the `big_int_or_float` type (there is no check against the return type of `OpConstant` right now). The default op for a `OpSpecConstantOp` instruction is specified using the type `spec_op`. The values of `spec_op` are the valid `OpSpecConstantOp` instructions, except that the result type and result are removed and the `Op` prefix is removed (e.g. ```OpSpecConstantOp (type_id, result_id, `IAdd (constant_a, constant_b))``).

Extended instructions are currently implemented through a function abstraction. The extended instruction and it's operands are specified with a function in `OpExtInst` which has the type signature `unit -> int32 list`. The idea behind this is that extended instructions can be provided through other OCaml libraries which would return the compiled instruction and operands as a list of SpirV words.



---
* Homepage: https://github.com/nholland94/spirv-ocaml
* Source repo: https://github.com/nholland94/spirv-ocaml.git
* Bug tracker: https://github.com/nholland94/spirv-ocaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5