### PR TITLE
charInfo_width 0.1.0    determine colum width for a character

### DIFF
--- a/packages/charInfo_width/charInfo_width.0.1.0/opam
+++ b/packages/charInfo_width/charInfo_width.0.1.0/opam
@@ -6,15 +6,15 @@ bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
 license: "MIT"
 dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
 build: [
-  [make]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
+  "result"
   "camomile" {>= "1.0.0" & < "2.0~"}
   "dune" {build}
-]
-depopts: [
-  "charInfo_width_extra"
+  "ppx_expect" {with-test}
 ]
 
 synopsis: "Determine column width of a character"

--- a/packages/charInfo_width/charInfo_width.0.1.0/opam
+++ b/packages/charInfo_width/charInfo_width.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://bitbucket.org/zandoye/charinfo_width/"
+bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
+license: "MIT"
+dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
+build: [
+  [make]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "camomile" {>= "1.0.0" & < "2.0~"}
+  "dune" {build}
+]
+depopts: [
+  "charInfo_width_extra"
+]
+
+synopsis: "Determine column width of a character"
+description: """
+This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
+
+url {
+  src:"https://bitbucket.org/zandoye/charinfo_width/get/0.1.0.tar.gz"
+  checksum: "md5=b1856eb22cafcaf564d2d11be5d522c0"
+}


### PR DESCRIPTION
CharInfo_width determines column width for a character.

This module is implemented purely in OCaml and the `width` function follows the prototype of POSIX's wcwidth.

The document is available [here](https://zandoye.bitbucket.io/doc/_html/charInfo_width/CharInfo_width/index.html)