### PR TITLE
new release: mirage{-runtime,-types,-types-lwt}.3.2.0

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.2.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.2.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage"
+doc: "https://mirage.github.io/mirage/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "ipaddr" {>= "2.6.0"}
+  "functoria-runtime" {>= "2.0.0"}
+  "fmt"
+  "astring"
+  "logs"
+]
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage.git"
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack."""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.2.0/mirage-3.2.0.tbz"
+  checksum: [
+    "md5=7f4b5c6dbb811ffe8cf3b9f4bbfb41ae"
+    "sha256=6d90167f4e609a663e2b8e45c73f682e0e72e54e6deaf5a7da5ebb47efd2fb7a"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: "The MirageOS team"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt"
+  "cstruct" {>= "1.4.0"}
+  "io-page" {>= "1.4.0"}
+  "ipaddr"
+  "mirage-types" {>= "3.2.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-console-lwt" {>= "1.2.0"}
+  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-fs-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
+]
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage.git"
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack."""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.2.0/mirage-3.2.0.tbz"
+  checksum: [
+    "md5=7f4b5c6dbb811ffe8cf3b9f4bbfb41ae"
+    "sha256=6d90167f4e609a663e2b8e45c73f682e0e72e54e6deaf5a7da5ebb47efd2fb7a"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.2.0/opam
+++ b/packages/mirage-types/mirage-types.3.2.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-time" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-console" {>= "2.2.0"}
+  "mirage-protocols" {>= "1.4.0"}
+  "mirage-stack" {>= "1.3.0"}
+  "mirage-block" {>= "1.0.0"}
+  "mirage-net" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0"}
+  "mirage-channel" {>= "3.0.0"}
+]
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage.git"
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack."""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.2.0/mirage-3.2.0.tbz"
+  checksum: [
+    "md5=7f4b5c6dbb811ffe8cf3b9f4bbfb41ae"
+    "sha256=6d90167f4e609a663e2b8e45c73f682e0e72e54e6deaf5a7da5ebb47efd2fb7a"
+  ]
+}

--- a/packages/mirage/mirage.3.2.0/opam
+++ b/packages/mirage/mirage.3.2.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage"
+doc: "https://mirage.github.io/mirage/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "ipaddr" {>= "2.6.0"}
+  "functoria" {>= "2.2.0"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime" {>= "3.2.0"}
+]
+conflicts: [
+  "nocrypto" {< "0.4.0"}
+  "cstruct" {< "1.0.1"}
+  "io-page" {< "1.4.0"}
+  "crunch" {< "1.2.2"}
+  "jbuilder" {= "1.0+beta18"}
+  "mirage-solo5" {< "0.4.0"}
+  "tcpip" {< "3.5.0"}
+]
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage.git"
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack."""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.2.0/mirage-3.2.0.tbz"
+  checksum: [
+    "md5=7f4b5c6dbb811ffe8cf3b9f4bbfb41ae"
+    "sha256=6d90167f4e609a663e2b8e45c73f682e0e72e54e6deaf5a7da5ebb47efd2fb7a"
+  ]
+}
+post-messages: [
+  "As of MirageOS 3.2.0 / Solo5 0.4.0, the 'ukvm' target has been renamed to 'hvt'. Please refer to https://github.com/mirage/mirage/blob/master/CHANGES.md for further details on this change."
+]


### PR DESCRIPTION
### 3.2.0 (2018-09-23)

* adapt to solo5 0.4.0 changes  (by @mato)
Upgrading from Mirage 3.1.x or earlier

Due to conflicting packages, opam will not upgrade mirage to version 3.2.0 or newer if a version of mirage-solo5 older than 0.4.0 is installed in the switch. To perform the upgrade you must run `opam upgrade mirage` explicitly.

Changes required to rebuild and run ukvm unikernels

As of Solo5 0.4.0, the ukvm target has been renamed to hvt. If you are working out of an existing, dirty, source tree, you should initially run:

```
mirage configure -t hvt
mirage clean
mirage configure -t hvt
```

and then proceed as normal. If you are working with a clean source tree, then simply configuring with the new hvt target is sufficient:

`mirage configure -t hvt`

Note that the build products have changed:

The unikernel binary is now named `<unikernel>.hvt`,
the `ukvm-bin` binary is now named `solo5-hvt`.

* adapt to mirage-protocols, mirage-stack, tcpip changes (by @hannesm)

This is a breaking change: mirage 3.2.0 requires mirage-protocols 1.4.0, mirage-stack 1.3.0, and tcpip 3.5.0 to work (charru-client-mirage 0.10 and mirage-qubes-ipv4 0.6 are adapted to the changes).  An older mirage won't be able to use these new libraries correctly.  Conflicts were introduced in the opam-repository.

In more detail,  direct and socket stack initialisation changed, which is automatically generated by the mirage tool for each unikernel (as part of `main.ml`).  A record was built up, which is no longer needed.

Several unneeded type aliases were removed:
  `netif` from Mirage_protocols.ETHIF
  `ethif` and `prefix` from Mirage_protocols.IP
  `ip` from Mirage_protocols.{UDP,TCP}
  `netif` and `'netif config` from Mirage_stack.V4
  `'netif stackv4_config` and `socket_stack_config` in Mirage_stack

* squash unnecessary warning from `mirage build` (by @mato)