### PR TITLE
[new release] vchan, vchan-xen and vchan-unix (4.0.0)

### DIFF
--- a/packages/vchan-unix/vchan-unix.4.0.0/opam
+++ b/packages/vchan-unix/vchan-unix.4.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "vchan"
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "xen-evtchn-unix"
+  "xen-gnt-unix"
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/4.0.0/vchan-4.0.0.tbz"
+  checksum: "md5=8b88d9f8d013469e99ecf5a91b9f78e3"
+}

--- a/packages/vchan-xen/vchan-xen.4.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "vchan"
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_cstruct" {build}
+  "io-page"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "mirage-xen"
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/4.0.0/vchan-4.0.0.tbz"
+  checksum: "md5=8b88d9f8d013469e99ecf5a91b9f78e3"
+}

--- a/packages/vchan/vchan.4.0.0/opam
+++ b/packages/vchan/vchan.4.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+description: """
+This is an implementation of the Xen "libvchan" or "vchan" communication
+protocol in OCaml. It allows fast inter-domain communication using shared
+memory.
+"""
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan/"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/4.0.0/vchan-4.0.0.tbz"
+  checksum: "md5=8b88d9f8d013469e99ecf5a91b9f78e3"
+}


### PR DESCRIPTION
Xen Vchan implementation

- Project page: <a href="https://github.com/mirage/ocaml-vchan">https://github.com/mirage/ocaml-vchan</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vchan/">https://mirage.github.io/ocaml-vchan/</a>

##### CHANGES:

* Modernise build for OCaml 4.04 and port to Dune (mirage/ocaml-vchan#120 @talex5 @avsm)
* Upgrade opam metadata files to 2.0 (mirage/ocaml-vchan#120 @avsm @talex5)
* Remove mli only module (mirage/ocaml-vchan#114 @rgrinberg @samoht)
* Fix deprecation warning on String.create (mirage/ocaml-vchan#112 @samoht)
* Make OCaml 4.04 the minimum version (mirage/ocaml-vchan#111 @cfcs @hannesm)
* Update test cases for Mirage 3 (mirage/ocaml-vchan#110 @mneilsen)
