### PR TITLE
[new release] landmarks (1.3)

### DIFF
--- a/packages/landmarks/landmarks.1.3/opam
+++ b/packages/landmarks/landmarks.1.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "landmarks"
+version: "1.3"
+
+maintainer: "Marc Lasson <marc.lasson@lexifi.com>"
+authors: "Marc Lasson <marc.lasson@lexifi.com>"
+homepage: "https://lexifi.github.io/landmarks/"
+bug-reports: "https://github.com/LexiFi/landmarks/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/LexiFi/landmarks.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+doc: "http://lexifi.github.io/landmarks/"
+run-test: ["dune" "runtest" "-p" name]
+depends: [
+  "ocaml" { >= "4.02" }
+  "ocaml-migrate-parsetree"
+  "dune" {build & >= "1.4"}
+]
+
+synopsis: "A simple profiling library"
+description: """
+Landmarks is a simple profiling library for OCaml. It provides primitives to
+measure time spent in portion of instrumented code. The instrumentation of the
+code may either done by hand, automatically or semi-automatically using a PPX
+extension.
+"""
+url {
+  src:
+    "https://github.com/lexifi/landmarks/releases/download/v1.3/landmarks-v1.3.tbz"
+  checksum: "md5=b8804e724e265fe9192e0403fcfd0ac8"
+}

--- a/packages/landmarks/landmarks.1.3/opam
+++ b/packages/landmarks/landmarks.1.3/opam
@@ -1,7 +1,4 @@
 opam-version: "2.0"
-name: "landmarks"
-version: "1.3"
-
 maintainer: "Marc Lasson <marc.lasson@lexifi.com>"
 authors: "Marc Lasson <marc.lasson@lexifi.com>"
 homepage: "https://lexifi.github.io/landmarks/"

--- a/packages/landmarks/landmarks.1.3/opam
+++ b/packages/landmarks/landmarks.1.3/opam
@@ -29,5 +29,5 @@ extension.
 url {
   src:
     "https://github.com/lexifi/landmarks/releases/download/v1.3/landmarks-v1.3.tbz"
-  checksum: "md5=b8804e724e265fe9192e0403fcfd0ac8"
+  checksum: "md5=92e0f9442d8ea91915bee492b1bb1655"
 }


### PR DESCRIPTION
A simple profiling library

- Project page: <a href="https://lexifi.github.io/landmarks/">https://lexifi.github.io/landmarks/</a>
- Documentation: <a href="http://lexifi.github.io/landmarks/">http://lexifi.github.io/landmarks/</a>

##### CHANGES:

* migrate from jbuilder to dune
* migrate to opam 2.0
* adds two new primitives: push/pop_profiling_state
* prepare migration for Pervasives deprecation
* redefine 'Stdlib.raise' in the 'Landmark' to allow using landmark with -no-stdlib (as 'raise' is used to wrap exception in the generated code).
