### PR TITLE
4 packages from c-cube/qcheck at 0.9

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
 tags: ["test" "property" "quickcheck"]

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "alcotest"
+  "odoc" {doc}
+]
+available: ocaml-version >= "4.03.0"
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+build-doc: ["dune" "build" "@doc" "-p" name]
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -7,17 +7,19 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune" {build}
+  "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-unix"
   "qcheck-core" {>= "0.9"}
   "alcotest"
   "odoc" {doc}
 ]
-available: ocaml-version >= "4.03.0"
-build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name]
+build:[
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
-build-doc: ["dune" "build" "@doc" "-p" name]
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [

--- a/packages/qcheck-core/qcheck-core.0.9/opam
+++ b/packages/qcheck-core/qcheck-core.0.9/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
 tags: ["test" "property" "quickcheck"]

--- a/packages/qcheck-core/qcheck-core.0.9/opam
+++ b/packages/qcheck-core/qcheck-core.0.9/opam
@@ -7,6 +7,7 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune" {build}
+  "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-unix"
   "odoc" {doc}
@@ -14,11 +15,12 @@ depends: [
 conflicts: [
   "ounit" {< "2.0"}
 ]
-available: ocaml-version >= "4.03.0"
-build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
-build-doc: ["dune" "build" "@doc" "-p" name]
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [

--- a/packages/qcheck-core/qcheck-core.0.9/opam
+++ b/packages/qcheck-core/qcheck-core.0.9/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "odoc" {doc}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+available: ocaml-version >= "4.03.0"
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+build-doc: ["dune" "build" "@doc" "-p" name]
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.9/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.9/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
 tags: ["test" "property" "quickcheck"]

--- a/packages/qcheck-ounit/qcheck-ounit.0.9/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "ounit" {>= "2.0"}
+  "odoc" {doc}
+]
+available: ocaml-version >= "4.03.0"
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+build-doc: ["dune" "build" "@doc" "-p" name]
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.9/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.9/opam
@@ -7,17 +7,19 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune" {build}
+  "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-unix"
   "qcheck-core" {>= "0.9"}
   "ounit" {>= "2.0"}
   "odoc" {doc}
 ]
-available: ocaml-version >= "4.03.0"
-build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
-build-doc: ["dune" "build" "@doc" "-p" name]
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [

--- a/packages/qcheck/qcheck.0.9/opam
+++ b/packages/qcheck/qcheck.0.9/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "qcheck-ounit" {>= "0.9"}
+  "odoc" {doc}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+available: ocaml-version >= "4.03.0"
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+build-doc: ["dune" "build" "@doc" "-p" name]
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcheck/qcheck.0.9/opam
+++ b/packages/qcheck/qcheck.0.9/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
 tags: ["test" "property" "quickcheck"]

--- a/packages/qcheck/qcheck.0.9/opam
+++ b/packages/qcheck/qcheck.0.9/opam
@@ -7,6 +7,7 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune" {build}
+  "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-unix"
   "qcheck-core" {>= "0.9"}
@@ -16,11 +17,12 @@ depends: [
 conflicts: [
   "ounit" {< "2.0"}
 ]
-available: ocaml-version >= "4.03.0"
-build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
-build-doc: ["dune" "build" "@doc" "-p" name]
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.9`
-`qcheck-alcotest.0.9`
-`qcheck-core.0.9`
-`qcheck-ounit.0.9`



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.0~beta