### PR TITLE
herdtools7.7.51 - via opam-publish

### DIFF
--- a/packages/herdtools7/herdtools7.7.51/descr
+++ b/packages/herdtools7/herdtools7.7.51/descr
@@ -1,0 +1,7 @@
+herdtools7, a tool suite for shared memory models.
+
+herdtools7 is a tool suite for testing shared memory models.
+
+We provide several tools, litmus7 for running tests, diy7 generators for producing tests from concise specifications, and herd7 for simulating memory models.
+
+See also <http://diy.inria.fr/>

--- a/packages/herdtools7/herdtools7.7.51/opam
+++ b/packages/herdtools7/herdtools7.7.51/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Vincent Jacques <vincent@russian-dolls-sunflowers.com>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+  "Vincent Jacques <vincent@russian-dolls-sunflowers.com>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "https://github.com/herd/herdtools7.git"
+build: ["./build.sh" "%{prefix}%"]
+install: ["./install.sh" "%{prefix}%"]
+remove: ["./uninstall.sh" "%{prefix}%"]
+depends: [
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/herdtools7/herdtools7.7.51/url
+++ b/packages/herdtools7/herdtools7.7.51/url
@@ -1,0 +1,2 @@
+http: "https://github.com/herd/herdtools7/archive/7.51.tar.gz"
+checksum: "e33078375362610343508d267748abc4"


### PR DESCRIPTION
herdtools7, a tool suite for shared memory models.

herdtools7 is a tool suite for testing shared memory models.

We provide several tools, litmus7 for running tests, diy7 generators for producing tests from concise specifications, and herd7 for simulating memory models.

See also <http://diy.inria.fr/>

---
* Homepage: http://diy.inria.fr/
* Source repo: https://github.com/herd/herdtools7.git
* Bug tracker: http://github.com/herd/herdtools7/issues/

---

Pull-request generated by opam-publish v0.3.3