### PR TITLE
+conex{-nocrypto}.0.10.1

### DIFF
--- a/packages/conex-nocrypto/conex-nocrypto.0.10.1/descr
+++ b/packages/conex-nocrypto/conex-nocrypto.0.10.1/descr
@@ -1,0 +1,8 @@
+Establish trust in community repositories
+
+
+Conex is a utility for verify and attest release integrity and authenticity of community repositories through the use of cryptographic signatures (RSA-PSS-SHA256). It is based on [the update framework](https://theupdateframework.github.io/), especially on their [CCS 2010 paper](https://isis.poly.edu/~jcappos/papers/samuel_tuf_ccs_2010.pdf), and adapted to the requirements of the [opam](https://ocaml.opam.org) [repository](https://github.com/ocaml/opam-repository).
+
+The developer sign their release checksums and build instructions.  A quorum (with a configurable threshold) of repository maintainers signs the package name to developer key relation.  These repository maintainers are enrolled by a quorum of offline root keys.
+
+The [TUF spec](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) has a good overview of attacks and threat model, both of which are shared by conex.

--- a/packages/conex-nocrypto/conex-nocrypto.0.10.1/opam
+++ b/packages/conex-nocrypto/conex-nocrypto.0.10.1/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+homepage:     "https://github.com/hannesm/conex"
+dev-repo:     "https://github.com/hannesm/conex.git"
+bug-reports:  "https://github.com/hannesm/conex/issues"
+doc:          "https://hannesm.github.io/conex/doc"
+author:       ["Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>"]
+license:      "BSD2"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+build-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build}
+  "alcotest" {test}
+  "cmdliner"
+  "conex" {>= "0.10.0"}
+  "cstruct" {>= "1.6.0"}
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.4.0"}
+  "logs" "fmt" "rresult"
+]
+
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/conex-nocrypto/conex-nocrypto.0.10.1/url
+++ b/packages/conex-nocrypto/conex-nocrypto.0.10.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hannesm/conex/releases/download/0.10.1/conex-0.10.1.tbz"
+checksum: "1e09e8e28c4b26d5a22b3a5afd1fdc5c"

--- a/packages/conex/conex.0.10.1/descr
+++ b/packages/conex/conex.0.10.1/descr
@@ -1,0 +1,8 @@
+Establish trust in community repositories
+
+
+Conex is a utility for verify and attest release integrity and authenticity of community repositories through the use of cryptographic signatures (RSA-PSS-SHA256). It is based on [the update framework](https://theupdateframework.github.io/), especially on their [CCS 2010 paper](https://isis.poly.edu/~jcappos/papers/samuel_tuf_ccs_2010.pdf), and adapted to the requirements of the [opam](https://ocaml.opam.org) [repository](https://github.com/ocaml/opam-repository).
+
+The developer sign their release checksums and build instructions.  A quorum (with a configurable threshold) of repository maintainers signs the package name to developer key relation.  These repository maintainers are enrolled by a quorum of offline root keys.
+
+The [TUF spec](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) has a good overview of attacks and threat model, both of which are shared by conex.

--- a/packages/conex/conex.0.10.1/opam
+++ b/packages/conex/conex.0.10.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+homepage:     "https://github.com/hannesm/conex"
+dev-repo:     "https://github.com/hannesm/conex.git"
+bug-reports:  "https://github.com/hannesm/conex/issues"
+doc:          "https://hannesm.github.io/conex/doc"
+author:       ["Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>"]
+license:      "BSD2"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build}
+  "cmdliner"
+  "opam-file-format" {>= "2.0.0~rc2"}
+]
+
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/conex/conex.0.10.1/url
+++ b/packages/conex/conex.0.10.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/hannesm/conex/releases/download/0.10.1/conex-0.10.1.tbz"
+checksum: "1e09e8e28c4b26d5a22b3a5afd1fdc5c"


### PR DESCRIPTION
the only change in contrast to 0.10.0 is that a non-empty LICENSE.md file was added (2 clause BSD license, as advertised in the opam files) //cc @avsm