### PR TITLE
Package ocsigen-toolkit.1.1.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.1.1.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.1.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "calendar"
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-toolkit/archive/1.1.1.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/1.1.1.tar.gz"
   checksum: [
     "md5=d59fef91dff56d2a20d0f2e43bdfe3cd"
     "sha512=33bc240345216b50563c5785e70d9c387f2a36149931f12456d95cfc415dda62d1e7ef8030a2ee07fb1e1de4497ccc78ba241a73e7365e5ed4b717192c2e1b85"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.1.1.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.1.1.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications. The toolkit is in beta state."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "eliom" {>= "6.3.1" < "6.4"}
+  "calendar"
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-toolkit/archive/1.1.1.tar.gz"
+  checksum: [
+    "md5=d59fef91dff56d2a20d0f2e43bdfe3cd"
+    "sha512=33bc240345216b50563c5785e70d9c387f2a36149931f12456d95cfc415dda62d1e7ef8030a2ee07fb1e1de4497ccc78ba241a73e7365e5ed4b717192c2e1b85"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.1.1.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications. The toolkit is in beta state.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0