### PR TITLE
Package parany.5.0.0

### DIFF
--- a/packages/parany/parany.5.0.0/opam
+++ b/packages/parany/parany.5.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: "Francois Berenger"
+license: "LGPL"
+homepage: "https://github.com/UnixJunkie/parany"
+bug-reports: "https://github.com/UnixJunkie/parany/issues"
+dev-repo: "git+https://github.com/UnixJunkie/parany.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "base-unix"
+  "ocamlnet"
+]
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+synopsis: "Parallelize any computation"
+description: """
+Generalized map reduce for parallel computers (not distributed computing).
+Can process in parallel an infinite stream of elements.
+
+Can process a very large file in parallel on a multicore computer;
+provided there is a way to cut your file into independent blocks
+(the 'demux' function).
+The processing function is called 'work'.
+The function gathering the results is called 'mux'.
+The number of processors running your computation in parallel is called
+'nprocs'.
+The chunk size (number of items) processed by one call to the 'work' function
+is called 'csize'.
+
+Read the corresponding ocamldoc before using.
+"""
+url {
+  src: "https://github.com/UnixJunkie/parany/archive/v5.0.0.tar.gz"
+  checksum: [
+    "md5=3ad4d567fae0b331d3a84330084458ab"
+    "sha512=7c722f2549c5ba505277b03df0954bf90b9b92afeafe26a53b73e1835b249497789a201afa91e159cdf4ca0683971ea9dd60170d010b41556d71fc50e6a9cdb5"
+  ]
+}


### PR DESCRIPTION
### `parany.5.0.0`
Parallelize any computation
Generalized map reduce for parallel computers (not distributed computing).
Can process in parallel an infinite stream of elements.

Can process a very large file in parallel on a multicore computer;
provided there is a way to cut your file into independent blocks
(the 'demux' function).
The processing function is called 'work'.
The function gathering the results is called 'mux'.
The number of processors running your computation in parallel is called
'nprocs'.
The chunk size (number of items) processed by one call to the 'work' function
is called 'csize'.

Read the corresponding ocamldoc before using.



---
* Homepage: https://github.com/UnixJunkie/parany
* Source repo: git+https://github.com/UnixJunkie/parany.git
* Bug tracker: https://github.com/UnixJunkie/parany/issues

---
:camel: Pull-request generated by opam-publish v2.0.0