### PR TITLE
dockerfile.5.0.0: ppx_sexp_conv shouldn't be a build dependency

### DIFF
--- a/packages/dockerfile/dockerfile.5.0.0/opam
+++ b/packages/dockerfile/dockerfile.5.0.0/opam
@@ -10,7 +10,7 @@ tags: ["org:mirage" "org:ocamllabs"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "base-bytes"
   "fmt"


### PR DESCRIPTION
Spotted in https://api.travis-ci.org/v3/job/449440504/log.txt where `dockerfile-cmd` and `ppx_sexp_conv` was being rebuilt at the same time but as `dockerfile-cmd` doesn't have a direct dependency to `ppx_sexp_conv`, it is possible for the former to be built before `ppx_sexp_conv` has been installed.

`dockerfile-cmd` should also probably have a direct dependency to `ppx_sexp_conv` but I think `dockerfile.5.0.0` shouldn't have that dependency marked as a build dependency as `ppx_sexp_conv` has a runtime dependency to `ppx_sexp_conv.runtime-lib`.