### PR TITLE
Update mlmpfr 3.1.6 package (bugfix)

### DIFF
--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -23,7 +23,7 @@ depexts: [
   ["libmpfr-dev"] {os-distribution = "ubuntu"}
   ["libmpfr-dev"] {os-distribution = "debian"}
 ]
-synopsis: "OCaml C bindings for MPFR 3.1.6."
+synopsis: "OCaml C bindings for MPFR 3.1.6"
 flags: light-uninstall
 url {
   src: "https://github.com/thvnx/mlmpfr/archive/mlmpfr.3.1.6.tar.gz"

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -27,5 +27,5 @@ synopsis: "OCaml C bindings for MPFR 3.1.6."
 flags: light-uninstall
 url {
   src: "https://github.com/thvnx/mlmpfr/archive/mlmpfr.3.1.6.tar.gz"
-  checksum: "md5=9cb14670f034e0c588ecb96863cd6386"
+  checksum: "md5=adf35a48868fcc5b08da1056e8a648c2"
 }


### PR DESCRIPTION
Update mlmpfr, an OCaml bindings for MPFR package (synced on MPFR 3.1.6).