### PR TITLE
Package earlybird.0.1

### DIFF
--- a/packages/earlybird/earlybird.0.1/opam
+++ b/packages/earlybird/earlybird.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "2.0"
+synopsis: "OCaml debug adapter"
+description: """
+OCaml debug adapter.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+dev-repo: "git://github.com:hackwaly/ocamlearlybird.git"
+depends: [ "ocaml" "dune" "batteries" "lwt" "lwt_ppx" "angstrom" "angstrom-lwt-unix" "yojson" "ppx_deriving_yojson" ]
+build: ["dune" "build" "-p" name]


### PR DESCRIPTION
### `earlybird.0.1`
OCaml debug adapter
OCaml debug adapter.



---
* Homepage: https://github.com/hackwaly/ocamlearlybird
* Source repo: git+ssh://github.com/hackwaly/ocamlearlybird.git
* Bug tracker: https://github.com/hackwaly/ocamlearlybird/issues

---
:camel: Pull-request generated by opam-publish v2.0.0