### PR TITLE
Partial format upgrade (mirage.3.0.0, mirage.3.0.1, mirage.3.0.2, mirage.3.0.4, mirage.3.0.5, ...)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.1.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.1.1/opam
@@ -18,7 +18,12 @@ depends: [
   "mirage-profile" {>= "0.3"}
   "ocaml-freestanding" {< "0.3.0"}
 ]
-conflicts: [ "io-page" {>= "2.0.0"} ]
+conflicts: [
+  "io-page" {>= "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 synopsis: "Platform bindings for Mirage on Solo5"
 description: "This package provides the platform bindings for Mirage/Solo5."
 url {

--- a/packages/mirage-solo5/mirage-solo5.0.2.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.0/opam
@@ -24,7 +24,12 @@ depends: [
   "ocaml-freestanding" {< "0.3.0"}
   "logs"
 ]
-conflicts: [ "io-page" {>= "2.0.0"} ]
+conflicts: [
+  "io-page" {>= "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 synopsis: "Solo5 core platform libraries for MirageOS"
 description: """
 This package provides the MirageOS `OS` library for

--- a/packages/mirage-solo5/mirage-solo5.0.2.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.2.1/opam
@@ -23,10 +23,15 @@ depends: [
   "lwt" {>= "2.4.3"}
   "ocaml-freestanding" {< "0.3.0"}
   "logs"
-  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |
-   "solo5-kernel-muen" {< "0.3.0"})
+  "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |
+  "solo5-kernel-muen" {< "0.3.0"}
 ]
-conflicts: [ "io-page" {< "2.0.0"} ]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 synopsis: "Solo5 core platform libraries for MirageOS"
 description: """
 This package provides the MirageOS `OS` library for

--- a/packages/mirage-solo5/mirage-solo5.0.3.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.3.0/opam
@@ -29,7 +29,12 @@ depends: [
   "solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} |
   "solo5-kernel-muen" {>= "0.3.0"}
 ]
-conflicts: [ "io-page" {< "2.0.0"} ]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
 synopsis: "Solo5 core platform libraries for MirageOS"
 description: """
 This package provides the MirageOS `OS` library for

--- a/packages/mirage/mirage.3.0.0/opam
+++ b/packages/mirage/mirage.3.0.0/opam
@@ -25,10 +25,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {> "3.0.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {> "3.0.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.0.1/opam
+++ b/packages/mirage/mirage.3.0.1/opam
@@ -25,10 +25,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.0.2/opam
+++ b/packages/mirage/mirage.3.0.2/opam
@@ -25,10 +25,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.0.4/opam
+++ b/packages/mirage/mirage.3.0.4/opam
@@ -25,12 +25,13 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "2.0.0"}
-  "mirage-qubes" {< "0.5" }
-  "mirage-solo5" {< "0.2.1" }
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "2.0.0"}
+  "mirage-qubes" {< "0.5"}
+  "mirage-solo5" {< "0.2.1"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.0.5/opam
+++ b/packages/mirage/mirage.3.0.5/opam
@@ -28,10 +28,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.0.7/opam
+++ b/packages/mirage/mirage.3.0.7/opam
@@ -28,10 +28,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.0.8/opam
+++ b/packages/mirage/mirage.3.0.8/opam
@@ -28,10 +28,11 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "tcpip"    {>= "3.5.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.1.0/opam
+++ b/packages/mirage/mirage.3.1.0/opam
@@ -26,11 +26,12 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
-  "tcpip"    {>= "3.5.0"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.1.1/opam
+++ b/packages/mirage/mirage.3.1.1/opam
@@ -26,11 +26,12 @@ depends: [
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
-  "tcpip"    {>= "3.5.0"}
+  "tcpip" {>= "3.5.0"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
@@ -13,10 +13,13 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"})
+  "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"}
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available: arch = "x86_64"
 synopsis: "Freestanding OCaml runtime"

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
@@ -14,12 +14,15 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"})
+  "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"}
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
-available: arch = "x86_64" | arch = "amd64"
+available: arch = "x86_64" | arch = "x86_64"
 synopsis: "Freestanding OCaml runtime"
 description:
   "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer."

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
@@ -14,13 +14,16 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |
-   "solo5-kernel-muen" {< "0.3.0"})
+  "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |
+  "solo5-kernel-muen" {< "0.3.0"}
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
-available: arch = "x86_64" | arch = "amd64"
+available: arch = "x86_64" | arch = "x86_64"
 synopsis: "Freestanding OCaml runtime"
 description:
   "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer."

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
@@ -14,15 +14,18 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |
-   "solo5-kernel-muen" {< "0.3.0"})
+  "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |
+  "solo5-kernel-muen" {< "0.3.0"}
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available:
-  os = "linux" & (arch = "x86_64" | arch = "aarch64") |
-  os = "freebsd" & arch = "amd64"
+  os = "linux" & (arch = "x86_64" | arch = "arm64") |
+  os = "freebsd" & arch = "x86_64"
 synopsis: "Freestanding OCaml runtime"
 description:
   "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer."

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
@@ -19,6 +19,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available:
   os = "linux" & (arch = "x86_64" | arch = "arm64") |

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.1/opam
@@ -19,6 +19,9 @@ depends: [
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
 ]
 available:
   os = "linux" & (arch = "x86_64" | arch = "arm64") |


### PR DESCRIPTION
Update done by Camelus based on opam-lib 2.0.0~rc3
This might overwrite changes done on the current 2.0.0 branch, so it was not automatically merged. Conflicting files:
  - packages/mirage-solo5/mirage-solo5.0.2.1/opam
  - packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
  - packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
  - packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
  - packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam