### PR TITLE
Package ocsigen-toolkit.2.0.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "eliom" {>= "6.4"}
+  "calendar"
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=1d4ff06dd85dedcdb885bd97109bcc7e"
+    "sha512=2b501b1ead3ef36ef5ebf304de3d6f38cf833685793ba2c6dea2ce0ccecf28f586eb4426b84e3579debb77f7fbc6ab87e76bf270b95c88cd108ce7a55bdbc1a5"
+  ]
+}

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "calendar"
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.0.0.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.0.0.tar.gz"
   checksum: [
     "md5=1d4ff06dd85dedcdb885bd97109bcc7e"
     "sha512=2b501b1ead3ef36ef5ebf304de3d6f38cf833685793ba2c6dea2ce0ccecf28f586eb4426b84e3579debb77f7fbc6ab87e76bf270b95c88cd108ce7a55bdbc1a5"


### PR DESCRIPTION
### `ocsigen-toolkit.2.0.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0