### PR TITLE
[new release] qcheck (52e4193)

### DIFF
--- a/packages/qcheck/qcheck.52e4193/descr
+++ b/packages/qcheck/qcheck.52e4193/descr
@@ -1,0 +1,6 @@
+QuickCheck inspired property-based testing for OCaml.
+
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them.
+

--- a/packages/qcheck/qcheck.52e4193/opam
+++ b/packages/qcheck/qcheck.52e4193/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+author: [ "Simon Cruanes <simon.cruanes.2007@m4x.orgr>" ]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+version: "0.9"
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+build-doc: [
+  ["dune" "build" "@doc" "-p" name]
+]
+build-test: [
+  ["dune" "runtest" "-p" name]
+]
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { >= "0.9" }
+  "qcheck-ounit" { >= "0.9" }
+  "odoc" {doc}
+]
+available: [ ocaml-version >= "4.03.0" ]
+dev-repo: "https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]

--- a/packages/qcheck/qcheck.52e4193/url
+++ b/packages/qcheck/qcheck.52e4193/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/c-cube/qcheck/releases/download/52e4193/qcheck-52e4193.tbz"
+checksum: "b02ed778aa2009fc3238465535d4c9dd"


### PR DESCRIPTION
QuickCheck inspired property-based testing for OCaml.

- Project page: <a href="https://github.com/c-cube/qcheck/">https://github.com/c-cube/qcheck/</a>
- Documentation: <a href="http://c-cube.github.io/qcheck/">http://c-cube.github.io/qcheck/</a>

##### CHANGES:

## 0.9

- add `qcheck-ounit` sublibrary
- use environment variables to configure `qcheck-alcotest` tests
- alcotest backend for qcheck
- make `qcheck.ounit` tests verbose by default
- make `qcheck` is a compatibility library, depends on `qcheck-core`
- split lib into `qcheck` and `qcheck.ounit`
- add `TestResult.is_success` helper
- give access to list of instances in test results
- allow setting `time_between_msg` in runner

- chore: remove submodule
- chore: add travis support
- doc: explanations about qcheck.ounit runners
- doc: update readme

## 0.8

- migrate to jbuilder
- fix warnings
- add some useful functions
- update oasis files (close c-cube/qcheck#48)
- update copyright header (closes c-cube/qcheck#47)

## 0.7

- switch to BSD license, make it more explicit (close c-cube/qcheck#43)
- improve multi-line message printing in ounit (closes c-cube/qcheck#46)
- fix complexity of `add_stat`
- allow negative entries in statistics (see c-cube/qcheck#40)
- add a way for tests to report messages to the user (see c-cube/qcheck#39)
- add `QCheck.Shrink.int_aggressive` and make default int shrinker faster
- shrinker for `map_keep_input`
- add `QCheck.set_gen`, missing for some reason

- more compact verbose output (see c-cube/qcheck#33)
- better handling of dynamic progress line
- Add colors to checkmarks in verbose mode
- improve statistics display for runner

- recover exception of shrunk input
- print status line before the solving starts

## 0.6

- add `find_example` and `find_example_gen` to synthesize values from
  properties (see c-cube/qcheck#31)
- add `QCheck.gen` for accessing the random generator easily
- colorful runners, with `--no-colors` to disable them
- add more generator (for corner cases)
- better generation of random functions (see c-cube/qcheck#8),
  using `Observable` and an efficient internal representation using
  heterogeneous tuples, printing, and shrinking.  deprecate old hacks.
- add statistics gathering and display (see c-cube/qcheck#30)

- better printing of Tuple
- improve `Shrink.{array,list}` (see c-cube/qcheck#32)
- Change asserts to raise `Invalid_arg` (following the doc), and update doc
- Change `Gen.{int_bount,int_range}` to support up to 2^62

## 0.5.3.1

- fix regression in runner output (print results of `collect`)
- update the `@since` tags

## 0.5.3

- missing char in `Gen.char` (close c-cube/qcheck#23)
- add `test` and `doc` to opam
- add `small_list` generator
- add `~long_factor` to tests and runner, for long tests
- add more examples in readme, better doc for runners
- improved reporting when running qcheck tests
- add `Test.get_count` on test cells

## 0.5.2

- Add cli option for backtraces in `QCheck_runner`
- Add test case for raising exception
- Better handling of backtraces
- All tests now have a name
- Add step function called on each instance in a test
- make `small_int` a deprecated alias to `small_nat`
- add `small_signed_int`
- remove some warnings
- use safe-string, and fix related bug
- Add long tests options to `QCheck_runner`
- Add `length` specification for `to_ounit2_test`
- Added paragraph in README about long tests

## 0.5.1

- document exceptions
- add `small_nat`, change `small_int` semantics (close c-cube/qcheck#10)
- add `QCheck.assume_fail`
- add `QCheck.assume`; explain preconditions a bit (close c-cube/qcheck#9)
- Polish documentation
- Added quad support uniformly

## 0.5

- merge back from `qtest`: big changes in API, shrinking, use `'a arbitrary`
  type that combines printer, generator, shrinker, etc. (see git log)
- merlin file
- reorganize sources, `_oasis`, `.merlin`, etc.

## 0.4

- bugfix in `fix_fuel`

- if verbose enabled, print each test case
- add `QCheck.run_main`
- `QCheck_ounit.~::`
- add `(>:::)`
- add `qcheck_ounit ml{lib,dylib}`
- trivial ounit integration
- make `test_cell.name` optional
- `Arbitrary.fix_fuel(_gen)`: add a recursive case
- `Arbitrary.fix_fuel_gen`, similar to `fix_fuel` but threading a state bottom-up to make choices depend on the path
- `Arbitrary.fail_fix` to fail in a fixpoint
- helper cases for `Arbitrary.fix_fuel`

## 0.3

- get rid of submodule `generator`
- `Arbitrary.fix_fuel`, to generate complex recursive structures
- new combinators (infix map, applicative funs, shuffle)
- remove generator/Generator, and a deprecation warning
- output of printers of lists/arrays now parsable by ocaml toplevel

## 0.2

- integrate Gabriel Scherer's `Generator` into `QCheck`
- add `|||`
- add `Prop.raises`
- print the faulty instance in case of error (if a printer is available)
- some combinators for `QCheck.Arbitrary`
- `QCheck.mk_test` takes more arguments

## 0.1

- oasis based build system
- source files
