### PR TITLE
Fix archive access for users using recent openssl

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.6.4/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.6.4/opam
@@ -28,6 +28,6 @@ this part is currently work in progress)."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1150/ANSITerminal-0.6.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1150/ANSITerminal-0.6.4.tar.gz"
   checksum: "md5=f2c02c5f77f3438af456c2f0d6e58c7b"
 }

--- a/packages/ANSITerminal/ANSITerminal.0.6.5/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.6.5/opam
@@ -29,6 +29,6 @@ this part is currently work in progress)."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1206/ANSITerminal-0.6.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1206/ANSITerminal-0.6.5.tar.gz"
   checksum: "md5=508022a9a64a0983bc7d3a53139c6b8b"
 }

--- a/packages/ANSITerminal/ANSITerminal.0.6/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.6/opam
@@ -29,6 +29,6 @@ this part is currently work in progress)."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/610/ANSITerminal-0.6.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/610/ANSITerminal-0.6.tar.gz"
   checksum: "md5=d44571177c6a3a9f6ba45def99b2ae80"
 }

--- a/packages/aio/aio.0.0.3/opam
+++ b/packages/aio/aio.0.0.3/opam
@@ -24,6 +24,6 @@ efficiency, all data is read and written in page-aligned buffers."""
 extra-files: ["meta.patch" "md5=b76689eef7b6f6fb1373ee82c79e0b54"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/818/libaio-ocaml_1.0.orig.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/818/libaio-ocaml_1.0.orig.tar.gz"
   checksum: "md5=bc99ae0567d9feb4952c73da305aeb95"
 }

--- a/packages/archimedes/archimedes.0.4.15/opam
+++ b/packages/archimedes/archimedes.0.4.15/opam
@@ -36,6 +36,6 @@ Graphics and Cairo."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1025/archimedes-0.4.15.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1025/archimedes-0.4.15.tar.gz"
   checksum: "md5=a61aca722e8b3e2218edc8c7f01cd43d"
 }

--- a/packages/archimedes/archimedes.0.4.17/opam
+++ b/packages/archimedes/archimedes.0.4.17/opam
@@ -58,6 +58,6 @@ flags: light-uninstall
 extra-files: ["archimedes.install" "md5=77a877e7628a37723cfe5460c4090831"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1270/archimedes-0.4.17.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1270/archimedes-0.4.17.tar.gz"
   checksum: "md5=14b6cf3d52326af03952c2b5038d1d29"
 }

--- a/packages/archimedes/archimedes.0.4.18/opam
+++ b/packages/archimedes/archimedes.0.4.18/opam
@@ -55,6 +55,6 @@ plotting library. It provides dynamically loaded backends such as
 Graphics and Cairo."""
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1610/archimedes-0.4.18.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1610/archimedes-0.4.18.tar.gz"
   checksum: "md5=2013720e3df3fa3eaa098710a64dbf1d"
 }

--- a/packages/benchmark/benchmark.1.1/opam
+++ b/packages/benchmark/benchmark.1.1/opam
@@ -19,6 +19,6 @@ synopsis: "Benchmark running times of code"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/734/benchmark-1.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/734/benchmark-1.1.tar.gz"
   checksum: "md5=ae6885082c68f319ded4a1bb25ec5b37"
 }

--- a/packages/benchmark/benchmark.1.2/opam
+++ b/packages/benchmark/benchmark.1.2/opam
@@ -24,6 +24,6 @@ is used to determine whether the results truly differ."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1207/benchmark-1.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1207/benchmark-1.2.tar.gz"
   checksum: "md5=31f04b492314ec4850a768c03dd17d9f"
 }

--- a/packages/benchmark/benchmark.1.3/opam
+++ b/packages/benchmark/benchmark.1.3/opam
@@ -24,6 +24,6 @@ is used to determine whether the results truly differ."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1252/benchmark-1.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1252/benchmark-1.3.tar.gz"
   checksum: "md5=c265ba144aaad600a3714f08d43596cc"
 }

--- a/packages/bes/bes.0.9.3/opam
+++ b/packages/bes/bes.0.9.3/opam
@@ -17,6 +17,6 @@ synopsis:
   "OCaml library and command line frontend to simplify/minimize boolean expressions"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1041/bes-0.9.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1041/bes-0.9.3.tar.gz"
   checksum: "md5=4c25d97ef216ebc686c84cf56a6fda9a"
 }

--- a/packages/bes/bes.0.9.4.2/opam
+++ b/packages/bes/bes.0.9.4.2/opam
@@ -27,6 +27,6 @@ boolean expressions (boolean expression simplifier)"""
 flags: light-uninstall
 extra-files: ["bes.install" "md5=4f47f034403de389e2804b3997bcd38f"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1170/bes-0.9.4.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1170/bes-0.9.4.2.tar.gz"
   checksum: "md5=5ab46d03b38ea244e2f41705bc27ebe0"
 }

--- a/packages/bitcoin/bitcoin.1.0/opam
+++ b/packages/bitcoin/bitcoin.1.0/opam
@@ -18,6 +18,6 @@ synopsis:
   "Library offering an OCaml interface to the official Bitcoin client API"
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1042/ocaml-bitcoin-1.0.tgz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1042/ocaml-bitcoin-1.0.tgz"
   checksum: "md5=6f8ec4b5d677935e443907b6a6c47b0c"
 }

--- a/packages/bolt/bolt.1.3/opam
+++ b/packages/bolt/bolt.1.3/opam
@@ -22,6 +22,6 @@ synopsis: "Bolt is an OCaml Logging Tool"
 flags: light-uninstall
 extra-files: ["opam.patch" "md5=fb8f2a98f7e3c18ade131044ab96231f"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/974/bolt-1.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/974/bolt-1.3.tar.gz"
   checksum: "md5=5e3fd4038e5ad4d9954cbcfde385d2b8"
 }

--- a/packages/bolt/bolt.1.4/opam
+++ b/packages/bolt/bolt.1.4/opam
@@ -33,6 +33,6 @@ extra-files: [
   ["opam.bolt.META.patch" "md5=b62fb003991b9dd09a01ade5067056d9"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1043/bolt-1.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1043/bolt-1.4.tar.gz"
   checksum: "md5=26d10d36debfabbc6782d442d5d852d6"
 }

--- a/packages/cairo/cairo.0.4.2/opam
+++ b/packages/cairo/cairo.0.4.2/opam
@@ -44,6 +44,6 @@ the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
 and SVG file output."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1003/cairo-0.4.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1003/cairo-0.4.2.tar.gz"
   checksum: "md5=cbd64bfe6a3eb120ae98deb5ce6980ae"
 }

--- a/packages/cairo2/cairo2.0.4.3/opam
+++ b/packages/cairo2/cairo2.0.4.3/opam
@@ -41,6 +41,6 @@ the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
 and SVG file output."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1200/cairo-0.4.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1200/cairo-0.4.3.tar.gz"
   checksum: "md5=0eec598d0736434bee438f2063221286"
 }

--- a/packages/cairo2/cairo2.0.4.4/opam
+++ b/packages/cairo2/cairo2.0.4.4/opam
@@ -34,6 +34,6 @@ the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
 and SVG file output."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1226/cairo-0.4.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1226/cairo-0.4.4.tar.gz"
   checksum: "md5=74a071e39cee3cf732b310318f8c23e7"
 }

--- a/packages/cairo2/cairo2.0.4.5/opam
+++ b/packages/cairo2/cairo2.0.4.5/opam
@@ -35,6 +35,6 @@ and SVG file output."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1236/cairo2-0.4.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1236/cairo2-0.4.5.tar.gz"
   checksum: "md5=3f9999fc541319cdd897e20f0f4121ac"
 }

--- a/packages/cairo2/cairo2.0.4.6/opam
+++ b/packages/cairo2/cairo2.0.4.6/opam
@@ -46,6 +46,6 @@ and SVG file output."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1279/cairo2-0.4.6.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1279/cairo2-0.4.6.tar.gz"
   checksum: "md5=ad1f9a4eff1d60c2c6bb3c078cc716e9"
 }

--- a/packages/camlbz2/camlbz2.0.6.0/opam
+++ b/packages/camlbz2/camlbz2.0.6.0/opam
@@ -20,6 +20,6 @@ install: [make "install"]
 synopsis: "Bindings for bzip2"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/72/camlbz2-0.6.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/72/camlbz2-0.6.0.tar.gz"
   checksum: "md5=7a1cf822b3fe0ef57df4f8ebd86cac99"
 }

--- a/packages/camltemplate/camltemplate.1.0.2/opam
+++ b/packages/camltemplate/camltemplate.1.0.2/opam
@@ -9,7 +9,7 @@ build: [
   [make "opt"]
 ]
 remove: [["ocamlfind" "remove" "camltemplate"]]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {< "4.06.0"} "ocamlfind"]
 install: [
   [make "-C" "src" "install"]
   [make "-C" "doc" "install" "INSTALL_DIR=%{doc}%/camltemplate"]

--- a/packages/camltemplate/camltemplate.1.0.2/opam
+++ b/packages/camltemplate/camltemplate.1.0.2/opam
@@ -22,6 +22,6 @@ queries, XML documents and other sorts of text."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/29/camltemplate-1.0.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/29/camltemplate-1.0.2.tar.gz"
   checksum: "md5=b2fec2070e2480d80752251953be1bd1"
 }

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -40,6 +40,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1616/camlzip-1.06.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1616/camlzip-1.06.tar.gz"
   checksum: "md5=0874be16d02a7165dfc31edc06636e4c"
 }

--- a/packages/config-file/config-file.1.1/opam
+++ b/packages/config-file/config-file.1.1/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Small library to define, load and save options files."
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/845/config-file-1.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/845/config-file-1.1.tar.gz"
   checksum: "md5=7bc051234ceb29ffd5823ee6bcffe19c"
 }

--- a/packages/config-file/config-file.1.2/opam
+++ b/packages/config-file/config-file.1.2/opam
@@ -20,6 +20,6 @@ synopsis: "Small library to define, load and save options files."
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1387/config-file-1.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1387/config-file-1.2.tar.gz"
   checksum: "md5=fece1f143285fb5fddf17d5d36a577c5"
 }

--- a/packages/cryptokit/cryptokit.1.10/opam
+++ b/packages/cryptokit/cryptokit.1.10/opam
@@ -18,6 +18,6 @@ generation -- all presented with a compositional, extensible interface."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1493/cryptokit-1.10.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1493/cryptokit-1.10.tar.gz"
   checksum: "md5=aa697b894f87cc19643543ad1dae6c3f"
 }

--- a/packages/cryptokit/cryptokit.1.11/opam
+++ b/packages/cryptokit/cryptokit.1.11/opam
@@ -30,6 +30,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1618/cryptokit-1.11.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1618/cryptokit-1.11.tar.gz"
   checksum: "md5=931f8240ad30d9930d0f584f2921de69"
 }

--- a/packages/cryptokit/cryptokit.1.7/opam
+++ b/packages/cryptokit/cryptokit.1.7/opam
@@ -22,6 +22,6 @@ generation -- all presented with a compositional, extensible interface."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1166/cryptokit-1.7.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1166/cryptokit-1.7.tar.gz"
   checksum: "md5=93db223a3d832cf047d56596de23d470"
 }

--- a/packages/cryptokit/cryptokit.1.9/opam
+++ b/packages/cryptokit/cryptokit.1.9/opam
@@ -22,6 +22,6 @@ generation -- all presented with a compositional, extensible interface."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1229/cryptokit-1.9.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1229/cryptokit-1.9.tar.gz"
   checksum: "md5=4432a426c9d260822f4ff2b0750413de"
 }

--- a/packages/csv/csv.1.2.2/opam
+++ b/packages/csv/csv.1.2.2/opam
@@ -28,6 +28,6 @@ etc. The library comes with a handy command line tool called csvtool
 for handling CSV files from shell scripts."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/613/csv-1.2.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/613/csv-1.2.2.tar.gz"
   checksum: "md5=4b177e332719de1f9f5b16a31985d536"
 }

--- a/packages/csv/csv.1.2.6/opam
+++ b/packages/csv/csv.1.2.6/opam
@@ -31,6 +31,6 @@ line tool called csvtool for handling CSV files from shell scripts."""
 flags: light-uninstall
 extra-files: ["csv.install" "md5=32f2e83491f3337ed73738e2330b40ea"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1152/csv-1.2.6.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1152/csv-1.2.6.tar.gz"
   checksum: "md5=7530b3870048355aa73f35689ca3d918"
 }

--- a/packages/csv/csv.1.3.0/opam
+++ b/packages/csv/csv.1.3.0/opam
@@ -31,6 +31,6 @@ line tool called csvtool for handling CSV files from shell scripts."""
 flags: light-uninstall
 extra-files: ["csv.install" "md5=32f2e83491f3337ed73738e2330b40ea"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1172/csv-1.3.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1172/csv-1.3.0.tar.gz"
   checksum: "md5=6cbd2eb36603b6c7ccacdc330f3e4d7d"
 }

--- a/packages/csv/csv.1.3.1/opam
+++ b/packages/csv/csv.1.3.1/opam
@@ -31,6 +31,6 @@ line tool called csvtool for handling CSV files from shell scripts."""
 flags: light-uninstall
 extra-files: ["csv.install" "md5=32f2e83491f3337ed73738e2330b40ea"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1235/csv-1.3.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1235/csv-1.3.1.tar.gz"
   checksum: "md5=762593f6216564274962c5f360b406c7"
 }

--- a/packages/csv/csv.1.3.2/opam
+++ b/packages/csv/csv.1.3.2/opam
@@ -31,6 +31,6 @@ line tool called csvtool for handling CSV files from shell scripts."""
 flags: light-uninstall
 extra-files: ["csv.install" "md5=32f2e83491f3337ed73738e2330b40ea"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1298/csv-1.3.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1298/csv-1.3.2.tar.gz"
   checksum: "md5=23c71896013c69af55c868868f308236"
 }

--- a/packages/csv/csv.1.3.3/opam
+++ b/packages/csv/csv.1.3.3/opam
@@ -28,6 +28,6 @@ line tool called csvtool for handling CSV files from shell scripts."""
 flags: light-uninstall
 extra-files: ["csv.install" "md5=32f2e83491f3337ed73738e2330b40ea"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1376/csv-1.3.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1376/csv-1.3.3.tar.gz"
   checksum: "md5=d44ad52d0224c296e169448573d7cc16"
 }

--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -46,6 +46,6 @@ extra-files: [
   ["hasgotfix.patch" "md5=b47c3bd0728c929227ca30463f41a7f7"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/728/camldbm-1.0.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/728/camldbm-1.0.tgz"
   checksum: "md5=79a297c0e0c54fbb3c7e795359e5f902"
 }

--- a/packages/debian-formats/debian-formats.0.1.1/opam
+++ b/packages/debian-formats/debian-formats.0.1.1/opam
@@ -39,6 +39,6 @@ synopsis: "Parse debian files"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1682/ocaml-debian-formats-0.1.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1682/ocaml-debian-formats-0.1.1.tar.gz"
   checksum: "md5=fec8f1adf5a521b5ae1baea34c8d9e71"
 }

--- a/packages/efl/efl.1.10.0/opam
+++ b/packages/efl/efl.1.10.0/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.10.0/opam
+++ b/packages/efl/efl.1.10.0/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1431/ocaml-efl-1.10.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1431/ocaml-efl-1.10.0.tar.gz"
   checksum: "md5=c64f22a5b137dc7ed2e33d95624f10ef"
 }

--- a/packages/efl/efl.1.10.1/opam
+++ b/packages/efl/efl.1.10.1/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1440/ocaml-efl-1.10.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1440/ocaml-efl-1.10.1.tar.gz"
   checksum: "md5=f2f2e244c8f323603a0f94863a582f50"
 }

--- a/packages/efl/efl.1.10.1/opam
+++ b/packages/efl/efl.1.10.1/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.11.0/opam
+++ b/packages/efl/efl.1.11.0/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.11.0/opam
+++ b/packages/efl/efl.1.11.0/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1442/ocaml-efl-1.11.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1442/ocaml-efl-1.11.0.tar.gz"
   checksum: "md5=ea2c5be9cc377dc8498947cafdcb9a5e"
 }

--- a/packages/efl/efl.1.11.1/opam
+++ b/packages/efl/efl.1.11.1/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1467/ocaml-efl-1.11.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1467/ocaml-efl-1.11.1.tar.gz"
   checksum: "md5=910180a88e725241e31d48a93e0efbd8"
 }

--- a/packages/efl/efl.1.11.1/opam
+++ b/packages/efl/efl.1.11.1/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.12.0/opam
+++ b/packages/efl/efl.1.12.0/opam
@@ -33,6 +33,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1490/ocaml-efl-1.12.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1490/ocaml-efl-1.12.0.tar.gz"
   checksum: "md5=503d046c8827adc25423783cd9728d2d"
 }

--- a/packages/efl/efl.1.13.0/opam
+++ b/packages/efl/efl.1.13.0/opam
@@ -33,6 +33,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1499/ocaml-efl-1.13.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1499/ocaml-efl-1.13.0.tar.gz"
   checksum: "md5=b7e5fc04f8fa644b30032da471d557e6"
 }

--- a/packages/efl/efl.1.17.0/opam
+++ b/packages/efl/efl.1.17.0/opam
@@ -33,6 +33,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1598/ocaml-efl-1.17.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1598/ocaml-efl-1.17.0.tar.gz"
   checksum: "md5=c9a34031f788470efb5f437c12af8b6b"
 }

--- a/packages/efl/efl.1.18.0/opam
+++ b/packages/efl/efl.1.18.0/opam
@@ -34,6 +34,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1661/ocaml-efl-1.18.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1661/ocaml-efl-1.18.0.tar.gz"
   checksum: "md5=9f47a05ac71ad068c521e880af8d24f4"
 }

--- a/packages/efl/efl.1.19.0/opam
+++ b/packages/efl/efl.1.19.0/opam
@@ -34,6 +34,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1700/ocaml-efl-1.19.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1700/ocaml-efl-1.19.0.tar.gz"
   checksum: "md5=dc3f9af24e449a6001f726de143f96a9"
 }

--- a/packages/efl/efl.1.20.0/opam
+++ b/packages/efl/efl.1.20.0/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1733/ocaml-efl-1.20.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1733/ocaml-efl-1.20.0.tar.gz"
   checksum: "md5=55bada4887008b29ed112241478fb32f"
 }

--- a/packages/efl/efl.1.8.2/opam
+++ b/packages/efl/efl.1.8.2/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1384/ocaml-efl-1.8.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1384/ocaml-efl-1.8.2.tar.gz"
   checksum: "md5=b367036a01836a1aa74b30f08bcd7caf"
 }

--- a/packages/efl/efl.1.8.2/opam
+++ b/packages/efl/efl.1.8.2/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.8.3/opam
+++ b/packages/efl/efl.1.8.3/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1429/ocaml-efl-1.8.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1429/ocaml-efl-1.8.3.tar.gz"
   checksum: "md5=dd5e50723e379f7c4fe1ebbef135e585"
 }

--- a/packages/efl/efl.1.8.3/opam
+++ b/packages/efl/efl.1.8.3/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.8.4/opam
+++ b/packages/efl/efl.1.8.4/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1438/ocaml-efl-1.8.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1438/ocaml-efl-1.8.4.tar.gz"
   checksum: "md5=a6474ab3abc3b6299867b5f92a1199d8"
 }

--- a/packages/efl/efl.1.8.4/opam
+++ b/packages/efl/efl.1.8.4/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.9.0/opam
+++ b/packages/efl/efl.1.9.0/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.9.0/opam
+++ b/packages/efl/efl.1.9.0/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1385/ocaml-efl-1.9.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1385/ocaml-efl-1.9.0.tar.gz"
   checksum: "md5=025fe45c7a93cefa60c902421040f91e"
 }

--- a/packages/efl/efl.1.9.1/opam
+++ b/packages/efl/efl.1.9.1/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1430/ocaml-efl-1.9.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1430/ocaml-efl-1.9.1.tar.gz"
   checksum: "md5=52308bae13ce0b49ba5073ff4fa1a5c1"
 }

--- a/packages/efl/efl.1.9.1/opam
+++ b/packages/efl/efl.1.9.1/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.9.2/opam
+++ b/packages/efl/efl.1.9.2/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "efl"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-efl"

--- a/packages/efl/efl.1.9.2/opam
+++ b/packages/efl/efl.1.9.2/opam
@@ -35,6 +35,6 @@ https://github.com/axiles/ocaml-efl"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1439/ocaml-efl-1.9.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1439/ocaml-efl-1.9.2.tar.gz"
   checksum: "md5=294914c1844b66a0aaf2b530d0e1433b"
 }

--- a/packages/estring/estring.1.3/opam
+++ b/packages/estring/estring.1.3/opam
@@ -24,6 +24,6 @@ them with a specifier. For example ``u"foo"'' can be automatically
 replaced by ``Unicode.of_string "foo"''."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1012/estring-1.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1012/estring-1.3.tar.gz"
   checksum: "md5=b96f06de405ea3a6b4a21b672672bb14"
 }

--- a/packages/estring/estring.1.3/opam
+++ b/packages/estring/estring.1.3/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "estring"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/exenum/exenum.0.7/opam
+++ b/packages/exenum/exenum.0.7/opam
@@ -63,6 +63,6 @@ antique Intel Centrino)."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1583/exenum-source-0.7.tgz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1583/exenum-source-0.7.tgz"
   checksum: "md5=31ec3baafaff2fbd49eb420728fbf6db"
 }

--- a/packages/expect/expect.0.0.2/opam
+++ b/packages/expect/expect.0.0.2/opam
@@ -31,6 +31,6 @@ http://expect.nist.gov/"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/475/ocaml-expect-0.0.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/475/ocaml-expect-0.0.2.tar.gz"
   checksum: "md5=723288a1c9078f86e6185e78a6baa577"
 }

--- a/packages/expect/expect.0.0.3/opam
+++ b/packages/expect/expect.0.0.3/opam
@@ -28,6 +28,6 @@ http://expect.nist.gov/"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/894/ocaml-expect-0.0.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/894/ocaml-expect-0.0.3.tar.gz"
   checksum: "md5=3ac7f4bf2cfa9e7e8375c231be384248"
 }

--- a/packages/expect/expect.0.0.4/opam
+++ b/packages/expect/expect.0.0.4/opam
@@ -28,6 +28,6 @@ http://expect.nist.gov/"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1289/ocaml-expect-0.0.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1289/ocaml-expect-0.0.4.tar.gz"
   checksum: "md5=ec0839ed6d5fecbe204299ec4161bb0d"
 }

--- a/packages/expect/expect.0.0.6/opam
+++ b/packages/expect/expect.0.0.6/opam
@@ -29,6 +29,6 @@ http://expect.nist.gov/"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1736/ocaml-expect-0.0.6.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1736/ocaml-expect-0.0.6.tar.gz"
   checksum: "md5=894a7d6ded68d9d10a18ab7b79a8e961"
 }

--- a/packages/extunix/extunix.0.1.1/opam
+++ b/packages/extunix/extunix.0.1.1/opam
@@ -56,6 +56,6 @@ Motto: "Be to Unix, what extlib is to stdlib"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1403/ocaml-extunix-0.1.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1403/ocaml-extunix-0.1.1.tar.gz"
   checksum: "md5=6daa21e697ffbb08b689be8b05ca6742"
 }

--- a/packages/fileutils/fileutils.0.5.0/opam
+++ b/packages/fileutils/fileutils.0.5.0/opam
@@ -21,6 +21,6 @@ synopsis:
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1531/ocaml-fileutils-0.5.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1531/ocaml-fileutils-0.5.0.tar.gz"
   checksum: "md5=7d767cdfec85c846bd1d6f75a73abb01"
 }

--- a/packages/fileutils/fileutils.0.5.1/opam
+++ b/packages/fileutils/fileutils.0.5.1/opam
@@ -24,6 +24,6 @@ synopsis:
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1651/ocaml-fileutils-0.5.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1651/ocaml-fileutils-0.5.1.tar.gz"
   checksum: "md5=2fe185bbce4357eb5fba1dfc0b3e63c5"
 }

--- a/packages/fileutils/fileutils.0.5.2/opam
+++ b/packages/fileutils/fileutils.0.5.2/opam
@@ -25,6 +25,6 @@ synopsis: "Functions to manipulate real file (POSIX like) and filename."
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1695/ocaml-fileutils-0.5.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1695/ocaml-fileutils-0.5.2.tar.gz"
   checksum: "md5=ea653868e5e7a4a9316f7338b971df62"
 }

--- a/packages/fileutils/fileutils.0.5.3/opam
+++ b/packages/fileutils/fileutils.0.5.3/opam
@@ -26,6 +26,6 @@ synopsis: "Functions to manipulate real file (POSIX like) and filename."
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1728/ocaml-fileutils-0.5.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1728/ocaml-fileutils-0.5.3.tar.gz"
   checksum: "md5=9b719b19b96525004c88bf7bc846fa1d"
 }

--- a/packages/format/format.0.1/opam
+++ b/packages/format/format.0.1/opam
@@ -11,6 +11,6 @@ strings and writing to buffers, channels, and formatters, with data
 being inserted through antiquotations rather than subsequent
 arguments."""
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/376/format-1.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/376/format-1.0.tar.gz"
   checksum: "md5=2631ab7980b55a296f974f640af21ac7"
 }

--- a/packages/freetds/freetds.0.4.1/opam
+++ b/packages/freetds/freetds.0.4.1/opam
@@ -45,6 +45,6 @@ servers."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1161/freetds-0.4.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1161/freetds-0.4.1.tar.gz"
   checksum: "md5=224d27d7f630eaf8c733318dd963e332"
 }

--- a/packages/freetds/freetds.0.4.2/opam
+++ b/packages/freetds/freetds.0.4.2/opam
@@ -45,6 +45,6 @@ servers."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1165/freetds-0.4.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1165/freetds-0.4.2.tar.gz"
   checksum: "md5=5cf5a36fa4002f4a07018143102a3ced"
 }

--- a/packages/freetds/freetds.0.5.1/opam
+++ b/packages/freetds/freetds.0.5.1/opam
@@ -44,6 +44,6 @@ servers."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1171/freetds-0.5.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1171/freetds-0.5.1.tar.gz"
   checksum: "md5=7beea50fe8cd7957d2883993ffcfdcd3"
 }

--- a/packages/freetds/freetds.0.5/opam
+++ b/packages/freetds/freetds.0.5/opam
@@ -44,6 +44,6 @@ It allows to access Sybase and Microsoft (or other TDS) database
 servers."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1168/freetds-0.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1168/freetds-0.5.tar.gz"
   checksum: "md5=df5063d112f561b875f7832435a50e75"
 }

--- a/packages/fury-puyo/fury-puyo.0.5/opam
+++ b/packages/fury-puyo/fury-puyo.0.5/opam
@@ -5,7 +5,7 @@ maintainer: "pierre.chambart@ocamlpro.com"
 substs: ["data_dir.patch"]
 build: [[make]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "ocamlsdl"
   "conf-sdl-ttf"

--- a/packages/fury-puyo/fury-puyo.0.5/opam
+++ b/packages/fury-puyo/fury-puyo.0.5/opam
@@ -29,6 +29,6 @@ extra-files: [
   ["4.05-compatibility.patch" "md5=3b5db4489c1a4d09e9deeed5e5bccb34"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/352/furypuyo-0.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/352/furypuyo-0.5.tar.gz"
   checksum: "md5=bb7263a1a9b57542442656e907a476b1"
 }

--- a/packages/gammu/gammu.0.9.2/opam
+++ b/packages/gammu/gammu.0.9.2/opam
@@ -38,6 +38,6 @@ Gammu is a binding to libGammu which allows to manage data in your
 cell phone such as contacts, calendar or messages."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1153/gammu-0.9.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1153/gammu-0.9.2.tar.gz"
   checksum: "md5=f12232e69d989f2d353117bc33ade0e4"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.1/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.1/opam
@@ -39,6 +39,6 @@ Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1274/gapi-ocaml-0.2.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1274/gapi-ocaml-0.2.1.tar.gz"
   checksum: "md5=c87aa3b2c9afef190307d8da51d65875"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.10/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.10/opam
@@ -45,6 +45,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1601/gapi-ocaml-0.2.10.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1601/gapi-ocaml-0.2.10.tar.gz"
   checksum: "md5=14ddd4dfbabdc560c9719bcffeafe58b"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.13/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.13/opam
@@ -46,6 +46,6 @@ API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1647/gapi-ocaml-0.2.13.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1647/gapi-ocaml-0.2.13.tar.gz"
   checksum: "md5=d7acc5dc7645b82a557f97622cc192fd"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.14/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.14/opam
@@ -46,6 +46,6 @@ API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1657/gapi-ocaml-0.2.14.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1657/gapi-ocaml-0.2.14.tar.gz"
   checksum: "md5=0f59862148d26665587760538fa7f2ec"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.3/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.3/opam
@@ -41,6 +41,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1445/gapi-ocaml-0.2.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1445/gapi-ocaml-0.2.3.tar.gz"
   checksum: "md5=a42aec2eb734f16af7c12261b86eaea4"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.4/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.4/opam
@@ -41,6 +41,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1448/gapi-ocaml-0.2.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1448/gapi-ocaml-0.2.4.tar.gz"
   checksum: "md5=6396613e70d8c768e81295ed677cc204"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.5/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.5/opam
@@ -41,6 +41,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1460/gapi-ocaml-0.2.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1460/gapi-ocaml-0.2.5.tar.gz"
   checksum: "md5=656396569f5bb469f9ea8ebd09d49dbb"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.6/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.6/opam
@@ -41,6 +41,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1468/gapi-ocaml-0.2.6.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1468/gapi-ocaml-0.2.6.tar.gz"
   checksum: "md5=e158c98587681652decdff6302e423b7"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.7/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.7/opam
@@ -45,6 +45,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1581/gapi-ocaml-0.2.7.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1581/gapi-ocaml-0.2.7.tar.gz"
   checksum: "md5=54d49c6675488b63aae72e4ba9fc67ca"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.8/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.8/opam
@@ -45,6 +45,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1584/gapi-ocaml-0.2.8.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1584/gapi-ocaml-0.2.8.tar.gz"
   checksum: "md5=0547ec33a53ad275281c66d22a9e55b6"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2.9/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2.9/opam
@@ -45,6 +45,6 @@ Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1600/gapi-ocaml-0.2.9.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1600/gapi-ocaml-0.2.9.tar.gz"
   checksum: "md5=18320f61dad3587e5c3ea8f25e202e50"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.2/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.2/opam
@@ -29,6 +29,6 @@ v2. Google Data Protocol APIs (GData): Google Documents List API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1067/gapi-ocaml-0.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1067/gapi-ocaml-0.2.tar.gz"
   checksum: "md5=8636499bd962cfa9b87d743a7eec5230"
 }

--- a/packages/gapi-ocaml/gapi-ocaml.0.3.1/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.3.1/opam
@@ -46,6 +46,6 @@ API v3."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1665/gapi-ocaml-0.3.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1665/gapi-ocaml-0.3.1.tar.gz"
   checksum: "md5=9375d72d95238825ed66c1e2bfa6fefa"
 }

--- a/packages/getopt/getopt.20120615/opam
+++ b/packages/getopt/getopt.20120615/opam
@@ -23,6 +23,6 @@ flags: light-uninstall
 extra-files: ["getopt.install" "md5=a223c91cdc8bc9d22343511155616c57"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/896/ocaml-getopt-20120615.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/896/ocaml-getopt-20120615.tar.gz"
   checksum: "md5=ebd953313fa183d596704e41b90178ee"
 }

--- a/packages/gettext/gettext.0.3.5/opam
+++ b/packages/gettext/gettext.0.3.5/opam
@@ -43,6 +43,6 @@ flags: light-uninstall
 extra-files: ["gettext.install" "md5=e11873c06814eb2a66ebc66a984d3e4e"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1433/ocaml-gettext-0.3.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1433/ocaml-gettext-0.3.5.tar.gz"
   checksum: "md5=3c3c5156578104819b486584aa14f807"
 }

--- a/packages/gettext/gettext.0.3.7/opam
+++ b/packages/gettext/gettext.0.3.7/opam
@@ -43,6 +43,6 @@ flags: light-uninstall
 extra-files: ["gettext.install" "md5=e11873c06814eb2a66ebc66a984d3e4e"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1678/ocaml-gettext-0.3.7.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1678/ocaml-gettext-0.3.7.tar.gz"
   checksum: "md5=63349846b7456b1be23737e4a2c6bad7"
 }

--- a/packages/gettext/gettext.0.3.8/opam
+++ b/packages/gettext/gettext.0.3.8/opam
@@ -38,6 +38,6 @@ flags: light-uninstall
 extra-files: ["gettext.install" "md5=e11873c06814eb2a66ebc66a984d3e4e"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1731/ocaml-gettext-0.3.8.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1731/ocaml-gettext-0.3.8.tar.gz"
   checksum: "md5=bf3c82cada6be0f97b0b228e39f7e877"
 }

--- a/packages/headache/headache.1.03/opam
+++ b/packages/headache/headache.1.03/opam
@@ -14,6 +14,6 @@ depends: ["ocaml"]
 extra-files: ["headache.install" "md5=40aff1104ada2e8aef9f57edb8cf34d4"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/415/headache-1.03.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/415/headache-1.03.tar.gz"
   checksum: "md5=9b17f6d9ff73c54bb1be02717e06ec46"
 }

--- a/packages/headache/headache.1.03/opam
+++ b/packages/headache/headache.1.03/opam
@@ -10,7 +10,7 @@ synopsis: "Automatic generation of files headers"
 description: """
 Lightweight tool for managing headers in source code files. It can
 update in any source code files (OCaml, C, XML et al)."""
-depends: ["ocaml"]
+depends: ["ocaml" {< "4.06.0"}]
 extra-files: ["headache.install" "md5=40aff1104ada2e8aef9f57edb8cf34d4"]
 url {
   src:

--- a/packages/integration1d/integration1d.0.4.1/opam
+++ b/packages/integration1d/integration1d.0.4.1/opam
@@ -26,6 +26,6 @@ code."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1149/integration1d-0.4.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1149/integration1d-0.4.1.tar.gz"
   checksum: "md5=3eb445621ae233a4296ce3b74d46661f"
 }

--- a/packages/irrlicht/irrlicht.0.0.3/opam
+++ b/packages/irrlicht/irrlicht.0.0.3/opam
@@ -33,6 +33,6 @@ This binding is still in Alpha stage."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1301/ocaml-irrlicht-0.0.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1301/ocaml-irrlicht-0.0.3.tar.gz"
   checksum: "md5=bb6673efbb4598232d42479bb5f09139"
 }

--- a/packages/irrlicht/irrlicht.0.0.3/opam
+++ b/packages/irrlicht/irrlicht.0.0.3/opam
@@ -8,7 +8,7 @@ remove: [
   ["ocamlfind" "remove" "irrlicht"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -45,6 +45,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/816/lablgl-20120306.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/816/lablgl-20120306.tar.gz"
   checksum: "md5=c850c8500837165adfa98535ad33f770"
 }

--- a/packages/lablgl/lablgl.1.05/opam
+++ b/packages/lablgl/lablgl.1.05/opam
@@ -38,6 +38,6 @@ extra-files: [
   ["META" "md5=a777ae07a9eb6c09b9559e472eb9c974"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1254/lablgl-1.05.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1254/lablgl-1.05.tar.gz"
   checksum: "md5=b64662bf47f2973f836d33ae1365244f"
 }

--- a/packages/lablgtk-extras/lablgtk-extras.1.2/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.2/opam
@@ -18,6 +18,6 @@ synopsis:
   "A collection of additional tools and libraries to develop ocaml applications based on Lablgtk2."
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1060/lablgtkextras-1.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1060/lablgtkextras-1.2.tar.gz"
   checksum: "md5=f17d9c5d8ec76b677919332ad50e2111"
 }

--- a/packages/lablgtk-extras/lablgtk-extras.1.4/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.4/opam
@@ -28,6 +28,6 @@ synopsis:
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1282/lablgtkextras-1.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1282/lablgtkextras-1.4.tar.gz"
   checksum: "md5=4a64ad1380e8ec5796448f2bb60121b1"
 }

--- a/packages/lablgtk-extras/lablgtk-extras.1.5/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.5/opam
@@ -28,6 +28,6 @@ synopsis:
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1453/lablgtkextras-1.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1453/lablgtkextras-1.5.tar.gz"
   checksum: "md5=5d22389967edcab9e39dadca368e99dd"
 }

--- a/packages/lablgtk/lablgtk.2.16.0/opam
+++ b/packages/lablgtk/lablgtk.2.16.0/opam
@@ -53,6 +53,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/979/lablgtk-2.16.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/979/lablgtk-2.16.0.tar.gz"
   checksum: "md5=052519ce2a77d2316732bc4d565b6399"
 }

--- a/packages/lablgtk/lablgtk.2.18.2/opam
+++ b/packages/lablgtk/lablgtk.2.18.2/opam
@@ -53,6 +53,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1456/lablgtk-2.18.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1456/lablgtk-2.18.2.tar.gz"
   checksum: "md5=382003b46e52249810b3d6e7e9f3c80b"
 }

--- a/packages/lablgtk/lablgtk.2.18.3/opam
+++ b/packages/lablgtk/lablgtk.2.18.3/opam
@@ -53,6 +53,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz"
   checksum: "md5=bcbad64a28c3dc40f24cc7a4d2f1d0dd"
 }

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -58,6 +58,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1602/lablgtk-2.18.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1602/lablgtk-2.18.4.tar.gz"
   checksum: "md5=cb95497a3a34facd70d475892a806d02"
 }

--- a/packages/lablgtk/lablgtk.2.18.5/opam
+++ b/packages/lablgtk/lablgtk.2.18.5/opam
@@ -50,6 +50,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1627/lablgtk-2.18.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1627/lablgtk-2.18.5.tar.gz"
   checksum: "md5=43eb7062439f7ddd0d8ad96c3e3b87dd"
 }

--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -50,6 +50,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1726/lablgtk-2.18.6.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1726/lablgtk-2.18.6.tar.gz"
   checksum: "md5=30e9eef159eb88db0dce2438a60a6402"
 }

--- a/packages/labltk/labltk.8.06.0/opam
+++ b/packages/labltk/labltk.8.06.0/opam
@@ -22,6 +22,6 @@ description: "For details, see https://forge.ocamlcore.org/projects/labltk/"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1455/labltk-8.06.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1455/labltk-8.06.0.tar.gz"
   checksum: "md5=740398be4bb4cea11bddf03f27f50df9"
 }

--- a/packages/labltk/labltk.8.06.0/opam
+++ b/packages/labltk/labltk.8.06.0/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "labltk"]]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "4.07.0"}
   "ocamlfind"
   "conf-tcl"
   "conf-tk"

--- a/packages/labltk/labltk.8.06.1/opam
+++ b/packages/labltk/labltk.8.06.1/opam
@@ -28,6 +28,6 @@ description: "For details, see https://forge.ocamlcore.org/projects/labltk/"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1603/labltk-8.06.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1603/labltk-8.06.1.tar.gz"
   checksum: "md5=f38637d8fc8cccb2e08232cbb8ea4686"
 }

--- a/packages/labltk/labltk.8.06.1/opam
+++ b/packages/labltk/labltk.8.06.1/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "labltk"]]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.07.0"}
   "ocamlfind"
   "conf-tcl"
   "conf-tk"

--- a/packages/labltk/labltk.8.06.2/opam
+++ b/packages/labltk/labltk.8.06.2/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "labltk"]]
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.04" & < "4.07.0"}
   "ocamlfind"
   "conf-tcl"
   "conf-tk"

--- a/packages/labltk/labltk.8.06.2/opam
+++ b/packages/labltk/labltk.8.06.2/opam
@@ -29,6 +29,6 @@ flags: light-uninstall
 extra-files: ["cltkImg.patch" "md5=d3fbf34d6c96edcc4b3d80be2338e2a7"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1628/labltk-8.06.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1628/labltk-8.06.2.tar.gz"
   checksum: "md5=15020ef74baa688536ce1d38525462f8"
 }

--- a/packages/labltk/labltk.8.06.3/opam
+++ b/packages/labltk/labltk.8.06.3/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "labltk"]]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "4.07.0"}
   "ocamlfind"
   "conf-tcl"
   "conf-tk"

--- a/packages/labltk/labltk.8.06.3/opam
+++ b/packages/labltk/labltk.8.06.3/opam
@@ -28,6 +28,6 @@ description: "For details, see https://forge.ocamlcore.org/projects/labltk/"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1701/labltk-8.06.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1701/labltk-8.06.3.tar.gz"
   checksum: "md5=55c00fcd70381ec426b74568301c1a2e"
 }

--- a/packages/labltk/labltk.8.06.4/opam
+++ b/packages/labltk/labltk.8.06.4/opam
@@ -28,6 +28,6 @@ description: "For details, see https://forge.ocamlcore.org/projects/labltk/"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1727/labltk-8.06.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1727/labltk-8.06.4.tar.gz"
   checksum: "md5=48c3815461fb6d060dac9c7d574a7a4f"
 }

--- a/packages/labltk/labltk.8.06.4/opam
+++ b/packages/labltk/labltk.8.06.4/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "labltk"]]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "4.07.0"}
   "ocamlfind"
   "conf-tcl"
   "conf-tk"

--- a/packages/labltk/labltk.8.06.5/opam
+++ b/packages/labltk/labltk.8.06.5/opam
@@ -28,6 +28,6 @@ description: "For details, see https://forge.ocamlcore.org/projects/labltk/"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1764/labltk-8.06.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1764/labltk-8.06.5.tar.gz"
   checksum: "md5=a2741cebd8d59565ac35814074ca3002"
 }

--- a/packages/lambdoc/lambdoc.1.0-beta2/opam
+++ b/packages/lambdoc/lambdoc.1.0-beta2/opam
@@ -43,6 +43,6 @@ flags: light-uninstall
 extra-files: ["lambdoc.install" "md5=c48589f24468c2c0c7e87bbc25f6ed95"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1459/lambdoc-1.0-beta2.tgz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1459/lambdoc-1.0-beta2.tgz"
   checksum: "md5=d6e5607ceff3642914a5b8b9ecdba7e2"
 }

--- a/packages/lbfgs/lbfgs.0.8.3/opam
+++ b/packages/lbfgs/lbfgs.0.8.3/opam
@@ -42,6 +42,6 @@ extra-files: [
   ["setup.patch" "md5=65f2130d19ef96e4e9dbf93be19f75cd"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/778/lbfgs-0.8.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/778/lbfgs-0.8.3.tar.gz"
   checksum: "md5=98d2210538709389d55a9974e89f3b52"
 }

--- a/packages/lbfgs/lbfgs.0.8.5/opam
+++ b/packages/lbfgs/lbfgs.0.8.5/opam
@@ -32,6 +32,6 @@ This is a binding to L-BFGS-B, a library for Large-scale
 Bound-constrained Optimization."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1251/lbfgs-0.8.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1251/lbfgs-0.8.5.tar.gz"
   checksum: "md5=f25658c8f8ac4df800d58a3bf8021a66"
 }

--- a/packages/litiom/litiom.2.1/opam
+++ b/packages/litiom/litiom.2.1/opam
@@ -26,6 +26,6 @@ Presently, the library contains only the Litiom_type module, which contains faci
 improving modularity and abstraction in Eliom applications."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1237/litiom-2.1.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1237/litiom-2.1.tgz"
   checksum: "md5=14a0d67d6ba1d54d6b18c74eeac6c75d"
 }

--- a/packages/litiom/litiom.4.0/opam
+++ b/packages/litiom/litiom.4.0/opam
@@ -27,6 +27,6 @@ Litiom aims to complement Eliom, the web programming framework part of the Ocsig
 Litiom is basically a repository for modules offering high-level constructs for web programming."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1470/litiom-4.0.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1470/litiom-4.0.tgz"
   checksum: "md5=c98ac7129f473004cf0d72d6c24c52b1"
 }

--- a/packages/lpd/lpd.1.2/opam
+++ b/packages/lpd/lpd.1.2/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "lpd"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/lpd/lpd.1.2/opam
+++ b/packages/lpd/lpd.1.2/opam
@@ -24,6 +24,6 @@ example of a spooler that prints jobs on win32 machines (through
 GSPRINT) is provided."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1155/lpd-1.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1155/lpd-1.2.tar.gz"
   checksum: "md5=f2ee2ea7c4c8ddaacc9f69ffc72aa739"
 }

--- a/packages/melt/melt.1.4.0/opam
+++ b/packages/melt/melt.1.4.0/opam
@@ -30,6 +30,6 @@ include figures."""
 flags: light-uninstall
 extra-files: ["melt.install" "md5=5cc7d7def4d66dea8aef23b1931e41c4"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/727/melt-1.4.0.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/727/melt-1.4.0.tgz"
   checksum: "md5=ba26ca7b21d255d3c4ddfaac54ae5d71"
 }

--- a/packages/mesh/mesh.0.8.1/opam
+++ b/packages/mesh/mesh.0.8.1/opam
@@ -39,6 +39,6 @@ points and to export meshes and piecewise linear functions defined on
 them to TikZ, Scilab, Matlab, and Mathematica formats."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1361/mesh-0.8.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1361/mesh-0.8.1.tar.gz"
   checksum: "md5=bc3af5c0fbe13e8bbf01e221f6ad8502"
 }

--- a/packages/mesh/mesh.0.8.2/opam
+++ b/packages/mesh/mesh.0.8.2/opam
@@ -39,6 +39,6 @@ points and to export meshes and piecewise linear functions defined on
 them to TikZ, Scilab, Matlab, and Mathematica formats."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1362/mesh-0.8.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1362/mesh-0.8.2.tar.gz"
   checksum: "md5=26a3f8f495e5f5c38e1f97bf5ff29f2e"
 }

--- a/packages/mesh/mesh.0.8.3/opam
+++ b/packages/mesh/mesh.0.8.3/opam
@@ -39,6 +39,6 @@ points and to export meshes and piecewise linear functions defined on
 them to TikZ, Scilab, Matlab, and Mathematica formats."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1365/mesh-0.8.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1365/mesh-0.8.3.tar.gz"
   checksum: "md5=b3de98c6be5a870458393a74c25ca0af"
 }

--- a/packages/mesh/mesh.0.8.4/opam
+++ b/packages/mesh/mesh.0.8.4/opam
@@ -39,6 +39,6 @@ points and to export meshes and piecewise linear functions defined on
 them to TikZ, Scilab, Matlab, and Mathematica formats."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1396/mesh-0.8.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1396/mesh-0.8.4.tar.gz"
   checksum: "md5=c39186607ba6a3dd6286307ec6db30c4"
 }

--- a/packages/mesh/mesh.0.8.5/opam
+++ b/packages/mesh/mesh.0.8.5/opam
@@ -41,6 +41,6 @@ points and to export meshes and piecewise linear functions defined on
 them to TikZ, Scilab, Matlab, and Mathematica formats."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1454/mesh-0.8.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1454/mesh-0.8.5.tar.gz"
   checksum: "md5=91417a9793b38594d8e2b8abb8ba9f51"
 }

--- a/packages/mesh/mesh.0.8/opam
+++ b/packages/mesh/mesh.0.8/opam
@@ -39,6 +39,6 @@ points and to export meshes and piecewise linear functions defined on
 them to TikZ, Scilab, Matlab, and Mathematica formats."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1360/mesh-0.8.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1360/mesh-0.8.tar.gz"
   checksum: "md5=3c8a03793a5cc906bd2ae20ed091620d"
 }

--- a/packages/milter/milter.1.0.1/opam
+++ b/packages/milter/milter.1.0.1/opam
@@ -23,6 +23,6 @@ synopsis: "OCaml libmilter bindings"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1474/ocaml-milter-1.0.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1474/ocaml-milter-1.0.1.tar.gz"
   checksum: "md5=9416907d3b6c05dd3f85e7bff70fa8f4"
 }

--- a/packages/mysql/mysql.1.1.2/opam
+++ b/packages/mysql/mysql.1.1.2/opam
@@ -29,6 +29,6 @@ synopsis: "Bindings to libmysqlclient for interacting with mysql databases"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1308/ocaml-mysql-1.1.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1308/ocaml-mysql-1.1.2.tar.gz"
   checksum: "md5=1a5842c82110a65cc37f6fce460ada07"
 }

--- a/packages/mysql/mysql.1.1.3/opam
+++ b/packages/mysql/mysql.1.1.3/opam
@@ -37,6 +37,6 @@ synopsis: "Bindings to libmysqlclient for interacting with mysql databases"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1472/ocaml-mysql-1.1.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1472/ocaml-mysql-1.1.3.tar.gz"
   checksum: "md5=29952f3fd5fcb2aa1edc789de61e1b76"
 }

--- a/packages/mysql/mysql.1.2.0/opam
+++ b/packages/mysql/mysql.1.2.0/opam
@@ -28,6 +28,6 @@ synopsis: "Bindings to libmysqlclient for interacting with mysql databases"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1500/ocaml-mysql-1.2.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1500/ocaml-mysql-1.2.0.tar.gz"
   checksum: "md5=81d3bf217e4ed1829b9ea19f037dce65"
 }

--- a/packages/oasis/oasis.0.2.0/opam
+++ b/packages/oasis/oasis.0.2.0/opam
@@ -32,6 +32,6 @@ OASIS first target is OCamlbuild, but other build system support is
 planned."""
 extra-files: ["oasis.install" "md5=5d129946ad00d0240a82059d956d0659"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/501/oasis-0.2.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/501/oasis-0.2.0.tar.gz"
   checksum: "md5=e5d04bfe41eacd4f58a156784700a2ba"
 }

--- a/packages/oasis/oasis.0.3.0/opam
+++ b/packages/oasis/oasis.0.3.0/opam
@@ -29,6 +29,6 @@ planned."""
 flags: light-uninstall
 extra-files: ["oasis.install" "md5=2161502825015b83d45282b90368a2fd"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/918/oasis-0.3.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/918/oasis-0.3.0.tar.gz"
   checksum: "md5=c2b6dec8c12517d85ce98e7feffe2531"
 }

--- a/packages/oasis/oasis.0.4.0/opam
+++ b/packages/oasis/oasis.0.4.0/opam
@@ -29,6 +29,6 @@ planned."""
 flags: light-uninstall
 extra-files: ["oasis.install" "md5=2161502825015b83d45282b90368a2fd"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1352/oasis-0.4.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1352/oasis-0.4.0.tar.gz"
   checksum: "md5=c0284612163ec366336bc9e163e09e09"
 }

--- a/packages/oasis/oasis.0.4.1/opam
+++ b/packages/oasis/oasis.0.4.1/opam
@@ -34,6 +34,6 @@ planned."""
 flags: light-uninstall
 extra-files: ["oasis.install" "md5=2161502825015b83d45282b90368a2fd"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1355/oasis-0.4.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1355/oasis-0.4.1.tar.gz"
   checksum: "md5=15f8de126b860287e7b5ae1d2227b3b1"
 }

--- a/packages/oasis/oasis.0.4.10/opam
+++ b/packages/oasis/oasis.0.4.10/opam
@@ -56,6 +56,6 @@ like OPAM."""
 extra-files: ["oasis.install" "md5=ecc97c692bb2f70fe50124a88d705fde"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1694/oasis-0.4.10.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1694/oasis-0.4.10.tar.gz"
   checksum: "md5=84de67188d6c1ba4499aee6d4cb8cb54"
 }

--- a/packages/oasis/oasis.0.4.11/opam
+++ b/packages/oasis/oasis.0.4.11/opam
@@ -56,6 +56,6 @@ like OPAM."""
 extra-files: ["oasis.install" "md5=ecc97c692bb2f70fe50124a88d705fde"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1757/oasis-0.4.11.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1757/oasis-0.4.11.tar.gz"
   checksum: "md5=98492f4657c2c5b30e3b1bc945e58419"
 }

--- a/packages/oasis/oasis.0.4.4/opam
+++ b/packages/oasis/oasis.0.4.4/opam
@@ -29,6 +29,6 @@ planned."""
 flags: light-uninstall
 extra-files: ["oasis.install" "md5=2161502825015b83d45282b90368a2fd"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1391/oasis-0.4.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1391/oasis-0.4.4.tar.gz"
   checksum: "md5=847c0cc9ec02109e3a1d8464ded0d9e4"
 }

--- a/packages/oasis/oasis.0.4.5/opam
+++ b/packages/oasis/oasis.0.4.5/opam
@@ -65,6 +65,6 @@ extra-files: [
   ["_oasis_remove_.ml" "md5=6100ca146fa97d2196eb49a2631d0796"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1475/oasis-0.4.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1475/oasis-0.4.5.tar.gz"
   checksum: "md5=c6e319e75f4fd3302e030909714851fe"
 }

--- a/packages/oasis/oasis.0.4.6/opam
+++ b/packages/oasis/oasis.0.4.6/opam
@@ -65,6 +65,6 @@ extra-files: [
   ["_oasis_remove_.ml" "md5=6100ca146fa97d2196eb49a2631d0796"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1604/oasis-0.4.6.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1604/oasis-0.4.6.tar.gz"
   checksum: "md5=d939fc5cb9c914965051f7453fee4a81"
 }

--- a/packages/oasis/oasis.0.4.7/opam
+++ b/packages/oasis/oasis.0.4.7/opam
@@ -78,6 +78,6 @@ extra-files: [
   ["_oasis_remove_.ml" "md5=6100ca146fa97d2196eb49a2631d0796"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1635/oasis-0.4.7.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1635/oasis-0.4.7.tar.gz"
   checksum: "md5=d848bac0234ed1849a9187d16630cda3"
 }

--- a/packages/oasis/oasis.0.4.8/opam
+++ b/packages/oasis/oasis.0.4.8/opam
@@ -55,6 +55,6 @@ to integrates your libraries and software with third parties tools
 like OPAM."""
 extra-files: ["oasis.install" "md5=ecc97c692bb2f70fe50124a88d705fde"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1669/oasis-0.4.8.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1669/oasis-0.4.8.tar.gz"
   checksum: "md5=9ba176512a3cc008ec39cd4b528cc4e5"
 }

--- a/packages/oasis2debian/oasis2debian.0.1.3/opam
+++ b/packages/oasis2debian/oasis2debian.0.1.3/opam
@@ -40,6 +40,6 @@ displayed to gather more data."""
 extra-files: ["oasis.install" "md5=ecc97c692bb2f70fe50124a88d705fde"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1684/oasis2debian-0.1.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1684/oasis2debian-0.1.3.tar.gz"
   checksum: "md5=0180f7756214a3b7ca609f9c3b003090"
 }

--- a/packages/oasis2debian/oasis2debian.0.1.4/opam
+++ b/packages/oasis2debian/oasis2debian.0.1.4/opam
@@ -50,6 +50,6 @@ displayed to gather more data."""
 extra-files: ["oasis.install" "md5=ecc97c692bb2f70fe50124a88d705fde"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1758/oasis2debian-0.1.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1758/oasis2debian-0.1.4.tar.gz"
   checksum: "md5=a8ac3abba318546e9a1460f1e529cfb4"
 }

--- a/packages/oasis2debian/oasis2debian.0.1.5/opam
+++ b/packages/oasis2debian/oasis2debian.0.1.5/opam
@@ -50,6 +50,6 @@ displayed to gather more data."""
 extra-files: ["oasis.install" "md5=ecc97c692bb2f70fe50124a88d705fde"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1760/oasis2debian-0.1.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1760/oasis2debian-0.1.5.tar.gz"
   checksum: "md5=4db8cb503728ef54d596b12738479e0f"
 }

--- a/packages/objsize/objsize.0.16/opam
+++ b/packages/objsize/objsize.0.16/opam
@@ -23,6 +23,6 @@ heap blocks constituting the value in question.
 There are functions to get sizes of values in bytes too."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/442/objsize-0.16.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/442/objsize-0.16.tar.gz"
   checksum: "md5=66f550c611d3a3499454ff906d60b42d"
 }

--- a/packages/obus/obus.1.1.5/opam
+++ b/packages/obus/obus.1.1.5/opam
@@ -22,6 +22,6 @@ install: ["ocaml" "setup.ml" "-install"]
 synopsis: "A pure OCaml implementation of DBus"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1026/obus-1.1.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1026/obus-1.1.5.tar.gz"
   checksum: "md5=d8d25c4b40aebcf6d219cba39490278a"
 }

--- a/packages/ocaml-data-notation/ocaml-data-notation.0.0.11/opam
+++ b/packages/ocaml-data-notation/ocaml-data-notation.0.0.11/opam
@@ -17,6 +17,6 @@ generator, like OASIS."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1310/ocaml-data-notation-0.0.11.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1310/ocaml-data-notation-0.0.11.tar.gz"
   checksum: "md5=0ab9cd196b4a7f22a037ab96a477896f"
 }

--- a/packages/ocaml-data-notation/ocaml-data-notation.0.0.11/opam
+++ b/packages/ocaml-data-notation/ocaml-data-notation.0.0.11/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 remove: [["ocamlfind" "remove" "odn"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "type_conv" {>= "108.07.01"}
   "ocamlbuild" {build}

--- a/packages/ocaml-http/ocaml-http.0.1.5/opam
+++ b/packages/ocaml-http/ocaml-http.0.1.5/opam
@@ -11,6 +11,6 @@ synopsis: "Library freely inspired from Perl's HTTP::Daemon module"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/545/ocaml-http-0.1.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/545/ocaml-http-0.1.5.tar.gz"
   checksum: "md5=5426221ff76d7095fa1f5ee873b07829"
 }

--- a/packages/ocaml-markdown/ocaml-markdown.0.1.0/opam
+++ b/packages/ocaml-markdown/ocaml-markdown.0.1.0/opam
@@ -22,6 +22,6 @@ flags: light-uninstall
 extra-files: ["opam.patch" "md5=a3cadb33568bc0520538263a1a48a736"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/900/ocaml-markdown-0.1.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/900/ocaml-markdown-0.1.0.tar.gz"
   checksum: "md5=49486e7285bd1a6abc62b3e24680c50a"
 }

--- a/packages/ocaml-markdown/ocaml-markdown.0.1.1/opam
+++ b/packages/ocaml-markdown/ocaml-markdown.0.1.1/opam
@@ -20,6 +20,6 @@ synopsis: "Markdown processor for Ocsigen"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1196/ocaml-markdown-0.1.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1196/ocaml-markdown-0.1.1.tar.gz"
   checksum: "md5=9884d41e3aa587676bff5183532c694c"
 }

--- a/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.2/opam
+++ b/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.2/opam
@@ -23,6 +23,6 @@ http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/902/ocaml-xdg-basedir-0.0.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/902/ocaml-xdg-basedir-0.0.2.tar.gz"
   checksum: "md5=6ecdb1fbf5bc307c8fd29afe72ec7d76"
 }

--- a/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.2/opam
+++ b/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.2/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "xdg-basedir"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "fileutils"
   "ounit"

--- a/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.3/opam
+++ b/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.3/opam
@@ -27,6 +27,6 @@ http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1734/ocaml-xdg-basedir-0.0.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1734/ocaml-xdg-basedir-0.0.3.tar.gz"
   checksum: "md5=68367eba73f6094fea8c6ffee0072e20"
 }

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs/opam
@@ -26,6 +26,6 @@ synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1074/ocamlfuse-2.7.1-cvs.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1074/ocamlfuse-2.7.1-cvs.tar.gz"
   checksum: "md5=3e9e7ee2fd89e033a265840ca5aa4d44"
 }

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs2/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs2/opam
@@ -29,6 +29,6 @@ synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1369/ocamlfuse-2.7.1_cvs2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1369/ocamlfuse-2.7.1_cvs2.tar.gz"
   checksum: "md5=639c41e535acb1d983d16e67e2d015db"
 }

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs3/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs3/opam
@@ -30,6 +30,6 @@ synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1662/ocamlfuse-2.7.1-cvs3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1662/ocamlfuse-2.7.1-cvs3.tar.gz"
   checksum: "md5=96217775a14e5c91f1267a2cdf42cfeb"
 }

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
@@ -41,6 +41,6 @@ do zero-copy in OCaml land."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1663/ocamlfuse-2.7.1-cvs4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1663/ocamlfuse-2.7.1-cvs4.tar.gz"
   checksum: "md5=bc8e70d6886fd6a45387c3a7992a31cb"
 }

--- a/packages/ocamlmod/ocamlmod.0.0.4/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.4/opam
@@ -15,6 +15,6 @@ synopsis: "Generate OCaml modules from source files"
 extra-files: ["ocamlmod.install" "md5=db6d5efdd322f1916ae243d65937d587"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1204/ocamlmod-0.0.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1204/ocamlmod-0.0.4.tar.gz"
   checksum: "md5=6e1f70c8b70c534908054cd68852e8c8"
 }

--- a/packages/ocamlmod/ocamlmod.0.0.7/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.7/opam
@@ -31,6 +31,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1350/ocamlmod-0.0.7.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1350/ocamlmod-0.0.7.tar.gz"
   checksum: "md5=502acf75f5263afecf29566e3e766677"
 }

--- a/packages/ocamlmod/ocamlmod.0.0.8/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.8/opam
@@ -31,6 +31,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1544/ocamlmod-0.0.8.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1544/ocamlmod-0.0.8.tar.gz"
   checksum: "md5=411e5b3f3321945fc53d9377a1a17f91"
 }

--- a/packages/ocamlmod/ocamlmod.0.0.9/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.9/opam
@@ -29,6 +29,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1702/ocamlmod-0.0.9.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1702/ocamlmod-0.0.9.tar.gz"
   checksum: "md5=b52bfbab6bb77f9736bde9c2fe81c508"
 }

--- a/packages/ocurl/ocurl.0.5.4/opam
+++ b/packages/ocurl/ocurl.0.5.4/opam
@@ -21,6 +21,6 @@ Client-side URL transfer library, supporting HTTP and a multitude of
 other network protocols."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1106/ocurl-0.5.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1106/ocurl-0.5.4.tar.gz"
   checksum: "md5=3829652064722d8ed490486a2570fe8d"
 }

--- a/packages/ocurl/ocurl.0.5.5/opam
+++ b/packages/ocurl/ocurl.0.5.5/opam
@@ -21,6 +21,6 @@ Client-side URL transfer library, supporting HTTP and a multitude of
 other network protocols."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1117/ocurl-0.5.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1117/ocurl-0.5.5.tar.gz"
   checksum: "md5=5bb45c4e25691675f186096be4ae1df6"
 }

--- a/packages/ocurl/ocurl.0.5.6/opam
+++ b/packages/ocurl/ocurl.0.5.6/opam
@@ -21,6 +21,6 @@ Client-side URL transfer library, supporting HTTP and a multitude of
 other network protocols."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1134/ocurl-0.5.6.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1134/ocurl-0.5.6.tar.gz"
   checksum: "md5=7c613c097b98e446c8f4c859865de167"
 }

--- a/packages/ocurl/ocurl.0.6.0/opam
+++ b/packages/ocurl/ocurl.0.6.0/opam
@@ -21,6 +21,6 @@ Client-side URL transfer library, supporting HTTP and a multitude of
 other network protocols."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1238/ocurl-0.6.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1238/ocurl-0.6.0.tar.gz"
   checksum: "md5=21575e86b390c6c182a8dee42e8db1f3"
 }

--- a/packages/ocurl/ocurl.0.6.1/opam
+++ b/packages/ocurl/ocurl.0.6.1/opam
@@ -22,6 +22,6 @@ Client-side URL transfer library, supporting HTTP and a multitude of
 other network protocols."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1374/ocurl-0.6.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1374/ocurl-0.6.1.tar.gz"
   checksum: "md5=637336f41eb047b246e30a4c3caddc94"
 }

--- a/packages/ocurl/ocurl.0.7.0/opam
+++ b/packages/ocurl/ocurl.0.7.0/opam
@@ -27,6 +27,6 @@ Client-side URL transfer library, supporting HTTP and a multitude of
 other network protocols (FTP/SMTP/RTSP/etc)."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1382/ocurl-0.7.0.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1382/ocurl-0.7.0.tar.gz"
   checksum: "md5=8502e3e5e578e2d9b82ade73d16dd894"
 }

--- a/packages/ocurl/ocurl.0.7.1/opam
+++ b/packages/ocurl/ocurl.0.7.1/opam
@@ -32,6 +32,6 @@ Client-side URL transfer library, supporting HTTP and a multitude of
 other network protocols (FTP/SMTP/RTSP/etc)."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1400/ocurl-0.7.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1400/ocurl-0.7.1.tar.gz"
   checksum: "md5=d138fd78538ae3bd008d6e9c2993d240"
 }

--- a/packages/odbc/odbc.3.0/opam
+++ b/packages/odbc/odbc.3.0/opam
@@ -28,6 +28,6 @@ libraries before compiling this package."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1452/ocaml-odbc-3.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1452/ocaml-odbc-3.0.tar.gz"
   checksum: "md5=2399d644496c8bfacc674aa84910b84e"
 }

--- a/packages/odepack/odepack.0.6.2/opam
+++ b/packages/odepack/odepack.0.6.2/opam
@@ -18,6 +18,6 @@ value problem for ordinary differential equation systems."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/780/odepack-0.6.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/780/odepack-0.6.2.tar.gz"
   checksum: "md5=372b0843c6bc6c48d857686cd2cc8576"
 }

--- a/packages/odepack/odepack.0.6.6/opam
+++ b/packages/odepack/odepack.0.6.6/opam
@@ -33,6 +33,6 @@ ordinary differential equation systems."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1402/odepack-0.6.6.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1402/odepack-0.6.6.tar.gz"
   checksum: "md5=02522ea07d02bc094d856fc2abd9d26e"
 }

--- a/packages/optcomp/optcomp.1.4/opam
+++ b/packages/optcomp/optcomp.1.4/opam
@@ -21,6 +21,6 @@ install: [make "install"]
 synopsis: "Optional compilation with cpp-like directives"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1011/optcomp-1.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1011/optcomp-1.4.tar.gz"
   checksum: "md5=696e603c47c9e02554ab659b57d1da56"
 }

--- a/packages/ospec/ospec.0.2.1/opam
+++ b/packages/ospec/ospec.0.2.1/opam
@@ -19,6 +19,6 @@ extension."""
 flags: light-uninstall
 extra-files: ["ospec.install" "md5=dd4b55de1f9b61c9876361234ed88fe4"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/831/ospec-0.2.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/831/ospec-0.2.1.tar.gz"
   checksum: "md5=ce216b17ee6c62b1ce879cd667cb1a20"
 }

--- a/packages/ospec/ospec.0.3.1/opam
+++ b/packages/ospec/ospec.0.3.1/opam
@@ -20,6 +20,6 @@ extension."""
 flags: light-uninstall
 extra-files: ["ospec.install" "md5=f2ed71b731c02e59d45ae029f9c9351a"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1211/ospec-0.3.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1211/ospec-0.3.1.tar.gz"
   checksum: "md5=b60505aa89c177e9b2ff3dd019f408ef"
 }

--- a/packages/ospec/ospec.0.3.2/opam
+++ b/packages/ospec/ospec.0.3.2/opam
@@ -20,6 +20,6 @@ extension."""
 flags: light-uninstall
 extra-files: ["ospec.install" "md5=f2ed71b731c02e59d45ae029f9c9351a"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1220/ospec-0.3.2.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1220/ospec-0.3.2.tar.gz"
   checksum: "md5=b91a37fbc0f3cf2e50097142568e0d9c"
 }

--- a/packages/ounit/ounit.2.0.5/opam
+++ b/packages/ounit/ounit.2.0.5/opam
@@ -18,6 +18,6 @@ synopsis:
   "Unit testing framework loosely based on HUnit. It is similar to JUnit, and other XUnit testing frameworks"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1719/ounit-2.0.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1719/ounit-2.0.5.tar.gz"
   checksum: "md5=dbda9f8a5afe33461f638c2cc0a9e8f6"
 }

--- a/packages/ounit/ounit.2.0.6/opam
+++ b/packages/ounit/ounit.2.0.6/opam
@@ -18,6 +18,6 @@ synopsis:
   "Unit testing framework loosely based on HUnit. It is similar to JUnit, and other XUnit testing frameworks"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1722/ounit-2.0.6.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1722/ounit-2.0.6.tar.gz"
   checksum: "md5=9d656662ad5b38dfc6630cc2785d7913"
 }

--- a/packages/ounit/ounit.2.0.7/opam
+++ b/packages/ounit/ounit.2.0.7/opam
@@ -18,6 +18,6 @@ synopsis:
   "Unit testing framework loosely based on HUnit. It is similar to JUnit, and other XUnit testing frameworks"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1738/ounit-2.0.7.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1738/ounit-2.0.7.tar.gz"
   checksum: "md5=852bc74596501e79969eea522e1ae99e"
 }

--- a/packages/ounit/ounit.2.0.8/opam
+++ b/packages/ounit/ounit.2.0.8/opam
@@ -18,6 +18,6 @@ synopsis:
   "Unit testing framework loosely based on HUnit. It is similar to JUnit, and other XUnit testing frameworks"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1749/ounit-2.0.8.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1749/ounit-2.0.8.tar.gz"
   checksum: "md5=bd12d66c9dbd95a50570bb686b0f10f5"
 }

--- a/packages/pa_do/pa_do.0.8.15/opam
+++ b/packages/pa_do/pa_do.0.8.15/opam
@@ -12,6 +12,6 @@ synopsis: "Syntax extension to write arithmetic expressions"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1018/pa_do-0.8.15.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1018/pa_do-0.8.15.tar.gz"
   checksum: "md5=0092aaa3369f9e8fe954345e891a7ee0"
 }

--- a/packages/promela/promela.0.4.2/opam
+++ b/packages/promela/promela.0.4.2/opam
@@ -22,6 +22,6 @@ model checker."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1040/promela-0.4.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1040/promela-0.4.2.tar.gz"
   checksum: "md5=8fc98a1f7f1302d30e682382b186d2a3"
 }

--- a/packages/rdf/rdf.0.2/opam
+++ b/packages/rdf/rdf.0.2/opam
@@ -23,6 +23,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1036/ocaml-rdf-0.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1036/ocaml-rdf-0.2.tar.gz"
   checksum: "md5=58b22c35d69bca6670f304adbcee8ccb"
 }

--- a/packages/rdf/rdf.0.2/opam
+++ b/packages/rdf/rdf.0.2/opam
@@ -23,6 +23,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge-static.ocamlcore.org/frs/download.php/1036/ocaml-rdf-0.2.tar.gz"
+    "http://forge.ocamlcore.org/frs/download.php/1036/ocaml-rdf-0.2.tar.gz"
   checksum: "md5=58b22c35d69bca6670f304adbcee8ccb"
 }

--- a/packages/rdf/rdf.0.2/opam
+++ b/packages/rdf/rdf.0.2/opam
@@ -9,7 +9,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "4.06.0"}
   "ocamlfind"
   "camlp4"
   "xmlm" {>= "1.1.1"}

--- a/packages/rdf/rdf.0.3/opam
+++ b/packages/rdf/rdf.0.3/opam
@@ -23,6 +23,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1104/ocaml-rdf-0.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1104/ocaml-rdf-0.3.tar.gz"
   checksum: "md5=a985247f22998ebf149124b98cc7a0c0"
 }

--- a/packages/rdf/rdf.0.3/opam
+++ b/packages/rdf/rdf.0.3/opam
@@ -23,6 +23,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge-static.ocamlcore.org/frs/download.php/1104/ocaml-rdf-0.3.tar.gz"
+    "http://forge.ocamlcore.org/frs/download.php/1104/ocaml-rdf-0.3.tar.gz"
   checksum: "md5=a985247f22998ebf149124b98cc7a0c0"
 }

--- a/packages/rdf/rdf.0.3/opam
+++ b/packages/rdf/rdf.0.3/opam
@@ -9,7 +9,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "4.06.0"}
   "ocamlfind"
   "camlp4"
   "xmlm" {>= "1.1.1"}

--- a/packages/rdf/rdf.0.4/opam
+++ b/packages/rdf/rdf.0.4/opam
@@ -23,6 +23,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1131/ocaml-rdf-0.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1131/ocaml-rdf-0.4.tar.gz"
   checksum: "md5=6a9f69c08e7f40d3392f193707c1319d"
 }

--- a/packages/rdf/rdf.0.4/opam
+++ b/packages/rdf/rdf.0.4/opam
@@ -23,6 +23,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge-static.ocamlcore.org/frs/download.php/1131/ocaml-rdf-0.4.tar.gz"
+    "http://forge.ocamlcore.org/frs/download.php/1131/ocaml-rdf-0.4.tar.gz"
   checksum: "md5=6a9f69c08e7f40d3392f193707c1319d"
 }

--- a/packages/rdf/rdf.0.4/opam
+++ b/packages/rdf/rdf.0.4/opam
@@ -9,7 +9,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "4.06.0"}
   "ocamlfind"
   "camlp4"
   "xmlm" {>= "1.1.1"}

--- a/packages/rdf/rdf.0.5/opam
+++ b/packages/rdf/rdf.0.5/opam
@@ -35,6 +35,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge-static.ocamlcore.org/frs/download.php/1188/ocaml-rdf-0.5.tar.gz"
+    "http://forge.ocamlcore.org/frs/download.php/1188/ocaml-rdf-0.5.tar.gz"
   checksum: "md5=92ec0d2105aac2082775e454defa96a5"
 }

--- a/packages/rdf/rdf.0.5/opam
+++ b/packages/rdf/rdf.0.5/opam
@@ -35,6 +35,6 @@ install: [make "install"]
 synopsis: "Native OCaml library to manipulate RDF graphs."
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1188/ocaml-rdf-0.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1188/ocaml-rdf-0.5.tar.gz"
   checksum: "md5=92ec0d2105aac2082775e454defa96a5"
 }

--- a/packages/release/release.1.0.2/opam
+++ b/packages/release/release.1.0.2/opam
@@ -24,6 +24,6 @@ terminal and to release root privileges when those are not necessary."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1105/release-1.0.2.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1105/release-1.0.2.tar.gz"
   checksum: "md5=2a464eee0cb3252eebf56bf4bcc10556"
 }

--- a/packages/release/release.1.0.3/opam
+++ b/packages/release/release.1.0.3/opam
@@ -24,6 +24,6 @@ terminal and to release root privileges when those are not necessary."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1111/release-1.0.3.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1111/release-1.0.3.tar.gz"
   checksum: "md5=5868152283334c5ece3eb409087fd6a3"
 }

--- a/packages/release/release.1.0.4/opam
+++ b/packages/release/release.1.0.4/opam
@@ -24,6 +24,6 @@ terminal and to release root privileges when those are not necessary."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1113/release-1.0.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1113/release-1.0.4.tar.gz"
   checksum: "md5=5d34fd9d1a31c41cf06722e777d76e6a"
 }

--- a/packages/release/release.1.1.0/opam
+++ b/packages/release/release.1.1.0/opam
@@ -24,6 +24,6 @@ terminal and to release root privileges when those are not necessary."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1224/release-1.1.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1224/release-1.1.0.tar.gz"
   checksum: "md5=217b36500cae3d33477426b9f27b7b4c"
 }

--- a/packages/release/release.1.1.1/opam
+++ b/packages/release/release.1.1.1/opam
@@ -25,6 +25,6 @@ terminal and to release root privileges when those are not necessary."""
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1495/release-1.1.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1495/release-1.1.1.tar.gz"
   checksum: "md5=f2acce2f6726c67c47bd1285a7fadea8"
 }

--- a/packages/root1d/root1d.0.4/opam
+++ b/packages/root1d/root1d.0.4/opam
@@ -32,6 +32,6 @@ Collection of functions to seek roots of functions float -> float.
 Pure OCaml code."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1599/root1d-0.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1599/root1d-0.4.tar.gz"
   checksum: "md5=620bfdd6bd38221fb820968518a62831"
 }

--- a/packages/snappy/snappy.0.0.1/opam
+++ b/packages/snappy/snappy.0.0.1/opam
@@ -22,6 +22,6 @@ synopsis: "Bindings to snappy - fast compression/decompression library"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/874/ocaml-snappy-0.0.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/874/ocaml-snappy-0.0.1.tar.gz"
   checksum: "md5=1ec0a0deee71dc0fa5238d17ccf0ada8"
 }

--- a/packages/spf/spf.1.0.1/opam
+++ b/packages/spf/spf.1.0.1/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "spf"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/spf/spf.1.0.1/opam
+++ b/packages/spf/spf.1.0.1/opam
@@ -19,6 +19,6 @@ synopsis: "OCaml bindings for libspf2"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1112/ocaml-spf-1.0.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1112/ocaml-spf-1.0.1.tar.gz"
   checksum: "md5=a683728b235608dce78a85c10c0c79ed"
 }

--- a/packages/sqlexpr/sqlexpr.0.5.5/opam
+++ b/packages/sqlexpr/sqlexpr.0.5.5/opam
@@ -43,6 +43,6 @@ with Lwt
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1203/ocaml-sqlexpr-0.5.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1203/ocaml-sqlexpr-0.5.5.tar.gz"
   checksum: "md5=f0fb0e9caefd369736deed6d754ed71a"
 }

--- a/packages/tptp/tptp.0.2.0/opam
+++ b/packages/tptp/tptp.0.2.0/opam
@@ -20,6 +20,6 @@ synopsis:
   "Library for reading and writing FOF and CNF formulas in TPTP format"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1173/tptp-0.2.0.tar.bz2"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1173/tptp-0.2.0.tar.bz2"
   checksum: "md5=0d078205b46e178d7d81a9e5a025aa45"
 }

--- a/packages/tptp/tptp.0.2.0/opam
+++ b/packages/tptp/tptp.0.2.0/opam
@@ -20,6 +20,6 @@ synopsis:
   "Library for reading and writing FOF and CNF formulas in TPTP format"
 flags: light-uninstall
 url {
-  src: "https://forge-static.ocamlcore.org/frs/download.php/1173/tptp-0.2.0.tar.bz2"
+  src: "http://forge.ocamlcore.org/frs/download.php/1173/tptp-0.2.0.tar.bz2"
   checksum: "md5=0d078205b46e178d7d81a9e5a025aa45"
 }

--- a/packages/tptp/tptp.0.2.0/opam
+++ b/packages/tptp/tptp.0.2.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "tptp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "zarith"
   "ocamlbuild" {build}

--- a/packages/tptp/tptp.0.3.0/opam
+++ b/packages/tptp/tptp.0.3.0/opam
@@ -21,6 +21,6 @@ synopsis:
   "Library for reading and writing FOF and CNF formulas in TPTP format"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1405/tptp-0.3.0.tar.bz2"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1405/tptp-0.3.0.tar.bz2"
   checksum: "md5=7d4b075afc2ab4da330b341307c6982d"
 }

--- a/packages/tptp/tptp.0.3.0/opam
+++ b/packages/tptp/tptp.0.3.0/opam
@@ -21,6 +21,6 @@ synopsis:
   "Library for reading and writing FOF and CNF formulas in TPTP format"
 flags: light-uninstall
 url {
-  src: "https://forge-static.ocamlcore.org/frs/download.php/1405/tptp-0.3.0.tar.bz2"
+  src: "http://forge.ocamlcore.org/frs/download.php/1405/tptp-0.3.0.tar.bz2"
   checksum: "md5=7d4b075afc2ab4da330b341307c6982d"
 }

--- a/packages/tptp/tptp.0.3.0/opam
+++ b/packages/tptp/tptp.0.3.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "tptp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "zarith"
   "pprint"

--- a/packages/tptp/tptp.0.3.1/opam
+++ b/packages/tptp/tptp.0.3.1/opam
@@ -22,6 +22,6 @@ synopsis:
   "Library for reading and writing FOF and CNF formulas in TPTP format"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1437/tptp-0.3.1.tar.bz2"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1437/tptp-0.3.1.tar.bz2"
   checksum: "md5=7eea0f20f5734f9f678c23d2a84ceb3c"
 }

--- a/packages/tptp/tptp.0.3.1/opam
+++ b/packages/tptp/tptp.0.3.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "tptp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "zarith"
   "pprint"

--- a/packages/tptp/tptp.0.3.1/opam
+++ b/packages/tptp/tptp.0.3.1/opam
@@ -22,6 +22,6 @@ synopsis:
   "Library for reading and writing FOF and CNF formulas in TPTP format"
 flags: light-uninstall
 url {
-  src: "https://forge-static.ocamlcore.org/frs/download.php/1437/tptp-0.3.1.tar.bz2"
+  src: "http://forge.ocamlcore.org/frs/download.php/1437/tptp-0.3.1.tar.bz2"
   checksum: "md5=7eea0f20f5734f9f678c23d2a84ceb3c"
 }

--- a/packages/tuareg/tuareg.2.0.7/opam
+++ b/packages/tuareg/tuareg.2.0.7/opam
@@ -10,6 +10,6 @@ an interactive OCaml toplevel and debugger is provided."""
 depends: ["ocaml"]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1304/tuareg-2.0.7.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1304/tuareg-2.0.7.tar.gz"
   checksum: "md5=01fa65f62fc148736b3d0a4969630fa5"
 }

--- a/packages/tuareg/tuareg.2.0.7/opam
+++ b/packages/tuareg/tuareg.2.0.7/opam
@@ -7,7 +7,7 @@ description: """
 Tuareg handles automatic indentation of OCaml and Camllight codes.
 Key parts of the code are highlighted using Font-Lock.  Support to run
 an interactive OCaml toplevel and debugger is provided."""
-depends: ["ocaml"]
+depends: ["ocaml" "conf-emacs"]
 url {
   src:
     "https://forge-static.ocamlcore.org/frs/download.php/1304/tuareg-2.0.7.tar.gz"

--- a/packages/uint/uint.1.1.1/opam
+++ b/packages/uint/uint.1.1.1/opam
@@ -17,6 +17,6 @@ synopsis: "Unsigned ints for OCaml"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1377/ocaml-uint-1.1.1.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1377/ocaml-uint-1.1.1.tar.gz"
   checksum: "md5=7388b78c2bcfd41383854da5a0d5d98d"
 }

--- a/packages/uint/uint.1.1.4/opam
+++ b/packages/uint/uint.1.1.4/opam
@@ -17,6 +17,6 @@ synopsis: "Unsigned ints for OCaml"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1486/ocaml-uint-1.1.4.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1486/ocaml-uint-1.1.4.tar.gz"
   checksum: "md5=dd5967ea5be9827b3c09081809b3fa76"
 }

--- a/packages/uint/uint.1.1.5/opam
+++ b/packages/uint/uint.1.1.5/opam
@@ -17,6 +17,6 @@ synopsis: "Unsigned ints for OCaml"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1487/ocaml-uint-1.1.5.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1487/ocaml-uint-1.1.5.tar.gz"
   checksum: "md5=d58df49d9c83030a0a3a570fd7f5a74d"
 }

--- a/packages/uint/uint.1.2.0/opam
+++ b/packages/uint/uint.1.2.0/opam
@@ -17,6 +17,6 @@ synopsis: "Unsigned ints for OCaml"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1516/ocaml-uint-1.2.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/1516/ocaml-uint-1.2.0.tar.gz"
   checksum: "md5=e45a28c495cfaf9db714535c5f40876c"
 }

--- a/packages/usb/usb.1.3.0/opam
+++ b/packages/usb/usb.1.3.0/opam
@@ -23,6 +23,6 @@ synopsis: "OCaml bindings for libusb-1.0"
 flags: light-uninstall
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/946/ocaml-usb-1.3.0.tar.gz"
+    "https://forge-static.ocamlcore.org/frs/download.php/946/ocaml-usb-1.3.0.tar.gz"
   checksum: "md5=df0cfb6ace35ac8f183735ed284e21fb"
 }

--- a/packages/usb/usb.1.3.0/opam
+++ b/packages/usb/usb.1.3.0/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "usb"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "oasis" {>= "0.3.0"}
   "camlp4"

--- a/packages/utop/utop.1.2.1/opam
+++ b/packages/utop/utop.1.2.1/opam
@@ -22,6 +22,6 @@ install: [[make "install"]]
 synopsis: "improved toplevel"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/951/utop-1.2.1.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/951/utop-1.2.1.tar.gz"
   checksum: "md5=ace3b8347c7238c0978a907af72f40c4"
 }

--- a/packages/utop/utop.1.3.0/opam
+++ b/packages/utop/utop.1.3.0/opam
@@ -22,6 +22,6 @@ install: [[make "install"]]
 synopsis: "improved toplevel"
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1108/utop-1.3.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1108/utop-1.3.tar.gz"
   checksum: "md5=4bd99109beb5b806fc482cde532f9777"
 }

--- a/packages/utop/utop.1.4.0/opam
+++ b/packages/utop/utop.1.4.0/opam
@@ -31,6 +31,6 @@ It integrates with the tuareg mode in Emacs."""
 flags: light-uninstall
 extra-files: ["utop.install" "md5=706ad83234dd0b1d24961a8d9b6bac50"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1122/utop-1.4.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1122/utop-1.4.tar.gz"
   checksum: "md5=350bc972756317e3c74d730cdba7437c"
 }

--- a/packages/utop/utop.1.5/opam
+++ b/packages/utop/utop.1.5/opam
@@ -31,6 +31,6 @@ It integrates with the tuareg mode in Emacs."""
 flags: light-uninstall
 extra-files: ["utop.install" "md5=706ad83234dd0b1d24961a8d9b6bac50"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1169/utop-1.5.tar.gz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1169/utop-1.5.tar.gz"
   checksum: "md5=2f019f00b7067650b8f57172c9e10df5"
 }

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
@@ -27,6 +27,6 @@ extra-files: [
   ["config.diff" "md5=a1b990b42e0a16b8960995096e0722c8"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1574/zarith-1.4.1.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1574/zarith-1.4.1.tgz"
   checksum: "md5=9ab2482d57f632c9cb3d10149138bc6e"
 }

--- a/packages/zarith-freestanding/zarith-freestanding.1.4/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4/opam
@@ -28,6 +28,6 @@ extra-files: [
   ["config.diff" "md5=a1b990b42e0a16b8960995096e0722c8"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1567/zarith-1.4.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1567/zarith-1.4.tgz"
   checksum: "md5=8967de3cf9eabe1d73b663bc9916657d"
 }

--- a/packages/zarith-xen/zarith-xen.1.3/opam
+++ b/packages/zarith-xen/zarith-xen.1.3/opam
@@ -29,6 +29,6 @@ extra-files: [
   ["mirage-install.sh" "md5=dc7670c682280ed402e3937d4d6fbe04"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz"
   checksum: "md5=9ed8ddafdebfa8c1b673dbe91a181f66"
 }

--- a/packages/zarith-xen/zarith-xen.1.4/opam
+++ b/packages/zarith-xen/zarith-xen.1.4/opam
@@ -23,6 +23,6 @@ extra-files: [
   ["mirage-install.sh" "md5=fdda6c79ecac23b0c31852900674d7c6"]
 ]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1567/zarith-1.4.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1567/zarith-1.4.tgz"
   checksum: "md5=8967de3cf9eabe1d73b663bc9916657d"
 }

--- a/packages/zarith/zarith.1.3/opam
+++ b/packages/zarith/zarith.1.3/opam
@@ -32,6 +32,6 @@ unboxed integers, for speed and space economy."""
 flags: light-uninstall
 extra-files: ["z_pp.pl.patch" "md5=e138d44f86858d55c6e0911e1517ed2e"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz"
   checksum: "md5=9ed8ddafdebfa8c1b673dbe91a181f66"
 }

--- a/packages/zarith/zarith.1.4.1/opam
+++ b/packages/zarith/zarith.1.4.1/opam
@@ -31,6 +31,6 @@ arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 flags: light-uninstall
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1574/zarith-1.4.1.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1574/zarith-1.4.1.tgz"
   checksum: "md5=9ab2482d57f632c9cb3d10149138bc6e"
 }

--- a/packages/zarith/zarith.1.4/opam
+++ b/packages/zarith/zarith.1.4/opam
@@ -33,6 +33,6 @@ unboxed integers, for speed and space economy."""
 flags: light-uninstall
 extra-files: ["z_pp.pl.patch" "md5=91205dc2130807273fb83a00a3b54215"]
 url {
-  src: "https://forge.ocamlcore.org/frs/download.php/1567/zarith-1.4.tgz"
+  src: "https://forge-static.ocamlcore.org/frs/download.php/1567/zarith-1.4.tgz"
   checksum: "md5=8967de3cf9eabe1d73b663bc9916657d"
 }


### PR DESCRIPTION
With recent openssl (at least >= 1.1.1, maybe before as well) and curl the result of getting those archives is:
```
curl: (35) error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol
```
I contacted @gildor478 and the solution is to use either http or forge-static.ocamlcore.org. In this PR I choose the later.