### PR TITLE
Package ocp-indent.1.7.0

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.7.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.7.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "contact@ocamlpro.com"
+synopsis: "A simple tool to indent OCaml programs"
+description: """
+Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
+machine ; this is much faster and more reliable than using regexps. Presets and
+configuration options available, with the possibility to set them project-wide.
+Supports most common syntax extensions, and extensible for others.
+
+Includes:
+- An indentor program, callable from the command-line or from within editors
+- Bindings for popular editors
+- A library that can be directly used by editor writers, or just for
+  fault-tolerant/approximate parsing.
+"""
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "git+https://github.com/OCamlPro/ocp-indent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name]
+]
+depends: [
+  "ocaml"
+  "dune" {build}
+  "cmdliner" {>= "1.0.0"}
+  "ocamlfind"
+  "base-bytes"
+]
+post-messages: [
+  "This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")
+  (require 'ocp-indent)
+
+* for Vim, add this line to ~/.vimrc:
+  set rtp^=\"%{share}%/ocp-indent/vim\"
+"
+  {success & !user-setup:installed}
+]
+url {
+  src: "https://github.com/OCamlPro/ocp-indent/archive/1.7.0.tar.gz"
+  checksum: [
+    "md5=3bc327e38f453f38494098725c97d2cb"
+    "sha512=5b28ae8695612c95cb0f5748de9b9f01d8ef4ad18b31340dc526ccae5fb1b6ee7e12024ff1beb817a43796183a83bca144222ca2d77d7750f2ff56108b5fa350"
+  ]
+}


### PR DESCRIPTION
### `ocp-indent.1.7.0`
A simple tool to indent OCaml programs
Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
machine ; this is much faster and more reliable than using regexps. Presets and
configuration options available, with the possibility to set them project-wide.
Supports most common syntax extensions, and extensible for others.

Includes:
- An indentor program, callable from the command-line or from within editors
- Bindings for popular editors
- A library that can be directly used by editor writers, or just for
  fault-tolerant/approximate parsing.



---
* Homepage: http://www.typerex.org/ocp-indent.html
* Source repo: git+https://github.com/OCamlPro/ocp-indent.git
* Bug tracker: https://github.com/OCamlPro/ocp-indent/issues

---
:camel: Pull-request generated by opam-publish v2.0.0