### PR TITLE
Package ssl.0.5.6

### DIFF
--- a/packages/ssl/ssl.0.5.6/descr
+++ b/packages/ssl/ssl.0.5.6/descr
@@ -1,0 +1,1 @@
+Bindings for OpenSSL

--- a/packages/ssl/ssl.0.5.6/opam
+++ b/packages/ssl/ssl.0.5.6/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Christopher Zimmermann <christopher@gmerlin.de>"
+            author: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {build}
+  "base-unix"
+  "conf-openssl"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ssl/ssl.0.5.6/url
+++ b/packages/ssl/ssl.0.5.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/savonet/ocaml-ssl/archive/v0.5.6.tar.gz"
+checksum: "9035ad67d960d262d4a36f1e19abf37e"


### PR DESCRIPTION
### `ssl.0.5.6`

Bindings for OpenSSL



---
* Homepage: https://github.com/savonet/ocaml-ssl
* Source repo: https://github.com/savonet/ocaml-ssl.git
* Bug tracker: https://github.com/savonet/ocaml-ssl/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5