### PR TITLE
Package prepare.3.0

### DIFF
--- a/packages/prepare/prepare.3.0/opam
+++ b/packages/prepare/prepare.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Nicolas Barré <nicolas.barre@irisa.fr>"
+authors: "Javalib Development team"
+homepage: "https://javalib-team.github.io/javalib/"
+bug-reports: "https://github.com/javalib-team/javalib/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/javalib-team/javalib.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "javalib"]
+depends: [
+  "ocaml" {>= "4.02"}
+  "ocamlfind" {build}
+  "camlzip" {>= "1.05"}
+  "camlp4"
+  "extlib"
+  "camomile"
+]
+
+synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"
+
+description: """
+Thus it stands for a good starting point for people who want to
+develop static analyses for Java byte-code programs, benefiting from
+the strength of OCaml language.
+"""
+url {
+  src: "https://github.com/javalib-team/javalib/archive/v3.0.tar.gz"
+  checksum: [
+    "md5=2c17f98cbca186f9ef0568cc10481346"
+    "sha512=96e7fef22d09ed8279e801ef2e31cea067a903f13d14aa8f0dcf142897466f18492f14428aec4235e5ce2cc43a75a7779964b03938cbffbf3f70e4644b5982d4"
+  ]
+}


### PR DESCRIPTION
### `prepare.3.0`
Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files
Thus it stands for a good starting point for people who want to
develop static analyses for Java byte-code programs, benefiting from
the strength of OCaml language.



---
* Homepage: https://javalib-team.github.io/javalib/
* Source repo: git+https://github.com/javalib-team/javalib.git
* Bug tracker: https://github.com/javalib-team/javalib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0