### PR TITLE
stdcompat.8

### DIFF
--- a/packages/stdcompat/stdcompat.8/opam
+++ b/packages/stdcompat/stdcompat.8/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+version: "8"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+license: "BSD"
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depopts: [ "result" "seq" "uchar" ]
+synopsis: "Compatibility module for OCaml standard library"
+description: "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+depends: [
+  "ocaml" {>= "3.07" & < "4.09.0"}
+]
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/8/stdcompat-8.tar.gz"
+  checksum: "md5=ed0d166d07579e46b0651fe44c19a548"
+}

--- a/packages/stdcompat/stdcompat.8/opam
+++ b/packages/stdcompat/stdcompat.8/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "8"
 maintainer: "Thierry Martinez <martinez@nsup.org>"
 authors: "Thierry Martinez <martinez@nsup.org>"
 homepage: "https://github.com/thierry-martinez/stdcompat"


### PR DESCRIPTION
- Fix: module Fun was not exported

- Fix: value Stdlib.protect was not exported

- Fix: equality between aliases of Stdlib.result and of Seq.t

- Fix: Stdlib.result redefined before 4.03 (instead of 4.06)