### PR TITLE
[new release] edn (v0.1.6-1-gff9db95)

### DIFF
--- a/packages/edn/edn.0.1.6-1-gff9db95/descr
+++ b/packages/edn/edn.0.1.6-1-gff9db95/descr
@@ -1,0 +1,3 @@
+Parsing OCaml library for EDN format
+
+This library implements [EDN][edn] parser and generator for OCaml.

--- a/packages/edn/edn.0.1.6-1-gff9db95/opam
+++ b/packages/edn/edn.0.1.6-1-gff9db95/opam
@@ -11,6 +11,6 @@ build-test: ["dune" "runtest" "-p" name "-j" jobs]
 depends: [
   "dune" {build}
   "menhir" {build}
-  "oUnit" {test}
+  "ounit" {test}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.6-1-gff9db95/opam
+++ b/packages/edn/edn.0.1.6-1-gff9db95/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+license: "MIT"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+dev-repo: "https://github.com/prepor/ocaml-edn.git"
+doc: "https://prepor.github.io/ocaml-edn/doc"
+build: ["dune" "build" "-p" name "-j" jobs]
+build-test: ["dune" "runtest" "-p" name "-j" jobs]
+depends: [
+  "dune" {build}
+  "menhir" {build}
+  "oUnit" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/edn/edn.0.1.6-1-gff9db95/url
+++ b/packages/edn/edn.0.1.6-1-gff9db95/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/prepor/ocaml-edn/releases/download/v0.1.6-1-gff9db95/edn-0.1.6-1-gff9db95.tbz"
+checksum: "8ebf3671d4787d0a86be6dbe6f96d057"


### PR DESCRIPTION
Parsing OCaml library for EDN format

- Project page: <a href="http://github.com/prepor/ocaml-edn">http://github.com/prepor/ocaml-edn</a>
- Documentation: <a href="https://prepor.github.io/ocaml-edn/doc">https://prepor.github.io/ocaml-edn/doc</a>

##### CHANGES:

thanks to @Leonidas-from-XIV

- compatibility with OCaml 4.06
- migration to Dune
