### PR TITLE
[new release] uri (2.1.0)

### DIFF
--- a/packages/uri/uri.2.1.0/opam
+++ b/packages/uri/uri.2.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "re" {>= "1.7.2"}
+  "sexplib0"
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v2.1.0/uri-v2.1.0.tbz"
+  checksum: "md5=36b973b283cce2f3b31b121eccc5c2d1"
+}


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* Expose a `compare` function in `Uri_sexp` so that it will work
  with `deriving compare,sexp` (mirage/ocaml-uri#127 @avsm).
* `uri.top` now depends on compiler-libs, not compiler-libs.toplevel (mirage/ocaml-uri#130 @yallop)
* Upgrade the opam metadata to the 2.0 format (@avsm).
* Update Travis to test OCaml 4.04->4.07 (@avsm @mseri mirage/ocaml-uri#131).
* Minimum OCaml version is now 4.04.0+ due to sexplib0 dependency (@avsm).
