### PR TITLE
Release caqti.1.0.0

### DIFF
--- a/packages/caqti-async/caqti-async.1.0.0/opam
+++ b/packages/caqti-async/caqti-async.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "async" {>= "v0.11.0"}
+  "caqti" {>= "1.0.0" & < "2.0.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "core"
+  "dune" {build}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.0.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "1.1.0~"}
+  "dune" {build}
+  "mariadb" {>= "1.1.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.0.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "1.1.0~"}
+  "dune" {build}
+  "postgresql"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.0.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "1.1.0~"}
+  "dune" {build}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-dynload/caqti-dynload.1.0.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "caqti"
+  "dune" {build}
+  "ocamlfind"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Dynamic linking of Caqti drivers using findlib.dynload"
+description: """
+This library registers a dynamic linker which will be called when
+encoutering an unhandled database URI.  It tries to load a findlib package
+named "caqti-driver-<scheme>" where "<scheme>" is the scheme of the URI,
+which is expected register a driver for the scheme.
+
+This is a separate package to avoid the dependency on the findlib.dynload
+for architectures, like MirageOS, where dynamic linking may be unavailable.
+The alternative is to link drivers directly into the application.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-lwt/caqti-lwt.1.0.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "2.0.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "dune" {build}
+  "logs"
+  "lwt" {>= "3.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-type-calendar/caqti-type-calendar.1.0.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "2.0.0~"}
+  "calendar"
+  "dune" {build}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Date and time field types using the calendar library"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti/caqti.1.0.0/opam
+++ b/packages/caqti/caqti.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "logs"
+  "ptime"
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}


### PR DESCRIPTION
It's time for a stable release!

Changes since 0.11.0 include bug fixes, sub-second time precision for MariaDB, and adjustments of the driver API.