### PR TITLE
[new release] icalendar (0.1.0)

### DIFF
--- a/packages/icalendar/icalendar.0.1.0/opam
+++ b/packages/icalendar/icalendar.0.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/icalendar"
+bug-reports: "https://github.com/roburio/icalendar/issues"
+dev-repo: "git+https://github.com/roburio/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom"
+  "re"
+  "uri"
+  "astring"
+  "rresult"
+  "ptime"
+  "ppx_deriving"
+  "gmap"
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/roburio/icalendar/releases/download/0.1.0/icalendar-0.1.0.tbz"
+  checksum: "md5=78712da632d9faa5de197edababae369"
+}


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/roburio/icalendar">https://github.com/roburio/icalendar</a>
- Documentation: <a href="https://roburio.github.io/icalendar/">https://roburio.github.io/icalendar/</a>

##### CHANGES:

* initial release.
