### PR TITLE
cppo 1.6.5

### DIFF
--- a/packages/cppo/cppo.1.6.5/descr
+++ b/packages/cppo/cppo.1.6.5/descr
@@ -1,0 +1,1 @@
+Equivalent of the C preprocessor for OCaml programs

--- a/packages/cppo/cppo.1.6.5/opam
+++ b/packages/cppo/cppo.1.6.5/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "https://github.com/mjambon/cppo"
+dev-repo: "https://github.com/mjambon/cppo.git"
+bug-reports: "https://github.com/mjambon/cppo/issues"
+license: "BSD-3-Clause"
+
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta17"}
+  "base-unix"
+]

--- a/packages/cppo/cppo.1.6.5/url
+++ b/packages/cppo/cppo.1.6.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mjambon/cppo/archive/v1.6.5.tar.gz"
+checksum: "1cd25741d31417995b0973fe0b6f6c82"


### PR DESCRIPTION
Compared to the package for cppo 1.6.4, we removed `"base-bytes"` from the list of dependencies in the `opam` file (explained at https://github.com/mjambon/cppo/pull/57).