### PR TITLE
Add conf flag for conf-* packages

### DIFF
--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -19,3 +19,4 @@ depends: ["conf-which" {build}]
 synopsis: "Virtual package relying on aclocal"
 description:
   "This package can only install if the aclocal program is installed on the system."
+flags: conf

--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -28,3 +28,4 @@ synopsis: "Virtual package relying on autoconf installation"
 description: """
 This package can only install if the autoconf command
 is available on the system."""
+flags: conf

--- a/packages/conf-bap-llvm/conf-bap-llvm.1/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1/opam
@@ -19,3 +19,4 @@ depexts: [
 conflicts: ["conf-llvm"]
 synopsis: "Virtual package relying on llvm library installation for BAP"
 extra-files: ["configure" "md5=47b8674130ba68afeeabebb719960c0f"]
+flags: conf

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -30,3 +30,4 @@ extra-files: [
   ["test.c" "md5=2bf678ea49b283c0afeee23d2e05606d"]
   ["test-win.sh" "md5=55cb2c1d412d196ba5034905fd2f08de"]
 ]
+flags: conf

--- a/packages/conf-bmake/conf-bmake.1.0/opam
+++ b/packages/conf-bmake/conf-bmake.1.0/opam
@@ -27,3 +27,4 @@ description: """
 This package can only install if a BSD Make compatible program is
 available on the system."""
 extra-files: ["detect_program.sh" "md5=3f0146fa5b2daf78c62908b0a587f094"]
+flags: conf

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -23,3 +23,4 @@ depexts: [
 synopsis: "Virtual package relying on boost"
 description:
   "This package can only install if the boost library is installed on the system."
+flags: conf

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -15,3 +15,4 @@ synopsis: "Virtual package relying on a brotli system installation"
 description:
   "This package can only install if libbrotli is installed on the system."
 depends: ["conf-pkg-config" {build}]
+flags: conf

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -21,3 +21,4 @@ synopsis: "Virtual package relying on a Cairo system installation"
 description:
   "This package can only install if the cairo lib is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -24,3 +24,4 @@ depexts: [
   ["capnproto" "libcapnp-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on captnproto installation"
+flags: conf

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -24,3 +24,4 @@ synopsis: "Virtual package relying on cmake"
 description:
   "This package can only install if cmake is installed on the system."
 extra-files: ["configure.sh" "md5=0cae8434c6b69725503c46525063c505"]
+flags: conf

--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -33,3 +33,4 @@ extra-files: [
   ["test_gdbm.c" "md5=bb6869c63ffe5f767d859fb364fcecc8"]
   ["test_ndbm.c" "md5=f5f74ae297a6a7ced42843372156af85"]
 ]
+flags: conf

--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -21,3 +21,4 @@ synopsis: "Virtual package relying on the EFL system installation"
 description:
   "This package can only install if the EFL are installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-emacs/conf-emacs.1/opam
+++ b/packages/conf-emacs/conf-emacs.1/opam
@@ -18,3 +18,4 @@ synopsis: "Virtual package to install the Emacs editor"
 description:
   "This package will install a system emacs if invoked via `opam depext`"
 authors: "anil@recoil.org"
+flags: conf

--- a/packages/conf-env-travis/conf-env-travis.1/opam
+++ b/packages/conf-env-travis/conf-env-travis.1/opam
@@ -15,3 +15,4 @@ This package will expose variable an environment variable
 A variable `active` would be set to true, if travis environment was
 detected.  All variables except `active` are delimited with quotes."""
 extra-files: ["configure" "md5=c86f65c0f9cc790c542f27798a7989cd"]
+flags: conf

--- a/packages/conf-expat/conf-expat.1/opam
+++ b/packages/conf-expat/conf-expat.1/opam
@@ -15,3 +15,4 @@ depexts: [
 synopsis: "Virtual package relying on an expat system installation"
 description:
   "This package can only install if the expat lib is installed on the system."
+flags: conf

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -22,3 +22,4 @@ depexts: [
 synopsis: "Virtual package relying on a FFTW3 lib system installation"
 description:
   "This package can only install if the FFTW3 lib is installed on the system."
+flags: conf

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -22,3 +22,4 @@ depexts: [
 synopsis: "Virtual package relying on a freetype lib system installation"
 description:
   "This package can only install if the freetype lib is installed on the system."
+flags: conf

--- a/packages/conf-ftgl/conf-ftgl.1/opam
+++ b/packages/conf-ftgl/conf-ftgl.1/opam
@@ -15,3 +15,4 @@ depexts: [
 synopsis: "Virtual package relying on an ftgl system installation"
 description:
   "This package can only install if the ftgl lib is installed on the system."
+flags: conf

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -19,3 +19,4 @@ depexts: [
 synopsis: "Virtual package relying on the g++ compiler (for C++)"
 description:
   "This package can only install if the g++ compiler is installed on the system."
+flags: conf

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -21,3 +21,4 @@ depexts: [
 synopsis: "Virtual package relying on git"
 description:
   "This package can only install if the git program is installed on the system."
+flags: conf

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -14,3 +14,4 @@ synopsis: "Virtual package relying on a libglade system installation"
 description:
   "This package can only install if libglade2-dev is installed on the system."
 depends: ["conf-pkg-config" {build}]
+flags: conf

--- a/packages/conf-gles2/conf-gles2.1/opam
+++ b/packages/conf-gles2/conf-gles2.1/opam
@@ -14,3 +14,4 @@ depexts: [
   ["mesa-libGLES-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Virtual package relying on a OpenGL ES 2 system installation"
+flags: conf

--- a/packages/conf-glew/conf-glew.1/opam
+++ b/packages/conf-glew/conf-glew.1/opam
@@ -19,3 +19,4 @@ depexts: [
 synopsis: "Virtual package relying on a GLEW system installation"
 description:
   "This package can only install if the lib GLEW is installed on the system."
+flags: conf

--- a/packages/conf-glfw3/conf-glfw3.1/opam
+++ b/packages/conf-glfw3/conf-glfw3.1/opam
@@ -19,3 +19,4 @@ depexts: [
   ["libglfw-devel"] {os-distribution = "mageia"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]
+flags: conf

--- a/packages/conf-glib-2/conf-glib-2.1/opam
+++ b/packages/conf-glib-2/conf-glib-2.1/opam
@@ -26,3 +26,4 @@ and retry"""
 ]
 synopsis: "Virtual package relying on a system GLib 2 installation"
 depends: ["conf-pkg-config" {build}]
+flags: conf

--- a/packages/conf-glpk/conf-glpk.1/opam
+++ b/packages/conf-glpk/conf-glpk.1/opam
@@ -21,3 +21,4 @@ synopsis: "Virtual package for GLPK (GNU Linear Programming Kit)"
 description: """
 This package relies on GLPK being installed on the system. It requires static
 libraries to be available."""
+flags: conf

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
@@ -19,3 +19,4 @@ This package can only install if the GMP lib is installed on the system and
 corresponds to a version that has the mpz_powm_sec function."""
 authors: "Etienne Millon <etienne@cryptosense.com>"
 extra-files: ["test.c" "md5=1f737746280d037db069d178d0d52d39"]
+flags: conf

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -27,3 +27,4 @@ description:
   "This package can only install if the GMP lib is installed on the system."
 authors: "nbraud"
 extra-files: ["test.c" "md5=ec8cc21ab709bdd57103de36e7b0b53f"]
+flags: conf

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -18,3 +18,4 @@ This package can only install if libgnomecanvas2-dev is installed
 on the system."""
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-gnuplot/conf-gnuplot.0.1/opam
+++ b/packages/conf-gnuplot/conf-gnuplot.0.1/opam
@@ -21,3 +21,4 @@ synopsis: "Virtual package relying on gnuplot installation"
 description: """
 This package can only install if the gnuplot command
 is available on the system."""
+flags: conf

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -15,3 +15,4 @@ synopsis: "Virtual package relying on a gnutls system installation"
 description:
   "This package can only install if the gnutls lib is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -21,3 +21,4 @@ depexts: [
 synopsis: "Virtual package relying on graphviz installation"
 description:
   "This package can only install if the dot command is available on the system."
+flags: conf

--- a/packages/conf-gsl/conf-gsl.1/opam
+++ b/packages/conf-gsl/conf-gsl.1/opam
@@ -21,3 +21,4 @@ description:
   "This package can only install if the GSL lib is installed on the system."
 authors: "blue-prawn"
 depends: ["conf-pkg-config" {build}]
+flags: conf

--- a/packages/conf-gssapi/conf-gssapi.1/opam
+++ b/packages/conf-gssapi/conf-gssapi.1/opam
@@ -12,3 +12,4 @@ description:
   "This package can only install if the krb5-gssapi lib is installed on the system."
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -21,3 +21,4 @@ depexts: [
 synopsis: "Virtual package relying on a GtkSourceView system installation"
 description:
   "This package can only install if libgtksourceview2.0-dev is installed on the system."
+flags: conf

--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -20,3 +20,4 @@ depexts: [
 synopsis: "Virtual package relying on a hidapi system installation"
 description:
   "This package can only install if the hidapi lib is installed on the system."
+flags: conf

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -30,3 +30,4 @@ extra-files: [
   ["test.c" "md5=ac2a49147c4af466c3b3251dbd3960ff"]
   ["test-win.sh" "md5=8143befd9947d11f4baecf3dbf0167f5"]
 ]
+flags: conf

--- a/packages/conf-leveldb/conf-leveldb.1/opam
+++ b/packages/conf-leveldb/conf-leveldb.1/opam
@@ -15,3 +15,4 @@ synopsis: "Virtual package relying on a LevelDB lib system installation"
 description:
   "This package can only install if the LevelDB lib is installed on the system."
 extra-files: ["test.cc" "md5=10b6f9d2e02bdee700ad6cb387f3a0a8"]
+flags: conf

--- a/packages/conf-libMagickCore/conf-libMagickCore.1/opam
+++ b/packages/conf-libMagickCore/conf-libMagickCore.1/opam
@@ -15,3 +15,4 @@ This package can only install if the Core lib of ImageMagick is
 installed on the system."""
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -20,3 +20,4 @@ synopsis: "Virtual package relying on a libcurl system installation"
 description:
   "This package can only install if the libcurl is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -27,3 +27,4 @@ extra-files: [
   ["build.sh" "md5=f37b5eb73ebeb177dff1cd8bb2f38c4e"]
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libffi/conf-libffi.1/opam
+++ b/packages/conf-libffi/conf-libffi.1/opam
@@ -14,3 +14,4 @@ description:
   "This package can only install if the libffi is installed on the system."
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libgif/conf-libgif.1/opam
+++ b/packages/conf-libgif/conf-libgif.1/opam
@@ -24,3 +24,4 @@ synopsis: "Virtual package relying on a libgif system installation"
 description:
   "This package can only install if the libgif is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libgsasl/conf-libgsasl.1/opam
+++ b/packages/conf-libgsasl/conf-libgsasl.1/opam
@@ -14,3 +14,4 @@ synopsis: "Virtual package relying on a GSASL lib system installation"
 description:
   "This package can only install if the GSASL lib is installed on the system."
 extra-files: ["test.c" "md5=7350e0fdcca0cf6c19efaf9b4862dee7"]
+flags: conf

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -18,3 +18,4 @@ synopsis: "Virtual package relying on a libjpeg system installation"
 description:
   "This package can only install if the libjpeg is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -17,3 +17,4 @@ depexts: [
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on liblz4 system installation"
+flags: conf

--- a/packages/conf-libmosquitto/conf-libmosquitto.1/opam
+++ b/packages/conf-libmosquitto/conf-libmosquitto.1/opam
@@ -17,3 +17,4 @@ depexts: [
 synopsis: "Virtual package relying on a libmosquitto system installation"
 description:
   "This package can only install if the libmosquitto is installed on the system."
+flags: conf

--- a/packages/conf-libpcre/conf-libpcre.1/opam
+++ b/packages/conf-libpcre/conf-libpcre.1/opam
@@ -25,3 +25,4 @@ depexts: [
 synopsis: "Virtual package relying on a libpcre system installation"
 description:
   "This package can only install if the libpcre is installed on the system."
+flags: conf

--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -19,3 +19,4 @@ description:
   "This package can only install if the libpng is installed on the system."
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libsodium/conf-libsodium.1/opam
+++ b/packages/conf-libsodium/conf-libsodium.1/opam
@@ -31,3 +31,4 @@ synopsis: "Virtual package relying on a libsodium system installation"
 description:
   "This package can only install if the libsodium is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libsvm/conf-libsvm.3/opam
+++ b/packages/conf-libsvm/conf-libsvm.3/opam
@@ -24,3 +24,4 @@ This package can only install if the libsvm library is available on the system:
 - `libsvm/svm.h` is at an include path.
 - `libsvm.so` is at a library path."""
 extra-files: ["test.c" "md5=a8bf07a6d8723a85c7777bde2d041e3f"]
+flags: conf

--- a/packages/conf-libudev/conf-libudev.1/opam
+++ b/packages/conf-libudev/conf-libudev.1/opam
@@ -23,3 +23,4 @@ post-messages: [
 synopsis: "Virtual package relying on a libudev system installation"
 description:
   "This package can only install if libudev is installed on the system."
+flags: conf

--- a/packages/conf-libuv/conf-libuv.1/opam
+++ b/packages/conf-libuv/conf-libuv.1/opam
@@ -24,3 +24,4 @@ post-messages: [
 synopsis: "Virtual package relying on a libuv system installation"
 description:
   "This package can only install if libuv 1.0 or later is installed on the system."
+flags: conf

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -18,3 +18,4 @@ synopsis:
   "Virtual package relying on the installation of the Linux kernel headers files"
 description:
   "This package can only install if the kernel headers for user space applications are installed on the system."
+flags: conf

--- a/packages/conf-lldb/conf-lldb.3.5/opam
+++ b/packages/conf-lldb/conf-lldb.3.5/opam
@@ -14,3 +14,4 @@ post-messages: [
 synopsis:
   "Virtual package to check the availability of LLDB 3.5 development packages"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-llvm/conf-llvm.3.4/opam
+++ b/packages/conf-llvm/conf-llvm.3.4/opam
@@ -18,3 +18,4 @@ post-messages:
     {failure & (os = "macos" | os = "macos")}
 synopsis: "Virtual package relying on llvm library installation"
 extra-files: ["configure" "md5=67afff0753bd62bc5adbe9e205c91138"]
+flags: conf

--- a/packages/conf-llvm/conf-llvm.3.8/opam
+++ b/packages/conf-llvm/conf-llvm.3.8/opam
@@ -16,3 +16,4 @@ depexts: [
 ]
 synopsis: "Virtual package relying on llvm library installation"
 extra-files: ["configure.sh" "md5=67afff0753bd62bc5adbe9e205c91138"]
+flags: conf

--- a/packages/conf-llvm/conf-llvm.3.9/opam
+++ b/packages/conf-llvm/conf-llvm.3.9/opam
@@ -18,3 +18,4 @@ depexts: [
 ]
 synopsis: "Virtual package relying on llvm library installation"
 extra-files: ["configure.sh" "md5=67afff0753bd62bc5adbe9e205c91138"]
+flags: conf

--- a/packages/conf-llvm/conf-llvm.4.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.4.0.0/opam
@@ -18,3 +18,4 @@ depexts: [
 ]
 synopsis: "Virtual package relying on llvm library installation"
 extra-files: ["configure.sh" "md5=f569dbbd49aedc28b93f9aec79f3d532"]
+flags: conf

--- a/packages/conf-llvm/conf-llvm.5.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.5.0.0/opam
@@ -18,3 +18,4 @@ depexts: [
 ]
 synopsis: "Virtual package relying on llvm library installation"
 extra-files: ["configure.sh" "md5=8ceb5a52ef850ddffa7d5f41838eb1ff"]
+flags: conf

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -18,3 +18,4 @@ depexts: [
 ]
 synopsis: "Virtual package relying on llvm library installation"
 extra-files: ["configure.sh" "md5=8ceb5a52ef850ddffa7d5f41838eb1ff"]
+flags: conf

--- a/packages/conf-llvm/conf-llvm.7.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.7.0.0/opam
@@ -18,3 +18,4 @@ depexts: [
 ]
 synopsis: "Virtual package relying on llvm library installation"
 extra-files: ["configure.sh" "md5=836e64e25614e30874c1bd6e4c45a113"]
+flags: conf

--- a/packages/conf-lua/conf-lua.1/opam
+++ b/packages/conf-lua/conf-lua.1/opam
@@ -18,3 +18,4 @@ description:
   "This package can only install if the lua lib is installed on the system."
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -20,3 +20,4 @@ depexts: [
 synopsis: "Virtual package relying on m4"
 description:
   "This package can only install if the m4 binary is installed on the system."
+flags: conf

--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -17,3 +17,4 @@ synopsis:
   "Virtual package relying on a libmariadbclient system installation"
 description:
   "This package can only install if the libmariadbclient is installed on the system."
+flags: conf

--- a/packages/conf-mecab/conf-mecab.0.996/opam
+++ b/packages/conf-mecab/conf-mecab.0.996/opam
@@ -18,3 +18,4 @@ description: """
 This package can only install if the MeCab devel library is installed
 on the system."""
 extra-files: ["test.c" "md5=122154cf89fb9d22215f32b776285f42"]
+flags: conf

--- a/packages/conf-mpfr/conf-mpfr.1/opam
+++ b/packages/conf-mpfr/conf-mpfr.1/opam
@@ -23,3 +23,4 @@ synopsis: "Virtual package relying on library MPFR installation"
 description:
   "This package can only install if the MPFR library is installed on the system."
 extra-files: ["test.c" "md5=ac7e04b5e22a41cb3c028180d1b811d6"]
+flags: conf

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -22,3 +22,4 @@ synopsis: "Virtual package relying on a mpi system installation"
 description:
   "This package can only install if the (open)mpi development files are installed on the system."
 extra-files: ["configure" "md5=cb39084281574e972fed895953734a78"]
+flags: conf

--- a/packages/conf-mysql/conf-mysql.1/opam
+++ b/packages/conf-mysql/conf-mysql.1/opam
@@ -16,3 +16,4 @@ depexts: [
 synopsis: "Virtual package relying on a libmysqlclient system installation"
 description:
   "This package can only install if the libmysqlclient is installed on the system."
+flags: conf

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -15,3 +15,4 @@ description:
   "This package can only install if the nanomsg lib is installed on the system."
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-ncurses/conf-ncurses.1+system/opam
+++ b/packages/conf-ncurses/conf-ncurses.1+system/opam
@@ -8,3 +8,4 @@ available: os = "macos" | os = "freebsd" | os = "netbsd" | os = "openbsd"
 synopsis: "Virtual package relying on ncurses"
 description:
   "This package can only install if the ncurses library is installed on the system."
+flags: conf

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -22,3 +22,4 @@ available: os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"
 synopsis: "Virtual package relying on ncurses"
 description:
   "This package can only install if the ncurses library is installed on the system."
+flags: conf

--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -18,3 +18,4 @@ synopsis: "Virtual package relying on a Neko system installation"
 description:
   "This package can only install if Neko is installed on the system."
 authors: "Haxe Foundation <contact@haxe.org>"
+flags: conf

--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
@@ -30,3 +30,4 @@ url {
     "https://www.github.com/stevebleazard/ocaml-conf-netsnmp/releases/download/v1.0.0/conf-netsnmp-1.0.0.tbz"
   checksum: "md5=b7182d9bed4e50b2c7fc94b4a1a303d3"
 }
+flags: conf

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -23,3 +23,4 @@ depexts: [
   ["npm"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on npm installation"
+flags: conf

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -18,8 +18,4 @@ synopsis: "Package relying on libnuma"
 description: """
 Virtual package relying on a libnuma system installation.
 This package can only install if the libnuma lib is installed on the system."""
-url {
-  src:
-    "https://www.github.com/stevebleazard/ocaml-conf-numa/releases/download/v0.1.0/conf-numa-0.1.0.tbz"
-  checksum: "md5=7f5a5d170a8f8718162b021072e17ec2"
-}
+flags: conf

--- a/packages/conf-ode/conf-ode.1/opam
+++ b/packages/conf-ode/conf-ode.1/opam
@@ -14,3 +14,4 @@ description:
   "This package can only install if the ODE lib is installed on the system."
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -26,3 +26,4 @@ description: """
 This package can only install if the openbabel devel library is installed
 on the system."""
 extra-files: ["test.cpp" "md5=0a2f6ad381a1624089cd12718bfbfdd8"]
+flags: conf

--- a/packages/conf-openblas/conf-openblas.0.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.1/opam
@@ -33,3 +33,4 @@ extra-files: [
   ["test.c" "md5=dcf8ee02542457dde43e1e4917897416"]
   ["centos_install.sh" "md5=46ee889588a424b2d5b25b3de906ed6c"]
 ]
+flags: conf

--- a/packages/conf-openblas/conf-openblas.0.2.0/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.0/opam
@@ -28,3 +28,4 @@ synopsis: "Virtual package to install OpenBLAS and LAPACKE"
 description:
   "The package prepares OpenBLAS (CBLAS) and LAPACKE backend for Owl (OCaml numerical library). It can only be installed if OpenBLAS and LAPACKE are installed on the system."
 extra-files: ["test.c" "md5=dcf8ee02542457dde43e1e4917897416"]
+flags: conf

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -27,3 +27,4 @@ synopsis: "Virtual package relying on an OpenSSL system installation"
 description:
   "This package can only install if OpenSSL is installed on the system."
 extra-files: ["osx-build.sh" "md5=351f350c49d98ef4b77037c9ed277d52"]
+flags: conf

--- a/packages/conf-pango/conf-pango.1/opam
+++ b/packages/conf-pango/conf-pango.1/opam
@@ -17,3 +17,4 @@ synopsis: "Virtual package relying on a Pango system installation"
 description:
   "This package can only install if the Pango lib is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -16,3 +16,4 @@ depexts: [
 synopsis: "Virtual package relying on perl"
 description:
   "This package can only install if the perl program is installed on the system."
+flags: conf

--- a/packages/conf-pic-switch/conf-pic-switch.0.1/opam
+++ b/packages/conf-pic-switch/conf-pic-switch.0.1/opam
@@ -13,3 +13,4 @@ depends: [
 ]
 conflicts: ["ocaml-system"]
 extra-files: ["check.sh" "md5=584e1b9ef424cc069f7273d451b6f8ae"]
+flags: conf

--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -27,3 +27,4 @@ synopsis: "Virtual package relying on pkg-config installation"
 description: """
 This package can only install if the pkg-config package is installed
 on the system."""
+flags: conf

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -35,4 +35,4 @@ synopsis: "Virtual package relying on pkg-config installation"
 description: """
 This package can only install if the pkg-config package is installed
 on the system."""
-flags: light-uninstall
+flags: conf

--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -24,3 +24,4 @@ description:
   "This package can only install if PPL is installed on the system."
 authors: "R. Bagnara, P. M. Hill, E. Zaffanella, A. Bagnara et. al."
 extra-files: ["test.c" "md5=7de4a76f91cee3f8cd52220b7edd16cb"]
+flags: conf

--- a/packages/conf-python-2-7-dev/conf-python-2-7-dev.1.0/opam
+++ b/packages/conf-python-2-7-dev/conf-python-2-7-dev.1.0/opam
@@ -18,3 +18,4 @@ description: """
 This package can only install if the "python2.7/Python.h" C header file
 is available on the system."""
 extra-files: ["test.c" "md5=38169957900602d7c02af0d5040f3a6d"]
+flags: conf

--- a/packages/conf-python-2-7/conf-python-2-7.1.0/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.0/opam
@@ -26,3 +26,4 @@ description: """
 This package can only install if the Python-2.7 interpreter is available
 on the system."""
 extra-files: ["test.py" "md5=b2b11a2f587814ed4c08b109d9ed949f"]
+flags: conf

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -24,3 +24,4 @@ depexts: [
   ["qt5-qtbase-devel" "qt5-qtdeclarative-devel"] {os-distribution = "fedora"}
 ]
 synopsis: "Installation of Qt5 using APT packages or from source"
+flags: conf

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -23,3 +23,4 @@ synopsis:
 description:
   "This package can only install if R Standalone Mathlib is installed on the system."
 authors: "https://www.r-project.org/contributors.html"
+flags: conf

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -21,3 +21,4 @@ description: """
 This package can only install if the R interpreter (for statistics)
 is installed on the system."""
 extra-files: ["check.r" "md5=4157c5cc4c887be63e9dbc88aa47a603"]
+flags: conf

--- a/packages/conf-rdkit/conf-rdkit.0.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.0.1/opam
@@ -21,5 +21,5 @@ synopsis: "Virtual package relying on rdkit library installation"
 description: """
 This package can only install if the rdkit devel library is installed
 on the system."""
-flags: light-uninstall
 extra-files: ["test.cpp" "md5=8079a0c593690540fbcb2f848f5b43d5"]
+flags: conf

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -14,3 +14,4 @@ build: [
 ]
 synopsis: "Virtual package relying on a system installation of RocksDB"
 extra-files: ["main.c" "md5=5c11ff1def313f2a87eabf3a30f130ad"]
+flags: conf

--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -25,3 +25,4 @@ depexts: [
 synopsis: "Virtual package relying on Ruby"
 description:
   "This package can only install if the `ruby` program is available on the system."
+flags: conf

--- a/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
+++ b/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl-image/conf-sdl-image.1/opam
+++ b/packages/conf-sdl-image/conf-sdl-image.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
+++ b/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl-net/conf-sdl-net.1/opam
+++ b/packages/conf-sdl-net/conf-sdl-net.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
+++ b/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl2-image/conf-sdl2-image.1/opam
+++ b/packages/conf-sdl2-image/conf-sdl2-image.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
+++ b/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
+++ b/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
@@ -14,3 +14,4 @@ description:
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
+flags: conf

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -21,3 +21,4 @@ synopsis: "Virtual package relying on a SDL2 system installation"
 description:
   "This package can only install if libSDL2 is installed on the system."
 depends: ["conf-pkg-config" {build}]
+flags: conf

--- a/packages/conf-sdpa/conf-sdpa.1/opam
+++ b/packages/conf-sdpa/conf-sdpa.1/opam
@@ -11,3 +11,4 @@ synopsis: "Virtual package relying on a SDPA binary system installation"
 description:
   "This package can only install if the SDPA binary is installed on the system."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
@@ -16,7 +16,4 @@ depexts: [
 synopsis: "Virtual package relying on a secp256k1 lib system installation"
 description:
   "This package can only install if the secp256k1 lib is installed on the system."
-url {
-  src: "https://github.com/dakk/conf-secp256k1/archive/1.0.0.tar.gz"
-  checksum: "md5=6492be9ed737be2a2b9f4db7d015b1e8"
-}
+flags: conf

--- a/packages/conf-sfml2/conf-sfml2.1/opam
+++ b/packages/conf-sfml2/conf-sfml2.1/opam
@@ -14,3 +14,4 @@ description:
   "This package can only install if libSFML2.X is installed on the system."
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -16,3 +16,4 @@ description:
   "This package can only install if the snappy library is installed on the system."
 authors: "Gabriel Scherer"
 extra-files: ["test.cpp" "md5=90fb2f59e92b7f5a3a65e776249d233f"]
+flags: conf

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -28,3 +28,4 @@ depexts: [
 synopsis: "Virtual package relying on an sqlite3 system installation"
 description:
   "This package can only install if sqlite3 is installed on the system."
+flags: conf

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -17,3 +17,4 @@ extra-files: [
   ["compiletest.c" "md5=519d14d3baadfe9a94982fa58a596820"]
   ["check.sh" "md5=23052a7642deaf090480b4162d365358"]
 ]
+flags: conf

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -16,3 +16,4 @@ depexts: [
 synopsis: "Virtual package relying on the \"time\" command"
 description:
   "This package can only install if the \"time\" command is installed on the system.  It does not enforce having the GNU utility: it may find a BSD time command (BSD, OSX) or a Busybox command (Alpine) that have different options. The only common functionality is \"time <command>\"."
+flags: conf

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -17,3 +17,4 @@ extra-files: [
   ["compiletest.c" "md5=9495fa2a30a3dad2180634786f6bef2b"]
   ["check.sh" "md5=9a83fb7a0b708bb6129c032fb27e1609"]
 ]
+flags: conf

--- a/packages/conf-vim/conf-vim.1/opam
+++ b/packages/conf-vim/conf-vim.1/opam
@@ -16,3 +16,4 @@ synopsis: "Virtual package to install the Vim editor"
 description:
   "This package will install a system vim if invoked via `opam depext`"
 authors: "anil@recoil.org"
+flags: conf

--- a/packages/conf-wget/conf-wget.1/opam
+++ b/packages/conf-wget/conf-wget.1/opam
@@ -20,3 +20,4 @@ depexts: [
 synopsis: "Virtual package relying on wget"
 description:
   "This package can only install if the wget program is installed on the system."
+flags: conf

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -17,3 +17,4 @@ depexts: [
 synopsis: "Virtual package relying on which"
 description:
   "This package can only install if the which program is installed on the system."
+flags: conf

--- a/packages/conf-wxwidgets/conf-wxwidgets.3.0/opam
+++ b/packages/conf-wxwidgets/conf-wxwidgets.3.0/opam
@@ -20,3 +20,4 @@ post-messages: [
 synopsis:
   "Virtual package to check the availability of wxWidgets 3.0 development packages"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -19,3 +19,4 @@ depexts: [
 synopsis: "Virtual package relying on zlib"
 description:
   "This package can only install if the zlib library is installed on the system."
+flags: conf

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -20,3 +20,4 @@ description: """
 This package can only install if the zmq devel library is installed
 on the system."""
 extra-files: ["test.c" "md5=2272935eca81c8bc500270c30c558fa3"]
+flags: conf


### PR DESCRIPTION
Add only `conf` flags for all, except:
- `conf-netsnmp.1.0.0` - `conf-numa.0.1.0` - `conf-secp256k1.1.0.0`:  remove url
- `conf-pkg-config` - `conf-rdkit`: remove light_uninstalll flag

For `conf-pkg-config`, it's not a real [conf](http://opam.ocaml.org/doc/Manual.html#opamflag-conf) package as it adds a link on openbsd.

As there is an error on conf flaggued packages check (cf https://github.com/ocaml/opam/issues/3625 & https://github.com/ocaml/opam/pull/3631), linting will certainly fail. Note that even after the PR merged on opam, `conf-pkg-config` will still fail linting.