### PR TITLE
Prevents 'opam install' from proposing javalib 3.0 in the future

### DIFF
--- a/packages/sawja/sawja.1.5.4/opam
+++ b/packages/sawja/sawja.1.5.4/opam
@@ -15,7 +15,7 @@ homepage: "http://sawja.inria.fr"
 depends: [
   "ocaml" {>= "4.02"}
   "ocamlfind" {build}
-  "javalib" {>= "2.3.5"}
+  "javalib" {>= "2.3.5" & < "3.0"}
 ]
 synopsis:
   "Provide a high level representation of Java bytecode programs and static analysis tools."


### PR DESCRIPTION
- javalib 3.0 will not be compatible with this version of sawja
- a new version of sawja will be released just after javalib 3.0