### PR TITLE
[new release] bigstringaf (0.4.0)

### DIFF
--- a/packages/bigstringaf/bigstringaf.0.4.0/opam
+++ b/packages/bigstringaf/bigstringaf.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/bigstringaf"
+bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
+dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "alcotest" {with-test}
+  "base-bigarray"
+  "ocaml" {>= "4.03.0"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.4.1"}
+]
+synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"
+description: """
+Bigstring intrinsics and fast blits based on memcpy/memmove
+
+The OCaml compiler has a bunch of intrinsics for Bigstrings, but they're not
+widely-known, sometimes misused, and so programs that use Bigstrings are slower
+than they have to be. And even if a library got that part right and exposed the
+intrinsics properly, the compiler doesn't have any fast blits between
+Bigstrings and other string-like types.
+
+So here they are. Go crazy.
+"""
+url {
+  src:
+    "https://github.com/inhabitedtype/bigstringaf/releases/download/0.4.0/bigstringaf-0.4.0.tbz"
+  checksum: "md5=d1ff1ab40aad48627686f9b8c02d985a"
+}


### PR DESCRIPTION
CHANGES:

* freestanding: fix dependencies (ocaml-freestanding inhabitedtype/bigstringaf#22 @hannesm)
* xen: unify usage of mirage-xen-posix package (inhabitedtype/bigstringaf#17 @hannesm)
* fix typo in comment (inhabitedtype/bigstringaf#18 @tiensonqin)
* jbuild: do not use bash (inhabitedtype/bigstringaf#16 inhabitedtype/bigstringaf#21 @rgrinberg, inhabitedtype/bigstringaf#22 @hannesm)
* opam: add '"-p" name' to subst command (inhabitedtype/bigstringaf#15 @seliopou)