### PR TITLE
[new release] optint (v0.0.2)

### DIFF
--- a/packages/optint/optint.0.0.2/descr
+++ b/packages/optint/optint.0.0.2/descr
@@ -1,0 +1,18 @@
+Abstract type on integer between x64 and x86 architecture
+
+This library provide one module `Optint` which use internally an `int` if you
+are in a x64 architecture or an `int32` (boxed value) if you are in a x86
+architecture. This module is __really__ unsafe and does not care some details
+(like the sign bit) for any cast.
+
+## Goal
+
+The main difference between an `int` and an `int32` is the second is boxed.
+About performance this is not the best. However, you can not ensure to be in an
+x64 architecture where you can use directly an `int` instead an `int32` (and
+improve performance).
+
+So, this library provide an abstraction about a real `int32`. In a x64
+architecture, internally, we use a `int` and in a x86 architure, we use a
+`int32`. By this way, we ensure to have in any platform 32 free bits in
+`Optint.t`.

--- a/packages/optint/optint.0.0.2/opam
+++ b/packages/optint/optint.0.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer:   [ "romain.calascibetta@gmail.com" ]
+authors:      "Romain Calascibetta"
+license:      "ISC"
+homepage:     "https://github.com/dinosaure/optint"
+bug-reports:  "https://github.com/dinosaure/optint/issues"
+dev-repo:     "https://github.com/dinosaure/optint.git"
+doc:          "https://dinosaure.github.io/optint/"
+synopsis:     "Abstract type on integer between x64 and x86 architecture"
+description: """
+This library provide an abstract type which represents at least a 32-bits integer.
+On x64, this library use a native unboxed integer (63 bits).
+On x86, this library use a boxed int32.
+
+Implementation depends on target architecture.
+"""
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/optint/optint.0.0.2/url
+++ b/packages/optint/optint.0.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/dinosaure/optint/releases/download/v0.0.2/optint-0.0.2.tbz"
+checksum: "4022c24067659e401e371b3b9b6544b8"


### PR DESCRIPTION
Abstract type on integer between x64 and x86 architecture

- Project page: <a href="https://github.com/dinosaure/optint">https://github.com/dinosaure/optint</a>
- Documentation: <a href="https://dinosaure.github.io/optint/">https://dinosaure.github.io/optint/</a>

##### CHANGES:

- _Dunify_ project
- Fix dependencies on `dune` file when we select impl. (@rgrinberg)
