### PR TITLE
Package vg.0.9.2

### DIFF
--- a/packages/vg/vg.0.9.2/opam
+++ b/packages/vg/vg.0.9.2/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/vg"
+authors: ["The vg programmers"]
+doc: "http://erratique.ch/software/vg/doc/Vg"
+dev-repo: "git+http://erratique.ch/repos/vg.git"
+bug-reports: "https://github.com/dbuenzli/vg/issues"
+tags: [
+  "pdf" "svg" "html-canvas" "cairo" "declarative" "graphics"
+  "org:erratique"
+]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "gg" {>= "0.9.0"}
+  "result"
+  "uchar"
+  "js_of_ocaml" {>= "3.0"}   # Can be moved to depopt once this is distributed:
+                             # https://github.com/ocsigen/js_of_ocaml/pull/541
+  "js_of_ocaml-compiler" {>= "3.0"}
+  "js_of_ocaml-ocamlbuild" {>= "3.0"}
+  "js_of_ocaml-ppx" {>= "3.0"}
+]
+depopts: [
+  "uutf"
+  "otfm"
+  "cairo2"
+]
+conflicts: [
+  "otfm" {< "0.3.0"}
+  "uutf" {< "1.0.0"}
+  "cairo2" {< "0.6"}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-uutf" "%{uutf:installed}%"
+          "--with-otfm" "%{otfm:installed}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-cairo2" "%{cairo2:installed}%" ]]
+
+synopsis: """Declarative 2D vector graphics for OCaml"""
+description: """\
+
+Vg is an OCaml module for declarative 2D vector graphics. In Vg,
+images are values that denote functions mapping points of the
+cartesian plane to colors. The module provides combinators to define
+and compose these values.
+
+Renderers for PDF, SVG, Cairo and the HTML canvas are distributed with the
+module. An API allows to implement new renderers.
+     
+Vg depends only on [Gg][gg]. The SVG renderer has no dependency, the
+PDF renderer depends on [Uutf][uutf] and [Otfm][otfm], the HTML canvas
+renderer depends on [js_of_ocaml][jsoo], the Cairo renderer depends on
+[cairo2][cairo2]. Vg and its renderers are distributed under the ISC
+license.
+     
+[gg]: http://erratique.ch/software/gg
+[uutf]: http://erratique.ch/software/uutf
+[otfm]: http://erratique.ch/software/otfm
+[jsoo]: http://ocsigen.org/js_of_ocaml/ 
+[cairo2]: https://forge.ocamlcore.org/projects/cairo/
+"""
+url {
+archive: "http://erratique.ch/software/vg/releases/vg-0.9.2.tbz"
+checksum: "87f2f4d8528cbdb3aa4f1433783e9f42"
+}


### PR DESCRIPTION
### `vg.0.9.2`
Declarative 2D vector graphics for OCaml
Vg is an OCaml module for declarative 2D vector graphics. In Vg,
images are values that denote functions mapping points of the
cartesian plane to colors. The module provides combinators to define
and compose these values.

Renderers for PDF, SVG, Cairo and the HTML canvas are distributed with the
module. An API allows to implement new renderers.
     
Vg depends only on [Gg][gg]. The SVG renderer has no dependency, the
PDF renderer depends on [Uutf][uutf] and [Otfm][otfm], the HTML canvas
renderer depends on [js_of_ocaml][jsoo], the Cairo renderer depends on
[cairo2][cairo2]. Vg and its renderers are distributed under the ISC
license.
     
[gg]: http://erratique.ch/software/gg
[uutf]: http://erratique.ch/software/uutf
[otfm]: http://erratique.ch/software/otfm
[jsoo]: http://ocsigen.org/js_of_ocaml/ 
[cairo2]: https://forge.ocamlcore.org/projects/cairo/



---
* Homepage: http://erratique.ch/software/vg
* Source repo: git+http://erratique.ch/repos/vg.git
* Bug tracker: https://github.com/dbuenzli/vg/issues

---
v0.9.2 2018-11-02 Zagreb
------------------------

- Fix bug in `cairo2` backend. The initial clip region and clear
  was not done correctly.
- Require `cairo2` 0.6.
- Require OCaml 4.03.
- Deprecate `Vg.(>>)`. Use OCaml's stdlib's `|>` operator instead.

---
:camel: Pull-request generated by opam-publish v2.0.0