### PR TITLE
[new release] dune-release (1.1.0)

### DIFF
--- a/packages/dune-release/dune-release.1.1.0/opam
+++ b/packages/dune-release/dune-release.1.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire"]
+homepage: "https://github.com/samoht/dune-release"
+license: "ISC"
+dev-repo: "git+https://github.com/samoht/dune-release.git"
+bug-reports: "https://github.com/samoht/dune-release/issues"
+doc: "https://samoht.github.io/dune-release/"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "opam-format"
+  "opam-state"
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+]
+
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com).
+"""
+url {
+  src:
+    "https://github.com/samoht/dune-release/releases/download/1.1.0/dune-release-1.1.0.tbz"
+  checksum: "md5=4be067b0d9ab63b0180f4b2366768920"
+}

--- a/packages/dune-release/dune-release.1.1.0/opam
+++ b/packages/dune-release/dune-release.1.1.0/opam
@@ -10,9 +10,6 @@ doc: "https://samoht.github.io/dune-release/"
 build: [
   ["dune" "subst"]
   ["dune" "build" "-p" name "-j" jobs]
-]
-
-run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/samoht/dune-release">https://github.com/samoht/dune-release</a>
- Documentation: <a href="https://samoht.github.io/dune-release/">https://samoht.github.io/dune-release/</a>

##### CHANGES:

- Remove the status and log commands (samoht/dune-release#95, @samoht)
- Fix `dune-release publish doc` when using multiple packages (samoht/dune-release#96, @samoht)
- Fix inferred package name when reading `dune-project` files (samoht/dune-release#104. @samoht)
- Add .ps and .eps files to default files excluded from watermarking
  (backport of dbuenzli/topkg@6cf1eae)
- Fix distribution uri when homepage is using github.io (samoht/dune-release#102, @samoht)
- `dune-release lint` now checks that a description and a synopsis exist
  in opam2 files (samoht/dune-release#101, @samoht)
- Add a more explicit error message if `git checkout` fails in the local
  opam-repository (samoht/dune-release#98, @samoht)
- Do not create an extra `_html` folder when publishing docs on Linux
  (samoht/dune-release#94, @anuragsoni and @samoht)
