### PR TITLE
8 packages from ocaml/opam at 2.0.1

### DIFF
--- a/packages/opam-client/opam-client.2.0.1/opam
+++ b/packages/opam-client/opam-client.2.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= "2.0.1"}
+  "opam-solver" {= "2.0.1"}
+  "re" {>= "1.7.2"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta20"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+opam 2.0 development libraries
+
+Actions on the opam root, switches, installations, and front-end.
+"""

--- a/packages/opam-core/opam-core.2.0.1/opam
+++ b/packages/opam-core/opam-core.2.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "cppo" {build}
+]
+conflicts: ["extlib-compat"]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+opam 2.0 development libraries
+
+Small standard library extensions, and generic system interaction modules used
+by opam.
+"""

--- a/packages/opam-devel/opam-devel.2.0.1/opam
+++ b/packages/opam-devel/opam-devel.2.0.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= "2.0.1"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta20"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+  [make "tests"] {with-test}
+]
+post-messages:
+  """
+The development version of opam has been successfuly compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/* /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+opam 2.0.0 development version
+
+This package compiles (bootstraps) opam 2.0.0. For consistency and safety of the
+installation, the binaries are not installed into the PATH, but into
+lib/opam-devel, from where the user can manually install them system-wide.
+"""

--- a/packages/opam-format/opam-format.2.0.1/opam
+++ b/packages/opam-format/opam-format.2.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= "2.0.1"}
+  "opam-file-format" {>= "2.0.0~rc2"}
+  "jbuilder" {build & >= "1.0+beta18"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+opam 2.0 development libraries
+
+Definition of opam datastructures and its file interface.
+"""

--- a/packages/opam-installer/opam-installer.2.0.1/opam
+++ b/packages/opam-installer/opam-installer.2.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= "2.0.1"}
+  "cmdliner" {>= "0.9.8"}
+  "jbuilder" {build & >= "1.0+beta17"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["touch" "src/tools/.merlin-exists"]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+Installation of files to a prefix, following opam conventions
+
+opam-installer is a small tool that can read *.install files, as defined by
+opam [1], and execute them to install or remove package files without going
+through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
+"""

--- a/packages/opam-repository/opam-repository.2.0.1/opam
+++ b/packages/opam-repository/opam-repository.2.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= "2.0.1"}
+  "jbuilder" {build & >= "1.0+beta17"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+opam 2.0 development libraries
+
+This library includes repository and remote sources handling, including
+curl/wget, rsync, git, mercurial, darcs backends.
+"""

--- a/packages/opam-solver/opam-solver.2.0.1/opam
+++ b/packages/opam-solver/opam-solver.2.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= "2.0.1"}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "5"}
+  "cudf" {>= "0.7"}
+  "jbuilder" {build & >= "1.0+beta17"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+opam 2.0 development libraries
+
+Solver and Cudf interaction. This library is based on the Cudf and Dose
+libraries, and handles calls to the external solver from opam.
+"""

--- a/packages/opam-state/opam-state.2.0.1/opam
+++ b/packages/opam-state/opam-state.2.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= "2.0.1"}
+  "jbuilder" {build & >= "1.0+beta18"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=91a3b7aff1970692ba77aafb92d192d1"
+    "sha512=ec18d7f5c8b84303bb12a85baff7140b315b551a0c25e07c712c7c6368c8f3e359706590146c8f9248a7c34e35689ade06b3ef57f0562cecb5a86685438b4d8c"
+  ]
+}
+description:"""
+opam 2.0 development libraries
+
+Handling of the ~/.opam hierarchy, repository and switch states.
+"""


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.0.1`
-`opam-core.2.0.1`
-`opam-devel.2.0.1`
-`opam-format.2.0.1`
-`opam-installer.2.0.1`
-`opam-repository.2.0.1`
-`opam-solver.2.0.1`
-`opam-state.2.0.1`



---
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.0.0