### PR TITLE
cairo2-gtk: Fix typo in dependency

### DIFF
--- a/packages/cairo2-gtk/cairo2-gtk.0.6/opam
+++ b/packages/cairo2-gtk/cairo2-gtk.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-pkg-config" {build}
   "conf-cairo"
   "cairo2"
-  "lablgtk2"
+  "lablgtk"
 ]
 synopsis: "Rendering Cairo on Gtk canvas"
 description: """


### PR DESCRIPTION
Thanks to @phstrauss https://github.com/Chris00/ocaml-cairo/issues/13