### PR TITLE
Package tensorflow.0.0.11

### DIFF
--- a/packages/tensorflow/tensorflow.0.0.11/opam
+++ b/packages/tensorflow/tensorflow.0.0.11/opam
@@ -27,7 +27,7 @@ depopts: [
   "npy"
 ]
 
-available: [ os != "macos" ]
+available: [ os = "linux" | os = "macos" ]
 
 synopsis: "TensorFlow bindings for OCaml"
 description: """

--- a/packages/tensorflow/tensorflow.0.0.11/opam
+++ b/packages/tensorflow/tensorflow.0.0.11/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+bug-reports:  "https://github.com/LaurentMazare/tensorflow-ocaml/issues"
+homepage:     "https://github.com/LaurentMazare/tensorflow-ocaml"
+dev-repo:     "git+https://github.com/LaurentMazare/tensorflow-ocaml.git"
+maintainer:   "Laurent Mazare <lmazare@gmail.com>"
+authors:      [ "Laurent Mazare" ]
+
+build: [
+  ["dune" "build" "-j" jobs "@install"]
+]
+depends: [
+  "base" {>= "0.11.0"}
+  "cmdliner"
+  "conf-wget" {build}
+  "ctypes" {>= "0.5"}
+  "ctypes-foreign"
+  "dune" {>= "1.3.0" build}
+  "libtensorflow"
+  "ocaml" {>= "4.06"}
+  "ocamlfind" {build}
+  "stdio"
+]
+
+depopts: [
+  "camlimages"
+  "gnuplot"
+  "npy"
+]
+
+available: [ os != "macos" ]
+
+synopsis: "TensorFlow bindings for OCaml"
+description: """
+The tensorflow-ocaml project provides some OCaml bindings for TensorFlow, a
+machine learning framework. These bindings are in an early stage of their
+development. Some operators are not supported and the API is likely to change
+in the future. You may also encounter some segfaults. That being said they
+already contain the necessary to train a convolution network using various
+optimizers.
+"""
+url {
+  src:
+    "https://github.com/LaurentMazare/tensorflow-ocaml/archive/0.0.11.tar.gz"
+  checksum: [
+    "md5=fddcb9d2655e2e4740457041ed93107f"
+    "sha512=7cbfc5f54cade7e05a648d7bc3a1ee9b4d08e414f1b3c7d8ffa375bfa954cb6f495a14863943e0ed12844100324451822ad88cef42faa1dd2d46bdefd57808ba"
+  ]
+}

--- a/packages/tensorflow/tensorflow.0.0.11/opam
+++ b/packages/tensorflow/tensorflow.0.0.11/opam
@@ -27,7 +27,7 @@ depopts: [
   "npy"
 ]
 
-available: [ os = "linux" | os = "macos" ]
+available: [ os = "linux" ]
 
 synopsis: "TensorFlow bindings for OCaml"
 description: """

--- a/packages/tensorflow/tensorflow.0.0.11/opam
+++ b/packages/tensorflow/tensorflow.0.0.11/opam
@@ -6,7 +6,7 @@ maintainer:   "Laurent Mazare <lmazare@gmail.com>"
 authors:      [ "Laurent Mazare" ]
 
 build: [
-  ["dune" "build" "-j" jobs "@install"]
+  ["dune" "build" "-j" jobs "-p" name]
 ]
 depends: [
   "base" {>= "0.11.0"}


### PR DESCRIPTION
### `tensorflow.0.0.11`
TensorFlow bindings for OCaml
The tensorflow-ocaml project provides some OCaml bindings for TensorFlow, a
machine learning framework. These bindings are in an early stage of their
development. Some operators are not supported and the API is likely to change
in the future. You may also encounter some segfaults. That being said they
already contain the necessary to train a convolution network using various
optimizers.



---
* Homepage: https://github.com/LaurentMazare/tensorflow-ocaml
* Source repo: git+https://github.com/LaurentMazare/tensorflow-ocaml.git
* Bug tracker: https://github.com/LaurentMazare/tensorflow-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0