### PR TITLE
Package torch.dev

### DIFF
--- a/packages/torch/torch.dev/opam
+++ b/packages/torch/torch.dev/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+bug-reports:  "https://github.com/LaurentMazare/ocaml-torch/issues"
+homepage:     "https://github.com/LaurentMazare/ocaml-torch"
+dev-repo:     "git+https://github.com/LaurentMazare/ocaml-torch.git"
+maintainer:   "Laurent Mazare <lmazare@gmail.com>"
+authors:      [ "Laurent Mazare" ]
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "base" {>= "0.11.0"}
+  "cmdliner"
+  "ctypes" {>= "0.5"}
+  "ctypes-foreign"
+  "dune" {>= "1.3.0" build}
+  "imagelib"
+  "libtorch"
+  "npy"
+  "ocaml" {>= "4.06"}
+  "ocaml-compiler-libs"
+  "ppx_custom_printf"
+  "ppx_expect"
+  "ppx_sexp_conv"
+  "sexplib"
+  "stdio"
+]
+
+synopsis: "PyTorch bindings for OCaml"
+description: """
+The ocaml-torch project provides some OCaml bindings for the PyTorch library.
+This brings to OCaml NumPy-like tensor computations with GPU acceleration and
+tape-based automatic differentiation.
+"""
+url {
+  src: "https://github.com/LaurentMazare/ocaml-torch/archive/0.1.tar.gz"
+  checksum: [
+    "md5=ad661b445b52f68a9b36098b7ad1e69f"
+    "sha512=bbcc002f75ecf90db0ef613efd7c28383fb7737689f0edb9598499f6ff08d31b33c0c161c4744eaa852525ffe3c6ba2ca585e91502b64ff630986706ad62cd5d"
+  ]
+}


### PR DESCRIPTION
### `torch.dev`
PyTorch bindings for OCaml
The ocaml-torch project provides some OCaml bindings for the PyTorch library.
This brings to OCaml NumPy-like tensor computations with GPU acceleration and
tape-based automatic differentiation.



---
* Homepage: https://github.com/LaurentMazare/ocaml-torch
* Source repo: git+https://github.com/LaurentMazare/ocaml-torch.git
* Bug tracker: https://github.com/LaurentMazare/ocaml-torch/issues

---
:camel: Pull-request generated by opam-publish v2.0.0