### PR TITLE
Put upper bound on cairo2 dependency

### DIFF
--- a/packages/DrawGrammar/DrawGrammar.0.2.1/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder" {build}
   "menhir"
   "JsOfOCairo" {>= "1.0.1"}
-  "cairo2"
+  "cairo2" {>= "0.5" & < "0.6"}
   "General" {>= "0.4.0"}
 ]
 synopsis: "Draw railroad diagrams of EBNF grammars"

--- a/packages/JsOfOCairo/JsOfOCairo.1.1.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "js_of_ocaml-ppx" {>= "3.0" & < "4.0"}
   "js_of_ocaml" {>= "3.0" & < "4.0"}
   "General" {with-test & >= "0.5.0"}
-  "cairo2" {with-test & >= "0.5"}
+  "cairo2" {with-test & >= "0.5" & < "0.6"}
   "conf-npm" {with-test}
   "conf-libjpeg" {with-test}
   "conf-libgif" {with-test}


### PR DESCRIPTION
An non-backward-compatible change was introduced in cairo2 0.6
https://github.com/Chris00/ocaml-cairo/commit/9aa9ce403fd16c56245c695eb0108aebdedec150#diff-d9fad5803a4c2c22f5c1be3854b69e50

This should fix https://github.com/jacquev6/DrawGrammar/issues/7