### PR TITLE
mccs: restrain dune version

### DIFF
--- a/packages/mccs/mccs.1.1+5/opam
+++ b/packages/mccs/mccs.1.1+5/opam
@@ -8,10 +8,10 @@ homepage: "http://www.i3s.unice.fr/~cpjm/misc/"
 bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
 license: "LGPL-2.1 with OCaml linking exception, BSD-3-clause, GPL-3.0"
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
-build: ["jbuilder" "build" "-p" name]
+build: ["dune" "build" "-p" name]
 depends: [
   "ocaml"
-  "jbuilder" {build & >= "1.0+beta14"}
+  "dune" {build & (< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"

--- a/packages/mccs/mccs.1.1+6/opam
+++ b/packages/mccs/mccs.1.1+6/opam
@@ -8,10 +8,10 @@ homepage: "http://www.i3s.unice.fr/~cpjm/misc/"
 bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
 license: "LGPL-2.1 with OCaml linking exception, BSD-3-clause, GPL-3.0"
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
-build: ["jbuilder" "build" "-p" name]
+build: ["dune" "build" "-p" name]
 depends: [
   "ocaml"
-  "jbuilder" {build & >= "1.0+beta19.1"}
+  "dune" {build & (< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"

--- a/packages/mccs/mccs.1.1+8/opam
+++ b/packages/mccs/mccs.1.1+8/opam
@@ -9,13 +9,13 @@ bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
 license: "LGPL-2.1 with OCaml linking exception, BSD-3-clause, GPL-3.0"
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 build: [
-  ["jbuilder" "build" "-p" name]
-  ["sh" "-c" "jbuilder build @settests --auto-promote || true"] {with-test}
-  ["jbuilder" "runtest"] {with-test}
+  ["dune" "build" "-p" name]
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
+  ["dune" "runtest"] {with-test}
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & (< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"

--- a/packages/mccs/mccs.1.1+9/opam
+++ b/packages/mccs/mccs.1.1+9/opam
@@ -9,13 +9,13 @@ homepage: "http://www.i3s.unice.fr/~cpjm/misc/"
 bug-reports: "https://github.com/AltGr/ocaml-mccs/issues"
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & (< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
 ]
 build: [
-  ["jbuilder" "build" "-p" name]
-  ["sh" "-c" "jbuilder build @settests --auto-promote || true"] {with-test}
-  ["jbuilder" "runtest"] {with-test}
+  ["dune" "build" "-p" name]
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
+  ["dune" "runtest"] {with-test}
 ]
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 url {


### PR DESCRIPTION
Update mccs 1.1+{5-9} packages to restrain dune version (cf https://github.com/ocaml/dune/issues/734#issuecomment-444177134)
Preferably not to merge before #13089 
cc @AltGr 