### PR TITLE
[new release] Package tldr.0.2

### DIFF
--- a/packages/tldr/tldr.0.2/opam
+++ b/packages/tldr/tldr.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "An ocaml tldr client"
+maintainer: "coby@case.edu"
+authors: "Jacob Rosales Chase <coby@case.edu>"
+license: "MIT"
+homepage: "https://github.com/RosalesJ/tldr-ocaml/"
+bug-reports: "https://github.com/RosalesJ/tldr-ocaml/issues"
+depends: [
+  "dune" {build}
+  "core" {>= "v0.10.0"}
+  "ppx_jane"
+  "bos"
+  "cohttp-lwt-unix"
+  "lwt_ssl"
+  "ANSITerminal"
+  "angstrom"
+]
+conflicts: [
+  "ssl" {= "0.5.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/RosalesJ/tldr-ocaml.git"
+url {
+  src: "https://github.com/RosalesJ/tldr-ocaml/archive/v0.2.tar.gz"
+  checksum: [
+    "md5=2d6c2a5fb31b4d2ed3b8b623adf07443"
+    "sha512=b4d7810a8ac43cea7f5274f9329c7ad74b035198e68ce1a882d84029be85b7179398d93671b908156a9aa3ec0f9575db73874bcb5c99fd35b56df410fde6b26d"
+  ]
+}


### PR DESCRIPTION
### [New Release] `tldr.0.2`
An ocaml tldr client: now in v0.2.

---
* Homepage: https://github.com/RosalesJ/tldr-ocaml/
* Source repo: git+https://github.com/RosalesJ/tldr-ocaml.git
* Bug tracker: https://github.com/RosalesJ/tldr-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0