### PR TITLE
nocrypto.0.5.4-1 works on bsd with opam2 (which uses gpatch instead of bsd patch)

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -7,7 +7,6 @@ authors:      ["David Kaloper <david@numm.org>"]
 maintainer:   "David Kaloper <david@numm.org>"
 license:      "ISC"
 tags:          [ "org:mirage" ]
-available: os != "freebsd" & os != "openbsd"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
                 "--jobs" "1"
                 "--with-lwt" "%{lwt:installed}%"


### PR DESCRIPTION
now that opam2 is default, which uses `gpatch` on *BSD (see https://github.com/ocaml/opam/pull/3444), the patches for nocrypto 0.5.4-1 apply nicely on these OS, /cc @copy
#12062 #12252 #12253 #12286 