### PR TITLE
[new release] alcotest (0.8.4)

### DIFF
--- a/packages/alcotest/alcotest.0.8.4/opam
+++ b/packages/alcotest/alcotest.0.8.4/opam
@@ -25,7 +25,6 @@ depends: [
   "cmdliner"
   "uuidm"
 ]
-flags: light-uninstall
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/alcotest/alcotest.0.8.4/opam
+++ b/packages/alcotest/alcotest.0.8.4/opam
@@ -27,7 +27,7 @@ depends: [
 ]
 flags: light-uninstall
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/alcotest/alcotest.0.8.4/opam
+++ b/packages/alcotest/alcotest.0.8.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework."
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run."""
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest/"
+doc: "https://mirage.github.io/alcotest/"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "fmt" {>= "0.8.0"}
+  "astring"
+  "result"
+  "cmdliner"
+  "uuidm"
+]
+flags: light-uninstall
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/0.8.4/alcotest-0.8.4.tbz"
+  checksum: "md5=c940f89a2bb2e23d3f1422ce61d1396b"
+}

--- a/packages/alcotest/alcotest.0.8.4/opam
+++ b/packages/alcotest/alcotest.0.8.4/opam
@@ -27,7 +27,7 @@ depends: [
 ]
 flags: light-uninstall
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "subst"] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework.

- Project page: <a href="https://github.com/mirage/alcotest/">https://github.com/mirage/alcotest/</a>
- Documentation: <a href="https://mirage.github.io/alcotest/">https://mirage.github.io/alcotest/</a>

##### CHANGES:

- Improve documentation for speed and tests (mirage/alcotest#129, @raphael-proust)
- Improve documentation on test case filtering and flush error formatter on exit
  (mirage/alcotest#133, @edwintorok)
- Create a fresh log sub-dir for every run (mirage/alcotest#125, @m-harrison)
- Fix wrong location hint for test files when using dune (mirage/alcotest#135, @m-harrison)
