### PR TITLE
recent versions of opam-depext do not work on 3.12

### DIFF
--- a/packages/opam-depext/opam-depext.1.1.0/opam
+++ b/packages/opam-depext/opam-depext.1.1.0/opam
@@ -13,5 +13,5 @@ license: "LGPL-3.0 with OCaml linking exception"
 tags: "flags:plugin"
 dev-repo: "https://github.com/ocaml/opam-depext.git#2.0"
 build: [make]
-available: [opam-version >= "2.0.0~beta5"]
+available: [opam-version >= "2.0.0~beta5" & ocaml-version >= "4.0.0"]
 conflicts: "depext" {!= "transition"}

--- a/packages/opam-depext/opam-depext.1.1.2/opam
+++ b/packages/opam-depext/opam-depext.1.1.2/opam
@@ -13,4 +13,4 @@ license: "LGPL-2.1 with OCaml linking exception"
 tags: "flags:plugin"
 dev-repo: "https://github.com/ocaml/opam-depext.git#2.0"
 build: [make]
-available: [opam-version >= "2.0.0~beta5"]
+available: [opam-version >= "2.0.0~beta5" & ocaml-version >= "4.0.0"]


### PR DESCRIPTION
(because of String.trim)