### PR TITLE
Package varint.1.0

### DIFF
--- a/packages/varint/varint.1.0/descr
+++ b/packages/varint/varint.1.0/descr
@@ -1,0 +1,7 @@
+A simple varint implementation modeled after the one found in Go's standard library.
+
+
+Originally I wrote it because I wanted to implement a protocol in ocaml that used it, but did not want to use piqi, or protobuf. 
+
+What varint encoding does is that you can input an int32 or int64, and for smaller numbers, it will take up less space, protobuf uses this technique for field length prefixing,  as a result it is more space efficient than using an 32 bit or 64 bit int, but on the other hand it does take more CPU time.
+

--- a/packages/varint/varint.1.0/opam
+++ b/packages/varint/varint.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "flatmapds@gmail.com"
+authors: ["Sam Riyad"]
+tags: ["mirage" "encoding"]
+license: "MIT"
+         
+homepage: "https://github.com/XnuKernPoll/ocaml-varint"
+dev-repo: "https://github.com:XnuKernPoll/ocaml-varint.git"
+bug-reports: "https://github.com/XnuKernPoll/ocaml-varint/issues"
+             
+          
+build: [
+  ["jbuilder" "subst" "-p" name "--name" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+  
+depends: [
+  "jbuilder" {build}
+  "mstruct"
+]

--- a/packages/varint/varint.1.0/url
+++ b/packages/varint/varint.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/XnuKernPoll/ocaml-varint/archive/v1.0.tar.gz"
+checksum: "591f6b0f54f288bc2950ed597fa9f0e3"


### PR DESCRIPTION
### `varint.1.0`

A simple varint implementation modeled after the one found in Go's standard library.


Originally I wrote it because I wanted to implement a protocol in ocaml that used it, but did not want to use piqi, or protobuf. 

What varint encoding does is that you can input an int32 or int64, and for smaller numbers, it will take up less space, protobuf uses this technique for field length prefixing,  as a result it is more space efficient than using an 32 bit or 64 bit int, but on the other hand it does take more CPU time.




---
* Homepage: https://github.com/XnuKernPoll/ocaml-varint
* Source repo: https://github.com:XnuKernPoll/ocaml-varint.git
* Bug tracker: https://github.com/XnuKernPoll/ocaml-varint/issues

---

:camel: Pull-request generated by opam-publish v0.3.5