### PR TITLE
Packages DrawGrammar.0.2.2, General.0.6.0, hashids.1.0.1 and JsOfOCairo.2.0.0

### DIFF
--- a/packages/DrawGrammar/DrawGrammar.0.2.2/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Draw railroad diagrams of EBNF grammars"
+description:
+  "An [interactive demo](http://jacquev6.github.io/DrawGrammar/) is available."
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+license: "MIT"
+homepage: "https://jacquev6.github.io/DrawGrammar/"
+doc: "https://jacquev6.github.io/DrawGrammar/"
+bug-reports: "http://github.com/jacquev6/DrawGrammar/issues/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "menhir"
+  "JsOfOCairo" {>= "2.0.0" & < "3"}
+  "cairo2" {>= "0.6" & < "0.7"}
+  "General" {>= "0.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/jacquev6/DrawGrammar.git"
+url {
+  src: "https://github.com/jacquev6/DrawGrammar/archive/0.2.2.tar.gz"
+  checksum: [
+    "md5=660bd6c5bef5b1fe1d76c2b9482873c2"
+    "sha512=50ab57a300eafe2768fd415fb2cf585bf4cb9a6642e0a18146d0f56f8b4d01fd13e7895e97c063bc7445d0e7e860db29752c325aaa36cd20f83522846d8b09de"
+  ]
+}

--- a/packages/General/General.0.6.0/opam
+++ b/packages/General/General.0.6.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Rich functionality for built-in and basic OCaml types"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+license: "MIT"
+homepage: "https://jacquev6.github.io/General/"
+doc: "https://jacquev6.github.io/General/"
+bug-reports: "http://github.com/jacquev6/General/issues/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "js_of_ocaml-compiler" {with-test}
+  "cppo" {build & >= "1.3.0"}
+  "num"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/jacquev6/General.git"
+url {
+  src: "https://github.com/jacquev6/General/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=1413435192734d7168026b33bd415481"
+    "sha512=06ffef437509d75d4ae6cb66030b63f11223ce4bafb47c271180ee232bfabc70858621917aeddd8bc708ca8a77095e228e6efc018eafc1eea814ff7af1f95d0f"
+  ]
+}

--- a/packages/JsOfOCairo/JsOfOCairo.2.0.0/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Library to reuse Cairo-based drawing code in web browsers"
+description: """
+JsOfOCairo is an OCaml (4.02.3+) library to reuse Cairo-based drawing code in web browsers.
+It's an adapter, implementing (a reasonable subset of) the interface of [Cairo OCaml](https://github.com/Chris00/ocaml-cairo/)
+targeting HTML5 canvas elements as exposed to OCaml by [js_of_ocaml](https://ocsigen.org/js_of_ocaml/) (3.0.0+)."""
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+license: "MIT"
+homepage: "https://github.com/jacquev6/JsOfOCairo"
+doc: "https://github.com/jacquev6/JsOfOCairo"
+bug-reports: "http://github.com/jacquev6/JsOfOCairo/issues/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "js_of_ocaml-compiler" {build & >= "3.0" & < "4.0"}
+  "js_of_ocaml-ppx" {build & >= "3.0" & < "4.0"}
+  "js_of_ocaml" {>= "3.0" & < "4.0"}
+  "General" {with-test & >= "0.6.0"}
+  "cairo2" {with-test & >= "0.6" & < "0.7"}
+  "conf-npm" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/jacquev6/JsOfOCairo.git"
+url {
+  src: "https://github.com/jacquev6/JsOfOCairo/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=87870fb6886cf2d28dee9d51df86817c"
+    "sha512=b6aef679252745c07566b365acbd351123c5578f4ee9464ea028a05a0a27f0b16d55483a816766d7b66435edea366014efe13bc4840e8042634f761a48bf4e82"
+  ]
+}

--- a/packages/hashids/hashids.1.0.1/opam
+++ b/packages/hashids/hashids.1.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "[hashids](http://hashids.org/): generate short, unique, non-sequential ids from numbers, that you can also decode"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+license: "MIT"
+homepage: "https://jacquev6.github.io/hashids-ocaml/"
+doc: "https://jacquev6.github.io/hashids-ocaml/"
+bug-reports: "http://github.com/jacquev6/hashids-ocaml/issues/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "General" {>= "0.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/jacquev6/hashids-ocaml.git"
+url {
+  src: "https://github.com/jacquev6/hashids-ocaml/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=e0c0f1d5d413b745f2a8af1a4b4fe929"
+    "sha512=17d68dacd21a47f04cfb0a6246d6a8211a46db5c85068d7a2d78508f657aa0980f2ebf189aa6c45ce4c11da09b7f98b9aadc21a253d5fe578db8a2bcf826c062"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`DrawGrammar.0.2.2`: Draw railroad diagrams of EBNF grammars
-`General.0.6.0`: Rich functionality for built-in and basic OCaml types
-`hashids.1.0.1`: [hashids](http://hashids.org/): generate short, unique, non-sequential ids from numbers, that you
 can also decode
-`JsOfOCairo.2.0.0`: Library to reuse Cairo-based drawing code in web browsers



---

---
:camel: Pull-request generated by opam-publish v2.0.0