### PR TITLE
sedlex: update to new github repository

### DIFF
--- a/packages/sedlex/sedlex.1.99.1/opam
+++ b/packages/sedlex/sedlex.1.99.1/opam
@@ -1,9 +1,9 @@
 opam-version: "1.2"
 maintainer: "alain.frisch@lexifi.com"
 author: "alain.frisch@lexifi.com"
-homepage: "https://github.com/alainfrisch/sedlex"
-bug-reports: "https://github.com/alainfrisch/sedlex/issues"
-dev-repo: "https://github.com/alainfrisch/sedlex.git"
+homepage: "https://github.com/ocaml-community/sedlex"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
+dev-repo: "https://github.com/ocaml-community/sedlex.git"
 build: [
   [make "all"]
   [make "opt"]

--- a/packages/sedlex/sedlex.1.99.1/url
+++ b/packages/sedlex/sedlex.1.99.1/url
@@ -1,1 +1,1 @@
-git: "git://github.com/alainfrisch/sedlex.git"
+git: "git://github.com/ocaml-community/sedlex.git"

--- a/packages/sedlex/sedlex.1.99.2/opam
+++ b/packages/sedlex/sedlex.1.99.2/opam
@@ -6,9 +6,9 @@ build: [
   [make "opt"]
 ]
 install: [make "install"]
-homepage: "https://github.com/alainfrisch/sedlex"
-bug-reports: "https://github.com/alainfrisch/sedlex/issues"
-dev-repo: "https://github.com/alainfrisch/sedlex.git"
+homepage: "https://github.com/ocaml-community/sedlex"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
+dev-repo: "https://github.com/ocaml-community/sedlex.git"
 remove: [["ocamlfind" "remove" "sedlex"]]
 depends: ["ocamlfind" {>= "1.5.0"}
           "ppx_tools" {>= "0.99"}

--- a/packages/sedlex/sedlex.1.99.2/url
+++ b/packages/sedlex/sedlex.1.99.2/url
@@ -1,3 +1,3 @@
-archive: "http://github.com/alainfrisch/sedlex/archive/sedlex-1.99.2.tar.gz"
+archive: "http://github.com/ocaml-community/sedlex/archive/sedlex-1.99.2.tar.gz"
 checksum: "1ff403ddfb964b69343674766ad68e55"
 

--- a/packages/sedlex/sedlex.1.99.3/opam
+++ b/packages/sedlex/sedlex.1.99.3/opam
@@ -12,7 +12,7 @@ depends: ["ocamlfind" {build}
           "gen"
          ]
 available: [ ocaml-version >= "4.02.0" ]
-homepage: "https://github.com/alainfrisch/sedlex"
-bug-reports: "https://github.com/alainfrisch/sedlex/issues"
+homepage: "https://github.com/ocaml-community/sedlex"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 license: "MIT"
-dev-repo: "https://github.com/alainfrisch/sedlex.git"
+dev-repo: "https://github.com/ocaml-community/sedlex.git"

--- a/packages/sedlex/sedlex.1.99.3/url
+++ b/packages/sedlex/sedlex.1.99.3/url
@@ -1,2 +1,2 @@
-archive: "http://github.com/alainfrisch/sedlex/archive/v1.99.3.tar.gz"
+archive: "http://github.com/ocaml-community/sedlex/archive/v1.99.3.tar.gz"
 checksum: "abfc762b516583747e475cc7642ee098"

--- a/packages/sedlex/sedlex.1.99.4/opam
+++ b/packages/sedlex/sedlex.1.99.4/opam
@@ -12,7 +12,7 @@ depends: ["ocamlfind" {build}
           "gen"
          ]
 available: [ ocaml-version >= "4.02.3" ]
-homepage: "https://github.com/alainfrisch/sedlex"
-bug-reports: "https://github.com/alainfrisch/sedlex/issues"
+homepage: "https://github.com/ocaml-community/sedlex"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 license: "MIT"
-dev-repo: "https://github.com/alainfrisch/sedlex.git"
+dev-repo: "https://github.com/ocaml-community/sedlex.git"

--- a/packages/sedlex/sedlex.1.99.4/url
+++ b/packages/sedlex/sedlex.1.99.4/url
@@ -1,2 +1,2 @@
-http: "https://github.com/alainfrisch/sedlex/archive/v1.99.4.tar.gz"
+http: "https://github.com/ocaml-community/sedlex/archive/v1.99.4.tar.gz"
 checksum: "f621d80e36cda2548528766f31b16b12"

--- a/packages/sedlex/sedlex.1.99/opam
+++ b/packages/sedlex/sedlex.1.99/opam
@@ -6,9 +6,9 @@ build: [
   [make "opt"]
 ]
 install: [make "install"]
-homepage: "https://github.com/alainfrisch/sedlex"
-bug-reports: "https://github.com/alainfrisch/sedlex/issues"
-dev-repo: "https://github.com/alainfrisch/sedlex.git"
+homepage: "https://github.com/ocaml-community/sedlex"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
+dev-repo: "https://github.com/ocaml-community/sedlex.git"
 remove: [["ocamlfind" "remove" "sedlex"]]
 depends: ["ocamlfind"]
 available: [ocaml-version >= "4.01.0" & ocaml-version < "4.02.0"]


### PR DESCRIPTION
sedlex has been moved to the ocaml-community repository.
This commit reflects the change in repository location.
It otherwise makes no changes.