### PR TITLE
[new release] mdx (1.2.0)

### DIFF
--- a/packages/mdx/mdx.1.2.0/opam
+++ b/packages/mdx/mdx.1.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org"]
+homepage:     "https://github.com/realworldocaml/mdx"
+license:      "ISC"
+dev-repo:     "git+https://github.com/realworldocaml/mdx.git"
+bug-reports:  "https://github.com/realworldocaml/mdx/issues"
+doc:          "https://realworldocaml.github.io/mdx/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "fmt"
+  "cppo" {build}
+  "astring"
+  "logs"
+  "cmdliner"
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "lwt" {with-test}
+  "conf-pandoc" {with-test}
+]
+
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`mdx pp`)
+and tests (`mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`mdx` is released as a single binary (called `mdx`).
+"""
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.2.0/mdx-1.2.0.tbz"
+  checksum: "md5=c8237ce970b3e891d608bf061350552c"
+}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>
- Documentation: <a href="https://realworldocaml.github.io/mdx/">https://realworldocaml.github.io/mdx/</a>

##### CHANGES:

- Support end-of-line ellipsis (@dra27, realworldocaml/mdx#85)
- Support OCaml 4.02.3 (@gpetiot, realworldocaml/mdx#86)
- Support `version=..`, `version<=..` and `version>=..` keywords to run
  a code-block depending on the currently installed OCaml version
  (@gpetiot, realworldocaml/mdx#87, realworldocaml/mdx#90)
- Upgrade Travis tests to use opam 2.0.2 (@avsm, realworldocaml/mdx#89)
- Do not depend on `ppx_tools` for toplevel (@avsm, realworldocaml/mdx#89)
- Fix embedding in a larger Dune project with a cppo override (@avsm, realworldocaml/mdx#89)
- `mdx output`: escape HTML entities in code blocks (realworldocaml/mdx#91, @samoht)
