### PR TITLE
sedlex: constrain recent versions to OCaml 4.03 and above

### DIFF
--- a/packages/sedlex/sedlex.1.99.3/opam
+++ b/packages/sedlex/sedlex.1.99.3/opam
@@ -11,7 +11,7 @@ depends: ["ocamlfind" {build}
           "ppx_tools" {>= "5.0"}
           "gen"
          ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.03.0" ]
 homepage: "https://github.com/ocaml-community/sedlex"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 license: "MIT"

--- a/packages/sedlex/sedlex.1.99.4/opam
+++ b/packages/sedlex/sedlex.1.99.4/opam
@@ -11,7 +11,7 @@ depends: ["ocamlfind" {build}
           "ocaml-migrate-parsetree"
           "gen"
          ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.03.0" ]
 homepage: "https://github.com/ocaml-community/sedlex"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 license: "MIT"


### PR DESCRIPTION
The recent versions don't build on 4.01 and 4.02, so we constrain that properly in the opam files.

CC: @Drup 