### PR TITLE
Package coq-simple-io.0.2

### DIFF
--- a/packages/coq-simple-io/coq-simple-io.0.2/descr
+++ b/packages/coq-simple-io/coq-simple-io.0.2/descr
@@ -1,0 +1,1 @@
+IO monad for Coq

--- a/packages/coq-simple-io/coq-simple-io.0.2/opam
+++ b/packages/coq-simple-io/coq-simple-io.0.2/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Li-yao Xia <lysxia@gmail.com>"
+authors: "Li-yao Xia"
+homepage: "https://github.com/Lysxia/coq-simple-io"
+bug-reports: "https://github.com/Lysxia/coq-simple-io/issues"
+license: "MIT"
+dev-repo: "https://github.com/Lysxia/coq-simple-io.git"
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: "coq"
+tags: [
+    "date:2018-07-27"
+    "logpath:SimpleIO"
+    "keyword:extraction"
+    "keyword:effects"
+  ]

--- a/packages/coq-simple-io/coq-simple-io.0.2/url
+++ b/packages/coq-simple-io/coq-simple-io.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Lysxia/coq-simple-io/archive/0.2.tar.gz"
+checksum: "25bab5d590d6976ca1aa2c93a70d64c5"


### PR DESCRIPTION
### `coq-simple-io.0.2`

IO monad for Coq



---
* Homepage: https://github.com/Lysxia/coq-simple-io
* Source repo: https://github.com/Lysxia/coq-simple-io.git
* Bug tracker: https://github.com/Lysxia/coq-simple-io/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5