### PR TITLE
Markup.ml 0.7.7: standards-compliant HTML5 parser

### DIFF
--- a/packages/markup/markup.0.7.7/descr
+++ b/packages/markup/markup.0.7.7/descr
@@ -1,0 +1,20 @@
+Error-recovering functional HTML5 and XML parsers and writers
+
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8.

--- a/packages/markup/markup.0.7.7/opam
+++ b/packages/markup/markup.0.7.7/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+version: "0.7.7"
+
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "https://github.com/aantron/markup.ml.git"
+license: "BSD"
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta17"}
+  "ounit" {test}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+]
+depopts: [
+  "lwt"
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of
+# Jbuilder. Without that, Markup.ml implicitly requires OCaml 4.01.0, as this is
+# a constraint of Uutf. Without *that*, Markup.ml works on OCaml 3.11 or
+# earlier.
+
+build: [
+  ["ocaml" "src/configure.ml"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/markup/markup.0.7.7/url
+++ b/packages/markup/markup.0.7.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/aantron/markup.ml/archive/0.7.7.tar.gz"
+checksum: "44b9dca277115c478ebbde081de43436"


### PR DESCRIPTION
This release fixes one bug (aantron/markup.ml#33).