### PR TITLE
Package reactiveData.0.2.2

### DIFF
--- a/packages/reactiveData/reactiveData.0.2.2/opam
+++ b/packages/reactiveData/reactiveData.0.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Declarative events and signals for OCaml"
+description: "React is an OCaml module for functional reactive programming (FRP). It provides support to program with time varying values : declarative events and signals. React doesn't define any primitive event or signal, it lets the client chooses the concrete timeline."
+maintainer: "Hugo Heuzard <hugo.heuzard@gmail.com>"
+authors: ["Hugo Heuzard <hugo.heuzard@gmail.com>"]
+homepage: "https://github.com/ocsigen/reactiveData"
+dev-repo: "git+https://github.com/ocsigen/reactiveData.git"
+bug-reports: "https://github.com/ocsigen/reactiveData/issues"
+
+doc:"http://ocsigen.github.io/reactiveData/dev/"
+
+tags: [ "reactive" "declarative" "signal" "event" "frp" ]
+license: "LGPL-3.0 with OCaml linking exception"
+
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "react" {>= "1.2.1" < "1.3"}
+]
+build: [
+  [
+    "ocaml"
+    "pkg/build.ml"
+    "native=%{ocaml:native}%"
+    "native-dynlink=%{ocaml:native}%"
+  ]
+  ["ocamlbuild" "-use-ocamlfind" "src/api.docdir/index.html"] {with-doc}
+]
+url {
+  src: "https://github.com/ocsigen/reactiveData/archive/0.2.2.tar.gz"
+  checksum: [
+    "md5=d08a22087b617ce50ac279e3f058674a"
+    "sha512=56c03d528feec769718c92075c49759dac287b93fe97d816da5cfadb26836d3855176cd81d4cec4441591dd9314e881045912a37edf584ad149ebd048016a4bf"
+  ]
+}


### PR DESCRIPTION
### `reactiveData.0.2.2`
Declarative events and signals for OCaml
React is an OCaml module for functional reactive programming (FRP). It provides support to program with time varying values : declarative events and signals. React doesn't define any primitive event or signal, it lets the client chooses the concrete timeline.



---
* Homepage: https://github.com/ocsigen/reactiveData
* Source repo: git+https://github.com/ocsigen/reactiveData.git
* Bug tracker: https://github.com/ocsigen/reactiveData/issues

---
:camel: Pull-request generated by opam-publish v2.0.0