### PR TITLE
Release ppx_regexp.0.4.0 and ppx_tyre.0.4.0.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.4.0/descr
+++ b/packages/ppx_regexp/ppx_regexp.0.4.0/descr
@@ -1,0 +1,16 @@
+Matching Regular Expressions with OCaml Patterns
+
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations to the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, except groups can be bound to
+variables using the syntax `(?<var>...)`.  The type of `var` will be
+`string` if a match is of the groups is guaranteed given a match of the
+whole pattern, and `string option` if the variable is bound to or nested
+below an optionally matched group.

--- a/packages/ppx_regexp/ppx_regexp.0.4.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.4.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Gabriel Radanne <drupyog@zoho.com>"
+]
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+dev-repo: "https://github.com/paurkedal/ppx_regexp.git"
+license: "LGPL-3 with OCaml linking exception"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {build}
+  "ocaml-migrate-parsetree"
+  "re" {>= "1.7.1"}
+  "ppx_tools_versioned"
+  "qcheck" {test}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/ppx_regexp/ppx_regexp.0.4.0/url
+++ b/packages/ppx_regexp/ppx_regexp.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ppx_regexp/releases/download/v0.4.0/ppx_regexp-0.4.0.tbz"
+checksum: "44691d6e1c6c02300329a4eb769922ab"

--- a/packages/ppx_tyre/ppx_tyre.0.4.0/descr
+++ b/packages/ppx_tyre/ppx_tyre.0.4.0/descr
@@ -1,0 +1,28 @@
+PPX syntax for tyre regular expressions and routes
+
+This PPX compiles
+
+    [%tyre {|re|}]
+
+into `'a Tyre.t` and
+
+    function%tyre
+    | {|re1|} as x1 -> e1
+    ...
+    | {|reN|} as x2 -> eN
+
+into `'a Type.route`, where `re`, `re1`, ... are regular expressions
+expressed in a slightly extended subset of PCRE.  The interpretations are:
+
+- `re?` extracts an option of what `re` extracts.
+- `re+`, `re*`, `re{n,m}` extracts a list of what `re` extracts.
+- `(?@qname)` refers to any identifier bound to a typed regular expression
+  of type `'a Tyre.t`.
+- One or more `(?<v>re)` at the top level can be used to bind variables
+  instead of `as ...`.
+- One or more `(?<v>re)` in a sequence extracts an object where each method
+  `v` is bound to what `re` extracts.
+- An alternative with one `(?<v>re)` per branch extracts a polymorphic
+  variant where each constructor `` `v`` receives what `re` extracts as its
+  argument.
+- `(?&v:qname)` is a shortcut for `(?<v>(?&qname))`.

--- a/packages/ppx_tyre/ppx_tyre.0.4.0/opam
+++ b/packages/ppx_tyre/ppx_tyre.0.4.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Gabriel Radanne <drupyog@zoho.com>"
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+]
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+dev-repo: "https://github.com/paurkedal/ppx_regexp.git"
+license: "LGPL-3 with OCaml linking exception"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {build}
+  "ocaml-migrate-parsetree"
+  "re" {>= "1.7.1"}
+  "ppx_tools_versioned"
+  "tyre" {>= "0.4.1"}
+  "qcheck" {test}
+]
+available: [ocaml-version >= "4.06.0"]

--- a/packages/ppx_tyre/ppx_tyre.0.4.0/url
+++ b/packages/ppx_tyre/ppx_tyre.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/paurkedal/ppx_regexp/releases/download/v0.4.0/ppx_regexp-0.4.0.tbz"
+checksum: "44691d6e1c6c02300329a4eb769922ab"


### PR DESCRIPTION
This PR updates `ppx_regexp` and adds `ppx_tyre` (syntax support for tyre).  Both packages are based on the same repo and the plan is to keep versions is sync.