### PR TITLE
Package ptime.0.8.4

### DIFF
--- a/packages/ptime/ptime.0.8.4/descr
+++ b/packages/ptime/ptime.0.8.4/descr
@@ -1,0 +1,20 @@
+POSIX time for OCaml
+
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
+human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime depends on the `result` compatibility package. Ptime_clock
+depends on your system library. Ptime_clock's optional JavaScript
+support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
+distributed under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+[jsoo]: http://ocsigen.org/js_of_ocaml/

--- a/packages/ptime/ptime.0.8.4/opam
+++ b/packages/ptime/ptime.0.8.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The ptime programmers"]
+homepage: "http://erratique.ch/software/ptime"
+doc: "http://erratique.ch/software/ptime/doc"
+dev-repo: "http://erratique.ch/repos/ptime.git"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+tags: [ "time" "posix" "system" "org:erratique" ]
+license: "ISC"
+available: [ ocaml-version >= "4.01.0"]
+depends: [
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "result"
+]
+depopts: [ "js_of_ocaml" ]
+build:[[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]

--- a/packages/ptime/ptime.0.8.4/url
+++ b/packages/ptime/ptime.0.8.4/url
@@ -1,0 +1,2 @@
+archive: "http://erratique.ch/software/ptime/releases/ptime-0.8.4.tbz"
+checksum: "12fb5e8c3eb1d2e6075ac31ce93f7dd6"


### PR DESCRIPTION
### `ptime.0.8.4`

POSIX time for OCaml

Ptime has platform independent POSIX time support in pure OCaml. It
provides a type to represent a well-defined range of POSIX timestamps
with picosecond precision, conversion with date-time values,
conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
human-readable, locale-independent representation.

The additional Ptime_clock library provides access to a system POSIX
clock and to the system's current time zone offset.

Ptime is not a calendar library.

Ptime depends on the `result` compatibility package. Ptime_clock
depends on your system library. Ptime_clock's optional JavaScript
support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
distributed under the ISC license.

[rfc3339]: http://tools.ietf.org/html/rfc3339
[jsoo]: http://ocsigen.org/js_of_ocaml/



---
* Homepage: http://erratique.ch/software/ptime
* Source repo: http://erratique.ch/repos/ptime.git
* Bug tracker: https://github.com/dbuenzli/ptime/issues

---


---
v0.8.4 2018-07-26 Zagreb
------------------------

* `Ptime_clock`: Windows support. Thanks to IndiscriminateCoding
  and David Allsopp for the contribution.
* Fix `Ptime.frac_s` on pre-epoch time stamps. The function computed a
  span of `1s - f` instead of `f` on these.  This function is not used
  internally so this only affects users of this function that apply it
  on pre-epoch time stamps (#12). Thanks to David Kaloper Meršinjak
  for the report.
:camel: Pull-request generated by opam-publish v0.3.5