### PR TITLE
mirage-{protocols,stack} reverse dependencies adjust upper bounds (prepare for API changes)

### DIFF
--- a/packages/charrua-client-mirage/charrua-client-mirage.0.9/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.9/opam
@@ -31,6 +31,6 @@ depends: [
   "tcpip" {>= "3.2.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>="3.0.0"}
+  "mirage-types-lwt" {>="3.0.0" & < "3.2.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
@@ -15,9 +15,9 @@ build: [
 depends: [
   "jbuilder"  {build & >="1.0+beta9"}
   "mirage-qubes" {>= "0.5" }
-  "tcpip"
+  "tcpip" {>= "3.0.0" & < "3.5.0"}
   "ipaddr"
-  "mirage-protocols-lwt"
+  "mirage-protocols-lwt" {< "1.4.0"}
   "cstruct" { >= "1.9.0" }
   "lwt"
   "mirage-types-lwt" { >= "3.0.0" }

--- a/packages/mirage-qubes/mirage-qubes.0.4/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.4/opam
@@ -28,4 +28,9 @@ depopts: [
   "tcpip"
   "mirage-protocols-lwt"
 ]
+conflicts: [
+  "tcpip" {< "3.0.0"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-protocols-lwt" {>= "1.4.0"}
+]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-stack/mirage-stack.1.2.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
   "mirage-device" {>= "1.0.0"}
-  "mirage-protocols" {>= "1.3.0"}
+  "mirage-protocols" {>= "1.3.0" & < "1.4.0"}
   "fmt"
 ]
 

--- a/packages/mirage/mirage.3.0.1/opam
+++ b/packages/mirage/mirage.3.0.1/opam
@@ -27,5 +27,6 @@ conflicts: [
   "cstruct"  {< "1.0.1"}
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.2/opam
+++ b/packages/mirage/mirage.3.0.2/opam
@@ -27,5 +27,6 @@ conflicts: [
   "cstruct"  {< "1.0.1"}
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.4/opam
+++ b/packages/mirage/mirage.3.0.4/opam
@@ -29,5 +29,6 @@ conflicts: [
   "mirage-qubes" {< "0.5" }
   "mirage-solo5" {< "0.2.1" }
   "crunch"   {< "1.2.2"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.5/opam
+++ b/packages/mirage/mirage.3.0.5/opam
@@ -30,5 +30,6 @@ conflicts: [
   "cstruct"  {< "1.0.1"}
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.7/opam
+++ b/packages/mirage/mirage.3.0.7/opam
@@ -30,5 +30,6 @@ conflicts: [
   "cstruct"  {< "1.0.1"}
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.04.2" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.8/opam
+++ b/packages/mirage/mirage.3.0.8/opam
@@ -30,5 +30,6 @@ conflicts: [
   "cstruct"  {< "1.0.1"}
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.04.2" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.1.0/opam
+++ b/packages/mirage/mirage.3.1.0/opam
@@ -29,5 +29,6 @@ conflicts: [
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.04.2" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.1.1/opam
+++ b/packages/mirage/mirage.3.1.1/opam
@@ -29,5 +29,6 @@ conflicts: [
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
+  "tcpip"    {>= "3.5.0"}
 ]
 available: [ocaml-version >= "4.04.2"]

--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -31,9 +31,9 @@ depends: [
   "mirage-clock" {>= "1.2.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
-  "mirage-stack-lwt" {>= "1.2.0"}
-  "mirage-protocols" {>= "1.3.0"}
-  "mirage-protocols-lwt" {>= "1.3.0"}
+  "mirage-stack-lwt" {>= "1.2.0" & < "1.3.0"}
+  "mirage-protocols" {>= "1.3.0" & < "1.4.0"}
+  "mirage-protocols-lwt" {>= "1.3.0" & < "1.4.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}

--- a/packages/tcpip/tcpip.3.4.1/opam
+++ b/packages/tcpip/tcpip.3.4.1/opam
@@ -31,9 +31,9 @@ depends: [
   "mirage-clock" {>= "1.2.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
-  "mirage-stack-lwt" {>= "1.2.0"}
-  "mirage-protocols" {>= "1.3.0"}
-  "mirage-protocols-lwt" {>= "1.3.0"}
+  "mirage-stack-lwt" {>= "1.2.0" & < "1.3.0"}
+  "mirage-protocols" {>= "1.3.0" & < "1.4.0"}
+  "mirage-protocols-lwt" {>= "1.3.0" & < "1.4.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}


### PR DESCRIPTION
(as explained in https://github.com/mirage/mirage-protocols/pull/11) -- I hope I got most of them in here :)