### PR TITLE
Add a libtorch package.

### DIFF
--- a/packages/libtorch/libtorch.1.0.0/opam
+++ b/packages/libtorch/libtorch.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-torch"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-torch/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    """
+test -d %{lib}%/libtorch/lib/libtorch.so ||
+  ( unzip libtorch-linux.zip &&
+    mv -f libtorch %{lib}%/
+  )
+    """
+  ] { os = "linux" }
+  [
+    "sh"
+    "-c"
+    """
+test -d %{lib}%/libtorch/lib/libtorch.so ||
+  ( unzip libtorch-macos.zip &&
+    mv -f libtorch %{lib}%/
+  )
+    """
+  ] { os = "macos" }
+]
+remove: [
+  [ "rm" "-Rf" "%{lib}%/libtorch" ]
+]
+synopsis: "LibTorch library package"
+description: """
+This is used by the torch package to trigger the install of the
+libtorch library."""
+extra-source "libtorch-linux.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.0.0.zip"
+  checksum: "md5=0b9e7a3da5da473760709dbf84c292dc"
+}
+extra-source "libtorch-macos.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip"
+  checksum: "md5=82f52647daa39c189a573115d440d09d"
+}


### PR DESCRIPTION
This is similar to #13046 but for libtorch. This package just downloads and extracts pre-built binaries for libtorch 1.0.0. This will be used as a dependency by the torch package based on [ocaml-torch](https://github.com/LaurentMazare/ocaml-torch).

One current limitation is that both the linux and macos binaries are downloaded as I'm not sure how to apply a filter to extra-source.

