### PR TITLE
[new release] logs-syslog (0.2.0)

### DIFF
--- a/packages/logs-syslog/logs-syslog.0.2.0/opam
+++ b/packages/logs-syslog/logs-syslog.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/logs-syslog"
+doc: "https://hannesm.github.io/logs-syslog/doc"
+dev-repo: "git+https://github.com/hannesm/logs-syslog.git"
+bug-reports: "https://github.com/hannesm/logs-syslog/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1.0" & build}
+  "logs"
+  "ptime"
+  "syslog-message" {>= "1.0.0"}
+]
+
+depopts: [
+  "lwt"
+  "x509" "tls" "cstruct"
+  "mirage-kv-lwt"
+  "mirage-console-lwt" "mirage-clock" "mirage-stack-lwt" "ipaddr"
+]
+
+conflicts: [
+  "mirage-types-lwt" {< "3.0.0"}
+  "x509" {< "0.6.0"}
+  "tls" {< "0.8.0"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+
+synopsis: "Logs reporter to syslog (UDP/TCP/TLS)"
+description: """
+This library provides log reporters using syslog over various transports (UDP,
+TCP, TLS) with various effectful layers: Unix, Lwt, MirageOS.  It integrates the
+[Logs](http://erratique.ch/software/logs) library, which provides logging
+infrastructure for OCaml, with the
+[syslog-message](http://verbosemo.de/syslog-message/) library, which provides
+encoding and decoding of syslog messages ([RFC
+3164](https://tools.ietf.org/html/rfc3164)).
+"""
+url {
+  src:
+    "https://github.com/hannesm/logs-syslog/releases/download/0.2.0/logs-syslog-0.2.0.tbz"
+  checksum: "md5=56b3c8007cfad68e843b6d66c2fb780f"
+}


### PR DESCRIPTION
CHANGES:

- support for syslog-message.1.0.0
  it split the `message` field of Syslog_message.t into `tag` and `content`
  use the name of Logs.src as tag when sending messages
- move build system to dune (hannesm/logs-syslog#10 by @dra27)
- provide Logs_syslog.facility Logs.Tag.def to specify facility in log
  message, add ?facility as default facility to all reporters (reported in hannesm/logs-syslog#7,
  fixed in hannesm/logs-syslog#9 by @dra27)
- append ':' to source (reported in hannesm/logs-syslog#6, fixed in hannesm/logs-syslog#8 by @dra27)
- add missing dependency on unix for logs-syslog.unix (hannesm/logs-syslog#4 by @dra27)