### PR TITLE
[new release] mirage-random (1.2.0)

### DIFF
--- a/packages/mirage-random/mirage-random.1.2.0/opam
+++ b/packages/mirage-random/mirage-random.1.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-random"
+bug-reports:   "https://github.com/mirage/mirage-random/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random.git"
+doc:           "https://mirage.github.io/mirage-random/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {build & >="1.1.0"}
+  "cstruct" {>= "1.9.0"}
+  "ocaml" {>= "4.04.2"}
+]
+
+synopsis: "Random-related devices for MirageOS"
+description: """
+mirage-random defines `Mirage_random.S` and `Mirage_random.C` the signature for
+random-related devices for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random/releases/download/v1.2.0/mirage-random-v1.2.0.tbz"
+  checksum: "md5=a0458f255fd042b4434d4dcf1e177f84"
+}


### PR DESCRIPTION
CHANGES:

* Move Stdlibrandom to a separate package, mirage-random-stdlib
* Port to dune