### PR TITLE
[new release] core (v0.11.3)

### DIFF
--- a/packages/async_extra/async_extra.v0.11.0/opam
+++ b/packages/async_extra/async_extra.v0.11.0/opam
@@ -18,4 +18,4 @@ depends: [
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.04.1" & ocaml-version < "4.07" ]

--- a/packages/core/core.v0.11.3/descr
+++ b/packages/core/core.v0.11.3/descr
@@ -1,0 +1,5 @@
+Industrial strength alternative to OCaml's standard library
+
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/core/core.v0.11.3/opam
+++ b/packages/core/core.v0.11.3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "git+https://github.com/janestreet/core.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.11" & < "v0.12"}
+  "configurator"            {>= "v0.11" & < "v0.12"}
+  "core_kernel"             {>= "v0.11" & < "v0.12"}
+  "ppx_assert"              {>= "v0.11" & < "v0.12"}
+  "ppx_jane"                {>= "v0.11" & < "v0.12"}
+  "sexplib"                 {>= "v0.11" & < "v0.12"}
+  "spawn"                   {>= "v0.12"}
+  "stdio"                   {>= "v0.11" & < "v0.12"}
+  "base-threads"
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
+  "ppxlib"                  {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]

--- a/packages/core/core.v0.11.3/url
+++ b/packages/core/core.v0.11.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/core/releases/core-v0.11.3.tbz"
+checksum: "89ca9e9aa9f1742790efb5016cc5d69b"

--- a/packages/core/core.v0.11.3/url
+++ b/packages/core/core.v0.11.3/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/janestreet/core/releases/core-v0.11.3.tbz"
+archive: "https://github.com/janestreet/core/releases/download/v0.11.3/core-v0.11.3.tbz"
 checksum: "89ca9e9aa9f1742790efb5016cc5d69b"

--- a/packages/email_message/email_message.v0.11.0/opam
+++ b/packages/email_message/email_message.v0.11.0/opam
@@ -22,4 +22,4 @@ depends: [
   "magic-mime"
   "ocaml-migrate-parsetree" {>= "1.0"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.04.1" & ocaml-version < "4.07" ]


### PR DESCRIPTION
Industrial strength alternative to OCaml's standard library

- Project page: <a href="https://github.com/janestreet/core">https://github.com/janestreet/core</a>

##### CHANGES:

- Fix musl compilation (janestreet/core#115, fix janestreet/core#109, @copy)

- Fix inclusion of makedev inLinux on glibc 2.26 (janestreet/core#114, @dark)
