### PR TITLE
Add ocamlfind dependency to ppxfind

### DIFF
--- a/packages/ppxfind/ppxfind.1.1/opam
+++ b/packages/ppxfind/ppxfind.1.1/opam
@@ -23,3 +23,4 @@ url {
     "https://github.com/diml/ppxfind/releases/download/1.1/ppxfind-1.1.tbz"
   checksum: "md5=9be19346b530d2dfb862f1cc1562ae21"
 }
+conflicts: [ "dune" {= "1.2.0" | = "1.2.1"} ]

--- a/packages/ppxfind/ppxfind.1.1/opam
+++ b/packages/ppxfind/ppxfind.1.1/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-migrate-parsetree"
+  "ocamlfind"
 ]
 synopsis: "ocamlfind ppx tool"
 description: """

--- a/packages/ppxfind/ppxfind.1.2/opam
+++ b/packages/ppxfind/ppxfind.1.2/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-migrate-parsetree"
+  "ocamlfind"
 ]
 synopsis: "ocamlfind ppx tool"
 description: """

--- a/packages/ppxfind/ppxfind.1.2/opam
+++ b/packages/ppxfind/ppxfind.1.2/opam
@@ -23,3 +23,4 @@ url {
     "https://github.com/diml/ppxfind/releases/download/1.2/ppxfind-1.2.tbz"
   checksum: "md5=3c6f81800bb816e190a64f9898481f82"
 }
+conflicts: [ "dune" {= "1.2.0" | = "1.2.1"} ]


### PR DESCRIPTION
`ppxfind` uses `findlib.dynload` so it should depend on `ocamlfind` explicitly.