### PR TITLE
Change the dependency on menhir into a build dependency.

### DIFF
--- a/packages/atd/atd.1.12.0/opam
+++ b/packages/atd/atd.1.12.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta7"}
-  "menhir"
+  "menhir" {build}
   "easy-format"
 ]
 synopsis: "Parser for the ATD data format description language"


### PR DESCRIPTION
This allows me not to lose atd (and its descendants)
whenever I remove menhir from my system.