### PR TITLE
stdcompat-6

### DIFF
--- a/packages/stdcompat/stdcompat.6/descr
+++ b/packages/stdcompat/stdcompat.6/descr
@@ -1,0 +1,1 @@
+Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml.

--- a/packages/stdcompat/stdcompat.6/opam
+++ b/packages/stdcompat/stdcompat.6/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+version: "6"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+license: "BSD"
+dev-repo: "https://github.com/thierry-martinez/stdcompat.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depopts : [ "result" "seq" "uchar" ]
+available: [ocaml-version >= "3.07" & ocaml-version < "4.09.0"]

--- a/packages/stdcompat/stdcompat.6/url
+++ b/packages/stdcompat/stdcompat.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/thierry-martinez/stdcompat/releases/download/6/stdcompat-6.tar.gz"
+checksum: "23cabc8aa659f1f58199a5a7136af603"


### PR DESCRIPTION
- Support for OCaml 4.08.0

- Support VPATH build, i.e. when configure is executed in a build directory
  distinct from the source directory

- Lexing.new_line

- Bigarray: only available from 4.02.0. From 4.02.0 and before 4.07.0,
  --no-alias-deps is used to allow the alias to appear in Stdcompat without
  requiring the library to be linked. Bigarray library should be linked if it is
  effectively used.

- Fix implementations with --disable-magic

- Fix license conflict: The project was intended to be under BSD license
  since the beginning, and a LICENSE file was provided accordingly.
  However, automake generated a COPYING file with the GPLv3 by default. The
  COPYING file now contains the BSD license, and the LICENSE file is removed.
  (reported by Török Edwin,
   https://github.com/thierry-martinez/stdcompat/issues/5)

- Fix auto-generated interfaces for Hashtbl.MakeSeeded

- Exceptions are reexported again. They were missing in auto-generated
  interfaces.

- min_binding_opt and max_binding_opt are not redefined if OCaml >=4.05.

- Array.of_seq is redefined in OCaml 4.07.0 to circumvent a bug in the
  implementation of the standard library. See:
    - https://caml.inria.fr/mantis/view.php?id=7820
    - https://github.com/ocaml/ocaml/pull/1897