### PR TITLE
Package eliom.6.3.1

### DIFF
--- a/packages/eliom/eliom.6.3.1/opam
+++ b/packages/eliom/eliom.6.3.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind"
+  "deriving" {>= "0.6"}
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml" {>= "3.0" & < "3.3"}
+  "js_of_ocaml-lwt" {< "3.3"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx" {<= "3.0.2"} | "js_of_ocaml-ppx_deriving_json"
+  "js_of_ocaml-tyxml" {< "3.2.0"}
+  "lwt" {< "4.0"}
+  "lwt_log"
+  "lwt_ppx"
+  "lwt_camlp4"
+  "tyxml" {>= "4.0.0" & < "4.3.0"}
+  "ocsigenserver" {< "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/jrochel/eliom/archive/6.3.1.tar.gz"
+  checksum: [
+    "md5=3b599cea055d3fdef57ae819ee444c1f"
+    "sha512=b7ef5ff6e84162100bf457af2c6acd19a3bdaa2a40e65abe72ed2a37d3d4dca262a017f3c7d9d4c29d3b41aac840b84e9bb6991ad23637ccf73ce970e9bab732"
+  ]
+}

--- a/packages/eliom/eliom.6.3.1/opam
+++ b/packages/eliom/eliom.6.3.1/opam
@@ -32,7 +32,7 @@ depends: [
   "base-bytes"
 ]
 url {
-  src: "https://github.com/jrochel/eliom/archive/6.3.1.tar.gz"
+  src: "https://github.com/ocsigen/eliom/archive/6.3.1.tar.gz"
   checksum: [
     "md5=3b599cea055d3fdef57ae819ee444c1f"
     "sha512=b7ef5ff6e84162100bf457af2c6acd19a3bdaa2a40e65abe72ed2a37d3d4dca262a017f3c7d9d4c29d3b41aac840b84e9bb6991ad23637ccf73ce970e9bab732"


### PR DESCRIPTION
### `eliom.6.3.1`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0