### PR TITLE
[compilers] add 4.06.1+no-naked-pointers+flambda

### DIFF
--- a/compilers/4.06.1/4.06.1+no-naked-pointers+flambda/4.06.1+no-naked-pointers+flambda.comp
+++ b/compilers/4.06.1/4.06.1+no-naked-pointers+flambda/4.06.1+no-naked-pointers+flambda.comp
@@ -1,0 +1,22 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-naked-pointers" "-flambda"
+  ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }
+  ["./configure"
+    "-prefix" prefix "-with-debug-runtime" "-no-naked-pointers" "-flambda"
+    "-cc" "cc"
+    "-aspp" "cc -c"
+  ] { os  = "openbsd" | os  = "freebsd" | os  = "darwin" }
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.06.1/4.06.1+no-naked-pointers+flambda/4.06.1+no-naked-pointers+flambda.descr
+++ b/compilers/4.06.1/4.06.1+no-naked-pointers+flambda/4.06.1+no-naked-pointers+flambda.descr
@@ -1,0 +1,1 @@
+Official 4.06.1 release, with naked pointers forbidden and flambda activated


### PR DESCRIPTION
This new switch turns on both `-no-naked-pointers` and `-flambda` to get more performance out of the compiler.

There's currently no opam switch to get a compiler with the `-no-naked-pointers` option. Compiling with `-no-naked-pointers` gives good results on infer for example, with as much as 4% CPU win on some workloads.