### PR TITLE
+tls 0.9.2

### DIFF
--- a/packages/tls/tls.0.9.2/descr
+++ b/packages/tls/tls.0.9.2/descr
@@ -1,0 +1,15 @@
+Transport Layer Security purely in OCaml
+
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).

--- a/packages/tls/tls.0.9.2/opam
+++ b/packages/tls/tls.0.9.2/opam
@@ -1,0 +1,56 @@
+opam-version: "1.2"
+name:         "tls"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+author:       ["David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD2"
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+    "--with-lwt" "%{lwt+ptime:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ]
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+    "--with-lwt" "%{lwt+ptime+astring:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "ppx_cstruct" {>= "3.0.0"}
+  "result"
+  "cstruct" {>= "3.0.0"}
+  "sexplib"
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.6.1"}
+  "cstruct-unix" {test & >= "3.0.0"}
+  "ounit" {test}
+]
+depopts: [
+  "lwt"
+  "mirage-flow-lwt"
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "ptime"
+  "astring" {test}
+]
+conflicts: [
+  "lwt" {<"2.4.8"}
+  "mirage-net-xen" {<"1.3.0"}
+  "mirage-types" {<"3.0.0"}
+  "sexplib" {= "v0.9.0"}
+  "ppx_sexp_conv" {= "v0.11.0"}
+  "ptime" {< "0.8.1"}
+]
+
+tags: [ "org:mirage"]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/tls/tls.0.9.2/url
+++ b/packages/tls/tls.0.9.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-tls/releases/download/0.9.2/tls-0.9.2.tbz"
+checksum: "611e4b66825cb934c7e24b7ddf7b6c06"


### PR DESCRIPTION
NEWS in 0.9.2 (from changes):
- 4.07 support by adding an optional runtime dependency of `ppx_sexp_conv` (required since `v0.11.0`)
- ALPN (RFC [7301](https://tools.ietf.org/html/rfc7301)) support by @bobbypriambodo