### PR TITLE
Package sanddb.0.2

### DIFF
--- a/packages/sanddb/sanddb.0.2/opam
+++ b/packages/sanddb/sanddb.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A simple immutable database for the masses"
+description: """
+SandDB is a simple immutable database, which is also:
+- Simple: It only does one thing, which is persisting data in a file.
+- Easy to use: SandDB's API is extremely small, so you only need to know few functions to use it.
+- Type safe: Every common dangerous operation (like parsing) is covered by the Result type, so you will know where to expect errors.
+- Immutable: Database is based on the immutable stack idea, where you can only push onto the stack.
+- Crud capable: Even though the database is immutable you still can update and delete records, by shadowing them.
+- Version keeping: Every update and delete operation will produce a new version of the affected record, without modifying the original, so you will have all versions of your data.
+- Concurrent: SandDB is based on lwt, so every database operation is asynchronous.
+- Supports multiple serializers: SandDB supports both json and biniou serialization format thanks to the atdgen library.
+"""
+maintainer: "Robert Toth <kkdstryker@gmail.com>"
+authors: ["Robert Toth"]
+homepage: "https://github.com/StrykerKKD/SandDB"
+bug-reports: "https://github.com/StrykerKKD/SandDB/issues"
+dev-repo: "git+https://github.com/StrykerKKD/SandDB.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {build}
+  "atdgen" {>= "1.12.0"}
+  "lwt" {>= "3.3.0"}
+  "uuidm" {>= "0.9.6"}
+  "base" {>= "v0.11.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.04.2"}
+]
+url {
+  src: "https://github.com/StrykerKKD/SandDB/archive/0.2.tar.gz"
+  checksum: [
+    "md5=576971abffbcee20fb27bb49fb8dc3db"
+    "sha512=df9ca4eed6988b7d482bbae86043ba66a27d422606d65b14b0eb2030d603282f5d4499ebd178d5f3e2d676120820b0fcb4304b8d50f4ce956547527635a838a9"
+  ]
+}

--- a/packages/sanddb/sanddb.0.2/opam
+++ b/packages/sanddb/sanddb.0.2/opam
@@ -37,8 +37,5 @@ depends: [
 ]
 url {
   src: "https://github.com/StrykerKKD/SandDB/archive/0.2.tar.gz"
-  checksum: [
-    "md5=576971abffbcee20fb27bb49fb8dc3db"
-    "sha512=df9ca4eed6988b7d482bbae86043ba66a27d422606d65b14b0eb2030d603282f5d4499ebd178d5f3e2d676120820b0fcb4304b8d50f4ce956547527635a838a9"
-  ]
+  checksum: "md5=576971abffbcee20fb27bb49fb8dc3db"
 }


### PR DESCRIPTION
### `sanddb.0.2`
A simple immutable database for the masses
SandDB is a simple immutable database, which is also:
- Simple: It only does one thing, which is persisting data in a file.
- Easy to use: SandDB's API is extremely small, so you only need to know few functions to use it.
- Type safe: Every common dangerous operation (like parsing) is covered by the Result type, so you will know where to expect errors.
- Immutable: Database is based on the immutable stack idea, where you can only push onto the stack.
- Crud capable: Even though the database is immutable you still can update and delete records, by shadowing them.
- Version keeping: Every update and delete operation will produce a new version of the affected record, without modifying the original, so you will have all versions of your data.
- Concurrent: SandDB is based on lwt, so every database operation is asynchronous.
- Supports multiple serializers: SandDB supports both json and biniou serialization format thanks to the atdgen library.



---
* Homepage: https://github.com/StrykerKKD/SandDB
* Source repo: git+https://github.com/StrykerKKD/SandDB.git
* Bug tracker: https://github.com/StrykerKKD/SandDB/issues

---
:camel: Pull-request generated by opam-publish v2.0.0