### PR TITLE
Mirage/Solo5: Sync OPAM metadata with master, upper bounds

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}
-  "mirage-solo5" {>= "0.3.0"}
+  "mirage-solo5" {>= "0.3.0" & < "0.5.0"}
   "fmt"
 ]
 synopsis: "Solo5 implementation of MirageOS block interface"

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
   "ipaddr" {>= "1.0.0"}
-  "mirage-solo5" {>= "0.3.0"}
+  "mirage-solo5" {>= "0.3.0" & < "0.5.0"}
   "logs" {>= "0.6.0"}
   "fmt"
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
@@ -12,10 +12,7 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "hvt"]
 install: [make "opam-hvt-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
-depends: [
-  "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
-]
+depends: "conf-pkg-config"
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-distribution = "debian"}
@@ -24,12 +21,14 @@ depexts: [
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
-  "solo5-bindings-virtio"
+  "solo5-bindings-genode"
   "solo5-bindings-muen"
+  "solo5-bindings-virtio"
 ]
-available:
-  (arch = "x86_64" | arch = "x86_64" | arch = "arm64") &
+available: [
+  (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
+]
 synopsis: "Solo5 sandboxed execution environment (hvt target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
@@ -12,17 +12,16 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "muen"]
 install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
-depends: [
-  "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
-]
+depends: "conf-pkg-config"
 conflicts: [
+  "solo5-bindings-genode"
   "solo5-bindings-hvt"
   "solo5-bindings-virtio"
 ]
-available:
-  (arch = "x86_64" | arch = "x86_64") &
+available: [
+  arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
+]
 synopsis: "Solo5 sandboxed execution environment (muen target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
@@ -12,15 +12,16 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "virtio"]
 install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
-depends: [
-  "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
-]
+depends: "conf-pkg-config"
 conflicts: [
+  "solo5-bindings-genode"
   "solo5-bindings-hvt"
   "solo5-bindings-muen"
 ]
-available: (arch = "x86_64" | arch = "x86_64") & os != "macos"
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
 synopsis: "Solo5 sandboxed execution environment (virtio target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended


### PR DESCRIPTION
- solo5-bindings-*: Sync metadata with that on master. Adds conflicts
for upcoming solo5-bindings-genode, drop ocaml dependency here (handled
by ocaml-freestanding).
- mirage-{block,net}-solo5: Add upper bounds for mirage-solo5.