### PR TITLE
[new release] noise (0.2.0)

### DIFF
--- a/packages/noise/noise.0.2.0/opam
+++ b/packages/noise/noise.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <me@emillon.org>"
+authors: "Etienne Millon <me@emillon.org>"
+license: "BSD-2"
+homepage: "https://github.com/emillon/ocaml-noise"
+doc: "https://emillon.github.io/ocaml-noise/doc"
+bug-reports: "https://github.com/emillon/ocaml-noise/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "callipyge" {>= "0.2"}
+  "cstruct"
+  "digestif" {>= "0.7"}
+  "dune" {build & >= "1.1.0"}
+  "eqaf"
+  "hex"
+  "lwt_ppx" {with-test}
+  "lwt" {with-test}
+  "nocrypto"
+  "ounit" {with-test}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {with-test}
+  "ppx_let"
+  "ppxlib" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/emillon/ocaml-noise.git"
+synopsis: "The Noise Protocol Framework"
+description: """
+This library contains an implementation of the Noise Protocol Framework using
+different cryptographic libraries.
+"""
+url {
+  src:
+    "https://github.com/emillon/ocaml-noise/releases/download/v0.2.0/noise-v0.2.0.tbz"
+  checksum: "md5=8e879479c16dd2cc31ff35140373897f"
+}


### PR DESCRIPTION
The Noise Protocol Framework

- Project page: <a href="https://github.com/emillon/ocaml-noise">https://github.com/emillon/ocaml-noise</a>
- Documentation: <a href="https://emillon.github.io/ocaml-noise/doc">https://emillon.github.io/ocaml-noise/doc</a>

##### CHANGES:

Use digestif 0.7 and remove custom HMAC implementation (emillon/ocaml-noise#2).
