### PR TITLE
Package aws-lambda.0.1

### DIFF
--- a/packages/aws-lambda/aws-lambda.0.1/opam
+++ b/packages/aws-lambda/aws-lambda.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Jordan Van Walleghem <j.vanwall@gmail.com>"
+authors: "Jordan Van Walleghem <j.vanwall@gmail.com>"
+homepage: "https://github.com/vanwalj/aws-lambda-ocaml"
+doc: "https://vanwalj.github.io/aws-lambda-ocaml/"
+bug-reports: "https://github.com/vanwalj/aws-lambda-ocaml/issues"
+dev-repo: "git+https://github.com/vanwalj/aws-lambda-ocaml.git"
+license: "MIT"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"
+  "dune" {build}
+  "lwt"
+  "lwt_ppx"
+  "cohttp"
+  "cohttp-lwt-unix"
+]
+
+synopsis: "Let you use ocaml as a custom runtime in AWS Lambda"
+
+description: """
+`aws-lambda-bootstrap` is a package for creating AWS Lambda handlers. 
+"""
+url {
+  src: "https://github.com/vanwalj/aws-lambda-ocaml/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=d4f595bc6dd63b407dfe7b6df7874f02"
+    "sha512=f3753bfdc1d1564a31c5f2498e51a3d5855f6fe36403a5b859f7fadd89e9455e5cb5e9c152366d293342abd9cb0b8f9fc568a00a7f96b1cce751558153fe7d3d"
+  ]
+}


### PR DESCRIPTION
### `aws-lambda.0.1`
Let you use ocaml as a custom runtime in AWS Lambda
`aws-lambda-bootstrap` is a package for creating AWS Lambda handlers.



---
* Homepage: https://github.com/vanwalj/aws-lambda-ocaml
* Source repo: git+https://github.com/vanwalj/aws-lambda-ocaml.git
* Bug tracker: https://github.com/vanwalj/aws-lambda-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0