### PR TITLE
Package containers.2.3

### DIFF
--- a/packages/containers/containers.2.3/descr
+++ b/packages/containers/containers.2.3/descr
@@ -1,0 +1,12 @@
+A modular, clean and powerful extension of the OCaml standard library.
+
+Containers is an extension of OCaml's standard library (under BSD license)
+focused on data structures, combinators and iterators, without dependencies on
+unix, str or num. Every module is independent and is prefixed with 'CC' in the
+global namespace. Some modules extend the stdlib (e.g. CCList provides safe
+map/fold_right/append, and additional functions on lists).
+Alternatively, `open Containers` will bring enhanced versions of the standard
+modules into scope.
+
+It also features sub-libraries for dealing with threads, S-expressions,
+and the intricacies of unix.

--- a/packages/containers/containers.2.3/opam
+++ b/packages/containers/containers.2.3/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+doc: "https://c-cube.github.io/ocaml-containers"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+dev-repo: "https://github.com/c-cube/ocaml-containers.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
+build-doc: ["jbuilder" "build" "@doc"]
+depends: [
+  "jbuilder" {build & >= "1.0+beta12"}
+  "result"
+  "uchar"
+  "qtest" {test}
+  "qcheck" {test}
+  "ounit" {test}
+  "sequence" {test}
+  "gen" {test}
+  "uutf" {test}
+  "odoc" {doc}
+]
+depopts: ["base-unix" "base-threads"]
+conflicts: [
+  "sequence" {< "0.5"}
+]
+available: [ocaml-version >= "4.02.0"]
+post-messages: [
+"Containers 2.3 is a small release with a few more functions in existing modules,
+some bugfixes, and many performance improvements.
+
+Changelog: https://github.com/c-cube/ocaml-containers/blob/2.3/CHANGELOG.adoc"
+]

--- a/packages/containers/containers.2.3/url
+++ b/packages/containers/containers.2.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-containers/archive/2.3.tar.gz"
+checksum: "8169302b511ccb13061bdeee9aaf68c3"


### PR DESCRIPTION
### `containers.2.3`

A modular, clean and powerful extension of the OCaml standard library.

Containers is an extension of OCaml's standard library (under BSD license)
focused on data structures, combinators and iterators, without dependencies on
unix, str or num. Every module is independent and is prefixed with 'CC' in the
global namespace. Some modules extend the stdlib (e.g. CCList provides safe
map/fold_right/append, and additional functions on lists).
Alternatively, `open Containers` will bring enhanced versions of the standard
modules into scope.

It also features sub-libraries for dealing with threads, S-expressions,
and the intricacies of unix.



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---

:camel: Pull-request generated by opam-publish v0.3.5