### PR TITLE
get_line: bugfix release

### DIFF
--- a/packages/get_line/get_line.4.0.1/opam
+++ b/packages/get_line/get_line.4.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "batteries" {>= "2.6.0"}
 ]
 synopsis:
-  "robustly select lines from file; can replace the head and tail shell commands and do even more"
+  "Robustly select lines from file; can replace the head and tail shell commands and do even more"
 description: """
 usage:
 get_line {--range|-r} {+n|-n|i|i..j|i,j[,...]} [-i FILE] [--rand] [-v] (1 <= i [<= j] <= N; N = nb. lines in FILE)

--- a/packages/get_line/get_line.4.0.1/opam
+++ b/packages/get_line/get_line.4.0.1/opam
@@ -9,7 +9,7 @@ license: "GPL"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build}
   "batteries" {>= "2.6.0"}
 ]
 synopsis:

--- a/packages/get_line/get_line.4.0.1/opam
+++ b/packages/get_line/get_line.4.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "get_line"
+maintainer: "unixjunkie@sdf.org"
+authors: "Francois Berenger"
+homepage: "https://github.com/UnixJunkie/get_line"
+bug-reports: "https://github.com/UnixJunkie/get_line/issues"
+dev-repo: "git://github.com/UnixJunkie/get_line"
+license: "GPL"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml"
+  "jbuilder" {build}
+  "batteries" {>= "2.6.0"}
+]
+synopsis:
+  "robustly select lines from file; can replace the head and tail shell commands and do even more"
+description: """
+usage:
+get_line {--range|-r} {+n|-n|i|i..j|i,j[,...]} [-i FILE] [--rand] [-v] (1 <= i [<= j] <= N; N = nb. lines in FILE)
+
+  -v invert the selection of lines (like 'grep -v')
+  --rand randomize selected lines before writing them out
+  -i <filename> where to read lines from (default=stdin)
+  -o <filename> where to write lines to (default=stdout)
+  {-r|--range} {+n|-n|i|i..j|i,j[,...]}: line selection policy;
+               (+n => top n lines;
+                -n => last n lines;
+                n => only line n;
+                i..j => lines i to j;
+                i,j[,...] => only lines i,j,...
+  {-help|--help} Display this list of options"""
+url {
+  src: "https://github.com/UnixJunkie/get_line/archive/v4.0.1.tar.gz"
+  checksum: "md5=a3713e755fe3d7e01bc35db0df971614"
+}


### PR DESCRIPTION
explicitely opening "/dev/stdout" was truncating the file in case
stdout was redirected to a file (from the command line); quite strange