### PR TITLE
Package linenoise.1.2.0

### DIFF
--- a/packages/linenoise/linenoise.1.2.0/opam
+++ b/packages/linenoise/linenoise.1.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Lightweight readline alternative"
+maintainer: "Simon Cruanes"
+authors: ["Edgar Aroutiounian <edgar.factorial@gmail.com>" "Simon Cruanes"]
+license: "BSD-3-clause"
+homepage: "https://github.com/fxfactorial/ocaml-linenoise"
+bug-reports: "https://github.com/fxfactorial/ocaml-linenoise/issues"
+depends: [
+  "dune" {build}
+  "result"
+]
+build: [
+  ["dune" "build" "@install" "-p" name]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/fxfactorial/ocaml-linenoise.git"
+url {
+  src: "https://github.com/fxfactorial/ocaml-linenoise/archive/v1.2.0.tar.gz"
+  checksum: [
+    "md5=02425012bdb9fed1ea3359bbac814a92"
+    "sha512=b006eedb1b44d00aded8db8b155215057fd7e8750feb2dc7f28a6f272c5cc24f9a8b9b802c0fa078a7976b2130bc2a1c97468e5cc5b5f67d98e51912e9641448"
+  ]
+}


### PR DESCRIPTION
### `linenoise.1.2.0`
Lightweight readline alternative



---
* Homepage: https://github.com/fxfactorial/ocaml-linenoise
* Source repo: git+https://github.com/fxfactorial/ocaml-linenoise.git
* Bug tracker: https://github.com/fxfactorial/ocaml-linenoise/issues

---
:camel: Pull-request generated by opam-publish v2.0.0