### PR TITLE
Add a version of ocaml-manual for OCaml 4.07.0

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.4.07.0/descr
+++ b/packages/ocaml-manual/ocaml-manual.4.07.0/descr
@@ -1,0 +1,1 @@
+The OCaml system manual

--- a/packages/ocaml-manual/ocaml-manual.4.07.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.07.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
+dev-repo: "https://github.com/ocaml/ocaml.git"
+bug-reports: "http://caml.inria.fr/mantis/"
+available: [ ocaml-version >= "4.07.0" & ocaml-version < "4.08.0" ]
+build:
+[
+ [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+]

--- a/packages/ocaml-manual/ocaml-manual.4.07.0/url
+++ b/packages/ocaml-manual/ocaml-manual.4.07.0/url
@@ -1,0 +1,2 @@
+archive: "http://caml.inria.fr/distrib/ocaml-4.07/ocaml-4.07-refman-html.tar.gz"
+checksum: "213876c268a93250ed766b159bc3f7be"


### PR DESCRIPTION
The changes required seemed very small and this was absent.