### PR TITLE
mirage-qubes-ipv4, charrua-core, charrua-client-lwt: upper bounds for ipaddr 3

### DIFF
--- a/packages/charrua-client-lwt/charrua-client-lwt.0.10/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.10/opam
@@ -21,7 +21,7 @@ depends: [
   "charrua-core" {= "0.10"}
   "charrua-client" {= "0.10"}
   "cstruct" {>= "3.0.2"}
-  "ipaddr"
+  "ipaddr" {< "3.0.0"}
   "rresult"
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "duration"

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "charrua-core" {>= "0.11.0"}
   "charrua-client" {>= "0.11.0"}
   "cstruct" {>="3.0.2"}
-  "ipaddr"
+  "ipaddr" {< "3.0.0"}
   "rresult"
   "mirage-random" {>= "1.0.0"}
   "duration"

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
@@ -22,7 +22,7 @@ depends: [
   "charrua-core" {= "0.9"}
   "charrua-client" {= "0.9"}
   "cstruct" {>= "3.0.2"}
-  "ipaddr"
+  "ipaddr" {< "3.0.0"}
   "rresult"
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "duration"

--- a/packages/charrua-core/charrua-core.0.10/opam
+++ b/packages/charrua-core/charrua-core.0.10/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir" {build}
   "cstruct" {>= "3.0.1"}
   "sexplib" {< "v0.12"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "3.2.0"}
   "rresult"
   "io-page-unix" {with-test}

--- a/packages/charrua-core/charrua-core.0.11.0/opam
+++ b/packages/charrua-core/charrua-core.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml"         {>= "4.0.3"}
   "cstruct"       {>= "3.0.1"}
   "sexplib"       {< "v0.12"}
-  "ipaddr"        {>= "2.5.0"}
+  "ipaddr"        {>= "2.5.0" & < "3.0.0"}
   "tcpip"         {>= "3.2.0"}
   "rresult"
   "io-page-unix"  {with-test}

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "cstruct-unix"
   "sexplib" {< "v0.12"}
   "menhir"
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "2.6.0" & < "3.0.0"}
 ]
 synopsis: "Charrua DHCP core library."

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "sexplib" {< "v0.12"}
   "menhir"
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "3.0.0" & < "3.1.0"}
   "result"
   "rresult"

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -27,7 +27,7 @@ depends: [
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "ppx_cstruct"
   "sexplib" {< "v0.12"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "3.1.0" & < "3.2.0"}
   "rresult"
   "io-page" {with-test}

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -26,7 +26,7 @@ depends: [
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "ppx_cstruct"
   "sexplib" {< "v0.12"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "3.1.0" & < "3.2.0"}
   "rresult"
   "io-page" {with-test}

--- a/packages/charrua-core/charrua-core.0.7/opam
+++ b/packages/charrua-core/charrua-core.0.7/opam
@@ -26,7 +26,7 @@ depends: [
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "ppx_cstruct"
   "sexplib" {< "v0.12"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "3.1.0" & < "3.2.0"}
   "rresult"
   "io-page" {with-test}

--- a/packages/charrua-core/charrua-core.0.8/opam
+++ b/packages/charrua-core/charrua-core.0.8/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir" {build}
   "cstruct" {>= "3.0.1"}
   "sexplib" {< "v0.12"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "3.1.0" & < "3.2.0"}
   "rresult"
   "io-page" {with-test}

--- a/packages/charrua-core/charrua-core.0.9/opam
+++ b/packages/charrua-core/charrua-core.0.9/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir" {build}
   "cstruct" {>= "3.0.1"}
   "sexplib" {< "v0.12"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "tcpip" {>= "3.2.0"}
   "rresult"
   "io-page-unix" {with-test}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "mirage-qubes" {>= "0.5"}
   "tcpip" {>= "3.0.0" & < "3.5.0"}
-  "ipaddr"
+  "ipaddr" {< "3.0.0"}
   "mirage-protocols-lwt" {< "1.4.0"}
   "cstruct" {>= "1.9.0"}
   "lwt"

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "mirage-qubes" {>= "0.6"}
   "tcpip" {>= "3.5.0"}
-  "ipaddr"
+  "ipaddr" {< "3.0.0"}
   "mirage-random"
   "mirage-clock"
   "mirage-protocols-lwt"


### PR DESCRIPTION
//cc @avsm