### PR TITLE
[coq-serapi] Fix constraint on old coq-serapi.

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
@@ -8,7 +8,7 @@ license:      "GPL 3"
 
 name: "coq-serapi"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "4.07.0" }
   "coq" {>= "8.7.2" & < "8.8"}
   "camlp5"
   "cmdliner"


### PR DESCRIPTION
Unfortunately this older release is not compatible with OCaml >= 4.07
due to a problem with `Stdlib` packing.