### PR TITLE
[new release] dune (1.1.1)

### DIFF
--- a/packages/dune/dune.1.1.1/descr
+++ b/packages/dune/dune.1.1.1/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/dune/dune.1.1.1/opam
+++ b/packages/dune/dune.1.1.1/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "MIT"
+build: [
+  ["ocaml" "configure.ml" "--libdir" lib]
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+available: [ ocaml-version >= "4.02.3" ]
+conflicts: [
+  "jbuilder" {!= "transition"}
+]

--- a/packages/dune/dune.1.1.1/url
+++ b/packages/dune/dune.1.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dune/releases/download/1.1.1/dune-1.1.1.tbz"
+checksum: "d1da3d5a9cd9f450bb35724d16fbcaf2"


### PR DESCRIPTION
CHANGES:

- Fix `$ jbuilder --dev` (ocaml/dune#1104, fixes ocaml/dune#1103, @rgrinberg)

- Fix dune exec when `--build-dir` is set to an absolute path (ocaml/dune#1105, fixes
  ocaml/dune#1101, @rgrinberg)

- Fix duplicate profile argument in suggested command when an external library
  is missing (ocaml/dune#1109, ocaml/dune#1106, @emillon)

- `-opaque` wasn't correctly being added to modules without an interface.
  (ocaml/dune#1108, fix ocaml/dune#1107, @rgrinberg)

- Fix validation of library `name` fields and make sure this validation also
  applies when the `name` is derived from the `public_name`. (ocaml/dune#1110, fix ocaml/dune#1102,
  @rgrinberg)

- Fix a bug causing the toplevel `env` stanza in the workspace file to
  be ignored when at least one context had `(merlin)` (ocaml/dune#1114, @diml)