### PR TITLE
Package earlybird.0.1

### DIFF
--- a/packages/earlybird/earlybird.0.1/opam
+++ b/packages/earlybird/earlybird.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "OCaml debug adapter"
+description: """
+OCaml debug adapter.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+dev-repo: "git://github.com:hackwaly/ocamlearlybird.git"
+depends: [
+  "ocaml" {>= "4.06" & < "4.07"}
+  "dune"
+  "cmdliner"
+  "batteries"
+  "lwt"
+  "lwt_ppx"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "yojson"
+  "ppx_deriving_yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/hackwaly/ocamlearlybird/archive/0.1.tar.gz"
+  checksum: [
+    "md5=64bdf6865cbc0a2e0022663942a2a3ae"
+    "sha512=47d0bae0d05d449cda7f931da9649a637317038193062dc4a8e0e1b3171c96aecfd56a51898c58daced5e8c79a63aa052c979e0ad161b0499b4190612b234080"
+  ]
+}


### PR DESCRIPTION
### `earlybird.0.1`
OCaml debug adapter
OCaml debug adapter.



---
* Homepage: https://github.com/hackwaly/ocamlearlybird
* Source repo: git+ssh://github.com/hackwaly/ocamlearlybird.git
* Bug tracker: https://github.com/hackwaly/ocamlearlybird/issues

---
:camel: Pull-request generated by opam-publish v2.0.0