### PR TITLE
Add tyre 0.4

### DIFF
--- a/packages/tyre/tyre.0.4/descr
+++ b/packages/tyre/tyre.0.4/descr
@@ -1,0 +1,7 @@
+Typed Regular Expressions
+
+Tyre is a set of combinators to build type-safe regular expressions,
+allowing automatic extraction and modification of matched groups.
+Tyre is bi-directional: a typed regular expressions can be used for
+parsing and unparsing. It also allows routing, by providing a list of
+regexs/routes and their handlers.

--- a/packages/tyre/tyre.0.4/opam
+++ b/packages/tyre/tyre.0.4/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "tyre"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+authors: "Gabriel Radanne <drupyog@zoho.com>"
+homepage: "https://github.com/Drup/tyre"
+doc: "https://drup.github.io/tyre/doc/0.4/tyre/Tyre/"
+bug-reports: "https://github.com/Drup/tyre/issues"
+license: "ISC"
+dev-repo: "https://github.com/Drup/tyre.git"
+tags: [ "regex" ]
+
+build: [
+  ["jbuilder" "subst"]{pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+]
+
+
+depends: [
+  "jbuilder" {build}
+  "re" {>= "1.8.0"}
+  "alcotest" {test & >= "0.8.0"}
+  "result"
+  "seq"
+]
+available: [ ocaml-version >= "4.02.0" ]

--- a/packages/tyre/tyre.0.4/url
+++ b/packages/tyre/tyre.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Drup/tyre/releases/download/0.4/tyre-0.4.tbz"
+checksum: "7be0f142c25c233a0e257adc76fdf5e9"


### PR DESCRIPTION
Once again, dune-release explodes halfway through, so here's a manual one. :)

[Tyre](https://github.com/Drup/tyre) is a set of combinators to build
type-safe regular expressions, allowing automatic extraction and
modification of matched groups.  Tyre is bi-directional: a typed
regular expressions can be used for parsing and unparsing. It also
allows routing, by providing a list of regexs/routes and their
handlers.

## Changelog

* Move to dune
* Remove the need for Re.marks. 
  This might open the way to alterative backends, such as JS regexs.
  See https://github.com/Drup/tyre/issues/1 for details.
* Use Seq instead of Gen. This is a breaking change.