### PR TITLE
Package opam-bundle.0.4

### DIFF
--- a/packages/opam-bundle/opam-bundle.0.4/opam
+++ b/packages/opam-bundle/opam-bundle.0.4/opam
@@ -5,14 +5,14 @@ license: "GPL-3"
 tags: "org:ocamlpro"
 homepage: "https://github.com/AltGr/opam-bundle"
 bug-reports: "https://github.com/AltGr/opam-bundle/issues"
-dev-repo: "git+https://github.com/AltGr/opam-bundle.git"
 depends: [
-  "ocaml"
-  "ocamlfind"
-  "cmdliner" {>= "1.0.0"}
-  "opam-client" {>= "2.0.0"}
+  "ocaml" {build}
+  "ocamlfind" {build}
+  "cmdliner" {build & >= "1.0.0"}
+  "opam-client" {build & >= "2.0.0"}
 ]
 build: make
+dev-repo: "git+https://github.com/AltGr/opam-bundle"
 flags: plugin
 synopsis: "A tool that creates stand-alone source bundles from opam packages"
 description: """
@@ -31,5 +31,8 @@ when needed for depexts and wrappers installation.
 """
 url {
   src: "https://github.com/AltGr/opam-bundle/archive/0.4.tar.gz"
-  checksum: "md5=588126fccd29d1f094ceee1dca13171f"
+  checksum: [
+    "md5=588126fccd29d1f094ceee1dca13171f"
+    "sha512=3e5b0a1430790bfb44aac39eabc53dbdb3f10da1f495303f547f11d5d93f43d67c5c661ecba039021fbe0110c16b32426e441348f2c7456d6d4c61c01f5c0b66"
+  ]
 }

--- a/packages/opam-bundle/opam-bundle.0.4/opam
+++ b/packages/opam-bundle/opam-bundle.0.4/opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/AltGr/opam-bundle/issues"
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}
-  "cmdliner" {build & >= "1.0.0"}
-  "opam-client" {build & >= "2.0.0"}
+  "cmdliner" {>= "1.0.0"}
+  "opam-client" {>= "2.0.0"}
 ]
 build: make
 dev-repo: "git+https://github.com/AltGr/opam-bundle"


### PR DESCRIPTION
### `opam-bundle.0.4`
A tool that creates stand-alone source bundles from opam packages
opam-bundle is a command-line tool that, given a selection of packages,
generates a .tar.gz (and optionally a self-extracting) archive containing their
sources, and everything needed to bootstrap and compile them:
- the sources of their dependencies
- the sources of the chosen version of OCaml
- the sources of opam
- a set of scripts to bootstrap, check and install external dependencies,
  compile all the above, install the packages within a sandbox, and optionally
  put wrapper scripts within your PATH

This is expected to be done as normal user, with constrained calls to `sudo`
when needed for depexts and wrappers installation.



---
* Homepage: https://github.com/AltGr/opam-bundle
* Source repo: git+https://github.com/AltGr/opam-bundle
* Bug tracker: https://github.com/AltGr/opam-bundle/issues

---
:camel: Pull-request generated by opam-publish v2.0.0