### PR TITLE
[new release] dune (1.6.0)

### DIFF
--- a/packages/dune/dune.1.6.0/opam
+++ b/packages/dune/dune.1.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-unix"
+  "base-threads"
+]
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+  "odoc" {< "1.3.0"}
+]
+
+synopsis: "Fast, portable and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+url {
+  src: "https://github.com/ocaml/dune/releases/download/1.6.0/dune-1.6.0.tbz"
+  checksum: "md5=ac99a0ece781c84117772219f5a39007"
+}


### PR DESCRIPTION
CHANGES:

- Expand variables in `install` stanzas (ocaml/dune#1354, @mseri)

- Add predicate language support for specifying sub directories. This allows the
  use globs, set operations, and special values in specifying the sub
  directories used for the build. For example: `(dirs :standard \ lib*)` will
  use all directories except those that start with `lib`. (ocaml/dune#1517, ocaml/dune#1568,
  @rgrinberg)

- Add `binaries` field to the `(env ..)` stanza. This field sets and overrides
  binaries for rules defined in a directory. (ocaml/dune#1521, @rgrinberg)

- Fix a crash caused by using an extension in a project without
  dune-project file (ocaml/dune#1535, fix ocaml/dune#1529, @diml)

- Allow `%{bin:..}`, `%{exe:..}`, and other static expansions in the `deps`
  field. (ocaml/dune#1155, fix ocaml/dune#1531, @rgrinberg)

- Fix bad interaction between on-demand ppx rewriters and using multiple build
  contexts (ocaml/dune#1545, @diml)

- Fix handling of installed .dune files when the backend is declared via a
  `dune` file (ocaml/dune#1551, fixes ocaml/dune#1549, @diml)

- Add a `--stats` command line option to record resource usage (ocaml/dune#1543, @diml)

- Fix `dune build @doc` deleting `highlight.pack.js` on rebuilds, after the
  first build (ocaml/dune#1557, @aantron).

- Allow targets to be directories, which Dune will treat opaquely
  (ocaml/dune#1547, @jordwalke)

- Support for OCaml 4.08: `List.t` is now provided by OCaml (ocaml/dune#1561, @ejgallego)

- Exclude the local esy directory (`_esy`) from the list of watched directories
  (ocaml/dune#1578, @andreypopp)

- Fix the output of `dune external-lib-deps` (ocaml/dune#1594, @diml)

- Introduce `data_only_dirs` to replace `ignored_subdirs`. `ignored_subdirs` is
  deprecated since 1.6. (ocaml/dune#1590, @rgrinberg)