### PR TITLE
[new release] docker-api (0.2)

### DIFF
--- a/packages/docker-api/docker-api.0.2/opam
+++ b/packages/docker-api/docker-api.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+license: "ISC"
+homepage: "https://github.com/Chris00/ocaml-docker"
+dev-repo: "git+https://github.com/Chris00/ocaml-docker.git"
+bug-reports: "https://github.com/Chris00/ocaml-docker/issues"
+doc: "https://Chris00.github.io/ocaml-docker/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "yojson"
+]
+synopsis: "Binding to the Docker Remote API"
+description: """
+Control Docker <https://www.docker.com/> containers using the remote API."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-docker/releases/download/0.2/docker-api-0.2.tbz"
+  checksum: "md5=72dc4fa2a3cf4eb707fca31bf247eb60"
+}


### PR DESCRIPTION
Binding to the Docker Remote API

- Project page: <a href="https://github.com/Chris00/ocaml-docker">https://github.com/Chris00/ocaml-docker</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-docker/doc">https://Chris00.github.io/ocaml-docker/doc</a>

##### CHANGES:

- Upgrade to API v1.29.
- New signature of `Container.create`.
- Add functions `Container.wait` and `Container.changes`.
- Handle errors `409 Conflict`.
- New exceptions `Docker.Failure` and `Docker.No_such_container`.
- Rename `Docker.Images` as `Docker.Image` and add the `create`
  function to pull images.
- Documentation improvements.
- New tests `ls` and `ps` and improve the other ones.
- Use [Dune](https://github.com/ocaml/dune) and
  [dune-release](https://github.com/samoht/dune-release).
