### PR TITLE
[new release] postgresql (4.4.1)

### DIFF
--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -32,8 +32,8 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-distribution = "opensuse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
-  ["postgresql"] {os-distribution = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {build & >= "1.4.0"}
+  "base" {build}
+  "stdio" {build}
+  "base-bytes"
+]
+
+depexts: [
+  ["libpq-dev"] {os-distribution = "debian"}
+  ["database/postgresql96-client"] {os-distribution = "freebsd"}
+  ["database/postgresql96-client"] {os-distribution = "openbsd"}
+  ["libpq-dev"] {os-distribution = "ubuntu"}
+  ["postgresql-devel"] {os-distribution = "centos"}
+  ["postgresql-devel"] {os-distribution = "rhel"}
+  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-dev"] {os-distribution = "alpine"}
+  ["postgresql"] {os-distribution = "opensuse"}
+  ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
+  ["postgresql96"] {os = "macos" & os-distribution = "macports"}
+]
+
+synopsis: "Bindings to the PostgreSQL library"
+
+description: """
+Postgresql offers library functions for accessing PostgreSQL databases."""
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/4.4.1/postgresql-4.4.1.tbz"
+  checksum: "md5=7d6acaa0166e9849b08ad16a2d0ed543"
+}


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

* Switched to dune, dune-release, and OPAM 2.0
