### PR TITLE
[new release] dune (1.2.1)

### DIFF
--- a/packages/dune/dune.1.2.1/descr
+++ b/packages/dune/dune.1.2.1/descr
@@ -1,0 +1,18 @@
+Fast, portable and opinionated build system
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.

--- a/packages/dune/dune.1.2.1/opam
+++ b/packages/dune/dune.1.2.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "MIT"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+available: [ ocaml-version >= "4.02.3" ]
+conflicts: [
+  "jbuilder" {!= "transition"}
+]

--- a/packages/dune/dune.1.2.1/url
+++ b/packages/dune/dune.1.2.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml/dune/releases/download/1.2.1/dune-1.2.1.tbz"
+checksum: "f96bdf1a893a2178c2ad9c388439bd18"


### PR DESCRIPTION
CHANGES:

- Enrich the `dune` Emacs mode with syntax highlighting and indentation. New
  file `dune-flymake` to provide a hook `dune-flymake-dune-mode-hook` to enable
  linting of dune files. (ocaml/dune#1265, @Chris00)

- Pass `link_flags` to `cc` when compiling with `Configurator.V1.c_test` (ocaml/dune#1274,
  @rgrinberg)

- Fix digest calculation of aliases. It should take into account extra bindings
  passed to the alias (ocaml/dune#1277, fix ocaml/dune#1276, @rgrinberg)

- Fix a bug causing `dune` to fail eagerly when an optional library
  isn't available (ocaml/dune#1281, @diml)

- ocamlmklib should use response files only if ocaml >= 4.08 (@1268, @bryphe)