### PR TITLE
3 packages from cyrus-/relit at 0.2.0

### DIFF
--- a/packages/ppx_relit/ppx_relit.0.2.0/opam
+++ b/packages/ppx_relit/ppx_relit.0.2.0/opam
@@ -12,13 +12,13 @@ build: [
   ["dune" "build" "-p" "ppx_relit"]
 ]
 depends: [
-  "dune"
+  "dune" {build}
   "ocamlfind"
-  "ocaml-migrate-parsetree" {= "1.0.11"}
+  "ocaml-migrate-parsetree"
   "relit-reason"
   "base64"
   "extlib"
-  "ppxlib" {= "0.3.1"}
+  "ppxlib" {>= "0.3.1"}
   "base-unix"
   "ppx_expect" {with-test}
   "ocaml" {>= "4.07.0" & < "4.08.0"}

--- a/packages/ppx_relit/ppx_relit.0.2.0/opam
+++ b/packages/ppx_relit/ppx_relit.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "relit-reason"
   "base64"
   "extlib"
-  "ppxlib" {= "0.3.0"}
+  "ppxlib" {= "0.3.1"}
   "base-unix"
   "ppx_expect" {with-test}
   "ocaml" {>= "4.07.0" & < "4.08.0"}

--- a/packages/ppx_relit/ppx_relit.0.2.0/opam
+++ b/packages/ppx_relit/ppx_relit.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Charles Chamberlain <charlespipin@gmail.com>"
+authors: [
+  "Charles Chamberlain <charlespipin@gmail.com>"
+  "Cyrus Omar <cyrus.omar@gmail.com>"
+]
+homepage: "https://github.com/cyrus-/relit"
+bug-reports: "https://github.com/cyrus-/relit/issues"
+license: "MIT"
+dev-repo: "git://github.com/cyrus-/relit.git"
+build: [
+  ["dune" "build" "-p" "ppx_relit"]
+]
+depends: [
+  "dune"
+  "ocamlfind"
+  "ocaml-migrate-parsetree" {= "1.0.11"}
+  "relit-reason"
+  "base64"
+  "extlib"
+  "ppxlib" {= "0.3.0"}
+  "base-unix"
+  "ppx_expect" {with-test}
+  "ocaml" {>= "4.07.0" & < "4.08.0"}
+  "relit_helper"
+]
+synopsis: "An implementation of Typed Literal Macros for Reason"
+url {
+  src: "https://github.com/cyrus-/relit/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=c2350b29ed2b2005846e0a60f1790de8"
+    "sha512=64553171caec9a0348d2327880722b5f860ce9c42b156e14058b4ad5c37b57583f2ca552f2f6b63e714b42d8105358a32274b07cd5c854e7345d31334b05e09b"
+  ]
+}

--- a/packages/relit-reason/relit-reason.0.0.2/opam
+++ b/packages/relit-reason/relit-reason.0.0.2/opam
@@ -17,7 +17,6 @@ build: [
 ]
 depends: [
   "dune"                    {build}
-  "ocamlfind"               {build}
   "menhir"                  {>= "20170418"}
   "merlin-extend"           {>= "0.3"}
   "ocaml" {>= "4.07.0" & < "4.08.0"}

--- a/packages/relit-reason/relit-reason.0.0.2/opam
+++ b/packages/relit-reason/relit-reason.0.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "relit-reason"
+maintainer: "Charles Chamberlain <charlespipin@gmail.com>"
+authors: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Charles Chamberlain <charlespipin@gmail.com"
+  "Cyrus Omar <cyrus.omar@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/charlesetc/reason/tree/reason-d-etre"
+doc: "https://github.com/cyrus-/relit/"
+bug-reports: "https://github.com/cyrus-/relit/issues"
+dev-repo: "git://github.com/charlesetc/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "build" "-p" "relit-reason" "-j" jobs]
+]
+depends: [
+  "dune"                    {build}
+  "ocamlfind"               {build}
+  "menhir"                  {>= "20170418"}
+  "merlin-extend"           {>= "0.3"}
+  "ocaml" {>= "4.06.0" & < "4.08.0"}
+  "result"
+  "ocaml-migrate-parsetree"
+]
+conflicts: ["reason"]
+synopsis: "Hygienic typed literal macros (TLMs) for Reason"
+url {
+  src: "https://github.com/charlesetc/reason/archive/relit-0.0.2.tar.gz"
+  checksum: "md5=c7b49b6632551331b75f593d32ea8350"
+}

--- a/packages/relit-reason/relit-reason.0.0.2/opam
+++ b/packages/relit-reason/relit-reason.0.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"               {build}
   "menhir"                  {>= "20170418"}
   "merlin-extend"           {>= "0.3"}
-  "ocaml" {>= "4.06.0" & < "4.08.0"}
+  "ocaml" {>= "4.07.0" & < "4.08.0"}
   "result"
   "ocaml-migrate-parsetree"
 ]

--- a/packages/relit_helper/relit_helper.0.2.0/opam
+++ b/packages/relit_helper/relit_helper.0.2.0/opam
@@ -12,10 +12,10 @@ build: [
   ["dune" "build" "-p" "relit_helper"]
 ]
 depends: [
-  "dune"
+  "dune" {build}
   "extlib"
-  "ppxlib" {= "0.3.1"}
-  "ocaml-migrate-parsetree" {= "1.0.11"}
+  "ppxlib" {>= "0.3.1"}
+  "ocaml-migrate-parsetree"
   "base64"
   "relit-reason"
   "ocaml" {>= "4.07.0" & < "4.08.0"}

--- a/packages/relit_helper/relit_helper.0.2.0/opam
+++ b/packages/relit_helper/relit_helper.0.2.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "dune"
   "extlib"
-  "ppxlib" {= "0.3.0"}
+  "ppxlib" {= "0.3.1"}
   "ocaml-migrate-parsetree" {= "1.0.11"}
   "base64"
   "relit-reason"

--- a/packages/relit_helper/relit_helper.0.2.0/opam
+++ b/packages/relit_helper/relit_helper.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Charles Chamberlain <charlespipin@gmail.com>"
+authors: [
+  "Charles Chamberlain <charlespipin@gmail.com>"
+  "Cyrus Omar <cyrus.omar@gmail.com>"
+]
+homepage: "https://github.com/cyrus-/relit"
+bug-reports: "https://github.com/cyrus-/relit/issues"
+license: "MIT"
+dev-repo: "git://github.com/cyrus-/relit.git"
+build: [
+  ["dune" "build" "-p" "relit_helper"]
+]
+depends: [
+  "dune"
+  "extlib"
+  "ppxlib" {= "0.3.0"}
+  "ocaml-migrate-parsetree" {= "1.0.11"}
+  "base64"
+  "relit-reason"
+  "ocaml" {>= "4.07.0" & < "4.08.0"}
+]
+synopsis: "A helper library for those wishing to write TLMs using Relit"
+url {
+  src: "https://github.com/cyrus-/relit/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=c2350b29ed2b2005846e0a60f1790de8"
+    "sha512=64553171caec9a0348d2327880722b5f860ce9c42b156e14058b4ad5c37b57583f2ca552f2f6b63e714b42d8105358a32274b07cd5c854e7345d31334b05e09b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ppx_relit.0.2.0`: An implementation of Typed Literal Macros for Reason
-`relit_helper.0.2.0`: A helper library for those wishing to write TLMs using Relit



---
* Homepage: https://github.com/cyrus-/relit
* Source repo: git://github.com/cyrus-/relit.git
* Bug tracker: https://github.com/cyrus-/relit/issues

---
:camel: Pull-request generated by opam-publish v2.0.0