### PR TITLE
ipaddr.2.9.0 uses 'lang dune 1.6' in dune-project, add this version constraint in opam

### DIFF
--- a/packages/ipaddr/ipaddr.2.9.0/opam
+++ b/packages/ipaddr/ipaddr.2.9.0/opam
@@ -28,7 +28,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune" {build & >= "1.6.0"}
   "base-bytes"
   "ppx_sexp_conv" {>="v0.9.0"}
   "sexplib"


### PR DESCRIPTION
see https://github.com/mirage/ocaml-ipaddr/issues/78