### PR TITLE
Package opam-publish.2.0.0

### DIFF
--- a/packages/opam-publish/opam-publish.2.0.0/opam
+++ b/packages/opam-publish/opam-publish.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+tags: "flags:plugin"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "opam-core" {build & >= "2.0.0~beta5"}
+  "opam-format" {build & >= "2.0.0~beta5"}
+  "opam-state" {build & >= "2.0.0~beta5"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  ("ssl" | "tls")
+  ("github" {build & >= "2.0.0" & < "3.0.0"} |
+   "github-unix" {build & >= "3.0.0"})
+]
+build: ["jbuilder" "build" "-p" name]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src: "https://github.com/ocaml/opam-publish/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=9a030e2c3083744e378f42791ec007e9"
+    "sha512=cf427e808aaa2da6270f916567158509d5669dbfa7d66abce203a8699e2744ac210e20dcd150aa07b8ac346439d942246fc874952583d54d98002076db6c15e0"
+  ]
+}

--- a/packages/opam-publish/opam-publish.2.0.0/opam
+++ b/packages/opam-publish/opam-publish.2.0.0/opam
@@ -10,9 +10,9 @@ tags: "flags:plugin"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "opam-core" {build & >= "2.0.0~beta5"}
-  "opam-format" {build & >= "2.0.0~beta5"}
-  "opam-state" {build & >= "2.0.0~beta5"}
+  "opam-core" {build & >= "2.0.0"}
+  "opam-format" {build & >= "2.0.0"}
+  "opam-state" {build & >= "2.0.0"}
   "ocamlfind" {build}
   "cmdliner" {build}
   ("ssl" | "tls")


### PR DESCRIPTION
### `opam-publish.2.0.0`



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.0.0