### PR TITLE
Package ocsigen-i18n.3.3.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom."
+description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-rewriter"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-checker"] ]
+
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind" {build}
+  "tyxml" { >= "4.3.0" }
+]
+authors: "Julien Sagot"
+flags: light-uninstall
+url {
+  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.3.0.tar.gz"
+  checksum: [
+    "md5=9cb8253e52bb6f5af763128f15c83dcf"
+    "sha512=312be7f18ceca558120ed6dd5872a29d9d5ada4ed39bc3e44e59ae4efca2dbb352af73144177be7a28b4a4fe173bd2fa1f676d89b39f3601cac4d4f9845fbaa9"
+  ]
+}

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
@@ -20,7 +20,7 @@ depends: [
 authors: "Julien Sagot"
 flags: light-uninstall
 url {
-  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.3.0.tar.gz"
+  src: "https://github.com/besport/ocsigen-i18n/archive/3.3.0.tar.gz"
   checksum: [
     "md5=9cb8253e52bb6f5af763128f15c83dcf"
     "sha512=312be7f18ceca558120ed6dd5872a29d9d5ada4ed39bc3e44e59ae4efca2dbb352af73144177be7a28b4a4fe173bd2fa1f676d89b39f3601cac4d4f9845fbaa9"


### PR DESCRIPTION
### `ocsigen-i18n.3.3.0`
I18n made easy for web sites written with eliom.
Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.0