### PR TITLE
Package javalib.3.0

### DIFF
--- a/packages/javalib/javalib.3.0/opam
+++ b/packages/javalib/javalib.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Nicolas Barré <nicolas.barre@irisa.fr>"
+authors: "Javalib Development team"
+homepage: "https://javalib-team.github.io/javalib/"
+bug-reports: "https://github.com/javalib-team/javalib/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/javalib-team/javalib.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "javalib"]
+depends: [
+  "ocaml" {>= "4.02"}
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "camlzip" {>= "1.05"}
+  "camlp4"
+  "extlib"
+  "camomile"
+]
+
+synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"
+
+description: """
+Thus it stands for a good starting point for people who want to
+develop static analyses for Java byte-code programs, benefiting from
+the strength of OCaml language.
+"""
+url {
+  src: "https://github.com/javalib-team/javalib/archive/v3.0.tar.gz"
+  checksum: [
+    "md5=dd84254ac8ce5d81216192c591204184"
+    "sha512=f04f7e9c13193dffa438db3a5a1e2adbdc7f1dfcd50e08bddbbece76f9f4ec4be0e74b88fb0c276b6570f149830aaec8f6a3355e2dccf561bd686178b9adbec3"
+  ]
+}


### PR DESCRIPTION
### `javalib.3.0`
Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files
Thus it stands for a good starting point for people who want to
develop static analyses for Java byte-code programs, benefiting from
the strength of OCaml language.



---
* Homepage: https://javalib-team.github.io/javalib/
* Source repo: git+https://github.com/javalib-team/javalib.git
* Bug tracker: https://github.com/javalib-team/javalib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0