### PR TITLE
Package resource-pooling.0.2

### DIFF
--- a/packages/resource-pooling/resource-pooling.0.2/descr
+++ b/packages/resource-pooling/resource-pooling.0.2/descr
@@ -1,0 +1,7 @@
+library for pooling resources like connections, threads, or similar
+
+This package is derived from the module Lwt_pool from the lwt package,
+which implements resource pooling. With Resource_pool this package
+provides a modified version with additional features. Also there is a
+module called Server_pool that manages resource clusters, specifically
+a cluster of servers each with its own connection pool.

--- a/packages/resource-pooling/resource-pooling.0.2/opam
+++ b/packages/resource-pooling/resource-pooling.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Jan Rochel <jan@besport.com>"
+authors: "Jan Rochel (BeSport)"
+homepage: "https://github.com/ocsigen/resource-pooling"
+bug-reports: "https://github.com/ocsigen/resource-pooling/issues"
+license: "MIT"
+dev-repo: "https://github.com/ocsigen/resource-pooling.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
+remove: ["ocamlfind" "remove" "resource-pooling"]
+depends: [
+  ("lwt" {>= "2.4.7" & < "4.0.0"})
+  ("oasis" {build & >= "0.4.7"} | "oasis-mirage" {build & >= "0.4.7"})
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.02"]

--- a/packages/resource-pooling/resource-pooling.0.2/url
+++ b/packages/resource-pooling/resource-pooling.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocsigen/resource-pooling/archive/0.2.tar.gz"
+checksum: "cdca2d97b7a0a8c9c29275b37a8718ed"


### PR DESCRIPTION
### `resource-pooling.0.2`

library for pooling resources like connections, threads, or similar

This package is derived from the module Lwt_pool from the lwt package,
which implements resource pooling. With Resource_pool this package
provides a modified version with additional features. Also there is a
module called Server_pool that manages resource clusters, specifically
a cluster of servers each with its own connection pool.



---
* Homepage: https://github.com/ocsigen/resource-pooling
* Source repo: https://github.com/ocsigen/resource-pooling.git
* Bug tracker: https://github.com/ocsigen/resource-pooling/issues

---

:camel: Pull-request generated by opam-publish v0.3.5