### PR TITLE
[new release] mirage-clock, mirage-clock-freestanding, mirage-clock-lwt and mirage-clock-unix (2.0.0)

### DIFF
--- a/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
+++ b/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "dns-forward" {>= "0.9.0"}
+  "dns-forward" {>= "0.9.0" & < "0.10.0"}
   "lwt" {>= "2.7.0"}
   "cstruct-lwt" {>= "3.0.0"}
   "io-page-unix" {>= "2.0.0"}

--- a/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
+++ b/packages/dns-forward-lwt-unix/dns-forward-lwt-unix.0.9.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "dns-forward" {>= "0.8.5"}
+  "dns-forward" {>= "0.9.0"}
   "lwt" {>= "2.7.0"}
   "cstruct-lwt" {>= "3.0.0"}
   "io-page-unix" {>= "2.0.0"}

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.2.0.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git://github.com/mirage/mirage-clock"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v2.0.0/mirage-clock-v2.0.0.tbz"
+  checksum: "md5=d51d5ec423bcb13bb03e7ebffc855f6a"
+}

--- a/packages/mirage-clock-lwt/mirage-clock-lwt.2.0.0/opam
+++ b/packages/mirage-clock-lwt/mirage-clock-lwt.2.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Lwt-based implementation of the MirageOS Clock interface"
+description: """
+This implementation of the MirageOS CLOCK interface specialises
+the `io` type to use the Lwt concurrency monad.
+"""
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "mirage-clock" {>= "1.2.0"}
+  "lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v2.0.0/mirage-clock-v2.0.0.tbz"
+  checksum: "md5=d51d5ec423bcb13bb03e7ebffc855f6a"
+}

--- a/packages/mirage-clock-unix/mirage-clock-unix.2.0.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Unix-based implementation for the MirageOS Clock interface"
+description: """
+The Unix implementation of the MirageOS Clock interface uses
+`gettimeofday` or `clock_gettime`, depending on
+which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+"""
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v2.0.0/mirage-clock-v2.0.0.tbz"
+  checksum: "md5=d51d5ec423bcb13bb03e7ebffc855f6a"
+}

--- a/packages/mirage-clock/mirage-clock.2.0.0/opam
+++ b/packages/mirage-clock/mirage-clock.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "mirage-device" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v2.0.0/mirage-clock-v2.0.0.tbz"
+  checksum: "md5=d51d5ec423bcb13bb03e7ebffc855f6a"
+}


### PR DESCRIPTION
Libraries and module types for portable clocks

- Project page: <a href="https://github.com/mirage/mirage-clock">https://github.com/mirage/mirage-clock</a>
- Documentation: <a href="https://mirage.github.io/mirage-clock/">https://mirage.github.io/mirage-clock/</a>

##### CHANGES:

* Constrain the clock type `t` to `unit` to improve compatability with
  the webmachine CLOCK interface. All current implementations satisfy
  this interface so there shouldn't be an issue, but bumping the
  library major version number to reflect the interface change (mirage/mirage-clock#38 @hannesm)

* Port library to Dune from jbuilder and use `dune-release` and the builtin
  `dune.configurator` to reduce the build dependency cone (mirage/mirage-clock#39 @avsm).

* Remove unused variable warnings (mirage/mirage-clock#39 @avsm).

* Update opam package metadata to 2.0 format (mirage/mirage-clock#39 @avsm).

* Fixes to the ocamldoc comment headers for odoc compatibility (@avsm)
