### PR TITLE
3 packages from ryanslade/influxdb-ocaml at 0.2.0

### DIFF
--- a/packages/influxdb-async/influxdb-async.0.2.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library using async for concurrency"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "alcotest" {test}
+  "influxdb"
+  "async"
+  "cohttp"
+  "cohttp-async"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=70f8cd3e75a411942b3dc49dd13e9beb"
+    "sha512=55d139138d6dba77a2dae0d2c76fae2c95eca59df586da4e15f1661e7c0180afb1da75d32ef7f24e5e1dc75fe05de04ff4cad3cc6dfa7a20b70c15c47b5cd29d"
+  ]
+}

--- a/packages/influxdb-lwt/influxdb-lwt.0.2.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library using lwt for concurrency"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "alcotest" {test}
+  "influxdb"
+  "lwt"
+  "cohttp"
+  "cohttp-lwt-unix"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=70f8cd3e75a411942b3dc49dd13e9beb"
+    "sha512=55d139138d6dba77a2dae0d2c76fae2c95eca59df586da4e15f1661e7c0180afb1da75d32ef7f24e5e1dc75fe05de04ff4cad3cc6dfa7a20b70c15c47b5cd29d"
+  ]
+}

--- a/packages/influxdb/influxdb.0.2.0/opam
+++ b/packages/influxdb/influxdb.0.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "base"
+  "stdio"
+  "ppx_expect"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=70f8cd3e75a411942b3dc49dd13e9beb"
+    "sha512=55d139138d6dba77a2dae0d2c76fae2c95eca59df586da4e15f1661e7c0180afb1da75d32ef7f24e5e1dc75fe05de04ff4cad3cc6dfa7a20b70c15c47b5cd29d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`influxdb.0.2.0`: InfluxDB client library
-`influxdb-async.0.2.0`: InfluxDB client library using async for concurrency
-`influxdb-lwt.0.2.0`: InfluxDB client library using lwt for concurrency



---
* Homepage: https://github.com/ryanslade/influxdb-ocaml
* Source repo: git://github.com/ryanslade/influxdb-ocaml.git
* Bug tracker: https://github.com/ryanslade/influxdb-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0