### PR TITLE
Package prepare.0.5.1

### DIFF
--- a/packages/prepare/prepare.0.5.1/opam
+++ b/packages/prepare/prepare.0.5.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jan Rochel <jan@besport.com>"
+authors: [ "Jan Rochel (BeSport)" ]
+synopsis: "Library for pooling resources like connections, threads, or similar"
+description: "This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool."
+license: "MIT"
+homepage: "https://github.com/ocsigen/resource-pooling"
+dev-repo: "git+https://github.com/ocsigen/resource-pooling.git"
+bug-reports: "https://github.com/ocsigen/resource-pooling/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "resource-pooling"]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "lwt" {>= "2.4.7"}
+  "lwt_log"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+flags: light-uninstall
+url {
+  src: "https://github.com/ocsigen/resource-pooling/archive/0.5.1.tar.gz"
+  checksum: [
+    "md5=f57cb8e3faad99588a9b7474c09393ec"
+    "sha512=8956f86e0a54a16ddc9c08dae7129361278c0fe36d6f7182891184912d633f5125bcff5724b77ffcbd4c2de30dbe58296f38425705358e2af55602559c2b3a0b"
+  ]
+}


### PR DESCRIPTION
### `prepare.0.5.1`
Library for pooling resources like connections, threads, or similar
This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool.



---
* Homepage: https://github.com/ocsigen/resource-pooling
* Source repo: git+https://github.com/ocsigen/resource-pooling.git
* Bug tracker: https://github.com/ocsigen/resource-pooling/issues

---
:camel: Pull-request generated by opam-publish v2.0.0