### PR TITLE
ocamlbuild: constraint ocaml-version to 4.07

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.11.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.11.0/opam
@@ -25,7 +25,7 @@ build: [
   [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
-available: [ocaml-version >= "4.03"]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.08.0"]
 depends: [ ]
 conflicts: [
   "base-ocamlbuild"

--- a/packages/ocamlbuild/ocamlbuild.0.12.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.12.0/opam
@@ -25,4 +25,4 @@ conflicts: [
   "base-ocamlbuild"
   "ocamlfind" {< "1.6.2"}
 ]
-available: [ocaml-version >= "4.03"]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.08.0"]

--- a/packages/ocamlbuild/ocamlbuild.0.9.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.1/opam
@@ -24,7 +24,7 @@ build: [
   [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
-available: [ocaml-version >= "4.03"]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.08.0"]
 depends: [ ]
 conflicts: [
   "base-ocamlbuild"

--- a/packages/ocamlbuild/ocamlbuild.0.9.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.2/opam
@@ -24,7 +24,7 @@ build: [
   [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
-available: [ocaml-version >= "4.03"]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.08.0"]
 depends: [ ]
 conflicts: [
   "base-ocamlbuild"

--- a/packages/ocamlbuild/ocamlbuild.0.9.3/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.9.3/opam
@@ -24,7 +24,7 @@ build: [
   [make "check-if-preinstalled" "all" "opam-install"]
 ]
 
-available: [ocaml-version >= "4.03"]
+available: [ocaml-version >= "4.03" & ocaml-version < "4.08.0"]
 depends: [ ]
 conflicts: [
   "base-ocamlbuild"


### PR DESCRIPTION
As packaged ocamlbuilds don't compile with 4.08.0, this PR set constraints on ocaml-versions.

/cc @gasche 