### PR TITLE
Bisect_ppx 1.3.4: code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.1.3.4/descr
+++ b/packages/bisect_ppx/bisect_ppx.1.3.4/descr
@@ -1,0 +1,19 @@
+Code coverage for OCaml
+
+Bisect_ppx helps you test thoroughly. It is a small preprocessor that inserts
+instrumentation at places in your code, such as if-then-else and match
+expressions. After you run tests, Bisect_ppx gives a nice HTML report showing
+which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, then run the
+report tool on the generated visitation files.
+
+This is an advanced fork of the original Bisect coverage tool. It has many
+improvements and updates.
+
+- Much more thorough code instrumentation, so you can find more gaps in your
+  testing.
+- Fast operation by default.
+- More legible and appealing HTML reports.
+- Various bugfixes.
+- No camlp4 dependency.

--- a/packages/bisect_ppx/bisect_ppx.1.3.4/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.4/opam
@@ -1,0 +1,37 @@
+version: "1.3.4"
+opam-version: "1.2"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "MPL2"
+homepage: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+dev-repo: "https://github.com/aantron/bisect_ppx.git"
+
+depends: [
+  "base-unix"
+  "jbuilder" {build & >= "1.0+beta13"}
+  "ocamlfind" {test}
+  "ocaml-migrate-parsetree" {>= "1.0.3"}
+  "ounit" {test}
+  "ppx_tools_versioned"
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+# Note that Bisect_ppx effectively requires 4.02.3, because Jbuilder requires
+# it. 4.02.0 is the natural constraint of Bisect_ppx.
+available: ocaml-version >= "4.02.0"
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]

--- a/packages/bisect_ppx/bisect_ppx.1.3.4/url
+++ b/packages/bisect_ppx/bisect_ppx.1.3.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aantron/bisect_ppx/archive/1.3.4.tar.gz"
+checksum: "7371bd9a98c43b952bfa1ae2d374af3d"


### PR DESCRIPTION
This release fixes a single bug, https://github.com/ocaml/dune/issues/1025. The fix was added by @rgrinberg in https://github.com/aantron/bisect_ppx/pull/173.