### PR TITLE
Added 4.07.0+32bit switch.

### DIFF
--- a/compilers/4.07.0/4.07.0+32bit/4.07.0+32bit.comp
+++ b/compilers/4.07.0/4.07.0+32bit/4.07.0+32bit.comp
@@ -1,0 +1,27 @@
+opam-version: "1"
+version: "4.07.0"
+src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"
+   "-cc" "gcc -m32"
+   "-as" "as --32"
+   "-aspp" "gcc -m32 -c"
+   "-host" "i386-linux"
+   "-partialld" "ld -r -melf_i386"
+  ] {os = "linux"}
+  ["./configure" "-prefix" prefix "-with-debug-runtime"
+   "-cc" "gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+    "-as" "as -arch i386"
+    "-aspp" "gcc -arch i386 -m32 -c"
+    "-host" "i386-apple-darwin13.2.0"
+  ] {os = "darwin"}
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.07.0/4.07.0+32bit/4.07.0+32bit.descr
+++ b/compilers/4.07.0/4.07.0+32bit/4.07.0+32bit.descr
@@ -1,0 +1,1 @@
+OCaml 4.07.0 compiled in 32-bit mode for 64-bit Linux and OS X hosts


### PR DESCRIPTION
This switch is particularly useful for [ocaml-cross/opam-cross-windows](https://github.com/ocaml-cross/opam-cross-windows/)