### PR TITLE
Markup 0.8.0: standards-compliant HTML5 parser

### DIFF
--- a/packages/markup-lwt/markup-lwt.0.5.0/opam
+++ b/packages/markup-lwt/markup-lwt.0.5.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+
+version: "0.5.0"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+license: "BSD"
+
+depends: [
+  "base-unix"
+  "dune" {build}
+  "lwt"
+  "markup"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Adapter between Markup.ml and Lwt"
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.0.tar.gz"
+  checksum: "md5=be0e44a8e8a540f633996e0e26109b4d"
+}

--- a/packages/markup/markup.0.8.0/opam
+++ b/packages/markup/markup.0.8.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+version: "0.8.0"
+
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+license: "BSD"
+
+depends: [
+  "ocaml"
+  "dune" {build}
+  "ounit" {with-test}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+# Without that, Markup.ml implicitly requires OCaml 4.01.0, as this is a
+# constraint of Uutf. Without *that*, Markup.ml works on OCaml 3.11 or searlier.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.0.tar.gz"
+  checksum: "md5=be0e44a8e8a540f633996e0e26109b4d"
+}


### PR DESCRIPTION
From the changelog:

> - `Markup.pretty_print` and `Markup.trim` now respect the significance of whitespace in HTML (aantron/markup.ml#39).
> - Modules `Markup_lwt` and `Markup_lwt_unix` have been factored out into a separate opam package `markup-lwt` (aantron/markup.ml#36).

