### PR TITLE
Package landmarks.1.3

### DIFF
--- a/packages/landmarks/landmarks.1.3/opam
+++ b/packages/landmarks/landmarks.1.3/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Marc Lasson <marc.lasson@lexifi.com>"
+authors: "Marc Lasson <marc.lasson@lexifi.com>"
+homepage: "http://lexifi.github.io/landmarks/"
+bug-reports: "https://github.com/LexiFi/landmarks/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/LexiFi/landmarks.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: ["dune" "runtest" "-p" name]
+depends: [
+  "ocaml" { >= "4.02" }
+  "ocaml-migrate-parsetree"
+  "dune" {build & >= "1.4"}
+]
+
+synopsis: "A simple profiling library"
+description: """
+Landmarks is a simple profiling library for OCaml. It provides primitives to
+measure time spent in portion of instrumented code. The instrumentation of the
+code may either done by hand, automatically or semi-automatically using a PPX
+extension.
+"""


### PR DESCRIPTION
### `landmarks.1.3`
A simple profiling library
Landmarks is a simple profiling library for OCaml. It provides primitives to
measure time spent in portion of instrumented code. The instrumentation of the
code may either done by hand, automatically or semi-automatically using a PPX
extension.



---
* Homepage: http://lexifi.github.io/landmarks/
* Source repo: git+https://github.com/LexiFi/landmarks.git
* Bug tracker: https://github.com/LexiFi/landmarks/issues

---
:camel: Pull-request generated by opam-publish v2.0.0