### PR TITLE
enables support for modern compilers in FrontC

### DIFF
--- a/packages/FrontC/FrontC.3.4.1/files/FrontC.install
+++ b/packages/FrontC/FrontC.3.4.1/files/FrontC.install
@@ -1,0 +1,6 @@
+bin: [
+  "calipso/calipso"
+  "calipso/calipso_stat"
+  "ctoxml/ctoxml"
+  "printc/printc"
+]

--- a/packages/FrontC/FrontC.3.4.1/files/META
+++ b/packages/FrontC/FrontC.3.4.1/files/META
@@ -1,0 +1,5 @@
+description = "Parser for the C language"
+version = "3.4"
+requires = "unix"
+archive(byte) = "frontc.cma"
+archive(native) = "frontc.cmxa"

--- a/packages/FrontC/FrontC.3.4.1/files/META
+++ b/packages/FrontC/FrontC.3.4.1/files/META
@@ -1,5 +1,5 @@
 description = "Parser for the C language"
-version = "3.4"
+version = "3.4.1"
 requires = "unix"
 archive(byte) = "frontc.cma"
 archive(native) = "frontc.cmxa"

--- a/packages/FrontC/FrontC.3.4.1/files/opam.patch
+++ b/packages/FrontC/FrontC.3.4.1/files/opam.patch
@@ -1,0 +1,25 @@
+diff -ru FrontC.3.4/Makefile.head FrontC.3.4/Makefile.head
+--- FrontC.3.4/Makefile.head	2008-04-01 15:53:52.000000000 +0200
++++ FrontC.3.4/Makefile.head	2012-10-05 18:14:56.993802068 +0200
+@@ -84,8 +84,8 @@
+ 	$$(OCAMLC) -a $$($(1)_LDFLAGS) $$(OCAMLC_LDFLAGS) -o $$@ $$($(1)_CMO) $$(OCAMLC_LIBS)
+ 
+ _install_$(1)_CMA:
+-	install -d $(OCAML_SITE)/$(1)
+-	install $(1).cma $$($(1)_CMIO) $(OCAML_SITE)/$(1)
++	install -d $(OCAML_SITE)/FrontC
++	install $(1).cma $$($(1)_CMIO) $(OCAML_SITE)/FrontC
+ 	
+ endef
+ 
+@@ -114,8 +114,8 @@
+ 	$$(OCAMLOPT) -a $$($(1)_LDFLAGS) $$(OCAMLOPT_LDFLAGS) -o $$@ $$($(1)_CMX) $$(OCAMLOPT_LIBS)
+ 
+ _install_$(1)_CMXA:
+-	install -d $(OCAML_SITE)/$(1)
+-	install $(1).cmxa $(1).a $$($(1)_CMIX) $(OCAML_SITE)/$(1)
++	install -d $(OCAML_SITE)/FrontC
++	install $(1).cmxa $(1).a $$($(1)_CMIX) $(OCAML_SITE)/FrontC
+ 	
+ endef
+ 

--- a/packages/FrontC/FrontC.3.4.1/files/opam.patch
+++ b/packages/FrontC/FrontC.3.4.1/files/opam.patch
@@ -1,6 +1,6 @@
-diff -ru FrontC.3.4/Makefile.head FrontC.3.4/Makefile.head
---- FrontC.3.4/Makefile.head	2008-04-01 15:53:52.000000000 +0200
-+++ FrontC.3.4/Makefile.head	2012-10-05 18:14:56.993802068 +0200
+diff -ru FrontC.3.4.1/Makefile.head FrontC.3.4.1/Makefile.head
+--- FrontC.3.4.1/Makefile.head	2008-04-01 15:53:52.000000000 +0200
++++ FrontC.3.4.1/Makefile.head	2012-10-05 18:14:56.993802068 +0200
 @@ -84,8 +84,8 @@
  	$$(OCAMLC) -a $$($(1)_LDFLAGS) $$(OCAMLC_LDFLAGS) -o $$@ $$($(1)_CMO) $$(OCAMLC_LIBS)
  

--- a/packages/FrontC/FrontC.3.4.1/opam
+++ b/packages/FrontC/FrontC.3.4.1/opam
@@ -1,10 +1,11 @@
 opam-version: "2.0"
+name: "FrontC"
 version: "3.4.1"
 authors: "Hugues Cassé <casse@irit.fr>"
 homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
-maintainer: "https://github.com/BinaryAnalysisPlatform/FrontC"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 remove: [["ocamlfind" "remove" "FrontC"]]
 depends: ["ocaml" {>= "4.02.0"} "ocamlfind"]
 patches: ["opam.patch"]

--- a/packages/FrontC/FrontC.3.4.1/opam
+++ b/packages/FrontC/FrontC.3.4.1/opam
@@ -24,8 +24,8 @@ standard GNU CC attributes.
 It provides also a C pretty printer as an example of use."""
 flags: light-uninstall
 extra-files: [
-  ["opam.patch" "md5=d787e470cdf98cef4ae22d5c922f27f6"]
-  ["META" "md5=d8750391ced674a0b52c20f3aecf296c"]
+  ["opam.patch" "md5=4352830449159cb6b45de35c59a6f149"]
+  ["META" "md5=bdbf1c230e0b897a898fd35dfc4cb475"]
   ["FrontC.install" "md5=c56e698d092d18179f9458f311c56412"]
 ]
 url {

--- a/packages/FrontC/FrontC.3.4.1/opam
+++ b/packages/FrontC/FrontC.3.4.1/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 remove: [["ocamlfind" "remove" "FrontC"]]
-depends: ["ocaml" {>= "4.02.0"} "ocamlfind"]
+depends: ["ocaml" "ocamlfind"]
 patches: ["opam.patch"]
 install: [
   [make "install" "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]
@@ -30,6 +30,6 @@ extra-files: [
 ]
 url {
   src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/V_3_4_1.tar.gz"
-  checksum: "md5=143d49c4bd263bdbab06a48dc98d667a"
+  checksum: "md5=1bc3d9c7829fad9d5e0499eecd84880e"
   mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/V_3_4_1.tar.gz"
 }

--- a/packages/FrontC/FrontC.3.4.1/opam
+++ b/packages/FrontC/FrontC.3.4.1/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
-version: "3.4"
+version: "3.4.1"
 authors: "Hugues Cassé <casse@irit.fr>"
 homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
 maintainer: "https://github.com/BinaryAnalysisPlatform/FrontC"
 remove: [["ocamlfind" "remove" "FrontC"]]
-depends: ["ocaml" {< "4.06.0"} "ocamlfind"]
+depends: ["ocaml" {>= "4.02.0"} "ocamlfind"]
 patches: ["opam.patch"]
 install: [
   [make "install" "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]
@@ -28,7 +28,7 @@ extra-files: [
   ["FrontC.install" "md5=c56e698d092d18179f9458f311c56412"]
 ]
 url {
-  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/V_3_4.tar.gz"
-  checksum: "md5=1abae6fff6f191ae65b0f6951c6a727c"
-  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/V_3_4.tar.gz"
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/V_3_4_1.tar.gz"
+  checksum: "md5=143d49c4bd263bdbab06a48dc98d667a"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/V_3_4_1.tar.gz"
 }

--- a/packages/FrontC/FrontC.3.4.1/opam
+++ b/packages/FrontC/FrontC.3.4.1/opam
@@ -7,7 +7,10 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 remove: [["ocamlfind" "remove" "FrontC"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
 patches: ["opam.patch"]
 install: [
   [make "install" "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]

--- a/packages/FrontC/FrontC.3.4/opam
+++ b/packages/FrontC/FrontC.3.4/opam
@@ -1,10 +1,11 @@
 opam-version: "2.0"
+name: "FrontC"
 version: "3.4"
 authors: "Hugues Cassé <casse@irit.fr>"
 homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
-maintainer: "https://github.com/BinaryAnalysisPlatform/FrontC"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 remove: [["ocamlfind" "remove" "FrontC"]]
 depends: ["ocaml" {< "4.06.0"} "ocamlfind"]
 patches: ["opam.patch"]

--- a/packages/FrontC/FrontC.3.4/opam
+++ b/packages/FrontC/FrontC.3.4/opam
@@ -7,7 +7,10 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 remove: [["ocamlfind" "remove" "FrontC"]]
-depends: ["ocaml" {< "4.06.0"} "ocamlfind"]
+depends: [
+  "ocaml" {< "4.06.0"}
+  "ocamlfind" {build}
+]
 patches: ["opam.patch"]
 install: [
   [make "install" "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]


### PR DESCRIPTION
FrontC can now be built with a modern version of OCaml which enables safe-strings by default.