### PR TITLE
[new release] launchd (1.3)

### DIFF
--- a/packages/launchd/launchd.1.3/opam
+++ b/packages/launchd/launchd.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-launchd"
+doc: "https://mirage.github.io/ocaml-launchd/"
+bug-reports: "https://github.com/mirage/ocaml-launchd/issues"
+synopsis: "Bindings for the launchd socket activation API"
+description: """
+Launchd on macOS takes care of binding and listening on sockets for you
+and can launch your program on demand. The API bindings are needed to
+receive the listening sockets from launchd.
+"""
+
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {build}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.0"}
+  "cstruct-lwt"
+]
+available: os = "macos"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-launchd.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-launchd/releases/download/v1.3/launchd-v1.3.tbz"
+  checksum: "md5=646fc8ad43bdf071838813eb57ebaeb5"
+}


### PR DESCRIPTION
Bindings for the launchd socket activation API

- Project page: <a href="https://github.com/mirage/ocaml-launchd">https://github.com/mirage/ocaml-launchd</a>
- Documentation: <a href="https://mirage.github.io/ocaml-launchd/">https://mirage.github.io/ocaml-launchd/</a>

##### CHANGES:

- port to Dune.
- support `-safe-string`.
- update opam metadata to 2.0 format.
