### PR TITLE
Add support for Nix openssl package on macOS

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
+++ b/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
@@ -2,7 +2,7 @@
 
 if [ -d "$HOME/.nix-profile/lib/pkgconfig/" ]; then
   # Nix on macOS
-  PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig openssl
+  PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig pkg-config openssl
 elif [ -d "/usr/local/opt/openssl/" ]; then
   # Homebrew
   PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl

--- a/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
+++ b/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-if [ -d "/usr/local/opt/openssl/" ]; then
+if [ -d "$HOME/.nix-profile/lib/pkgconfig/" ]; then
+  # Nix on macOS
+  PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig 
+elif [ -d "/usr/local/opt/openssl/" ]; then
   # Homebrew
   PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl
 else

--- a/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
+++ b/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
@@ -2,7 +2,7 @@
 
 if [ -d "$HOME/.nix-profile/lib/pkgconfig/" ]; then
   # Nix on macOS
-  PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig 
+  PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig openssl
 elif [ -d "/usr/local/opt/openssl/" ]; then
   # Homebrew
   PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -26,5 +26,5 @@ depexts: [
 synopsis: "Virtual package relying on an OpenSSL system installation"
 description:
   "This package can only install if OpenSSL is installed on the system."
-extra-files: ["osx-build.sh" "md5=6011487436e6dacb1f71324cad37ac74"]
+extra-files: ["osx-build.sh" "md5=680dec3dca799bf274da7d851321b40d"]
 flags: conf

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -26,5 +26,5 @@ depexts: [
 synopsis: "Virtual package relying on an OpenSSL system installation"
 description:
   "This package can only install if OpenSSL is installed on the system."
-extra-files: ["osx-build.sh" "md5=680dec3dca799bf274da7d851321b40d"]
+extra-files: ["osx-build.sh" "md5=3c1a4b3be6890300af26aa4802f4f836"]
 flags: conf

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -26,5 +26,5 @@ depexts: [
 synopsis: "Virtual package relying on an OpenSSL system installation"
 description:
   "This package can only install if OpenSSL is installed on the system."
-extra-files: ["osx-build.sh" "md5=351f350c49d98ef4b77037c9ed277d52"]
+extra-files: ["osx-build.sh" "md5=680dec3dca799bf274da7d851321b40d"]
 flags: conf


### PR DESCRIPTION
Nix can also be used as a package manager in macOS