### PR TITLE
ocp-index: constrain to ocaml versions below 4.07

### DIFF
--- a/packages/ocp-index/ocp-index.1.1.4/opam
+++ b/packages/ocp-index/ocp-index.1.1.4/opam
@@ -20,7 +20,7 @@ depopts: "lambda-term"
 conflicts: [
   "lambda-term" {< "1.7"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.07"]
 messages: [
   "For ocp-browser, please also install package lambda-term"
     {!lambda-term:installed}

--- a/packages/ocp-index/ocp-index.1.1.5/opam
+++ b/packages/ocp-index/ocp-index.1.1.5/opam
@@ -20,7 +20,7 @@ depopts: "lambda-term"
 conflicts: [
   "lambda-term" {< "1.7"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.07"]
 messages: [
   "For ocp-browser, please also install package lambda-term"
     {!lambda-term:installed}

--- a/packages/ocp-index/ocp-index.1.1.6/opam
+++ b/packages/ocp-index/ocp-index.1.1.6/opam
@@ -14,7 +14,7 @@ depends: [
   "re"
   "cmdliner"
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.07"]
 post-messages: [
   "
 This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:


### PR DESCRIPTION
As requested by @hcarty in #12513 