### PR TITLE
Package mccs.1.1+9

### DIFF
--- a/packages/mccs/mccs.1.1+9/opam
+++ b/packages/mccs/mccs.1.1+9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Claude Michel <claude.michel@unice.fr>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+license: "LGPL-2.1 with OCaml linking exception, BSD-3-clause, GPL-3.0"
+homepage: "http://www.i3s.unice.fr/~cpjm/misc/"
+bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
+depends: [
+  "ocaml"
+  "jbuilder" {build}
+  "cudf" {>= "0.7"}
+]
+build: [
+  ["jbuilder" "build" "-p" name]
+  ["sh" "-c" "jbuilder build @settests --auto-promote || true"] {with-test}
+  ["jbuilder" "runtest"] {with-test}
+]
+dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
+url {
+  src: "https://github.com/AltGr/ocaml-mccs/archive/1.1+9.tar.gz"
+  checksum: [
+    "md5=95aabb806fe6cbfab92a98b2a88d79c3"
+    "sha512=f3327290ace029f2a17e4270d1395238d9adad183f7ea2027efea0b68205b0ace52645556d4e079d6f49ebd943808e2b68c78f00914eb2d557bf18e782376650"
+  ]
+}


### PR DESCRIPTION
### `mccs.1.1+9`



---
* Homepage: http://www.i3s.unice.fr/~cpjm/misc/
* Source repo: git+https://github.com/AltGr/ocaml-mccs.git
* Bug tracker: https://github.com/AltGr/ocaml-mccs/issues

---
:camel: Pull-request generated by opam-publish v2.0.0