### PR TITLE
Add osx-secure-transport.0.1.1

### DIFF
--- a/packages/osx-secure-transport/osx-secure-transport.0.1.0/opam
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.0/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "osx-secure-transport"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06.0"}
   "ctypes" {>= "0.4"}
   "ctypes-foreign"
   "ocamlfind" {build}

--- a/packages/osx-secure-transport/osx-secure-transport.0.1.1/desr
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.1/desr
@@ -1,0 +1,1 @@
+macos/ios SecureTransport TLS OSX implementation API for OCaml

--- a/packages/osx-secure-transport/osx-secure-transport.0.1.1/desr
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.1/desr
@@ -1,1 +1,0 @@
-macos/ios SecureTransport TLS OSX implementation API for OCaml

--- a/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "Romain Beauxis <toots@rastageeks.org>"
+homepage: "https://github.com/toots/ocaml-osx-secure-transport"
+bug-reports: "https://github.com/toots/ocaml-osx-secure-transport/issues"
+license: "WTFPL"
+dev-repo: "git+https://github.com/toots/ocaml-osx-secure-transport.git"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "osx-secure-transport"]
+]
+depends: [
+  "ocaml"
+  "ctypes" {>= "0.4"}
+  "ctypes-foreign"
+  "ocamlfind" {build}
+]
+available: os = "macos"
+synopsis: "macos/ios SecureTransport TLS OSX implementation API for OCaml"
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/toots/ocaml-osx-secure-transport/releases/download/0.1.1/osx-secure-transport-0.1.1.tar.gz"
+  checksum: "md5=3d2579d654444026b68d0217baccf3b8"
+}

--- a/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
@@ -6,18 +6,14 @@ bug-reports: "https://github.com/toots/ocaml-osx-secure-transport/issues"
 license: "WTFPL"
 dev-repo: "git+https://github.com/toots/ocaml-osx-secure-transport.git"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
-  ["ocaml" "setup.ml" "-build"]
-]
-install: ["ocaml" "setup.ml" "-install"]
-remove: [
-  ["ocamlfind" "remove" "osx-secure-transport"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml"
   "ctypes" {>= "0.4"}
   "ctypes-foreign"
   "ocamlfind" {build}
+  "dune" {build}
 ]
 available: os = "macos"
 synopsis: "macos/ios SecureTransport TLS OSX implementation API for OCaml"
@@ -25,5 +21,5 @@ flags: light-uninstall
 url {
   src:
     "https://github.com/toots/ocaml-osx-secure-transport/releases/download/0.1.1/osx-secure-transport-0.1.1.tar.gz"
-  checksum: "md5=bb54beb12ee78ace4f386647727fff80"
+  checksum: "md5=5b943b0c2120abdfb4e6022d2e64f06e"
 }

--- a/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
@@ -25,5 +25,5 @@ flags: light-uninstall
 url {
   src:
     "https://github.com/toots/ocaml-osx-secure-transport/releases/download/0.1.1/osx-secure-transport-0.1.1.tar.gz"
-  checksum: "md5=3d2579d654444026b68d0217baccf3b8"
+  checksum: "md5=bb54beb12ee78ace4f386647727fff80"
 }

--- a/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml"
   "ctypes" {>= "0.4"}
   "ctypes-foreign"
-  "ocamlfind" {build}
   "dune" {build}
 ]
 available: os = "macos"

--- a/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
+++ b/packages/osx-secure-transport/osx-secure-transport.0.1.1/opam
@@ -17,7 +17,6 @@ depends: [
 ]
 available: os = "macos"
 synopsis: "macos/ios SecureTransport TLS OSX implementation API for OCaml"
-flags: light-uninstall
 url {
   src:
     "https://github.com/toots/ocaml-osx-secure-transport/releases/download/0.1.1/osx-secure-transport-0.1.1.tar.gz"


### PR DESCRIPTION
Previous release did not build with OCaml compilers where `string <> bytes`.