### PR TITLE
[new release] ppx_expect (v0.11.1)

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.11.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.11.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "v0.11.1"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+license: "MIT"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"                    {>= "v0.11" & < "v0.12"}
+  "ppx_assert"              {>= "v0.11" & < "v0.12"}
+  "ppx_compare"             {>= "v0.11" & < "v0.12"}
+  "ppx_custom_printf"       {>= "v0.11" & < "v0.12"}
+  "ppx_fields_conv"         {>= "v0.11" & < "v0.12"}
+  "ppx_here"                {>= "v0.11" & < "v0.12"}
+  "ppx_inline_test"         {>= "v0.11" & < "v0.12"}
+  "ppx_sexp_conv"           {>= "v0.11" & < "v0.12"}
+  "ppx_variants_conv"       {>= "v0.11" & < "v0.12"}
+  "stdio"                   {>= "v0.11" & < "v0.12"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
+  "ppxlib"                  {>= "0.1.0"}
+  "re"                      {>= "1.5.0"}
+  "ocaml"                   {>= "4.04.1"}
+]
+synopsis: "Cram like framework for OCaml"
+description: "Part of the Jane Street's PPX rewriters collection."
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/releases/download/v0.11.1/ppx_expect-v0.11.1.tbz"
+  checksum: "md5=ee5e03094674de295aadc10efe6bb7b7"
+}


### PR DESCRIPTION
Expect-test - a cram like framework for OCaml

- Project page: <a href="https://github.com/janestreet/ppx_expect">https://github.com/janestreet/ppx_expect</a>

##### CHANGES:

- Fix formatting check on Windows (@bryphe, janestreet/ppx_expect#12)
