### PR TITLE
[new release] eqaf (0.2)

### DIFF
--- a/packages/eqaf/eqaf.0.2/opam
+++ b/packages/eqaf/eqaf.0.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name:         "eqaf"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/dinosaure/eqaf"
+bug-reports:  "https://github.com/dinosaure/eqaf/issues"
+dev-repo:     "git+https://github.com/dinosaure/eqaf.git"
+doc:          "https://dinosaure.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {build}
+  "fmt"            {with-test}
+  "base-bytes"     {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/eqaf/releases/download/v0.2/eqaf-v0.2.tbz"
+  checksum: "md5=0832ef11a70fe5fe0c786fcf2a2a67cb"
+}


### PR DESCRIPTION
Constant time equal function on `string`

- Project page: <a href="https://github.com/dinosaure/eqaf">https://github.com/dinosaure/eqaf</a>
- Documentation: <a href="https://dinosaure.github.io/eqaf/">https://dinosaure.github.io/eqaf/</a>

##### CHANGES:

* _Dunify_ project
* Update OPAM file
* Avoid `core_bench` dependency
* Make benchmark to test constant-time on `eqml`
* __Move `equal` function to the OCaml implementation__ (instead C implementation)
* Port benchmark on Windows and Mac OSX
