### PR TITLE
Add a relit as an alias for ppx_relit

### DIFF
--- a/packages/relit/relit.0.2.0/opam
+++ b/packages/relit/relit.0.2.0/opam
@@ -8,17 +8,9 @@ homepage: "https://github.com/cyrus-/relit"
 bug-reports: "https://github.com/cyrus-/relit/issues"
 license: "MIT"
 dev-repo: "git://github.com/cyrus-/relit.git"
-build: []
 depends: [
   "ppx_relit" {= "0.2.0"}
   "relit_helper" {= "0.2.0"}
   "ocaml" {>= "4.07.0" & < "4.08.0"}
 ]
 synopsis: "An implementation of Typed Literal Macros for Reason"
-url {
-  src: "https://github.com/cyrus-/relit/archive/0.2.0.tar.gz"
-  checksum: [
-    "md5=c2350b29ed2b2005846e0a60f1790de8"
-    "sha512=64553171caec9a0348d2327880722b5f860ce9c42b156e14058b4ad5c37b57583f2ca552f2f6b63e714b42d8105358a32274b07cd5c854e7345d31334b05e09b"
-  ]
-}

--- a/packages/relit/relit.0.2.0/opam
+++ b/packages/relit/relit.0.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Charles Chamberlain <charlespipin@gmail.com>"
+authors: [
+  "Charles Chamberlain <charlespipin@gmail.com>"
+  "Cyrus Omar <cyrus.omar@gmail.com>"
+]
+homepage: "https://github.com/cyrus-/relit"
+bug-reports: "https://github.com/cyrus-/relit/issues"
+license: "MIT"
+dev-repo: "git://github.com/cyrus-/relit.git"
+build: []
+depends: [
+  "ppx_relit" {= "0.2.0"}
+  "relit_helper" {= "0.2.0"}
+  "ocaml" {>= "4.07.0" & < "4.08.0"}
+]
+synopsis: "An implementation of Typed Literal Macros for Reason"
+url {
+  src: "https://github.com/cyrus-/relit/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=c2350b29ed2b2005846e0a60f1790de8"
+    "sha512=64553171caec9a0348d2327880722b5f860ce9c42b156e14058b4ad5c37b57583f2ca552f2f6b63e714b42d8105358a32274b07cd5c854e7345d31334b05e09b"
+  ]
+}


### PR DESCRIPTION
Hi! I'm not sure what the status quo is for package aliases. Worst case scenario, it's totally fine just to have `ppx_relit` and `relit_helper` be separate, but it'd be nice to be able to run `opam install relit` and get the right packages. Does this sound reasonable? Thanks!