### PR TITLE
graphql_parser 0.7.0, graphql 0.7.0, graphql-lwt 0.7.0

### DIFF
--- a/packages/graphql-lwt/graphql-lwt.0.7.0/descr
+++ b/packages/graphql-lwt/graphql-lwt.0.7.0/descr
@@ -1,0 +1,3 @@
+Build GraphQL schemas with Lwt support
+
+`graphql-lwt` adds support for Lwt to `graphql`, so you can use Lwt in your GraphQL schema resolver functions.

--- a/packages/graphql-lwt/graphql-lwt.0.7.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.7.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "graphql"
+  "alcotest" {test}
+  "lwt"
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "crunch"
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql-lwt/graphql-lwt.0.7.0/url
+++ b/packages/graphql-lwt/graphql-lwt.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.7.0/graphql-0.7.0.tbz"
+checksum: "51eed76a0a389b1810d4af2cf1b499db"

--- a/packages/graphql/graphql.0.7.0/descr
+++ b/packages/graphql/graphql.0.7.0/descr
@@ -1,0 +1,12 @@
+Build GraphQL schemas and execute queries against them
+
+`graphql` is a package for creating GraphQL servers. Current feature set includes:
+
+- Type-safe schema design
+- GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- Query execution
+- Introspection of schemas
+- Arguments for fields
+- Allows variables in queries
+
+Use `graphql-lwt` for Lwt support, or `graphql-async` for Async support.

--- a/packages/graphql/graphql.0.7.0/opam
+++ b/packages/graphql/graphql.0.7.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "graphql_parser"
+  "yojson"
+  "rresult"
+  "alcotest" {test}
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql/graphql.0.7.0/url
+++ b/packages/graphql/graphql.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.7.0/graphql-0.7.0.tbz"
+checksum: "51eed76a0a389b1810d4af2cf1b499db"

--- a/packages/graphql_parser/graphql_parser.0.7.0/descr
+++ b/packages/graphql_parser/graphql_parser.0.7.0/descr
@@ -1,0 +1,1 @@
+Library for parsing GraphQL queries.

--- a/packages/graphql_parser/graphql_parser.0.7.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.7.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "https://github.com/andreas/ocaml-graphql-server.git"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build}
+  "angstrom" {>= "0.7.0"}
+  "sexplib"
+  "ppx_sexp_conv" {>= "0.9.0"}
+  "alcotest" {test}
+]
+available: [
+  ocaml-version >= "4.03.0"
+]

--- a/packages/graphql_parser/graphql_parser.0.7.0/url
+++ b/packages/graphql_parser/graphql_parser.0.7.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.7.0/graphql-0.7.0.tbz"
+checksum: "51eed76a0a389b1810d4af2cf1b499db"


### PR DESCRIPTION
Changes:

- Allow returning errors from resolve function of io_field (andreas/ocaml-graphql-server#69)
- Support for union and interface types (andreas/ocaml-graphql-server#70)
- Expose HTTP request to context construction function in Graphql_lwt.Server.start (andreas/ocaml-graphql-server#88)
- Fix error response from Graphql_lwt.Server (andreas/ocaml-graphql-server#96)
- Allow passing operation name to Graphql_lwt.Server (andreas/ocaml-graphql-server#103)
- Querying undefined fields gives validation error (andreas/ocaml-graphql-server#105)
- Fix parsing of enums with E (andreas/ocaml-graphql-server#109)