### PR TITLE
Batteries.2.9.0 with 4.07.0 support

### DIFF
--- a/packages/batteries/batteries.1.4.3/opam
+++ b/packages/batteries/batteries.1.4.3/opam
@@ -20,6 +20,6 @@ synopsis: "Community-maintained foundation library"
 flags: light-uninstall
 url {
   src:
-    "http://forge.ocamlcore.org/frs/download.php/884/batteries-1.4.3.tar.gz"
+    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v1.4.3/batteries-1.4.3.tar.gz"
   checksum: "md5=af93a95bcbfeaa188453b7495b815413"
 }

--- a/packages/batteries/batteries.1.5.0/opam
+++ b/packages/batteries/batteries.1.5.0/opam
@@ -20,6 +20,6 @@ synopsis: "Community-maintained foundation library"
 flags: light-uninstall
 url {
   src:
-    "http://forge.ocamlcore.org/frs/download.php/950/batteries-1.5.0.tar.gz"
+    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v1.5.0/batteries-1.5.0.tar.gz"
   checksum: "md5=40b7022fddba246062fd489eeb15cd84"
 }

--- a/packages/batteries/batteries.2.0.0/opam
+++ b/packages/batteries/batteries.2.0.0/opam
@@ -18,6 +18,6 @@ synopsis: "Community-maintained foundation library"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1096/batteries-2.0.tar.gz"
+    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.0.0/batteries-2.0.tar.gz"
   checksum: "md5=ab93a8a6ed7d94ca7c7be26862b4e1e9"
 }

--- a/packages/batteries/batteries.2.1.0/opam
+++ b/packages/batteries/batteries.2.1.0/opam
@@ -20,6 +20,6 @@ flags: light-uninstall
 extra-files: ["cloexec.patch" "md5=1e028dc99ffbdad4be64df4bc6ceecff"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1218/batteries-2.1.tar.gz"
+    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.1.0/batteries-2.1.tar.gz"
   checksum: "md5=95567687a675107e58c66b93b9ea9bb1"
 }

--- a/packages/batteries/batteries.2.2.0/opam
+++ b/packages/batteries/batteries.2.2.0/opam
@@ -20,6 +20,6 @@ description:
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1363/batteries-2.2.tar.gz"
+    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.2.0/batteries-2.2.tar.gz"
   checksum: "md5=42063b5f2da9a311ff16799b8bec4ba5"
 }

--- a/packages/batteries/batteries.2.9.0/opam
+++ b/packages/batteries/batteries.2.9.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+description: "A community-maintained standard library extension"
+maintainer: [
+  "Francois Berenger"
+  "Gabriel Scherer <gabriel.scherer@gmail.com>"
+  "Thibault Suzanne <thi.suzanne@gmail.com>"
+]
+authors: "OCaml batteries-included team"
+homepage: "http://batteries.forge.ocamlcore.org/"
+bug-reports: "https://github.com/ocaml-batteries-team/batteries-included/issues"
+dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
+license: "LGPL-2.1+ with OCaml linking exception"
+doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "batteries"]
+depends: [
+  "ocaml" {>= "4.00.0" & < "4.08.0"}
+  "ocamlfind" {build & >= "1.5.3"}
+  "ocamlbuild" {build}
+  "qtest" {test & >= "2.5"}
+  "qcheck" {test & >= "0.6"}
+  "num"
+]
+url {
+  src:
+    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.9.0/batteries-2.9.0.tar.gz"
+  checksum: "md5=482adf4d08e90cc215dbaee0314a84fa"
+}

--- a/packages/yajl-extra/yajl-extra.0.7.0/opam
+++ b/packages/yajl-extra/yajl-extra.0.7.0/opam
@@ -4,7 +4,7 @@ remove: [["ocamlfind" "remove" "JSON"]]
 depends: [
   "ocaml"
   "ocamlfind"
-  "batteries"
+  "batteries" {< "2.0.0"}
   "yajl"
   "ocamlbuild" {build}
 ]

--- a/packages/yajl-extra/yajl-extra.0.7.1/opam
+++ b/packages/yajl-extra/yajl-extra.0.7.1/opam
@@ -4,7 +4,7 @@ remove: [["ocamlfind" "remove" "yajl-extra"]]
 depends: [
   "ocaml"
   "ocamlfind"
-  "batteries"
+  "batteries" {< "2.0.0"}
   "yajl"
   "ocamlbuild" {build}
 ]

--- a/packages/yajl-extra/yajl-extra.0.7.2/opam
+++ b/packages/yajl-extra/yajl-extra.0.7.2/opam
@@ -4,7 +4,7 @@ remove: [["ocamlfind" "remove" "yajl-extra"]]
 depends: [
   "ocaml"
   "ocamlfind"
-  "batteries"
+  "batteries" {< "2.0.0"}
   "yajl"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
This minor release adds support for OCaml 4.07.0, as well as a certain
number of fixes, improvements and documentation clarification from our
contributors. Thanks in particular to Max Mouratov for his varied
contributions.

This release is compatible with OCaml 4.07.0, but it is not complete
with respect to the standard library of OCaml 4.07.0: this release saw
a lot of changes to the standard library, which have not yet been made
available in the corresponding Batteries module. This means that users
of OCaml 4.07.0 (and Batteries 2.9.0) will have access to these
functions, but users of older OCaml versions (and Batteries 2.9.0)
will not. If you are looking for this kind of backward-compatibility
of new functions, as provided by previous Batteries releases, we
recommend trying the new 'stdcompat' library by Thierry Martinez:

  https://github.com/thierry-martinez/stdcompat

Full changelog:

- add `BatString.cut_on_char : char -> int -> string -> string`
  (Kahina Fekir, Thibault Suzanne, request by François Bérenger)
  ocaml-batteries-team/batteries-included#807, ocaml-batteries-team/batteries-included#856

- add `BatString.index_after_n : char -> int -> string -> int`
  (Kahina Fekir)

- faster BatArray.partition
  ocaml-batteries-team/batteries-included#829
  (Francois Berenger, Gabriel Scherer)

- add `BatArray.split: ('a * 'b) array -> 'a array * 'b array`
  ocaml-batteries-team/batteries-included#826
  (Francois Berenger)

- add `BatString.count_string: string -> string -> int`
  ocaml-batteries-team/batteries-included#799
  (Francois Berenger)

- Int: optimized implementation of Safe_int.mul
  ocaml-batteries-team/batteries-included#808, ocaml-batteries-team/batteries-included#851
  (Max Mouratov)

- Fix: in case of conflicted bindings, [Map.union m1 m2] should
  prefer the value from [m2], as stated in documentation.
  ocaml-batteries-team/batteries-included#814
  (Max Mouratov)

- Fix: [Map.update k1 k2 v m] did not work correctly when [k1 = k2].
  ocaml-batteries-team/batteries-included#833
  (Max Mouratov)

- Fix: [Map.update k1 k2 v m] should throw [Not_found] if [k1] is not bound
  in [m], as stated in documentation.
  ocaml-batteries-team/batteries-included#833
  (Max Mouratov)

- Fix: [Set.update x y s] should throw [Not_found] if [x] is not in [s],
  as stated in documentation.
  ocaml-batteries-team/batteries-included#833
  (Max Mouratov)

- Fix: documentation of BatList.{hd,last} to match implementation w.r.t
  raised exceptions
  ocaml-batteries-team/batteries-included#840, ocaml-batteries-team/batteries-included#754
  (FkHina)

- Fix: [Array.insert] should throw a more relevant message on invalid indices
  instead of the generic [invalid_arg "index out of bounds].
  The assertion is now documented.
  ocaml-batteries-team/batteries-included#841
  (Max Mouratov)

- Implementation of [Array.insert] now uses [unsafe_get] and [unsafe_set].
  ocaml-batteries-team/batteries-included#841
  (Max Mouratov)

- Fix documentation of [String.right].
  ocaml-batteries-team/batteries-included#849, ocaml-batteries-team/batteries-included#844
  (Max Mouratov, reported by Thibault Suzanne)

- Fix: [Heap.del_min] should throw [Invalid_argument] with the specified
  "del_min" message instead of "find_min_tree".
  ocaml-batteries-team/batteries-included#850
  (Max Mouratov)

- More uniform and correct [Invalid_argument] messages.
  ocaml-batteries-team/batteries-included#850
  (Max Mouratov)

- Optimization of List.unique_cmp (using Set instead of Map).
  ocaml-batteries-team/batteries-included#852
  (Max Mouratov)

- Documentation of List.append and List.concat should not include invalid
  estimates of stack usage.
  ocaml-batteries-team/batteries-included#854
  (Max Mouratov)

- Implementation of String should use unsafe versions of [set] and [get].
  ocaml-batteries-team/batteries-included#836
  (Max Mouratov, review by Gabriel Scherer)

- Fix erroneous mentions of [Different_list_size] in List.mli.
  ocaml-batteries-team/batteries-included#857, ocaml-batteries-team/batteries-included#744
  (Max Mouratov, reported by Christoph Höger)

- fix Map.equal (for polymorphic maps) with custom equality function
  ocaml-batteries-team/batteries-included#865
  (Ralf Vogler)

- ocamlfind plugin support in META file
  (Arlen Cox)
  ocaml-batteries-team/batteries-included#867
