### PR TITLE
ppx_deriving_yojson.3.3

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving_yojson"
+doc: "http://whitequark.github.io/ppx_deriving_yojson"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+tags: [ "syntax" "json" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "yojson"
+  "result"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_tools"    {build}
+  "ppxfind"      {build}
+  "dune"         {build}
+  "cppo"         {build}
+  "ounit"        {with-test}
+]
+conflicts: [
+  "ppx_deriving" {= "4.2"}
+]
+synopsis: "JSON codec generator for OCaml"
+description: """
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator."""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/v3.3.tar.gz"
+  checksum: "sha512=e04ee424d89423ca891e018b3ea6e3f5f1e3714bd1ec1b07187143da1a646e51d068d1c09bc794e25b5b5be00ccb517212f62853ec66c17969a9795ba88fae6a"
+}


### PR DESCRIPTION
(3.2 broke backward-compatibility so it was not released: #13146 )

3.3
---

  * Make `_exn` functions opt-in (`[@@deriving yojson { exn = true }]`)
    to preserve backward-compatibility for fully-manual implementations
    of the [@@deriving yojson] interface.
    (https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/86)
    Gabriel Scherer

3.2
---

  * Add `let _ = to_yojson / of_yojson` to generated code to avoid warnings when
    they aren't used
    (https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/68)
    Steve Bleazard
  * Fix bug where doing [@@deriving of_yojson] causes an unused rec warning
    (https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/68)
    Steve Bleazard
  * Add generated `ty_of_yojson_exn` to raise an exception rather than return an
    error
    (https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/57, https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/68)
    Steve Bleazard
  * Port `ppx_deriving_yojson` to `dune`
    (https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/69, https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/85)
    Rudi Grinberg, Antonio Nuno Monteiro
  * Added deriver option `fields` to generate a `Yojson_meta` module containing
    all JSON key names.
    (https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/70)
    Steve Bleazard
  * Remove cppo that included support for versions no longer supported by
    `ppx_deriving_yojson`
    (https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/75)
    Rudi Grinberg