### PR TITLE
[new release] macaddr and ipaddr (3.0.0)

### DIFF
--- a/packages/ipaddr/ipaddr.3.0.0/opam
+++ b/packages/ipaddr/ipaddr.3.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "macaddr"
+  "sexplib0"
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/3.0.0/ipaddr-3.0.0.tbz"
+  checksum: "md5=29248b09ead9ac272cd0f4c8ae934082"
+}

--- a/packages/macaddr/macaddr.3.0.0/opam
+++ b/packages/macaddr/macaddr.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+description: """
+Manipulate 48-bit Ethernet MAC addresses using this library.
+
+There are the following ocamlfind libraries included as part of this
+package:
+
+- `macaddr`: The `Macaddr` module for MAC address manipulation.
+- `macaddr.top`: Toplevel printers for Macaddr.
+- `macaddr.sexp`: S-expression converters for Macaddr.
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "sexplib0"
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/3.0.0/ipaddr-3.0.0.tbz"
+  checksum: "md5=29248b09ead9ac272cd0f4c8ae934082"
+}


### PR DESCRIPTION
A library for manipulation of MAC address representations

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

This release features several backwards incompatible changes,
but ones that should increase the portability and robustness
of the library.

* Remove the sexp serialisers from the main interface in favour
  of `pp` functions.  Use the `Ipaddr_sexp` module if you still
  need a sexp serialiser.

  To use these with ppx-based derivers, simply replace the
  reference to the `Ipaddr` type definition with `Ipaddr_sexp`.
  That will import the sexp-conversion functions, and the actual
  type definitions are simply aliases to the corresponding type
  within `Ipaddr`.  For example, you might do:

  ```
  type t = {
    ip: Ipaddr_sexp.t;
    mac: Macaddr_sexp.t;
  } [@@deriving sexp]
  ```

  The actual types of the records will be aliases to the main
  library types, and there will be two new functions available
  as converters.  The signature after ppx has run will be:

  ```
  type t = {
    ip: Ipaddr.t;
    mac: Macaddr.t;
  }
  val sexp_of_t : t -> Sexplib0.t
  val t_of_sexp : Sexplib0.t -> t
  ```

* Break out the `Macaddr` module into a separate opam package so
  that the `Ipaddr` module can be wrapped.  Use the `macaddr`
  opam library now if you need just the MAC address functionality.

* Replace all the `of_string/bytes` functions that formerly returned
  option types with the `Rresult` result types instead. This stops
  the cause of the exception from being swallowed, and the error
  message in the new functions can be displayed usefully.

* In the `Ipaddr.V6.to_string` and `to_buffer` functions, remove the
  optional labelled argument `v4` and always output v4-mapped strings
  as recommended by RFC5952. (mirage/ocaml-ipaddr#80 by @hannesm).

* Remove `pp_hum` which was deprecated in 2.9.0.

* Sexplib0 is now used which is more lightweight tha the full
  Sexplib library. Minimum OCaml version is now 4.04.0+ as a result
  of this dependency.

* Improvements to the ocamldoc formatting strings for better
  layout and odoc compatibility.
