### PR TITLE
Partial format upgrade (ocaml-base-compiler.3.07, ocaml-base-compiler.3.08.0, ocaml-base-compiler.3.08.1, ocaml-base-compiler.3.08.2, ocaml-base-compiler.3.08.3, ...)

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -14,9 +14,9 @@ build: [
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -13,9 +13,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -14,9 +14,9 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals_asm.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.3.07+1/opam
+++ b/packages/ocaml-variants/ocaml-variants.3.07+1/opam
@@ -14,9 +14,9 @@ build: [
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-variants/ocaml-variants.3.07+2/opam
+++ b/packages/ocaml-variants/ocaml-variants.3.07+2/opam
@@ -14,9 +14,9 @@ build: [
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "darwin"}
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
   [make "install"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
@@ -13,7 +13,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -25,7 +25,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
@@ -19,7 +19,7 @@ build: [
     "-with-debug-runtime"
     "-no-naked-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -31,7 +31,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
@@ -13,7 +13,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "--statmemprof"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -24,7 +24,7 @@ build: [
     "cc -O2 -pipe"
     "-aspp"
     "cc -O2 -pipe -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sh" "./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -41,7 +41,7 @@ build: [
     "gcc -arch i386 -m32 -c"
     "-host"
     "i386-apple-darwin13.2.0"
-  ] {os = "darwin"}
+  ] {os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-afl-instrument"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,7 +23,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-default-unsafe-string"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,7 +28,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -19,7 +19,7 @@ build: [
     "-with-debug-runtime"
     "-flambda"
     "-no-flat-float-array"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -31,7 +31,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,7 +23,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,7 +23,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -18,7 +18,7 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -30,7 +30,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,7 +28,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-afl-instrument"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -18,7 +18,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-default-unsafe-string"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -29,7 +29,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,7 +23,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -13,7 +13,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -24,7 +24,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
@@ -19,7 +19,7 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -31,7 +31,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,7 +28,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-afl-instrument"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -18,7 +18,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-default-unsafe-string"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -29,7 +29,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -23,7 +23,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -13,7 +13,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -24,7 +24,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
@@ -19,7 +19,7 @@ build: [
     "-with-debug-runtime"
     "-with-frame-pointers"
     "-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -31,7 +31,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
@@ -17,7 +17,7 @@ build: [
     prefix
     "-with-debug-runtime"
     "-with-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "darwin"}
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -28,7 +28,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -12,7 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "darwin"}
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"
@@ -22,7 +22,7 @@ build: [
     "cc"
     "-aspp"
     "cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "darwin"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
 ]


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc3
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
  - packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
  - packages/ocaml-variants/ocaml-variants.3.07+1/opam
  - packages/ocaml-variants/ocaml-variants.3.07+2/opam