### PR TITLE
[new release] cairo2, cairo2-pango and cairo2-gtk (0.6)

### DIFF
--- a/packages/cairo2-gtk/cairo2-gtk.0.6/opam
+++ b/packages/cairo2-gtk/cairo2-gtk.0.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {build}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2"
+  "lablgtk2"
+]
+synopsis: "Rendering Cairo on Gtk canvas"
+description: """
+This provides the link between Cairo and Lablgtk.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6/cairo2-0.6.tbz"
+  checksum: "md5=9147030f57e10c9e9665396b92f6c9cc"
+}

--- a/packages/cairo2-pango/cairo2-pango.0.6/opam
+++ b/packages/cairo2-pango/cairo2-pango.0.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {build}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2"
+  "lablgtk2"
+]
+synopsis: "Interface between Cairo and Pango"
+description: """
+Interface lablgtk Pango interface with Cairo.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6/cairo2-0.6.tbz"
+  checksum: "md5=9147030f57e10c9e9665396b92f6c9cc"
+}

--- a/packages/cairo2/cairo2.0.6/opam
+++ b/packages/cairo2/cairo2.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {build}
+  "conf-cairo"
+]
+depopts: [
+  "conf-freetype"
+]
+conflicts: [
+  "cairo" {= "0.4.1"}
+  "cairo" {= "0.4.2"}
+]
+synopsis: "Binding to Cairo, a 2D Vector Graphics Library"
+description: """
+This is a binding to Cairo, a 2D graphics library with support for
+multiple output devices. Currently supported output targets include
+the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
+and SVG file output."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6/cairo2-0.6.tbz"
+  checksum: "md5=9147030f57e10c9e9665396b92f6c9cc"
+}

--- a/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/opam
+++ b/packages/jupyter-archimedes/jupyter-archimedes.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta14"}
   "jupyter" {>= "2.0.0"}
-  "cairo2"
+  "cairo2" {< "0.6.0"}
   "archimedes"
 ]
 synopsis: "A Jupyter-friendly 2D plotting library (Archimedes backend)"

--- a/packages/jupyter-archimedes/jupyter-archimedes.2.3.2/opam
+++ b/packages/jupyter-archimedes/jupyter-archimedes.2.3.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build & >= "1.0.0"}
   "jupyter" {> "2.0.0"}
-  "cairo2"
+  "cairo2" {< "0.6.0"}
   "archimedes"
 ]
 synopsis: "A Jupyter-friendly 2D plotting library (Archimedes backend)"

--- a/packages/vg/vg.0.9.0/opam
+++ b/packages/vg/vg.0.9.0/opam
@@ -34,6 +34,7 @@ depopts: [
 conflicts: [
   "otfm" {< "0.3.0"}
   "uutf" {< "1.0.0"}
+  "cairo2" {>= "0.6.0"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/vg/vg.0.9.1/opam
+++ b/packages/vg/vg.0.9.1/opam
@@ -34,6 +34,7 @@ depopts: [
 conflicts: [
   "otfm" {< "0.3.0"}
   "uutf" {< "1.0.0"}
+  "cairo2" {>= "0.6.0"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"


### PR DESCRIPTION
Interface to Cairo

- Project page: <a href="https://github.com/Chris00/ocaml-cairo">https://github.com/Chris00/ocaml-cairo</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-cairo/doc">https://Chris00.github.io/ocaml-cairo/doc</a>

##### CHANGES:

- New `Ft` module to support FreeType fonts.  This is enabled if the
  package `conf-freetype` is installed.  On the C side, the exported
  header file `cairo_ocaml.h` defines the macro `OCAML_CAIRO_HAS_FT`
  when the Cairo bindings were compiled with TrueType support.
- New package `Cairo2-pango` providing the module `Cairo_pango`.
- Remove labels that were not bringing a clear benefit.  With Dune
  default behavior, users will feel compelled to write labels which
  was cluttering the code with the previous interface.  With Merlin,
  it is now possible to have the documentation of a function under the
  cursor displayed with a simple keystroke which should alleviate
  having slightly less documentation in the types.
- Improve the documentation.
- Use Dune (not the former Jbuilder) to compile.
