### PR TITLE
pcap-format require ppx_cstruct > 0

### DIFF
--- a/packages/pcap-format/pcap-format.0.5.1/opam
+++ b/packages/pcap-format/pcap-format.0.5.1/opam
@@ -22,6 +22,6 @@ depends: [
   "jbuilder"   {build & >="1.0+beta10"}
   "ppx_tools"  {build}
   "cstruct"    {>= "1.9.0"}
-  "ppx_cstruct"
+  "ppx_cstruct" {> "0"}
   "ounit"      {test}
 ]


### PR DESCRIPTION
as discovered in https://travis-ci.org/mirage/mirage-protocols/jobs/428313682 -- only affects master and most recent release (due to switch to jbuilder).