### PR TITLE
[new release] travis-opam (1.3.0)

### DIFF
--- a/packages/travis-opam/travis-opam.1.3.0/descr
+++ b/packages/travis-opam/travis-opam.1.3.0/descr
@@ -1,0 +1,6 @@
+Scripts for OCaml projects
+
+Supported CI:
+
+- **stable**: [Travis CI](/README-travis.md) Ubuntu, Debian and OSX workers.
+- **experimental**: [Appveyor](/README-appveyor.md) Windows Server 2012 R2 (x64) workers.

--- a/packages/travis-opam/travis-opam.1.3.0/opam
+++ b/packages/travis-opam/travis-opam.1.3.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+homepage:     "https://github.com/ocaml/ocaml-ci-scripts"
+bug-reports:  "https://github.com/ocaml/ocaml-ci-scripts/issues"
+dev-repo:     "https://github.com/ocaml/ocaml-ci-scripts.git"
+doc:          "https://ocaml.github.io/ocaml-ci-scripts/"
+
+authors: [
+  "Thomas Gazagnaire"
+  "Richard Mortier"
+  "David Sheets"
+]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build}
+  "jsonm" {build}
+]

--- a/packages/travis-opam/travis-opam.1.3.0/url
+++ b/packages/travis-opam/travis-opam.1.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/ocaml-ci-scripts/releases/download/1.3.0/travis-opam-1.3.0.tbz"
+checksum: "92ec20a8e0e86c0599b909c50d478b9c"


### PR DESCRIPTION
CHANGES:

* `OCAML_VERSION=4.06` now uses 4.06.1 instead 4.06.0 (ocaml/ocaml-ci-scripts#218, @yomimono)
* Fix travis docker when the current image is using the system switch
  (ocaml/ocaml-ci-scripts#219, @kit-ty-kate)
* Fix opam 1.3/2.0 json format parsing (ocaml/ocaml-ci-scripts#220, @kit-ty-kate)
* Fix BASE_REMOTE in .travis-docker.sh in CentOS 7 containers (ocaml/ocaml-ci-scripts#222, @gaborigloi)
* update some version numbers in travis readme (ocaml/ocaml-ci-scripts#224, @yomimono)
* (not so) temporary workaround for python failure on OS X (ocaml/ocaml-ci-scripts#225, @fdopen)
* travis-docker: try to make git quieter (ocaml/ocaml-ci-scripts#227, @mor1)
* Add branches for OCaml 4.07 (ocaml/ocaml-ci-scripts#230, @Leonidas-from-XIV)
* Use opam2 by default (ocaml/ocaml-ci-scripts#232, @samoht)