### PR TITLE
[new release] key-parsers (0.10.0)

### DIFF
--- a/packages/key-parsers/key-parsers.0.10.0/descr
+++ b/packages/key-parsers/key-parsers.0.10.0/descr
@@ -1,0 +1,3 @@
+Parsers for multiple key formats
+
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or Elliptic curve public and private keys.

--- a/packages/key-parsers/key-parsers.0.10.0/opam
+++ b/packages/key-parsers/key-parsers.0.10.0/opam
@@ -27,4 +27,4 @@ depends: [
 conflicts: [
   "ppx_driver" {= "v0.9.1"}
 ]
-available: [ocaml-version >= "4.04.1"]
+available: [ocaml-version >= "4.04.1" & ocaml-version < "4.07.0"]

--- a/packages/key-parsers/key-parsers.0.10.0/opam
+++ b/packages/key-parsers/key-parsers.0.10.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+author: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+build-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
+  "ounit" {test & >= "2.0.0"}
+  "hex" {>= "1.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "zarith" {>= "1.4.1"}
+  "result" {>= "1.2"}
+  "ppx_bin_prot"
+  "cstruct" {>= "1.6.0"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+available: [ocaml-version >= "4.04.1"]

--- a/packages/key-parsers/key-parsers.0.10.0/url
+++ b/packages/key-parsers/key-parsers.0.10.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/cryptosense/key-parsers/releases/download/0.10.0/key-parsers-0.10.0.tbz"
+checksum: "21762cff24aeefd3775000ce59519f85"


### PR DESCRIPTION
CHANGES:

*2018-08-27*

### Add

- Lowercase aliases for uppercase modules `RSA`, `DSA`, `EC` and `DH` in `Asn1`, `Cvc` and `Ltpa`

### Deprecates

- `Yojson` and `Bin_prot` (de)serializers are deprecated ahead of their removal in `1.0.0`.
- Uppercase modules such as `Asn1.RSA` in favor of their lowercase counterparts

### Changes

- Use dune instead of ocamlbuild and topkg
- Rename uppercase private variants and modules to lowercase ones