### PR TITLE
[new release] travesty (0.2.0)

### DIFF
--- a/packages/travesty/travesty.0.2.0/opam
+++ b/packages/travesty/travesty.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Monadically traversable containers"
+description:
+  "'Travesty' is a library for defining containers with monadic traversals,
+   inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
+   Core library ecosystem."
+maintainer: "Matt Windsor <m.windsor@imperial.ac.uk>"
+authors: "Matt Windsor <m.windsor@imperial.ac.uk>"
+license: "MIT"
+doc: "https://MattWindsor91.github.io/travesty/"
+homepage: "https://MattWindsor91.github.io/travesty"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {build}
+  "ppx_deriving"
+  "ppx_expect"
+  "ppx_jane"
+  "ppx_sexp_message"
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/MattWindsor91/travesty"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.2.0/travesty-v0.2.0.tbz"
+  checksum: "md5=e1193d5877fafac13235778fa1c9455b"
+}


### PR DESCRIPTION
Monadically traversable containers

- Project page: <a href="https://MattWindsor91.github.io/travesty">https://MattWindsor91.github.io/travesty</a>
- Documentation: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>

##### CHANGES:

## Breaking changes

- _Potentially breaking change:_ `Traversable.S0_container` now
  contains `module Elt : Equal.S`, and constrains `type elt` to be
  equal to `Elt.t`.  This reflects the situation in
  `Basic_container0`, and shouldn't break any code using
  `Make_container0`, but may cause custom-built modules to fail to
  type-check.
- `T_container.any`'s arguments have swapped order, to be more
  in line with `Core` idioms.

## New features

- Add `Traversable.Chain0`, a functor for combining two
  `S0_container` instances together for nested traversal.
- Add `T_fn.disj` to go with `T_fn.conj`.
- Add `Filter_mappable`, which generalises `List.filter_map`.
- Add `tee_m` to monad extensions.  This is a small wrapper over
  `f x >>| fun () -> x` that allows unit-returning monadic
  side-effects to be treated as part of a monad pipeline.
- Add `T_or_error`: monad extensions for `Core.Or_error`.
- `one` and `two` are now implemented on `T_container`, not just
  `T_list`.  The errors are slightly less precise, but otherwise
  nothing has changed.
- Add `T_container.at_most_one` to complement `one` and `two`.
- Add `Monad.To_mappable`, which makes sure that monads can be
  converted to mappables.
- Add `T_container.all` and `none`, to complement `any`.

## Other

- Improve API documentation.
