### PR TITLE
Package ocsigen-start.1.3.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.1.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"
+description: "Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management."
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "pgocaml" {>= "2.3"}
+  "macaque" {>= "0.7.4"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "3.1.0"}
+  "eliom" {>= "6.4.0"}
+  "ocsigen-toolkit" {>= "2.0.0"}
+  "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "yojson" {>= "1.4.1"}
+  "resource-pooling" {>= "0.5.2"}
+]
+depexts: [
+  ["imagemagick"] {os-distribution = "debian"}
+  ["ruby-sass"] {os-distribution = "debian"}
+  ["postgresql"] {os-distribution = "debian"}
+  ["postgresql-common"] {os-distribution = "debian"}
+  ["imagemagick"] {os-distribution = "ubuntu"}
+  ["ruby-sass"] {os-distribution = "ubuntu"}
+  ["postgresql"] {os-distribution = "ubuntu"}
+  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["npm"] {os-distribution = "ubuntu"}
+  ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-start/archive/1.3.0.tar.gz"
+  checksum: [
+    "md5=298efa9bbb051537a1df7ba2d253f93d"
+    "sha512=42e1cb0222847e024d14e2e0206161e3b2597d9e1fed76ff3f384390b91cf36f2bdb094c7a63362edd3cd149a1ab752a4b42aae4f53d41d60043da067736d1d9"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-start.1.3.0`
An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.0.0