### PR TITLE
duppy.0.8.0 for opam 1.2.2

### DIFF
--- a/packages/duppy/duppy.0.8.0/descr
+++ b/packages/duppy/duppy.0.8.0/descr
@@ -1,0 +1,1 @@
+Library providing monadic threads

--- a/packages/duppy/duppy.0.8.0/opam
+++ b/packages/duppy/duppy.0.8.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-duppy"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: ["ocamlfind" "remove" "duppy"]
+depends: [
+  "ocamlfind" {build}
+  "pcre"
+]
+depopts: [
+  "ssl"
+  "osx-secure-transport"
+]
+conflicts: ["liquidsoap" {<= "1.2.1"}]
+available: [ ocaml-version >= "4.02.3" ]
+bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
+dev-repo: "https://github.com/savonet/ocaml-duppy.git"

--- a/packages/duppy/duppy.0.8.0/url
+++ b/packages/duppy/duppy.0.8.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/savonet/ocaml-duppy/releases/download/0.8.0/ocaml-duppy-0.8.0.tar.gz"
+checksum: "07c0eab9584b2236e90e2b88ee246677"

--- a/packages/liquidsoap/liquidsoap.1.3.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.4/opam
@@ -15,7 +15,7 @@ remove: [
 depends: [
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.1"}
-  "duppy" {>= "0.6.0"}
+  "duppy" {>= "0.8.0"}
   "mm" {>= "0.4.0"}
   "ocamlfind" {build}
   "pcre"


### PR DESCRIPTION
Please consider an update of this package in the `1.2` branch. It fixes an important bug in `liquidsoap` and it would be nice to also push it to users of the old version.