### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.0.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL and distribution support"
+description: """
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile-opam" {>= "3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "csv"
+  "ppx_sexp_conv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.0.0/dockerfile-v6.0.0.tbz"
+  checksum: "md5=a062b0263ead65417c01c521730a74b3"
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL and distribution support"
+description: """
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile" {>= "3.0.0"}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.0.0/dockerfile-v6.0.0.tbz"
+  checksum: "md5=a062b0263ead65417c01c521730a74b3"
+}

--- a/packages/dockerfile/dockerfile.6.0.0/opam
+++ b/packages/dockerfile/dockerfile.6.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL and distribution support"
+description: """
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.0.0/dockerfile-v6.0.0.tbz"
+  checksum: "md5=a062b0263ead65417c01c521730a74b3"
+}

--- a/packages/obi/obi.1.0.0/opam
+++ b/packages/obi/obi.1.0.0/opam
@@ -10,9 +10,9 @@ tags: ["org:mirage" "org:ocamllabs"]
 depends: [
   "ocaml" {>= "4.05.0"}
   "jbuilder" {build & >= "1.0+beta17"}
-  "dockerfile-opam" {>= "5.0.0"}
+  "dockerfile-opam" {>= "5.0.0" & <"6.0.0"}
   "dockerfile-cmd" {>= "5.0.0"}
-  "ocaml-version" {>= "0.3.0"}
+  "ocaml-version" {>= "0.3.0" & <"1.0.0"}
   "yaml" {>= "0.2.0"}
   "uri"
   "ezjsonm"


### PR DESCRIPTION
Dockerfile eDSL and distribution support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/doc">https://avsm.github.io/ocaml-dockerfile/doc</a>

##### CHANGES:

This release focuses on the opam 2.0 release and the resulting
containers built on ocaml/opam2 on the Docker Hub.

- set the `OPAMYES` variable to true by default in ocaml
  containers so they remain non-interactive.
- install rsync in RPM distros
- Install opam-depext in the containers by default
- fix opam2 alpine and centos installation by installing openssl
- add a dependency on `ppx_sexp_conv` for dockerfile-cmd
- add support for Aarch32 in distros
- install coreutils in Alpine since OCaml 4.08 needs GNU stat to compile
- add support for Ubuntu 18.10 and Alpine 3.8 releases.
- add xz to Alpine and Zypper distributions.
- `install_opam_from_source` requires an explicit branch rather
  than defaulting to master.
- update version of Bubblewrap in containers to 0.3.1.
- port build system from Jbuilder to Dune.
