### PR TITLE
some versions of mirage-xen-ocaml do not work with opam2

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: [os = "linux" & opam-version < "2.0.0"]
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: [os = "linux" & opam-version < "2.0.0"]
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."


### PR DESCRIPTION
Because they call `opam config exec` during build.