### PR TITLE
Bisect_ppx 1.4.0: coverage analysis for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.1.4.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+license: "MPL2"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "dune" {build}
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.0.3"}
+  "ppx_tools_versioned"
+
+  "ocamlfind" {dev}
+  "ounit" {dev}
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/1.4.0.tar.gz"
+  checksum: "md5=1d7990510bb53dd7ee13a5629ce2aa66"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/bisect_ppx/releases/tag/1.4.0):

> Additions
>
> - Coveralls reports with `bisect-ppx-report -coveralls ...` (aantron/bisect_ppx#176, Sam Miller).
>
> Bugs fixed
>
> - Infinite loop when unable to create `bisect*.out` files (aantron/bisect_ppx#175, reported Josh Berdine).
> - Infinite loop when source file was compiled with an absolute path (aantron/bisect_ppx#180, reported Calvin Beck).