### PR TITLE
Package abella.2.0.6

### DIFF
--- a/packages/abella/abella.2.0.6/opam
+++ b/packages/abella/abella.2.0.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Interactive theorem prover based on lambda-tree syntax"
+maintainer: "kaustuv@chaudhuri.info"
+authors: [
+  "Andrew Gacek"
+  "Yuting Wang"
+  "Kaustuv Chaudhuri"
+]
+homepage: "http://abella-prover.org"
+license: "GPL 3"
+build: [
+  [make "all" "abella.install"]
+]
+depends: [
+  "ocaml" { >= "4.02.3" }
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+bug-reports: "https://github.com/abella-prover/abella/issues"
+dev-repo: "git+https://github.com/abella-prover/abella.git"
+url {
+  src: "https://github.com/abella-prover/abella/archive/v2.0.6.tar.gz"
+  checksum: [
+    "md5=077cb3fbbdf35159e4b8860faf431c6a"
+    "sha512=b2d0346926a9d9d5cb6ea24ee6143f314ea16d5e82c7327b289dc33ad0943923beef9f14fd441a9acc26666424cf141dd94e7fc361e764b2ee879871ea63e39e"
+  ]
+}


### PR DESCRIPTION
### `abella.2.0.6`
Interactive theorem prover based on lambda-tree syntax



---
* Homepage: http://abella-prover.org
* Source repo: git+https://github.com/abella-prover/abella.git
* Bug tracker: https://github.com/abella-prover/abella/issues

---
:camel: Pull-request generated by opam-publish v2.0.0