### PR TITLE
[new release] benchmark (1.6)

### DIFF
--- a/packages/benchmark/benchmark.1.6/descr
+++ b/packages/benchmark/benchmark.1.6/descr
@@ -1,0 +1,5 @@
+Benchmark running times of code
+
+This module provides a set of tools to measure the running times of
+your functions and to easily compare the results.  A statistical test
+is used to determine whether the results truly differ.

--- a/packages/benchmark/benchmark.1.6/opam
+++ b/packages/benchmark/benchmark.1.6/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+          "Doug Bagley"]
+tags: ["benchmark"]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-benchmark"
+dev-repo: "https://github.com/Chris00/ocaml-benchmark.git"
+bug-reports: "https://github.com/Chris00/ocaml-benchmark/issues"
+doc: "https://Chris00.github.io/ocaml-benchmark/doc"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "base-unix"
+]
+available: [ ocaml-version >= "3.12.0" ]

--- a/packages/benchmark/benchmark.1.6/url
+++ b/packages/benchmark/benchmark.1.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/ocaml-benchmark/releases/download/1.6/benchmark-1.6.tbz"
+checksum: "425d16d91e11bc81e3d347884f8fe991"


### PR DESCRIPTION
Benchmark running times of code

- Project page: <a href="https://github.com/Chris00/ocaml-benchmark">https://github.com/Chris00/ocaml-benchmark</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-benchmark/doc">https://Chris00.github.io/ocaml-benchmark/doc</a>

##### CHANGES:

- Port to Dune (not the former Jbuilder) and dune-release.
- Fix some typos in the documentation.
