### PR TITLE
Package telegraml.2.2.1

### DIFF
--- a/packages/telegraml/telegraml.2.2.1/descr
+++ b/packages/telegraml/telegraml.2.2.1/descr
@@ -1,0 +1,5 @@
+Telegram Bot API for OCaml
+An implementation of the Telegram Bot API in 100% OCaml,
+using Lwt for asynchronous operations and Cohttp for networking.
+Implements most basic functionality present in the API, plus
+convenience modules for error handling and defining commands.

--- a/packages/telegraml/telegraml.2.2.1/opam
+++ b/packages/telegraml/telegraml.2.2.1/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "nv-vn <nv@cock.li>"
+authors: "nv-vn <nv@cock.li>"
+homepage: "https://github.com/nv-vn/telegraml"
+bug-reports: "https://github.com/nv-vn/telegraml/issues"
+license: "MIT"
+dev-repo: "https://github.com/nv-vn/telegraml.git"
+build: ["dune" "build" "-p" name "-j" jobs "@install"]
+install: ["dune" "install"]
+depends: [
+  "jbuilder" {build}
+  "lwt" {>= "2.5.0"}
+  "lwt_ssl"
+  "cohttp" {>= "1.0.0"}
+  "cohttp-lwt" {>= "1.0.0"}
+  "yojson" {>= "1.3.0"}
+]
+available: [ocaml-version >= "4.03"]

--- a/packages/telegraml/telegraml.2.2.1/opam
+++ b/packages/telegraml/telegraml.2.2.1/opam
@@ -6,9 +6,8 @@ bug-reports: "https://github.com/nv-vn/telegraml/issues"
 license: "MIT"
 dev-repo: "https://github.com/nv-vn/telegraml.git"
 build: ["dune" "build" "-p" name "-j" jobs "@install"]
-install: ["dune" "install"]
 depends: [
-  "jbuilder" {build}
+  "dune" {build}
   "lwt" {>= "2.5.0"}
   "lwt_ssl"
   "cohttp" {>= "1.0.0"}

--- a/packages/telegraml/telegraml.2.2.1/url
+++ b/packages/telegraml/telegraml.2.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/nv-vn/TelegraML/archive/v2.2.1.tar.gz"
+checksum: "60fdc7fc798306ff350561dbd0aa9a9b"


### PR DESCRIPTION
### `telegraml.2.2.1`

Telegram Bot API for OCaml
An implementation of the Telegram Bot API in 100% OCaml,
using Lwt for asynchronous operations and Cohttp for networking.
Implements most basic functionality present in the API, plus
convenience modules for error handling and defining commands.



---
* Homepage: https://github.com/nv-vn/telegraml
* Source repo: https://github.com/nv-vn/telegraml.git
* Bug tracker: https://github.com/nv-vn/telegraml/issues

---
### opam-lint failures
- **WARNING** 27 No field 'remove' while a field 'install' is present, uncomplete uninstallation suspected

---

:camel: Pull-request generated by opam-publish v0.3.5