### PR TITLE
Package kinetic-client.0.0.11

### DIFF
--- a/packages/kinetic-client/kinetic-client.0.0.11/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.11/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Client API for Seagate's Kinetic drives"
+maintainer: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
+authors: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
+homepage: "https://github.com/openvstorage/kinetic-ocaml-client"
+bug-reports: "https://github.com/openvstorage/kinetic-ocaml-client"
+dev-repo: "git+https://github.com/openvstorage/kinetic-ocaml-client.git"
+license: "LGPL"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@examples" "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build & >= "1.1.0"}
+  "ocaml-protoc" {>= "1.2.0"}
+  "lwt" {>= "3.2.0"}
+  "lwt_log"
+  "lwt_ssl"
+  "cryptokit"
+  "ppx_deriving"
+  "cmdliner" {with-test}
+]
+url {
+  src:
+    "https://github.com/openvstorage/kinetic-ocaml-client/archive/0.0.11.tar.gz"
+  checksum: [
+    "md5=acc775dbd08f7cdbdd7955f2a284b2f0"
+    "sha512=d7374b38a9cfee05b6b820c72d88a2626fb9af6ab972a4596aaa2cdc708042b4003b1c5f525121791bfe9140c65b49c9f3a5e8e50f70d432f0e979cfd8a7d5a4"
+  ]
+}


### PR DESCRIPTION
### `kinetic-client.0.0.11`
Client API for Seagate's Kinetic drives



---
* Homepage: https://github.com/openvstorage/kinetic-ocaml-client
* Source repo: git+https://github.com/openvstorage/kinetic-ocaml-client.git
* Bug tracker: https://github.com/openvstorage/kinetic-ocaml-client

---
:camel: Pull-request generated by opam-publish v2.0.0