### PR TITLE
[frama-c] blacklist incompatible why3 version

### DIFF
--- a/packages/frama-c/frama-c.20171101/opam
+++ b/packages/frama-c/frama-c.20171101/opam
@@ -88,10 +88,6 @@ build-doc: [
    [make "-C" "doc" "install"]
 ]
 
-build-test: [
-  [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"]
-]
-
 depends: [
   "ocamlgraph" { >= "1.8.8" & < "1.9~" }
   "ocamlfind"

--- a/packages/frama-c/frama-c.20171101/opam
+++ b/packages/frama-c/frama-c.20171101/opam
@@ -116,7 +116,7 @@ messages: [
 ]
 
 conflicts: [
-  "why3-base" { < "0.86" } #for WP plug-in
+  "why3-base" { < "0.86" >= "1.0.0" } #for WP plug-in
   "coq"      { < "8.4.6" } #for WP plug-in
   "coq"      { >= "8.7"  } #for WP plug-in
   "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1

--- a/packages/frama-c/frama-c.20180501/opam
+++ b/packages/frama-c/frama-c.20180501/opam
@@ -119,7 +119,7 @@ messages: [
 ]
 
 conflicts: [
-  "why3-base" { < "0.88" } #for WP plug-in
+  "why3-base" { < "0.88" >= "1.0.0" } #for WP plug-in
   "coq"      { < "8.4.6" } #for WP plug-in
   "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1
   "frama-c-e-acsl" #avoid mixing old releases of E-ACSL, it is already

--- a/packages/frama-c/frama-c.20180502/opam
+++ b/packages/frama-c/frama-c.20180502/opam
@@ -119,7 +119,7 @@ messages: [
 ]
 
 conflicts: [
-  "why3-base" { < "0.88" } #for WP plug-in
+  "why3-base" { < "0.88" >= "1.0.0" } #for WP plug-in
   "coq"      { < "8.4.6" } #for WP plug-in
   "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1
   "frama-c-e-acsl" #avoid mixing old releases of E-ACSL, it is already


### PR DESCRIPTION
why3 1.0.0 was released shortly before Frama-C-20180502, but both are incompatible. Compilation works, but some specific parts of Frama-C are not compatible with this version of why3, so it is blacklisted in the latest versions of Frama-C (to avoid opam from trying to downgrade Frama-C if this version of why3 is already installed).