### PR TITLE
Package ocp-reloc.0.1

### DIFF
--- a/packages/ocp-reloc/ocp-reloc.0.1/descr
+++ b/packages/ocp-reloc/ocp-reloc.0.1/descr
@@ -1,0 +1,4 @@
+Relocation of OCaml bytecode executables
+
+Changes the headers of (non-custom) OCaml bytecode files to account for a
+different location of ocamlrun than what is was built into the compiler.

--- a/packages/ocp-reloc/ocp-reloc.0.1/opam
+++ b/packages/ocp-reloc/ocp-reloc.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "http://www.typerex.org"
+bug-reports: "https://github.com/OCamlPro/ocp-reloc/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "git://github.com/OCamlPro/ocp-reloc"
+build: [
+  "ocamlfind"
+  "ocamlopt"
+  "-package"
+  "unix,cmdliner"
+  "-linkpkg"
+  "-I"
+  "src"
+  "src/reloc.mli"
+  "src/reloc.ml"
+  "src/relocMain.ml"
+  "-o"
+  "ocp-reloc"
+]
+depends: [
+  "ocamlfind" {build}
+  "cmdliner" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ocp-reloc/ocp-reloc.0.1/url
+++ b/packages/ocp-reloc/ocp-reloc.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AltGr/ocp-reloc/archive/0.1.tar.gz"
+checksum: "050377bbd4c0c8711cd9baf891212d68"


### PR DESCRIPTION
### `ocp-reloc.0.1`

Relocation of OCaml bytecode executables

Changes the headers of (non-custom) OCaml bytecode files to account for a
different location of ocamlrun than what is was built into the compiler.



---
* Homepage: http://www.typerex.org
* Source repo: git://github.com/OCamlPro/ocp-reloc
* Bug tracker: https://github.com/OCamlPro/ocp-reloc/issues

---

:camel: Pull-request generated by opam-publish v0.3.5