### PR TITLE
Download 4.01.0+BER patch from github

### DIFF
--- a/compilers/4.01.0/4.01.0+BER.comp
+++ b/compilers/4.01.0/4.01.0+BER.comp
@@ -2,7 +2,7 @@ opam-version: "1"
 version: "4.01.0"
 src: "https://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
 patches:[
-  "http://pim.happyleptic.org/~rixed/metaocaml-opam/ber-101.patch"
+  "https://github.com/rixed/ocaml/compare/1f0b8877a79f34117bb6ce72457530c91f91ecb3...BER.diff"
   "https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
 ]
 build: [


### PR DESCRIPTION
Rather than from my own machine that's going to be decommissioned (and
that's probably not secure enough to host a compiler patch that's
downloaded, surprisingly enough, several times a day).