### PR TITLE
[new release] travis-opam (1.4.0)

### DIFF
--- a/packages/travis-opam/travis-opam.1.4.0/opam
+++ b/packages/travis-opam/travis-opam.1.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Scripts for OCaml projects"
+description: """
+Supported CI:
+
+- **stable**: [Travis CI](/README-travis.md) Ubuntu, Debian and OSX workers.
+- **experimental**: [Appveyor](/README-appveyor.md) Windows Server 2012 R2 (x64) workers."""
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Richard Mortier" "David Sheets"]
+homepage: "https://github.com/ocaml/ocaml-ci-scripts"
+doc: "https://ocaml.github.io/ocaml-ci-scripts/"
+bug-reports: "https://github.com/ocaml/ocaml-ci-scripts/issues"
+depends: [
+  "ocaml"
+  "jbuilder" {build}
+  "jsonm" {build}
+]
+flags: light-uninstall
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-ci-scripts.git"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-ci-scripts/releases/download/1.4.0/travis-opam-1.4.0.tbz"
+  checksum: "md5=b4bf6f93c03cb65a4ba4e22a062a6554"
+}


### PR DESCRIPTION
Scripts for OCaml projects

- Project page: <a href="https://github.com/ocaml/ocaml-ci-scripts">https://github.com/ocaml/ocaml-ci-scripts</a>
- Documentation: <a href="https://ocaml.github.io/ocaml-ci-scripts/">https://ocaml.github.io/ocaml-ci-scripts/</a>

##### CHANGES:

* Set variables before installing ppas (ocaml/ocaml-ci-scripts#234, @samoht)
* Fix name of system switch when using INSTALL_LOCAL=1 (ocaml/ocaml-ci-scripts#236, @samoht)
* Fix .travis-docker.sh when opam 2 is used (ocaml/ocaml-ci-scripts#237, @gaborigloi)
* Add support for BASE_REMOTE_BRANCH (ocaml/ocaml-ci-scripts#239, @lindig)
* Create a new switch if not pre-installed (ocaml/ocaml-ci-scripts#242, @NathanReb)
* Better lint for opam 1.2 files when using opam2 (ocaml/ocaml-ci-scripts#245, @samoht)
