### PR TITLE
Package tip-parser.0.5

### DIFF
--- a/packages/tip-parser/tip-parser.0.5/opam
+++ b/packages/tip-parser/tip-parser.0.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+tags: ["TIP" "parse" "inductive" "logic"]
+homepage: "https://github.com/c-cube/tip-parser/"
+bug-reports: "https://github.com/c-cube/tip-parser/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {doc}
+]
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/tip-parser.git"
+url {
+  src: "https://github.com/c-cube/tip-parser/archive/0.5.tar.gz"
+  checksum: [
+    "md5=2b274e79df05a71de86a4cd98c928996"
+    "sha512=be061fc1ab6c122a876f014b682b0eb8257eb557e99ba90a2a871daa55aed85246352db1ee52db337d9cbcb9a8ed6d84325ec4166c5d93b9bd8df9ea57617fa4"
+  ]
+}


### PR DESCRIPTION
### `tip-parser.0.5`



---
* Homepage: https://github.com/c-cube/tip-parser/
* Source repo: git+https://github.com/c-cube/tip-parser.git
* Bug tracker: https://github.com/c-cube/tip-parser/issues

---
:camel: Pull-request generated by opam-publish v2.0.0