### PR TITLE
[new release] dune (1.5.0)

### DIFF
--- a/packages/dune/dune.1.5.0/opam
+++ b/packages/dune/dune.1.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02"}
+]
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+]
+
+synopsis: "Fast, portable and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+url {
+  src: "https://github.com/ocaml/dune/releases/download/1.5.0/dune-1.5.0.tbz"
+  checksum: "md5=100af30f3c734f066191b8fde28271bc"
+}


### PR DESCRIPTION
CHANGES:

- Filter out empty paths from `OCAMLPATH` and `PATH` (ocaml/dune#1436, @rgrinberg)

- Do not add the `lib.cma.js` target in lib's directory. Put this target in a
  sub directory instead. (ocaml/dune#1435, fix ocaml/dune#1302, @rgrinberg)

- Install generated OCaml files with a `.ml` rather than a `.ml-gen` extension
  (ocaml/dune#1425, fix ocaml/dune#1414, @rgrinberg)

- Allow to use the `bigarray` library in >= 4.07 without ocamlfind and without
  installing the corresponding `otherlib`. (ocaml/dune#1455, @nojb)

- Add `@all` alias to build all targets defined in a directory (ocaml/dune#1409, fix
  ocaml/dune#1220, @rgrinberg)

- Add `@check` alias to build all targets required for type checking and tooling
  support. (ocaml/dune#1447, fix ocaml/dune#1220, @rgrinberg)

- Produce the odoc index page with the content wrapper to make it consistent
  with odoc's theming (ocaml/dune#1469, @rizo)

- Unblock signals in processes started by dune (ocaml/dune#1461, fixes ocaml/dune#1451,
  @diml)

- Respect `OCAMLFIND_TOOLCHAIN` and add a `toolchain` option to contexts in the
  workspace file. (ocaml/dune#1449, fix ocaml/dune#1413, @rgrinberg)

- Fix error message when using `copy_files` stanza to copy files from
  a non sub directory with lang set to dune < 1.3 (ocaml/dune#1486, fixes ocaml/dune#1485,
  @NathanReb)

- Install man pages in the correct subdirectory (ocaml/dune#1483, fixes ocaml/dune#1441, @emillon)

- Fix version syntax check for `test` stanza's `action` field. Only
  emits a warning for retro-compatibility (ocaml/dune#1474, fixes ocaml/dune#1471,
  @NathanReb)

- Fix interpretation of paths in `env` stanzas (ocaml/dune#1509, fixes ocaml/dune#1508, @diml)

- Add `context_name` expansion variable (ocaml/dune#1507, @rgrinberg)

- Use shorter paths for generated on-demand ppx drivers. This is to
  help Windows builds where paths are limited in length (ocaml/dune#1511, fixes
  ocaml/dune#1497, @diml)

- Fix interpretation of environment variables under `setenv`. Also forbid
  dynamic environment names or values (ocaml/dune#1503, @rgrinberg).