### PR TITLE
opam-ed.0.1: relax opam bound, it is compatible with 4.02.3 (at least)

### DIFF
--- a/packages/opam-ed/opam-ed.0.1/opam
+++ b/packages/opam-ed/opam-ed.0.1/opam
@@ -10,7 +10,7 @@ build: [
   "COMP=ocamlc" {!ocaml:native}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.02.3"}
   "ocamlfind"
   "cmdliner"
   "opam-file-format" {= "2.0.0~beta3"}


### PR DESCRIPTION
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>