### PR TITLE
Package ulid.0.1

### DIFF
--- a/packages/ulid/ulid.0.1/opam
+++ b/packages/ulid/ulid.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "stripedpajamas273@gmail.com"
+authors: [ "Peter Squicciarini" ]
+license: "MIT"
+homepage: "https://github.com/stripedpajamas/ocaml-ulid"
+doc: "https://github.com/stripedpajamas/ocaml-ulid"
+bug-reports: "https://github.com/stripedpajamas/ocaml-ulid/issues"
+dev-repo: "git+https://github.com/stripedpajamas/ocaml-ulid.git"
+synopsis: "ULIDs for OCaml"
+description: """
+ULIDs are Universally Unique Lexicographically Sortable Identifiers
+"""
+depends: [
+  "dune" {build & >= "1.0.1"}
+  "nocrypto"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src: "https://github.com/stripedpajamas/ocaml-ulid/archive/0.1.tar.gz"
+  checksum: [
+    "md5=832e5db6c4a2d1cbc67e93cf75ea484f"
+    "sha512=f9ee4d4b960e923f8a6ff81d667d3228bf18df71ca6188cc512332dd61ad6e3635ae7e08aab7c5807656be42f72a4d57540ddb2e1916dd588881253994069619"
+  ]
+}


### PR DESCRIPTION
### `ulid.0.1`
ULIDs for OCaml
ULIDs are Universally Unique Lexicographically Sortable Identifiers



---
* Homepage: https://github.com/stripedpajamas/ocaml-ulid
* Source repo: git+https://github.com/stripedpajamas/ocaml-ulid.git
* Bug tracker: https://github.com/stripedpajamas/ocaml-ulid/issues

---
:camel: Pull-request generated by opam-publish v2.0.0