### PR TITLE
[new release] ocaml-version (1.0.0)

### DIFF
--- a/packages/dockerfile-opam/dockerfile-opam.4.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.4.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
   "dockerfile" {>= "3.0.0"}
-  "ocaml-version"
+  "ocaml-version" {<"1.0.0"}
   "cmdliner"
   "astring"
   "sexplib"

--- a/packages/dockerfile-opam/dockerfile-opam.5.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.5.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
   "dockerfile" {>= "3.0.0"}
-  "ocaml-version" {>= "0.3.0"}
+  "ocaml-version" {>= "0.3.0" & <"1.0.0"}
   "cmdliner"
   "astring"
 ]

--- a/packages/ocaml-version/ocaml-version.1.0.0/opam
+++ b/packages/ocaml-version/ocaml-version.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/avsm/ocaml-version"
+doc: "https://avsm.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/avsm/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+Browse the [API documentation](http://anil-code.recoil.org/ocaml-version/ocaml-version/Ocaml_version/index.html) for more
+details.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/avsm/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/avsm/ocaml-version/releases/download/v1.0.0/ocaml-version-v1.0.0.tbz"
+  checksum: "md5=8403259f96ff8d17e2142e84671ffd51"
+}


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/avsm/ocaml-version">https://github.com/avsm/ocaml-version</a>
- Documentation: <a href="https://avsm.github.io/ocaml-version/doc">https://avsm.github.io/ocaml-version/doc</a>

##### CHANGES:

* Add ARM32 (aarch32, arm32v7) architecture.
* Add more OCaml 4.07.[0,1] functions and mark it as latest stable.
* Port to Dune from Jbuilder.
* Add several modules related to compiler configuration, in order
  to faciliate mechanical generation of opam2 compiler packages.
* Drop support for opam 1.2.x in favour of opam 2.0.0.
* Update opam metadata to 2.0 format.
