### PR TITLE
text.0.{6,7,7.1} are not safe-strings compatible

### DIFF
--- a/packages/text/text.0.6/opam
+++ b/packages/text/text.0.6/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 remove: [["ocamlfind" "remove" "text"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/text/text.0.7.1/opam
+++ b/packages/text/text.0.7.1/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "text"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/text/text.0.7/opam
+++ b/packages/text/text.0.7/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "text"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Noticed with `opam-check-all`