### PR TITLE
patch the compiler source to fix compilation with glibc ≥ 2.26

### DIFF
--- a/compilers/3.07/3.07+1/3.07+1.comp
+++ b/compilers/3.07/3.07+1/3.07+1.comp
@@ -5,6 +5,7 @@ patches: ["https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.07/3.07+2/3.07+2.comp
+++ b/compilers/3.07/3.07+2/3.07+2.comp
@@ -5,6 +5,7 @@ patches: ["https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.07/3.07/3.07.comp
+++ b/compilers/3.07/3.07/3.07.comp
@@ -4,6 +4,7 @@ src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
 build: [
   # ensure sed is not interpreting characters >= 128
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.08.0/3.08.0/3.08.0.comp
+++ b/compilers/3.08.0/3.08.0/3.08.0.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.08.0"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.08.1/3.08.1/3.08.1.comp
+++ b/compilers/3.08.1/3.08.1/3.08.1.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.08.1"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.08.2/3.08.2/3.08.2.comp
+++ b/compilers/3.08.2/3.08.2/3.08.2.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.08.2"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.08.3/3.08.3/3.08.3.comp
+++ b/compilers/3.08.3/3.08.3/3.08.3.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.08.3"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.08.4/3.08.4/3.08.4.comp
+++ b/compilers/3.08.4/3.08.4/3.08.4.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.08.4"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.09.0/3.09.0/3.09.0.comp
+++ b/compilers/3.09.0/3.09.0/3.09.0.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.09.0"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.09.1/3.09.1/3.09.1.comp
+++ b/compilers/3.09.1/3.09.1/3.09.1.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.09.1"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.09.2/3.09.2/3.09.2.comp
+++ b/compilers/3.09.2/3.09.2/3.09.2.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.09.2"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.09.3/3.09.3/3.09.3.comp
+++ b/compilers/3.09.3/3.09.3/3.09.3.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.09.3"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/compilers/3.10.0/3.10.0/3.10.0.comp
+++ b/compilers/3.10.0/3.10.0/3.10.0.comp
@@ -2,6 +2,7 @@ opam-version: "1"
 version: "3.10.0"
 src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals_asm.c" ]
   ["./configure"
     "-prefix" prefix
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }


### PR DESCRIPTION
- glibc versions ≥ 2.26 have retired the `struct sigaltstack` tag name
- use the POSIX `stack_t` name instead

fixes #12504