### PR TITLE
[new release] conf-glfw3 (2)

### DIFF
--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Virtual package relying on a GLFW3 system installation"
+description: "This package can only install if libglfw3 is installed on the system."
+maintainer: "Sylvain BOILARD <boilard@crans.org>"
+authors: ["Sylvain BOILARD <boilard@crans.org>"]
+homepage: "http://www.glfw.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "Zlib"
+build: [["pkg-config" "glfw3"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["libglfw3-dev"] {os-distribution = "debian"}
+  ["libglfw3-dev"] {os-distribution = "ubuntu"}
+  ["glfw-devel" "epel-release" "mesa-libGL-devel"] {os-distribution = "centos"}
+  ["glfw-devel"] {os-distribution = "rhel"}
+  ["glfw-devel"] {os-distribution = "fedora"}
+  ["glfw-dev"] {os-distribution = "alpine"}
+  ["libglfw-devel"] {os-distribution = "opensuse"}
+  ["libglfw-devel"] {os-distribution = "mageia"}
+  ["glfw"] {os = "macos" & os-distribution = "homebrew"}
+]

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -6,6 +6,7 @@ authors: ["Sylvain BOILARD <boilard@crans.org>"]
 homepage: "http://www.glfw.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Zlib"
+flags: conf
 build: [["pkg-config" "glfw3"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [


### PR DESCRIPTION
Added an external dependency for mesa-libGL-devel on CentOS which provides the OpenGL header files used in the GLFW headers.

I will also raise the issue on the CentOS bug tracker since this looks like a dependency problem in their GLFW package.