### PR TITLE
Package ocsigen-i18n.3.2.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom."
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-rewriter"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-checker"] ]
+
+depends: [
+  "ocaml" {>= "4.03"}
+  "ocamlfind" {build}
+  "tyxml" {< "4.3.0"}
+]
+authors: "Julien Sagot"
+flags: light-uninstall
+url {
+  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.2.0.tar.gz"
+  checksum: [
+    "md5=d2b90674033967ca28a6f07e602b8b53"
+    "sha512=02d65b5a996e85cc53a4065712bc58f04bd986024583a46d62640970f38947122fd62024b06394519b2d3936256397619940da6d3e6a13f987496da300f65aee"
+  ]
+}

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -19,7 +19,7 @@ depends: [
 authors: "Julien Sagot"
 flags: light-uninstall
 url {
-  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.2.0.tar.gz"
+  src: "https://github.com/besport/ocsigen-i18n/archive/3.2.0.tar.gz"
   checksum: [
     "md5=d2b90674033967ca28a6f07e602b8b53"
     "sha512=02d65b5a996e85cc53a4065712bc58f04bd986024583a46d62640970f38947122fd62024b06394519b2d3936256397619940da6d3e6a13f987496da300f65aee"


### PR DESCRIPTION
### `ocsigen-i18n.3.2.0`
I18n made easy for web sites written with eliom.



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.0