### PR TITLE
[new release] edn (v0.1.6)

### DIFF
--- a/packages/edn/edn.0.1.6/descr
+++ b/packages/edn/edn.0.1.6/descr
@@ -1,0 +1,3 @@
+Parsing OCaml library for EDN format
+
+This library implements [EDN][edn] parser and generator for OCaml.

--- a/packages/edn/edn.0.1.6/opam
+++ b/packages/edn/edn.0.1.6/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+license: "MIT"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+dev-repo: "https://github.com/prepor/ocaml-edn.git"
+doc: "https://prepor.github.io/ocaml-edn/doc"
+build: ["dune" "build" "-p" name "-j" jobs]
+build-test: ["dune" "runtest" "-p" name "-j" jobs]
+depends: [
+  "dune" {build}
+  "menhir" {build}
+  "oUnit" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.6/url
+++ b/packages/edn/edn.0.1.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/prepor/ocaml-edn/releases/download/v0.1.6/edn-0.1.6.tbz"
+checksum: "c233f7ad13b22ba776929ad1a1530049"


### PR DESCRIPTION
Parsing OCaml library for EDN format

- Project page: <a href="http://github.com/prepor/ocaml-edn">http://github.com/prepor/ocaml-edn</a>
- Documentation: <a href="https://prepor.github.io/ocaml-edn/doc">https://prepor.github.io/ocaml-edn/doc</a>

##### CHANGES:

thanks to @Leonidas-from-XIV

- compatibility with OCaml 4.06
- migration to Dune
