### PR TITLE
patch the compiler source to fix compilation with glibc ≥ 2.26 — version 2.0

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -12,6 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -11,6 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -12,6 +12,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals_asm.c" ]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]


### PR DESCRIPTION
same as #12510, but for the `2.0.0` branch.

fixes #12504