### PR TITLE
[new release] callipyge (v0.2)

### DIFF
--- a/packages/callipyge/callipyge.0.2/descr
+++ b/packages/callipyge/callipyge.0.2/descr
@@ -1,0 +1,4 @@
+Pure OCaml implementation of Curve25519.
+
+Pure OCaml implementation of Curve25519.
+

--- a/packages/callipyge/callipyge.0.2/opam
+++ b/packages/callipyge/callipyge.0.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name:         "callipyge"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/oklm-wsh/callipyge"
+bug-reports:  "https://github.com/oklm-wsh/callipyge/issues"
+dev-repo:     "https://github.com/oklm-wsh/callipyge.git"
+doc:          "https://oklm-wsh.github.io/callipyge/"
+license:      "MIT"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+
+depends: [
+  "jbuilder" {build}
+  "fmt"
+  "eqaf"
+  "alcotest" {test}
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/callipyge/callipyge.0.2/url
+++ b/packages/callipyge/callipyge.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/oklm-wsh/callipyge/releases/download/v0.2/callipyge-0.2.tbz"
+checksum: "99084083c29ce79f92330f97b59f5bb4"


### PR DESCRIPTION
CHANGES:

* New version of Callipyge (**break API**) (thx to @cfcs, @hannesm and @emillon)
* Fix tests
* Benchmarks