### PR TITLE
afl-persistent.1.3

### DIFF
--- a/packages/afl-persistent/afl-persistent.1.3/opam
+++ b/packages/afl-persistent/afl-persistent.1.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "stephen.dolan@cl.cam.ac.uk"
+authors: ["Stephen Dolan"]
+homepage: "https://github.com/stedolan/ocaml-afl-persistent"
+bug-reports: "https://github.com/stedolan/ocaml-afl-persistent/issues"
+dev-repo: "git+https://github.com/stedolan/ocaml-afl-persistent.git"
+license: "MIT"
+build: [[ "./build.sh" ]]
+depends: [
+  "ocaml" {>= "4.00"}
+  "ocamlfind"
+  "base-unix"
+]
+post-messages: [
+"afl-persistent is installed, but since AFL instrumentation is not available
+with this OCaml compiler, instrumented fuzzing with afl-fuzz won't work.
+
+To use instrumented fuzzing, switch to an OCaml version supporting AFL, such
+as 4.07.1+afl." {success & !afl-available}
+
+"afl-persistent is installed, but since the current OCaml compiler does
+not enable AFL instrumentation by default, most packages will not be
+instrumented and fuzzing with afl-fuzz may not be effective.
+
+To globally enable AFL instrumentation, use an OCaml switch such as
+4.07.1+afl." {success & afl-available & !afl-always}
+]
+synopsis: "Use afl-fuzz in persistent mode"
+description: """
+afl-fuzz normally works by repeatedly fork()ing the program being
+tested. using this package, you can run afl-fuzz in 'persistent mode',
+which avoids repeated forking and is much faster."""
+url {
+  src: "https://github.com/stedolan/ocaml-afl-persistent/archive/v1.3.tar.gz"
+  checksum: "md5=613ae369149ae8e2942e3c8bddd6798b"
+}

--- a/packages/afl-persistent/afl-persistent.1.3/opam
+++ b/packages/afl-persistent/afl-persistent.1.3/opam
@@ -8,7 +8,6 @@ license: "MIT"
 build: [[ "./build.sh" ]]
 depends: [
   "ocaml" {>= "4.00"}
-  "ocamlfind"
   "base-unix"
 ]
 post-messages: [


### PR DESCRIPTION
New release of afl-persistent.

The only change is to replace a `/bin/bash` with `/bin/sh`, making the package installable on bash-less systems.

cc @hannesm 