### PR TITLE
Package ocamlformat.0.7

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.7/descr
+++ b/packages/ocamlformat/ocamlformat.0.7/descr
@@ -1,0 +1,3 @@
+Auto-formatter for OCaml code
+
+OCamlFormat is a tool to automatically format OCaml code in a uniform style.

--- a/packages/ocamlformat/ocamlformat.0.7/opam
+++ b/packages/ocamlformat/ocamlformat.0.7/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["tools/gen_version.sh" "src/Version.ml" version] {pinned}
+  ["dune" "build" "-p" "ocamlformat_support,ocamlformat" "-j" jobs]
+]
+depends: [
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {build}
+  "ocaml-migrate-parsetree" {>= "1.0.10"}
+  "stdio"
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/ocamlformat/ocamlformat.0.7/url
+++ b/packages/ocamlformat/ocamlformat.0.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocamlformat/archive/0.7.tar.gz"
+checksum: "820682dc16465cf455e2715f2d4f50a3"


### PR DESCRIPTION
### `ocamlformat.0.7`

Auto-formatter for OCaml code

OCamlFormat is a tool to automatically format OCaml code in a uniform style.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat
* Source repo: https://github.com/ocaml-ppx/ocamlformat.git
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---

:camel: Pull-request generated by opam-publish v0.3.5