### PR TITLE
[new release] github-unix, github-jsoo and github (4.0.0)

### DIFF
--- a/packages/github-jsoo/github-jsoo.3.0.1/opam
+++ b/packages/github-jsoo/github-jsoo.3.0.1/opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt-jsoo" {>= "0.99.0"}
   "js_of_ocaml"
-  "github"
+  "github" {="3.0.1"}
 ]
 synopsis: "GitHub APIv3 OCaml Library"
 description: """

--- a/packages/github-jsoo/github-jsoo.3.1.0/opam
+++ b/packages/github-jsoo/github-jsoo.3.1.0/opam
@@ -32,7 +32,7 @@ depends: [
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt-jsoo" {>= "0.99.0"}
   "js_of_ocaml"
-  "github"
+  "github" {="3.1.0"}
 ]
 synopsis: "GitHub APIv3 OCaml Library"
 description: """

--- a/packages/github-jsoo/github-jsoo.4.0.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+"""
+
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml-lwt"
+  "github"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.0.0/github-4.0.0.tbz"
+  checksum: "md5=6aac5e6fefb29582ad452ef21ceffdea"
+}

--- a/packages/github-jsoo/github-jsoo.4.0.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt-jsoo" {>= "0.99.0"}
   "js_of_ocaml-lwt"
-  "github"
+  "github" {="4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/github-unix/github-unix.3.0.0/opam
+++ b/packages/github-unix/github-unix.3.0.0/opam
@@ -27,7 +27,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "github" {>= "3.0.0"}
+  "github" {= "3.0.0"}
   "cohttp" {>= "0.20.0" & < "0.99"}
   "tls"
   "stringext"

--- a/packages/github-unix/github-unix.3.0.1/opam
+++ b/packages/github-unix/github-unix.3.0.1/opam
@@ -27,7 +27,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "github"
+  "github" {="3.0.1"}
   "cohttp-lwt-unix"
   "tls"
   "stringext"

--- a/packages/github-unix/github-unix.3.1.0/opam
+++ b/packages/github-unix/github-unix.3.1.0/opam
@@ -29,7 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "github"
+  "github" {="3.1.0"}
   "cohttp-lwt-unix"
   "stringext"
   "lambda-term"

--- a/packages/github-unix/github-unix.4.0.0/opam
+++ b/packages/github-unix/github-unix.4.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON).  This package installs the Unix (Lwt) version.
+"""
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "github"
+  "cohttp-lwt-unix"
+  "stringext"
+  "lambda-term"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.0.0/github-4.0.0.tbz"
+  checksum: "md5=6aac5e6fefb29582ad452ef21ceffdea"
+}

--- a/packages/github/github.4.0.0/opam
+++ b/packages/github/github.4.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON). It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+"""
+
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "2.0.0"}
+  "yojson" {>= "1.2.0"}
+  "stringext"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.0.0/github-4.0.0.tbz"
+  checksum: "md5=6aac5e6fefb29582ad452ef21ceffdea"
+}


### PR DESCRIPTION
GitHub APIv3 Unix library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Port to latest Atd 2.0.0 interfaces (mirage/ocaml-github#218 by @mjambon and @avsm)
- Port build system to Dune (@avsm)
- Properly expose the GitHub JavaScript library and fix dependencies (mirage/ocaml-github#216 by @samoht)
- Add `pull.merge_commit_sha` (mirage/ocaml-github#217 from @AltGr)
- Convert local opam files to the 2.0 format. (@avsm)
