### PR TITLE
vendors FrontC under CMU BAP (#fix 12285)

### DIFF
--- a/packages/FrontC/FrontC.3.4/opam
+++ b/packages/FrontC/FrontC.3.4/opam
@@ -23,7 +23,7 @@ extra-files: [
   ["FrontC.install" "md5=c56e698d092d18179f9458f311c56412"]
 ]
 url {
-  src: "http://www.irit.fr/recherches/ARCHI/MARCH/frontc/Frontc-3.4.tgz"
-  checksum: "md5=953417daaa2647ed8df45dee3d9f19f0"
-  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/extra/Frontc-3.4.tgz"
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/V_3_4.tar.gz"
+  checksum: "md5=1abae6fff6f191ae65b0f6951c6a727c"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/extra/V_3_4.tar.gz"
 }

--- a/packages/FrontC/FrontC.3.4/opam
+++ b/packages/FrontC/FrontC.3.4/opam
@@ -25,5 +25,5 @@ extra-files: [
 url {
   src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/V_3_4.tar.gz"
   checksum: "md5=1abae6fff6f191ae65b0f6951c6a727c"
-  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/extra/V_3_4.tar.gz"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/V_3_4.tar.gz"
 }


### PR DESCRIPTION
Since FrontC is no longer hosted by the original authors and is no longer maintained we decided to vendor it under the CMU BAP platform.
The original authors were contacted, but we didn't get any response yet. Insofar as we don't receive any objections from their side we're going to continue the line of the development and will release some new versions soon.

# What we did

We imported the [mercurial repository][1] from INRIT and found a version that corresponds the most to the package that was released to OPAM. It happened to be the revision 30:e3a45506311e, made on Apr 01, 2008. We added the V_3_4 tag to and made a GitHub release.

# What we plan to do

There are 60 more commits in the trunk that didn't land into the opam repository, which we're going to release soon as 3.5. We're also going to add `-safe-strings` support so that FrontC could be used under modern versions of OCaml (that's actually is the main reason why we started the adoption process), that will be released in 3.4.1. Finally, there is some hot patching in FrontC opam packaging, which we're going to remove and probably update the build system to Dune.

# Expected failures

The package will fail in CI on newer versions of OCaml, that is expected. We will fix it in the next PR with a bumped version of the package. Our intention here is to fix the broken link first and make sure that the new archive is a closest to the original as possible.

This PR will fix #12285. See also #12284

[1]: https://www.irit.fr/hg/TRACES/frontc/3.4/