### PR TITLE
[new release] ocaml-makefile (6.39.2)

### DIFF
--- a/packages/ocaml-makefile/ocaml-makefile.6.39.2/opam
+++ b/packages/ocaml-makefile/ocaml-makefile.6.39.2/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/ocaml-makefile"
+doc: "https://mmottl.github.io/ocaml-makefile/api"
+dev-repo: "git+https://github.com/mmottl/ocaml-makefile.git"
+bug-reports: "https://github.com/mmottl/ocaml-makefile/issues"
+
+synopsis: "Generic Makefile for building OCaml projects"
+
+description: """
+OCamlMakefile supports a large variety of build target kinds for building small
+OCaml projects using GNU make."""
+url {
+  src:
+    "https://github.com/mmottl/ocaml-makefile/releases/download/6.39.2/ocaml-makefile-6.39.2.tbz"
+  checksum: "md5=9c1d8556745d8840d14f770ccc9925c0"
+}


### PR DESCRIPTION
Generic Makefile for building OCaml projects

- Project page: <a href="https://mmottl.github.io/ocaml-makefile">https://mmottl.github.io/ocaml-makefile</a>
- Documentation: <a href="https://mmottl.github.io/ocaml-makefile/api">https://mmottl.github.io/ocaml-makefile/api</a>

##### CHANGES:

* Improved OPAM package for dune-release
