### PR TITLE
ppx_deriving_yojson incompatible with dune < 1.2

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ppx_tools"    {build}
   "ppxfind"      {build}
-  "dune"         {build}
+  "dune"         {build & >= "1.2"}
   "cppo"         {build}
   "ounit"        {with-test}
 ]


### PR DESCRIPTION
ppx_deriving_yojson 3.3 includes a dune-project file which specifies the 1.2 language format, so the opam file has to depend on a newer dune.

A pull request to resolve this issue exists upstream: https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/88 where compatibility with older dune is restored, but for opam it is easier to patch the opam file than to patch the dune-project.