### PR TITLE
[new release] digestif (v0.6.1)

### DIFF
--- a/packages/digestif/digestif.0.6.1/descr
+++ b/packages/digestif/digestif.0.6.1/descr
@@ -1,0 +1,54 @@
+Hash algorithms in C and OCaml
+
+[![Build Status](https://travis-ci.org/mirage/digestif.svg?branch=master)](https://travis-ci.org/mirage/digestif)
+
+Digestif is a toolbox which implements hashes:
+
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+
+Digestif uses a trick about linking and let the end-user to choose which
+implementation he wants to use. We provide 2 implementations:
+
+ * C implementation with `digestif.c`
+ * OCaml implementation with `digestif.ocaml`
+ 
+Both are well-tested. However, OCaml implementation is slower than the C
+implementation.
+
+
+
+## API
+
+For each hash, we implement the same API which is referentially transparent.
+Then, on the top of these, we reflect functions (like `digesti` or `hmaci`) with
+GADT - however, conversion from GADT to hash type is not possible (but you can
+destruct GADT to a `string`).
+
+## Build Requirements
+
+ * OCaml >= 4.03.0 (may be less but need test)
+ * `base-bytes` meta-package
+ * Bigarray module (provided by the standard library of OCaml)
+ * `dime` to build the project
+ 
+If you want to compile the test program, you need:
+
+ * `alcotest`
+
+## Credits
+
+This work is from the [nocrypto](https://github.com/mirleft/nocrypto) library
+and the Vincent hanquez's work in
+[ocaml-sha](https://github.com/vincenthz/ocaml-sha).
+
+All credits appear in the begin of files and this library is motivated by two reasons:
+
+  * delete the dependancy with `nocrypto` if you don't use the encryption (and common) part
+  * aggregate all hashes functions in one library

--- a/packages/digestif/digestif.0.6.1/opam
+++ b/packages/digestif/digestif.0.6.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name:         "digestif"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+
+build: [ "jbuilder" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "jbuilder"       {build}
+  "base-bytes"
+  "base-bigarray"
+]
+
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/digestif/digestif.0.6.1/url
+++ b/packages/digestif/digestif.0.6.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/digestif/releases/download/v0.6.1/digestif-0.6.1.tbz"
+checksum: "9100e0067018123634d3959eb37fdbd2"


### PR DESCRIPTION
CHANGES:

- *breaking change* API: Digestif implements a true linking trick. End-user need
  to explicitely link with `digestif.{c,ocaml}` and it needs to be the first of
  your dependencies.
- move to `jbuilder`/`dune`