### PR TITLE
mirage.3.1.1

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.1.1/descr
+++ b/packages/mirage-runtime/mirage-runtime.3.1.1/descr
@@ -1,0 +1,1 @@
+A bundle of useful runtime functions for applications built with Mirage

--- a/packages/mirage-runtime/mirage-runtime.3.1.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.1.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/mirage/mirage.git"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["jbuilder" "subst" "-p" name]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder"   {build & >= "1.0+beta10"}
+  "ipaddr"             {>= "2.6.0"}
+  "functoria-runtime"  {>= "2.0.0"}
+  "fmt"
+  "astring"
+  "logs"
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/mirage-runtime/mirage-runtime.3.1.1/url
+++ b/packages/mirage-runtime/mirage-runtime.3.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage/releases/download/3.1.1/mirage-3.1.1.tbz"
+checksum: "7888dc6a9769e6a5b593e7b6e78c435f"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/descr
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/descr
@@ -1,0 +1,14 @@
+Lwt module type definitions for Mirage-compatible applications
+
+This is a virtual package that pulls in all the concrete
+dependencies required for the `mirage-types.lwt` ocamlfind
+package to become available.
+
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/mirage/mirage.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["jbuilder" "subst" "-p" name]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends:   [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt"
+  "cstruct" {>="1.4.0"}
+  "io-page" {>="1.4.0"}
+  "ipaddr"
+  "mirage-types" {>= "3.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-protocols-lwt" {>= "1.0.0"}
+  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-console-lwt" {>= "1.2.0"}
+  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-fs-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
+]
+available: [ ocaml-version >= "4.04.2" ]

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/url
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage/releases/download/3.1.1/mirage-3.1.1.tbz"
+checksum: "7888dc6a9769e6a5b593e7b6e78c435f"

--- a/packages/mirage-types/mirage-types.3.1.1/descr
+++ b/packages/mirage-types/mirage-types.3.1.1/descr
@@ -1,0 +1,1 @@
+Module type definitions for Mirage-compatible applications

--- a/packages/mirage-types/mirage-types.3.1.1/opam
+++ b/packages/mirage-types/mirage-types.3.1.1/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/mirage/mirage.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["jbuilder" "subst" "-p" name]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends:   [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-time" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-console" {>= "2.2.0"}
+  "mirage-protocols" {>= "1.0.0"}
+  "mirage-stack" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0"}
+  "mirage-net" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0"}
+  "mirage-channel" {>= "3.0.0"}
+]
+available: [ ocaml-version >= "4.04.2" ]

--- a/packages/mirage-types/mirage-types.3.1.1/url
+++ b/packages/mirage-types/mirage-types.3.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage/releases/download/3.1.1/mirage-3.1.1.tbz"
+checksum: "7888dc6a9769e6a5b593e7b6e78c435f"

--- a/packages/mirage/mirage.3.1.1/descr
+++ b/packages/mirage/mirage.3.1.1/descr
@@ -1,0 +1,12 @@
+The MirageOS library operating system
+
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.

--- a/packages/mirage/mirage.3.1.1/opam
+++ b/packages/mirage/mirage.3.1.1/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/mirage/mirage.git"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["jbuilder" "subst" "-p" name]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder"   {build & >= "1.0+beta10"}
+  "ipaddr"             {>= "2.6.0"}
+  "functoria"          {>= "2.2.0"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.0.0"}
+]
+conflicts: [
+  "nocrypto" {< "0.4.0"}
+  "cstruct"  {< "1.0.1"}
+  "io-page"  {< "1.4.0"}
+  "crunch"   {< "1.2.2"}
+  "jbuilder" {= "1.0+beta18"}
+]
+available: [ocaml-version >= "4.04.2"]

--- a/packages/mirage/mirage.3.1.1/url
+++ b/packages/mirage/mirage.3.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage/releases/download/3.1.1/mirage-3.1.1.tbz"
+checksum: "7888dc6a9769e6a5b593e7b6e78c435f"


### PR DESCRIPTION
- for the unix target, add `-tags thread`, as done for the mac osx target (suggested by @cfcs)
- bump minimum mirage-solo5* and solo5-kernel* to 0.3.0 (by @hannesm, as suggested by @mato)
- use the exposed signature in functoria for `Key` modules (by @Drup)
- add `?group` param to all generic devices (by @samoht)
