### PR TITLE
[new release] fftw3 (0.8.2)

### DIFF
--- a/packages/conf-fftw3/conf-fftw3.1/descr
+++ b/packages/conf-fftw3/conf-fftw3.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on a FFTW3 lib system installation.
+This package can only install if the FFTW3 lib is installed on the system.

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -5,6 +5,9 @@ homepage: "http://www.fftw.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL"
 build: [["pkg-config" "fftw3"]]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
   [ [ "ubuntu"  ] [ "libfftw3-dev" ] ]
   [ [ "debian"  ] [ "libfftw3-dev" ] ]

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "http://www.fftw.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL"
+build: [["pkg-config" "fftw3"]]
+depexts: [
+  [ [ "ubuntu"  ] [ "libfftw3-dev" ] ]
+  [ [ "debian"  ] [ "libfftw3-dev" ] ]
+  [ [ "centos"  ] [ "fftw-devel" ] ]
+  [ [ "alpine"  ] [ "fftw-dev" ] ]
+  [ [ "fedora"  ] [ "fftw-devel" ] ]
+  [ [ "rhel"    ] [ "fftw-devel" ] ]
+  [ [ "mageia"  ] [ "libfftw-devel" ] ]
+  [ [ "opensuse" ] [ "fftw3-devel" ] ]
+  [ [ "freebsd" ] [ "math/fftw3" ] ]
+  [ [ "openbsd" ] [ "math/fftw3" ] ]
+  [ [ "osx" "homebrew" ] [ "fftw" ] ]
+]

--- a/packages/fftw3/fftw3.0.8.2/descr
+++ b/packages/fftw3/fftw3.0.8.2/descr
@@ -1,0 +1,1 @@
+Binding to the famous Fast Fourier Transform library FFTW

--- a/packages/fftw3/fftw3.0.8.2/opam
+++ b/packages/fftw3/fftw3.0.8.2/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+maintainer: "Christophe.Troestler@umons.ac.be"
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/fftw-ocaml"
+dev-repo: "https://github.com/Chris00/fftw-ocaml.git"
+bug-reports: "https://github.com/Chris00/fftw-ocaml/issues"
+doc: "https://Chris00.github.io/fftw-ocaml/doc"
+tags: ["FFT"]
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ] { os != "darwin" }
+  [ "env" "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
+    "dune" "build" "-p" name "-j" jobs ] { os = "darwin" }
+]
+build-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
+depends: [
+  "dune" {build}
+  "cppo"     {build}
+  "lacaml" {test}
+  "conf-fftw3"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/fftw3/fftw3.0.8.2/url
+++ b/packages/fftw3/fftw3.0.8.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/fftw-ocaml/releases/download/0.8.2/fftw3-0.8.2.tbz"
+checksum: "c0729cf62f11485f23b6e6785a67ed28"


### PR DESCRIPTION
Binding to the famous Fast Fourier Transform library FFTW

- Project page: <a href="https://github.com/Chris00/fftw-ocaml">https://github.com/Chris00/fftw-ocaml</a>
- Documentation: <a href="https://Chris00.github.io/fftw-ocaml/doc">https://Chris00.github.io/fftw-ocaml/doc</a>

##### CHANGES:

- Fix enabling the single precision module `Fftw3.S`.
- Enable robustness tests at compile time (thanks to Dune.configurator).
- Switch to Dune.
- Rely on a `conf-fftw3` package for the presence of the C FFTW3 library.
