### PR TITLE
ppx_tools_versioned.5.2: avoid installation thereof (leads to huge binaries), fixed in 5.2.1

### DIFF
--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2/opam
@@ -18,4 +18,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta17"}
   "ocaml-migrate-parsetree" { >= "0.5" }
 ]
-available: ocaml-version >= "4.02.0"
+available: false


### PR DESCRIPTION
would be happy to hear what @avsm @samoht and other think about this, my reasoning is that I'd like to avoid anyone from installing this package.  I'd be glad to remove the metadata completely instead of marking it as unavailable (as you prefer).