### PR TITLE
[new release] dune-release (1.0.0)

### DIFF
--- a/packages/dune-release/dune-release.1.0.0/opam
+++ b/packages/dune-release/dune-release.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports only projects be built
+with [Dune](https://github.com/ocaml/dune) and released on
+[GitHub](https://github.com)."""
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/samoht/dune-release"
+doc: "https://samoht.github.io/dune-release/"
+bug-reports: "https://github.com/samoht/dune-release/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "opam-format"
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+dev-repo: "git+https://github.com/samoht/dune-release.git"
+url {
+  src:
+    "https://github.com/samoht/dune-release/releases/download/1.0.0/dune-release-1.0.0.tbz"
+  checksum: "md5=7bceb7ca71e4d12862473c8cbd5c189d"
+}


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/samoht/dune-release">https://github.com/samoht/dune-release</a>
- Documentation: <a href="https://samoht.github.io/dune-release/">https://samoht.github.io/dune-release/</a>

##### CHANGES:

- Determine opam-repository fork user from URI (samoht/dune-release#64, @NathanReb and @diml)
- All subcommands now support multiple package names (@samoht)
- Do not remove `Makefile` from the distribution archives (samoht/dune-release#71, @samoht)
- Do not duplicate version strings in opam file (samoht/dune-release#72, @samoht)
- Fix configuration file upgrade from 0.2 (samoht/dune-release#55, @samoht)
- Add a `--tag` option to select the release tag (@samoht)
- Add a `--version` option to select the release version (@samoht)
- Fix `--keep-v` (samoht/dune-release#70, @samoht)
- Make `dune-release <OPTIONS>` a shorchut to  `dune-release bistro <OPTIONS>`
  (samoht/dune-release#75, @samoht)
- Add a --no-open option to not open a browser after creating a new P
  (samoht/dune-release#79, @samoht)
- Control `--keep-v` and `--no-auto-open` via options in the config file
  (samoht/dune-release#79, @samoht)
- Be flexible with file names (samoht/dune-release#86 and samoht/dune-release#20, @anuragsoni)
