### PR TITLE
(do not merge) conf-pkg-config: add version 1.2 with setenv

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL"
+build: [
+  ["pkg-config" "--help"]
+]
+install: [
+  ["ln" "-s" "/usr/local/bin/pkgconf" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+remove: [
+  ["rm" "-f" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+setenv: PKG_CONFIG_PATH += "%{lib}%/pkgconfig:%{share}%/pkgconfig"
+depexts: [
+  ["pkg-config"] {os-distribution = "debian"}
+  ["pkg-config"] {os-distribution = "ubuntu"}
+  ["pkg-config"] {os-distribution = "archlinux"}
+  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "centos"}
+  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "rhel"}
+  ["pkgconfig"] {os-distribution = "oraclelinux"}
+  ["pkgconfig"] {os-distribution = "alpine"}
+  ["devel/pkgconf"] {os = "freebsd"}
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on pkg-config installation"
+description: """
+This package can only install if the pkg-config package is installed
+on the system."""
+flags: conf


### PR DESCRIPTION
Hi,

I believe that when `conf-pkg-config` is installed, `pkg-config` should see libraries installed by opam itself in `%{lib}%/pkgconfig`. I described the use case in ocaml/opam#3676 and the linked dune issues.

This adds a warning because it is discouraged for non-compiler packages, but it looks like this is what we want here. But I'm a bit wary since this is the only such case in the repository, so I'm curious about the opinion of the repository maintainers (cc @UnixJunkie).

As for the patch itself, this makes sure that the `PKG_CONFIG_PATH` environment variable is properly extended in the opam environment, and in particular that `pkg-config` can automatically find the libraries installed by opam itself. In addition, the post-message changelog from 1.1 is removed.

What do you think about this?

Thanks!