### PR TITLE
duppy.0.8.0

### DIFF
--- a/packages/duppy/duppy.0.8.0/opam
+++ b/packages/duppy/duppy.0.8.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-duppy"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "duppy"]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "ocamlfind" {build}
+  "pcre"
+]
+depopts: [
+  "ssl"
+  "osx-secure-transport"
+]
+conflicts: ["liquidsoap" {<= "1.2.1"}]
+bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
+dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
+synopsis: "Library providing monadic threads"
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/savonet/ocaml-duppy/releases/download/0.8.0/ocaml-duppy-0.8.0.tar.gz"
+  checksum: "md5=07c0eab9584b2236e90e2b88ee246677"
+}

--- a/packages/liquidsoap/liquidsoap.1.3.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.1"}
-  "duppy" {>= "0.6.0"}
+  "duppy" {>= "0.8.0"}
   "mm" {>= "0.4.0"}
   "ocamlfind" {build}
   "pcre"


### PR DESCRIPTION
This PR updates `ocaml-duppy` with a release without `camlp4` which seems to have been buggy. It also carries over an important bugfix from `0.7.4` which would be nice to see pushed soon. Accordingly, `liquidsoap.0.3.4` dependency on `duppy` has been bumped to make sure that the fixed version is used.