### PR TITLE
[new release] syslog-message (1.0.0)

### DIFF
--- a/packages/syslog-message/syslog-message.1.0.0/opam
+++ b/packages/syslog-message/syslog-message.1.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Syslog message parser"
+description:
+  "This is a library for parsing and generating RFC 3164 compatible Syslog messages."
+maintainer: "Jochen Bartl <jochenbartl@mailbox.org>"
+authors: "Jochen Bartl <jochenbartl@mailbox.org>"
+license: "BSD2"
+homepage: "https://github.com/verbosemode/syslog-message"
+doc: "https://verbosemode.github.io/syslog-message/doc"
+bug-reports: "https://github.com/verbosemode/syslog-message/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1.0" & build}
+  "astring"
+  "ptime"
+  "rresult"
+  "qcheck" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest"] {with-test}
+]
+dev-repo: "git+https://github.com/verbosemode/syslog-message.git"
+url {
+  src:
+    "https://github.com/verbosemode/syslog-message/releases/download/1.0.0/syslog-message-1.0.0.tbz"
+  checksum: "md5=c0e6bda6b173d86a49697deb3e016b64"
+}

--- a/packages/syslog-message/syslog-message.1.0.0/opam
+++ b/packages/syslog-message/syslog-message.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/verbosemode/syslog-message.git"
 url {


### PR DESCRIPTION
Syslog message parser

- Project page: <a href="https://github.com/verbosemode/syslog-message">https://github.com/verbosemode/syslog-message</a>
- Documentation: <a href="https://verbosemode.github.io/syslog-message/doc">https://verbosemode.github.io/syslog-message/doc</a>

##### CHANGES:

* Warning: encode function no longer truncates messages to 1024 bytes by default
* split message part into tag and content (verbosemode/syslog-message#20, by @hannesm)
* use result types instead of option (verbosemode/syslog-message#20, by @hannesm)
* remove transport-dependent length check from encode (verbosemode/syslog-message#20, by @hannesm)
* switch build system to Dune (verbosemode/syslog-message#19, by @dra27)
* add encode_local for sending to local syslog (verbosemode/syslog-message#17, by @dra27)
* forgot to thank @hannesm, @Leonidas-from-XIV for past contributions
