### PR TITLE
[new release] ocaml-migrate-parsetree (v1.1.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ocamlfind" {build}
+  "dune" {build}
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
@@ -15,7 +15,6 @@ build: [
 ]
 depends: [
   "result"
-  "ocamlfind" {build}
   "dune" {build}
 ]
 available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -7,7 +7,7 @@ authors: [
 license: "LGPL-2.1"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
-dev-repo: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
 doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
 tags: [ "syntax" "org:ocamllabs" ]
 build: [
@@ -16,5 +16,5 @@ build: [
 depends: [
   "result"
   "dune" {build}
+  "ocaml" {>= "4.02.0"}
 ]
-available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.1.0/ocaml-migrate-parsetree-1.1.0.tbz"
+checksum: "7dd4808e27af98065f63604c9658d311"


### PR DESCRIPTION
Convert OCaml parsetrees between different versions 

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Allow ppx rewriters to specify when they should be applied
