### PR TITLE
Package sid.1

### DIFF
--- a/packages/sid/sid.1/opam
+++ b/packages/sid/sid.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Handle security identfiers"
+maintainer: "Philipp Gesang <phg@phi-gamma.net>"
+authors: "Philipp Gesang"
+license: "LGPL-3.0-only with OCaml linking exception"
+homepage: "https://gitlab.com/phgsng/ocaml-sid"
+bug-reports: "https://gitlab.com/phgsng/ocaml-sid"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlbuild" {build}
+  "oasis" {build}
+  "stdint"
+  "ounit" {with-test}
+]
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-doc"] {with-doc}
+]
+run-test: [make "test"]
+install: [make "install"]
+dev-repo: "git+https://gitlab.com/phgsng/ocaml-sid.git"
+url {
+  src: "https://gitlab.com/phgsng/ocaml-sid/-/archive/v1/ocaml-sid-v1.tar.gz"
+  checksum: [
+    "md5=a775346240970a2c46b9c4b44da075d0"
+    "sha512=cb47b70e7b2b5db10b4edf42f1c500ac168f1711e6461a12b61eee51475ee4b9e49a96616d931270e52cf6a1aefa6c160bbea7347f8d5f2ffa3a965f8fdc2972"
+  ]
+}


### PR DESCRIPTION
### `sid.1`
Handle security identfiers



---
* Homepage: https://gitlab.com/phgsng/ocaml-sid
* Source repo: git+https://gitlab.com/phgsng/ocaml-sid.git
* Bug tracker: https://gitlab.com/phgsng/ocaml-sid

---
:camel: Pull-request generated by opam-publish v2.0.0