### PR TITLE
conduit: add upper bounds to ipaddr

### DIFF
--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "conduit-lwt" {>= "1.0.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}
-  "ipaddr" {>= "2.8.0"}
+  "ipaddr" {>= "2.8.0" & < "3.0.0"}
 ]
 depopts: [
   "tls"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
@@ -19,7 +19,7 @@ depends: [
   "conduit-lwt" {>= "1.0.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}
-  "ipaddr" {>= "2.8.0"}
+  "ipaddr" {>= "2.8.0" & < "3.0.0"}
 ]
 depopts: [
   "tls"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "conduit-lwt" {>= "1.1.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}
-  "ipaddr" {>= "2.8.0"}
+  "ipaddr" {>= "2.8.0" & < "3.0.0"}
 ]
 depopts: [
   "tls"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.2.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "conduit-lwt"
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}
-  "ipaddr" {>= "2.8.0"}
+  "ipaddr" {>= "2.8.0" & < "3.0.0"}
 ]
 depopts: [
   "tls"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.3.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.3.0/opam
@@ -52,7 +52,7 @@ depends: [
   "conduit-lwt" {>= "1.3.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}
-  "ipaddr" {>= "2.8.0"}
+  "ipaddr" {>= "2.8.0" & < "3.0.0"}
 ]
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [

--- a/packages/conduit/conduit.0.15.4/opam
+++ b/packages/conduit/conduit.0.15.4/opam
@@ -27,7 +27,7 @@ depends: [
   "uri" {< "2.0.0"}
   "result"
   "logs" {>= "0.5.0"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
 ]
 depopts: [
   "async" {< "v0.12"}

--- a/packages/conduit/conduit.0.6.0/opam
+++ b/packages/conduit/conduit.0.6.0/opam
@@ -19,7 +19,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.6.1/opam
+++ b/packages/conduit/conduit.0.6.1/opam
@@ -19,7 +19,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.7.0/opam
+++ b/packages/conduit/conduit.0.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.7.1/opam
+++ b/packages/conduit/conduit.0.7.1/opam
@@ -16,7 +16,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.7.2/opam
+++ b/packages/conduit/conduit.0.7.2/opam
@@ -16,7 +16,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.0/opam
+++ b/packages/conduit/conduit.0.8.0/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.1/opam
+++ b/packages/conduit/conduit.0.8.1/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.2/opam
+++ b/packages/conduit/conduit.0.8.2/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.4/opam
+++ b/packages/conduit/conduit.0.8.4/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.5/opam
+++ b/packages/conduit/conduit.0.8.5/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.6/opam
+++ b/packages/conduit/conduit.0.8.6/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.7/opam
+++ b/packages/conduit/conduit.0.8.7/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.8.8/opam
+++ b/packages/conduit/conduit.0.8.8/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.0.9.0/opam
+++ b/packages/conduit/conduit.0.9.0/opam
@@ -18,7 +18,7 @@ depends: [
   "stringext"
   "uri" {< "2.0.0"}
   "cstruct" {>= "1.0.1"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/conduit/conduit.1.0.0/opam
+++ b/packages/conduit/conduit.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "result"
   "astring"
   "logs" {>= "0.5.0"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
 ]
 synopsis: "Network conduit library"
 description: """

--- a/packages/conduit/conduit.1.0.3/opam
+++ b/packages/conduit/conduit.1.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "uri" {< "2.0.0"}
   "result"
   "logs" {>= "0.5.0"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit/conduit.1.1.0/opam
+++ b/packages/conduit/conduit.1.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "uri" {< "2.0.0"}
   "result"
   "logs" {>= "0.5.0"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit/conduit.1.3.0/opam
+++ b/packages/conduit/conduit.1.3.0/opam
@@ -54,7 +54,7 @@ depends: [
   "uri"
   "result"
   "logs" {>= "0.5.0"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
in preparation for https://github.com/mirage/ocaml-ipaddr/pull/79 in ipaddr 3.0.0