### PR TITLE
Fix patch files of old versions of coq and coqide

### DIFF
--- a/packages/coq/coq.8.3/files/configure.patch
+++ b/packages/coq/coq.8.3/files/configure.patch
@@ -1,5 +1,5 @@
---- configure	2014-04-14 22:28:39.174177924 +0200
-+++ configure	2014-04-14 22:29:23.253025166 +0200
+--- coq.8.3/configure	2014-04-14 22:28:39.174177924 +0200
++++ coq.8.3/configure	2014-04-14 22:29:23.253025166 +0200
 @@ -335,7 +335,7 @@
    MAKEVERSION=`$MAKE -v | head -1 | cut -d" " -f3`
    MAKEVERSIONMAJOR=`echo $MAKEVERSION | cut -d. -f1`

--- a/packages/coq/coq.8.3/opam
+++ b/packages/coq/coq.8.3/opam
@@ -24,7 +24,7 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 extra-files: [
   ["coq.install" "md5=90aa43dcd6bdeb615b19364fe1c72dfb"]
-  ["configure.patch" "md5=ceb020fc5add6f85be608671c21e78a8"]
+  ["configure.patch" "md5=57538c85ccec8ae97e06ae3b6697cf0e"]
 ]
 url {
   src: "http://coq.inria.fr/distrib/V8.3pl5/files/coq-8.3pl5.tar.gz"

--- a/packages/coq/coq.8.4pl1/files/CAML_LD_LIBRARY_PATH.patch
+++ b/packages/coq/coq.8.4pl1/files/CAML_LD_LIBRARY_PATH.patch
@@ -1,5 +1,5 @@
---- configure	2012-12-22 11:06:16.000000000 +0100
-+++ configure	2013-01-18 16:30:02.110785838 +0100
+--- coq.8.4pl1/configure	2012-12-22 11:06:16.000000000 +0100
++++ coq.8.4pl1/configure	2013-01-18 16:30:02.110785838 +0100
 @@ -887,7 +887,7 @@
      */true/*/*) COQRUNBYTEFLAGS="-dllib -lcoqrun -dllpath '$COQTOP'/kernel/byterun";;
      *)

--- a/packages/coq/coq.8.4pl1/files/configure.patch
+++ b/packages/coq/coq.8.4pl1/files/configure.patch
@@ -1,5 +1,5 @@
---- configure	2014-04-14 22:28:39.174177924 +0200
-+++ configure	2014-04-14 22:29:23.253025166 +0200
+--- coq.8.4pl1/configure	2014-04-14 22:28:39.174177924 +0200
++++ coq.8.4pl1/configure	2014-04-14 22:29:23.253025166 +0200
 @@ -335,7 +335,7 @@
    MAKEVERSION=`$MAKE -v | head -1 | cut -d" " -f3`
    MAKEVERSIONMAJOR=`echo $MAKEVERSION | cut -d. -f1`

--- a/packages/coq/coq.8.4pl1/files/coqmktop.patch
+++ b/packages/coq/coq.8.4pl1/files/coqmktop.patch
@@ -1,5 +1,5 @@
---- scripts/coqmktop.ml	2012/12/04 13:40:45	16015
-+++ scripts/coqmktop.ml	2013/01/12 19:12:14	16122
+--- coq.8.4pl1/scripts/coqmktop.ml	2012/12/04 13:40:45	16015
++++ coq.8.4pl1/scripts/coqmktop.ml	2013/01/12 19:12:14	16122
 @@ -45,8 +45,7 @@
      [ "Camlp4Top.cmo";
        "Camlp4Parsers/Camlp4OCamlRevisedParser.cmo";

--- a/packages/coq/coq.8.4pl1/opam
+++ b/packages/coq/coq.8.4pl1/opam
@@ -32,10 +32,10 @@ patches: [
 install: [make "install"]
 synopsis: "Formal proof management system"
 extra-files: [
-  ["coqmktop.patch" "md5=fb6e0a49d347feab499d32e56d219c08"]
+  ["coqmktop.patch" "md5=acae67a08b2a91d17966bee2e4ef2d00"]
   ["coq.install" "md5=90aa43dcd6bdeb615b19364fe1c72dfb"]
-  ["configure.patch" "md5=ceb020fc5add6f85be608671c21e78a8"]
-  ["CAML_LD_LIBRARY_PATH.patch" "md5=54b992d3e1d9fb7ca31bcd2d96e2cdfb"]
+  ["configure.patch" "md5=0ca3a939dc36edc33f2090be491c07e7"]
+  ["CAML_LD_LIBRARY_PATH.patch" "md5=7ae1df6a74ae04bf1471e66c35145a1c"]
 ]
 url {
   src: "http://coq.inria.fr/distrib/V8.4pl1/files/coq-8.4pl1.tar.gz"

--- a/packages/coq/coq.8.4pl2/files/CAML_LD_LIBRARY_PATH.patch
+++ b/packages/coq/coq.8.4pl2/files/CAML_LD_LIBRARY_PATH.patch
@@ -1,5 +1,5 @@
---- configure	2012-12-22 11:06:16.000000000 +0100
-+++ configure	2013-01-18 16:30:02.110785838 +0100
+--- coq.8.4pl2/configure	2012-12-22 11:06:16.000000000 +0100
++++ coq.8.4pl2/configure	2013-01-18 16:30:02.110785838 +0100
 @@ -887,7 +887,7 @@
      */true/*/*) COQRUNBYTEFLAGS="-dllib -lcoqrun -dllpath '$COQTOP'/kernel/byterun";;
      *)

--- a/packages/coq/coq.8.4pl2/files/configure.patch
+++ b/packages/coq/coq.8.4pl2/files/configure.patch
@@ -1,5 +1,5 @@
---- configure	2014-04-14 22:28:39.174177924 +0200
-+++ configure	2014-04-14 22:29:23.253025166 +0200
+--- coq.8.4pl2/configure	2014-04-14 22:28:39.174177924 +0200
++++ coq.8.4pl2/configure	2014-04-14 22:29:23.253025166 +0200
 @@ -335,7 +335,7 @@
    MAKEVERSION=`$MAKE -v | head -1 | cut -d" " -f3`
    MAKEVERSIONMAJOR=`echo $MAKEVERSION | cut -d. -f1`

--- a/packages/coq/coq.8.4pl2/opam
+++ b/packages/coq/coq.8.4pl2/opam
@@ -31,8 +31,8 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 extra-files: [
   ["coq.install" "md5=90aa43dcd6bdeb615b19364fe1c72dfb"]
-  ["configure.patch" "md5=ceb020fc5add6f85be608671c21e78a8"]
-  ["CAML_LD_LIBRARY_PATH.patch" "md5=54b992d3e1d9fb7ca31bcd2d96e2cdfb"]
+  ["configure.patch" "md5=95c231681553311984dc0eaf1611b333"]
+  ["CAML_LD_LIBRARY_PATH.patch" "md5=e4ee7ff6d89c5bc32e8392faad13584e"]
 ]
 url {
   src: "http://coq.inria.fr/distrib/V8.4pl2/files/coq-8.4pl2.tar.gz"

--- a/packages/coqide/coqide.8.4.5/files/MAKEFILE_remove_useless_for_coqide.patch
+++ b/packages/coqide/coqide.8.4.5/files/MAKEFILE_remove_useless_for_coqide.patch
@@ -1,5 +1,5 @@
---- Makefile	2012-05-29 13:22:26.000000000 +0200
-+++ Makefile	2013-04-12 19:02:49.019720957 +0200
+--- coqide.8.4.5/Makefile	2012-05-29 13:22:26.000000000 +0200
++++ coqide.8.4.5/Makefile	2013-04-12 19:02:49.019720957 +0200
 @@ -96,7 +96,7 @@
   $(strip $(foreach f, $(1), $(if $(filter $(f),$(2)),,$f)))
  endef
@@ -9,8 +9,8 @@
  export MLSTATICFILES := $(call diff, $(EXISTINGML), $(MLEXTRAFILES))
  export MLIFILES := $(sort $(GENMLIFILES) $(EXISTINGMLI))
  
---- Makefile.build	2012-10-29 15:46:37.000000000 +0100
-+++ Makefile.build	2013-04-12 18:59:45.199717036 +0200
+--- coqide.8.4.5/Makefile.build	2012-10-29 15:46:37.000000000 +0100
++++ coqide.8.4.5/Makefile.build	2013-04-12 18:59:45.199717036 +0200
 @@ -39,7 +39,8 @@
  MLFILES:=$(MLSTATICFILES) $(MLEXTRAFILES)
  
@@ -37,8 +37,8 @@
  	$(SHOW)'OCAMLC -o $@'
  	$(HIDE)$(OCAMLC) $(COQIDEFLAGS) $(BYTEFLAGS) -o $@ unix.cma threads.cma lablgtk.cma gtkThread.cmo\
  		str.cma $(COQRUNBYTEFLAGS) $(LINKIDE)
---- Makefile.common	2012-10-29 15:46:40.000000000 +0100
-+++ Makefile.common	2013-04-12 19:00:55.099718527 +0200
+--- coqide.8.4.5/Makefile.common	2012-10-29 15:46:40.000000000 +0100
++++ coqide.8.4.5/Makefile.common	2013-04-12 19:00:55.099718527 +0200
 @@ -269,7 +269,7 @@
  
  ## we now retrieve the names of .vo file to compile in */vo.itarget files

--- a/packages/coqide/coqide.8.4.5/opam
+++ b/packages/coqide/coqide.8.4.5/opam
@@ -35,7 +35,7 @@ install: [make "install-coqide"]
 synopsis: "IDE of the coq formal proof management system"
 extra-files: [
   "MAKEFILE_remove_useless_for_coqide.patch"
-  "md5=4726acb2340f2d808344f8c2a7c3b685"
+  "md5=478ed6e68fa46d00d0a6acfb53d39e52"
 ]
 url {
   src: "http://coq.inria.fr/distrib/8.4pl5/files/coq-8.4pl5.tar.gz"

--- a/packages/coqide/coqide.8.4.6/files/MAKEFILE_remove_useless_for_coqide.patch
+++ b/packages/coqide/coqide.8.4.6/files/MAKEFILE_remove_useless_for_coqide.patch
@@ -1,5 +1,5 @@
---- Makefile	2012-05-29 13:22:26.000000000 +0200
-+++ Makefile	2013-04-12 19:02:49.019720957 +0200
+--- coqide.8.4.6/Makefile	2012-05-29 13:22:26.000000000 +0200
++++ coqide.8.4.6/Makefile	2013-04-12 19:02:49.019720957 +0200
 @@ -96,7 +96,7 @@
   $(strip $(foreach f, $(1), $(if $(filter $(f),$(2)),,$f)))
  endef
@@ -9,8 +9,8 @@
  export MLSTATICFILES := $(call diff, $(EXISTINGML), $(MLEXTRAFILES))
  export MLIFILES := $(sort $(GENMLIFILES) $(EXISTINGMLI))
  
---- Makefile.build	2012-10-29 15:46:37.000000000 +0100
-+++ Makefile.build	2013-04-12 18:59:45.199717036 +0200
+--- coqide.8.4.6/Makefile.build	2012-10-29 15:46:37.000000000 +0100
++++ coqide.8.4.6/Makefile.build	2013-04-12 18:59:45.199717036 +0200
 @@ -39,7 +39,8 @@
  MLFILES:=$(MLSTATICFILES) $(MLEXTRAFILES)
  
@@ -37,8 +37,8 @@
  	$(SHOW)'OCAMLC -o $@'
  	$(HIDE)$(OCAMLC) $(COQIDEFLAGS) $(BYTEFLAGS) -o $@ unix.cma threads.cma lablgtk.cma gtkThread.cmo\
  		str.cma $(COQRUNBYTEFLAGS) $(LINKIDE)
---- Makefile.common	2012-10-29 15:46:40.000000000 +0100
-+++ Makefile.common	2013-04-12 19:00:55.099718527 +0200
+--- coqide.8.4.6/Makefile.common	2012-10-29 15:46:40.000000000 +0100
++++ coqide.8.4.6/Makefile.common	2013-04-12 19:00:55.099718527 +0200
 @@ -269,7 +269,7 @@
  
  ## we now retrieve the names of .vo file to compile in */vo.itarget files

--- a/packages/coqide/coqide.8.4.6/opam
+++ b/packages/coqide/coqide.8.4.6/opam
@@ -35,7 +35,7 @@ install: [make "install-coqide"]
 synopsis: "IDE of the coq formal proof management system"
 extra-files: [
   "MAKEFILE_remove_useless_for_coqide.patch"
-  "md5=4726acb2340f2d808344f8c2a7c3b685"
+  "md5=cf7fa3750fa80405b1f117c3c3304c63"
 ]
 url {
   src: "https://coq.inria.fr/distrib/V8.4pl6/files/coq-8.4pl6.tar.gz"

--- a/packages/coqide/coqide.8.4pl2/files/CAML_LD_LIBRARY_PATH.patch
+++ b/packages/coqide/coqide.8.4pl2/files/CAML_LD_LIBRARY_PATH.patch
@@ -1,5 +1,5 @@
---- configure	2012-12-22 11:06:16.000000000 +0100
-+++ configure	2013-01-18 16:30:02.110785838 +0100
+--- coqide.8.4pl2/configure	2012-12-22 11:06:16.000000000 +0100
++++ coqide.8.4pl2/configure	2013-01-18 16:30:02.110785838 +0100
 @@ -887,7 +887,7 @@
      */true/*/*) COQRUNBYTEFLAGS="-dllib -lcoqrun -dllpath '$COQTOP'/kernel/byterun";;
      *)

--- a/packages/coqide/coqide.8.4pl2/files/CONFIGURE_allow_make4.patch
+++ b/packages/coqide/coqide.8.4pl2/files/CONFIGURE_allow_make4.patch
@@ -2,8 +2,8 @@ $NetBSD: patch-configure,v 1.1 2013/10/26 19:44:34 asau Exp $
 
 Accept GNU Make 4 and later.
 
---- configure.orig	2013-10-26 19:28:30.000000000 +0000
-+++ configure
+--- coqide.8.4pl2/configure.orig	2013-10-26 19:28:30.000000000 +0000
++++ coqide.8.4pl2/configure
 @@ -335,7 +335,7 @@ if [ "$MAKE" != "" ]; then
    MAKEVERSION=`$MAKE -v | head -1 | cut -d" " -f3`
    MAKEVERSIONMAJOR=`echo $MAKEVERSION | cut -d. -f1`

--- a/packages/coqide/coqide.8.4pl2/files/MAKEFILE_remove_useless_for_coqide.patch
+++ b/packages/coqide/coqide.8.4pl2/files/MAKEFILE_remove_useless_for_coqide.patch
@@ -1,5 +1,5 @@
---- Makefile	2012-05-29 13:22:26.000000000 +0200
-+++ Makefile	2013-04-12 19:02:49.019720957 +0200
+--- coqide.8.4pl2/Makefile	2012-05-29 13:22:26.000000000 +0200
++++ coqide.8.4pl2/Makefile	2013-04-12 19:02:49.019720957 +0200
 @@ -96,7 +96,7 @@
   $(strip $(foreach f, $(1), $(if $(filter $(f),$(2)),,$f)))
  endef
@@ -9,8 +9,8 @@
  export MLSTATICFILES := $(call diff, $(EXISTINGML), $(MLEXTRAFILES))
  export MLIFILES := $(sort $(GENMLIFILES) $(EXISTINGMLI))
  
---- Makefile.build	2012-10-29 15:46:37.000000000 +0100
-+++ Makefile.build	2013-04-12 18:59:45.199717036 +0200
+--- coqide.8.4pl2/Makefile.build	2012-10-29 15:46:37.000000000 +0100
++++ coqide.8.4pl2/Makefile.build	2013-04-12 18:59:45.199717036 +0200
 @@ -39,7 +39,8 @@
  MLFILES:=$(MLSTATICFILES) $(MLEXTRAFILES)
  
@@ -37,8 +37,8 @@
  	$(SHOW)'OCAMLC -o $@'
  	$(HIDE)$(OCAMLC) $(COQIDEFLAGS) $(BYTEFLAGS) -o $@ unix.cma threads.cma lablgtk.cma gtkThread.cmo\
  		str.cma $(COQRUNBYTEFLAGS) $(LINKIDE)
---- Makefile.common	2012-10-29 15:46:40.000000000 +0100
-+++ Makefile.common	2013-04-12 19:00:55.099718527 +0200
+--- coqide.8.4pl2/Makefile.common	2012-10-29 15:46:40.000000000 +0100
++++ coqide.8.4pl2/Makefile.common	2013-04-12 19:00:55.099718527 +0200
 @@ -269,7 +269,7 @@
  
  ## we now retrieve the names of .vo file to compile in */vo.itarget files

--- a/packages/coqide/coqide.8.4pl2/opam
+++ b/packages/coqide/coqide.8.4pl2/opam
@@ -34,10 +34,10 @@ synopsis: "IDE of the coq formal proof management system"
 extra-files: [
   [
     "MAKEFILE_remove_useless_for_coqide.patch"
-    "md5=4726acb2340f2d808344f8c2a7c3b685"
+    "md5=0ef819341127690e51ba1ee0f73df43e"
   ]
-  ["CONFIGURE_allow_make4.patch" "md5=de289bd72e77531351acf47e3575ddc9"]
-  ["CAML_LD_LIBRARY_PATH.patch" "md5=54b992d3e1d9fb7ca31bcd2d96e2cdfb"]
+  ["CONFIGURE_allow_make4.patch" "md5=35c2acdbe16b8ffb9a9c4673026c15d0"]
+  ["CAML_LD_LIBRARY_PATH.patch" "md5=cb40fd11d27c93a077f668a15e467e7a"]
 ]
 url {
   src: "http://coq.inria.fr/distrib/V8.4pl2/files/coq-8.4pl2.tar.gz"

--- a/packages/coqide/coqide.8.4pl4/files/MAKEFILE_remove_useless_for_coqide.patch
+++ b/packages/coqide/coqide.8.4pl4/files/MAKEFILE_remove_useless_for_coqide.patch
@@ -1,5 +1,5 @@
---- Makefile	2012-05-29 13:22:26.000000000 +0200
-+++ Makefile	2013-04-12 19:02:49.019720957 +0200
+--- coqide.8.4pl4/Makefile	2012-05-29 13:22:26.000000000 +0200
++++ coqide.8.4pl4/Makefile	2013-04-12 19:02:49.019720957 +0200
 @@ -96,7 +96,7 @@
   $(strip $(foreach f, $(1), $(if $(filter $(f),$(2)),,$f)))
  endef
@@ -9,8 +9,8 @@
  export MLSTATICFILES := $(call diff, $(EXISTINGML), $(MLEXTRAFILES))
  export MLIFILES := $(sort $(GENMLIFILES) $(EXISTINGMLI))
  
---- Makefile.build	2012-10-29 15:46:37.000000000 +0100
-+++ Makefile.build	2013-04-12 18:59:45.199717036 +0200
+--- coqide.8.4pl4/Makefile.build	2012-10-29 15:46:37.000000000 +0100
++++ coqide.8.4pl4/Makefile.build	2013-04-12 18:59:45.199717036 +0200
 @@ -39,7 +39,8 @@
  MLFILES:=$(MLSTATICFILES) $(MLEXTRAFILES)
  
@@ -37,8 +37,8 @@
  	$(SHOW)'OCAMLC -o $@'
  	$(HIDE)$(OCAMLC) $(COQIDEFLAGS) $(BYTEFLAGS) -o $@ unix.cma threads.cma lablgtk.cma gtkThread.cmo\
  		str.cma $(COQRUNBYTEFLAGS) $(LINKIDE)
---- Makefile.common	2012-10-29 15:46:40.000000000 +0100
-+++ Makefile.common	2013-04-12 19:00:55.099718527 +0200
+--- coqide.8.4pl4/Makefile.common	2012-10-29 15:46:40.000000000 +0100
++++ coqide.8.4pl4/Makefile.common	2013-04-12 19:00:55.099718527 +0200
 @@ -269,7 +269,7 @@
  
  ## we now retrieve the names of .vo file to compile in */vo.itarget files

--- a/packages/coqide/coqide.8.4pl4/opam
+++ b/packages/coqide/coqide.8.4pl4/opam
@@ -35,7 +35,7 @@ install: [make "install-coqide"]
 synopsis: "IDE of the coq formal proof management system"
 extra-files: [
   "MAKEFILE_remove_useless_for_coqide.patch"
-  "md5=4726acb2340f2d808344f8c2a7c3b685"
+  "md5=f17447834f0d663923b21e5c0c188a4a"
 ]
 url {
   src: "http://coq.inria.fr/distrib/V8.4pl4/files/coq-8.4pl4.tar.gz"


### PR DESCRIPTION
The coqide files seem to have been ported to opam 2 without updating accordingly the .patch files. Indeed, opam 2 uses `patch -p1` instead of `patch -p0`, thus some paths in the .patch files needed to be prefixed.