### PR TITLE
Update existing package descriptions for nunchaku and frenetic.

### DIFF
--- a/packages/frenetic/frenetic.5.0.0/opam
+++ b/packages/frenetic/frenetic.5.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "cstruct-async"
   "ipaddr" {>= "2.5.0"}
-  "menhir"
+  "menhir" {build & <= "20181026"}
   "mparser"
   "ocamlgraph" {>= "1.8.7"}
   "ppx_compare"

--- a/packages/frenetic/frenetic.5.0.2/opam
+++ b/packages/frenetic/frenetic.5.0.2/opam
@@ -24,7 +24,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "cstruct-async"
   "ipaddr" {>= "2.5.0"}
-  "menhir"
+  "menhir" {build & <= "20181026"}
   "mparser"
   "ocamlgraph" {>= "1.8.7"}
   "ppx_compare"

--- a/packages/frenetic/frenetic.5.0.3/opam
+++ b/packages/frenetic/frenetic.5.0.3/opam
@@ -24,7 +24,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "cstruct-async"
   "ipaddr" {>= "2.5.0"}
-  "menhir"
+  "menhir" {build & <= "20181026"}
   "mparser"
   "ocamlgraph" {>= "1.8.7"}
   "ppxlib"

--- a/packages/nunchaku/nunchaku.0.3.1/opam
+++ b/packages/nunchaku/nunchaku.0.3.1/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
   "containers" {>= "0.16" & < "1.0"}
-  "menhir" {build}
+  "menhir" {build & <= "20181026"}
   "sequence"
   "base-unix"
   "base-threads"

--- a/packages/nunchaku/nunchaku.0.3/opam
+++ b/packages/nunchaku/nunchaku.0.3/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.04.0"}
   "ocamlfind" {build}
   "containers" {>= "0.16" & < "1.0"}
-  "menhir" {build}
+  "menhir" {build & <= "20181026"}
   "sequence"
   "base-unix"
   "base-threads"

--- a/packages/nunchaku/nunchaku.0.4/opam
+++ b/packages/nunchaku/nunchaku.0.4/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "containers" {>= "1.0"}
-  "menhir" {build}
+  "menhir" {build & <= "20181026"}
   "sequence"
   "base-unix"
   "base-threads"

--- a/packages/nunchaku/nunchaku.0.5.1/opam
+++ b/packages/nunchaku/nunchaku.0.5.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build}
   "containers" {>= "1.0"}
-  "menhir" {build}
+  "menhir" {build & <= "20181026"}
   "sequence"
   "base-unix"
   "base-threads"

--- a/packages/nunchaku/nunchaku.0.5/opam
+++ b/packages/nunchaku/nunchaku.0.5/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
   "containers" {>= "1.0"}
-  "menhir" {build}
+  "menhir" {build & <= "20181026"}
   "sequence"
   "base-unix"
   "base-threads"

--- a/packages/nunchaku/nunchaku.0.6/opam
+++ b/packages/nunchaku/nunchaku.0.6/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/nunchaku-inria/nunchaku/issues"
 depends: [
   "jbuilder" {build}
   "containers" {>= "1.0"}
-  "menhir" {build}
+  "menhir" {build & <= "20181026"}
   "sequence" {>= "1.0"}
   "base-unix"
   "base-threads"


### PR DESCRIPTION
nunchaku: update existing packages to require menhir <= 20181026.
frenetic: update existing packages to require menhir <= 20181026.
          also note that menhir is only a build dependency.