### PR TITLE
[new release] mirage-random-stdlib (0.0.1)

### DIFF
--- a/packages/mirage-random-stdlib/mirage-random-stdlib.0.0.1/opam
+++ b/packages/mirage-random-stdlib/mirage-random-stdlib.0.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:    "hannes@mehnert.org"
+homepage:      "https://github.com/mirage/mirage-random-stdlib"
+bug-reports:   "https://github.com/mirage/mirage-random-stdlib/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random-stdlib.git"
+doc:           "https://mirage.github.io/mirage-random-stdlib/"
+authors:       ["Thomas Gazagnaire" "Hannes Mehnert"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {build & >="1.1.0"}
+  "cstruct" {>= "1.9.0"}
+  "ocaml" {>= "4.04.2"}
+  "mirage-random"
+  "mirage-entropy"
+]
+
+synopsis: "Random device implementation using the OCaml stdlib"
+description: """
+mirage-random-stdlib implements `Mirage_random.C` using the `Random` from
+the OCaml standard library (a lagged-Fibonacci PRNG). The entropy is seeded
+by mirage-entropy, depending on CPU features.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random-stdlib/releases/download/0.0.1/mirage-random-stdlib-0.0.1.tbz"
+  checksum: "md5=63a8d2f730750f7cd4f4377b7adca88e"
+}


### PR DESCRIPTION
CHANGES:

* seed is now done via mirage-entropy instead of gettimeofday (by OCaml stdlib),
  thanks to Spencer Michaels and Jeff Dileo of NCC Group for reporting
* initial version imported from mirage-random