### PR TITLE
Package eliom.6.4.0

### DIFF
--- a/packages/eliom/eliom.6.4.0/opam
+++ b/packages/eliom/eliom.6.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: """
+Eliom is a framework for implementing client/server Web
+applications. It introduces new concepts to simplify the
+implementation of common behaviors, and uses advanced static typing
+features of OCaml to check many properties of the Web application at
+compile-time. Eliom allows implementing the whole application as a
+single program that includes both the client and the server code. We
+use a syntax extension to distinguish between the two sides. The
+client-side code is compiled to JS using Ocsigen Js_of_ocaml."""
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind"
+  "deriving" {>= "0.6"}
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml" {>= "3.0" & < "3.3"}
+  "js_of_ocaml-lwt" {< "3.3"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx" {<= "3.0.2"} | "js_of_ocaml-ppx_deriving_json"
+  "js_of_ocaml-tyxml" {< "3.2.0"}
+  "lwt_log"
+  "lwt_ppx"
+  "lwt_camlp4"
+  "tyxml" {>= "4.0.0" & < "4.3.0"}
+  "ocsigenserver" {>= "2.9"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/jrochel/eliom/archive/6.4.0.tar.gz"
+  checksum: [
+    "md5=d9c8464169bc1109b3181a7ff41b8dd3"
+    "sha512=b07267e40f30a1a616e1d0478a48c8998ed652fba2e7595b15442be321e46588411cbdb01f290e6dcffc4c1907f726e48ed6658a712f22ce55ba167664ecba0a"
+  ]
+}


### PR DESCRIPTION
### `eliom.6.4.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web
applications. It introduces new concepts to simplify the
implementation of common behaviors, and uses advanced static typing
features of OCaml to check many properties of the Web application at
compile-time. Eliom allows implementing the whole application as a
single program that includes both the client and the server code. We
use a syntax extension to distinguish between the two sides. The
client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0