### PR TITLE
[new release] lpd (1.2.2)

### DIFF
--- a/packages/lpd/lpd.1.2.2/descr
+++ b/packages/lpd/lpd.1.2.2/descr
@@ -1,0 +1,7 @@
+A Line Printer Daemon (LPD) server library written entirely in OCaml.
+
+Lpd is a Line Printer Daemon compliant with RFC 1179 written entirely
+in OCaml.  It allows to define your own actions for LPD events.  An
+example of a spooler that prints jobs on win32 machines (through
+GSPRINT) is provided.
+

--- a/packages/lpd/lpd.1.2.2/opam
+++ b/packages/lpd/lpd.1.2.2/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+tags: ["lpd" "print"]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/lpd"
+dev-repo: "https://github.com/Chris00/lpd.git"
+bug-reports: "https://github.com/Chris00/lpd/issues"
+doc: "https://Chris00.github.io/lpd/doc"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+]

--- a/packages/lpd/lpd.1.2.2/url
+++ b/packages/lpd/lpd.1.2.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/Chris00/lpd/releases/download/1.2.2/lpd-1.2.2.tbz"
+checksum: "e0ce4ad3d6d2c9b2e548e38da4d79bd2"


### PR DESCRIPTION
CHANGES:

- Use Dune to compile.
- Fix safe-string issues so it works with OCaml ≥ 4.06