### PR TITLE
Package ocsigen-i18n.3.2.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom."
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-rewriter"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-checker"] ]
+
+depends: [
+  "ocaml" {>= "4.03"}
+  "ocamlfind" {build}
+  "tyxml" {< "4.3.0"}
+]
+authors: "Julien Sagot"
+flags: light-uninstall
+url {
+  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.2.0.tar.gz"
+  checksum: [
+    "md5=6181dc74e8952177e9f8ac71c561e3c1"
+    "sha512=765eff57a59f878d93aedd5c2f692b9f276858441ce110a28af0f46b199476c49bcea9de1220f3053ce8eda4d3cd67dfda188ac466820eb3d241acc6c3eff1ea"
+  ]
+}

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -19,7 +19,7 @@ depends: [
 authors: "Julien Sagot"
 flags: light-uninstall
 url {
-  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.2.0.tar.gz"
+  src: "https://github.com/besport/ocsigen-i18n/archive/3.2.0.tar.gz"
   checksum: [
     "md5=6181dc74e8952177e9f8ac71c561e3c1"
     "sha512=765eff57a59f878d93aedd5c2f692b9f276858441ce110a28af0f46b199476c49bcea9de1220f3053ce8eda4d3cd67dfda188ac466820eb3d241acc6c3eff1ea"


### PR DESCRIPTION
### `ocsigen-i18n.3.2.0`
I18n made easy for web sites written with eliom.



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.0