### PR TITLE
qocamlbrowser.0.2.10: update opam bound

### DIFF
--- a/packages/qocamlbrowser/qocamlbrowser.0.2.10/opam
+++ b/packages/qocamlbrowser/qocamlbrowser.0.2.10/opam
@@ -21,5 +21,5 @@ depends: [
   "conf-qt" {>= "5.2.1"}
   "ocamlbuild" {build}
 ]
-available: (ocaml-version >= "4.07.0")
+available: (ocaml-version >= "4.04.0")
 


### PR DESCRIPTION
This fixes a too strict bound merged in https://github.com/ocaml/opam-repository/pull/12367. Thanks @kit-ty-kate for spotting it.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>