### PR TITLE
[new release] mirage-unix (3.2.0)

### DIFF
--- a/packages/mirage-unix/mirage-unix.3.2.0/opam
+++ b/packages/mirage-unix/mirage-unix.3.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-unix"
+bug-reports:  "https://github.com/mirage/mirage-unix/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-unix.git"
+doc:          "https://mirage.github.io/mirage-unix/"
+license:      "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "lwt" {>= "2.4.3"}
+  "logs"
+  "io-page-unix" {>= "2.0.0"}
+]
+tags: "org:mirage"
+synopsis: "Unix core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Unix targets, which handles the main loop and timers.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-unix/releases/download/3.2.0/mirage-unix-3.2.0.tbz"
+  checksum: "md5=a995a735e6d6a13af00c0b8933abae6c"
+}


### PR DESCRIPTION
Unix core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-unix">https://github.com/mirage/mirage-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-unix/">https://mirage.github.io/mirage-unix/</a>

##### CHANGES:

* port to Dune from ocamlbuild, and replace packing with
  module aliases for the `OS` module (mirage/mirage-unix#8 by @avsm)
* Improve ocamldoc slightly for the main module (@avsm)
