### PR TITLE
Package ocsigen-i18n.3.2.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom."
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-rewriter"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-checker"] ]
+
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind" {build}
+  "tyxml" {< "4.3.0"}
+]
+authors: "Julien Sagot"
+flags: light-uninstall
+url {
+  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.2.0.tar.gz"
+  checksum: [
+    "md5=3882bd530f3a2799127c1793f40e0126"
+    "sha512=65e2af152e48e21a6ab06d5bf9c6a8fb9a9c385ab979ccb1f38b9f3ea1197061392d2f9109a4ae33c95d0e5c5ce5c73bf8ccc531a122b7bc5f6db59e4a57f1a5"
+  ]
+}

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -19,7 +19,7 @@ depends: [
 authors: "Julien Sagot"
 flags: light-uninstall
 url {
-  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.2.0.tar.gz"
+  src: "https://github.com/besport/ocsigen-i18n/archive/3.2.0.tar.gz"
   checksum: [
     "md5=3882bd530f3a2799127c1793f40e0126"
     "sha512=65e2af152e48e21a6ab06d5bf9c6a8fb9a9c385ab979ccb1f38b9f3ea1197061392d2f9109a4ae33c95d0e5c5ce5c73bf8ccc531a122b7bc5f6db59e4a57f1a5"


### PR DESCRIPTION
### `ocsigen-i18n.3.2.0`
I18n made easy for web sites written with eliom.



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.0