### PR TITLE
Package obeam.0.1.2

### DIFF
--- a/packages/obeam/obeam.0.1.2/opam
+++ b/packages/obeam/obeam.0.1.2/opam
@@ -6,6 +6,7 @@ license: "Boost License Version 1.0"
 homepage: "https://github.com/yutopp/obeam"
 bug-reports: "https://github.com/yutopp/obeam/issues"
 depends: [
+  "ocaml"
   "base" {>= "v0.11.0"}
   "stdio" {>= "v0.11.0"}
   "bitstring" {>= "3.0.0"}

--- a/packages/obeam/obeam.0.1.2/opam
+++ b/packages/obeam/obeam.0.1.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A utility library for parsing BEAM format"
+maintainer: "yutopp <yutopp@gmail.com>"
+authors: ["yutopp <yutopp@gmail.com>" "amutake <amutake.s@gmail.com>"]
+license: "Boost License Version 1.0"
+homepage: "https://github.com/yutopp/obeam"
+bug-reports: "https://github.com/yutopp/obeam/issues"
+depends: [
+  "base" {>= "v0.11.0"}
+  "stdio" {>= "v0.11.0"}
+  "bitstring" {>= "3.0.0"}
+  "camlzip" {>= "1.07"}
+  "zarith" {>= "1.7"}
+  "ppx_here" {>= "v0.11.0"}
+  "ppx_let" {>= "v0.11.0"}
+  "ppx_sexp_conv" {>= "v0.11.2"}
+  "dune" {build}
+  "bisect_ppx" {build}
+  "expect_test_helpers_kernel" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/yutopp/obeam.git"
+url {
+  src: "https://github.com/yutopp/obeam/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=31157380fee6ce135c47d3583def89c2"
+    "sha512=56066dc8064c1294cc7781728edfdf3acb386812243eb8ddc5a33ed4fe35df95bbc583de895a709b15a1028d74f1a7f95169686cea6a2c03973556c500ddb074"
+  ]
+}


### PR DESCRIPTION
### `obeam.0.1.2`
A utility library for parsing BEAM format



---
* Homepage: https://github.com/yutopp/obeam
* Source repo: git+https://github.com/yutopp/obeam.git
* Bug tracker: https://github.com/yutopp/obeam/issues

---
:camel: Pull-request generated by opam-publish v2.0.0