### PR TITLE
Package morbig.0.9.1

### DIFF
--- a/packages/morbig/morbig.0.9.1/opam
+++ b/packages/morbig/morbig.0.9.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+synopsis: "A trustworthy parser for POSIX shell"
+description: """
+Morbig is a parser for shell scripts written in the POSIX shell script
+language. It parses the scripts statically, that is without executing
+them, and constructs a concrete syntax tree for each of them. The
+concrete syntax trees are built using constructors according to the
+shell grammar of the POSIX standard.
+"""
+
+maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+authors: [
+  "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+  "Ralf Treinen <ralf.treinen@irif.fr>"
+  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+]
+license: "GPL3"
+
+homepage: "https://github.com/colis-anr/morbig"
+bug-reports: "https://github.com/colis-anr/morbig/issues"
+dev-repo: "git://github.com/colis-anr/morbig.git"
+
+available: [os != "macos"]
+depends: [
+  "menhir"
+  "ocaml"                {build & >= "4.03"}
+  "ocamlbuild"           {build}
+  "ppx_deriving_yojson"
+  "visitors"
+  "yojson"
+]
+
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+
+run-test: [make "check"]
+url {
+  src: "https://github.com/colis-anr/morbig/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=2a1b7a85a095a6229d099972142c3f6b"
+    "sha512=4b3dca99870de7863701fa887cc1d4135ecb5b5523a22b7df8a553da8d17f40c40062e2c968b3538ad3cb40e923af639f895b48c8aa73b1d3c806811ca0b662f"
+  ]
+}


### PR DESCRIPTION
### `morbig.0.9.1`
A trustworthy parser for POSIX shell
Morbig is a parser for shell scripts written in the POSIX shell script
language. It parses the scripts statically, that is without executing
them, and constructs a concrete syntax tree for each of them. The
concrete syntax trees are built using constructors according to the
shell grammar of the POSIX standard.



---
* Homepage: https://github.com/colis-anr/morbig
* Source repo: git://github.com/colis-anr/morbig.git
* Bug tracker: https://github.com/colis-anr/morbig/issues

---
:camel: Pull-request generated by opam-publish v2.0.0