### PR TITLE
Add the conf-tensorflow package.

### DIFF
--- a/packages/conf-tensorflow/conf-tensorflow.0.1/opam
+++ b/packages/conf-tensorflow/conf-tensorflow.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/tensorflow-ocaml"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/tensorflow-ocaml/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    """
+test -d %{lib}%/tensorflow/libtensorflow.so ||
+  ( tar xzf libtensorflow.tar.gz &&
+    mkdir -p %{lib}%/tensorflow &&
+    cp lib/libtensorflow.so %{lib}%/tensorflow/ &&
+    cp lib/libtensorflow_framework.so %{lib}%/tensorflow/
+  )
+    """
+  ]
+]
+remove: [
+  [ "rm" "%{lib}%/tensorflow/libtensorflow.so" ]
+  [ "rm" "%{lib}%/tensorflow/libtensorflow_framework.so" ]
+]
+available: [os = "linux"]
+depends: [
+  "conf-wget" {build}
+]
+synopsis: "TensorFlow library package"
+description: """
+This is used by the tensorflow package to trigger the install of the
+TensorFlow library."""
+extra-source "libtensorflow.tar.gz" {
+  src: "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.10.0.tar.gz"
+  checksum: "md5=30fb0d167c453821ea84f8627233341a"
+}

--- a/packages/libtensorflow/libtensorflow.0.1/opam
+++ b/packages/libtensorflow/libtensorflow.0.1/opam
@@ -11,13 +11,25 @@ install: [
     "-c"
     """
 test -d %{lib}%/tensorflow/libtensorflow.so ||
-  ( tar xzf libtensorflow.tar.gz &&
+  ( tar xzf libtensorflow-linux.tar.gz &&
     mkdir -p %{lib}%/tensorflow &&
     cp lib/libtensorflow.so %{lib}%/tensorflow/ &&
     cp lib/libtensorflow_framework.so %{lib}%/tensorflow/
   )
     """
-  ]
+  ] { os = "linux" }
+  [
+    "sh"
+    "-c"
+    """
+test -d %{lib}%/tensorflow/libtensorflow.so ||
+  ( tar xzf libtensorflow-darwin.tar.gz &&
+    mkdir -p %{lib}%/tensorflow &&
+    cp lib/libtensorflow.so %{lib}%/tensorflow/ &&
+    cp lib/libtensorflow_framework.so %{lib}%/tensorflow/
+  )
+    """
+  ] { os = "macos" }
 ]
 remove: [
   [ "rm" "%{lib}%/tensorflow/libtensorflow.so" ]
@@ -31,7 +43,11 @@ synopsis: "TensorFlow library package"
 description: """
 This is used by the tensorflow package to trigger the install of the
 TensorFlow library."""
-extra-source "libtensorflow.tar.gz" {
+extra-source "libtensorflow-linux.tar.gz" {
   src: "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.10.0.tar.gz"
   checksum: "md5=30fb0d167c453821ea84f8627233341a"
+}
+extra-source "libtensorflow-darwin.tar.gz" {
+  src: "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.10.0.tar.gz"
+  checksum: "md5=402c3ac68d7467c176e64c65bf03f2e6"
 }

--- a/packages/libtensorflow/libtensorflow.0.1/opam
+++ b/packages/libtensorflow/libtensorflow.0.1/opam
@@ -35,10 +35,6 @@ remove: [
   [ "rm" "%{lib}%/tensorflow/libtensorflow.so" ]
   [ "rm" "%{lib}%/tensorflow/libtensorflow_framework.so" ]
 ]
-available: [os = "linux"]
-depends: [
-  "conf-wget" {build}
-]
 synopsis: "TensorFlow library package"
 description: """
 This is used by the tensorflow package to trigger the install of the


### PR DESCRIPTION
This PR adds a conf-tensorflow package.
This linux only packages triggers the install of the libtensorflow library. As this library is not available for most linux distributions the binaries produced by Google gets downloaded and copied to the opam lib directory.
This will be used for a new version of the tensorflow package (which has not been updated since building requires the presence of the libtensorflow shared library).