### PR TITLE
Fix liquidsoap 1.3.4 depopts

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.3.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.4/opam
@@ -32,6 +32,7 @@ depopts: [
   "flac"
   "frei0r"
   "gavl"
+  "gstreamer"
   "inotify"
   "ladspa"
   "lame"
@@ -58,7 +59,7 @@ depopts: [
 conflicts: [
   "alsa" {< "0.2.1"}
   "ao" {< "0.2.0"}
-  "bjack" {>= "0.1.3"}
+  "bjack" {< "0.1.3"}
   "cry" {< "0.6.0"}
   "dssi" {< "0.1.1"}
   "faad" {< "0.4.0"}
@@ -67,6 +68,7 @@ conflicts: [
   "flac" {< "0.1.2"}
   "frei0r" {< "0.1.0"}
   "gavl" {< "0.1.4"}
+  "gstreamer" {< "0.3.0"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.1.4"}
   "lame" {< "0.3.2"}


### PR DESCRIPTION
This PR fixes two issues with `gstreamer` missing and `bjack` conflict version. Sorry for the oversight in the previous PR.