### PR TITLE
add gnomecanvas depext for Archlinux

### DIFF
--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -8,4 +8,5 @@ depexts: [
   [["ubuntu"] ["libgnomecanvas2-dev"]]
   [["fedora"] ["libgnomecanvas-devel"]]
   [["osx" "homebrew"] ["libgnomecanvas"]]
+  [["archlinux"] ["libgnomecanvas"]]
 ]


### PR DESCRIPTION
Everything is in the title: this one-liner allows depext to install libgnomecanvas on Arch as needed.