### PR TITLE
[coq-serapi] New upstream release.

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/descr
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/descr
@@ -1,0 +1,1 @@
+Sexp Protocol for machine-based interaction with the Coq Proof Assistant.

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/files/coq-serapi.install
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/files/coq-serapi.install
@@ -1,0 +1,4 @@
+bin: [
+  "_build/sertop/sertop.native"  { "sertop"  }
+  "_build/sertop/sercomp.native" { "sercomp" }
+]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer:   "e@x80.org"
+authors:      "Emilio Jesús Gallego Arias"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL 3"
+
+name: "coq-serapi"
+available: [ ocaml-version >= "4.06.0" ]
+
+# ppx depends are so strict due to the issues with ppx_import and
+# ppx_driver integration in the past.
+# ppx_sexp_conv includes a runtime library now, thus it is not a build
+# dep anymore.
+depends: [
+  "coq"           { >= "8.8.0" & < "8.9" }
+  "camlp5"
+  "cmdliner"
+  "sexplib"
+  "ocamlfind"     { build }
+  "ocamlbuild"    { build }
+  "ppx_import"    {  >= "1.4" }
+  "ppx_deriving"  {  >= "4.2.1" }
+  "ppx_sexp_conv" { >= "v0.11.0" }
+]
+
+build:    [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/url
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ejgallego/coq-serapi/archive/8.8.0+0.5.3.tar.gz"
+checksum: "5fbe0ab4c29f34712143ddba53ddabd8"


### PR DESCRIPTION
_Version 0.5.3_:

 * [sertop] Support for `-I` option (`--ml-include-path`).

Thanks to @Ptival for the patch.