### PR TITLE
Package ocaml-http.0.1.6

### DIFF
--- a/packages/ocaml-http/ocaml-http.0.1.6/opam
+++ b/packages/ocaml-http/ocaml-http.0.1.6/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "claudio.sacerdoticoen@unibo.it"
+bug-reports: "https://github.com/sacerdot/ocaml-http/issues"
+homepage: "https://github.com/sacerdot/ocaml-http"
+authors: "Stefano Zacchiroli"
+dev-repo: "git+https://github.com/sacerdot/ocaml-http.git"
+build: [
+  [make "all"]
+  [make "opt"]
+]
+remove: [["ocamlfind" "remove" "http"]]
+depends: ["ocaml" {>="4.03.0"} "ocamlfind" {build} "ocamlnet" "pcre"]
+install: [make "install"]
+synopsis: "Library freely inspired from Perl's HTTP::Daemon module"
+flags: light-uninstall
+url {
+  src: "https://github.com/sacerdot/ocaml-http/archive/v0.1.6.tar.gz"
+  checksum: [
+    "md5=3eb1319d30a24802d77eaf0e852953ff"
+    "sha512=ca8522f8627e91def30440fa94b57c2beb916b6d9e9c68f9c2ae1f75abbaa948cdda631ec56b62a18f5f94581a6bfa9676ce33b1347e9a457ea03d7c3e123462"
+  ]
+}


### PR DESCRIPTION
### `ocaml-http.0.1.6`
Library freely inspired from Perl's HTTP::Daemon module



---
* Homepage: https://github.com/sacerdot/ocaml-http
* Source repo: git+https://github.com/sacerdot/ocaml-http.git
* Bug tracker: https://github.com/sacerdot/ocaml-http/issues

---
:camel: Pull-request generated by opam-publish v2.0.0