### PR TITLE
[new release] pcre (7.3.5)

### DIFF
--- a/packages/pcre/pcre.7.3.5/opam
+++ b/packages/pcre/pcre.7.3.5/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build & >= "1.4.0"}
+  "conf-libpcre" {build}
+  "base" {build}
+  "base-bytes"
+]
+
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.3.5/pcre-7.3.5.tbz"
+  checksum: "md5=f1ad11d393d2df08c03c0e7eb0ce85e4"
+}


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

* Switched to dune, dune-release, and OPAM 2.0
