### PR TITLE
3 packages from ryanslade/influxdb-ocaml at 0.1.0

### DIFF
--- a/packages/influxdb-async/influxdb-async.0.1.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "alcotest" {test}
+  "influxdb"
+  "async"
+  "cohttp"
+  "cohttp-async"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a9f2988f5053b40a0ea0852bb3521fd9"
+    "sha512=8c3e0ff4d7ea4bee64b2f07c5a775746ee6d23b2fc72d59f31f3e31d1f3038b8dbc0346ce725f22f3add5ae04b7bab0d127fef4e1b2b9c3b283c261a440d5d69"
+  ]
+}

--- a/packages/influxdb-lwt/influxdb-lwt.0.1.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "alcotest" {test}
+  "influxdb"
+  "lwt"
+  "cohttp"
+  "cohttp-lwt-unix"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a9f2988f5053b40a0ea0852bb3521fd9"
+    "sha512=8c3e0ff4d7ea4bee64b2f07c5a775746ee6d23b2fc72d59f31f3e31d1f3038b8dbc0346ce725f22f3add5ae04b7bab0d127fef4e1b2b9c3b283c261a440d5d69"
+  ]
+}

--- a/packages/influxdb/influxdb.0.1.0/opam
+++ b/packages/influxdb/influxdb.0.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "stdio"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a9f2988f5053b40a0ea0852bb3521fd9"
+    "sha512=8c3e0ff4d7ea4bee64b2f07c5a775746ee6d23b2fc72d59f31f3e31d1f3038b8dbc0346ce725f22f3add5ae04b7bab0d127fef4e1b2b9c3b283c261a440d5d69"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`influxdb.0.1.0`
-`influxdb-async.0.1.0`
-`influxdb-lwt.0.1.0`



---
* Homepage: https://github.com/ryanslade/influxdb-ocaml
* Source repo: git://github.com/ryanslade/influxdb-ocaml.git
* Bug tracker: https://github.com/ryanslade/influxdb-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0~beta