### PR TITLE
Add package mlmpfr.4.0.0

### DIFF
--- a/packages/mlmpfr/mlmpfr.4.0.0/files/test.c
+++ b/packages/mlmpfr/mlmpfr.4.0.0/files/test.c
@@ -1,0 +1,19 @@
+#include <string.h>
+#include <stdio.h>
+#include <mpfr.h>
+
+int main(int argc, char **argv)
+{
+  const char *version = mpfr_get_version();
+  char subversion[5];
+  memcpy(subversion, version, 5);
+  subversion[5] = '\0';
+
+  if(strcmp(subversion, "4.0.0") == 0)
+    return 0;
+
+  if(strcmp(subversion, "4.0.1") == 0)
+    return 0;
+
+  return 1;
+}

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
 license:      "LGPL-3.0"
 dev-repo: "git+https://github.com/thvnx/mlmpfr.git"
 build: [
-  ["cc" "test.c" "-lmpfr"]
+  ["cc" "test.c" "-lmpfr" "&&" "./a.out"]
   ["oasis" "setup"]
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -8,6 +8,7 @@ bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
 license:      "LGPL-3.0"
 dev-repo: "git+https://github.com/thvnx/mlmpfr.git"
 build: [
+  ["cc" "$CFLAGS" "test.c" "-lmpfr"]
   ["oasis" "setup"]
   ["./configure" "--prefix=%{prefix}%"]
   [make]
@@ -29,3 +30,6 @@ url {
   src: "https://github.com/thvnx/mlmpfr/archive/mlmpfr.4.0.0.tar.gz"
   checksum: "md5=b37796f5abc665fcbe89a16fa9708eba"
 }
+description:
+  "The package provides bindings for MPFR 4.0.0 or MPFR 4.0.1. It can only be installed if MPFR targeted version is installed on the system."
+extra-files: ["test.c" md5="a73d17e79e4f6876be6a0685d0ba90ed"]

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -8,7 +8,8 @@ bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
 license:      "LGPL-3.0"
 dev-repo: "git+https://github.com/thvnx/mlmpfr.git"
 build: [
-  ["cc" "test.c" "-lmpfr" "&&" "./a.out"]
+  ["cc" "test.c" "-lmpfr" "-o" "test_installed"]
+  ["./test_installed"]
   ["oasis" "setup"]
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
 license:      "LGPL-3.0"
 dev-repo: "git+https://github.com/thvnx/mlmpfr.git"
 build: [
-  ["cc" "$CFLAGS" "test.c" "-lmpfr"]
+  ["cc" "test.c" "-lmpfr"]
   ["oasis" "setup"]
   ["./configure" "--prefix=%{prefix}%"]
   [make]
@@ -23,6 +23,9 @@ depends: [
 depexts: [
   ["libmpfr-dev"] {os-distribution = "ubuntu"}
   ["libmpfr-dev"] {os-distribution = "debian"}
+]
+post-messages: [
+  "Make sure you had MPFR version 4.0.0 or 4.0.1 installed on your system." {failure}
 ]
 synopsis: "OCaml C bindings for MPFR 4.0.0"
 flags: light-uninstall

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -36,4 +36,4 @@ url {
 }
 description:
   "The package provides bindings for MPFR 4.0.0 or MPFR 4.0.1. It can only be installed if MPFR targeted version is installed on the system."
-extra-files: ["test.c" md5="a73d17e79e4f6876be6a0685d0ba90ed"]
+extra-files: ["test.c" "md5=a73d17e79e4f6876be6a0685d0ba90ed"]

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name:         "mlmpfr"
+version:      "4.0.0"
+maintainer:   "Laurent Thévenoux <laurent.thevenoux@gmail.com>"
+authors:      "Laurent Thévenoux <laurent.thevenoux@gmail.com>"
+homepage:     "https://github.com/thvnx/mlmpfr"
+bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
+license:      "LGPL-3.0"
+dev-repo: "git+https://github.com/thvnx/mlmpfr.git"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove:  ["ocamlfind" "remove" "mlmpfr"]
+depends: [
+  "ocaml" {>= "4.04"}
+  "ocamlfind"
+  "oasis"
+]
+depexts: [
+  ["libmpfr-dev"] {os-distribution = "ubuntu"}
+  ["libmpfr-dev"] {os-distribution = "debian"}
+]
+synopsis: "OCaml C bindings for MPFR 4.0.0"
+flags: light-uninstall
+url {
+  src: "https://github.com/thvnx/mlmpfr/archive/mlmpfr.4.0.0.tar.gz"
+  checksum: "md5=b37796f5abc665fcbe89a16fa9708eba"
+}


### PR DESCRIPTION
This commit introduces mlmpfr 4.0.0, some OCaml bindings for MPFR 4.0.0.
This version is an update of the opam package mlmpfr.3.1.6 which was release for MPFR 3.1.6.

The new features of mlmpfr 4.0.0 are:
- root function replaced by rootn_ui
- support failthful rounding mode support
- support for mpfr_flags_* functions
- support mpfr_beta
- support mpfr_fmodquo
- support mpfr_fmma and mpfr_fmms
- support mpfr_log_ui and mpfr_gamma_inc
- support mpfr_rint_roundeven and mpfr_roundeven

See https://github.com/thvnx/mlmpfr/tree/release_400.