### PR TITLE
Package camelsnakekebab.0.4

### DIFF
--- a/packages/camelsnakekebab/camelsnakekebab.0.4/opam
+++ b/packages/camelsnakekebab/camelsnakekebab.0.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A Ocaml library for word case conversion"
+description:"""
+conversion bettween upper_camel_case, lower_camel_case 
+lower_snake_case, lower_snake_case, upper_snake_case,
+constant_case, kebab_case, http_header_case 
+"""
+maintainer: "Hao Wu <echowuhao@gmail.com>"
+authors: ["Hao Wu <echowuhao@gmail.com>"]
+license:  "MIT"
+build: [
+["dune" "build" "-p" name]
+["dune" "runtest" "-p" name] {with-test}
+]
+homepage: "https://github.com/swuecho/camelsnakekebab"
+bug-reports: "https://github.com/swuecho/camelsnakekebab/issues"
+dev-repo: "git+https://github.com/swuecho/camelsnakekebab.git"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {build}
+  "base"
+  "pcre"
+  "ounit" {with-test}
+]
+url {
+  src: "https://github.com/swuecho/camelsnakekebab/archive/0.4.tar.gz"
+  checksum: [
+    "md5=40b248887e33f5e76383784ce7d659e2"
+    "sha512=8c49df7db806650f11ff8af2aa8ad4a3c19356508f033621d493fa63f3688c4c9276c2cd88dc53bf017fa67c91f3557542d6efce1b5c1d282304f6465c56d2c3"
+  ]
+}


### PR DESCRIPTION
### `camelsnakekebab.0.4`
A Ocaml library for word case conversion
conversion bettween upper_camel_case, lower_camel_case 
lower_snake_case, lower_snake_case, upper_snake_case,
constant_case, kebab_case, http_header_case



---
* Homepage: https://github.com/swuecho/camelsnakekebab
* Source repo: git+https://github.com/swuecho/camelsnakekebab.git
* Bug tracker: https://github.com/swuecho/camelsnakekebab/issues

---
:camel: Pull-request generated by opam-publish v2.0.0