### PR TITLE
Fix ppx_deriving dependency of nocrypto

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -21,7 +21,7 @@ depends: [
   "topkg" {build}
   "cpuid" {build}
   "ocb-stubblr" {build}
-  "ppx_deriving" {build}
+  "ppx_deriving"
   "ppx_sexp_conv" {>= "113.33.01" & != "v0.11.0"}
   "ounit" {test}
   "cstruct" {>="2.4.0"}


### PR DESCRIPTION

The library seems to depend on `ppx_deriving.runtime` at runtime.