### PR TITLE
Package earlybird.0.1

### DIFF
--- a/packages/earlybird/earlybird.0.1/opam
+++ b/packages/earlybird/earlybird.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "OCaml debug adapter"
+description: """
+OCaml debug adapter.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+dev-repo: "git://github.com:hackwaly/ocamlearlybird.git"
+depends: [
+  "ocaml" {>= "4.06" & < "4.07"}
+  "dune"
+  "batteries"
+  "lwt"
+  "lwt_ppx"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "yojson"
+  "ppx_deriving_yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/hackwaly/ocamlearlybird/archive/0.1.tar.gz"
+  checksum: [
+    "md5=c339bbb4b8a734a258a28645fac3b074"
+    "sha512=5fff1b2a42479dd73f8046607fbf660733f47da306c4715c4d26b9d8eb1c46a15cfc9e77afc45d38fe984b103f29d7999b7b9060c6e7246f08d5f132455dc0db"
+  ]
+}


### PR DESCRIPTION
### `earlybird.0.1`
OCaml debug adapter
OCaml debug adapter.



---
* Homepage: https://github.com/hackwaly/ocamlearlybird
* Source repo: git+ssh://github.com/hackwaly/ocamlearlybird.git
* Bug tracker: https://github.com/hackwaly/ocamlearlybird/issues

---
:camel: Pull-request generated by opam-publish v2.0.0