### PR TITLE
fix opensuse metadata for packages

### DIFF
--- a/packages/alsa/alsa.0.2.3/opam
+++ b/packages/alsa/alsa.0.2.3/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["alsa-lib-devel"] {os-distribution = "centos"}
   ["alsa-lib-devel"] {os-distribution = "fedora"}
-  ["alsa-lib-devel"] {os-distribution = "opensuse"}
+  ["alsa-lib-devel"] {os-family = "suse"}
   ["libasound2-dev"] {os-distribution = "debian"}
   ["libasound2-dev"] {os-distribution = "ubuntu"}
 ]

--- a/packages/ao/ao.0.2.1/opam
+++ b/packages/ao/ao.0.2.1/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["libao-devel"] {os-distribution = "centos"}
   ["libao-devel"] {os-distribution = "fedora"}
-  ["libao-devel"] {os-distribution = "opensuse"}
+  ["libao-devel"] {os-family = "suse"}
   ["libao"] {os = "macos" & os-distribution = "homebrew"}
   ["libao-dev"] {os-distribution = "debian"}
   ["libao-dev"] {os-distribution = "ubuntu"}

--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -9,7 +9,7 @@ depexts: [
   ["automake"] {os-distribution = "alpine"}
   ["automake"] {os-distribution = "centos"}
   ["automake"] {os-distribution = "fedora"}
-  ["automake"] {os-distribution = "opensuse"}
+  ["automake"] {os-family = "suse"}
   ["automake"] {os-distribution = "debian"}
   ["automake"] {os-distribution = "ubuntu"}
   ["automake"] {os-distribution = "nixos"}

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["blas-devel"] {os-distribution = "fedora"}
   ["blas-devel"] {os-distribution = "rhel"}
   ["lapack-dev"] {os-distribution = "alpine"}
-  ["blas-devel"] {os-distribution = "opensuse"}
+  ["blas-devel"] {os-family = "suse"}
   ["blas" "gcc"] {os = "freebsd"}
 ]
 synopsis: "Virtual package for BLAS configuration"

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["boost-devel"] {os-distribution = "oraclelinux"}
   ["boost-devel"] {os-distribution = "centos"}
   ["boost-devel"] {os-distribution = "rhel"}
-  ["boost-devel"] {os-distribution = "opensuse"}
+  ["boost-devel"] {os-family = "suse"}
   ["boost"] {os-distribution = "archlinux"}
   ["boost"] {os = "macos" & os-distribution = "homebrew"}
   ["boost-all"] {os = "freebsd"}

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libcairo-devel"] {os-distribution = "mageia"}
   ["cairo" "cairo-devel"] {os-distribution = "centos"}
   ["cairo-devel"] {os-distribution = "fedora"}
-  ["cairo-devel"] {os-distribution = "opensuse"}
+  ["cairo-devel"] {os-family = "suse"}
   ["cairo-dev"] {os-distribution = "alpine"}
   ["graphics/cairo"] {os = "freebsd"}
   ["graphics/cairo"] {os = "openbsd"}

--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -20,7 +20,7 @@ depexts: [
   ["capnproto"] {os-distribution = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}
-  ["capnproto"] {os-distribution = "opensuse"}
+  ["capnproto"] {os-family = "suse"}
   ["capnproto" "libcapnp-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on captnproto installation"

--- a/packages/conf-emacs/conf-emacs.1/opam
+++ b/packages/conf-emacs/conf-emacs.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["emacs-nox"] {os-distribution = "rhel"}
   ["emacs-nox"] {os-distribution = "fedora"}
   ["emacs-nox"] {os-distribution = "alpine"}
-  ["emacs-nox"] {os-distribution = "opensuse"}
+  ["emacs-nox"] {os-family = "suse"}
   ["emacs-nox"] {os-distribution = "oraclelinux"}
 ]
 synopsis: "Virtual package to install the Emacs editor"

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["fftw-devel"] {os-distribution = "fedora"}
   ["fftw-devel"] {os-distribution = "rhel"}
   ["libfftw-devel"] {os-distribution = "mageia"}
-  ["fftw3-devel"] {os-distribution = "opensuse"}
+  ["fftw3-devel"] {os-family = "suse"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
   ["fftw"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["freetype-devel"] {os-distribution = "fedora"}
   ["freetype-devel"] {os-distribution = "rhel"}
   ["libfreetype2-devel"] {os-distribution = "mageia"}
-  ["freetype2-devel"] {os-distribution = "opensuse"}
+  ["freetype2-devel"] {os-family = "suse"}
   ["print/freetype2"] {os = "freebsd"}
   ["print/freetype2"] {os = "openbsd"}
   ["freetype"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -9,7 +9,7 @@ depends: ["conf-which" {build}]
 depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
   ["gcc-c++"] {os-distribution = "fedora"}
-  ["gcc-c++"] {os-distribution = "opensuse"}
+  ["gcc-c++"] {os-family = "suse"}
   ["g++"] {os-distribution = "debian"}
   ["g++"] {os-distribution = "ubuntu"}
   ["gcc"] {os-distribution = "nixos"}

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -11,7 +11,7 @@ depends: [
 depexts: [
   ["git"] {os-distribution = "centos"}
   ["git"] {os-distribution = "fedora"}
-  ["git"] {os-distribution = "opensuse"}
+  ["git"] {os-family = "suse"}
   ["git"] {os-distribution = "debian"}
   ["git"] {os-distribution = "ubuntu"}
   ["git"] {os-distribution = "nixos"}

--- a/packages/conf-glfw3/conf-glfw3.1/opam
+++ b/packages/conf-glfw3/conf-glfw3.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["glfw-devel"] {os-distribution = "rhel"}
   ["glfw-devel"] {os-distribution = "fedora"}
   ["glfw-dev"] {os-distribution = "alpine"}
-  ["libglfw-devel"] {os-distribution = "opensuse"}
+  ["libglfw-devel"] {os-family = "suse"}
   ["libglfw-devel"] {os-distribution = "mageia"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -16,7 +16,7 @@ depexts: [
   ["glfw-devel"] {os-distribution = "rhel"}
   ["glfw-devel"] {os-distribution = "fedora"}
   ["glfw-dev"] {os-distribution = "alpine"}
-  ["libglfw-devel"] {os-distribution = "opensuse"}
+  ["libglfw-devel"] {os-family = "suse"}
   ["libglfw-devel"] {os-distribution = "mageia"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-glpk/conf-glpk.1/opam
+++ b/packages/conf-glpk/conf-glpk.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["glpk"] {os-distribution = "fedora"}
   ["glpk"] {os-distribution = "centos"}
   ["glpk"] {os-distribution = "rhel"}
-  ["glpk"] {os-distribution = "opensuse"}
+  ["glpk"] {os-family = "suse"}
   ["glpk"] {os-distribution = "archlinux"}
   ["glpk"] {os-distribution = "homebrew"}
 ]

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -20,7 +20,7 @@ depexts: [
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}
   ["gmp-dev"] {os-distribution = "alpine"}
-  ["gmp-devel"] {os-distribution = "opensuse"}
+  ["gmp-devel"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on a GMP lib system installation"
 description:

--- a/packages/conf-gnuplot/conf-gnuplot.0.1/opam
+++ b/packages/conf-gnuplot/conf-gnuplot.0.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["gnuplot"] {os-distribution = "fedora"}
   ["gnuplot"] {os = "macos" & os-distribution = "homebrew"}
   ["gnuplot"] {os-distribution = "alpine"}
-  ["gnuplot"] {os-distribution = "opensuse"}
+  ["gnuplot"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on gnuplot installation"
 description: """

--- a/packages/conf-gsl/conf-gsl.1/opam
+++ b/packages/conf-gsl/conf-gsl.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["gsl-devel"] {os-distribution = "fedora"}
   ["gsl-devel"] {os-distribution = "rhel"}
   ["gsl-dev"] {os-distribution = "alpine"}
-  ["gsl-devel"] {os-distribution = "opensuse"}
+  ["gsl-devel"] {os-family = "suse"}
   ["gsl"] {os = "freebsd"}
   ["gsl"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -13,7 +13,7 @@ depexts: [
   ["gtk3-devel"] {os-distribution = "fedora"}
   ["gtk3-devel"] {os-distribution = "oraclelinux"}
   ["gtk+3.0-dev"] {os-distribution = "alpine"}
-  ["gtk3-devel"] {os-distribution = "opensuse"}
+  ["gtk3-devel"] {os-family = "suse"}
 ]
 post-messages: [
   "This package requires gtk+ 3.0 development packages installed on your system"

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -14,7 +14,7 @@ depexts: [
   ["gtksourceview2-devel"] {os-distribution = "fedora"}
   ["gtksourceview2"] {os = "freebsd"}
   ["gtksourceview"] {os = "openbsd"}
-  ["gtksourceview2-devel"] {os-distribution = "opensuse"}
+  ["gtksourceview2-devel"] {os-family = "suse"}
   ["libgtksourceview2.0-dev"] {os-distribution = "ubuntu"}
   ["gtksourceview" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -14,7 +14,7 @@ depexts: [
   ["gtksourceview3-devel"] {os-distribution = "fedora"}
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
-  ["gtksourceview3-devel"] {os-distribution = "opensuse"}
+  ["gtksourceview3-devel"] {os-family = "suse"}
   ["libgtksourceview-3.0-dev"] {os-distribution = "ubuntu"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["lapack-devel"] {os-distribution = "fedora"}
   ["lapack-devel"] {os-distribution = "rhel"}
   ["lapack-dev"] {os-distribution = "alpine"}
-  ["lapack-devel"] {os-distribution = "opensuse"}
+  ["lapack-devel"] {os-family = "suse"}
   ["lapack" "gcc"] {os = "freebsd"}
 ]
 synopsis: "Virtual package for LAPACK configuration"

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["curl"] {os-distribution = "nixos"}
   ["curl"] {os-distribution = "archlinux"}
   ["curl-dev"] {os-distribution = "alpine"}
-  ["libcurl-devel"] {os-distribution = "opensuse"}
+  ["libcurl-devel"] {os-family = "suse"}
   ["libcurl-devel"] {os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on a libcurl system installation"

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libev-devel"] {os-distribution = "fedora"}
   ["libev-devel"] {os-distribution = "rhel"}
   ["libev-devel"] {os-distribution = "centos"}
-  ["libev-devel"] {os-distribution = "opensuse"}
+  ["libev-devel"] {os-family = "suse"}
   ["libev"] {os = "freebsd"}
   ["libev"] {os = "openbsd"}
   ["libev"] {os-distribution = "archlinux"}

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["lz4-devel"] {os-distribution = "rhel"}
   ["lz4-devel"] {os-distribution = "fedora"}
   ["lz4-dev"] {os-distribution = "alpine"}
-  ["liblz4-devel"] {os-distribution = "opensuse"}
+  ["liblz4-devel"] {os-family = "suse"}
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on liblz4 system installation"

--- a/packages/conf-libpcre/conf-libpcre.1/opam
+++ b/packages/conf-libpcre/conf-libpcre.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["pcre-devel"] {os-distribution = "fedora"}
   ["pcre-devel"] {os-distribution = "rhel"}
   ["pcre-dev"] {os-distribution = "alpine"}
-  ["pcre-devel"] {os-distribution = "opensuse"}
+  ["pcre-devel"] {os-family = "suse"}
   ["pcre"] {os = "freebsd"}
   ["pcre"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -8,7 +8,7 @@ build: [["ls" "/usr/include/linux/stddef.h"]]
 depexts: [
   ["linux-libc-dev"] {os-distribution = "debian"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
-  ["linux-glibc-devel"] {os-distribution = "opensuse"}
+  ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/conf-llvm/conf-llvm.4.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.4.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["llvm-4.0-dev"] {os-distribution = "debian"}
   ["llvm-4.0-dev"] {os-distribution = "ubuntu"}
   ["llvm4"] {os-distribution = "alpine"}
-  ["llvm4"] {os-distribution = "opensuse"}
+  ["llvm4"] {os-family = "suse"}
   ["devel/llvm40"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.5.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.5.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["llvm-5.0-dev"] {os-distribution = "debian"}
   ["llvm-5.0-dev"] {os-distribution = "ubuntu"}
   ["llvm5"] {os-distribution = "alpine"}
-  ["llvm5"] {os-distribution = "opensuse"}
+  ["llvm5"] {os-family = "suse"}
   ["devel/llvm50"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["llvm-6.0-dev"] {os-distribution = "debian"}
   ["llvm-6.0-dev"] {os-distribution = "ubuntu"}
   ["llvm6"] {os-distribution = "alpine"}
-  ["llvm6"] {os-distribution = "opensuse"}
+  ["llvm6"] {os-family = "suse"}
   ["devel/llvm60"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.7.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.7.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["llvm-7-dev"] {os-distribution = "debian"}
   ["llvm-7-dev"] {os-distribution = "ubuntu"}
   ["llvm7"] {os-distribution = "alpine"}
-  ["llvm7"] {os-distribution = "opensuse"}
+  ["llvm7"] {os-family = "suse"}
   ["devel/llvm70"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["m4"] {os-distribution = "centos"}
   ["m4"] {os-distribution = "alpine"}
   ["m4"] {os-distribution = "nixos"}
-  ["m4"] {os-distribution = "opensuse"}
+  ["m4"] {os-family = "suse"}
   ["m4"] {os-distribution = "oraclelinux"}
   ["m4"] {os-distribution = "archlinux"}
 ]

--- a/packages/conf-mpfr/conf-mpfr.1/opam
+++ b/packages/conf-mpfr/conf-mpfr.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["mpfr"] {os = "openbsd"}
   ["mpfr-dev"] {os-distribution = "alpine"}
   ["mpfr-devel"] {os-distribution = "centos"}
-  ["mpfr-devel"] {os-distribution = "opensuse"}
+  ["mpfr-devel"] {os-family = "suse"}
 ]
 depends: ["conf-gmp"]
 synopsis: "Virtual package relying on library MPFR installation"

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["mpi-default-dev"] {os-distribution = "ubuntu"}
   ["openmpi-devel"] {os-distribution = "centos"}
   ["openmpi-devel"] {os-distribution = "fedora"}
-  ["openmpi"] {os-distribution = "opensuse"}
+  ["openmpi"] {os-family = "suse"}
   ["openmpi"] {os-distribution = "archlinux"}
   ["openmpi-dev"] {os-distribution = "alpine"}
   ["openmpi"] {os = "freebsd"}

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["ncurses-devel"] {os-distribution = "oraclelinux"}
   ["ncurses-devel"] {os-distribution = "centos"}
   ["ncurses-devel"] {os-distribution = "rhel"}
-  ["ncurses-devel"] {os-distribution = "opensuse"}
+  ["ncurses-devel"] {os-family = "suse"}
   ["ncurses"] {os-distribution = "archlinux"}
 ]
 available: os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"

--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libsnmp-dev"] {os-distribution = "ubuntu"}
   ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "centos"}
   ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "fedora"}
-  ["libsnmp30" "net-snmp-devel"] {os-distribution = "opensuse"}
+  ["libsnmp30" "net-snmp-devel"] {os-family = "suse"}
   ["net-snmp-libs" "net-snmp-dev"] {os-distribution = "alpine"}
   [] {os = "freebsd"}
   [] {os = "openbsd"}

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -19,7 +19,7 @@ depexts: [
   ["npm5"] {os-distribution = "macports" & os = "macos"}
   ["nodejs"] {os = "netbsd"}
   ["node"] {os = "openbsd"}
-  ["npm"] {os-distribution = "opensuse"}
+  ["npm"] {os-family = "suse"}
   ["npm"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on npm installation"

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libnuma-dev"] {os-distribution = "ubuntu"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "centos"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "fedora"}
-  ["libnuma-devel"] {os-distribution = "opensuse"}
+  ["libnuma-devel"] {os-family = "suse"}
   ["libnuma-dev"] {os-distribution = "alpine"}
 ]
 available: os != "macos" & os != "freebsd" & os != "openbsd"

--- a/packages/conf-openblas/conf-openblas.0.2.0/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.0/opam
@@ -21,7 +21,7 @@ depexts: [
   ["libopenblas-dev" "liblapacke-dev"] {os-distribution = "debian"}
   ["libopenblas-dev" "liblapacke-dev"] {os-distribution = "ubuntu"}
   ["openblas-devel"] {os-distribution = "fedora"}
-  ["openblas-devel"] {os-distribution = "opensuse"}
+  ["openblas-devel"] {os-family = "suse"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package to install OpenBLAS and LAPACKE"

--- a/packages/conf-opencc0/conf-opencc0.1/opam
+++ b/packages/conf-opencc0/conf-opencc0.1/opam
@@ -16,7 +16,7 @@ build: [
 depexts: [
   ["libopencc1"] {os-distribution = "debian"}
   ["libopencc1"] {os-distribution = "ubuntu"}
-  ["libopencc1"] {os-distribution = "opensuse"}
+  ["libopencc1"] {os-family = "suse"}
 ]
 
 post-messages: [

--- a/packages/conf-opencc1/conf-opencc1.1/opam
+++ b/packages/conf-opencc1/conf-opencc1.1/opam
@@ -16,7 +16,7 @@ build: [
 depexts: [
   ["libopencc2"] {os-distribution = "debian"}
   ["libopencc2"] {os-distribution = "ubuntu"}
-  ["libopencc2"] {os-distribution = "opensuse"}
+  ["libopencc2"] {os-family = "suse"}
   ["opencc"] {os-distribution = "archlinux"}
   ["app-i18n/opencc"] {os-distribution = "gentoo"}
   ["opencc"] {os-distribution = "fedora"}

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["libressl-dev"] {os-distribution = "alpine"}
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "archlinux"}
-  ["libopenssl-devel"] {os-distribution = "opensuse"}
+  ["libopenssl-devel"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on an OpenSSL system installation"
 description:

--- a/packages/conf-pandoc/conf-pandoc.0.1/opam
+++ b/packages/conf-pandoc/conf-pandoc.0.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["pandoc" "epel-release"] {os-distribution = "centos"}
   ["pandoc"] {os-distribution = "fedora"}
   ["pandoc"] {os = "macos" & os-distribution = "homebrew"}
-  ["pandoc"] {os-distribution = "opensuse"}
+  ["pandoc"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on pandoc installation"
 description: """

--- a/packages/conf-python-2-7/conf-python-2-7.1.0/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["python"] {os-distribution = "centos"}
   ["python2"] {os-distribution = "fedora"}
   ["python2"] {os-distribution = "archlinux"}
-  ["python"] {os-distribution = "opensuse"}
+  ["python"] {os-family = "suse"}
   ["dev-lang/python:2.7"] {os-distribution = "gentoo"}
   ["python/2.7"] {os = "openbsd"}
   ["lang/python27"] {os = "netbsd"}

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libRmath-devel"] {os-distribution = "fedora"}
   ["libRmath-devel"] {os-distribution = "rhel"}
   ["R-mathlib"] {os-distribution = "alpine"}
-  ["R-base"] {os-distribution = "opensuse"}
+  ["R-base"] {os-family = "suse"}
   ["libRmath"] {os = "freebsd"}
   ["r"] {os = "macos" & os-distribution = "homebrew"}
   ["r"] {os-distribution = "archlinux"}

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["r"] {os-distribution = "archlinux"}
   ["r-base-core"] {os-distribution = "debian"}
   ["r-base-core"] {os-distribution = "ubuntu"}
-  ["R-core"] {os-distribution = "opensuse"}
+  ["R-core"] {os-family = "suse"}
   ["R"] {os-distribution = "alpine"}
   ["epel-release" "R"] {os-distribution = "centos"}
   ["R"] {os-distribution = "fedora"}

--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -18,7 +18,7 @@ depexts: [
   ["ruby"] {os = "netbsd"}
   ["ruby"] {os-distribution = "nixos"}
   ["ruby"] {os = "openbsd"}
-  ["ruby"] {os-distribution = "opensuse"}
+  ["ruby"] {os-family = "suse"}
   ["ruby"] {os-distribution = "oraclelinux"}
   ["ruby"] {os-distribution = "ubuntu"}
 ]

--- a/packages/conf-rust/conf-rust.0.1/opam
+++ b/packages/conf-rust/conf-rust.0.1/opam
@@ -12,7 +12,7 @@ depends: ["conf-which" {build}]
 depexts: [
   ["cargo"] {os-distribution = "centos"}
   ["cargo"] {os-distribution = "fedora"}
-  ["cargo"] {os-distribution = "opensuse"}
+  ["cargo"] {os-family = "suse"}
   ["cargo"] {os-distribution = "debian"}
   ["cargo"] {os-distribution = "ubuntu"}
   ["cargo"] {os-distribution = "nixos"}

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["sdl2"] {os = "macos" & os-distribution = "homebrew"}
   ["libsdl2-devel"] {os-distribution = "mageia"}
   ["sdl2"] {os = "openbsd"}
-  ["sdl2"] {os-distribution = "opensuse"}
+  ["sdl2"] {os-family = "suse"}
   ["libsdl2-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a SDL2 system installation"

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-distribution = "opensuse"}
+  ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -8,7 +8,7 @@ build: [["which" "which"]]
 depexts: [
   ["which"] {os-distribution = "centos"}
   ["which"] {os-distribution = "fedora"}
-  ["which"] {os-distribution = "opensuse"}
+  ["which"] {os-family = "suse"}
   ["debianutils"] {os-distribution = "debian"}
   ["debianutils"] {os-distribution = "ubuntu"}
   ["which"] {os-distribution = "nixos"}

--- a/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "oraclelinux"}
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
-  ["libffi-devel"] {os-distribution = "opensuse"}
+  ["libffi-devel"] {os-family = "suse"}
 ]
 tags: ["org:ocamllabs" "org:mirage"]
 post-messages: [

--- a/packages/ctypes/ctypes.0.1.1/opam
+++ b/packages/ctypes/ctypes.0.1.1/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "oraclelinux"}
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
-  ["libffi-devel"] {os-distribution = "opensuse"}
+  ["libffi-devel"] {os-family = "suse"}
 ]
 dev-repo: "git://github.com/ocamllabs/ocaml-ctypes"
 install: [make "install"]

--- a/packages/ctypes/ctypes.0.2.3/opam
+++ b/packages/ctypes/ctypes.0.2.3/opam
@@ -20,7 +20,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "oraclelinux"}
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
-  ["libffi-devel"] {os-distribution = "opensuse"}
+  ["libffi-devel"] {os-family = "suse"}
 ]
 tags: ["org:ocamllabs" "org:mirage"]
 dev-repo: "git://github.com/ocamllabs/ocaml-ctypes"

--- a/packages/ctypes/ctypes.0.3.4/opam
+++ b/packages/ctypes/ctypes.0.3.4/opam
@@ -21,7 +21,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "oraclelinux"}
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
-  ["libffi-devel"] {os-distribution = "opensuse"}
+  ["libffi-devel"] {os-family = "suse"}
 ]
 tags: ["org:ocamllabs" "org:mirage"]
 patches: [ "build_with_trunk.patch" ]

--- a/packages/dlm/dlm.0.3.0/opam
+++ b/packages/dlm/dlm.0.3.0/opam
@@ -27,7 +27,7 @@ depexts: [
   ["dlm-devel"] {os-distribution = "fedora"}
   ["dlm-devel"] {os-distribution = "oraclelinux"}
   ["dlm-git"] {os-distribution = "archlinux"}
-  ["libdlm-devel"] {os-distribution = "opensuse"}
+  ["libdlm-devel"] {os-family = "suse"}
 ]
 available: [ os = "linux" & os != "alpine" ]
 synopsis: "Libdlm bindings"

--- a/packages/dssi/dssi.0.1.2/opam
+++ b/packages/dssi/dssi.0.1.2/opam
@@ -16,7 +16,7 @@ depexts: [
   ["dssi-dev"] {os-distribution = "ubuntu"}
   ["dssi-devel"] {os-distribution = "centos"}
   ["dssi-devel"] {os-distribution = "fedora"}
-  ["dssi-devel"] {os-distribution = "opensuse"}
+  ["dssi-devel"] {os-family = "suse"}
   ["dssi"] {os-distribution = "nixos"}
   ["dssi"] {os-distribution = "archlinux"}
 ]

--- a/packages/faad/faad.0.4.0/opam
+++ b/packages/faad/faad.0.4.0/opam
@@ -28,7 +28,7 @@ depexts: [
   ["faad2"] {os-distribution = "archlinux"}
   ["faad2-devel"] {os-distribution = "centos"}
   ["faad2-devel"] {os-distribution = "fedora"}
-  ["faad2-devel"] {os-distribution = "opensuse"}
+  ["faad2-devel"] {os-family = "suse"}
   ["libfaad-dev"] {os-distribution = "debian"}
   ["libfaad-dev"] {os-distribution = "ubuntu"}
   ["faad2"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libfdk-aac"] {os-distribution = "archlinux"}
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
-  ["fdk-aac-devel"] {os-distribution = "opensuse"}
+  ["fdk-aac-devel"] {os-family = "suse"}
   ["libfdk-aac-dev"] {os-distribution = "debian"}
   ["libfdk-aac-dev"] {os-distribution = "ubuntu"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.1.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["ffmpeg"] {os-distribution = "archlinux"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
-  ["ffmpeg-devel"] {os-distribution = "opensuse"}
+  ["ffmpeg-devel"] {os-family = "suse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.1.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.2/opam
@@ -22,7 +22,7 @@ depexts: [
   ["ffmpeg"] {os-distribution = "archlinux"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
-  ["ffmpeg-devel"] {os-distribution = "opensuse"}
+  ["ffmpeg-devel"] {os-family = "suse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.2.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["ffmpeg"] {os-distribution = "archlinux"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
-  ["ffmpeg-devel"] {os-distribution = "opensuse"}
+  ["ffmpeg-devel"] {os-family = "suse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.2.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["ffmpeg"] {os-distribution = "archlinux"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
-  ["ffmpeg-devel"] {os-distribution = "opensuse"}
+  ["ffmpeg-devel"] {os-family = "suse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/fftw3/fftw3.0.8.1/opam
+++ b/packages/fftw3/fftw3.0.8.1/opam
@@ -39,7 +39,7 @@ depexts: [
   ["fftw-devel"] {os-distribution = "fedora"}
   ["fftw-devel"] {os-distribution = "rhel"}
   ["libfftw-devel"] {os-distribution = "mageia"}
-  ["fftw3-devel"] {os-distribution = "opensuse"}
+  ["fftw3-devel"] {os-family = "suse"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
   ["fftw"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.2/opam
+++ b/packages/flac/flac.0.1.2/opam
@@ -26,7 +26,7 @@ depends: [
 depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
-  ["flac-devel"] {os-distribution = "opensuse"}
+  ["flac-devel"] {os-family = "suse"}
   ["libflac-dev"] {os-distribution = "debian"}
   ["libflac-dev"] {os-distribution = "ubuntu"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.3/opam
+++ b/packages/flac/flac.0.1.3/opam
@@ -28,7 +28,7 @@ depexts: [
   ["flac"] {os-distribution = "archlinux"}
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
-  ["flac-devel"] {os-distribution = "opensuse"}
+  ["flac-devel"] {os-family = "suse"}
   ["libflac-dev"] {os-distribution = "debian"}
   ["libflac-dev"] {os-distribution = "ubuntu"}
   ["flac"] {os-distribution = "nixos"}

--- a/packages/freetds/freetds.0.6/opam
+++ b/packages/freetds/freetds.0.6/opam
@@ -36,7 +36,7 @@ depexts: [
   ["freetds-devel"] {os-distribution = "fedora"}
   ["freetds-devel"] {os-distribution = "rhel"}
   ["libfreetds-devel"] {os-distribution = "mageia"}
-  ["freetds-devel"] {os-distribution = "opensuse"}
+  ["freetds-devel"] {os-family = "suse"}
   ["freetds-devel"] {os = "freebsd"}
   ["freetds"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/frei0r/frei0r.0.1.1/opam
+++ b/packages/frei0r/frei0r.0.1.1/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["frei0r-devel"] {os-distribution = "centos"}
   ["frei0r-devel"] {os-distribution = "fedora"}
-  ["frei0r-devel"] {os-distribution = "opensuse"}
+  ["frei0r-devel"] {os-family = "suse"}
   ["frei0r"] {os = "macos" & os-distribution = "homebrew"}
   ["frei0r-plugins-dev"] {os-distribution = "debian"}
   ["frei0r-plugins-dev"] {os-distribution = "ubuntu"}

--- a/packages/gammu/gammu.0.9.1/opam
+++ b/packages/gammu/gammu.0.9.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
-  ["gammu-devel"] {os-distribution = "opensuse"}
+  ["gammu-devel"] {os-family = "suse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gammu/gammu.0.9.2/opam
+++ b/packages/gammu/gammu.0.9.2/opam
@@ -27,7 +27,7 @@ depexts: [
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
-  ["gammu-devel"] {os-distribution = "opensuse"}
+  ["gammu-devel"] {os-family = "suse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gammu/gammu.0.9.3/opam
+++ b/packages/gammu/gammu.0.9.3/opam
@@ -33,7 +33,7 @@ depexts: [
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
-  ["gammu-devel"] {os-distribution = "opensuse"}
+  ["gammu-devel"] {os-family = "suse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gammu/gammu.0.9.4/opam
+++ b/packages/gammu/gammu.0.9.4/opam
@@ -29,7 +29,7 @@ depexts: [
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
-  ["gammu-devel"] {os-distribution = "opensuse"}
+  ["gammu-devel"] {os-family = "suse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gavl/gavl.0.1.6/opam
+++ b/packages/gavl/gavl.0.1.6/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["gavl-devel"] {os-distribution = "centos"}
   ["gavl-devel"] {os-distribution = "fedora"}
-  ["gavl-devel"] {os-distribution = "opensuse"}
+  ["gavl-devel"] {os-family = "suse"}
   ["libgavl-dev"] {os-distribution = "debian"}
   ["libgavl-dev"] {os-distribution = "ubuntu"}
   ["drfill/liquidsoap/libgavl"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/gstreamer/gstreamer.0.2.3/opam
+++ b/packages/gstreamer/gstreamer.0.2.3/opam
@@ -17,7 +17,7 @@ depends: [
 depexts: [
   ["gstreamer1-dev" "gst-plugins-base1-dev"] {os-distribution = "alpine"}
   ["gstreamer-devel" "gstreamer-plugins-base-devel"]
-    {os-distribution = "opensuse"}
+    {os-family = "suse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]

--- a/packages/gstreamer/gstreamer.0.3.0/opam
+++ b/packages/gstreamer/gstreamer.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
 depexts: [
   ["gstreamer-dev" "gst-plugins-base-dev"] {os-distribution = "alpine"}
   ["gstreamer-devel" "gstreamer-plugins-base-devel"]
-    {os-distribution = "opensuse"}
+    {os-family = "suse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]

--- a/packages/lablgtk/lablgtk.2.16.0/opam
+++ b/packages/lablgtk/lablgtk.2.16.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "fedora"}
   ["gtk2-devel"] {os-distribution = "oraclelinux"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
-  ["gtk2-devel"] {os-distribution = "opensuse"}
+  ["gtk2-devel"] {os-family = "suse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.2/opam
+++ b/packages/lablgtk/lablgtk.2.18.2/opam
@@ -25,7 +25,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "fedora"}
   ["gtk2-devel"] {os-distribution = "oraclelinux"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
-  ["gtk2-devel"] {os-distribution = "opensuse"}
+  ["gtk2-devel"] {os-family = "suse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.3/opam
+++ b/packages/lablgtk/lablgtk.2.18.3/opam
@@ -25,7 +25,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "fedora"}
   ["gtk2-devel"] {os-distribution = "oraclelinux"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
-  ["gtk2-devel"] {os-distribution = "opensuse"}
+  ["gtk2-devel"] {os-family = "suse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -31,7 +31,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "fedora"}
   ["gtk2-devel"] {os-distribution = "oraclelinux"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
-  ["gtk2-devel"] {os-distribution = "opensuse"}
+  ["gtk2-devel"] {os-family = "suse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.5/opam
+++ b/packages/lablgtk/lablgtk.2.18.5/opam
@@ -31,7 +31,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "fedora"}
   ["gtk2-devel"] {os-distribution = "oraclelinux"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
-  ["gtk2-devel"] {os-distribution = "opensuse"}
+  ["gtk2-devel"] {os-family = "suse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -31,7 +31,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "fedora"}
   ["gtk2-devel"] {os-distribution = "oraclelinux"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
-  ["gtk2-devel"] {os-distribution = "opensuse"}
+  ["gtk2-devel"] {os-family = "suse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -28,7 +28,7 @@ depexts: [
   ["libgc-dev"] {os-distribution = "ubuntu"}
   ["gc-devel"] {os-distribution = "centos"}
   ["gc-devel"] {os-distribution = "fedora"}
-  ["gc-devel"] {os-distribution = "opensuse"}
+  ["gc-devel"] {os-family = "suse"}
   ["gc"] {os-distribution = "archlinux"}
   ["gc-dev"] {os-distribution = "alpine"}
   ["boehmgc"] {os-distribution = "macports" & os = "macos"}

--- a/packages/ladspa/ladspa.0.1.5/opam
+++ b/packages/ladspa/ladspa.0.1.5/opam
@@ -22,7 +22,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["ladspa-devel"] {os-distribution = "centos"}
   ["ladspa-devel"] {os-distribution = "fedora"}
-  ["ladspa-devel"] {os-distribution = "opensuse"}
+  ["ladspa-devel"] {os-family = "suse"}
   ["ladspa-sdk"] {os-distribution = "debian"}
   ["ladspa-sdk"] {os-distribution = "ubuntu"}
   ["drfill/liquidsoap/ladspa_header"]

--- a/packages/lame/lame.0.3.3/opam
+++ b/packages/lame/lame.0.3.3/opam
@@ -23,7 +23,7 @@ depexts: [
   ["lame-dev"] {os-distribution = "alpine"}
   ["lame-devel"] {os-distribution = "centos"}
   ["lame-devel"] {os-distribution = "fedora"}
-  ["lame-devel"] {os-distribution = "opensuse"}
+  ["lame-devel"] {os-family = "suse"}
   ["libmp3lame-dev"] {os-distribution = "debian"}
   ["libmp3lame-dev"] {os-distribution = "ubuntu"}
   ["lame"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/lbfgs/lbfgs.0.9.1/opam
+++ b/packages/lbfgs/lbfgs.0.9.1/opam
@@ -29,7 +29,7 @@ depexts: [
   ["gcc-gfortran"] {os-distribution = "fedora"}
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}
-  ["gcc-fortran"] {os-distribution = "opensuse"}
+  ["gcc-fortran"] {os-family = "suse"}
   ["gcc"] {os = "freebsd"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/lbfgs/lbfgs.0.9/opam
+++ b/packages/lbfgs/lbfgs.0.9/opam
@@ -32,7 +32,7 @@ depexts: [
   ["gcc-gfortran"] {os-distribution = "fedora"}
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}
-  ["gcc-fortran"] {os-distribution = "opensuse"}
+  ["gcc-fortran"] {os-family = "suse"}
   ["gcc"] {os = "freebsd"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/lmdb/lmdb.0.1/opam
+++ b/packages/lmdb/lmdb.0.1/opam
@@ -31,7 +31,7 @@ depexts: [
   ["lmdb"] {os = "macos" & os-distribution = "homebrew"}
   ["lmdb"] {os = "macos" & os-distribution = "macports"}
   ["lmdb-devel"] {os-distribution = "fedora"}
-  ["lmdb-devel"] {os-distribution = "opensuse"}
+  ["lmdb-devel"] {os-family = "suse"}
   ["lmdb"] {os-distribution = "archlinux"}
 ]
 url {

--- a/packages/mad/mad.0.4.5/opam
+++ b/packages/mad/mad.0.4.5/opam
@@ -16,7 +16,7 @@ depexts: [
   ["libmad"] {os-distribution = "archlinux"}
   ["libmad-devel"] {os-distribution = "centos"}
   ["libmad-devel"] {os-distribution = "fedora"}
-  ["libmad-devel"] {os-distribution = "opensuse"}
+  ["libmad-devel"] {os-family = "suse"}
   ["libmad0-dev"] {os-distribution = "debian"}
   ["libmad0-dev"] {os-distribution = "ubuntu"}
   ["libmad"] {os-distribution = "nixos"}

--- a/packages/magic/magic.0.7.3/opam
+++ b/packages/magic/magic.0.7.3/opam
@@ -13,7 +13,7 @@ depexts: [
   ["file-dev"] {os-distribution = "alpine"}
   ["file-devel"] {os-distribution = "centos"}
   ["file-devel"] {os-distribution = "fedora"}
-  ["file-devel"] {os-distribution = "opensuse"}
+  ["file-devel"] {os-family = "suse"}
   ["libmagic-dev"] {os-distribution = "debian"}
   ["libmagic-dev"] {os-distribution = "ubuntu"}
   ["libmagic"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -20,7 +20,7 @@ depexts: [
   ["libmilter"] {os-distribution = "macports"}
   ["libmilter-dev"] {os-distribution = "debian"}
   ["sendmail-devel"] {os-distribution = "mageia"}
-  ["sendmail-devel"] {os-distribution = "opensuse"}
+  ["sendmail-devel"] {os-family = "suse"}
   ["libmilter"] {os = "netbsd"}
   ["libmilter-dev"] {os-distribution = "ubuntu"}
 ]

--- a/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
@@ -32,7 +32,7 @@ depends: [
 depexts: [
   ["linux-libc-dev"] {os-distribution = "debian"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
-  ["linux-glibc-devel"] {os-distribution = "opensuse"}
+  ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
@@ -28,7 +28,7 @@ depends: [
 depexts: [
   ["linux-libc-dev"] {os-distribution = "debian"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
-  ["linux-glibc-devel"] {os-distribution = "opensuse"}
+  ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
@@ -28,7 +28,7 @@ depends: [
 depexts: [
   ["linux-libc-dev"] {os-distribution = "debian"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
-  ["linux-glibc-devel"] {os-distribution = "opensuse"}
+  ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -21,7 +21,7 @@ depexts: [
   ["epel-release" "jack-audio-connection-kit-devel"]
     {os-distribution = "centos"}
   ["jack-audio-connection-kit-devel"] {os-distribution = "rhel"}
-  ["libjack-devel"] {os-distribution = "opensuse"}
+  ["libjack-devel"] {os-family = "suse"}
   ["jack"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis:

--- a/packages/ocaml-lua/ocaml-lua.1.0/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["liblua5.1-0-dev"] {os-distribution = "debian"}
   ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.1/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.1/opam
@@ -35,7 +35,7 @@ depexts: [
   ["liblua5.1-0-dev"] {os-distribution = "debian"}
   ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.2/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.2/opam
@@ -35,7 +35,7 @@ depexts: [
   ["liblua5.1-0-dev"] {os-distribution = "debian"}
   ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.3/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.3/opam
@@ -37,7 +37,7 @@ depexts: [
   ["compat-lua-devel"] {os-distribution = "fedora"}
   ["lua-devel"] {os-distribution = "centos"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.4/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.4/opam
@@ -38,7 +38,7 @@ depexts: [
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocaml-lua/ocaml-lua.1.5/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.5/opam
@@ -38,7 +38,7 @@ depexts: [
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocaml-lua/ocaml-lua.1.6/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.6/opam
@@ -38,7 +38,7 @@ depexts: [
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocaml-lua/ocaml-lua.1.7/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.7/opam
@@ -38,7 +38,7 @@ depexts: [
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
-  ["lua51-devel"] {os-distribution = "opensuse"}
+  ["lua51-devel"] {os-family = "suse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
@@ -27,7 +27,7 @@ depexts: [
   ["fuse-dev"] {os-distribution = "alpine"}
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
-  ["fuse-devel"] {os-distribution = "opensuse"}
+  ["fuse-devel"] {os-family = "suse"}
   ["Caskroom/cask/osxfuse"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
@@ -27,7 +27,7 @@ depexts: [
   ["fuse-dev"] {os-distribution = "alpine"}
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
-  ["fuse-devel"] {os-distribution = "opensuse"}
+  ["fuse-devel"] {os-family = "suse"}
   ["Caskroom/cask/osxfuse"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/odepack/odepack.0.6.8/opam
+++ b/packages/odepack/odepack.0.6.8/opam
@@ -29,7 +29,7 @@ depexts: [
   ["gfortran"] {os-distribution = "ubuntu"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "fedora"}
-  ["gcc-fortran"] {os-distribution = "opensuse"}
+  ["gcc-fortran"] {os-family = "suse"}
   ["lang/f77"] {os = "freebsd"}
   ["lang/f77"] {os = "openbsd"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/odepack/odepack.0.6.9/opam
+++ b/packages/odepack/odepack.0.6.9/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gfortran"] {os-distribution = "ubuntu"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "fedora"}
-  ["gcc-fortran"] {os-distribution = "opensuse"}
+  ["gcc-fortran"] {os-family = "suse"}
   ["lang/f77"] {os = "freebsd"}
   ["lang/f77"] {os = "openbsd"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ogg/ogg.0.5.0/opam
+++ b/packages/ogg/ogg.0.5.0/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libogg-dev"] {os-distribution = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
-  ["libogg-devel"] {os-distribution = "opensuse"}
+  ["libogg-devel"] {os-family = "suse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ogg/ogg.0.5.1/opam
+++ b/packages/ogg/ogg.0.5.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libogg-dev"] {os-distribution = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
-  ["libogg-devel"] {os-distribution = "opensuse"}
+  ["libogg-devel"] {os-family = "suse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ogg/ogg.0.5.2/opam
+++ b/packages/ogg/ogg.0.5.2/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libogg-dev"] {os-distribution = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
-  ["libogg-devel"] {os-distribution = "opensuse"}
+  ["libogg-devel"] {os-family = "suse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/opus/opus.0.1.2/opam
+++ b/packages/opus/opus.0.1.2/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libopus-dev"] {os-distribution = "ubuntu"}
   ["opus-devel"] {os-distribution = "centos"}
   ["opus-devel"] {os-distribution = "fedora"}
-  ["opus-devel"] {os-distribution = "opensuse"}
+  ["opus-devel"] {os-family = "suse"}
   ["libopus"] {os-distribution = "nixos"}
   ["opus"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/pcre/pcre.7.2.3/opam
+++ b/packages/pcre/pcre.7.2.3/opam
@@ -27,7 +27,7 @@ depends: [
 depexts: [
   ["ocaml-ocamldoc"] {os-distribution = "centos"}
   ["ocaml-ocamldoc"] {os-distribution = "fedora"}
-  ["ocaml-ocamldoc"] {os-distribution = "opensuse"}
+  ["ocaml-ocamldoc"] {os-family = "suse"}
 ]
 synopsis:
   "Bindings to the Perl Compatibility Regular Expressions library"

--- a/packages/postgresql/postgresql.3.2.1/opam
+++ b/packages/postgresql/postgresql.3.2.1/opam
@@ -52,7 +52,7 @@ depexts: [
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}
-  ["postgresql-devel"] {os-distribution = "opensuse"}
+  ["postgresql-devel"] {os-family = "suse"}
 ]
 synopsis: "Bindings to the PostgreSQL library"
 description: """

--- a/packages/postgresql/postgresql.4.0.0/opam
+++ b/packages/postgresql/postgresql.4.0.0/opam
@@ -52,7 +52,7 @@ depexts: [
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}
-  ["postgresql-devel"] {os-distribution = "opensuse"}
+  ["postgresql-devel"] {os-family = "suse"}
 ]
 synopsis: "Bindings to the PostgreSQL library"
 description: """

--- a/packages/postgresql/postgresql.4.0.1/opam
+++ b/packages/postgresql/postgresql.4.0.1/opam
@@ -52,7 +52,7 @@ depexts: [
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}
-  ["postgresql-devel"] {os-distribution = "opensuse"}
+  ["postgresql-devel"] {os-family = "suse"}
 ]
 synopsis: "Bindings to the PostgreSQL library"
 description: """

--- a/packages/postgresql/postgresql.4.1.0/opam
+++ b/packages/postgresql/postgresql.4.1.0/opam
@@ -34,7 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
-  ["postgresql"] {os-distribution = "opensuse"}
+  ["postgresql"] {os-family = "suse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.2.0/opam
+++ b/packages/postgresql/postgresql.4.2.0/opam
@@ -34,7 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
-  ["postgresql"] {os-distribution = "opensuse"}
+  ["postgresql"] {os-family = "suse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.2.1/opam
+++ b/packages/postgresql/postgresql.4.2.1/opam
@@ -34,7 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
-  ["postgresql"] {os-distribution = "opensuse"}
+  ["postgresql"] {os-family = "suse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.3.0/opam
+++ b/packages/postgresql/postgresql.4.3.0/opam
@@ -34,7 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
-  ["postgresql"] {os-distribution = "opensuse"}
+  ["postgresql"] {os-family = "suse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.4.0/opam
+++ b/packages/postgresql/postgresql.4.4.0/opam
@@ -33,7 +33,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
-  ["postgresql"] {os-distribution = "opensuse"}
+  ["postgresql"] {os-family = "suse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -32,7 +32,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
-  ["postgresql-devel"] {os-distribution = "opensuse"}
+  ["postgresql-devel"] {os-family = "suse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}

--- a/packages/pulseaudio/pulseaudio.0.1.3/opam
+++ b/packages/pulseaudio/pulseaudio.0.1.3/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["pulseaudio-libs-devel"] {os-distribution = "centos"}
   ["pulseaudio-libs-devel"] {os-distribution = "fedora"}
-  ["pulseaudio-libs-devel"] {os-distribution = "opensuse"}
+  ["pulseaudio-libs-devel"] {os-family = "suse"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["libpulse-dev"] {os-distribution = "debian"}
   ["libpulse-dev"] {os-distribution = "ubuntu"}

--- a/packages/samplerate/samplerate.0.1.4/opam
+++ b/packages/samplerate/samplerate.0.1.4/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["libsamplerate-devel"] {os-distribution = "centos"}
   ["libsamplerate-devel"] {os-distribution = "fedora"}
-  ["libsamplerate-devel"] {os-distribution = "opensuse"}
+  ["libsamplerate-devel"] {os-family = "suse"}
   ["libsamplerate-dev"] {os-distribution = "alpine"}
   ["libsamplerate0-dev"] {os-distribution = "debian"}
   ["libsamplerate0-dev"] {os-distribution = "ubuntu"}

--- a/packages/shine/shine.0.2.1/opam
+++ b/packages/shine/shine.0.2.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["shine"] {os-distribution = "alpine"}
   ["libshine-devel"] {os-distribution = "centos"}
   ["libshine-devel"] {os-distribution = "fedora"}
-  ["libshine-devel"] {os-distribution = "opensuse"}
+  ["libshine-devel"] {os-family = "suse"}
   ["libshine-dev"] {os-distribution = "debian"}
   ["libshine-dev"] {os-distribution = "ubuntu"}
   ["drfill/liquidsoap/libshine"]

--- a/packages/soundtouch/soundtouch.0.1.8/opam
+++ b/packages/soundtouch/soundtouch.0.1.8/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["soundtouch-devel"] {os-distribution = "centos"}
   ["soundtouch-devel"] {os-distribution = "fedora"}
-  ["soundtouch-devel"] {os-distribution = "opensuse"}
+  ["soundtouch-devel"] {os-family = "suse"}
   ["libsoundtouch-dev"] {os-distribution = "debian"}
   ["libsoundtouch-dev"] {os-distribution = "ubuntu"}
   ["drfill/homebrew-liquidsoap/soundtouch"]

--- a/packages/speex/speex.0.2.1/opam
+++ b/packages/speex/speex.0.2.1/opam
@@ -22,7 +22,7 @@ depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
   ["speex-devel"] {os-distribution = "centos"}
   ["speex-devel"] {os-distribution = "fedora"}
-  ["speex-devel"] {os-distribution = "opensuse"}
+  ["speex-devel"] {os-family = "suse"}
   ["libspeex-dev"] {os-distribution = "ubuntu"}
   ["libspeex-dev"] {os-distribution = "debian"}
   ["speex"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/spf/spf.2.0.2/opam
+++ b/packages/spf/spf.2.0.2/opam
@@ -21,7 +21,7 @@ depexts: [
   ["libspf2-devel"] {os-distribution = "mageia"}
   ["libspf2"] {os = "netbsd"}
   ["libspf2"] {os = "openbsd"}
-  ["libspf2-devel"] {os-distribution = "opensuse"}
+  ["libspf2-devel"] {os-family = "suse"}
   ["libspf2-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml bindings for libspf2"

--- a/packages/sqlite3/sqlite3.4.1.2/opam
+++ b/packages/sqlite3/sqlite3.4.1.2/opam
@@ -36,7 +36,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-distribution = "opensuse"}
+  ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sqlite3/sqlite3.4.1.3/opam
+++ b/packages/sqlite3/sqlite3.4.1.3/opam
@@ -36,7 +36,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-distribution = "opensuse"}
+  ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sqlite3/sqlite3.4.2.0/opam
+++ b/packages/sqlite3/sqlite3.4.2.0/opam
@@ -33,7 +33,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-distribution = "opensuse"}
+  ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sqlite3/sqlite3.4.3.0/opam
+++ b/packages/sqlite3/sqlite3.4.3.0/opam
@@ -33,7 +33,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-distribution = "opensuse"}
+  ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sqlite3/sqlite3.4.3.1/opam
+++ b/packages/sqlite3/sqlite3.4.3.1/opam
@@ -33,7 +33,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-distribution = "opensuse"}
+  ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sqlite3/sqlite3.4.3.2/opam
+++ b/packages/sqlite3/sqlite3.4.3.2/opam
@@ -33,7 +33,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-distribution = "opensuse"}
+  ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/taglib/taglib.0.3.3/opam
+++ b/packages/taglib/taglib.0.3.3/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "taglib"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["taglib-dev"] {os-distribution = "alpine"}
-  ["gcc-c++" "taglib-devel"] {os-distribution = "opensuse"}
+  ["gcc-c++" "taglib-devel"] {os-family = "suse"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "fedora"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "centos"}
   ["libtag1-dev"] {os-distribution = "debian"}

--- a/packages/theora/theora.0.3.1/opam
+++ b/packages/theora/theora.0.3.1/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
   ["libtheora-devel"] {os-distribution = "centos"}
   ["libtheora-devel"] {os-distribution = "fedora"}
-  ["libtheora-devel"] {os-distribution = "opensuse"}
+  ["libtheora-devel"] {os-family = "suse"}
   ["theora"] {os = "macos" & os-distribution = "homebrew"}
   ["libtheora-dev"] {os-distribution = "ubuntu"}
   ["libtheora-dev"] {os-distribution = "debian"}

--- a/packages/travis-opam/travis-opam.1.1.0/opam
+++ b/packages/travis-opam/travis-opam.1.1.0/opam
@@ -19,7 +19,7 @@ depexts: [
   ["jq"] {os-distribution = "debian"}
   ["jq"] {os-distribution = "fedora"}
   ["jq"] {os-distribution = "homebrew" & os = "macos"}
-  ["jq"] {os-distribution = "opensuse"}
+  ["jq"] {os-family = "suse"}
   ["jq"] {os-distribution = "oraclelinux"}
   ["jq"] {os-distribution = "ubuntu"}
 ]

--- a/packages/vorbis/vorbis.0.6.2/opam
+++ b/packages/vorbis/vorbis.0.6.2/opam
@@ -18,7 +18,7 @@ depends: [
 depexts: [
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
-  ["libvorbis-devel"] {os-distribution = "opensuse"}
+  ["libvorbis-devel"] {os-family = "suse"}
   ["libvorbis-dev"] {os-distribution = "debian"}
   ["libvorbis-dev"] {os-distribution = "ubuntu"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/vorbis/vorbis.0.7.0/opam
+++ b/packages/vorbis/vorbis.0.7.0/opam
@@ -19,7 +19,7 @@ depexts: [
   ["libvorbis-dev"] {os-distribution = "alpine"}
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
-  ["libvorbis-devel"] {os-distribution = "opensuse"}
+  ["libvorbis-devel"] {os-family = "suse"}
   ["libvorbis-dev"] {os-distribution = "debian"}
   ["libvorbis-dev"] {os-distribution = "ubuntu"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/vorbis/vorbis.0.7.1/opam
+++ b/packages/vorbis/vorbis.0.7.1/opam
@@ -19,7 +19,7 @@ depexts: [
   ["libvorbis-dev"] {os-distribution = "alpine"}
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
-  ["libvorbis-devel"] {os-distribution = "opensuse"}
+  ["libvorbis-devel"] {os-family = "suse"}
   ["pkg-config" "libvorbis-dev"] {os-distribution = "debian"}
   ["pkg-config" "libvorbis-dev"] {os-distribution = "ubuntu"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
OpenSUSE leap self-identifies as "opensuse-leap" now, so this
patch uses `os-family` instead so that any suse distribution
will return the depext. This should maintain compatability with
opensuse 42.3 while working with opensuse-leap 15.0 as well.
