### PR TITLE
added git+https to bap-emacs urls

### DIFF
--- a/packages/bap-emacs-dot/bap-emacs-dot.0.1/opam
+++ b/packages/bap-emacs-dot/bap-emacs-dot.0.1/opam
@@ -18,5 +18,5 @@ synopsis:
 depends: ["ocaml"]
 flags: light-uninstall
 url {
-  src: "git://github.com/ivg/emacs-dot.git"
+  src: "git+https://github.com/ivg/emacs-dot.git"
 }

--- a/packages/bap-emacs-mode/bap-emacs-mode.0.1/opam
+++ b/packages/bap-emacs-mode/bap-emacs-mode.0.1/opam
@@ -21,5 +21,5 @@ https://github.com/fkie-cad/bap-mode"""
 depends: ["ocaml"]
 flags: light-uninstall
 url {
-  src: "git://github.com/fkie-cad/bap-mode.git"
+  src: "git+https://github.com/fkie-cad/bap-mode.git"
 }


### PR DESCRIPTION
This PR adds the `https` protocol to the url field of `bap-emacs-dot` and `bap-emacs-mode` packages. 

Thanks  @jishoon  for reporting