### PR TITLE
Package opam-publish.2.0.1

### DIFF
--- a/packages/opam-publish/opam-publish.2.0.1/opam
+++ b/packages/opam-publish/opam-publish.2.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+tags: "flags:plugin"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "opam-core" {build & >= "2.0.0"}
+  "opam-format" {build & >= "2.0.0"}
+  "opam-state" {build & >= "2.0.0"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  "lwt_ssl"
+  ("ssl" {build & = "0.5.5"} | "tls")
+  ("github" {build & >= "2.0.0" & < "3.0.0"} |
+   "github-unix" {build & >= "3.0.0"})
+]
+build: ["jbuilder" "build" "-p" name]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git#2.0"
+url {
+  src: "https://github.com/ocaml/opam-publish/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=2d8fcf689db536d555a47686ada07c30"
+    "sha512=8214f1ec88b545b9aed93d6baf1dce6295372eaf6421b17fac7579e1318bd02ad5a4fc5e4754fb6ff92821deb433d8925265a184e5d0f841314bfce625ce3f62"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.0.1`



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git#2.0
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.0.0