### PR TITLE
Package oseq.0.2

### DIFF
--- a/packages/oseq/oseq.0.2/opam
+++ b/packages/oseq/oseq.0.2/opam
@@ -8,11 +8,11 @@ doc: "https://c-cube.github.io/oseq/"
 bug-reports: "https://github.com/c-cube/oseq/issues"
 depends: [
   "dune" {build}
-  "qcheck" {test}
-  "qtest" {test}
-  "gen" {test}
-  "containers" {test}
-  "odoc" {doc}
+  "qcheck" {with-test}
+  "qtest" {with-test}
+  "gen" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
   "seq"
 ]
 build: [

--- a/packages/oseq/oseq.0.2/opam
+++ b/packages/oseq/oseq.0.2/opam
@@ -28,3 +28,5 @@ url {
     "sha512=1a983fb6d92780beb7e6a09c7883060df060b5bb52397a89eb86a8b1b863bbec032a2b38cef441bfc5c33374e3ea2c24c40777774b6e7fbf6528039e154b2a39"
   ]
 }
+synopsis: "Simple list of suspensions, as a composable lazy iterator that behaves like a value"
+description: "Extends the new standard library's `Seq` module with many useful combinators."

--- a/packages/oseq/oseq.0.2/opam
+++ b/packages/oseq/oseq.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+license: "BSD-2-clauses"
+tags: ["sequence" "iterator" "seq" "pure" "list"]
+homepage: "https://github.com/c-cube/oseq/"
+doc: "https://c-cube.github.io/oseq/"
+bug-reports: "https://github.com/c-cube/oseq/issues"
+depends: [
+  "dune" {build}
+  "qcheck" {test}
+  "qtest" {test}
+  "gen" {test}
+  "containers" {test}
+  "odoc" {doc}
+  "seq"
+]
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/oseq.git"
+url {
+  src: "https://github.com/c-cube/oseq/archive/0.2.tar.gz"
+  checksum: [
+    "md5=18a41450acd7da1648a2a24229f00d7a"
+    "sha512=1a983fb6d92780beb7e6a09c7883060df060b5bb52397a89eb86a8b1b863bbec032a2b38cef441bfc5c33374e3ea2c24c40777774b6e7fbf6528039e154b2a39"
+  ]
+}


### PR DESCRIPTION
### `oseq.0.2`



---
* Homepage: https://github.com/c-cube/oseq/
* Source repo: git+https://github.com/c-cube/oseq.git
* Bug tracker: https://github.com/c-cube/oseq/issues

---
:camel: Pull-request generated by opam-publish v2.0.0