### PR TITLE
Ocamlbuild revdep fixes

### DIFF
--- a/packages/argon2/argon2.0.1/opam
+++ b/packages/argon2/argon2.0.1/opam
@@ -20,4 +20,4 @@ depends: [
   "result"
   "ppx_deriving" {>= "2.0"}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.06.0"]

--- a/packages/argon2/argon2.0.2/opam
+++ b/packages/argon2/argon2.0.2/opam
@@ -20,4 +20,4 @@ depends: [
   "result"
   "ppx_deriving" {>= "2.0"}
 ]
-available: [ocaml-version >= "4.02.1"]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.06.0"]

--- a/packages/bolt/bolt.1.4/opam
+++ b/packages/bolt/bolt.1.4/opam
@@ -25,3 +25,4 @@ homepage: "http://bolt.x9c.fr/"
 license: "LGPL v3"
 authors: ["Xavier Clerc"]
 install: [make "install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/cairo/cairo.0.4.2/opam
+++ b/packages/cairo/cairo.0.4.2/opam
@@ -27,4 +27,5 @@ conflicts: [ "cairo2" ]
 # The package does not build without Graphics,
 # which is not available by default on OS X.
 # Use cairo2 >= 0.5.
-available: [ os != "darwin" ]
+available: [ ocaml-version < "4.06.0"
+             & os != "darwin" ]

--- a/packages/cairo/cairo.1.2.0/opam
+++ b/packages/cairo/cairo.1.2.0/opam
@@ -32,3 +32,4 @@ authors: [
 homepage: "http://cairographics.org/cairo-ocaml/"
 dev-repo: "git+http://anongit.freedesktop.org/git/cairo-ocaml.git"
 bug-reports: "https://bugs.freedesktop.org/buglist.cgi?quicksearch=cairo%20ocaml"
+available: [ ocaml-version < "4.06.0" ]

--- a/packages/camltc/camltc.0.8.1/opam
+++ b/packages/camltc/camltc.0.8.1/opam
@@ -12,6 +12,6 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version > "4.00.0" ]
+available: [ ocaml-version > "4.00.0" & ocaml-version < "4.06.0" ]
 dev-repo: "git://github.com/toolslive/camltc"
 install: [make "-C" "src" "install" "DESTDIR=%{prefix}%"]

--- a/packages/camltc/camltc.0.8.2/opam
+++ b/packages/camltc/camltc.0.8.2/opam
@@ -12,6 +12,6 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version > "4.00.0" ]
+available: [ ocaml-version > "4.00.0" & ocaml-version < "4.06.0" ]
 dev-repo: "git://github.com/toolslive/camltc"
 install: [make "-C" "src" "install" "DESTDIR=%{prefix}%"]

--- a/packages/camltc/camltc.0.8.3/opam
+++ b/packages/camltc/camltc.0.8.3/opam
@@ -12,6 +12,6 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version > "4.00.0" ]
+available: [ ocaml-version > "4.00.0" & ocaml-version < "4.06.0" ]
 dev-repo: "git://github.com/toolslive/camltc"
 install: [make "-C" "src" "install" "DESTDIR=%{prefix}%"]

--- a/packages/camltc/camltc.0.9.0/opam
+++ b/packages/camltc/camltc.0.9.0/opam
@@ -12,6 +12,6 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version > "4.00.0" ]
+available: [ ocaml-version > "4.00.0" & ocaml-version < "4.06.0" ]
 dev-repo: "git://github.com/toolslive/camltc"
 install: [make "-C" "src" "install" "DESTDIR=%{prefix}%"]

--- a/packages/camltc/camltc.0.9.1/opam
+++ b/packages/camltc/camltc.0.9.1/opam
@@ -12,6 +12,6 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version > "4.00.0" ]
+available: [ ocaml-version > "4.00.0" & ocaml-version < "4.06.0" ]
 dev-repo: "git://github.com/toolslive/camltc"
 install: [make "-C" "src" "install" "DESTDIR=%{prefix}%"]

--- a/packages/camltc/camltc.0.9.3/opam
+++ b/packages/camltc/camltc.0.9.3/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {>= "2.4.4" & < "4.0.0"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version > "4.02.2" ]
+available: [ ocaml-version > "4.02.2" & ocaml-version < "4.06.0" ]
 
 depexts:[
   [[ "ubuntu"] ["git"] ]

--- a/packages/camltc/camltc.0.9.4/opam
+++ b/packages/camltc/camltc.0.9.4/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {>= "2.4.4" & < "4.0.0"}
   "ocamlbuild" {build}
 ]
-available: [ ocaml-version > "4.02.2" & opam-version > "1.2.0" ]
+available: [ ocaml-version > "4.02.2" & ocaml-version < "4.06.0" & opam-version > "1.2.0" ]
 
 depexts:[
   [[ "ubuntu"] ["git"] ]

--- a/packages/cconv/cconv.0.1/opam
+++ b/packages/cconv/cconv.0.1/opam
@@ -23,5 +23,5 @@ depends: [
 ]
 depopts: ["bencode" "sexplib" "yojson"]
 dev-repo: "git://github.com/c-cube/cconv"
-available: ocaml-version >= "4.00.0"
+available: [ocaml-version >= "4.00.0" & ocaml-version < "4.06.0"]
 install: [make "install"]

--- a/packages/ospec/ospec.0.2.1/opam
+++ b/packages/ospec/ospec.0.2.1/opam
@@ -9,5 +9,5 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-available: ocaml-version = "3.12.1"
+available: [ocaml-version = "3.12.1"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/ospec/ospec.0.3.0/opam
+++ b/packages/ospec/ospec.0.3.0/opam
@@ -10,5 +10,5 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-available: ocaml-version = "broken"
+available: [ocaml-version = "broken"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/ospec/ospec.0.3.1/opam
+++ b/packages/ospec/ospec.0.3.1/opam
@@ -11,3 +11,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]

--- a/packages/ospec/ospec.0.3.2/opam
+++ b/packages/ospec/ospec.0.3.2/opam
@@ -11,3 +11,4 @@ depends: [
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
+available: [ocaml-version < "4.06.0"]


### PR DESCRIPTION
metadata update for the first N=6 packages in ocamlbuild reverse dependencies that require an ocaml version bound, mostly because they need `-unsafe-string`.