### PR TITLE
[coq-serapi] Update to fix compatibility with OCaml 4.07.0

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/descr
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/descr
@@ -1,0 +1,1 @@
+Sexp Protocol for machine-based interaction with the Coq Proof Assistant.

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/files/coq-serapi.install
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/files/coq-serapi.install
@@ -1,0 +1,4 @@
+bin: [
+  "_build/sertop/sertop.native"  { "sertop"  }
+  "_build/sertop/sercomp.native" { "sercomp" }
+]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/opam
@@ -7,7 +7,7 @@ dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
 license:      "GPL 3"
 
 name: "coq-serapi"
-available: [ ocaml-version >= "4.06.0" & ocaml-version < "4.07.0" ]
+available: [ ocaml-version >= "4.06.0" ]
 
 # ppx depends are so strict due to the issues with ppx_import and
 # ppx_driver integration in the past.

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/url
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ejgallego/coq-serapi/archive/8.8.0+0.5.2.tar.gz"
+checksum: "b00e72caa0fbb600fa91b863a261335e"


### PR DESCRIPTION
This was due to `Stdlib` packing.