### PR TITLE
[new release] opium_kernel and opium (0.17.0)

### DIFF
--- a/packages/opium/opium.0.17.0/opam
+++ b/packages/opium/opium.0.17.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/opium"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+synopsis: "Sinatra like web toolkit based on Lwt + Cohttp"
+description: """
+Opium is a minimalistic library for quickly binding functions to http routes. Its features include (but not limited to):
+
+    Middleware system for app independent components
+    A simple router for matching urls and parsing parameters
+    Request/Response pretty printing for easier debugging
+"""
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {build}
+  "opium_kernel"
+  "cohttp-lwt-unix" {>= "0.99.0"}
+  "base-unix"
+  "lwt"
+  "logs"
+  "cmdliner"
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "re" {>= "1.3.0"}
+  "magic-mime"
+  "stringext"
+  "alcotest" {with-test}
+  "cow" {with-test & >= "0.10.0"}
+]
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/v0.17.0/opium-v0.17.0.tbz"
+  checksum: "md5=c5b1d4e885f6b7d9a0c44d59f59242fc"
+}

--- a/packages/opium_kernel/opium_kernel.0.17.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.17.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+
+homepage: "https://github.com/rgrinberg/opium"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+synopsis: "Sinatra like web toolkit based on Lwt + Cohttp"
+description: """
+Opium_kernel is the Unix indpendent core of Opium. Useful for extremely portable environments such as mirage.
+"""
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {build}
+  "hmap"
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99.0"}
+  "ezjsonm" {>= "0.4.0"}
+  "base64" {>= "2.0.0"}
+  "lwt"
+  "fieldslib" {>= "v0.9.0"}
+  "sexplib" {>= "v0.9.0"}
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "re" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "cow" {with-test & >= "0.10.0"}
+]
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/v0.17.0/opium-v0.17.0.tbz"
+  checksum: "md5=c5b1d4e885f6b7d9a0c44d59f59242fc"
+}


### PR DESCRIPTION
Sinatra like web toolkit based on Lwt + Cohttp

- Project page: <a href="https://github.com/rgrinberg/opium">https://github.com/rgrinberg/opium</a>

##### CHANGES:

- Switch to dune (rgrinberg/opium#88, anuragoni)

- Keep the "/" cookie default and expose all cookie directives (rgrinberg/opium#82,
  @actionshrimp)

- Do not assume base 64 encoding of cookies (rgrinberg/opium#74, @malthe)

- Add caching capabilities to middleware (rgrinberg/opium#76, @mattjbray)
