### PR TITLE
[new upstream] ppx_import (1.5-3-gbd627d5)

### DIFF
--- a/packages/ppx_import/ppx_import.1.5-3-gbd627d5/opam
+++ b/packages/ppx_import/ppx_import.1.5-3-gbd627d5/opam
@@ -1,0 +1,30 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+name: "ppx_import"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
+  "dune"                    { build &      >= "1.2.0"  }
+  "ppxlib"                  {              >= "0.3.1"  }
+  "ppx_tools_versioned"     {              >= "5.2.1"  }
+  "ocaml-migrate-parsetree" {              >= "1.1.0"  }
+  "ounit"                   { with-test                }
+  "ppx_deriving"            { with-test  & >= "4.2.1"  }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src: "https://github.com/ocaml-ppx/ppx_import/archive/bd627d5afee597589761d6fee30359300b5e1d80.tar.gz"
+  checksum: "md5=0d04de821f75be32427bebcedae79e8d"
+}


### PR DESCRIPTION
CHANGES:

  * ocaml-migrate-parsetree + dune support ocaml-ppx/ppx_import#26
    (Jérémie Dimino & Emilio Jesús Gallego Arias)

  * Move to OPAM 2.0, adapt Travis CI.
    (Emilio Jesús Gallego Arias)
