### PR TITLE
[new release] cairo2, cairo2-pango and cairo2-gtk (0.6)

### DIFF
--- a/packages/cairo2-gtk/cairo2-gtk.0.6/opam
+++ b/packages/cairo2-gtk/cairo2-gtk.0.6/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Rendering Cairo on Gtk canvas."
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Pierre Hauweele <pierre@hauweele.net>"
+]
+license: "LGPL-3.0 with OCaml linking exception"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+homepage: "https://github.com/Chris00/ocaml-cairo"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {build}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2"
+  "lablgtk2"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6/cairo2-0.6.tbz"
+  checksum: "md5=2204218b8743f43710c9788943cfc527"
+}

--- a/packages/cairo2-pango/cairo2-pango.0.6/opam
+++ b/packages/cairo2-pango/cairo2-pango.0.6/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Interface between Cairo and Pango"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Pierre Hauweele <pierre@hauweele.net>"
+]
+license: "LGPL-3.0 with OCaml linking exception"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+homepage: "https://github.com/Chris00/ocaml-cairo"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {build}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2"
+  "lablgtk2"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6/cairo2-0.6.tbz"
+  checksum: "md5=2204218b8743f43710c9788943cfc527"
+}

--- a/packages/cairo2/cairo2.0.6/opam
+++ b/packages/cairo2/cairo2.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Binding to Cairo, a 2D Vector Graphics Library."
+description: """
+This is a binding to Cairo, a 2D graphics library with support for
+multiple output devices. Currently supported output targets include
+the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
+and SVG file output."""
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Pierre Hauweele <pierre@hauweele.net>"
+]
+license: "LGPL-3.0 with OCaml linking exception"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+homepage: "https://github.com/Chris00/ocaml-cairo"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {build}
+  "conf-cairo"
+]
+depopts: ["conf-freetype"]
+conflicts: [
+  "cairo" {= "0.4.1"}
+  "cairo" {= "0.4.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6/cairo2-0.6.tbz"
+  checksum: "md5=2204218b8743f43710c9788943cfc527"
+}


### PR DESCRIPTION
Binding to Cairo, a 2D Vector Graphics Library.

- Project page: <a href="https://github.com/Chris00/ocaml-cairo">https://github.com/Chris00/ocaml-cairo</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-cairo/doc">https://Chris00.github.io/ocaml-cairo/doc</a>

##### CHANGES:

- New `Ft` module to support FreeType fonts.  This is enabled if the
  package `conf-freetype` is installed.  On the C side, the exported
  header file `cairo_ocaml.h` defines the macro `OCAML_CAIRO_HAS_FT`
  when the Cairo bindings were compiled with TrueType support.
- New package `Cairo2-pango` providing the module `Cairo_pango`.
- Remove labels that were not bringing a clear benefit.  With Dune
  default behavior, users will feel compelled to write labels which
  was cluttering the code with the previous interface.  With Merlin,
  it is now possible to have the documentation of a function under the
  cursor displayed with a simple keystroke which should alleviate
  having slightly less documentation in the types.
- Improve the documentation.
- Use Dune (not the former Jbuilder) to compile.
