### PR TITLE
Package opam-lock.0.2

### DIFF
--- a/packages/opam-lock/opam-lock.0.2/opam
+++ b/packages/opam-lock/opam-lock.0.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Locking of development package definition dependency versions"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "https://github.com/AltGr/opam-lock"
+bug-reports: "https://github.com/AltGr/opam-lock/issues"
+dev-repo: "git+https://github.com/AltGr/opam-lock.git"
+depends: [
+  "cmdliner" {>= "1.0"}
+  "opam-solver" {>= "2.0.0~beta5"}
+  "opam-state" {>= "2.0.0~beta5"}
+]
+build: ["jbuilder" "build" "-p" name]
+flags: plugin
+url {
+  src: "https://github.com/AltGr/opam-lock/archive/0.2.tar.gz"
+  checksum: [
+    "md5=6fb2e5e91837a7f2056255390ce90328"
+    "sha512=6c4680ce60f8f85d4a74b4a17ee292349cd85ae94bb02e8b2a6e78ab7ff48f987142396c68c4e2d638a7830791e3a4d6e00800a0d06e1962b3bf7cc322de0566"
+  ]
+}


### PR DESCRIPTION
### `opam-lock.0.2`
Locking of development package definition dependency versions



---
* Homepage: https://github.com/AltGr/opam-lock
* Source repo: git+https://github.com/AltGr/opam-lock.git
* Bug tracker: https://github.com/AltGr/opam-lock/issues

---
:camel: Pull-request generated by opam-publish v2.0.0