### PR TITLE
[new release] ppx_yojson (0.2.0)

### DIFF
--- a/packages/ppx_yojson/ppx_yojson.0.2.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.0.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan.p.rebours@gmail.com>"
+homepage: "https://github.com/NathanReb/ppx_yojson"
+bug-reports: "https://github.com/NathanReb/ppx_yojson/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/NathanReb/ppx_yojson.git"
+doc: "https://nathanreb.github.io/ppx_yojson/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.04.2"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppxlib" {>= "0.3.0"}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test}
+]
+synopsis: "PPX extension for Yojson literals and patterns"
+authors: "Nathan Rebours <nathan.p.rebours@gmail.com>"
+url {
+  src:
+    "https://github.com/NathanReb/ppx_yojson/releases/download/0.2.0/ppx_yojson-0.2.0.tbz"
+  checksum: "md5=5f7525ef90823186e366616eaeb3f630"
+}


### PR DESCRIPTION
CHANGES:

*2018-12-04*

### Additions

- Add an extension to write Yojson patterns
- Add anti-quotations `[%y expr]` in expression extension
- Add support for `int32`, `int64` and `nativeint` payloads

### Fixes

- Improve error's loc for unsupported int literals in expression extension's payload