### PR TITLE
cppo_ocamlbuild: add missing ocamlfind dependency

### DIFF
--- a/packages/0install/0install.2.12.3/opam
+++ b/packages/0install/0install.2.12.3/opam
@@ -9,7 +9,7 @@ build: [
   [make "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.07"}
   "yojson"
   "xmlm"
   "ounit" {with-test}

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.0/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta10"}
   "ocamlbuild"
+  "ocamlfind"
   "cppo" {>= "1.6.0"}
 ]
 synopsis: "ocamlbuild support for cppo, OCaml-friendly source preprocessor"

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
@@ -29,6 +29,7 @@ depends: [
   "ocamlfind" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
+  "result"
   "ounit" {with-test}
   "ppx_import" {with-test}
 ]

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
@@ -23,7 +23,7 @@ build: [
   ] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "4.05"}
   "ppx_deriving" {>= "3.0" & < "5.0"}
   "ppx_tools" {>= "4.02.3"}
   "ocamlfind" {build}

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/opam
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.5/opam
@@ -25,7 +25,7 @@ build: [
   [make "doc"] {with-doc}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.02.3" & < "4.06"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "cppo" {build}


### PR DESCRIPTION
Should fix https://github.com/ocaml/opam-repository/issues/12640

I thought that using dune could have been enough but we have often seen a similar failure in the CI even when `jbuilder.transition` is used, so I went with adding the dependency without too many cases and combinations of packages.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>