### PR TITLE
ocb-stubblr.0.1.1-1: pass -cclib to custom runtime, work with opam2 sandboxing mechanism

### DIFF
--- a/packages/ocb-stubblr/ocb-stubblr.0.1.1-1/files/custom-cclib.patch
+++ b/packages/ocb-stubblr/ocb-stubblr.0.1.1-1/files/custom-cclib.patch
@@ -1,0 +1,22 @@
+From d51b3f3a49f159469e00d23524db915f19bb0127 Mon Sep 17 00:00:00 2001
+From: Hannes Mehnert <hannes@mehnert.org>
+Date: Tue, 3 Oct 2017 13:55:16 +0100
+Subject: [PATCH] bytecode / custom needs -cclib as well
+
+---
+ src/ocb_stubblr.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ocb_stubblr.ml b/src/ocb_stubblr.ml
+index b68c37a..a0ee035 100644
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -160,7 +160,7 @@ let link_flag () =
+     S [A switch; A ("-l"^name)]
+   and dep flag = Pathname.([remove_extension flag -.- "a"]) in
+   pflag ["link"; "ocaml"; "library"; "byte"] tag (libarg "-dllib");
+-  pflag ["link"; "ocaml"; "library"; "native"] tag  (libarg "-cclib");
++  pflag ["link"; "ocaml"; "library"] tag  (libarg "-cclib");
+   pdep ["link"; "ocaml"] tag dep;
+   pdep ["compile"; "ocaml"] tag dep
+   (* XXX sneak in '-I' for compile;ocaml;program ?? *)

--- a/packages/ocb-stubblr/ocb-stubblr.0.1.1-1/files/use-OPAM_SWITCH_PREFIX.patch
+++ b/packages/ocb-stubblr/ocb-stubblr.0.1.1-1/files/use-OPAM_SWITCH_PREFIX.patch
@@ -1,0 +1,33 @@
+From f1c9340f3ab973ad1e8dcc4b7065bbe6cfaa028f Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Sun, 1 Jul 2018 09:54:32 +0100
+Subject: [PATCH] Use OPAM_SWITCH_PREFIX before opam config var prefix
+
+opam 2's sandbox doesn't expose the mount point for the opam root.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ src/ocb_stubblr.ml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/ocb_stubblr.ml b/src/ocb_stubblr.ml
+index b68c37a..2cc5332 100644
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -31,11 +31,15 @@ module Pkg_config = struct
+ 
+   (* XXX Would be nice to move pkg-config results to a build artefact. *)
+ 
+-  let opam_prefix =
++  let opam_prefix_cmd =
+     let cmd = "opam config var prefix" in
+     lazy ( try run_and_read cmd with Failure _ ->
+             error_msgf "error running opam")
+ 
++  let opam_prefix =
++    lazy (try Sys.getenv "OPAM_SWITCH_PREFIX"
++          with Not_found -> Lazy.force opam_prefix_cmd)
++
+   let var = "PKG_CONFIG_PATH"
+ 
+   let path () =

--- a/packages/ocb-stubblr/ocb-stubblr.0.1.1-1/opam
+++ b/packages/ocb-stubblr/ocb-stubblr.0.1.1-1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/ocb-stubblr"
+doc: "https://pqwy.github.io/ocb-stubblr/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/pqwy/ocb-stubblr.git"
+bug-reports: "https://github.com/pqwy/ocb-stubblr/issues"
+tags: ["ocamlbuild"]
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {>= "0.9.3" | < "0.9.0"}
+  "topkg" {>= "0.8.1"}
+  "astring"
+]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+
+patches: [
+    "custom-cclib.patch"
+    "use-OPAM_SWITCH_PREFIX.patch"
+]
+
+synopsis: "OCamlbuild plugin for C stubs"
+description: """
+Do you get excited by C stubs? Do they sometimes make you swoon, and even faint,
+and in the end no `cmxa`s get properly linked -- not to mention correct
+multi-lib support?
+
+Do you wish that the things that excite you the most, would excite you just a
+little less? Then ocb-stubblr is just the library for you.
+
+ocb-stubblr is about ten lines of code that you need to repeat over, over, over
+and over again if you are using `ocamlbuild` to build OCaml projects that
+contain C stubs -- now with 100% more lib!
+
+It does what everyone wants to do with `.clib` files in their project
+directories. It can also clone the `.clib` and arrange for multiple compilations
+with different sets of discovered `cflags`.
+
+ocb-stubblr is distributed under the ISC license."""
+url {
+  src:
+    "https://github.com/pqwy/ocb-stubblr/releases/download/v0.1.1/ocb-stubblr-0.1.1.tbz"
+  checksum: "md5=607720dd18ca51e40645b42df5c1273e"
+}
+extra-files: [
+  [
+    "custom-cclib.patch"
+    "md5=d479b52a50d53dd79da2d6eea2a9a9e3"
+  ]
+  [
+    "use-OPAM_SWITCH_PREFIX.patch"
+    "md5=a7271bb1f862bd3da4ffd9caa87ca76f"
+  ]
+]


### PR DESCRIPTION
fixes https://github.com/ocaml/opam-repository/issues/12777, using patches from ocb-stubblr github repository