### PR TITLE
ahrocksdb 0.2.0: fix dependencies issues

### DIFF
--- a/packages/ahrocksdb/ahrocksdb.0.2.0/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.0/opam
@@ -26,6 +26,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {build}
   "base" {build}
+  "stdio" {build}
   "ctypes" {>= "0.12.0"}
   "astring"
   "conf-rocksdb"


### PR DESCRIPTION
This adds a base dependency only needed at build time (which was removed in later versions) and fix the problem with rresult that is an actual dependency to the package.