### PR TITLE
ocaml-manual packages move instruction from build: to install:

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.4.01.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.01.0/opam
@@ -11,7 +11,7 @@ doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
-build: [
+install: [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
  [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
 ]

--- a/packages/ocaml-manual/ocaml-manual.4.02.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.02.0/opam
@@ -11,7 +11,7 @@ doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
-build:
+install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
  [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.03.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.03.0/opam
@@ -11,7 +11,7 @@ doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
-build:
+install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
  [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.04.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.04.0/opam
@@ -11,7 +11,7 @@ doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
-build:
+install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
  [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.05.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.05.0/opam
@@ -11,7 +11,7 @@ doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
-build:
+install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
  [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.05.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.05.0/opam
@@ -23,5 +23,5 @@ depends: [
 url {
   src:
     "http://caml.inria.fr/distrib/ocaml-4.05/ocaml-4.05-refman-html.tar.gz"
-  checksum: "md5=1649c91a84fd35444192d6a55f932939"
+  checksum: "md5=724ac6f96f019999cb83d95adafdda8e"
 }

--- a/packages/ocaml-manual/ocaml-manual.4.06.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.06.0/opam
@@ -11,7 +11,7 @@ doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
-build:
+install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
  [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.07.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.07.0/opam
@@ -11,7 +11,7 @@ doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "http://caml.inria.fr/mantis/"
-build:
+install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
  [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}


### PR DESCRIPTION
This no longer works because of opam v2 sandboxing.
Hopefully closes #12731.