### PR TITLE
3 packages from ryanslade/influxdb-ocaml at 0.1.0

### DIFF
--- a/packages/influxdb-async/influxdb-async.0.1.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library using async for concurrency"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "alcotest" {test}
+  "influxdb"
+  "async"
+  "cohttp"
+  "cohttp-async"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=82bb1cb46de165e39bca7bdec0c1f18a"
+    "sha512=93e0c3da2c5f78f0ee31e225a945bdad25804e7482b422545531084c540846c5f2412ac2eae8f6b821e172c068fab2a68e935852fbbf59ed28e0ccdbbcf150a7"
+  ]
+}

--- a/packages/influxdb-lwt/influxdb-lwt.0.1.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library using lwt for concurrency"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "alcotest" {test}
+  "influxdb"
+  "lwt"
+  "cohttp"
+  "cohttp-lwt-unix"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=82bb1cb46de165e39bca7bdec0c1f18a"
+    "sha512=93e0c3da2c5f78f0ee31e225a945bdad25804e7482b422545531084c540846c5f2412ac2eae8f6b821e172c068fab2a68e935852fbbf59ed28e0ccdbbcf150a7"
+  ]
+}

--- a/packages/influxdb/influxdb.0.1.0/opam
+++ b/packages/influxdb/influxdb.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "stdio"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=82bb1cb46de165e39bca7bdec0c1f18a"
+    "sha512=93e0c3da2c5f78f0ee31e225a945bdad25804e7482b422545531084c540846c5f2412ac2eae8f6b821e172c068fab2a68e935852fbbf59ed28e0ccdbbcf150a7"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`influxdb.0.1.0`: InfluxDB client library
-`influxdb-async.0.1.0`: InfluxDB client library using async for concurrency
-`influxdb-lwt.0.1.0`: InfluxDB client library using lwt for concurrency



---
* Homepage: https://github.com/ryanslade/influxdb-ocaml
* Source repo: git://github.com/ryanslade/influxdb-ocaml.git
* Bug tracker: https://github.com/ryanslade/influxdb-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0