### PR TITLE
+mirage-xen-ocaml.3.2.0 and +mirage-xen-posix.3.2.0

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
@@ -22,5 +22,5 @@ description:
   "The package contains the OCaml runtime patches and build system."
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.2.0.tar.gz"
-  checksum: "md5=6cb875b80d51f9a26eb05db7f9779011"
+  checksum: "md5=ea82478dd96782965324c939e9e9bfc4"
 }

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-platform.git"
+build: [make "-C" "xen-ocaml" "build"]
+install: [make "-C" "xen-ocaml" "install" "PREFIX=%{prefix}%"]
+remove: [make "-C" "xen-ocaml" "uninstall" "PREFIX=%{prefix}%"]
+tags: ["org:mirage"]
+depends: [
+  "ocaml" {>= "4.04.2" & <= "4.07.1"}
+  "mirage-xen-posix" {>= "2.6.0"}
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src"
+  "ocamlbuild" {build}
+]
+available: os = "linux"
+synopsis: "MirageOS headers for the OCaml runtime"
+description:
+  "The package contains the OCaml runtime patches and build system."
+url {
+  src: "https://github.com/mirage/mirage-platform/archive/3.2.0.tar.gz"
+  checksum: "md5=6cb875b80d51f9a26eb05db7f9779011"
+}

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
@@ -21,6 +21,6 @@ synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."
 url {
-  src: "https://github.com/mirage/mirage-platform/archive/3.2.0.tar.gz"
+  src: "https://github.com/mirage/mirage-platform/archive/v3.2.0.tar.gz"
   checksum: "md5=6cb875b80d51f9a26eb05db7f9779011"
 }

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
@@ -20,6 +20,6 @@ This package contains the header files to pretend a posix
 system (required to compile the OCaml runtime), plus minilibc and
 float formating."""
 url {
-  src: "https://github.com/mirage/mirage-platform/archive/3.2.0.tar.gz"
+  src: "https://github.com/mirage/mirage-platform/archive/v3.2.0.tar.gz"
   checksum: "md5=6cb875b80d51f9a26eb05db7f9779011"
 }

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
@@ -21,5 +21,5 @@ system (required to compile the OCaml runtime), plus minilibc and
 float formating."""
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.2.0.tar.gz"
-  checksum: "md5=6cb875b80d51f9a26eb05db7f9779011"
+  checksum: "md5=ea82478dd96782965324c939e9e9bfc4"
 }

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-platform"
+bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-platform.git"
+build:   [make "xen-posix-build"]
+install: [make "xen-posix-install" "PREFIX=%{prefix}%"]
+remove:  [make "xen-posix-uninstall" "PREFIX=%{prefix}%"]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "conf-pkg-config"
+]
+available: os = "linux"
+synopsis: "MirageOS library for posix headers"
+description: """
+This package contains the header files to pretend a posix
+system (required to compile the OCaml runtime), plus minilibc and
+float formating."""
+url {
+  src: "https://github.com/mirage/mirage-platform/archive/3.2.0.tar.gz"
+  checksum: "md5=6cb875b80d51f9a26eb05db7f9779011"
+}


### PR DESCRIPTION
- add support for OCaml 4.06 and 4.07 in the xen backend (mirage/mirage-platform#205 by @anmonteiro)
- update opam metadata to 2.0 format (@avsm)