### PR TITLE
[coq-serapi] New upstream version.

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.5/files/coq-serapi.install
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.5/files/coq-serapi.install
@@ -1,0 +1,4 @@
+bin: [
+  "_build/sertop/sertop.native"  { "sertop"  }
+  "_build/sertop/sercomp.native" { "sercomp" }
+]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.5/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.5/opam
@@ -1,0 +1,31 @@
+synopsis:     "Sexp-based Protocol for machine-based interaction with the Coq Proof Assistant"
+name:         "coq-serapi"
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+authors:      "Emilio Jesús Gallego Arias"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL 3"
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "coq" {>= "8.8.0" & < "8.9"}
+  "camlp5"
+  "cmdliner"
+  "sexplib"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_import" {>= "1.4"}
+  "ppx_deriving" {>= "4.2.1"}
+  "ppx_sexp_conv" {>= "v0.11.0"}
+]
+
+build:    [ make "-j%{jobs}%" "TARGET=native" ]
+
+extra-files: ["coq-serapi.install" "md5=5f618a1d7a4105aaac53506065bf7d8b"]
+
+url {
+  src: "https://github.com/ejgallego/coq-serapi/archive/8.8.0+0.5.5.tar.gz"
+  checksum: "sha512=ea96e4c5b032601e07fd092e4bc8769335c5efb36a67d8a4ae8507cb7598c27f06d7ab797c622af11c93c3f32ca748359a00b42b53a52f952c037c2da6b6843c"
+}


### PR DESCRIPTION
- [serlib] Be more lenient when parsing back `Id.t` as to accommodate
  hacks in the Coq AST (#64) Thanks to @palmskog for the report.