### PR TITLE
[new release] mdx (1.1.0)

### DIFF
--- a/packages/mdx/mdx.1.1.0/opam
+++ b/packages/mdx/mdx.1.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org"]
+homepage:     "https://github.com/realworldocaml/mdx"
+license:      "ISC"
+dev-repo:     "git+https://github.com/realworldocaml/mdx.git"
+bug-reports:  "https://github.com/realworldocaml/mdx/issues"
+doc:          "https://realworldocaml.github.io/mdx/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "fmt"
+  "cppo"
+  "astring"
+  "logs"
+  "cmdliner"
+  "re" {>= "1.7.2"}
+  "ppx_tools"
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "lwt" {with-test}
+  "conf-pandoc" {with-test}
+]
+
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`mdx pp`)
+and tests (`mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`mdx` is released as a single binary (called `mdx`) and
+can be installed using opam:
+"""
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.1.0/mdx-1.1.0.tbz"
+  checksum: "md5=56fd42147992391fb7b0d95145482b37"
+}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>
- Documentation: <a href="https://realworldocaml.github.io/mdx/">https://realworldocaml.github.io/mdx/</a>

##### CHANGES:

- Add a mechanism to promote files to blocks and blocks to file
  (@gpetiot, realworldocaml/mdx#37)
- Support multiple toplevel environments (@gpetiot, realworldocaml/mdx#38)
- Use ocaml-migrate-parsetree to compile in 4.06.1 & 4.07.0 (@gpetiot, realworldocaml/mdx#41)
- Add a `mdx'rule` command to generate dune rules (@gpetiot, realworldocaml/mdx#44)
- Add a `mdx output` command to generate an HTML document (@samoht, realworldocaml/mdx#45)
- Support empty code blocks (@samoht, realworldocaml/mdx#46)
- Fix detection of OCaml code/toplevel (@samoht, realworldocaml/mdx#47)
- Better handling of multi-line shell scripts (@samoht, realworldocaml/mdx#48)
- Fix regression in toplevel blocks when creating newtype (@samoht, realworldocaml/mdx#49)
- Fix evaluation of non-determinitic test (@samoht, realworldocaml/mdx#50)
- Improve mdx rules to take into account more precise dependencies (@samoht, realworldocaml/mdx#51)
- Fix promotion of blocks to complete ML files (@samoht, realworldocaml/mdx#52)
- mdx does not use the `cppo` library, just the binary (@samoht, realworldocaml/mdx#53)
- fix ellipsis in code blocks (@samoht, realworldocaml/mdx#57)
- Fix relative paths for promoted blocks to files (@samoht, realworldocaml/mdx#58)
- Fix location of errors for multi-line commands (@samoht, realworldocaml/mdx#60)
- improve the parser for shell blocks (@samoht, realworldocaml/mdx#61)
- Allow to load preludes in specific environments (@samoht, realworldocaml/mdx#63)
- Fix evaluation of code after directives in prelude (@samoht, realworldocaml/mdx#64)
- Improve promotion to ml files (@samoht, realworldocaml/mdx#66)
- mdx rule: generates (source_tree) dependencies for directory metadata (@samoht, realworldocaml/mdx#67)
- Fix handling of 'module type' in multiple toplevel environment (@samoht, realworldocaml/mdx#68)
- Add an eval=false label to skip the evaluation of a code block (@samoht, realworldocaml/mdx#69)
- Fix parsing of shell blocks with multiple exit codes (@samoht, realworldocaml/mdx#71)
- Support source-tree as extra block metadata (@samoht, realworldocaml/mdx#72)
- Better formatting of non-compiling promoted contents (@samoht, realworldocaml/mdx#73)
- Be sure to remove the .corrected files if the promotion to ML file works (mdx74)
- Add missing dependency in test/dune (@samoht, realworldocaml/mdx#75)
- Support `dir=..` labels in ml code blocks (@samoht, realworldocaml/mdx#76)
- Allow to promote to mli files too (@samoht, realworldocaml/mdx#77)
- Support multi-line strings (@samoht, realworldocaml/mdx#78)
- fail (and exit 1) if prelude and ml blocks cannot be evaluated properly
  (@samoht, realworldocaml/mdx#80, @samoht, realworldocaml/mdx#83)
- Allow to pass --root to `mdx rule` (@samoht, realworldocaml/mdx#81)
- mdx rule: do not add (package mdx) in the dependencies (@samoht, realworldocaml/mdx#82)
