### PR TITLE
bigstringaf: depopt on mirage-xen, as the conditional compilation in lib/xen/jbuild is done

### DIFF
--- a/packages/bigstringaf/bigstringaf.0.3.0/opam
+++ b/packages/bigstringaf/bigstringaf.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "base-bigarray"
 ]
 depopts: [
-  "mirage-xen-ocaml"
+  "mirage-xen"
   "ocaml-freestanding"
 ]
 synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"


### PR DESCRIPTION
//cc @seliopou see https://github.com/reynir/qubes-mirage-ssh-agent/issues/7 for the reported issue.  upstream is a slightly better fix https://github.com/inhabitedtype/bigstringaf/pull/17

this fix works since mirage-xen depends on mirage-xen-posix, which is ultimately used when calling out to `pkg-config`