### PR TITLE
Solo5: Add constraints for 0.4.0 release

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.1.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.1.1/opam
@@ -17,5 +17,10 @@ depends: [
   "mirage-profile" {>= "0.3"}
   "ocaml-freestanding" {< "0.3.0"}
 ]
-conflicts: [ "io-page" {>= "2.0.0"} ]
+conflicts: [
+  "io-page" {>= "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-solo5/mirage-solo5.0.2.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.0/opam
@@ -23,5 +23,10 @@ depends: [
   "ocaml-freestanding" {< "0.3.0"}
   "logs"
 ]
-conflicts: [ "io-page" {>= "2.0.0"} ]
+conflicts: [
+  "io-page" {>= "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 available: [ ocaml-version >= "4.02.3" ]

--- a/packages/mirage-solo5/mirage-solo5.0.2.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.1/opam
@@ -24,5 +24,10 @@ depends: [
   "logs"
   ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} | "solo5-kernel-muen" {< "0.3.0"})
 ]
-conflicts: [ "io-page" {< "2.0.0"} ]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mirage-solo5/mirage-solo5.0.3.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.3.0/opam
@@ -27,5 +27,10 @@ depends: [
   "logs"
   ("solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} | "solo5-kernel-muen" {>= "0.3.0"})
 ]
-conflicts: [ "io-page" {< "2.0.0"} ]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 available: [ ocaml-version >= "4.04.2" ]

--- a/packages/mirage/mirage.3.0.0/opam
+++ b/packages/mirage/mirage.3.0.0/opam
@@ -24,9 +24,10 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {> "3.0.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {> "3.0.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.1/opam
+++ b/packages/mirage/mirage.3.0.1/opam
@@ -24,9 +24,10 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.2/opam
+++ b/packages/mirage/mirage.3.0.2/opam
@@ -24,9 +24,10 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.4/opam
+++ b/packages/mirage/mirage.3.0.4/opam
@@ -24,11 +24,12 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "2.0.0"}
-  "mirage-qubes" {< "0.5" }
-  "mirage-solo5" {< "0.2.1" }
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "2.0.0"}
+  "mirage-qubes" {< "0.5"}
+  "mirage-solo5" {< "0.2.1"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.5/opam
+++ b/packages/mirage/mirage.3.0.5/opam
@@ -27,9 +27,10 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.02.3" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.7/opam
+++ b/packages/mirage/mirage.3.0.7/opam
@@ -27,9 +27,10 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.04.2" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.0.8/opam
+++ b/packages/mirage/mirage.3.0.8/opam
@@ -27,9 +27,10 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.04.2" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.1.0/opam
+++ b/packages/mirage/mirage.3.1.0/opam
@@ -25,10 +25,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
-  "tcpip"    {>= "3.5.0"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.04.2" & ocaml-version < "4.07.0"]

--- a/packages/mirage/mirage.3.1.1/opam
+++ b/packages/mirage/mirage.3.1.1/opam
@@ -25,10 +25,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
-  "tcpip"    {>= "3.5.0"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.04.2"]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
@@ -16,6 +16,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available: [
  ocaml-version >= "4.02.3" & ocaml-version <= "4.03.0" & arch = "x86_64"

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
@@ -17,6 +17,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available: [
   ocaml-version >= "4.02.3" & ocaml-version < "4.05.0" &

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
@@ -17,6 +17,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available: [
   ocaml-version >= "4.02.3" & ocaml-version < "4.06.0" &

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
@@ -17,6 +17,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available: [
   ocaml-version >= "4.02.3" & ocaml-version < "4.07.0" &

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
@@ -17,6 +17,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available: [
   ocaml-version >= "4.04.2" & ocaml-version < "4.07.0" &

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.1/opam
@@ -17,6 +17,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available: [
   ocaml-version >= "4.04.2" & ocaml-version < "4.08.0" &


### PR DESCRIPTION
As part of the 0.4.0 release, the Solo5 packages (solo5-kernel-*) will
be renamed. Add the appropriate constraints to existing published
packages that depend/make use of the old package names.

See Solo5/solo5#274 for details.