### PR TITLE
[new release] key-parsers (0.10.1)

### DIFF
--- a/packages/key-parsers/key-parsers.0.10.1/opam
+++ b/packages/key-parsers/key-parsers.0.10.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "asn1-combinators" {>= "0.2.0"}
+  "cstruct" {>= "1.6.0"}
+  "dune" {build}
+  "hex" {>= "1.0.0"}
+  "ocaml" {>= "4.04.1" & < "4.07.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppx_bin_prot"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
+  "result" {>= "1.2"}
+  "zarith" {>= "1.4.1"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+synopsis: "Parsers for multiple key formats"
+description: """
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or
+Elliptic curve public and private keys.
+"""
+authors: "Nathan Rebours <nathan@cryptosense.com>"
+url {
+  src:
+    "https://github.com/cryptosense/key-parsers/releases/download/0.10.1/key-parsers-0.10.1.tbz"
+  checksum: "md5=a662b863973cef70f4c95e581853eef2"
+}


### PR DESCRIPTION
Parsers for multiple key formats

- Project page: <a href="https://github.com/cryptosense/key-parsers">https://github.com/cryptosense/key-parsers</a>
- Documentation: <a href="https://cryptosense.github.io/key-parsers/doc">https://cryptosense.github.io/key-parsers/doc</a>

##### CHANGES:

*2018-10-31*

### Fixes

- Allow RSA parameters to be absent form the AlgorithmIdentifier Sequence
