### PR TITLE
[new release] ppxlib (0.4.0)

### DIFF
--- a/packages/ppxlib/ppxlib.0.4.0/opam
+++ b/packages/ppxlib/ppxlib.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "base"                    {>= "v0.11.0"}
+  "dune"                    {build}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.0.9"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+  "ocamlfind"               {with-test}
+]
+synopsis: "Base library and tools for ppx rewriters"
+description: """
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.4.0/ppxlib-0.4.0.tbz"
+  checksum: "md5=bf164142e98fa9bb6f8ee923fbd1d9f4"
+}


### PR DESCRIPTION
Base library and tools for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Do not report errors about dropped or uninterpreted attributes
  starting with `_` (ocaml-ppx/ppxlib#46, fix ocaml-ppx/ppxlib#40, @diml)

- Fix he `special_function` rule for dotted operators and allow
  `Longident.parse` to parse dotted operators (ocaml-ppx/ppxlib#44, @Octachron)

- Port to `dune` and remove use of bash (ocaml-ppx/ppxlib#45, @rgrinberg)

- Ignore all attribites starting with `_` (ocaml-ppx/ppxlib#46, @diml)

- Reserve the `reason` and `refmt` namespaces (ocaml-ppx/ppxlib#46, @diml)

- Reserve the `metaocaml` namespace (ocaml-ppx/ppxlib#50, @rgrinberg)

- Fix attribute extraction for Otag/Rtag (ocaml-ppx/ppxlib#51, @xclerc)

- Do not relocate files unless `-loc-filename` is passed (ocaml-ppx/ppxlib#55, @hhugo)

- Perserve the filename in the output (ocaml-ppx/ppxlib#56, @hhugo)
