### PR TITLE
Package submit.0.6.0

### DIFF
--- a/packages/submit/submit.0.6.0/opam
+++ b/packages/submit/submit.0.6.0/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/rresult"
+doc: "http://erratique.ch/software/rresult"
+dev-repo: "git+http://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+tags: [ "result" "error" "declarative" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+]
+build:[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]


### PR DESCRIPTION
### `submit.0.6.0`



---
* Homepage: http://erratique.ch/software/rresult
* Source repo: git+http://erratique.ch/repos/rresult.git
* Bug tracker: https://github.com/dbuenzli/rresult/issues

---
v0.6.0 2018-10-07 Zagreb
------------------------

* Add `R.failwith_error_msg`.

---
:camel: Pull-request generated by opam-publish v2.0.0