### PR TITLE
[new release] ipaddr (2.9.0)

### DIFF
--- a/packages/arp/arp.0.1.1/opam
+++ b/packages/arp/arp.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "cstruct" {>= "2.2.0"}
   "ppx_cstruct"
-  "ipaddr" {>= "2.2.0"}
+  "ipaddr" {>= "2.2.0" & <"2.9.0"}
   "logs"
   "alcotest" {with-test}
   "nocrypto" {with-test}

--- a/packages/ipaddr/ipaddr.2.9.0/opam
+++ b/packages/ipaddr/ipaddr.2.9.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "base-bytes"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/2.9.0/ipaddr-2.9.0.tbz"
+  checksum: "md5=7d4fa9d31d57d900f0042bd96cb76323"
+}

--- a/packages/websocket-lwt/websocket-lwt.2.11/opam
+++ b/packages/websocket-lwt/websocket-lwt.2.11/opam
@@ -19,6 +19,7 @@ depends: [
   "websocket" {= "2.10"}
   "ipaddr" {>= "2.8.0"}
   "lwt_ssl" {>= "1.1.0"}
+  "lwt" {<"4.0.0"}
   "cohttp-lwt-unix" {>= "1.0"}
 ]
 synopsis: "Websocket library"


### PR DESCRIPTION
A library for manipulation of IP (and MAC) address representations

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

* Add `pp` functions for prettyprinting and deprecate `pp_hum` variants.
  The two functions are currently the same, so porting is just a matter
  of replacing existing uses of `pp_hum` with `pp` (mirage/ocaml-ipaddr#71 @verbosemode)
* Fix deprecation warnings on newer OCaml standard libraries (mirage/ocaml-ipaddr#74 @cfcs).
* Fix `base-unix` depopt to be a real dependency (mirage/ocaml-ipaddr#68 @rgrinberg).
* Fix missing `sexplib` dependency (mirage/ocaml-ipaddr#66 mirage/ocaml-ipaddr#67 @bmillwood).
* Port to Dune from jbuilder and update opam metadata to 2.0 format (mirage/ocaml-ipaddr#76 @avsm).
* Remove unused variable and bindings warnings in the implementation and
  signatures (mirage/ocaml-ipaddr#76 @avsm)
* Fix toplevel handling of the `ipaddr.top` package by linking
  to compiler-libs instead of compiler-libs.toplevel (mirage/ocaml-ipaddr#76 @avsm based on
  fix in mirage/ocaml-uri#130 by @yallop)
* Update Travis to test latest distros by using their aliases (mirage/ocaml-ipaddr#76 @avsm)
* Upgrade opam metadata to the 2.0 format (mirage/ocaml-ipaddr#76 @avsm)
