### PR TITLE
Package glfw-ocaml.3.2.1~rc1

### DIFF
--- a/packages/glfw-ocaml/glfw-ocaml.3.2.1~rc1/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.2.1~rc1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A GLFW binding for OCaml"
+maintainer: "Sylvain BOILARD <boilard@crans.org>"
+authors: "Sylvain BOILARD <boilard@crans.org>"
+license: "Zlib"
+homepage: "https://github.com/SylvainBoilard/GLFW-OCaml"
+bug-reports: "https://github.com/SylvainBoilard/GLFW-OCaml/issues"
+depends: [
+  "conf-glfw3"
+  "base-bigarray"
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.02.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/SylvainBoilard/GLFW-OCaml.git"
+url {
+  src:
+    "https://github.com/SylvainBoilard/GLFW-OCaml/archive/3.2.1-rc1.tar.gz"
+  checksum: [
+    "md5=bdf85f62da32f1b90f4fbb65e882583e"
+    "sha512=a3700bb390d4ad7ddfc877b838c43313510ee5f1981279462da9df3dcbf3cd529112236e530630cc150f39d553962f29e0041ee87f7f25fd1035db47f9d1691c"
+  ]
+}


### PR DESCRIPTION
### `glfw-ocaml.3.2.1~rc1`
A GLFW binding for OCaml



---
* Homepage: https://github.com/SylvainBoilard/GLFW-OCaml
* Source repo: git+https://github.com/SylvainBoilard/GLFW-OCaml.git
* Bug tracker: https://github.com/SylvainBoilard/GLFW-OCaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0