### PR TITLE
+ppx_tools_versioned.5.2.1

### DIFF
--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/descr
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/descr
@@ -1,0 +1,1 @@
+A variant of ppx_tools based on ocaml-migrate-parsetree

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Alain Frisch <alain.frisch@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/let-def/ppx_tools_versioned"
+bug-reports: "https://github.com/let-def/ppx_tools_versioned/issues"
+dev-repo: "git://github.com/let-def/ppx_tools_versioned.git"
+tags: [ "syntax" ]
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "jbuilder" {build & >= "1.0+beta17"}
+  "ocaml-migrate-parsetree" { >= "1.0.10" }
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/url
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.1.tar.gz"
+checksum: "1ae6ae43ec161fbbf12c2b4d3a7e26f5"


### PR DESCRIPTION
primarily fixes https://github.com/mirage/ocaml-cstruct/pull/204
and other pulls of compiler-libs due to using ppx

cc @let-def 