### PR TITLE
[new release] zeit (v0.1.0)

### DIFF
--- a/packages/zeit/zeit.0.1.0/descr
+++ b/packages/zeit/zeit.0.1.0/descr
@@ -1,0 +1,1 @@
+Client for the Zeit API and now.sh

--- a/packages/zeit/zeit.0.1.0/opam
+++ b/packages/zeit/zeit.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <me@emillon.org>"
+authors: "Etienne Millon <me@emillon.org>"
+license: "BSD-2"
+homepage: "https://github.com/emillon/ocaml-zeit"
+doc: "https://emillon.github.io/ocaml-zeit/doc"
+bug-reports: "https://github.com/emillon/ocaml-zeit/issues"
+depends: [
+  "ocaml"
+  "cohttp-lwt-unix"
+  "digestif"
+  "dune" {build & >= "1.2.0"}
+  "mock-ounit" {with-test}
+  "ounit" {with-test}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_let"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/emillon/ocaml-zeit.git"

--- a/packages/zeit/zeit.0.1.0/url
+++ b/packages/zeit/zeit.0.1.0/url
@@ -1,0 +1,2 @@
+src: "https://github.com/emillon/ocaml-zeit/releases/download/v0.1.0/zeit-0.1.0.tbz"
+checksum: [ "md5=5da8524b892f5e37c296766e81f7d418" ]


### PR DESCRIPTION
Client for the Zeit API and now.sh

- Project page: <a href="https://github.com/emillon/ocaml-zeit">https://github.com/emillon/ocaml-zeit</a>
- Documentation: <a href="https://emillon.github.io/ocaml-zeit/doc">https://emillon.github.io/ocaml-zeit/doc</a>

##### CHANGES:

Initial release.
