### PR TITLE
Package gg.0.9.3

### DIFF
--- a/packages/gg/gg.0.9.3/opam
+++ b/packages/gg/gg.0.9.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "base-bigarray"
-  "bench" {test}
+  "bench" {with-test}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"

--- a/packages/gg/gg.0.9.3/opam
+++ b/packages/gg/gg.0.9.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/gg"
+authors: [ "The gg programmers" ]
+doc: "http://erratique.ch/software/gg/doc/Gg"
+dev-repo: "git+http://erratique.ch/repos/gg.git"
+bug-reports: "https://github.com/dbuenzli/gg/issues"
+tags: [ "matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.02.2"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bigarray"
+  "bench" {test}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+]]
+synopsis: """Basic types for computer graphics in OCaml"""
+description: """\
+
+Gg is an OCaml module providing basic types for computer graphics.
+
+It defines types and functions for floats, vectors, points, sizes,
+matrices, quaternions, axis-aligned boxes, colors, color spaces, and
+raster data.
+
+Gg is made of a single module, depends on bigarrays, and is
+distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/gg/releases/gg-0.9.3.tbz"
+checksum: "1801fc7b6af16c597ef0bfaacc12cd5b"
+}

--- a/packages/gg/gg.0.9.3/opam
+++ b/packages/gg/gg.0.9.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "base-bigarray"
-  "bench" {with-test}
+#  "bench" {with-test}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"


### PR DESCRIPTION
### `gg.0.9.3`
Basic types for computer graphics in OCaml
Gg is an OCaml module providing basic types for computer graphics.

It defines types and functions for floats, vectors, points, sizes,
matrices, quaternions, axis-aligned boxes, colors, color spaces, and
raster data.

Gg is made of a single module, depends on bigarrays, and is
distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/gg
* Source repo: git+http://erratique.ch/repos/gg.git
* Bug tracker: https://github.com/dbuenzli/gg/issues

---
v0.9.3 2018-10-23 Zagreb
------------------------

- Add `Color.to_srgbi` (inverse of `Color.v_srgbi`). Thanks to
  Christophe Troestler for the patch.
- Add missing constraints on `Float.{is_nan,equal,compare}`. Polymorphic
  equality was being used. Thanks to Christophe Troestler for the report
  (#17).
- Fix bug in `Gg.M3.rot2 ?pt:(Some _)` (#18).

---
:camel: Pull-request generated by opam-publish v2.0.0