### PR TITLE
[new release] ocaml-migrate-parsetree-ocamlbuild and ocaml-migrate-parsetree (1.2.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.2.0/opam
+++ b/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/let-def/ocaml-migrate-parsetree.git"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ocaml-migrate-parsetree"
+  "ocamlbuild"
+  "ocaml" {>= "4.02.0"}
+]
+synopsis: "Ocamlbuild plugin for ocaml-migrate-parsetree"
+description: """
+This package provides an ocamlbuild plugin that can be used to produce
+optimized on-demand statically linked ppx drivers, as Dune does
+by default.
+"""
+url {
+  src:
+    "https://github.com/let-def/ocaml-migrate-parsetree/releases/download/v1.2.0/ocaml-migrate-parsetree-v1.2.0.tbz"
+  checksum: "md5=cc6fb09ad6f99156c7dba47711c62c6f"
+}

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ppx_derivers"
+  "dune" {build}
+  "ocaml" {>= "4.02.0"}
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.2.0/ocaml-migrate-parsetree-v1.2.0.tbz"
+  checksum: "md5=cc6fb09ad6f99156c7dba47711c62c6f"
+}


### PR DESCRIPTION
Ocamlbuild plugin for ocaml-migrate-parsetree

- Project page: <a href="https://github.com/let-def/ocaml-migrate-parsetree">https://github.com/let-def/ocaml-migrate-parsetree</a>

##### CHANGES:

- Remove unused ocamlfind dependency in the opam file (let-def/ocaml-migrate-parsetree#53, @diml)

- Add `--print-transformations` to list registered transformations
  (let-def/ocaml-migrate-parsetree#55, @rgrinberg)

- Fix Windows compatibility by setting the output to binary mode when
  writing a binary ast (let-def/ocaml-migrate-parsetree#57, let-def/ocaml-migrate-parsetree#59, @bryphe and @dra27)

- Switch to dune and opam 2.0 (let-def/ocaml-migrate-parsetree#58, let-def/ocaml-migrate-parsetree#60, @diml)
