### PR TITLE
[new release] travesty (0.1.3)

### DIFF
--- a/packages/travesty/travesty.0.1.3/opam
+++ b/packages/travesty/travesty.0.1.3/opam
@@ -13,10 +13,10 @@ bug-reports: "https://github.com/MattWindsor91/travesty/issues"
 depends: [
   "ocaml" {>= "4.06"}
   "dune" {build}
-  "ppx_deriving" {build}
-  "ppx_expect" {build}
-  "ppx_jane" {build}
-  "ppx_sexp_message" {build}
+  "ppx_deriving"
+  "ppx_expect"
+  "ppx_jane"
+  "ppx_sexp_message"
   "core_kernel" {>= "v0.11" & < "v0.12"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/travesty/travesty.0.1.3/opam
+++ b/packages/travesty/travesty.0.1.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Monadically traversable containers"
+description:
+  "'Travesty' is a library for defining containers with monadic traversals,
+   inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
+   Core library ecosystem."
+maintainer: "Matt Windsor <m.windsor@imperial.ac.uk>"
+authors: "Matt Windsor <m.windsor@imperial.ac.uk>"
+license: "MIT"
+doc: "https://MattWindsor91.github.io/travesty/"
+homepage: "https://MattWindsor91.github.io/travesty"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {build}
+  "ppx_deriving" {build}
+  "ppx_expect" {build}
+  "ppx_jane" {build}
+  "ppx_sexp_message" {build}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/MattWindsor91/travesty"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.1.3/travesty-v0.1.3.tbz"
+  checksum: "md5=0f55119e314f91d3280fb065ff70dde7"
+}


### PR DESCRIPTION
Monadically traversable containers

- Project page: <a href="https://MattWindsor91.github.io/travesty">https://MattWindsor91.github.io/travesty</a>
- Documentation: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>

##### CHANGES:

- Fix incorrect module name (was `Lib`, not `Travesty`).
- Restrict to OCaml v4.06+ (this was the case in the final v0.1.2
  OPAM release, but not upstream).
