### PR TITLE
Fix paths for NetBSD in conf-gmp and zarith

### DIFF
--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -6,8 +6,9 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "darwin"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "darwin" & os != netbsd}
   ["sh" "-exc" "cc -c $CFLAGS -I/opt/local/include -I/usr/local/include test.c"] {os = "darwin"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/pkg/include test.c"] {os = "netbsd"}
 ]
 depexts: [
   [["debian"] ["libgmp-dev"]]
@@ -17,6 +18,7 @@ depexts: [
   [["fedora"] ["gmp" "gmp-devel"]]
   [["openbsd"] ["gmp"]]
   [["freebsd"] ["gmp"]]
+  [["netbsd"] ["gmp"]]
   [["alpine"] ["gmp-dev"]]
   [["opensuse"] ["gmp-devel"]]
 ]

--- a/packages/zarith/zarith.1.7/opam
+++ b/packages/zarith/zarith.1.7/opam
@@ -11,8 +11,9 @@ homepage: "https://github.com/ocaml/Zarith"
 bug-reports: "https://github.com/ocaml/Zarith/issues"
 dev-repo: "https://github.com/ocaml/Zarith.git"
 build: [
-  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ["./configure"] { os != "openbsd" & os != "freebsd" & os != "netbsd" & os != "darwin"}
   ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/usr/local/include\" ./configure"] { os = "openbsd" | os = "freebsd" }
+  ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/usr/pkg/lib\" CFLAGS=\"$CFLAGS -I/usr/pkg/include\" ./configure"] { os = "netbsd" }
   ["sh" "-exc" "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"] { os = "darwin" }
   [make]
 ]


### PR DESCRIPTION
On NetBSD (8.0 at least), by default (using pkgsrc/pkgin), files are installed in `/usr/pkg`.

I am not an expert NetBSD user, but fixing these paths allowed me to compile `conf-gmp` and `zarith`. However, the string `/usr/pkg` is entirely absent from `opam-repository`, which makes me wonder if previous NetBSD users have just not installed these packages, or if there is another way to configure NetBSD to avoid having to do so.

If there are more experienced NetBSD users in the opam community, I'd like them to review my commit, but I do not know how to find them.
