### PR TITLE
Package tip-parser.0.4

### DIFF
--- a/packages/smbc/smbc.0.2/opam
+++ b/packages/smbc/smbc.0.2/opam
@@ -14,7 +14,7 @@ depends: [
   "containers" {> "0.16" < "1.0" }
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.6"}
-  "tip-parser" {>= "0.3"}
+  "tip-parser" {>= "0.3" < "0.4"}
   "menhir"
 ]
 available: [ocaml-version >= "4.01"]

--- a/packages/smbc/smbc.0.3.1/opam
+++ b/packages/smbc/smbc.0.3.1/opam
@@ -14,7 +14,7 @@ depends: [
   "containers" {>= "1.0" < "2.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.7"}
-  "tip-parser" {>= "0.3"}
+  "tip-parser" {>= "0.3" < "0.4"}
   "menhir"
 ]
 available: [ocaml-version >= "4.01"]

--- a/packages/smbc/smbc.0.3/opam
+++ b/packages/smbc/smbc.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "containers" {> "0.16" & < "1.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.7"}
-  "tip-parser" {>= "0.3"}
+  "tip-parser" {>= "0.3" < "0.4"}
   "menhir"
 ]
 available: [ocaml-version >= "4.01"]

--- a/packages/smbc/smbc.0.4.1/opam
+++ b/packages/smbc/smbc.0.4.1/opam
@@ -14,7 +14,7 @@ depends: [
   "containers" {>= "1.0" < "2.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.8"}
-  "tip-parser" {>= "0.3"}
+  "tip-parser" {>= "0.3" < "0.4"}
   "menhir"
 ]
 available: [ocaml-version >= "4.01"]

--- a/packages/smbc/smbc.0.4.2/opam
+++ b/packages/smbc/smbc.0.4.2/opam
@@ -12,6 +12,6 @@ depends: [
   "containers" {>= "1.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.8"}
-  "tip-parser" {>= "0.3"}
+  "tip-parser" {>= "0.3" < "0.4"}
 ]
 available: [ocaml-version >= "4.03"]

--- a/packages/smbc/smbc.0.4/opam
+++ b/packages/smbc/smbc.0.4/opam
@@ -14,7 +14,7 @@ depends: [
   "containers" {>= "1.0" < "2.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.8"}
-  "tip-parser" {>= "0.3"}
+  "tip-parser" {>= "0.3" < "0.4"}
   "menhir"
 ]
 available: [ocaml-version >= "4.01"]

--- a/packages/tip-parser/tip-parser.0.4/descr
+++ b/packages/tip-parser/tip-parser.0.4/descr
@@ -1,0 +1,5 @@
+Parser for TIP (Tons of Inductive Problems)
+
+A simple AST and parser/printer for TIP (https://tip-org.github.io/), a simple
+format for writing problems in a typed logic with computable functions,
+datatypes, and axioms.

--- a/packages/tip-parser/tip-parser.0.4/opam
+++ b/packages/tip-parser/tip-parser.0.4/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/tip-parser/"
+bug-reports: "https://github.com/c-cube/tip-parser/issues"
+tags: ["TIP" "parse" "inductive" "logic"]
+dev-repo: "https://github.com/c-cube/tip-parser.git"
+build: ["dune" "build" "-p" name]
+build-test: ["dune" "runtest" "-p" name]
+build-doc: ["dune" "build" "@doc" "-p" name]
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {doc}
+]

--- a/packages/tip-parser/tip-parser.0.4/url
+++ b/packages/tip-parser/tip-parser.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/c-cube/tip-parser/archive/0.4.tar.gz"
+checksum: "8c95a6a99ec2ad2caf9b6383c91e1e0c"

--- a/packages/zipperposition/zipperposition.1.1/opam
+++ b/packages/zipperposition/zipperposition.1.1/opam
@@ -38,7 +38,7 @@ depends: [
   "oclock"
   "msat" {>= "0.5"}
   "menhir" {build}
-  "tip-parser"
+  "tip-parser" { < "0.4" }
   "num"
 ]
 depopts: [

--- a/packages/zipperposition/zipperposition.1.2/opam
+++ b/packages/zipperposition/zipperposition.1.2/opam
@@ -37,7 +37,7 @@ depends: [
   "sequence" {>= "0.4" < "1.0" }
   "msat" {>= "0.5"}
   "menhir" {build}
-  "tip-parser"
+  "tip-parser" { < "0.4" }
 ]
 depopts: [
   "qcheck" {test}


### PR DESCRIPTION
### `tip-parser.0.4`

Parser for TIP (Tons of Inductive Problems)

A simple AST and parser/printer for TIP (https://tip-org.github.io/), a simple
format for writing problems in a typed logic with computable functions,
datatypes, and axioms.



---
* Homepage: https://github.com/c-cube/tip-parser/
* Source repo: https://github.com/c-cube/tip-parser.git
* Bug tracker: https://github.com/c-cube/tip-parser/issues

---

:camel: Pull-request generated by opam-publish v0.3.5