### PR TITLE
[new release] mirage-xen-ocaml (3.0.6)

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/descr
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/descr
@@ -1,0 +1,3 @@
+MirageOS headers for the OCaml runtime
+
+The package contains the OCaml runtime patches and build system.

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "https://github.com/mirage/mirage-platform.git"
+build: [make "xen-ocaml-build"]
+install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+tags: ["org:mirage"]
+depends: [
+  "mirage-xen-posix" {>="2.6.0"}
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src"
+  "ocamlbuild" {build}
+]
+available: [ocaml-version >= "4.04.2" & ocaml-version <= "4.05.0" & os = "linux"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
@@ -4,9 +4,9 @@ authors: "The MirageOS team"
 homepage: "https://github.com/mirage/mirage-platform"
 bug-reports: "https://github.com/mirage/mirage-platform/issues/"
 dev-repo: "https://github.com/mirage/mirage-platform.git"
-build: [make "xen-ocaml-build"]
-install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
-remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+build: [make "-C" "xen-ocaml" "build"]
+install: [make "-C" "xen-ocaml" "install" "PREFIX=%{prefix}%"]
+remove: [make "-C" "xen-ocaml" "uninstall" "PREFIX=%{prefix}%"]
 tags: ["org:mirage"]
 depends: [
   "mirage-xen-posix" {>="2.6.0"}

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/url
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-platform/releases/download/3.0.6/mirage-xen-ocaml-3.0.6.tbz"
+checksum: "ead723d64c59b92c440f1f3d0d839332"


### PR DESCRIPTION
CHANGES:

* xen: do not use `opam config exec` during the build to be compatible
  with opam2 (mirage/mirage-platform#201, @reynir)