### PR TITLE
Remove dev-repo fields pointing to opam-repository

### DIFF
--- a/packages/base-implicits/base-implicits.base/opam
+++ b/packages/base-implicits/base-implicits.base/opam
@@ -4,7 +4,6 @@ authors: ["Jeremy Yallop"]
 depopts: ["ocamlfind"]
 homepage: "https://github.com/ocaml/opam-repository/tree/master/packages/base-implicits/base-implicits.base"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 install: []
 remove: []
 available: [ compiler = "4.02.0+modular-implicits" 

--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/opam
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/opam
@@ -4,7 +4,6 @@ authors: ["Jeremy Yallop"]
 depopts: ["ocamlfind"]
 homepage: "https://github.com/ocaml/opam-repository/tree/master/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 install: [
   [ "mkdir" "-p" "%{lib}%/findlib.conf.d/" ]
      {ocamlfind:installed}

--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 authors: "https://git.savannah.gnu.org/cgit/automake.git/tree/AUTHORS"
 homepage: "http://www.gnu.org/software/automake/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [["which" "aclocal"]]
 depexts: [

--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "http://www.gnu.org/software/autoconf"
 authors: "https://www.gnu.org/software/autoconf/autoconf.html#maintainer"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-3.0"
 build: [
   ["which" "autoconf"]

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.1/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.1/opam
@@ -4,7 +4,6 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 homepage: "http://llvm.org"
 authors: "The LLVM Team"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: [
   ["bash" "-ex" "configure"]

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
@@ -4,7 +4,6 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 homepage: "http://llvm.org"
 authors: "The LLVM Team"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: [
   ["bash" "-ex" "configure"]

--- a/packages/conf-bap-llvm/conf-bap-llvm.1/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1/opam
@@ -3,7 +3,6 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 homepage: "http://llvm.org"
 authors: "The LLVM Team"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: [
   ["sh" "-x" "configure" os]

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -3,7 +3,6 @@ maintainer: "mmottl"
 author: "mmottl"
 homepage: "http://www.netlib.org/blas"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2.0"
 build: [
   ["sh" "-exc" "cc $CFLAGS test.c -lblas"] {os != "darwin" & os != "freebsd" & os != "win32"}

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "thierry.martinez@inria.fr"
 homepage: "http://www.boost.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
 ]

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -4,7 +4,6 @@ authors: "The Brotli Authors"
 homepage: "https://github.com/google/brotli"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 install: [ "pkg-config" "libbrotlidec" "libbrotlienc" ]
 depexts: [
   [["debian"] ["libbrotli-dev"]]

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -3,7 +3,6 @@ maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: "Kitware, Inc. and Contributors"
 homepage: "https://cmake.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: ["bash" "-ex" "configure.sh"]
 depexts: [

--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "https://www.gnu.org.ua/software/gdbm"
 authors: "Philip A. Nelson, Jason Downs and Sergey Poznyakoff"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-3"
 build: [
   "sh" "-c" "cc test.c -I/usr/include -I/usr/local/include -I/usr/include/db1 -I/usr/include/gdbm ||

--- a/packages/conf-emacs/conf-emacs.1/opam
+++ b/packages/conf-emacs/conf-emacs.1/opam
@@ -3,7 +3,6 @@ maintainer: "anil@recoil.org"
 author: "anil@recoil.org"
 homepage: "http://gnu.org/software/emacs"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [ ]
 depexts: [

--- a/packages/conf-env-travis/conf-env-travis.1/opam
+++ b/packages/conf-env-travis/conf-env-travis.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 homepage: "https://travis-ci.org/"
 authors: "Ivan Gotovchits <ivg@ieee.org>"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
   ["sh" "-x" "configure" os]

--- a/packages/conf-expat/conf-expat.1/opam
+++ b/packages/conf-expat/conf-expat.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "blue-prawn"
 authors: "The Expat Authors"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 homepage: "http://www.libexpat.org/"
 license: "MIT"
 build: [["pkg-config" "expat"]]

--- a/packages/conf-ftgl/conf-ftgl.1/opam
+++ b/packages/conf-ftgl/conf-ftgl.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "blue-prawn"
 authors: ["Henry Maddocks"]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 homepage: "http://sourceforge.net/apps/mediawiki/ftgl/"
 license: "MIT"
 build: [["pkg-config" "ftgl"]]

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -3,7 +3,6 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "The Glade Authors"
 homepage: "https://glade.gnome.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "LGPL 2.1"
 build: [["pkg-config" "libglade-2.0"]]
 depexts: [

--- a/packages/conf-gles2/conf-gles2.1/opam
+++ b/packages/conf-gles2/conf-gles2.1/opam
@@ -4,7 +4,6 @@ authors: ["ARB"]
 homepage: "https://www.khronos.org/opengles"
 license: "Free of charge, royalty or licensing"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 build: [
   ["pkg-config" "glesv2"] {os != "darwin"}
 ]

--- a/packages/conf-glew/conf-glew.1/opam
+++ b/packages/conf-glew/conf-glew.1/opam
@@ -6,7 +6,6 @@ authors: [
   "Lev Povalahev"
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 homepage: "http://glew.sourceforge.net/"
 license: "modified BSD"
 build: [["pkg-config" "glew"]]

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
@@ -3,7 +3,6 @@ maintainer: "Etienne Millon <etienne@cryptosense.com>"
 author: "Etienne Millon <etienne@cryptosense.com>"
 homepage: "http://gmplib.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [
   ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "darwin"}

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -3,7 +3,6 @@ maintainer: "nbraud"
 author: "nbraud"
 homepage: "http://gmplib.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [
   ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "darwin"}

--- a/packages/conf-gnuplot/conf-gnuplot.0.1/opam
+++ b/packages/conf-gnuplot/conf-gnuplot.0.1/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "http://www.gnuplot.info/"
 authors: "http://www.gnuplot.info/faq/faq.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "gnuplot license"
 build: [
   ["which" "gnuplot"]

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "http://www.graphviz.org/"
 authors: "http://www.graphviz.org/Credits.php"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "Eclipse Public License v1.0"
 build: [
   ["which" "dot"]

--- a/packages/conf-gsl/conf-gsl.1/opam
+++ b/packages/conf-gsl/conf-gsl.1/opam
@@ -3,7 +3,6 @@ maintainer: "blue-prawn"
 author: "blue-prawn"
 homepage: "http://www.gnu.org/software/gsl/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [["pkg-config" "gsl"]]
 depexts: [

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "The gtksourceview programmers"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 homepage: "https://projects.gnome.org/gtksourceview/"
 license: "LGPL 2.1"
 build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-2.0"]]

--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -3,7 +3,6 @@ maintainer: "Vincent Bernardoff"
 authors: ["Signal 11 Software"]
 homepage: "http://www.signal11.us/oss/hidapi/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: [
   ["pkg-config" "hidapi-libusb"] {os != "darwin"}

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -3,7 +3,6 @@ maintainer: "mmottl"
 author: "mmottl"
 homepage: "http://www.netlib.org/lapack"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2.0"
 build: [
   ["sh" "-exc" "cc $CFLAGS test.c -llapack"] {os != "darwin" & os != "freebsd" & os != "win32"}

--- a/packages/conf-libmosquitto/conf-libmosquitto.1/opam
+++ b/packages/conf-libmosquitto/conf-libmosquitto.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
 authors: [ "Markus W. Weissmann <markus.weissmann@in.tum.de>" ]
 homepage: "https://mosquitto.org/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: [ "Eclipse Public License v1.0" "Eclipse Distribution License 1.0" ]
 build: [

--- a/packages/conf-libsvm/conf-libsvm.3/opam
+++ b/packages/conf-libsvm/conf-libsvm.3/opam
@@ -3,7 +3,6 @@ maintainer: "Akinori ABE <aabe.65535@gmail.com>"
 authors: [ "Akinori ABE <aabe.65535@gmail.com>" ]
 license: "MIT"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 homepage: "https://www.csie.ntu.edu.tw/~cjlin/libsvm/"
 build: [
   [ "sh" "-exc" "cc $CFLAGS test.c -lsvm" ] { os = "linux" }

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -3,7 +3,6 @@ maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
 authors: [ "Markus W. Weissmann <markus.weissmann@in.tum.de>" ]
 homepage: "https://kernel.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: [ "GPL 2.0" ]
 build: [["ls" "/usr/include/linux/stddef.h"]]
 depexts: [

--- a/packages/conf-llvm/conf-llvm.3.4/opam
+++ b/packages/conf-llvm/conf-llvm.3.4/opam
@@ -3,7 +3,6 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "The LLVM team"
 homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: [
   ["bash" "-ex" "configure" version]

--- a/packages/conf-llvm/conf-llvm.3.8/opam
+++ b/packages/conf-llvm/conf-llvm.3.8/opam
@@ -3,7 +3,6 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "The LLVM team"
 homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
   ["bash" "-ex" "configure.sh" version]

--- a/packages/conf-llvm/conf-llvm.3.9/opam
+++ b/packages/conf-llvm/conf-llvm.3.9/opam
@@ -3,7 +3,6 @@ maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: "The LLVM team"
 homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
   ["bash" "-ex" "configure.sh" version]

--- a/packages/conf-llvm/conf-llvm.4.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.4.0.0/opam
@@ -3,7 +3,6 @@ maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: "The LLVM team"
 homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
   ["bash" "-ex" "configure.sh" version]

--- a/packages/conf-llvm/conf-llvm.5.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.5.0.0/opam
@@ -3,7 +3,6 @@ maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: "The LLVM team"
 homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
   ["bash" "-ex" "configure.sh" version]

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -3,7 +3,6 @@ maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: "The LLVM team"
 homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
   ["bash" "-ex" "configure.sh" version]

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "tim@gfxmonk.net"
 homepage: "http://www.gnu.org/software/m4/m4.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-3"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [

--- a/packages/conf-mecab/conf-mecab.0.996/opam
+++ b/packages/conf-mecab/conf-mecab.0.996/opam
@@ -3,7 +3,6 @@ maintainer: "Akinori ABE <aabe.65535@gmail.com>"
 authors: ["Akinori ABE"]
 homepage: "http://taku910.github.io/mecab/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/opam-repository.git"
 license: "GPL-3"
 build: [
   ["cc" "test.c" "-I/usr/local/include" "-L/usr/local/lib" "-lmecab"]

--- a/packages/conf-mpfr/conf-mpfr.1/opam
+++ b/packages/conf-mpfr/conf-mpfr.1/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "http://www.mpfr.org/"
 authors: "http://www.mpfr.org/credit.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "LGPL"
 build: [
   ["cc" "test.c" "-I/usr/local/include" "-L/usr/local/lib" "-lgmp" "-lmpfr"]

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -5,7 +5,6 @@ authors: [
 ]
 homepage: "https://www.open-mpi.org"
 bug-reports: "mailto:tim@tbrk.org"
-dev-repo: "git@github.com:tbrk/opam-repository.git"
 build: [["sh" "configure" os]]
 depends: ["conf-pkg-config"]
 depexts: [

--- a/packages/conf-ncurses/conf-ncurses.1+system/opam
+++ b/packages/conf-ncurses/conf-ncurses.1+system/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "tim@gfxmonk.net"
 homepage: "https://www.gnu.org/software/ncurses/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
   ## Preinstalled...

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "tim@gfxmonk.net"
 homepage: "https://www.gnu.org/software/ncurses/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "MIT"
 build: [
 ]

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -3,7 +3,6 @@ maintainer: "npm, Inc."
 authors: "npm, Inc."
 homepage: "https://www.npmjs.com"
 bug-reports: "https://github.com/ocaml/opam-repository/issue"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "Artistic License 2.0"
 build: [
   ["npm" "--version"]

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -4,7 +4,6 @@ homepage: "http://openbabel.org/"
 license: "GPL"
 authors: "http://openbabel.org/wiki/THANKS"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 build: [
   ["c++" "-I/usr/include/openbabel-2.0" "test.cpp" "-lopenbabel"] { os != "darwin" }
   ["c++" "-I/usr/local/include/openbabel-2.0" "test.cpp" "-L/usr/local/lib" "-lopenbabel"] { os = "darwin" }

--- a/packages/conf-openblas/conf-openblas.0.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.1/opam
@@ -3,7 +3,6 @@ maintainer: "Liang Wang (ryanrhymes@gmail.com)"
 author: "Liang Wang (ryanrhymes@gmail.com)"
 homepage: "https://github.com/xianyi/OpenBLAS"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: [
   ["sh" "-exc" "%{build}%/centos_install.sh"] {os = "centos"}

--- a/packages/conf-openblas/conf-openblas.0.2.0/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.0/opam
@@ -3,7 +3,6 @@ maintainer: "Liang Wang <ryanrhymes@gmail.com>"
 authors: [ "Liang Wang" ]
 homepage: "https://github.com/xianyi/OpenBLAS"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD"
 build: [
   ["sh" "-exc" "cc $CFLAGS -I/usr/include/openblas test.c -lopenblas"] {os = "fedora" | os = "centos" | os = "opensuse"}

--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "tim@gfxmonk.net"
 homepage: "https://www.perl.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-1+"
 build: [["perl" "--version"]]
 depexts: [

--- a/packages/conf-pic-switch/conf-pic-switch.0.1/opam
+++ b/packages/conf-pic-switch/conf-pic-switch.0.1/opam
@@ -3,7 +3,6 @@ authors: ["Francois Berenger"]
 maintainer: "unixjunkie@sdf.org"
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 build: [
   ["bash" "./check.sh"]
 ]

--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git://github.com/ocaml/opam-repository"
 license: "GPL"
 build: [
   ["pkg-config" "--help"]

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git://github.com/ocaml/opam-repository"
 license: "GPL"
 build: [
   ["pkg-config" "--help"]

--- a/packages/conf-python-2-7/conf-python-2-7.1.0/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.0/opam
@@ -4,7 +4,6 @@ homepage: "https://www.python.org/download/releases/2.7/"
 authors: "Python Software Foundation"
 license: "PSF"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 build: ["python2.7" "test.py"]
 depexts: [
   [["debian"] ["python2.7"]]

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -3,7 +3,6 @@ maintainer: "Philippe Veber <philippe.veber@gmail.com>"
 author: "https://www.r-project.org/contributors.html"
 homepage: "https://www.r-project.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [["pkg-config" "libRmath"]]
 depends: ["conf-pkg-config"]

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "https://www.r-project.org/"
 authors: "https://www.r-project.org/contributors.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2+"
 build: ["R" "CMD" "BATCH" "check.r"]
 depexts: [

--- a/packages/conf-rdkit/conf-rdkit.0.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.0.1/opam
@@ -3,7 +3,6 @@ authors: "https://github.com/rdkit/rdkit/graphs/contributors"
 homepage: "http://www.rdkit.org/"
 maintainer: "unixjunkie@sdf.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "BSD-3"
 build: [
   ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include -L/usr/local/lib -lRDGeneral || \\

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 
 homepage: "http://rocksdb.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "Apache-2.0"
 
 depexts: [

--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -3,7 +3,6 @@ maintainer: "Takuma Ishikawa <nekketsuuu@gmail.com>"
 authors: "Yukihiro Matsumoto (Matz) and contributers"
 homepage: "https://www.ruby-lang.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "2-clause BSDL or the conditions in COPYING of the Ruby repository"
 build: [
   ["ruby" "--version"]

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -3,7 +3,6 @@ maintainer: "blue-prawn"
 authors: ["Sam Lantinga"]
 homepage: "http://libsdl.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "Zlib"
 build: [["pkg-config" "sdl2"]]
 depexts: [

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -3,7 +3,6 @@ author: ["Gabriel Scherer"]
 maintainer: "gabriel.scherer@inria.fr"
 homepage: "https://google.github.io/snappy/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 build: [
   ["c++" "test.cpp" "-lsnappy"]
 ]

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 maintainer: "tim@gfxmonk.net"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 build: [["sh" "check.sh"]]
 depends: ["conf-pkg-config"]
 depexts: [

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -3,7 +3,6 @@ maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
 authors: ["POSIX"]
 homepage: "https://github.com/ocaml/opam-repository/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL"
 build: [["which" "time"]]
 depends: ["conf-which"]

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 maintainer: "tim@gfxmonk.net"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 build: [["sh" "check.sh"]]
 depends: ["conf-pkg-config"]
 depexts: [

--- a/packages/conf-vim/conf-vim.1/opam
+++ b/packages/conf-vim/conf-vim.1/opam
@@ -3,7 +3,6 @@ maintainer: "anil@recoil.org"
 author: "anil@recoil.org"
 homepage: "http://vim.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "charityware"
 build: [ ]
 depexts: [

--- a/packages/conf-wget/conf-wget.1/opam
+++ b/packages/conf-wget/conf-wget.1/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 authors: "hniksic@xemacs.org"
 homepage: "https://www.gnu.org/software/wget/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2+"
 build: [["which" "wget"]]
 depends: [

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "http://www.gnu.org/software/which/"
 authors: "Carlo Wood"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "GPL-2+"
 build: [["which" "which"]]
 depexts: [

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -2,7 +2,6 @@ opam-version: "1.2"
 maintainer: "tim@gfxmonk.net"
 homepage: "http://www.zlib.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "https://github.com/ocaml/opam-repository.git"
 license: "zlib"
 build: [
   ["pkg-config" "zlib"] { os != "darwin" }


### PR DESCRIPTION
Dev-repo pointing to opam-repository are useless.

Detected by @rjbou in https://github.com/ocaml/opam/issues/3507