### PR TITLE
Put upper bound on cairo2 dependency (opam 1.2)

### DIFF
--- a/packages/DrawGrammar/DrawGrammar.0.2.1/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder" {build}
   "menhir"
   "JsOfOCairo" {>= "1.0.1"}
-  "cairo2"
+  "cairo2" {>= "0.5" & < "0.6"}
   "General" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/JsOfOCairo/JsOfOCairo.1.1.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "js_of_ocaml-ppx" { >= "3.0" & < "4.0"}
   "js_of_ocaml" {>= "3.0" & < "4.0"}
   "General" {test & >= "0.5.0"}
-  "cairo2" {test & >= "0.5"}
+  "cairo2" {test & >= "0.5" & < "0.6"}
   "conf-npm" {test}
   "conf-libjpeg" {test}
   "conf-libgif" {test}


### PR DESCRIPTION
This is a backport of #12905 to the 1.2 branch