### PR TITLE
Remove relit-reason version field

### DIFF
--- a/packages/relit-reason/relit-reason.0.0.1/opam
+++ b/packages/relit-reason/relit-reason.0.0.1/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 name: "relit-reason"
-version: "0.1"
 maintainer: "Charles Chamberlain <charlespipin@gmail.com>"
 authors: [
   "Jordan Walke <jordojw@gmail.com>"


### PR DESCRIPTION
Version field was wrong causing warning; it's not needed anymore anyway.