### PR TITLE
Package topkg.1.0.0

### DIFF
--- a/packages/topkg/topkg.1.0.0/opam
+++ b/packages/topkg/topkg.1.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "git+http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+  "result" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--dev-pkg" "%{pinned}%" ]]
+synopsis: """The transitory OCaml software packager"""
+description: """\
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+"""
+url {
+archive: "http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz"
+checksum: "e3d76bda06bf68cb5853caf6627da603"
+}


### PR DESCRIPTION
### `topkg.1.0.0`
The transitory OCaml software packager
Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution, creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml opam repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
[webbrowser][webbrowser] and `opam-format`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner
[webbrowser]: http://erratique.ch/software/webbrowser



---
* Homepage: http://erratique.ch/software/topkg
* Source repo: git+http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---
v1.0.0 2018-10-14 Zagreb
------------------------

- Support (only) for opam-publish v2.0.0. The `--pkg-opam-dir` option
  of `topkg opam` to indicate the old-style opam package directory to
  submit is renamed to `--opam-publish-file` to indicate the opam file
  to submit.
- Add `topkg opam publish` command, alias of `topkg opam submit`.
- Toy github delegate: make curl follow redirects. Before obscure
  failures would result when repos got moved around (#120). Thanks
  to Richard Mortier for the report.
- Fix infinite loop in `Topkg.OS.File.write_subst`. This could result
  in `topkg distrib` never finishing (#128). Thanks to Christophe
  Troestler for reporting and Jérémie Dimino for the patch.
- Add `.ps` and `.eps` files to default watermarking excludes.
  Thanks Christophe Troestler for the suggestion (#128).
- Use `command -v` rather than `type` to check for tool existence.
  Thanks to Hannes Mehnert for the patch.

---
:camel: Pull-request generated by opam-publish v2.0.0