### PR TITLE
mirage-types{-lwt}: adjust upper bounds of mirage-protocols and mirage-stack

### DIFF
--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/opam
@@ -20,8 +20,8 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-protocols-lwt" {>= "1.0.0"}
-  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
@@ -23,8 +23,8 @@ depends:   [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-protocols-lwt" {>= "1.0.0"}
-  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
@@ -23,8 +23,8 @@ depends:   [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-protocols-lwt" {>= "1.0.0"}
-  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
@@ -23,8 +23,8 @@ depends:   [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-protocols-lwt" {>= "1.0.0"}
-  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
@@ -23,8 +23,8 @@ depends:   [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-protocols-lwt" {>= "1.0.0"}
-  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/mirage-types/mirage-types.3.0.0/opam
+++ b/packages/mirage-types/mirage-types.3.0.0/opam
@@ -18,8 +18,8 @@ depends:   [
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}
-  "mirage-protocols" {>= "1.0.0"}
-  "mirage-stack" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack" {>= "1.0.0" & < "1.3.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0"}
   "mirage-fs" {>= "1.0.0"}

--- a/packages/mirage-types/mirage-types.3.0.5/opam
+++ b/packages/mirage-types/mirage-types.3.0.5/opam
@@ -22,8 +22,8 @@ depends:   [
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}
-  "mirage-protocols" {>= "1.0.0"}
-  "mirage-stack" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack" {>= "1.0.0" & < "1.3.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0"}
   "mirage-fs" {>= "1.0.0"}

--- a/packages/mirage-types/mirage-types.3.0.7/opam
+++ b/packages/mirage-types/mirage-types.3.0.7/opam
@@ -22,8 +22,8 @@ depends:   [
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}
-  "mirage-protocols" {>= "1.0.0"}
-  "mirage-stack" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack" {>= "1.0.0" & < "1.3.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0"}
   "mirage-fs" {>= "1.0.0"}

--- a/packages/mirage-types/mirage-types.3.1.0/opam
+++ b/packages/mirage-types/mirage-types.3.1.0/opam
@@ -22,8 +22,8 @@ depends:   [
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}
-  "mirage-protocols" {>= "1.0.0"}
-  "mirage-stack" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack" {>= "1.0.0" & < "1.3.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0"}
   "mirage-fs" {>= "1.0.0"}

--- a/packages/mirage-types/mirage-types.3.1.1/opam
+++ b/packages/mirage-types/mirage-types.3.1.1/opam
@@ -22,8 +22,8 @@ depends:   [
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}
-  "mirage-protocols" {>= "1.0.0"}
-  "mirage-stack" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
+  "mirage-stack" {>= "1.0.0" & < "1.3.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0"}
   "mirage-fs" {>= "1.0.0"}


### PR DESCRIPTION
see #12562 (this is just the mirage-types/-lwt packages)