### PR TITLE
[new release] res (5.0.1)

### DIFF
--- a/packages/res/res.5.0.1/opam
+++ b/packages/res/res.5.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/res"
+doc: "https://mmottl.github.io/res/api"
+dev-repo: "git+https://github.com/mmottl/res.git"
+bug-reports: "https://github.com/mmottl/res/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build & >= "1.4.0"}
+  "base-bytes"
+]
+
+synopsis: "RES - Library for resizable, contiguous datastructures"
+
+description: """
+RES is a library containing resizable arrays, strings, and bitvectors."""
+url {
+  src: "https://github.com/mmottl/res/releases/download/5.0.1/res-5.0.1.tbz"
+  checksum: "md5=386f1d006ba898c5f806db551719aec7"
+}


### PR DESCRIPTION
RES - Library for resizable, contiguous datastructures

- Project page: <a href="https://mmottl.github.io/res">https://mmottl.github.io/res</a>
- Documentation: <a href="https://mmottl.github.io/res/api">https://mmottl.github.io/res/api</a>

##### CHANGES:

* Switched to dune, dune-release, and OPAM 2.0
