### PR TITLE
Package orpie.1.6.0

### DIFF
--- a/packages/orpie/orpie.1.6.0/descr
+++ b/packages/orpie/orpie.1.6.0/descr
@@ -1,0 +1,5 @@
+Curses-based RPN calculator
+
+Orpie is a curses-based RPN calculator for the terminal.  It supports a
+large chunk of the features supported by classic HP RPN calculators, but
+the user interface is optimized for a keyboard.

--- a/packages/orpie/orpie.1.6.0/opam
+++ b/packages/orpie/orpie.1.6.0/opam
@@ -8,7 +8,6 @@ dev-repo: "https://github.com/pelzlpj/orpie.git"
 build: ["dune" "build" "-p" "orpie"]
 available: [ ocaml-version >= "4.03.0" ]
 depends: [
-  "ocamlfind" {build}
   "camlp5" {build}
   "dune" {build & >= "1.1"}
   "curses" {>= "1.0.3"}

--- a/packages/orpie/orpie.1.6.0/opam
+++ b/packages/orpie/orpie.1.6.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+authors: "Paul Pelzl <pelzlpj@gmail.com>"
+homepage: "https://github.com/pelzlpj/orpie"
+bug-reports: "https://github.com/pelzlpj/orpie/issues"
+license: "GPL-3"
+dev-repo: "https://github.com/pelzlpj/orpie.git"
+build: ["dune" "build" "-p" "orpie"]
+available: [ ocaml-version >= "4.03.0" ]
+depends: [
+  "ocamlfind" {build}
+  "camlp5" {build}
+  "dune" {build & >= "1.1"}
+  "curses" {>= "1.0.3"}
+  "gsl" {>= "1.22.0"}
+  "num"
+]

--- a/packages/orpie/orpie.1.6.0/url
+++ b/packages/orpie/orpie.1.6.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/pelzlpj/orpie/archive/release-1.6.0.tar.gz"
+checksum: "ff24eb67a8a8359bd71045c45466eadb"


### PR DESCRIPTION
### `orpie.1.6.0`

Curses-based RPN calculator

Orpie is a curses-based RPN calculator for the terminal.  It supports a
large chunk of the features supported by classic HP RPN calculators, but
the user interface is optimized for a keyboard.



---
* Homepage: https://github.com/pelzlpj/orpie
* Source repo: https://github.com/pelzlpj/orpie.git
* Bug tracker: https://github.com/pelzlpj/orpie/issues

---

:camel: Pull-request generated by opam-publish v0.3.5