### PR TITLE
Fix `with-test` filter on depends field

### DIFF
--- a/packages/jingoo/jingoo.1.2.19/opam
+++ b/packages/jingoo/jingoo.1.2.19/opam
@@ -17,7 +17,7 @@ depends: [
   "pcre"
   "uutf"
   "uucp"
-  "ounit" {test}
+  "ounit" {with-test}
 ]
 
 description: """

--- a/packages/jingoo/jingoo.1.2.20/opam
+++ b/packages/jingoo/jingoo.1.2.20/opam
@@ -17,7 +17,7 @@ depends: [
   "pcre"
   "uutf"
   "uucp"
-  "ounit" {test}
+  "ounit" {with-test}
 ]
 
 description: """

--- a/packages/oranger/oranger.0.9.11/opam
+++ b/packages/oranger/oranger.0.9.11/opam
@@ -22,9 +22,9 @@ depends: [
   "re"
   "dolog"
   "batteries"
-  "minicli" {test}
-  "cpm" {test}
-  "conf-gnuplot" {test}
+  "minicli" {with-test}
+  "cpm" {with-test}
+  "conf-gnuplot" {with-test}
 ]
 flags: light-uninstall
 synopsis: "OCaml wrapper for the ranger (C++) random forests implementation"

--- a/packages/piqi/piqi.0.7.6/opam
+++ b/packages/piqi/piqi.0.7.6/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "piqilib"
-  "num" {test}
+  "num" {with-test}
 ]
 dev-repo: "git://github.com/alavrik/piqi-ocaml"
 url {

--- a/packages/ppx_relit/ppx_relit.0.1/opam
+++ b/packages/ppx_relit/ppx_relit.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base64"
   "ppxlib" {= "0.3.0"}
   "base-unix"
-  "ocamlbuild" {test}
+  "ocamlbuild" {with-test}
   "ocaml" {>= "4.06.0" & < "4.07.0"}
   "relit_helper"
 ]

--- a/packages/tree_layout/tree_layout.0.1.0/opam
+++ b/packages/tree_layout/tree_layout.0.1.0/opam
@@ -24,7 +24,7 @@ remove: ["ocamlfind" "remove" "tree_layout"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "tyxml" {with-test}
+  "tyxml" {with-test & < "4.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Algorithms to layout trees in a pretty manner."

--- a/packages/tree_layout/tree_layout.0.1.0/opam
+++ b/packages/tree_layout/tree_layout.0.1.0/opam
@@ -11,8 +11,7 @@ build: [
     "ocaml"
     "setup.ml"
     "-configure"
-    "--enable-tests" {test}
-    "--enable-benchmark" {test}
+    "--enable-tests" {with-test}
     "--prefix"
     prefix
   ]


### PR DESCRIPTION
Correct filter is [`with-test`](https://opam.ocaml.org/doc/Manual.html#pkgvar-with-test), not `test`.
