### PR TITLE
Package rresult.0.6.0

### DIFF
--- a/packages/rresult/rresult.0.6.0/opam
+++ b/packages/rresult/rresult.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "git+http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "ISC"
+depends: [
+   "ocaml" {>= "4.01.0"}
+   "ocamlfind" {build}
+   "ocamlbuild" {build}
+   "topkg" {build}
+   "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]
+
+synopsis: """Result value combinators for OCaml"""
+description: """\
+
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+Rresult depends on the compatibility `result` package and is
+distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz"
+checksum: "aba88cffa29081714468c2c7bcdf7fb1"
+}


### PR DESCRIPTION
### `rresult.0.6.0`
Result value combinators for OCaml
Rresult is an OCaml module for handling computation results and errors
in an explicit and declarative manner, without resorting to
exceptions. It defines combinators to operate on the `result` type
available from OCaml 4.03 in the standard library.

Rresult depends on the compatibility `result` package and is
distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/rresult
* Source repo: git+http://erratique.ch/repos/rresult.git
* Bug tracker: https://github.com/dbuenzli/rresult/issues

---
:camel: Pull-request generated by opam-publish v2.0.0