### PR TITLE
[new release] docker-api (0.2.1)

### DIFF
--- a/packages/docker-api/docker-api.0.2.1/opam
+++ b/packages/docker-api/docker-api.0.2.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+license: "ISC"
+homepage: "https://github.com/Chris00/ocaml-docker"
+dev-repo: "git+https://github.com/Chris00/ocaml-docker.git"
+bug-reports: "https://github.com/Chris00/ocaml-docker/issues"
+doc: "https://Chris00.github.io/ocaml-docker/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "yojson"
+]
+synopsis: "Binding to the Docker Remote API"
+description: """
+Control Docker <https://www.docker.com/> containers using the remote API."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-docker/releases/download/0.2.1/docker-api-0.2.1.tbz"
+  checksum: "md5=16245b41b7d2a98d038e16140b45d2db"
+}


### PR DESCRIPTION
Binding to the Docker Remote API

- Project page: <a href="https://github.com/Chris00/ocaml-docker">https://github.com/Chris00/ocaml-docker</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-docker/doc">https://Chris00.github.io/ocaml-docker/doc</a>

##### CHANGES:

- Handle an undocumented status for `Docker.Container.start`.
