### PR TITLE
Fix incorrect dependency spec for piqilib.0.6.14

### DIFF
--- a/packages/piqilib/piqilib.0.6.14/opam
+++ b/packages/piqilib/piqilib.0.6.14/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 flags: light-uninstall
 conflicts: [
-    "piqi" {<= "0.7.6"}
+    "piqi" {< "0.7.6"}
 ]
 depends: [
   "ocaml" {>= "4.02.0"}


### PR DESCRIPTION
It was breaking piqi installation.