### PR TITLE
Packages toml.5.0.0 and toml-cconv.5.0.0

### DIFF
--- a/packages/toml-cconv/toml-cconv.5.0.0/descr
+++ b/packages/toml-cconv/toml-cconv.5.0.0/descr
@@ -1,0 +1,3 @@
+Interface between cconv and toml
+
+Allows to use TOML encoding/decoding with [cconv](https://github.com/c-cube/cconv)

--- a/packages/toml-cconv/toml-cconv.5.0.0/opam
+++ b/packages/toml-cconv/toml-cconv.5.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "support@toml.epimeros.org"
+authors: [
+  "Julien Sagot"
+  "Emmanuel Surleau"
+  "mackwic"
+  "Andrew Rudenko"
+  "orbifx"
+  "c-cube"
+]
+homepage: "http://mackwic.github.io/To.ml/"
+bug-reports: "https://github.com/mackwic/To.ml/issues"
+dev-repo: "https://github.com/mackwic/To.ml.git"
+build: ["dune" "build" "-p" name]
+license: "LGPL3"
+depends: [
+  "dune" {build}
+  "toml"
+  "cconv"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/toml-cconv/toml-cconv.5.0.0/url
+++ b/packages/toml-cconv/toml-cconv.5.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-toml/to.ml/archive/v5.0.0.tar.gz"
+checksum: "e68d21fdbb6b255909305f8707a54951"

--- a/packages/toml/toml.5.0.0/descr
+++ b/packages/toml/toml.5.0.0/descr
@@ -1,0 +1,4 @@
+TOML parser.
+The Toml library provides a parser and serializer for Tom's Obvious Minimal
+Language v0.4.0, a minimal configuration file format. Helpful getters to
+retrieve data as OCaml primitive types are also supplied.

--- a/packages/toml/toml.5.0.0/opam
+++ b/packages/toml/toml.5.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "support@toml.epimeros.org"
+authors: [
+  "Julien Sagot"
+  "Emmanuel Surleau"
+  "mackwic"
+  "Andrew Rudenko"
+  "orbifx"
+  "c-cube"
+]
+homepage: "http://mackwic.github.io/To.ml/"
+bug-reports: "https://github.com/mackwic/To.ml/issues"
+dev-repo: "https://github.com/mackwic/To.ml.git"
+build: ["dune" "build" "-p" name]
+build-test: ["dune" "runtest"]
+license: "LGPL3"
+depends: [
+  "dune" {build}
+  "menhir" {build}
+  "ounit" {test}
+  "bisect" {test}
+  "odoc" {doc}
+  "ISO8601"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/toml/toml.5.0.0/url
+++ b/packages/toml/toml.5.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-toml/to.ml/archive/v5.0.0.tar.gz"
+checksum: "e68d21fdbb6b255909305f8707a54951"


### PR DESCRIPTION
This pull-request concerns:
-`toml.5.0.0`: TOML parser.
-`toml-cconv.5.0.0`: Interface between cconv and toml



---
* Homepage: http://mackwic.github.io/To.ml/
* Source repo: https://github.com/mackwic/To.ml.git
* Bug tracker: https://github.com/mackwic/To.ml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5