### PR TITLE
[new release] duff (0.2)

### DIFF
--- a/packages/duff/duff.0.2/opam
+++ b/packages/duff/duff.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name:         "duff"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/duff"
+bug-reports:  "https://github.com/dinosaure/duff/issues"
+dev-repo:     "git+https://github.com/dinosaure/duff.git"
+doc:          "https://dinosaure.github.io/duff/"
+license:      "MIT"
+synopsis:     "Rabin's fingerprint and diff algorithm in OCaml"
+description: """
+This library provides a pure implementation of Rabin's fingerprint and diff algorithm in OCaml.
+
+It follows libXdiff C library. It is used by ocaml-git project.
+"""
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {build}
+  "fmt"
+  "cstruct"
+  "cmdliner" {>= "1.0.2"}
+  "logs"     {>= "0.6.2"}
+  "fmt"      {>= "0.8.5"}
+  "bos"      {>= "0.2.0"}
+  "fpath"    {>= "0.7.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/duff/releases/download/v0.2/duff-v0.2.tbz"
+  checksum: "md5=b0a60ff1efb160b1ded56c640b874be3"
+}


### PR DESCRIPTION
LibXdiff implementation in OCaml

- Project page: <a href="https://github.com/dinosaure/duff">https://github.com/dinosaure/duff</a>
- Documentation: <a href="https://dinosaure.github.io/duff/">https://dinosaure.github.io/duff/</a>

##### CHANGES:

- Improve `xduff` binary
- _Dunify_ project
- Add tests
- Update OPAM file
