### PR TITLE
[cleanup]: Add descr and or synopsis to packages that were missing it

### DIFF
--- a/packages/cohttp-async/cohttp-async.1.1.1/opam
+++ b/packages/cohttp-async/cohttp-async.1.1.1/opam
@@ -36,6 +36,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.1.1/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.1.1.1/opam
@@ -33,6 +33,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
@@ -35,6 +35,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/cohttp-lwt/cohttp-lwt.1.1.1/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.1.1.1/opam
@@ -30,6 +30,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
@@ -25,6 +25,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/cohttp-top/cohttp-top.1.1.1/opam
+++ b/packages/cohttp-top/cohttp-top.1.1.1/opam
@@ -24,6 +24,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.1/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.1/opam
@@ -15,4 +15,5 @@ depexts: [
   ["llvm-3.8"] {os = "macos" & os-distribution = "macports"}
   ["homebrew/versions/llvm38"] {os = "macos" & os-distribution = "homebrew"}
 ]
+synopsis: "Virtual package relying on llvm library installation for BAP"
 extra-files: ["configure" "md5=8b655d55580e497b799fb97d047dc15d"]

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
@@ -15,4 +15,5 @@ depexts: [
   ["llvm-3.8"] {os = "macos" & os-distribution = "macports"}
   ["homebrew/versions/llvm38"] {os = "macos" & os-distribution = "homebrew"}
 ]
+synopsis: "Virtual package relying on llvm library installation for BAP"
 extra-files: ["configure" "md5=a033126062cb57df9edae2909302d081"]

--- a/packages/conf-bap-llvm/conf-bap-llvm.1/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1/opam
@@ -15,4 +15,5 @@ depexts: [
   ["homebrew/versions/llvm34"] {os = "macos" & os-distribution = "homebrew"}
 ]
 conflicts: ["conf-llvm"]
+synopsis: "Virtual package relying on llvm library installation for BAP"
 extra-files: ["configure" "md5=d40412e781448f165982a36fe60c7bc0"]

--- a/packages/crlibm/crlibm.0.3/opam
+++ b/packages/crlibm/crlibm.0.3/opam
@@ -17,6 +17,7 @@ depends: [
   "base-bytes" {build}
   "benchmark" {with-test}
 ]
+synopsis: "Binding to CRlibm, a correctly rounded math lib"
 url {
   src:
     "https://github.com/Chris00/ocaml-crlibm/releases/download/0.3/crlibm-0.3.tbz"

--- a/packages/functoria-runtime/functoria-runtime.2.0.0/opam
+++ b/packages/functoria-runtime/functoria-runtime.2.0.0/opam
@@ -28,6 +28,125 @@ patches: [
   "num.patch"
 ]
 extra-files: ["num.patch" "md5=0a424789bef2d5ac3f230442e2fe03b1"]
+synopsis: "A DSL to organize functor applications"
+description: """
+[![Build Status](https://travis-ci.org/mirage/functoria.svg)](https://travis-ci.org/mirage/functoria)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/functoria/index.html)
+
+## What is this for?
+
+Functoria is a DSL to describe a set of modules and functors, their types and how to apply them in order to produce a complete application.
+
+The main use case is mirage. See the [mirage][] repository for details.
+
+## How to write a configuration file?
+
+There are numerous examples of configuration files in [mirage-skeleton][]. Most of them should be fairly general and understandable, even outside the context of mirage. We can distinguish two parts in a `config.ml`: Defining new modules and using them.
+
+In order to define a new module, we use the `foreign` function. Among its various arguments, it takes a module name and a type. The type is assembled with the DSL's combinators and the `@->` operator, which symbols a functor arrow.
+
+```ocaml
+let main = foreign "Unikernel.Main" (console @-> job)
+```
+
+Here, we declare the functor `Unikernel.Main` that takes a module that should be a `console` and returns a module that is a `job`. It is up to the user to ensure that the declaration matches the implementation (or be punished by a compiler error later on). If the declaration is correct, everything that follows will be.
+
+We can now use this declaration:
+
+```ocaml
+let () = register "console" [main $ default_console]
+```
+
+Here, we register a new application with the `register` function. This function should only be called once and takes as argument the name of the application and a list of jobs. We use the `$` operator to apply the functor `main` (aka `Unikernel.Main`) to the default console.
+
+Now that everything is ready, you can use the `configure` subcommand!
+
+### What is a job?
+
+A job is a module containing a function `start`. This function will receive one argument per functor argument and one per dependency, in this order. `foreign` assumes the function `start` returns `unit`.
+
+### Defining new keys
+
+A key is composed of:
+
+- _name_ : The name of the value in the program.
+- _description_ : How it should be displayed/serialized.
+- _stage_ : Is the key available only at runtime, at configure time or both?
+- _documentation_ : It is not optional so you should really write it.
+
+Consider a multilingual application: we want to pass the default language as a parameter. We will use a simple string, so we can use the predefined description `Key.Desc.string`. We want to be able to define it both at configure and run time, so we use the stage `` `Both``. This gives us the following code:
+
+```ocaml
+let lang_key =
+  let doc = Key.Doc.create
+      ~doc:"The default language for the application." [ "l" ; "lang" ]
+  in
+  Key.create ~doc ~stage:`Both ~default:"en" "language" Key.Desc.string
+```
+
+Here, we defined both a long option `--lang` and a short one `-l` (the format is similar to the one used by [Cmdliner][cmdliner]).
+In the application code, the value is retrieved with `Key_gen.language ()`.
+
+The option is also documented in the `--help` option for both the `configure` subcommand (at configure time) and `./my_application` (at startup time).
+
+```
+       -l VAL, --lang=VAL (absent=en)
+           The default language for the application.
+```
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+
+### Using switching keys
+
+We can do much more with keys: we can use them to switch implementation at configure time. Imagine we want to completely change some implementation based on the language. Finns are special snowflakes, they deserve their special application!
+
+First, we have to compute a boolean value from `lang`:
+
+```ocaml
+let is_fi = Key.(pure ((=) "fi") $ value lang_key)
+```
+
+We can use the `if_impl` combinator to choose between two implementations depending on the value of the key:
+
+```ocaml
+let dynamic_storage =
+  if_impl is_fi
+    finnish_implementation
+    not_finnish_implementation
+```
+
+This distinction will be visible using the `describe` subcommand and a dot diagram is available with the `--dot` option!
+
+## Internals
+
+### Phases
+
+Configuration is separated into phases:
+
+1. Specialized DSL keys
+   The specialized DSL's keys (along with functoria's keys) are resolved.
+2. Compilation and dynlink of the config file.
+3. Registering.
+   When the `register` function is called, the list of jobs is recorded and
+   immediately transformed into a graph.
+4. Switching keys and tree evaluation.
+   The switching keys are the keys inside the [If].
+   Those keys are resolved and the graph is simplified. At this point,
+   the actual modules used are fully known.
+   Note: for the `describe` command, Only _partial_ evaluation is done, which
+   means decision nodes are resolved only if the value was given on the command
+   line, disregarding default values.
+5. Full Key resolution.
+   Once the actual modules are known, we can resolve all the keys and figure out
+   libraries and packages.
+6. Dependency handling, configuration and code emission.
+
+Phases 1. to 4. are also applied for the `clean` command.
+
+
+
+[mirage]: https://github.com/mirage/mirage
+[mirage-skeleton]: https://github.com/mirage/mirage-skeleton"""
 url {
   src:
     "https://github.com/mirage/functoria/releases/download/2.0.0/functoria-runtime-2.0.0.tbz"

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.2.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.2.0/opam
@@ -19,6 +19,21 @@ build: [
   "ocaml" "pkg/pkg.ml" "build"
             "--pkg-name" name
             "--pinned" "%{pinned}%" ]
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+
+The following sources are used:
+
+* The Unix version uses `gettimeofday` or `clock_gettime`, depending on
+  which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+* The freestanding version uses the paravirtual clock source from the hypervisor."""
 url {
   src:
     "https://github.com/mirage/mirage-clock/releases/download/1.2.0/mirage-clock-freestanding-1.2.0.tbz"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/opam
@@ -20,6 +20,20 @@ depends: [
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to be used as MirageOS network implementations should implement.
+
+The set of protocols defined is:
+
+[Mirage_protocols.ETHIF](ethif) and [Mirage_protocols_lwt.ETHIF](ethif-lwt)
+[Mirage_protocols.ARP](arp) and [Mirage_protocols_lwt.ARP](arp-lwt)
+[Mirage_protocols.IP](ip) and [Mirage_protocols_lwt.IP](ip-lwt), via [Mirage_protocols_lwt.IPV4](ipv4-lwt) and [Mirage_protocols_lwt.IPV6](ipv6-lwt)
+[Mirage_protocols.ICMP](icmp) and [Mirage_protocols_lwt.ICMP](icmp-lwt), via [Mirage_protocols_lwt.ICMPV4](icmpv4-lwt)
+[Mirage_protocols.UDP](udp) and [Mirage_protocols_lwt.UDP](udp-lwt), via [Mirage_protocols_lwt.UDPV4](udpv4-lwt) and [Mirage_protocols_lwt.UDPV6](udpv6-lwt)
+[Mirage_protocols.TCP](tcp) and [Mirage_protocols_lwt.TCP](tcp-lwt), via [Mirage_protocols_lwt.TCPV4](tcpv4-lwt) and [Mirage_protocols_lwt.TCPV6](tcpv6-lwt)
+
+mirage-protocols is distributed under the ISC license."""
 url {
   src:
     "https://github.com/mirage/mirage-protocols/releases/download/1.0.0/mirage-protocols-lwt-1.0.0.tbz"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.1.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.1.0/opam
@@ -20,6 +20,20 @@ depends: [
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to be used as MirageOS network implementations should implement.
+
+The set of protocols defined is:
+
+[Mirage_protocols.ETHIF](ethif) and [Mirage_protocols_lwt.ETHIF](ethif-lwt)
+[Mirage_protocols.ARP](arp) and [Mirage_protocols_lwt.ARP](arp-lwt)
+[Mirage_protocols.IP](ip) and [Mirage_protocols_lwt.IP](ip-lwt), via [Mirage_protocols_lwt.IPV4](ipv4-lwt) and [Mirage_protocols_lwt.IPV6](ipv6-lwt)
+[Mirage_protocols.ICMP](icmp) and [Mirage_protocols_lwt.ICMP](icmp-lwt), via [Mirage_protocols_lwt.ICMPV4](icmpv4-lwt)
+[Mirage_protocols.UDP](udp) and [Mirage_protocols_lwt.UDP](udp-lwt), via [Mirage_protocols_lwt.UDPV4](udpv4-lwt) and [Mirage_protocols_lwt.UDPV6](udpv6-lwt)
+[Mirage_protocols.TCP](tcp) and [Mirage_protocols_lwt.TCP](tcp-lwt), via [Mirage_protocols_lwt.TCPV4](tcpv4-lwt) and [Mirage_protocols_lwt.TCPV6](tcpv6-lwt)
+
+mirage-protocols is distributed under the ISC license."""
 url {
   src:
     "https://github.com/mirage/mirage-protocols/releases/download/1.1.0/mirage-protocols-lwt-1.1.0.tbz"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/opam
@@ -21,6 +21,20 @@ depends: [
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to be used as MirageOS network implementations should implement.
+
+The set of protocols defined is:
+
+[Mirage_protocols.ETHIF](ethif) and [Mirage_protocols_lwt.ETHIF](ethif-lwt)
+[Mirage_protocols.ARP](arp) and [Mirage_protocols_lwt.ARP](arp-lwt)
+[Mirage_protocols.IP](ip) and [Mirage_protocols_lwt.IP](ip-lwt), via [Mirage_protocols_lwt.IPV4](ipv4-lwt) and [Mirage_protocols_lwt.IPV6](ipv6-lwt)
+[Mirage_protocols.ICMP](icmp) and [Mirage_protocols_lwt.ICMP](icmp-lwt), via [Mirage_protocols_lwt.ICMPV4](icmpv4-lwt)
+[Mirage_protocols.UDP](udp) and [Mirage_protocols_lwt.UDP](udp-lwt), via [Mirage_protocols_lwt.UDPV4](udpv4-lwt) and [Mirage_protocols_lwt.UDPV6](udpv6-lwt)
+[Mirage_protocols.TCP](tcp) and [Mirage_protocols_lwt.TCP](tcp-lwt), via [Mirage_protocols_lwt.TCPV4](tcpv4-lwt) and [Mirage_protocols_lwt.TCPV6](tcpv6-lwt)
+
+mirage-protocols is distributed under the ISC license."""
 url {
   src:
     "https://github.com/mirage/mirage-protocols/releases/download/v1.3.0/mirage-protocols-1.3.0.tbz"

--- a/packages/mirage-protocols/mirage-protocols.1.3.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.3.0/opam
@@ -21,6 +21,20 @@ depends: [
   "fmt"
   "duration"
 ]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to be used as MirageOS network implementations should implement.
+
+The set of protocols defined is:
+
+[Mirage_protocols.ETHIF](ethif) and [Mirage_protocols_lwt.ETHIF](ethif-lwt)
+[Mirage_protocols.ARP](arp) and [Mirage_protocols_lwt.ARP](arp-lwt)
+[Mirage_protocols.IP](ip) and [Mirage_protocols_lwt.IP](ip-lwt), via [Mirage_protocols_lwt.IPV4](ipv4-lwt) and [Mirage_protocols_lwt.IPV6](ipv6-lwt)
+[Mirage_protocols.ICMP](icmp) and [Mirage_protocols_lwt.ICMP](icmp-lwt), via [Mirage_protocols_lwt.ICMPV4](icmpv4-lwt)
+[Mirage_protocols.UDP](udp) and [Mirage_protocols_lwt.UDP](udp-lwt), via [Mirage_protocols_lwt.UDPV4](udpv4-lwt) and [Mirage_protocols_lwt.UDPV6](udpv6-lwt)
+[Mirage_protocols.TCP](tcp) and [Mirage_protocols_lwt.TCP](tcp-lwt), via [Mirage_protocols_lwt.TCPV4](tcpv4-lwt) and [Mirage_protocols_lwt.TCPV6](tcpv6-lwt)
+
+mirage-protocols is distributed under the ISC license."""
 url {
   src:
     "https://github.com/mirage/mirage-protocols/releases/download/v1.3.0/mirage-protocols-1.3.0.tbz"

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/opam
@@ -21,6 +21,18 @@ depends: [
   "lwt"
   "cstruct" {>= "2.4.0"}
 ]
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used as MirageOS network stacks should implement.
+
+The set of protocols defined is:
+
+[Mirage_stack.STACKV4](stackv4) and [Mirage_stack_lwt.STACKV4](stackv4-lwt)
+
+mirage-stack is distributed under the ISC license.
+
+[stackv4]: http://docs.mirage.io/mirage-stack/Mirage_stack/module-type-V4/index.html
+[stackv4-lwt]: http://docs.mirage.io/mirage-stack-lwt/Mirage_stack_lwt/module-type-V4/index.html"""
 url {
   src:
     "https://github.com/mirage/mirage-stack/releases/download/v1.2.0/mirage-stack-1.2.0.tbz"

--- a/packages/mirage-stack/mirage-stack.1.2.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.2.0/opam
@@ -20,6 +20,18 @@ depends: [
   "mirage-protocols" {>= "1.3.0" & < "1.4.0"}
   "fmt"
 ]
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used as MirageOS network stacks should implement.
+
+The set of protocols defined is:
+
+[Mirage_stack.STACKV4](stackv4) and [Mirage_stack_lwt.STACKV4](stackv4-lwt)
+
+mirage-stack is distributed under the ISC license.
+
+[stackv4]: http://docs.mirage.io/mirage-stack/Mirage_stack/module-type-V4/index.html
+[stackv4-lwt]: http://docs.mirage.io/mirage-stack-lwt/Mirage_stack_lwt/module-type-V4/index.html"""
 url {
   src:
     "https://github.com/mirage/mirage-stack/releases/download/v1.2.0/mirage-stack-1.2.0.tbz"

--- a/packages/opam-publish/opam-publish.2.0.0/opam
+++ b/packages/opam-publish/opam-publish.2.0.0/opam
@@ -21,6 +21,9 @@ depends: [
 ]
 build: ["jbuilder" "build" "-p" name]
 dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+synopsis: "A tool to ease contributions to opam repositories."
+description:
+  "Opam-publish helps gather metadata to form an OPAM package and submit it to a remote repository."
 url {
   src: "https://github.com/ocaml/opam-publish/archive/2.0.0.tar.gz"
   checksum: [

--- a/packages/opam-publish/opam-publish.2.0.0~beta/opam
+++ b/packages/opam-publish/opam-publish.2.0.0~beta/opam
@@ -21,6 +21,9 @@ depends: [
   ("github" {build & >= "2.0.0" & < "3.0.0"} |
    "github-unix" {build & >= "3.0.0"})
 ]
+synopsis: "A tool to ease contributions to opam repositories."
+description:
+  "Opam-publish helps gather metadata to form an OPAM package and submit it to a remote repository."
 url {
   src: "https://github.com/ocaml/opam-publish/archive/2.0.0-beta.tar.gz"
   checksum: [

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -20,6 +20,9 @@ build:[
     ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
+synopsis: "QuickCheck inspired property-based testing for OCaml."
+description: """
+This module provides QCheck integration with alcotest."""
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [

--- a/packages/qcheck-core/qcheck-core.0.9/opam
+++ b/packages/qcheck-core/qcheck-core.0.9/opam
@@ -21,6 +21,11 @@ build: [
     ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
+synopsis: "QuickCheck inspired property-based testing for OCaml."
+description: """
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them."""
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [

--- a/packages/qcheck-ounit/qcheck-ounit.0.9/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.9/opam
@@ -20,6 +20,9 @@ build: [
     ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
+synopsis: "QuickCheck inspired property-based testing for OCaml."
+description: """
+This module provides QCheck integration with OUnit."""
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [

--- a/packages/qcheck/qcheck.0.9/opam
+++ b/packages/qcheck/qcheck.0.9/opam
@@ -23,6 +23,11 @@ build: [
     ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
+synopsis: "QuickCheck inspired property-based testing for OCaml."
+description: """
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them."""
 url {
   src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
   checksum: [

--- a/packages/relit-reason/relit-reason.0.0.1/opam
+++ b/packages/relit-reason/relit-reason.0.0.1/opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml-migrate-parsetree"
 ]
 conflicts: ["reason"]
+synopsis: "Hygienic typed literal macros (TLMs) for Reason"
 url {
   src: "https://github.com/charlesetc/reason/archive/relit-0.0.1.tar.gz"
   checksum: "md5=1a788cb21707e826cc725b3aa15d5d19"


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/issues/12729#issuecomment-425925584

The values for synopis and/or description have been copied from previous (or newer) version of the relative packages when possible, otherwise come from the description of their github repository.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>