### PR TITLE
Package earlybird.0.1

### DIFF
--- a/packages/earlybird/earlybird.0.1/opam
+++ b/packages/earlybird/earlybird.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "OCaml debug adapter"
+description: """
+OCaml debug adapter.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+dev-repo: "git://github.com:hackwaly/ocamlearlybird.git"
+depends: [
+  "ocaml" {= "4.06"}
+  "dune"
+  "batteries"
+  "lwt"
+  "lwt_ppx"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "yojson"
+  "ppx_deriving_yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/hackwaly/ocamlearlybird/archive/0.1.tar.gz"
+  checksum: [
+    "md5=256fb56dcc2ff6c9a607544a77b3a8b7"
+    "sha512=7b65a85133890c3f78c9ce850642375432e51f80817fbbc23153e58ef1b77cfe6e767c6fe30a125ba7a07f4fe43b30a6120487e65b00aed5a750531d966029e3"
+  ]
+}


### PR DESCRIPTION
### `earlybird.0.1`
OCaml debug adapter
OCaml debug adapter.



---
* Homepage: https://github.com/hackwaly/ocamlearlybird
* Source repo: git+ssh://github.com/hackwaly/ocamlearlybird.git
* Bug tracker: https://github.com/hackwaly/ocamlearlybird/issues

---
:camel: Pull-request generated by opam-publish v2.0.0