### PR TITLE
Use the correct url to archives in ocamlforge

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.7/opam
+++ b/packages/lablgtk/lablgtk.2.18.7/opam
@@ -50,6 +50,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1773/lablgtk-2.18.7.tar.gz"
+    "http://forge.ocamlcore.org/frs/download.php/1773/lablgtk-2.18.7.tar.gz"
   checksum: "md5=2da57c6ebbb7ecba5c6d71576ec929ac"
 }

--- a/packages/lablgtk3/lablgtk3.0.beta1/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta1/opam
@@ -28,6 +28,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1772/lablgtk-3.0.beta1.tar.gz"
+    "http://forge.ocamlcore.org/frs/download.php/1772/lablgtk-3.0.beta1.tar.gz"
   checksum: "md5=20fcd8b8d3d79d27e66f985b0c8432ad"
 }

--- a/packages/lablgtk3/lablgtk3.0.beta2/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta2/opam
@@ -28,6 +28,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge.ocamlcore.org/frs/download.php/1774/lablgtk-3.0.beta2.tar.gz"
+    "http://forge.ocamlcore.org/frs/download.php/1774/lablgtk-3.0.beta2.tar.gz"
   checksum: "md5=1dd2c4ee1e1049afcaeeca3c3cceb64d"
 }


### PR DESCRIPTION
SSL is not correctly configured on the former (see https://github.com/ocaml/opam-repository/pull/12982)