### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-typ…

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.3.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "2.6.0"}
+  "functoria-runtime"  {>= "2.2.2"}
+  "fmt"
+  "astring"
+  "logs"
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.3.0/mirage-3.3.0.tbz"
+  checksum: "md5=3d6b891fb09e3cf577c770224ed8e9ac"
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "lwt"
+  "cstruct" {>="1.4.0"}
+  "io-page" {>="1.4.0"}
+  "ipaddr"
+  "mirage-types" {>= "3.3.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-console-lwt" {>= "1.2.0"}
+  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-fs-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.3.0/mirage-3.3.0.tbz"
+  checksum: "md5=3d6b891fb09e3cf577c770224ed8e9ac"
+}

--- a/packages/mirage-types/mirage-types.3.3.0/opam
+++ b/packages/mirage-types/mirage-types.3.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-time" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-console" {>= "2.2.0"}
+  "mirage-protocols" {>= "1.4.0"}
+  "mirage-stack" {>= "1.3.0"}
+  "mirage-block" {>= "1.0.0"}
+  "mirage-net" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0"}
+  "mirage-channel" {>= "3.0.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.3.0/mirage-3.3.0.tbz"
+  checksum: "md5=3d6b891fb09e3cf577c770224ed8e9ac"
+}

--- a/packages/mirage/mirage.3.3.0/opam
+++ b/packages/mirage/mirage.3.3.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "2.6.0"}
+  "functoria"          {>= "2.2.2"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.3.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/3.3.0/mirage-3.3.0.tbz"
+  checksum: "md5=3d6b891fb09e3cf577c770224ed8e9ac"
+}


### PR DESCRIPTION
…es (3.3.0)

CHANGES:

New target: (via solo5) Genode:
"Genode[4][5][6] is a free and open-source operating system framework consisting
of a microkernel abstraction layer and a collection of userspace components. The
framework is notable as one of the few open-source operating systems not derived
from a proprietary OS, such as Unix. The characteristic design philosophy is
that a small trusted computing base is of primary concern in a security oriented
OS." (from wikipedia, more at https://genode.org/ mirage/mirage#942, by @ehmry)

User-visible changes
* use mirage-bootvar-unix instead of OS.Env.argv
  (deprecated since mirage-{xen,unix,os-shim}.3.1.0, mirage-solo5.0.5.0) on unix
  (mirage/mirage#931, by @hannesm)

  WARNING: this leads to a different semantics for argument passing on Unix:
  all arguments are concatenated (using a whitespace " " as separator), and
  split on the whitespace character again (by parse-argv). This is coherent
  with all other backends, but the whitespace in "--hello=foo bar" needs to
  be escaped now.

* mirage now generates upper bounds for hard-coded packages that are used in
  generated code. When we now break the API, unikernels which are configured with
  an earlier version won't accept the new release of the dependency. This means
  API breakage is much smoother for us, apart from that we now track version
  numbers in the mirage utility. The following rules were applied for upper bounds:
  - if version < 1.0.0 then ~min:"a.b.c" ~max:"a.(b+1).0"
  - if version > 1.0.0 then ~min:"a.b.c" ~max:"(a+1).0.0"`
  - exceptions: tcpip (~min:"3.5.0" ~max:"3.6.0"), mirage-block-ramdisk (unconstrained)

  WARNING: Please be careful when release any of the referenced libraries by
  taking care of appropriate version numbering.
  (initial version in mirage/mirage#855 by @avsm, final mirage/mirage#946 by @hannesm)

* since functoria.2.2.2, the "package" function (used in unikernel configuration)
  is extended with the labeled argument ~pin that receives a string (e.g.
  ~pin:"git+https://github.com/mirage-random/mirage-random.git"), and is embedded
  into the generated opam file as [pin-depends](https://opam.ocaml.org/doc/Manual.html#opamfield-pin-depends)

* mirage-random-stdlib is now used for default_random instead of mirage-random
  (which since 1.2.0 no longer bundles the stdlib Random
  module). mirage-random-stdlib is not cryptographically secure, but "a
  lagged-Fibonacci F(55, 24, +) with a modified addition function to enhance the
  mixing of bits.", which is now seeded using mirage-entropy. If you configure
  your unikernel with "mirage configure --prng fortuna" (since mirage 3.0.0), a
  cryptographically secure PRNG will be used (read more at
  https://mirage.io/blog/mirage-entropy)

* mirage now revived its command-line "--no-depext", which removes the call to
  "opam depext" in the depend and depends target of the generated Makefile
  (mirage/mirage#948, by @hannesm)

* make depend no longer uses opam pin for opam install --deps-only (mirage/mirage#948, by @hannesm)

* remove unused io_page configuration (initial discussion in mirage/mirage#855, mirage/mirage#940, by @hannesm)

* charrua-client requires a Mirage_random interface since 0.11.0 (mirage/mirage#938, by @hannesm)

* split implementations into separate modules (mirage/mirage#933, by @emillon)

* improved opam2 support (declare ocaml as dependency mirage/mirage#926)

* switch build system to dune (mirage/mirage#927, by @emillon)

* block device writes has been fixed in mirage-solo5.0.5.0