### PR TITLE
charrua-client: explicitly require mirage-random (with upper bound due to interface changes in upcoming mirage-random)

### DIFF
--- a/packages/charrua-client/charrua-client.0.1.0/opam
+++ b/packages/charrua-client/charrua-client.0.1.0/opam
@@ -33,7 +33,7 @@ depends: [
   "cstruct"
   "ipaddr"
   "rresult"
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & <= "1.1.0"}
   "duration"
   "logs"
   "tcpip" {>= "3.0.0"}

--- a/packages/charrua-client/charrua-client.0.10/opam
+++ b/packages/charrua-client/charrua-client.0.10/opam
@@ -21,6 +21,7 @@ depends: [
   "charrua-core" {>= "0.10"}
   "cstruct" {>= "3.0.2"}
   "ipaddr"
+  "mirage-random" {>= "1.0.0" & <= "1.1.0"}
 ]
 synopsis: "DHCP - a DHCP client, server and wire frame encoder and decoder"
 description: """

--- a/packages/charrua-client/charrua-client.0.9/opam
+++ b/packages/charrua-client/charrua-client.0.9/opam
@@ -18,6 +18,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "ounit" {with-test}
   "alcotest" {with-test}
+  "cstruct-unix" {with-test}
   "charrua-core" {>= "0.9"}
   "cstruct" {>= "3.0.2"}
   "ipaddr"

--- a/packages/charrua-client/charrua-client.0.9/opam
+++ b/packages/charrua-client/charrua-client.0.9/opam
@@ -21,6 +21,7 @@ depends: [
   "charrua-core" {>= "0.9"}
   "cstruct" {>= "3.0.2"}
   "ipaddr"
+  "mirage-random" {>= "1.0.0" & <= "1.1.0"}
 ]
 synopsis: "DHCP - a DHCP client, server and wire frame encoder and decoder"
 description: """


### PR DESCRIPTION
see https://github.com/mirage/charrua-core/pull/85