### PR TITLE
+x509.0.6.2

### DIFF
--- a/packages/x509/x509.0.6.2/descr
+++ b/packages/x509/x509.0.6.2/descr
@@ -1,0 +1,10 @@
+Public Key Infrastructure purely in OCaml
+
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority.  Authorities must be exchanged over a second channel to establish the
+trust relationship.  This library implements most parts of
+[RFC5280](https://tools.ietf.org/html/rfc5280) and
+[RFC6125](https://tools.ietf.org/html/rfc6125).
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).

--- a/packages/x509/x509.0.6.2/opam
+++ b/packages/x509/x509.0.6.2/opam
@@ -1,0 +1,40 @@
+opam-version: "1.2"
+name:         "x509"
+homepage:     "https://github.com/mirleft/ocaml-x509"
+dev-repo:     "https://github.com/mirleft/ocaml-x509.git"
+bug-reports:  "https://github.com/mirleft/ocaml-x509/issues"
+doc:          "https://mirleft.github.io/ocaml-x509/doc"
+author:       [ "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   [ "Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>" ]
+license:      "BSD2"
+
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ppx_sexp_conv"
+  "result"
+  "cstruct" {>= "1.6.0"}
+  "sexplib"
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "nocrypto" {>= "0.5.3"}
+  "astring"
+  "ounit" {test}
+  "cstruct-unix" {test & >= "3.0.0"}
+]
+
+conflicts: [
+  "ppx_sexp_conv" {= "v0.11.0"}
+]
+
+tags: [ "org:mirage" ]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/x509/x509.0.6.2/url
+++ b/packages/x509/x509.0.6.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-x509/releases/download/0.6.2/x509-0.6.2.tbz"
+checksum: "b39c0ceae9bd22436bf5849316a7e0ee"


### PR DESCRIPTION
the changes only include support for `ppx_sexp_conv > v0.11.0`, which is required for 4.07.0 compatibility