### PR TITLE
Package aws-lambda.0.1

### DIFF
--- a/packages/aws-lambda/aws-lambda.0.1/opam
+++ b/packages/aws-lambda/aws-lambda.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jordan Van Walleghem <j.vanwall@gmail.com>"
+authors: "Jordan Van Walleghem <j.vanwall@gmail.com>"
+homepage: "https://github.com/vanwalj/aws-lambda-ocaml"
+bug-reports: "https://github.com/vanwalj/aws-lambda-ocaml/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/vanwalj/aws-lambda-ocaml.git"
+doc: "https://vanwalj.github.io/aws-lambda-ocaml/"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "lwt"
+  "lwt_ppx"
+  "cohttp"
+  "cohttp-lwt-unix"
+]
+
+synopsis: "Let you use ocaml as a custom runtime in AWS Lambda"
+url {
+  src: "https://github.com/vanwalj/aws-lambda-ocaml/archive/0.1.tar.gz"
+  checksum: [
+    "md5=ced076819a93efe3d9b9c82636dc873f"
+    "sha512=fd52d2f4bcbac96fac261cf5b2f2387e49a6b1359e5a58eeead54cc7241cf3ef2ab11b2fdcd8cd174e6167a91bded799e361ae4f2b873eae051e8f92faf6b4a5"
+  ]
+}


### PR DESCRIPTION
### `aws-lambda.0.1`
Let you use ocaml as a custom runtime in AWS Lambda



---
* Homepage: https://github.com/vanwalj/aws-lambda-ocaml
* Source repo: git+https://github.com/vanwalj/aws-lambda-ocaml.git
* Bug tracker: https://github.com/vanwalj/aws-lambda-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0