### PR TITLE
Package capnp.3.2.1

### DIFF
--- a/packages/capnp/capnp.3.2.1/descr
+++ b/packages/capnp/capnp.3.2.1/descr
@@ -1,0 +1,5 @@
+OCaml code generation plugin for the Cap'n Proto serialization framework
+Cap'n Proto is a multi-language code generation framework designed for
+high performance through the use of lazy parsing and arena allocation.
+This package provides a plugin for the Cap'n Proto compiler which enables
+OCaml code generation, as well as corresponding runtime library support.

--- a/packages/capnp/capnp.3.2.1/opam
+++ b/packages/capnp/capnp.3.2.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+authors: "Paul Pelzl <pelzlpj@gmail.com>"
+homepage: "https://github.com/capnproto/capnp-ocaml"
+bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
+dev-repo: "https://github.com/capnproto/capnp-ocaml.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "build" "@runtest" "@src/benchmark/benchmarks"]
+depends: [
+  "jbuilder" {build}
+  "result"
+  "core_kernel" {>= "v0.11.0"}
+  "extunix"
+  "ocplib-endian" {>= "0.7"}
+  "res"
+  "uint"
+  "core" {test}
+  "ounit" {test}
+  "conf-capnproto" {test}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/capnp/capnp.3.2.1/url
+++ b/packages/capnp/capnp.3.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/capnproto/capnp-ocaml/archive/v3.2.1.tar.gz"
+checksum: "1c8519640a3e5f06c48220d2194d9d36"


### PR DESCRIPTION
### `capnp.3.2.1`

OCaml code generation plugin for the Cap'n Proto serialization framework
Cap'n Proto is a multi-language code generation framework designed for
high performance through the use of lazy parsing and arena allocation.
This package provides a plugin for the Cap'n Proto compiler which enables
OCaml code generation, as well as corresponding runtime library support.



---
* Homepage: https://github.com/capnproto/capnp-ocaml
* Source repo: https://github.com/capnproto/capnp-ocaml.git
* Bug tracker: https://github.com/capnproto/capnp-ocaml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5