### PR TITLE
lablqml.0.6: Add missing build dependency

### DIFF
--- a/packages/lablqml/lablqml.0.6/opam
+++ b/packages/lablqml/lablqml.0.6/opam
@@ -19,6 +19,7 @@ depends: [
   "configurator" { build }
   "conf-qt"      { >= "5.2.1"}
   "ppxlib"
+  "conf-pkg-config" { build }
 #  "ocamlfind"    { test  }
 #  "lwt"          { test }
 #  "cppo"         { test }


### PR DESCRIPTION
Spotted in https://github.com/ocaml/opam-repository/pull/12372