### PR TITLE
CharInfo_width 1.0.0

### DIFF
--- a/packages/charInfo_width/charInfo_width.1.0.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.0.0/opam
@@ -7,7 +7,7 @@ license: "MIT"
 dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & (switch > "4.03.0") & (switch < "999.0~")}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/charInfo_width/charInfo_width.1.0.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://bitbucket.org/zandoye/charinfo_width/"
+bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
+license: "MIT"
+dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "result"
+  "camomile" {>= "1.0.0" & < "2.0~"}
+  "dune" {build}
+  "ppx_expect" {with-test}
+]
+
+synopsis: "Determine column width for a character"
+description: """
+This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
+
+url {
+  src:"https://bitbucket.org/zandoye/charinfo_width/get/1.0.0.tar.gz"
+  checksum: "md5=999d063b7beb2f082e88d22c354a2b3b"
+}

--- a/packages/charInfo_width/charInfo_width.1.0.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.0.0/opam
@@ -7,7 +7,7 @@ license: "MIT"
 dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & (switch > "4.03.0")}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/charInfo_width/charInfo_width.1.0.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.0.0/opam
@@ -7,7 +7,7 @@ license: "MIT"
 dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & (switch > "4.03.0")}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & (switch > "4.03.0") & (switch < "999.0~")}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}


### PR DESCRIPTION
* remove the width_utext function
* add the String functor to handle all kinds of unicode strings


dune runtest will fail with OCaml 4.02 and 4.03 due to ppx issue.