### PR TITLE
Package ocaml-curses-1.0.4

### DIFF
--- a/packages/ocaml-curses-1/ocaml-curses-1.0.4/opam
+++ b/packages/ocaml-curses-1/ocaml-curses-1.0.4/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "ogunden@phauna.org"
+authors: ["Nicolas George"]
+homepage: "https://www.nongnu.org/ocaml-tmk/"
+bug-reports: "http://savannah.nongnu.org/projects/ocaml-tmk/"
+dev-repo: "git+https://git.savannah.nongnu.org/git/ocaml-tmk.git"
+build: [
+  ["./configure" "--enable-widec"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "byte"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
+]
+remove: [["ocamlfind" "remove" "curses"]]
+depends: ["ocaml" "ocamlfind"]
+depexts: [
+  ["libncurses-dev"] {os-distribution = "ubuntu"}
+  ["libncurses-dev"] {os-distribution = "debian"}
+]
+install: [make "OCAMLMAKEFILE=OCamlMakefile" "install"]
+synopsis: "Bindings to curses/ncurses"
+description: "Tools for building terminal-based user interfaces"
+flags: light-uninstall
+url {
+  src: "http://ocaml.phauna.org/distfiles/ocaml-curses-1.0.4.ogunden1.tar.gz"
+  checksum: "md5=b734aae5b9087fa482a2b283f9ace328"
+}


### PR DESCRIPTION
### `ocaml-curses-1.0.4`
Bindings to curses/ncurses
Tools for building terminal-based user interfaces



---
* Homepage: https://www.nongnu.org/ocaml-tmk/
* Source repo: git+https://git.savannah.nongnu.org/git/ocaml-tmk.git
* Bug tracker: http://savannah.nongnu.org/projects/ocaml-tmk/

---
:camel: Pull-request generated by opam-publish v2.0.0