### PR TITLE
cohttp-async: add missing uri dependency and bounds

### DIFF
--- a/packages/cohttp-async/cohttp-async.0.99.0/opam
+++ b/packages/cohttp-async/cohttp-async.0.99.0/opam
@@ -28,6 +28,7 @@ depends: [
   "magic-mime"
   "fmt"
   "ounit" {with-test}
+  "uri" {< "2.0.0"}
 ]
 synopsis: "An OCaml library for HTTP clients and servers"
 description: """

--- a/packages/cohttp-async/cohttp-async.1.0.0/opam
+++ b/packages/cohttp-async/cohttp-async.1.0.0/opam
@@ -29,6 +29,7 @@ depends: [
   "logs"
   "fmt" {>= "0.8.2"}
   "ounit" {with-test}
+  "uri" {< "2.0.0"}
 ]
 synopsis: "An OCaml library for HTTP clients and servers"
 description: """

--- a/packages/cohttp-async/cohttp-async.1.0.2/opam
+++ b/packages/cohttp-async/cohttp-async.1.0.2/opam
@@ -29,6 +29,7 @@ depends: [
   "logs"
   "fmt" {>= "0.8.2"}
   "ounit" {with-test}
+  "uri" {< "2.0.0"}
 ]
 synopsis: "An OCaml library for HTTP clients and servers"
 description: """

--- a/packages/cohttp-async/cohttp-async.1.1.1/opam
+++ b/packages/cohttp-async/cohttp-async.1.1.1/opam
@@ -29,6 +29,7 @@ depends: [
   "sexplib"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ounit" {with-test}
+  "uri" {< "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-async/cohttp-async.1.2.0/opam
+++ b/packages/cohttp-async/cohttp-async.1.2.0/opam
@@ -56,6 +56,7 @@ depends: [
   "sexplib0"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ounit" {with-test}
+  "uri" {>= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
This should prevent further issues when different versions of uri, cohttp, and cohttp-async are installed or pinned

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>