### PR TITLE
2 packages from OCamlPro/ocp-index at 1.1.7

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.1.7/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis: "Console browser for the documentation of installed OCaml libraries"
+description: """
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocp-pp" {build}
+  "jbuilder" {build}
+  "ocp-index" {= version}
+  "cmdliner"
+  "lambda-term"
+]
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/1.1.7.tar.gz"
+  checksum: [
+    "md5=969fff19fb672c9a6c6c1feb49c72ced"
+    "sha512=13fd0885c02518a052a1ffcffac15f951b3d330f9df19cccb5373b834edeb4f7c1fbc0a8b1498e1b132a7f56a9721aa92c55b682fc5883533868400e13a1ee46"
+  ]
+}

--- a/packages/ocp-index/ocp-index.1.1.7/opam
+++ b/packages/ocp-index/ocp-index.1.1.7/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis:
+  "Lightweight completion and documentation browsing for OCaml libraries"
+description: """
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocp-pp" {build}
+  "jbuilder" {build}
+  "ocp-indent" {>= "1.4.2"}
+  "re" {>= "1.7.2"}
+  "cmdliner"
+]
+post-messages:
+  "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{prefix}%/share/emacs/site-lisp\")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim
+" {success & !user-setup:installed}
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/1.1.7.tar.gz"
+  checksum: [
+    "md5=969fff19fb672c9a6c6c1feb49c72ced"
+    "sha512=13fd0885c02518a052a1ffcffac15f951b3d330f9df19cccb5373b834edeb4f7c1fbc0a8b1498e1b132a7f56a9721aa92c55b682fc5883533868400e13a1ee46"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocp-browser.1.1.7`: Console browser for the documentation of installed OCaml libraries
-`ocp-index.1.1.7`: Lightweight completion and documentation browsing for OCaml libraries



---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: git+https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
:camel: Pull-request generated by opam-publish v2.0.0