### PR TITLE
Package ocsigen-start.1.1.1

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.1.1.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.1/opam
@@ -35,7 +35,7 @@ depexts: [
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-start/archive/1.1.1.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-start/archive/1.1.1.tar.gz"
   checksum: [
     "md5=53efc99518d016a6c812746a30654331"
     "sha512=799db75ff5d621735277ff48649091722a877416aa31f3bd0bcedf71fccd62d92472bdcf7b13f94bcdbc904cc24ec434c353d2bcf67e77edf3b2487ad9157e0f"

--- a/packages/ocsigen-start/ocsigen-start.1.1.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"
+description: "Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management."
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.03"}
+  "pgocaml" {>= "2.3"}
+  "macaque" {>= "0.7.4"}
+  "safepass"
+  "ocsigen-i18n" {>= "3.1.0"}
+  "eliom" {>= "6.3.1" < "6.4"}
+  "ocsigen-toolkit" {>= "1.1.1" < "2.0"}
+  "js_of_ocaml-camlp4"
+  "yojson"
+  "resource-pooling" {>= "0.5.2"}
+]
+depexts: [
+  ["imagemagick"] {os-distribution = "debian"}
+  ["ruby-sass"] {os-distribution = "debian"}
+  ["postgresql"] {os-distribution = "debian"}
+  ["postgresql-common"] {os-distribution = "debian"}
+  ["imagemagick"] {os-distribution = "ubuntu"}
+  ["ruby-sass"] {os-distribution = "ubuntu"}
+  ["postgresql"] {os-distribution = "ubuntu"}
+  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["npm"] {os-distribution = "ubuntu"}
+  ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-start/archive/1.1.1.tar.gz"
+  checksum: [
+    "md5=53efc99518d016a6c812746a30654331"
+    "sha512=799db75ff5d621735277ff48649091722a877416aa31f3bd0bcedf71fccd62d92472bdcf7b13f94bcdbc904cc24ec434c353d2bcf67e77edf3b2487ad9157e0f"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-start.1.1.1`
An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.0.0