### PR TITLE
fix packages that have `setup.ml` from an old oasis

### DIFF
--- a/packages/forkwork/forkwork.0.3.1/opam
+++ b/packages/forkwork/forkwork.0.3.1/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "mlin@mlin.net"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -8,6 +9,7 @@ remove: [["ocaml" "setup.ml" "-uninstall"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 dev-repo: "git://github.com/mlin/forkwork"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/forkwork/forkwork.0.3.1/opam
+++ b/packages/forkwork/forkwork.0.3.1/opam
@@ -7,7 +7,12 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [["ocaml" "setup.ml" "-uninstall"]]
+remove: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-uninstall"]
+  ["ocamlfind" "remove" "forkwork"]
+]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}

--- a/packages/forkwork/forkwork.0.3.1/opam
+++ b/packages/forkwork/forkwork.0.3.1/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "mlin@mlin.net"
+authors: ["Mike Lin"]
+homepage: "https://github.com/mlin/forkwork"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/forkwork/forkwork.0.3.2/opam
+++ b/packages/forkwork/forkwork.0.3.2/opam
@@ -4,6 +4,7 @@ authors: ["Mike Lin"]
 homepage: "https://github.com/mlin/forkwork"
 license: "LGPL-2.1 with OCaml linking exception"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -12,6 +13,7 @@ remove: [["ocamlfind" "remove" "forkwork"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depopts: ["kaputt"]
 dev-repo: "git://github.com/mlin/forkwork"

--- a/packages/genspir/genspir.0.1/opam
+++ b/packages/genspir/genspir.0.1/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "unixjunkie@sdf.org"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -8,6 +9,7 @@ remove: [["ocamlfind" "remove" "genspir"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 dev-repo: "git://github.com/HappyCrow/genspir"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/genspir/genspir.0.1/opam
+++ b/packages/genspir/genspir.0.1/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "https://github.com/UnixJunkie/genspir"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/indexmap/indexmap.0.0.3/opam
+++ b/packages/indexmap/indexmap.0.0.3/opam
@@ -4,6 +4,7 @@ authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
 license: "MIT"
 homepage: "https://github.com/hcarty/indexmap"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -13,6 +14,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 dev-repo: "git://github.com/hcarty/indexmap"
 available: ocaml-version >= "4.00.0"

--- a/packages/libvhd/libvhd.0.9.0/opam
+++ b/packages/libvhd/libvhd.0.9.0/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Jon Ludlam"]
+homepage: "https://github.com/xapi-project/libvhd"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/libvhd/libvhd.0.9.0/opam
+++ b/packages/libvhd/libvhd.0.9.0/opam
@@ -4,11 +4,15 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: make
+build: [
+  ["oasis" "setup"]
+  [make]
+]
 remove: [[make "uninstall" "BINDIR=%{bin}%"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depexts: [
  [ ["ubuntu"] ["blktap-dev" "uuid-dev"] ]

--- a/packages/lwt-binio/lwt-binio.0.2.1/opam
+++ b/packages/lwt-binio/lwt-binio.0.2.1/opam
@@ -4,6 +4,7 @@ authors: ["Hezekiah M. Carty <hez@0ok.org>"]
 homepage: "http://github.com/hcarty/lwt-binio"
 license: "MIT"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -13,7 +14,8 @@ depends: [
   "lwt"
   "ocplib-endian" {>= "0.6"}
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 dev-repo: "git://github.com/hcarty/lwt-binio"
-available: [ocaml-version >= "4.01.0" & ocaml-version < "4.06.0"]
+available: [ocaml-version >= "4.01.0"]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "michal.kurcewicz@gmail.com"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -8,6 +9,7 @@ remove: [["ocamlfind" "remove" "nlopt"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depexts: [
  [["debian"] ["libnlopt-dev"]]

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "michal.kurcewicz@gmail.com"
+authors: ["Michał Kurcewicz"]
+homepage: "https://bitbucket.org/mkur/nlopt-ocaml"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
@@ -3,6 +3,7 @@ maintainer: "michal.kurcewicz@gmail.com"
 homepage: "https://bitbucket.org/mkur/nlopt-ocaml"
 license: "LGPL-2.1+ with OCaml linking exception"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -10,6 +11,7 @@ remove: [["ocamlfind" "remove" "nlopt"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depexts: [
   [["debian"] ["libnlopt0" "libnlopt-dev"]]

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 maintainer: "michal.kurcewicz@gmail.com"
+authors: ["Michał Kurcewicz"]
 homepage: "https://bitbucket.org/mkur/nlopt-ocaml"
 license: "LGPL-2.1+ with OCaml linking exception"
 build: [

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "michal.kurcewicz@gmail.com"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -8,6 +9,7 @@ remove: [["ocamlfind" "remove" "nlopt"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depexts: [
  [["debian"] ["libnlopt-dev"]]

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "michal.kurcewicz@gmail.com"
+authors: ["Michał Kurcewicz"]
+homepage: "https://bitbucket.org/mkur/nlopt-ocaml"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/pci-db/pci-db.0.3.0/opam
+++ b/packages/pci-db/pci-db.0.3.0/opam
@@ -2,13 +2,17 @@ opam-version: "1.2"
 maintainer: "simon.beaumont@citrix.com"
 authors: [ "Si Beaumont" ]
 
-build: make
+build: [
+  ["oasis" "setup"]
+  [make]
+]
 remove: ["ocamlfind" "remove" "pci-db"]
 
 depends: [
   "ocamlfind"
   "ounit"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 dev-repo: "git://github.com/simonjbeaumont/ocaml-pci-db"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/pci-db/pci-db.0.3.0/opam
+++ b/packages/pci-db/pci-db.0.3.0/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "simon.beaumont@citrix.com"
 authors: [ "Si Beaumont" ]
+homepage: "https://github.com/simonjbeaumont/ocaml-pci-db"
 
 build: [
   ["oasis" "setup"]

--- a/packages/qrencode/qrencode.0.1/opam
+++ b/packages/qrencode/qrencode.0.1/opam
@@ -1,12 +1,16 @@
 opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
-build: make
+build: [
+  ["oasis" "setup"]
+  [make]
+]
 remove: [
   ["ocamlfind" "remove" "qrencode"]
 ]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depexts: [
 [ ["ubuntu"] ["libqrencode-dev" "libpng-dev"] ]

--- a/packages/qrencode/qrencode.0.1/opam
+++ b/packages/qrencode/qrencode.0.1/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
+authors: ["Vincent Bernardoff"]
+homepage: "https://github.com/vbmithr/qrencode-ocaml"
 build: [
   ["oasis" "setup"]
   [make]

--- a/packages/rtime/rtime.0.9.3/opam
+++ b/packages/rtime/rtime.0.9.3/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -9,5 +10,6 @@ depends: [
   "ocamlfind"
   "react"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/rtime/rtime.0.9.3/opam
+++ b/packages/rtime/rtime.0.9.3/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel Bünzli"]
+homepage: "http://erratique.ch/software/rtime"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/should/should.0.1.0/opam
+++ b/packages/should/should.0.1.0/opam
@@ -4,6 +4,7 @@ authors: ["Mike Lin"]
 homepage: "https://github.com/mlin/should.ml"
 license: "MIT"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -11,6 +12,7 @@ remove: [["ocamlfind" "remove" "should"]]
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 dev-repo: "git://github.com/mlin/should.ml"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/sqlite3EZ/sqlite3EZ.0.1.0/opam
+++ b/packages/sqlite3EZ/sqlite3EZ.0.1.0/opam
@@ -4,6 +4,7 @@ authors: ["Mike Lin"]
 homepage: "https://github.com/mlin/ocaml-sqlite3EZ"
 license: "MIT"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -14,6 +15,7 @@ depends: [
   "sqlite3"
   "ocaml-twt"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depopts: [
   "beluga"

--- a/packages/udunits/udunits.0.1.1/opam
+++ b/packages/udunits/udunits.0.1.1/opam
@@ -5,6 +5,7 @@ license: "MIT"
 homepage: "https://github.com/hcarty/ocaml-udunits"
 tags: [ "clib:udunits2" "clib:m" "clib:expat"  ]
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -14,6 +15,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depexts: [
   [["debian"] ["libudunits2-dev" "libexpat1-dev"]]

--- a/packages/udunits/udunits.0.2.0/opam
+++ b/packages/udunits/udunits.0.2.0/opam
@@ -5,6 +5,7 @@ license: "MIT"
 homepage: "https://github.com/hcarty/ocaml-udunits"
 tags: [ "clib:udunits2" "clib:m" "clib:expat"  ]
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -14,6 +15,7 @@ remove: [
 depends: [
   "ocamlfind"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depexts: [
   [["debian"] ["libudunits2-dev" "libexpat1-dev"]]

--- a/packages/zbar/zbar.0.9/opam
+++ b/packages/zbar/zbar.0.9/opam
@@ -1,6 +1,9 @@
 opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
-build: [make "PREFIX=%{prefix}%"]
+build: [
+  ["oasis" "setup"]
+  [make "PREFIX=%{prefix}%"]
+]
 remove: [
   ["ocamlfind" "remove" "zbar"]
   ["ocamlfind" "remove" "zbar_ctypes"]
@@ -8,12 +11,12 @@ remove: [
 depends: [
   "lwt"
   "ocamlbuild" {build}
+  "oasis" {build}
 ]
 depopts: ["ctypes" "ctypes-foreign"]
 depexts: [
 [ ["ubuntu"] ["libzbar-dev"] ]
 [ ["debian"] ["libzbar-dev"] ]
 ]
-available: [ocaml-version < "4.06.0"]
 dev-repo: "git://github.com/vbmithr/ocaml-zbar"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/zbar/zbar.0.9/opam
+++ b/packages/zbar/zbar.0.9/opam
@@ -1,5 +1,7 @@
 opam-version: "1.2"
 maintainer: "vb@luminar.eu.org"
+authors: ["Vincent Bernardoff"]
+homepage: "http://github.com/vbmithr/ocaml-zbar"
 build: [
   ["oasis" "setup"]
   [make "PREFIX=%{prefix}%"]


### PR DESCRIPTION
The packages `forkwork.0.3.1, forkwork.0.3.2, genspir, indexmap, libvhd, lwt-binio.0.2.1, nlopt-ocaml.0.4, nlopt-ocaml.0.5, nlopt-ocaml.0.5.1, pci-db, qrencode, rtime, should, sqlite3EZ, udunits.0.1.1, udunits.0.2.0, zbar` all have this in common:

- they use oasis
- they have a `setup.ml` file generated by an old version of oasis, which was broken by the switch to safe strings in 4.06.0
- they are otherwise not broken by safe strings

So we can fix them by changing the build instructions to regenerate `setup.ml` before building as before. This fix doesn't need any patch file or upstream change. The only drawback is that it introduces a build-time dependency on `oasis` (not a big deal IMO).
