### PR TITLE
Add upper bounds to reverse dependencies of Jane Street packages.

### DIFF
--- a/packages/charInfo_width/charInfo_width.1.0.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "result"
   "camomile" {>= "1.0.0" & < "2.0~"}
   "dune" {build}
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.12"}
 ]
 
 synopsis: "Determine column width for a character"

--- a/packages/charInfo_width/charInfo_width.1.1.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "result"
   "camomile" {>= "1.0.0" & < "2.0~"}
   "dune" {build}
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.12"}
 ]
 
 synopsis: "Determine column width for a character"

--- a/packages/obeam/obeam.0.1.0/opam
+++ b/packages/obeam/obeam.0.1.0/opam
@@ -9,15 +9,15 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "base"          {>= "v0.11.0"}
-  "stdio"         {>= "v0.11.0"}
+  "base"          {>= "v0.11.0" & < "v0.12"}
+  "stdio"         {>= "v0.11.0" & < "v0.12"}
   "bitstring"     {>= "3.0.0"}
   "camlzip"       {>= "1.07"}
   "zarith"        {>= "1.7"}
   "dune"          {build}
-  "ppx_here"
-  "ppx_let"
-  "ppx_sexp_conv"
+  "ppx_here"      {< "v0.12"}
+  "ppx_let"       {< "v0.12"}
+  "ppx_sexp_conv" {< "v0.12"}
   "bisect_ppx"    {build}
   "ounit"         {with-test}
 ]

--- a/packages/obeam/obeam.0.1.1/opam
+++ b/packages/obeam/obeam.0.1.1/opam
@@ -6,17 +6,17 @@ license: "Boost License Version 1.0"
 homepage: "https://github.com/yutopp/obeam"
 bug-reports: "https://github.com/yutopp/obeam/issues"
 depends: [
-  "base" {>= "v0.11.0"}
-  "stdio" {>= "v0.11.0"}
+  "base" {>= "v0.11.0" & < "v0.12"}
+  "stdio" {>= "v0.11.0" & < "v0.12"}
   "bitstring" {>= "3.0.0"}
   "camlzip" {>= "1.07"}
   "zarith" {>= "1.7"}
-  "ppx_here" {>= "v0.11.0"}
-  "ppx_let" {>= "v0.11.0"}
-  "ppx_sexp_conv" {>= "v0.11.2"}
+  "ppx_here" {>= "v0.11.0" & < "v0.12"}
+  "ppx_let" {>= "v0.11.0" & < "v0.12"}
+  "ppx_sexp_conv" {>= "v0.11.2" & < "v0.12"}
   "dune" {build}
   "bisect_ppx" {build}
-  "expect_test_helpers_kernel" {with-test}
+  "expect_test_helpers_kernel" {with-test & < "v0.12"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/yutopp/obeam.git"


### PR DESCRIPTION
Follow-up to https://github.com/ocaml/opam-repository/pull/13010 and https://github.com/ocaml/opam-repository/pull/13016.