### PR TITLE
Partial format upgrade (opam-depext.1.1.2)

### DIFF
--- a/packages/opam-depext/opam-depext.1.1.2/opam
+++ b/packages/opam-depext/opam-depext.1.1.2/opam
@@ -12,16 +12,19 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-2.1 with OCaml linking exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 build: [make]
-available: [opam-version >= "2.0.0~beta5"]
+available: opam-version >= "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between
 OPAM packages and the host package management system. It can query OPAM for the
 right external dependencies on a set of packages, depending on the host OS, and
 call the OS's package manager in the appropriate way to install them."""
-depends: ["ocaml"]
+depends: [
+  "ocaml" {>= "4.0.0"}
+]
 flags: plugin
 url {
-  src: "https://github.com/ocaml/opam-depext/releases/download/v1.1.2/opam-depext-full-1.1.2.tbz"
+  src:
+    "https://github.com/ocaml/opam-depext/releases/download/v1.1.2/opam-depext-full-1.1.2.tbz"
   checksum: "md5=d71c9c0ada811ccf0669d09e1b0329da"
 }


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc3
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/opam-depext/opam-depext.1.1.2/opam