### PR TITLE
Package reason.3.3.3

### DIFF
--- a/packages/reason/reason.3.3.3/opam
+++ b/packages/reason/reason.3.3.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/facebook/reason"
+doc: "http://reasonml.github.io/"
+bug-reports: "https://github.com/facebook/reason/issues"
+dev-repo: "git://github.com/facebook/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02" & < "4.08"}
+  "dune" {build & >= "1.4"}
+  "ocamlfind" {build}
+  "menhir" {>= "20170418"}
+  "merlin-extend" {>= "0.3"}
+  "result"
+  "ocaml-migrate-parsetree"
+]
+synopsis: "Reason: Syntax & Toolchain for OCaml"
+description: """
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem."""


### PR DESCRIPTION
### `reason.3.3.3`
Reason: Syntax & Toolchain for OCaml
Reason gives OCaml a new syntax that is remniscient of languages like
JavaScript. It's also the umbrella project for a set of tools for the OCaml &
JavaScript ecosystem.



---
* Homepage: https://github.com/facebook/reason
* Source repo: git://github.com/facebook/reason.git
* Bug tracker: https://github.com/facebook/reason/issues

---
:camel: Pull-request generated by opam-publish v2.0.0