### PR TITLE
[new release] dune (1.3.0)

### DIFF
--- a/packages/dune/dune.1.3.0/opam
+++ b/packages/dune/dune.1.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02"}
+]
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+]
+
+synopsis: "Fast, portable and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+url {
+  src: "https://github.com/ocaml/dune/releases/download/1.3.0/dune-1.3.0.tbz"
+  checksum: "md5=d7c926bd6b7549cb54d5463aaccf0c91"
+}


### PR DESCRIPTION
CHANGES:

- Support colors on Windows (ocaml/dune#1290, @diml)

- Allow `dune.configurator` and `base` to be used together (ocaml/dune#1291, fix
  ocaml/dune#1167, @diml)

- Support interrupting and restarting builds on file changes (ocaml/dune#1246,
  @kodek16)

- Fix findlib-dynload support with byte mode only (ocaml/dune#1295, @bobot)

- Make `dune rules -m` output a valid makefile (ocaml/dune#1293, @diml)

- Expand variables in `(targets ..)` field (ocaml/dune#1301, ocaml/dune#1320, fix ocaml/dune#1189, @nojb,
  @rgrinberg, @diml)

- Fix a race condition on Windows that was introduced in 1.2.0
  (ocaml/dune#1304, fix ocaml/dune#1303, @diml)

- Fix the generation of .merlin files to account for private modules
  (@rgrinberg, fix ocaml/dune#1314)

- Exclude the local opam switch directory (`_opam`) from the list of watched
  directories (ocaml/dune#1315, @dysinger)

- Fix compilation of the module generated for `findlib.dynload`
  (ocaml/dune#1317, fix ocaml/dune#1310, @diml)