### PR TITLE
add rfc7748 v1.0

### DIFF
--- a/packages/rfc7748/rfc7748.1.0/opam
+++ b/packages/rfc7748/rfc7748.1.0/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "rfc7748"
-version: "1.0"
 maintainer: ["Markus Rudy <webmaster@burgerdev.de>"]
 authors: ["Markus Rudy"]
 homepage: "https://github.com/burgerdev/ocaml-rfc7748"

--- a/packages/rfc7748/rfc7748.1.0/opam
+++ b/packages/rfc7748/rfc7748.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "rfc7748"
+version: "1.0"
+maintainer: ["Markus Rudy <webmaster@burgerdev.de>"]
+authors: ["Markus Rudy"]
+homepage: "https://github.com/burgerdev/ocaml-rfc7748"
+bug-reports: "https://github.com/burgerdev/ocaml-rfc7748/issues"
+dev-repo: "git+https://github.com/burgerdev/ocaml-rfc7748.git"
+license: "BSD"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.02" }
+  "zarith" { >= "1.5" }
+  "dune" { build & >= "1.2.1" }
+  "ounit" { with-test & >= "2.0.5" }
+]
+synopsis: "Edwards Curves X25519 and X448 from RFC 7748"
+description: """
+This library implements the ECDH functions 'X25519' and 'X448' as specified in
+RFC 7748, 'Elliptic curves for security'. In the spirit of the original
+publications, the public API is kept as simple as possible to make it easy to
+use and hard to misuse.
+
+The current version is written in plain OCaml, leveraging Zarith for integer
+arithmetic. While this makes the implementation straightforward and easy to
+reason about, the performance is nowhere near that of DJB's implementation using
+floating point registers (https://cr.yp.to/ecdh.html). """
+url {
+  src: "https://github.com/burgerdev/ocaml-rfc7748/archive/v1.0.tar.gz"
+  checksum: "md5=1f89a1d4d44ba5668d25575feca40461"
+}

--- a/packages/rfc7748/rfc7748.1.0/opam
+++ b/packages/rfc7748/rfc7748.1.0/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.02" }
+  "ocaml" { >= "4.03" }
   "zarith" { >= "1.5" }
   "dune" { build & >= "1.2.1" }
   "ounit" { with-test & >= "2.0.5" }
@@ -29,6 +29,6 @@ arithmetic. While this makes the implementation straightforward and easy to
 reason about, the performance is nowhere near that of DJB's implementation using
 floating point registers (https://cr.yp.to/ecdh.html). """
 url {
-  src: "https://github.com/burgerdev/ocaml-rfc7748/archive/v1.0.tar.gz"
-  checksum: "md5=1f89a1d4d44ba5668d25575feca40461"
+  src: "https://github.com/burgerdev/ocaml-rfc7748/archive/v1.0-rc2.tar.gz"
+  checksum: "md5=63d367245f45171feb8ee7027e0b2ace"
 }


### PR DESCRIPTION
This is the initial version of `Rfc7748`, an implementation of elliptic curves `X25519` and `X448` for ECDH.