### PR TITLE
odoc 1.3.0: OCaml documentation generator

### DIFF
--- a/packages/odoc/odoc.1.3.0/opam
+++ b/packages/odoc/odoc.1.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+
+name: "odoc"
+version: "1.3.0"
+homepage: "http://github.com/ocaml-doc/odoc"
+doc: "https://ocaml-doc.github.com/odoc/"
+bug-reports: "https://github.com/ocaml-doc/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+http://github.com/ocaml-doc/odoc.git"
+
+depends: [
+  "astring" {build}
+  "bos" {build}
+  "dune" {build}
+  "cmdliner" {build}
+  "cppo" {build}
+  "fpath" {build}
+  "ocaml" {build & >= "4.02.0"}
+  "result" {build}
+  "tyxml" {build & >= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "OCaml documentation generator"
+
+url {
+  src: "https://github.com/ocaml/odoc/archive/1.3.0.tar.gz"
+  checksum: "md5=c734b6ffc158b9519ef2c1463f5789ba"
+}


### PR DESCRIPTION
odoc is a (relatively) new OCaml documentation generator, meant to eventually replace `ocamldoc`:

> https://github.com/ocaml/odoc#readme

It features a powerful new cross-referencer that can handle the complexity of the OCaml module language. It's also a good opportunity to improve the quality of the output.

<br/>

The 1.3.0 release is odoc's first in nearly a year. It includes a pretty large refactoring, and many new features. Highlights include **new CSS**, **BuckleScript**, and **Reason support**.

See the [changelog](https://github.com/ocaml/odoc/releases/tag/1.3.0) below!

<br/>

> Additions
>
> - Reason syntax output (ocaml/odoc#156, Patrick Stapfer).
> - BuckleScript support (ocaml/odoc#179, Leandro Ostera).
> - New CSS, appearance (ocaml/odoc#139, Rizo Isrof).
> - Table of contents for the sections in each page (ocaml/odoc@fe26392).
> - Navigation breadcrumbs, and limit length of module paths in page titles (ocaml/odoc#150, Yotam Barnoy).
> - Syntax highlighting of code blocks (ocaml/odoc@99f2be9).
> - Compiled `odoc` binary is now self-contained and requires no external files (ocaml/odoc@bd3b53c).
> - `--theme-uri` option (ocaml/odoc#154, Rizo Isrof).
> - Option to convert `.mld` to HTML fragments rather than complete pages (ocaml/odoc#166, Rizo Isrof).
>
> Bugs fixed
>
> - Use regular dashes in arrows to support ligature fonts (ocaml/odoc#180, Leandro Ostera).
> - Do not excessively indent code blocks (ocaml/odoc#133, Bobby Priambodo).
> - Always prepend `page-` to output file name when compiling `.mld` files (ocaml/odoc#183, Rizo Isrof).
> - Support `floatarray` type introduced in OCaml 4.06 (ocaml/odoc@eb36158, Thomas Refis).
> - Support destructive type substitution (ocaml/odoc@57cbb4e, Thomas Refis).
> - Render `<i>` tags in italics (ocaml/odoc#104, Thibault Suzanne).
> - Flush HTML output correctly (ocaml/odoc#167, Rizo Isrof).
> - Make HTML output more valid (ocaml/odoc#185, Leandro Ostera).
> - Various improvements to parsing, output, documentation, and the development workflow (Yotam Barnoy, Luke Czyszczonik, Mohamed Elsharnouby, Rudi Grinberg, Rizo Isrof, Leandro Ostera, Bobby Priambodo, Thomas Refis, Patrick Stapfer).
>
> Build and development
>
> - odoc is now one repo.
> - Dropped several dependencies.
> - Considerable refactoring.
> - New commnt parser (ocaml/odoc@78a6699).
> - Improved development workflow, including `CONTRIBUTING.md`, tests, coverage analysis, CI, and issue organization.
> - Initial NPM packaging (Leandro Ostera, ocaml/odoc#214).
> - Skeleton of odoc manual (Leandro Ostera, ocaml/odoc#203).