### PR TITLE
Don't use opam-repository for dev-repo

### DIFF
--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 authors: "Francois Berenger"
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/opam-repository.git"
 license: "GPL-2+"
 build: [["which" "g++"]]
 depends: ["conf-which" {build}]

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -3,7 +3,6 @@ maintainer: "unixjunkie@sdf.org"
 homepage: "https://git-scm.com"
 authors: "Linus Torvalds"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/opam-repository.git"
 license: "GPL-2+"
 build: [["which" "git"]]
 depends: [


### PR DESCRIPTION
Stray `dev-repo` pointing to opam-repository in #12650 and #12665.

@AltGr - it seems too hard-coded to have `opam lint` actually warn about this, but perhaps Camelus specifically warn about `dev-repo` pointing to opam-repository.

I'm not sure if `opam lint` could in general warn if `dev-repo` is given but `url` is not (that would affect opam file is repos for pinning, I think?)