### PR TITLE
Package minisat.0.2

### DIFF
--- a/packages/minisat/minisat.0.2/descr
+++ b/packages/minisat/minisat.0.2/descr
@@ -1,0 +1,1 @@
+Bindings to Minisat-C-1.14.1, with the solver included

--- a/packages/minisat/minisat.0.2/opam
+++ b/packages/minisat/minisat.0.2/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/ocaml-minisat/"
+bug-reports: "https://github.com/c-cube/ocaml-minisat/issues"
+tags: ["minisat" "solver" "SAT"]
+license: "BSD-2-clause"
+dev-repo: "git+https://github.com/c-cube/ocaml-minisat.git"
+build: ["dune" "build" "-p" name]
+build-test: ["dune" "runtest"]
+build-doc: ["dune" "build" "@doc" "-p" name]
+depends: [
+  "dune" {build}
+  "odoc" {doc}
+]

--- a/packages/minisat/minisat.0.2/url
+++ b/packages/minisat/minisat.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/ocaml-minisat/archive/0.2.tar.gz"
+checksum: "792f4ba8fb4fe03948d006f2d33aaf04"


### PR DESCRIPTION
### `minisat.0.2`

Bindings to Minisat-C-1.14.1, with the solver included



---
* Homepage: https://github.com/c-cube/ocaml-minisat/
* Source repo: git+https://github.com/c-cube/ocaml-minisat.git
* Bug tracker: https://github.com/c-cube/ocaml-minisat/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5