### PR TITLE
[new release] github-hooks-unix and github-hooks (0.4.0)

### DIFF
--- a/packages/ascii85/ascii85.0.4/opam
+++ b/packages/ascii85/ascii85.0.4/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/lindig/ascii85/issues"
 license: "BSD"
 dev-repo: "git+https://github.com/lindig/ascii85.git"
 build: [
- ["jbuilder" "build" "-j" jobs "@install"]
+ ["jbuilder" "build" "-j" jobs "-p" name]
 ]
 depends: [
   "ocaml"

--- a/packages/bitmasks/bitmasks.1.1.0/opam
+++ b/packages/bitmasks/bitmasks.1.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://metastack.github.io/bitmasks"
 dev-repo: "git+https://github.com/metastack/bitmasks.git"
 bug-reports: "https://github.com/metastack/bitmasks/issues"
 build: [
-  ["jbuilder" "build" "@install"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
   [make "doc"] {with-doc}
 ]

--- a/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
@@ -7,7 +7,7 @@ doc: "https://gitlab.com/gasche/build_path_prefix_map/blob/master/README.md"
 bug-reports: "https://gitlab.com/gasche/build_path_prefix_map/issues"
 dev-repo: "git+https://gitlab.com/gasche/build_path_prefix_map.git"
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
   [make "doc"] {with-doc}
 ]

--- a/packages/caqti-async/caqti-async.1.0.0/opam
+++ b/packages/caqti-async/caqti-async.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "async" {>= "v0.11.0"}
+  "caqti" {>= "1.0.0" & < "2.0.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "core"
+  "dune" {build}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.0.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "1.1.0~"}
+  "dune" {build}
+  "mariadb" {>= "1.1.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.0.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "1.1.0~"}
+  "dune" {build}
+  "postgresql"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.0.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "1.1.0~"}
+  "dune" {build}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-dynload/caqti-dynload.1.0.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "caqti"
+  "dune" {build}
+  "ocamlfind"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Dynamic linking of Caqti drivers using findlib.dynload"
+description: """
+This library registers a dynamic linker which will be called when
+encoutering an unhandled database URI.  It tries to load a findlib package
+named "caqti-driver-<scheme>" where "<scheme>" is the scheme of the URI,
+which is expected register a driver for the scheme.
+
+This is a separate package to avoid the dependency on the findlib.dynload
+for architectures, like MirageOS, where dynamic linking may be unavailable.
+The alternative is to link drivers directly into the application.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-lwt/caqti-lwt.1.0.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "2.0.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "dune" {build}
+  "logs"
+  "lwt" {>= "3.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti-type-calendar/caqti-type-calendar.1.0.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.0.0" & < "2.0.0~"}
+  "calendar"
+  "dune" {build}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Date and time field types using the calendar library"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/caqti/caqti.1.0.0/opam
+++ b/packages/caqti/caqti.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "logs"
+  "ptime"
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+  checksum: [
+    "md5=6fb535971d307094a9f0bfb05ddc711c"
+    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+  ]
+}

--- a/packages/clarity/clarity.0.1.4/opam
+++ b/packages/clarity/clarity.0.1.4/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
 ]
 build: [
-  [ "jbuilder" "build" ]
+  [ "jbuilder" "build" "-p" name ]
 ]
 install: [
   [ "jbuilder" "install" ]

--- a/packages/clarity/clarity.0.2.0/opam
+++ b/packages/clarity/clarity.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
 ]
 build: [
-  [ "jbuilder" "build" ]
+  [ "jbuilder" "build" "-p" name ]
 ]
 synopsis: "Functional programming library."
 description: """

--- a/packages/clarity/clarity.0.3.0/opam
+++ b/packages/clarity/clarity.0.3.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
 ]
 build: [
-  [ "jbuilder" "build" ]
+  [ "jbuilder" "build" "-p" name ]
 ]
 synopsis: "Functional programming library."
 description: """

--- a/packages/clarity/clarity.0.3.1/opam
+++ b/packages/clarity/clarity.0.3.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
 ]
 build: [
-  [ "jbuilder" "build" ]
+  [ "jbuilder" "build" "-p" name ]
 ]
 synopsis: "Functional programming library."
 description: """

--- a/packages/cohttp-async/cohttp-async.1.1.1/opam
+++ b/packages/cohttp-async/cohttp-async.1.1.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {build & >= "1.1.0"}
+  "async_kernel" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0"}
+  "async_extra" {>= "v0.11.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "cohttp"
+  "conduit-async" {>= "1.0.3"}
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8ad6bb9dffd346bd88e556fc3cffafae"
+    "sha512=a5f7275c22866d24aa8e81687f7bad52e75872d655816b514996335053b5a2de9cc34f68bd077ad4059ff16b6ed3e76c02ef7f7b2e699472e42689643ade89f1"
+  ]
+}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.1.1/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.1.0"}
+  "cohttp" {>= "1.0.0"}
+  "cohttp-lwt" {>= "1.0.0"}
+  "lwt" {>= "3.0.0"}
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-ppx" {>= "3.0"}
+  "js_of_ocaml-lwt"
+]
+conflicts: [
+  "lwt" {< "2.5.0"}
+  "js_of_ocaml" {< "2.8"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8ad6bb9dffd346bd88e556fc3cffafae"
+    "sha512=a5f7275c22866d24aa8e81687f7bad52e75872d655816b514996335053b5a2de9cc34f68bd077ad4059ff16b6ed3e76c02ef7f7b2e699472e42689643ade89f1"
+  ]
+}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.1.0"}
+  "conduit-lwt-unix" {>= "1.0.3"}
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt"
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+conflicts: [
+  "lwt" {< "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8ad6bb9dffd346bd88e556fc3cffafae"
+    "sha512=a5f7275c22866d24aa8e81687f7bad52e75872d655816b514996335053b5a2de9cc34f68bd077ad4059ff16b6ed3e76c02ef7f7b2e699472e42689643ade89f1"
+  ]
+}

--- a/packages/cohttp-lwt/cohttp-lwt.1.1.1/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.1.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.1.0"}
+  "cohttp" {>= "1.0.0"}
+  "lwt"
+  "sexplib"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+]
+conflicts: [
+  "lwt" {< "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8ad6bb9dffd346bd88e556fc3cffafae"
+    "sha512=a5f7275c22866d24aa8e81687f7bad52e75872d655816b514996335053b5a2de9cc34f68bd077ad4059ff16b6ed3e76c02ef7f7b2e699472e42689643ade89f1"
+  ]
+}

--- a/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.1.0"}
+  "result"
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
+  "conduit" {>= "0.99"}
+  "mirage-conduit" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp"
+  "cohttp-lwt"
+  "astring"
+  "magic-mime"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8ad6bb9dffd346bd88e556fc3cffafae"
+    "sha512=a5f7275c22866d24aa8e81687f7bad52e75872d655816b514996335053b5a2de9cc34f68bd077ad4059ff16b6ed3e76c02ef7f7b2e699472e42689643ade89f1"
+  ]
+}

--- a/packages/cohttp-top/cohttp-top.1.1.1/opam
+++ b/packages/cohttp-top/cohttp-top.1.1.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.1.0"}
+  "cohttp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8ad6bb9dffd346bd88e556fc3cffafae"
+    "sha512=a5f7275c22866d24aa8e81687f7bad52e75872d655816b514996335053b5a2de9cc34f68bd077ad4059ff16b6ed3e76c02ef7f7b2e699472e42689643ade89f1"
+  ]
+}

--- a/packages/cohttp/cohttp.1.1.1/opam
+++ b/packages/cohttp/cohttp.1.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "uri" {>= "1.9.0"}
+  "fieldslib"
+  "sexplib"
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "stringext"
+  "base64" {>= "2.0.0"}
+  "fmt" {with-test}
+  "jsonm" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8ad6bb9dffd346bd88e556fc3cffafae"
+    "sha512=a5f7275c22866d24aa8e81687f7bad52e75872d655816b514996335053b5a2de9cc34f68bd077ad4059ff16b6ed3e76c02ef7f7b2e699472e42689643ade89f1"
+  ]
+}

--- a/packages/color/color.0.2.0/descr
+++ b/packages/color/color.0.2.0/descr
@@ -1,0 +1,7 @@
+Converts between different color formats
+
+Library that converts between different color formats. Right now it deals with
+HSL, HSLA, RGB and RGBA formats.
+
+The goal for this library is to provide easy handling of colors on the web, when working
+with `js_of_ocaml`.

--- a/packages/color/color.0.2.0/opam
+++ b/packages/color/color.0.2.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+name: "color"
+maintainer: "anuragsoni.13@gmail.com"
+authors: ["Anurag Soni"]
+homepage: "https://github.com/anuragsoni/color"
+dev-repo: "git+https://github.com/anuragsoni/color.git"
+bug-reports: "https://github.com/anuragsoni/color/issues"
+doc: "https://anuragsoni.github.io/color/"
+license: "MIT"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "gg"
+]

--- a/packages/color/color.0.2.0/url
+++ b/packages/color/color.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/anuragsoni/color/releases/download/0.2.0/color-0.2.0.tbz"
+checksum: "36a5d45385a02f96d07d40d1b0fbcf8a"

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://git-scm.com"
+authors: "Linus Torvalds"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/opam-repository.git"
+license: "GPL-2+"
+build: [["which" "git"]]
+depends: [
+  "conf-which" {build}
+]
+depexts: [
+  ["git"] {os-distribution = "centos"}
+  ["git"] {os-distribution = "fedora"}
+  ["git"] {os-distribution = "opensuse"}
+  ["git"] {os-distribution = "debian"}
+  ["git"] {os-distribution = "ubuntu"}
+  ["git"] {os-distribution = "nixos"}
+  ["git"] {os-distribution = "archlinux"}
+  ["git"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on git"
+description:
+  "This package can only install if the git program is installed on the system."

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.4/files/coq-serapi.install
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.4/files/coq-serapi.install
@@ -1,0 +1,4 @@
+bin: [
+  "_build/sertop/sertop.native"  { "sertop"  }
+  "_build/sertop/sercomp.native" { "sercomp" }
+]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.4/opam
@@ -1,0 +1,31 @@
+synopsis:     "Sexp-based Protocol for machine-based interaction with the Coq Proof Assistant"
+name:         "coq-serapi"
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+authors:      "Emilio Jesús Gallego Arias"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL 3"
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "coq" {>= "8.8.0" & < "8.9"}
+  "camlp5"
+  "cmdliner"
+  "sexplib"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
+  "ppx_sexp_conv" {>= "v0.11.0"}
+]
+
+build:    [ make "-j%{jobs}%" "TARGET=native" ]
+
+extra-files: ["coq-serapi.install" "md5=5f618a1d7a4105aaac53506065bf7d8b"]
+
+url {
+  src: "https://github.com/ejgallego/coq-serapi/archive/8.8.0+0.5.4.tar.gz"
+  checksum: "md5=1533833d0def8f278bcc2f4f96f18c0b"
+}

--- a/packages/cowabloga/cowabloga.0.3.0/opam
+++ b/packages/cowabloga/cowabloga.0.3.0/opam
@@ -8,7 +8,7 @@ homepage:     "https://github.com/mirage/cowabloga"
 bug-reports:  "https://github.com/mirage/cowabloga/issues"
 
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
 ]
 depends: [

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
@@ -34,7 +34,7 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "datakit-client" {>= "0.11.0"}
   "github-hooks" {>= "0.1.1" & < "0.2.0"}
-  "github" {>= "2.2.0"}
+  "github" {>= "2.2.0" & < "4.0.0"}
   "alcotest" {with-test & < "0.8.0"}
   "datakit" {with-test & >= "0.11.0"}
 ]

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.12.0/opam
@@ -33,7 +33,7 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "datakit-client" {>= "0.12.0"}
   "github-hooks-unix" {>= "0.2.0"}
-  "github" {>= "2.1.0"}
+  "github" {>= "2.1.0" & < "4.0.0"}
   "alcotest" {with-test}
   "datakit" {with-test & >= "0.12.0"}
 ]

--- a/packages/depyt/depyt.0.2.0/opam
+++ b/packages/depyt/depyt.0.2.0/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage"]
 
 build: [
   ["jbuilder" "subst" "-p" name]
-  ["jbuilder" "build" "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" jobs]
   ["jbuilder" "runtest" "-j" jobs] {with-test}
 ]
 depends: [

--- a/packages/dnssd/dnssd.0.5.0/opam
+++ b/packages/dnssd/dnssd.0.5.0/opam
@@ -12,7 +12,7 @@ tags: [
 
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
-  ["jbuilder" "build" "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" jobs]
   ["jbuilder" "runtest"] {with-test}
 ]
 depends: [

--- a/packages/earley-ocaml/earley-ocaml.1.1.0/opam
+++ b/packages/earley-ocaml/earley-ocaml.1.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer  : "Christophe Raffalli <christophe@raffalli.eu>"
+bug-reports : "https://github.com/rlepigre/ocaml-earley-ocaml/issues"
+authors     : [ "Christophe Raffalli <christophe@raffalli.eu>"
+                "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>" ]
+homepage    : "https://github.com/rlepigre/ocaml-earley-ocaml"
+license     : "CeCILL-B_V1"
+dev-repo: "git+https://github.com/rlepigre/ocaml-earley-ocaml.git"
+build       : [ [make] [make] ]
+install     : [make "install" "BINDIR=%{bin}%" ]
+remove      : [make "uninstall"]
+depends: [
+  "ocaml" {>= "4.03.0" & <= "4.07.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "earley" {= "1.1.0"}
+]
+synopsis:
+  "Earley-OCaml extensible parser for OCaml (and pa_ocaml preprocessos)"
+description: """
+Earley-OCaml is an (extensible) parser for OCaml,  written using the
+Earley library. It come with a built-in preprocessor called pa_ocaml
+which handles a natural BNF-like syntax extension for OCaml.  It can
+be used to define Earley parsers inside the language.
+
+Authors:
+ - Christophe Raffalli <christophe@raffalli.eu>
+ - Rodolphe Lepigre <rodolphe.lepigre@lepigre.fr>"""
+url {
+  src:
+    "https://github.com/rlepigre/ocaml-earley-ocaml/archive/ocaml-earley-ocaml_1.1.0.tar.gz"
+  checksum: "md5=67afefdd8b48ace35d1eb91b95c39ba5"
+}

--- a/packages/earley/earley.1.1.0/opam
+++ b/packages/earley/earley.1.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer  : "Christophe Raffalli <christophe@raffalli.eu>"
+bug-reports : "https://github.com/rlepigre/ocaml-earley/issues"
+authors     : [ "Christophe Raffalli <christophe@raffalli.eu>"
+                "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>" ]
+homepage    : "https://github.com/rlepigre/ocaml-earley"
+license     : "CeCILL-B_V1"
+dev-repo: "git+https://github.com/rlepigre/ocaml-earley.git"
+build: [
+  [make]
+  [make "tests" "TESTS=--full"] {with-test}
+]
+install     : [make "install"]
+remove      : [make "uninstall"]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+synopsis: "Earley parser combinator library"
+description: """
+Earley is a parser combinator library base on Earley's algorithm. It
+is intended to be used in conjunction with Earley-OCaml, which is an
+extensible parser for OCaml (distributed separately).  It contains a
+syntax extension for OCaml,  which allows the definition of  parsers
+inside the language.
+
+Authors:
+ - Christophe Raffalli <christophe@raffalli.eu>
+ - Rodolphe Lepigre <rodolphe.lepigre@inria.fr>"""
+url {
+  src:
+    "https://github.com/rlepigre/ocaml-earley/archive/ocaml-earley_1.1.0.tar.gz"
+  checksum: "md5=6dc57553fb1901ea454f6e30214955aa"
+}

--- a/packages/gen/gen.0.5.1/opam
+++ b/packages/gen/gen.0.5.1/opam
@@ -7,7 +7,7 @@ doc: "http://cedeela.fr/~simon/software/gen/"
 tags: ["gen" "iterator" "iter" "fold"]
 dev-repo: "git+https://github.com/c-cube/gen.git"
 build: [
-  ["jbuilder" "build" "@install"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
   ["jbuilder" "build" "@doc"] {with-doc}
 ]

--- a/packages/github-hooks-unix/github-hooks-unix.0.4.0/opam
+++ b/packages/github-hooks-unix/github-hooks-unix.0.4.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "GitHub API web hook listener library"
+description: """
+Library to create GitHub webhook server.
+
+### Web hook tests
+
+This repository contains a GitHub web hook test harness that confirms
+that ocaml-github can parse both polled and web-hook-received events and
+that the expected events are delivered in the correct order. To run the
+`test_hook_server` program, you must have a publicly accessible IP
+address with a DNS `A` record and a TLS certificate. You can use [Let's
+Encrypt](https://letsencrypt.org/) to get a TLS certificate for your
+domain for free. `test_hook_server` should be run from an account on the
+public-facing machine which also has agent access to an SSH key which is
+registered with GitHub. I recommend using a remote VM for the domain and
+forwarding a local ssh agent with something like `ssh -A example.net`.
+
+Once this is configured, place your TLS certificate in the file
+`webhook.crt` and the key for that certificate in
+`webhook.key`. Generate a personal GitHub token named `test` with `git
+jar make --scopes=admin:repo_hook,delete_repo,repo [GitHub token
+username] test` (with the `git-jar` subcommand from
+[mirage/ocaml-github](https://github.com/mirage/ocaml-github)) which has
+`admin:repo_hook`, `delete_repo`, and `repo` authority scopes. This
+token has quite a lot of authority so it is important to keep safe or
+use a test account rather than your primary GitHub account.
+
+Finally, run `make test` and then `_build/test/test_hook_server.native
+https://example.net:4433 [GitHub token username] test-github-hooks
+[GitHub SSH username]` to run the tests on your server at `example.net`
+on port `4433` as the user `[GitHub token username]` but git-pushing as the
+user `[GitHub SSH username]`. The test program will create and delete the
+repository `test-github-hooks` in the process of running. If the tests
+fail, you may have to remove the cloned repository called
+`test-github-hooks` and the GitHub repository `[GitHub token
+username]/test-github-hooks`."""
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Thomas Gazagnaire"]
+tags: ["git" "github"]
+homepage: "https://github.com/dsheets/ocaml-github-hooks"
+doc: "https://dsheets.github.io/ocaml-github-hooks/"
+bug-reports: "https://github.com/dsheets/ocaml-github-hooks/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "github-unix" {>= "3.0.1"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "github-hooks" {>= "0.3.0"}
+  "cohttp-lwt-unix" {>= "0.99.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dsheets/ocaml-github-hooks.git"
+url {
+  src:
+    "https://github.com/dsheets/ocaml-github-hooks/releases/download/0.4.0/github-hooks-0.4.0.tbz"
+  checksum: "md5=a38ffb298e3efeebf683106f37f4cb7d"
+}

--- a/packages/github-hooks/github-hooks.0.4.0/opam
+++ b/packages/github-hooks/github-hooks.0.4.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "GitHub API web hook listener library"
+description: """
+Library to create GitHub webhook server.
+
+### Web hook tests
+
+This repository contains a GitHub web hook test harness that confirms
+that ocaml-github can parse both polled and web-hook-received events and
+that the expected events are delivered in the correct order. To run the
+`test_hook_server` program, you must have a publicly accessible IP
+address with a DNS `A` record and a TLS certificate. You can use [Let's
+Encrypt](https://letsencrypt.org/) to get a TLS certificate for your
+domain for free. `test_hook_server` should be run from an account on the
+public-facing machine which also has agent access to an SSH key which is
+registered with GitHub. I recommend using a remote VM for the domain and
+forwarding a local ssh agent with something like `ssh -A example.net`.
+
+Once this is configured, place your TLS certificate in the file
+`webhook.crt` and the key for that certificate in
+`webhook.key`. Generate a personal GitHub token named `test` with `git
+jar make --scopes=admin:repo_hook,delete_repo,repo [GitHub token
+username] test` (with the `git-jar` subcommand from
+[mirage/ocaml-github](https://github.com/mirage/ocaml-github)) which has
+`admin:repo_hook`, `delete_repo`, and `repo` authority scopes. This
+token has quite a lot of authority so it is important to keep safe or
+use a test account rather than your primary GitHub account.
+
+Finally, run `make test` and then `_build/test/test_hook_server.native
+https://example.net:4433 [GitHub token username] test-github-hooks
+[GitHub SSH username]` to run the tests on your server at `example.net`
+on port `4433` as the user `[GitHub token username]` but git-pushing as the
+user `[GitHub SSH username]`. The test program will create and delete the
+repository `test-github-hooks` in the process of running. If the tests
+fail, you may have to remove the cloned repository called
+`test-github-hooks` and the GitHub repository `[GitHub token
+username]/test-github-hooks`."""
+maintainer: "sheets@alum.mit.edu"
+authors: ["David Sheets" "Thomas Gazagnaire"]
+tags: ["git" "github"]
+homepage: "https://github.com/dsheets/ocaml-github-hooks"
+doc: "https://dsheets.github.io/ocaml-github-hooks/"
+bug-reports: "https://github.com/dsheets/ocaml-github-hooks/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "fmt"
+  "logs"
+  "lwt"
+  "cohttp-lwt" {>= "0.99.0"}
+  "github" {>= "3.0.1"}
+  "nocrypto"
+  "cstruct"
+  "hex"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dsheets/ocaml-github-hooks.git"
+url {
+  src:
+    "https://github.com/dsheets/ocaml-github-hooks/releases/download/0.4.0/github-hooks-0.4.0.tbz"
+  checksum: "md5=a38ffb298e3efeebf683106f37f4cb7d"
+}

--- a/packages/hex/hex.1.1.0/opam
+++ b/packages/hex/hex.1.1.0/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/ocaml-hex/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-hex.git"
 license:      "ISC"
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
 ]
 depends: [

--- a/packages/jingoo/jingoo.1.2.19/descr
+++ b/packages/jingoo/jingoo.1.2.19/descr
@@ -1,0 +1,1 @@
+Template engine almost compatible with Jinja2(python template engine)

--- a/packages/jingoo/jingoo.1.2.19/opam
+++ b/packages/jingoo/jingoo.1.2.19/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Masaki WATANABE <lambda.watanabe@gmail.com>"
+authors: "Masaki WATANABE <lambda.watanabe@gmail.com>"
+homepage: "https://github.com/tategakibunko/jingoo"
+bug-reports: "https://github.com/tategakibunko/jingoo/issues"
+dev-repo: "git+https://github.com/tategakibunko/jingoo.git"
+license: "BSD-3"
+build: [
+  [make] {ocaml-native}
+  [make "byte"] {!ocaml-native}
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "jingoo"]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "ocamlfind" {build}
+  "pcre"
+  "uutf"
+  "uucp"
+  "ounit" {test}
+]
+url {
+  src: "https://github.com/tategakibunko/jingoo/archive/v1.2.19.tar.gz"
+  checksum: "md5=97fbeb07f5a3424b3ae65e2c2dedecda"
+}

--- a/packages/lambdapi/lambdapi.1.0/opam
+++ b/packages/lambdapi/lambdapi.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+bug-reports: "https://github.com/rlepigre/lambdapi/issues"
+homepage   : "https://github.com/rlepigre/lambdapi"
+dev-repo   : "git+https://github.com/rlepigre/lambdapi.git"
+
+authors:
+  [ "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>"
+    "Frédéric Blanqui <frederic.blanqui@inria.fr>" ]
+maintainer: "dedukti-dev@inria.fr"
+license: "CeCILL"
+
+build  : [make]
+install: [make "install"]
+remove : [make "uninstall"]
+
+depends:
+  [ "ocaml" {>= "4.04.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "menhir"
+    "earley" {>= "1.0.2"}
+    "earley-ocaml" {>= "1.0.2"}
+    "bindlib" {>= "5.0.0"}
+    "timed" {>= "1.0"} ]
+
+synopsis   : "Implementation of the λΠ-calculus modulo rewriting"
+description:
+"""
+Lambdapi is an implementation of the λΠ-calculus modulo rewriting, that is
+mostly compatible with Dedukti (https://github.com/Deducteam/Dedukti).
+"""
+
+url {
+  src: "https://github.com/rlepigre/lambdapi/archive/lambdapi-1.0.tar.gz"
+  checksum: "md5=16c3b0aea9e6aa0e13ee7dc59f9239cb"
+}

--- a/packages/markup-lwt/markup-lwt.0.5.0/opam
+++ b/packages/markup-lwt/markup-lwt.0.5.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+
+version: "0.5.0"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+license: "BSD"
+
+depends: [
+  "base-unix"
+  "dune" {build}
+  "lwt"
+  "markup"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Adapter between Markup.ml and Lwt"
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.0.tar.gz"
+  checksum: "md5=be0e44a8e8a540f633996e0e26109b4d"
+}

--- a/packages/markup/markup.0.8.0/opam
+++ b/packages/markup/markup.0.8.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+version: "0.8.0"
+
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+license: "BSD"
+
+depends: [
+  "ocaml"
+  "dune" {build}
+  "ounit" {with-test}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+# Without that, Markup.ml implicitly requires OCaml 4.01.0, as this is a
+# constraint of Uutf. Without *that*, Markup.ml works on OCaml 3.11 or searlier.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.0.tar.gz"
+  checksum: "md5=be0e44a8e8a540f633996e0e26109b4d"
+}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 
 
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
 ]
 depends: [

--- a/packages/morbig/morbig.0.9/opam
+++ b/packages/morbig/morbig.0.9/opam
@@ -1,5 +1,15 @@
 opam-version: "2.0"
-maintainer: "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+
+synopsis: "A trustworthy parser for POSIX shell"
+description: """
+Morbig is a parser for shell scripts written in the POSIX shell script
+language. It parses the scripts statically, that is without executing
+them, and constructs a concrete syntax tree for each of them. The
+concrete syntax trees are built using constructors according to the
+shell grammar of the POSIX standard.
+"""
+
+maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
 authors: [
   "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
   "Ralf Treinen <ralf.treinen@irif.fr>"
@@ -11,29 +21,25 @@ homepage: "https://github.com/colis-anr/morbig"
 bug-reports: "https://github.com/colis-anr/morbig/issues"
 dev-repo: "git://github.com/colis-anr/morbig.git"
 
-available: os != "macos"
+available: [os != "macos"]
 depends: [
-  "ocaml" {>= "4.03" & < "4.07"}
-  "ocamlbuild" {build}
-  "menhir" {build}
-  "yojson"
+  "menhir"               {build}
+  "ocaml"                {build & >= "4.03"}
+  "ocamlbuild"           {build}
   "ppx_deriving_yojson"
   "visitors"
+  "yojson"
 ]
-build: [
-  [make]
-  [make "check"] {with-test}
-]
+
+build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
-synopsis: "A trustworthy parser for POSIX shell"
-description: """
-Morbig is a parser for shell scripts written in the POSIX shell script
-language. It parses the scripts statically, that is without executing
-them, and constructs a concrete syntax tree for each of them.  The
-concrete syntax trees are built using constructors according to the
-shell grammar of the POSIX standard."""
+
+run-test: [make "check"]
 url {
   src: "https://github.com/colis-anr/morbig/archive/v0.9.tar.gz"
-  checksum: "md5=a3f8e32c87b6f401117946c7b6e1151d"
+  checksum: [
+    "md5=a3f8e32c87b6f401117946c7b6e1151d"
+    "sha512=4e6903e88af11b13dbf0314230a086ace5f317de71eb34cee04f63a676eac90dc32185075dc1381dac30404af61e9389b76864fddbd5c8b748825d802f273840"
+  ]
 }

--- a/packages/mstruct/mstruct.1.3.3/opam
+++ b/packages/mstruct/mstruct.1.3.3/opam
@@ -6,7 +6,7 @@ homepage:     "https://github.com/mirage/ocaml-mstruct"
 dev-repo: "git+https://github.com/mirage/ocaml-mstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-mstruct/issues"
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
 ]
 depends: [

--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -7,7 +7,6 @@ authors:      ["David Kaloper <david@numm.org>"]
 maintainer:   "David Kaloper <david@numm.org>"
 license:      "ISC"
 tags:          [ "org:mirage" ]
-available: os != "freebsd" & os != "openbsd"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
                 "--jobs" "1"
                 "--with-lwt" "%{lwt:installed}%"

--- a/packages/ocaml-http/ocaml-http.0.1.5/opam
+++ b/packages/ocaml-http/ocaml-http.0.1.5/opam
@@ -5,7 +5,7 @@ build: [
   [make "opt"]
 ]
 remove: [["ocamlfind" "remove" "http"]]
-depends: ["ocaml" "ocamlfind" "camlp4" "ocamlnet" "pcre"]
+depends: ["ocaml" {<"4.06.0"} "ocamlfind" "camlp4" "ocamlnet" "pcre"]
 install: [make "install"]
 synopsis: "Library freely inspired from Perl's HTTP::Daemon module"
 flags: light-uninstall

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "dune" {build}
+  "ocaml" {>= "4.02.0"}
+]

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.1.0/ocaml-migrate-parsetree-1.1.0.tbz"
+checksum: "7dd4808e27af98065f63604c9658d311"

--- a/packages/odisco/odisco.0.1.2/opam
+++ b/packages/odisco/odisco.0.1.2/opam
@@ -1,11 +1,13 @@
 opam-version: "2.0"
 maintainer: "pmundkur.ocaml@gmail.com"
+authors: ["Prashanth Mundkur"]
 homepage: "https://github.com/discoproject/odisco"
+bug-reports: "https://github.com/discoproject/odisco/issues"
 build: make
 remove: [["ocamlfind" "remove" "odisco"]]
 depends: [
   "ocaml" {>= "4.00.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "sonet"
   "atdgen" {< "1.13.0"}
   "biniou"

--- a/packages/odisco/odisco.0.1.3/opam
+++ b/packages/odisco/odisco.0.1.3/opam
@@ -1,11 +1,13 @@
 opam-version: "2.0"
 maintainer: "pmundkur.ocaml@gmail.com"
+authors: ["Prashanth Mundkur"]
 homepage: "https://github.com/discoproject/odisco"
+bug-reports: "https://github.com/discoproject/odisco/issues"
 build: make
 remove: [["ocamlfind" "remove" "odisco"]]
 depends: [
   "ocaml" {>= "4.00.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "sonet"
   "atdgen" {< "1.13.0"}
   "biniou"

--- a/packages/offheap/offheap.0.1.2/opam
+++ b/packages/offheap/offheap.0.1.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+version: "0.1.2"
+
+name: "offheap"
+synopsis: "Copies OCaml objects out of the OCaml heap"
+description: """
+A copy of OCaml objects is moved to memory managed by malloc and free, out of
+the reach of the GC. If the objects are very large, performance can be
+improved as the traversal of large live objects does not slow the GC down.
+"""
+
+maintainer: "Nandor Licker <n@ndor.email>"
+author: "Nandor Licker <n@ndor.email>"
+homepage: "https://github.com/nandor/offheap"
+bug-reports: "https://github.com/nandor/offheap/issues"
+dev-repo: "git+https://github.com/nandor/offheap"
+license: "MIT"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" {build}
+]
+
+url {
+  src: "https://github.com/nandor/offheap/archive/0.1.2.tar.gz"
+  checksum: "md5=0278b913dc2cdb74231d0ca3e4196e36"
+}

--- a/packages/opaca/opaca.0.1.5/opam
+++ b/packages/opaca/opaca.0.1.5/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/spreadLink/opaca/issues"
 dev-repo: "git+https://github.com/spreadLink/opaca.git"
 doc: "https://spreadlink.github.io/opaca/"
 license: "MIT License"
-build: ["jbuilder" "build"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta7"}

--- a/packages/opam-publish/opam-publish.2.0.0/opam
+++ b/packages/opam-publish/opam-publish.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+tags: "flags:plugin"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "opam-core" {build & >= "2.0.0"}
+  "opam-format" {build & >= "2.0.0"}
+  "opam-state" {build & >= "2.0.0"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  ("ssl" | "tls")
+  ("github" {build & >= "2.0.0" & < "3.0.0"} |
+   "github-unix" {build & >= "3.0.0"})
+]
+build: ["jbuilder" "build" "-p" name]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src: "https://github.com/ocaml/opam-publish/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=9a030e2c3083744e378f42791ec007e9"
+    "sha512=cf427e808aaa2da6270f916567158509d5669dbfa7d66abce203a8699e2744ac210e20dcd150aa07b8ac346439d942246fc874952583d54d98002076db6c15e0"
+  ]
+}

--- a/packages/osbx/osbx.1.0.0/opam
+++ b/packages/osbx/osbx.1.0.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "-p" name]
+build: ["jbuilder" "build" "@install"]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/osbx/osbx.1.0.0/opam
+++ b/packages/osbx/osbx.1.0.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/osbx/osbx.1.0.1/opam
+++ b/packages/osbx/osbx.1.0.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "-p" name]
+build: ["jbuilder" "build" "@install"]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/osbx/osbx.1.0.1/opam
+++ b/packages/osbx/osbx.1.0.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/osbx/osbx.1.1.1/opam
+++ b/packages/osbx/osbx.1.1.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/osbx/osbx.1.2.1/opam
+++ b/packages/osbx/osbx.1.2.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {build}

--- a/packages/osbx/osbx.1.2.2/opam
+++ b/packages/osbx/osbx.1.2.2/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {build}

--- a/packages/osbx/osbx.1.2.3/opam
+++ b/packages/osbx/osbx.1.2.3/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {build}

--- a/packages/osbx/osbx.1.2.4/opam
+++ b/packages/osbx/osbx.1.2.4/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build}

--- a/packages/oseq/oseq.0.1/opam
+++ b/packages/oseq/oseq.0.1/opam
@@ -8,9 +8,9 @@ doc: "https://c-cube.github.io/oseq/"
 tags: ["sequence" "iterator" "seq" "pure" "list"]
 dev-repo: "git+https://github.com/c-cube/oseq.git"
 build: [
-  [make "build"]
-  [make "test"] {with-test}
-  [make "doc"] {with-doc}
+  ["jbuilder" "build" "-p" name]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+  ["jbuilder" "build" "@doc" "-p" name] {with-doc}
 ]
 depends: [
   "ocaml" {>= "4.02.0"}

--- a/packages/otetris/otetris.1.0/opam
+++ b/packages/otetris/otetris.1.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/vzaliva/otetris"
 bug-reports: "https://github.com/vzaliva/otetris/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/vzaliva/otetris.git"
-build: ["jbuilder" "build"]
+build: ["jbuilder" "build" "-p" name]
 install: ["jbuilder" "install"]
 depends: [
   "ocaml"

--- a/packages/otetris/otetris.1.1/opam
+++ b/packages/otetris/otetris.1.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/vzaliva/otetris"
 bug-reports: "https://github.com/vzaliva/otetris/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/vzaliva/otetris.git"
-build: ["jbuilder" "build"]
+build: ["jbuilder" "build" "-p" name]
 install: ["jbuilder" "install"]
 depends: [
   "ocaml"

--- a/packages/pla/pla.1.2/opam
+++ b/packages/pla/pla.1.2/opam
@@ -5,7 +5,7 @@ homepage: "https://modlfo.github.io/pla/"
 bug-reports: "https://github.com/modlfo/pla/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/modlfo/pla.git"
-build: [["jbuilder" "build"]]
+build: [["jbuilder" "build" "-p" name]]
 
 depends: [
   "ocaml" {>= "4.02.1"}

--- a/packages/ppx_regexp/ppx_regexp.0.2.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.2.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/paurkedal/ppx_regexp"
 bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
 dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
 license: "LGPL-3 with OCaml linking exception"
-build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+build: ["jbuilder" "build" "--root" "." "-j" jobs "-p" name]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.03.0"}
   "jbuilder" {build}

--- a/packages/ppxfind/ppxfind.1.1/opam
+++ b/packages/ppxfind/ppxfind.1.1/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-migrate-parsetree"
+  "ocamlfind"
 ]
 synopsis: "ocamlfind ppx tool"
 description: """
@@ -22,3 +23,4 @@ url {
     "https://github.com/diml/ppxfind/releases/download/1.1/ppxfind-1.1.tbz"
   checksum: "md5=9be19346b530d2dfb862f1cc1562ae21"
 }
+conflicts: [ "dune" {= "1.2.0" | = "1.2.1"} ]

--- a/packages/ppxfind/ppxfind.1.2/opam
+++ b/packages/ppxfind/ppxfind.1.2/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta16"}
   "ocaml-migrate-parsetree"
+  "ocamlfind"
 ]
 synopsis: "ocamlfind ppx tool"
 description: """
@@ -22,3 +23,4 @@ url {
     "https://github.com/diml/ppxfind/releases/download/1.2/ppxfind-1.2.tbz"
   checksum: "md5=3c6f81800bb816e190a64f9898481f82"
 }
+conflicts: [ "dune" {= "1.2.0" | = "1.2.1"} ]

--- a/packages/ppxlib/ppxlib.0.3.1/descr
+++ b/packages/ppxlib/ppxlib.0.3.1/descr
@@ -1,0 +1,9 @@
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.

--- a/packages/ppxlib/ppxlib.0.3.1/opam
+++ b/packages/ppxlib/ppxlib.0.3.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.11.0"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.0.9"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+  "ocaml"                   {>= "4.04.1"}
+]

--- a/packages/ppxlib/ppxlib.0.3.1/url
+++ b/packages/ppxlib/ppxlib.0.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocaml-ppx/ppxlib/releases/download/0.3.1/ppxlib-0.3.1.tbz"
+checksum: "d83dd03bc744651d4642b84063bffcf9"

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "alcotest"
+  "odoc" {doc}
+]
+build:[
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.9/opam
+++ b/packages/qcheck-core/qcheck-core.0.9/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-unix"
+  "odoc" {doc}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.9/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.9/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "ounit" {>= "2.0"}
+  "odoc" {doc}
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcheck/qcheck.0.9/opam
+++ b/packages/qcheck/qcheck.0.9/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "qcheck-ounit" {>= "0.9"}
+  "odoc" {doc}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/packages/qcow-tool/qcow-tool.0.10.0/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.0/opam
@@ -37,7 +37,7 @@ depends: [
   "nbd" {with-test & >= "2.0.1"}
 ]
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name]
   [make "test"] {with-test}
 ]
 synopsis: "A command-line tool for manipulating qcow2-formatted data"

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
@@ -5,7 +5,7 @@ homepage: "https://gitlab.com/darrenldl/ocaml-reed-solomon-erasure"
 bug-reports: "https://gitlab.com/darrenldl/ocaml-reed-solomon-erasure/issues"
 license: "MIT"
 dev-repo: "git+https://gitlab.com/darrenldl/ocaml-reed-solomon-erasure.git"
-build: ["jbuilder" "build"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.06"}
   "jbuilder" {build}

--- a/packages/resp-server/resp-server.0.2/opam
+++ b/packages/resp-server/resp-server.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "conduit-lwt-unix" {>= "1.0"}
 ]
 build: [
-  ["jbuilder" "build"]
+  ["jbuilder" "build" "-p" name]
   ["jbuilder" "runtest"] {with-test}
 ]
 synopsis: "A server that communicates using the REdis Serialization Protocol"

--- a/packages/smbc/smbc.0.4.2/opam
+++ b/packages/smbc/smbc.0.4.2/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/c-cube/smbc"
 bug-reports: "https://github.com/c-cube/smbc/issues"
 tags: ["logic" "narrowing" "model" "smt"]
 dev-repo: "git+https://github.com/c-cube/smbc.git"
-build: ["jbuilder" "build" "@install"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03"}
   "jbuilder" {build & >= "1.0+beta6"}

--- a/packages/tuareg/tuareg.2.2.0/opam
+++ b/packages/tuareg/tuareg.2.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Christophe.Troestler@umons.ac.be"
+authors: [
+  "Albert Cohen <Albert.Cohen@prism.uvsq.fr>"
+  "Sam Steingold <sds@gnu.org>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Stefan Monnier <monnier@iro.umontreal.ca>"
+]
+homepage: "https://github.com/ocaml/tuareg"
+bug-reports: "https://github.com/ocaml/tuareg/issues"
+dev-repo: "git+https://github.com/ocaml/tuareg.git"
+doc: "https://github.com/ocaml/tuareg"
+build: [
+  [make "tuareg-site-file.el"]
+  [make "elc"] {os != "macos"}
+]
+depends: ["ocaml" "conf-emacs"]
+depopts: [
+  "caml-mode" # {>= "4.05"}
+  "merlin"
+]
+post-messages: [
+  "If you have not yet done so, please add the following line to ~/.emacs.d/init.el or ~/.emacs:
+    (load \"%{share}%/emacs/site-lisp/tuareg-site-file\")
+" {success & !user-setup:installed}
+  "You should consider installing \"merlin\" (completion, displaying types,...)
+or \"caml-mode\" (displaying types).  See https://github.com/ocaml/tuareg
+for customization tips."
+]
+synopsis: "OCaml mode for GNU Emacs and XEmacs."
+description: """
+Tuareg handles automatic indentation of OCaml and Camllight codes.
+Key parts of the code are highlighted using Font-Lock.  Support to run
+an interactive OCaml REPL and debugger is provided."""
+url {
+  src:
+    "https://github.com/ocaml/tuareg/releases/download/2.2.0/tuareg-2.2.0.tar.gz"
+  checksum: "md5=b863d3a4a2127816cfe995f9f8e5ff41"
+}

--- a/packages/vcardgen/vcardgen.1.0/opam
+++ b/packages/vcardgen/vcardgen.1.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/vzaliva/vcardgen"
 bug-reports: "https://github.com/vzaliva/vcardgen/issues"
 license: "BSD2"
 dev-repo: "git+https://github.com/vzaliva/vcardgen.git"
-build: ["jbuilder" "build"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta7"}

--- a/packages/vcardgen/vcardgen.1.1/opam
+++ b/packages/vcardgen/vcardgen.1.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/vzaliva/vcardgen"
 bug-reports: "https://github.com/vzaliva/vcardgen/issues"
 license: "BSD2"
 dev-repo: "git+https://github.com/vzaliva/vcardgen.git"
-build: ["jbuilder" "build"]
+build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
   "jbuilder" {build}

--- a/packages/zeit/zeit.0.1.0/descr
+++ b/packages/zeit/zeit.0.1.0/descr
@@ -1,0 +1,1 @@
+Client for the Zeit API and now.sh

--- a/packages/zeit/zeit.0.1.0/opam
+++ b/packages/zeit/zeit.0.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <me@emillon.org>"
+authors: "Etienne Millon <me@emillon.org>"
+license: "BSD-2"
+homepage: "https://github.com/emillon/ocaml-zeit"
+doc: "https://emillon.github.io/ocaml-zeit/doc"
+bug-reports: "https://github.com/emillon/ocaml-zeit/issues"
+depends: [
+  "ocaml"
+  "cohttp-lwt-unix"
+  "digestif"
+  "dune" {build & >= "1.2.0"}
+  "mock-ounit" {with-test}
+  "ounit" {with-test}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_let"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/emillon/ocaml-zeit.git"

--- a/packages/zeit/zeit.0.1.0/url
+++ b/packages/zeit/zeit.0.1.0/url
@@ -1,0 +1,2 @@
+src: "https://github.com/emillon/ocaml-zeit/releases/download/v0.1.0/zeit-0.1.0.tbz"
+checksum: [ "md5=5da8524b892f5e37c296766e81f7d418" ]

--- a/packages/zenon/zenon.0.8.4/opam
+++ b/packages/zenon/zenon.0.8.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+homepage: "http://zenon-prover.org/"
+dev-repo: "git+https://github.com/zenon-prover/zenon.git"
+maintainer: "Damien Doligez <damien.doligez@inria.fr>"
+authors: [ "R. Bonichon" "D. Delahaye" "D. Doligez" ]
+bug-reports: "https://github.com/zenon-prover/zenon/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+]
+depopts: [
+  "coq"
+]
+build: [
+  ["./configure" "--prefix" "%{prefix}%" "--libdir" "%{zenon:lib}%"]
+  [make]
+]
+install: [[make "install"]]
+remove:  [
+  ["./configure" "--prefix" prefix "--libdir" zenon:lib]
+  [make "uninstall" "BIN_DIR=%{zenon:bin}%" "LIB_DIR=%{lib}%"]
+]
+synopsis: "An Extensible Automated Theorem Prover Producing Checkable Proofs"
+description: """
+Automated theorem prover for first order classical logic (with
+equality), based on the tableau method. Zenon handles first-order
+logic with equality. Its most important feature is that it outputs the
+proofs of the theorems, in Coq-checkable form."""
+url {
+  src: "https://github.com/zenon-prover/zenon/archive/0.8.4.tar.gz"
+  checksum: "md5=c66dde20620b57d5b721a2ecb27cba25"
+}


### PR DESCRIPTION
GitHub API web hook listener library

- Project page: <a href="https://github.com/dsheets/ocaml-github-hooks">https://github.com/dsheets/ocaml-github-hooks</a>
- Documentation: <a href="https://dsheets.github.io/ocaml-github-hooks/">https://dsheets.github.io/ocaml-github-hooks/</a>

##### CHANGES:

- Support Lwt >= 4.0.0 (@avsm)
- Upgrade build system from jbuilder to dune (@avsm)
