### PR TITLE
3.07+1 and 3.07+2 were official releases

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-synopsis: "Official 3.07+2 release"
+synopsis: "Official 3.07+1 release"
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml" {= "3.07" & post}
+  "ocaml" {= "3.07+1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -25,12 +25,12 @@ build: [
 install: [
   "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
 ]
-patches: "ocaml-3.07-patch2.diffs"
+patches: "ocaml-3.07-patch1.diffs"
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
   checksum: "md5=2dd038055f5e1350078ad81270411b78"
 }
-extra-source "ocaml-3.07-patch2.diffs" {
-  src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"
-  checksum: "md5=f91d1f1e531f77011bd554817dbbc12a"
+extra-source "ocaml-3.07-patch1.diffs" {
+  src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"
+  checksum: "md5=50e158dee599e00a4b9b93041ea9d21f"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-synopsis: "Official 3.07+1 release"
+synopsis: "Official 3.07+2 release"
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml" {= "3.07" & post}
+  "ocaml" {= "3.07+2" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -25,12 +25,12 @@ build: [
 install: [
   "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
 ]
-patches: "ocaml-3.07-patch1.diffs"
+patches: "ocaml-3.07-patch2.diffs"
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
   checksum: "md5=2dd038055f5e1350078ad81270411b78"
 }
-extra-source "ocaml-3.07-patch1.diffs" {
-  src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"
-  checksum: "md5=50e158dee599e00a4b9b93041ea9d21f"
+extra-source "ocaml-3.07-patch2.diffs" {
+  src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"
+  checksum: "md5=f91d1f1e531f77011bd554817dbbc12a"
 }

--- a/packages/ocaml-system/ocaml-system.3.07+1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.07+1/files/gen_ocaml_config.ml.in
@@ -1,0 +1,25 @@
+let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ %%S %%S ]\n\
+                     variables { path: %%S }\n"
+    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+  close_out oc

--- a/packages/ocaml-system/ocaml-system.3.07+1/opam
+++ b/packages/ocaml-system/ocaml-system.3.07+1/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "3.07+1"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.3.07+2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.3.07+2/files/gen_ocaml_config.ml.in
@@ -1,0 +1,25 @@
+let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ %%S %%S ]\n\
+                     variables { path: %%S }\n"
+    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+  close_out oc

--- a/packages/ocaml-system/ocaml-system.3.07+2/opam
+++ b/packages/ocaml-system/ocaml-system.3.07+2/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "3.07+2"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"

--- a/packages/ocaml/ocaml.3.07+1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.07+1/files/gen_ocaml_config.ml.in
@@ -1,0 +1,51 @@
+let () =
+  let ocaml_version =
+    let v = Sys.ocaml_version in
+    try String.sub v 0 (String.index v '+') with Not_found -> v
+  in
+  if ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "OCaml version mismatch: %%s, expected %{_:version}%"
+       ocaml_version;
+     exit 1)
+  else
+  let oc = open_out "%{_:name}%.config" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
+  let libdir =
+    let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
+    let r = input_line ic in
+    if Unix.close_process_in ic <> Unix.WEXITED 0 then 
+      failwith "Bad return from 'ocamlc -where'";
+    r
+  in
+  let stubsdir =
+    let ic = open_in (Filename.concat libdir "ld.conf") in
+    let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
+    let lines = List.rev (r []) in
+    close_in ic;
+    String.concat ":" lines
+  in
+  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
+  p "opam-version: \"2.0\"";
+  p "variables {";
+  p "  native: %%b"
+    (Sys.file_exists (ocaml^"opt"^suffix));
+  p "  native-tools: %%b"
+    (Sys.file_exists (ocamlc^".opt"^suffix));
+  p "  native-dynlink: %%b"
+    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+  p "  stubsdir: %%S"
+    stubsdir;
+  p "  preinstalled: %{ocaml-system:installed}%";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
+  p "}";
+  close_out oc

--- a/packages/ocaml/ocaml.3.07+1/opam
+++ b/packages/ocaml/ocaml.3.07+1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-base-compiler" {= "3.07+1"} | "ocaml-variants" {>= "3.07+1" & < "3.8~"} |
+  "ocaml-system" {= "3.07+1"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "unix.cma" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.3.07+2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml.3.07+2/files/gen_ocaml_config.ml.in
@@ -1,0 +1,51 @@
+let () =
+  let ocaml_version =
+    let v = Sys.ocaml_version in
+    try String.sub v 0 (String.index v '+') with Not_found -> v
+  in
+  if ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "OCaml version mismatch: %%s, expected %{_:version}%"
+       ocaml_version;
+     exit 1)
+  else
+  let oc = open_out "%{_:name}%.config" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
+  let libdir =
+    let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
+    let r = input_line ic in
+    if Unix.close_process_in ic <> Unix.WEXITED 0 then 
+      failwith "Bad return from 'ocamlc -where'";
+    r
+  in
+  let stubsdir =
+    let ic = open_in (Filename.concat libdir "ld.conf") in
+    let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
+    let lines = List.rev (r []) in
+    close_in ic;
+    String.concat ":" lines
+  in
+  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
+  p "opam-version: \"2.0\"";
+  p "variables {";
+  p "  native: %%b"
+    (Sys.file_exists (ocaml^"opt"^suffix));
+  p "  native-tools: %%b"
+    (Sys.file_exists (ocamlc^".opt"^suffix));
+  p "  native-dynlink: %%b"
+    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+  p "  stubsdir: %%S"
+    stubsdir;
+  p "  preinstalled: %{ocaml-system:installed}%";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
+  p "}";
+  close_out oc

--- a/packages/ocaml/ocaml.3.07+2/opam
+++ b/packages/ocaml/ocaml.3.07+2/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-base-compiler" {= "3.07+2"} | "ocaml-variants" {>= "3.07+2" & < "3.8~"} |
+  "ocaml-system" {= "3.07+2"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "unix.cma" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+build-env: CAML_LD_LIBRARY_PATH = ""


### PR DESCRIPTION
One from the archive department! The three-part numbering scheme was introduced in 3.08.0 - prior to that the patch releases used `+` format. This means that old `3.07+1` and `3.07+2` compilers really belong in ocaml-base-compiler. FWIW, I've even promoted them to being primary releases... (i.e. with `ocaml` packages), but given that `ocaml-variants` may be moved to another remote at some point, it seems relevant to get those two to `ocaml-base-compiler`

cc @rjbou @AltGr as I can't remember if that affects the rewriter scripts in any way. Technically, I think the constraint on ocaml-variants in the ocaml package is not strictly correct, but, erm, that's too academic even for me...