### PR TITLE
Package bisec-tree.6.0.0

### DIFF
--- a/packages/bisec-tree/bisec-tree.6.0.0/opam
+++ b/packages/bisec-tree/bisec-tree.6.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "https://github.com/UnixJunkie/bisec-tree"
+bug-reports: "https://github.com/UnixJunkie/bisec-tree/issues"
+dev-repo: "git+https://github.com/UnixJunkie/bisec-tree.git"
+license: "BSD-3"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "batteries"
+  "dune" {build}
+  "unix" {with-test}
+  "dolog" {with-test}
+  "minicli" {with-test}
+]
+synopsis: "Bisector tree implementation in OCaml"
+description: """
+A bisector tree allows to do fast but exact nearest neighbor searches
+in any space provided that you can measure the
+distance between any two points in that space.
+A bisector tree also allows fast neighbor searches (range queries/
+finding all points within a given tolerance from your query point).
+Cf. this article for details:
+'A Data Structure and an Algorithm for the Nearest Point Problem';
+Iraj Kalaranti and Gerard McDonald.
+ieeexplore.ieee.org/iel5/32/35936/01703102.pdf
+"""
+url {
+  src: "https://github.com/UnixJunkie/bisec-tree/archive/v6.0.0.tar.gz"
+  checksum: [
+    "md5=e3bafda0a2b705c5cd24e0710dee9c37"
+    "sha512=4da3dab4a0dc09c1d09ff38d23e85e39171b8ce007031e8696ea7942d3abec91c3555fc98266147210518f4256a27c545fe2098acabb5a63243a84fb617850f4"
+  ]
+}


### PR DESCRIPTION
### `bisec-tree.6.0.0`
Bisector tree implementation in OCaml
A bisector tree allows to do fast but exact nearest neighbor searches
in any space provided that you can measure the
distance between any two points in that space.
A bisector tree also allows fast neighbor searches (range queries/
finding all points within a given tolerance from your query point).
Cf. this article for details:
'A Data Structure and an Algorithm for the Nearest Point Problem';
Iraj Kalaranti and Gerard McDonald.
ieeexplore.ieee.org/iel5/32/35936/01703102.pdf



---
* Homepage: https://github.com/UnixJunkie/bisec-tree
* Source repo: git+https://github.com/UnixJunkie/bisec-tree.git
* Bug tracker: https://github.com/UnixJunkie/bisec-tree/issues

---
:camel: Pull-request generated by opam-publish v2.0.0