### PR TITLE
[new release] digestif (0.7)

### DIFF
--- a/packages/digestif/digestif.0.7/opam
+++ b/packages/digestif/digestif.0.7/opam
@@ -9,11 +9,13 @@ bug-reports:  "https://github.com/mirage/digestif/issues"
 dev-repo:     "git+https://github.com/mirage/digestif.git"
 doc:          "https://mirage.github.io/digestif/"
 license:      "MIT"
-synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5) and HMAC of them"
 description: """
 Digestif is a toolbox to provide hashes implementations in C and OCaml.
 
-It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation
+from a shared interface. As a library, you should link with digestif, as an executable, you should choose between
+digestif.c or digestif.ocaml package.
 
 We provides implementation of:
  * MD5
@@ -25,6 +27,8 @@ We provides implementation of:
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160
+
+And HMAC of them.
 """
 
 build: [

--- a/packages/digestif/digestif.0.7/opam
+++ b/packages/digestif/digestif.0.7/opam
@@ -34,7 +34,7 @@ And HMAC of them.
 build: [
   [ "dune" "subst"]
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-j" jobs ] {with-test}
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 
 depends: [

--- a/packages/digestif/digestif.0.7/opam
+++ b/packages/digestif/digestif.0.7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+name:         "digestif"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "subst"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {build}
+  "eqaf"
+  "base-bytes"
+  "base-bigarray"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v0.7/digestif-v0.7.tbz"
+  checksum: "md5=3311058c71e874cda1a9eda1b4f757be"
+}

--- a/packages/noise/noise.0.1.0/opam
+++ b/packages/noise/noise.0.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "callipyge" {>= "0.2"}
   "cstruct"
-  "digestif"
+  "digestif" {>= "0.6" & < "0.7"}
   "dune" {build & >= "1.1.0"}
   "eqaf"
   "hex"


### PR DESCRIPTION
CHANGES:

- Fixed HMAC on BLAKE2{S,B} (@emillon)
- Fixed `convenient_of_hex` (@dinosaure, @hannesm, @cfcs)
- Add `of_raw_string`/`to_raw_string` (@samoht)
- Test `digestif` on solo5 and xen backends (@amoht)
- *breaking change*, commont type `t` is an abstract type
- Fixed META file (@dinosaure, @g2p)
- New dependency `eqaf` (@dinosaure, @cfcs, @hannesm) (constant-time equal function)
- Remove `Obj.magic` in common implementation (@dinosaure, @samoht)
- Add conveniences functions in common implementation (@hcarty)
- Add option-returning functions in common implementation (@harcty)
- Verify length of string on `of_raw_string` function (@hcarty)
- Release runtime lock (@andersfugmann, @dinosaure, @cfcs)
- Bounds check (@cfcs, @dinosaure)
- Fixed linking problem (@andersfugmann, @g2p, @dinosaure)
- Update OPAM file (@dinosaure)