### PR TITLE
move mirage-xen to correct subfolder

### DIFF
--- a/packages/mirage-xen/mirage-xen.3.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "xen-gnt" {>= "2.0.0"}
   "conf-pkg-config"
   "mirage-profile" {>= "0.3"}
-  "mirage-xen-ocaml" {>= "2.6.0"}
+  "mirage-xen-ocaml" {>= "3.1.0"}
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen-minios" {>= "0.7.0"}
   "logs"


### PR DESCRIPTION
oops, I wish @camelus would complain if you put package `x` into `y/x.a.b.c` (here, x being mirage-xen, and y mirage-unix)