### PR TITLE
opam 2.0.0~rc4 libs and devel packages

### DIFF
--- a/packages/opam-client/opam-client.2.0.0~rc4/descr
+++ b/packages/opam-client/opam-client.2.0.0~rc4/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Actions on the opam root, switches, installations, and front-end.

--- a/packages/opam-client/opam-client.2.0.0~rc4/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc4/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-state" {= "2.0.0~rc4"}
+  "opam-solver" {= "2.0.0~rc4"}
+  "re" {>= "1.7.2"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta20"}
+]
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-client/opam-client.2.0.0~rc4/url
+++ b/packages/opam-client/opam-client.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"

--- a/packages/opam-core/opam-core.2.0.0~rc4/descr
+++ b/packages/opam-core/opam-core.2.0.0~rc4/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Small standard library extensions, and generic system interaction modules used
+by opam.

--- a/packages/opam-core/opam-core.2.0.0~rc4/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc4/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "cppo" {build}
+]
+conflicts: "extlib-compat"
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-core/opam-core.2.0.0~rc4/url
+++ b/packages/opam-core/opam-core.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"

--- a/packages/opam-devel/opam-devel.2.0.0~rc4/descr
+++ b/packages/opam-devel/opam-devel.2.0.0~rc4/descr
@@ -1,0 +1,5 @@
+opam 2.0.0 development version
+
+This package compiles (bootstraps) opam 2.0.0. For consistency and safety of the
+installation, the binaries are not installed into the PATH, but into
+lib/opam-devel, from where the user can manually install them system-wide.

--- a/packages/opam-devel/opam-devel.2.0.0~rc4/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc4/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+build-test: [make "tests"]
+depends: [
+  "opam-client" {= "2.0.0~rc4"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta20"}
+]
+post-messages: [
+"The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/* /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""
+  {success}
+]
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-devel/opam-devel.2.0.0~rc4/url
+++ b/packages/opam-devel/opam-devel.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"

--- a/packages/opam-format/opam-format.2.0.0~rc4/descr
+++ b/packages/opam-format/opam-format.2.0.0~rc4/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Definition of opam datastructures and its file interface.

--- a/packages/opam-format/opam-format.2.0.0~rc4/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc4/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-core" {= "2.0.0~rc4"}
+  "opam-file-format" {>= "2.0.0~rc2"}
+  "jbuilder" {build & >= "1.0+beta18"}
+]
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-format/opam-format.2.0.0~rc4/url
+++ b/packages/opam-format/opam-format.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"

--- a/packages/opam-installer/opam-installer.2.0.0~rc4/descr
+++ b/packages/opam-installer/opam-installer.2.0.0~rc4/descr
@@ -1,0 +1,7 @@
+Installation of files to a prefix, following opam conventions
+
+opam-installer is a small tool that can read *.install files, as defined by
+opam [1], and execute them to install or remove package files without going
+through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install

--- a/packages/opam-installer/opam-installer.2.0.0~rc4/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc4/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["touch" "src/tools/.merlin-exists"]
+  # ^ see https://github.com/janestreet/jbuilder/issues/257
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-format" {= "2.0.0~rc4"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta17"}
+]
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-installer/opam-installer.2.0.0~rc4/url
+++ b/packages/opam-installer/opam-installer.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"

--- a/packages/opam-repository/opam-repository.2.0.0~rc4/descr
+++ b/packages/opam-repository/opam-repository.2.0.0~rc4/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+This library includes repository and remote sources handling, including
+curl/wget, rsync, git, mercurial, darcs backends.

--- a/packages/opam-repository/opam-repository.2.0.0~rc4/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc4/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-format" {= "2.0.0~rc4"}
+  "jbuilder" {build & >= "1.0+beta17"}
+]
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-repository/opam-repository.2.0.0~rc4/url
+++ b/packages/opam-repository/opam-repository.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"

--- a/packages/opam-solver/opam-solver.2.0.0~rc4/descr
+++ b/packages/opam-solver/opam-solver.2.0.0~rc4/descr
@@ -1,0 +1,4 @@
+opam 2.0 development libraries
+
+Solver and Cudf interaction. This library is based on the Cudf and Dose
+libraries, and handles calls to the external solver from opam.

--- a/packages/opam-solver/opam-solver.2.0.0~rc4/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~rc4/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-format" {= "2.0.0~rc4"}
+  "mccs" {>= "1.1+8"}
+  "dose3" {>= "5"}
+  "cudf" {>= "0.7"}
+  "jbuilder" {build & >= "1.0+beta17"}
+]
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-solver/opam-solver.2.0.0~rc4/url
+++ b/packages/opam-solver/opam-solver.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"

--- a/packages/opam-state/opam-state.2.0.0~rc4/descr
+++ b/packages/opam-state/opam-state.2.0.0~rc4/descr
@@ -1,0 +1,3 @@
+opam 2.0 development libraries
+
+Handling of the ~/.opam hierarchy, repository and switch states.

--- a/packages/opam-state/opam-state.2.0.0~rc4/opam
+++ b/packages/opam-state/opam-state.2.0.0~rc4/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "opam-repository" {= "2.0.0~rc4"}
+  "jbuilder" {build & >= "1.0+beta18"}
+]
+available: ocaml-version >= "4.02.3"

--- a/packages/opam-state/opam-state.2.0.0~rc4/url
+++ b/packages/opam-state/opam-state.2.0.0~rc4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
+checksum: "385612adf8733f6816cfcbc39e3e1b50"


### PR DESCRIPTION
I was unsure wether to name this 2.0.0 or 2.0.0~rc4, since they are expected to be equal, and renaming the package would cause unnecessarily recompilations. But since the upstream archives are called 'rc4' at this point, it seemed more consistent.