### PR TITLE
[new release] conduit-lwt-unix, conduit, conduit-async, mirage-conduit

### DIFF
--- a/packages/conduit-async/conduit-async.1.2.0/opam
+++ b/packages/conduit-async/conduit-async.1.2.0/opam
@@ -18,6 +18,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "sexplib" {< "v0.12"}
   "conduit"
+  "ipaddr" {<"3.0.0"}
   "async" {>= "v0.10.0" & < "v0.12"}
 ]
 depopts: [

--- a/packages/conduit-async/conduit-async.1.3.0/opam
+++ b/packages/conduit-async/conduit-async.1.3.0/opam
@@ -50,6 +50,7 @@ depends: [
   "core" {< "v0.12"}
   "ppx_sexp_conv" {< "v0.12"}
   "sexplib" {< "v0.12"}
+  "ipaddr" {<"3.0.0"}
   "conduit" {>= "1.3.0"}
   "async" {>= "v0.10.0" & < "v0.12"}
 ]

--- a/packages/conduit-async/conduit-async.1.4.0/opam
+++ b/packages/conduit-async/conduit-async.1.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "core"
+  "ppx_sexp_conv"
+  "sexplib"
+  "conduit" {>="1.4.0"}
+  "async" {>= "v0.10.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.4.0/conduit-v1.4.0.tbz"
+  checksum: "md5=204222b8a61692083b79c67c8967fb28"
+}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.4.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "base-unix"
+  "ppx_sexp_conv"
+  "conduit-lwt" {>="1.4.0"}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "3.0.0"}
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.4.0/conduit-v1.4.0.tbz"
+  checksum: "md5=204222b8a61692083b79c67c8967fb28"
+}

--- a/packages/conduit-lwt/conduit-lwt.1.4.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "base-unix"
+  "ppx_sexp_conv"
+  "sexplib"
+  "conduit" {>="1.4.0"}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.4.0/conduit-v1.4.0.tbz"
+  checksum: "md5=204222b8a61692083b79c67c8967fb28"
+}

--- a/packages/conduit/conduit.1.4.0/opam
+++ b/packages/conduit/conduit.1.4.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "ppx_sexp_conv"
+  "sexplib"
+  "astring"
+  "uri"
+  "result"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `mirage-conduit`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.4.0/conduit-v1.4.0.tbz"
+  checksum: "md5=204222b8a61692083b79c67c8967fb28"
+}

--- a/packages/mirage-conduit/mirage-conduit.1.0.3/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.0.3/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
+  "ipaddr" {<"3.0.0"}
   "ppx_sexp_conv" {< "v0.12"}
   "cstruct" {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}

--- a/packages/mirage-conduit/mirage-conduit.1.3.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.3.0/opam
@@ -46,6 +46,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
   "ppx_sexp_conv" {< "v0.12"}
+  "ipaddr" {<"3.0.0"}
   "sexplib" {< "v0.12"}
   "cstruct" {>= "3.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}

--- a/packages/mirage-conduit/mirage-conduit.3.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.0/opam
@@ -21,6 +21,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "3.0.0"}
   "conduit-lwt"
+  "ipaddr" {<"3.0.0"}
   "vchan" {>= "3.0.0"}
   "tls" {>= "0.8.0"}
 ]

--- a/packages/mirage-conduit/mirage-conduit.3.0.1/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.1/opam
@@ -21,6 +21,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "3.0.0"}
   "conduit-lwt"
+  "ipaddr" {<"3.0.0"}
   "vchan" {>= "3.0.0"}
   "tls" {>= "0.8.0"}
 ]

--- a/packages/mirage-conduit/mirage-conduit.3.1.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "3.1.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "ppx_sexp_conv"
+  "sexplib"
+  "ipaddr" {>="3.0.0"}
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-dns" {>= "3.0.0"}
+  "conduit-lwt" {>="1.4.0"}
+  "vchan" {>= "3.0.0"}
+  "xenstore"
+  "tls" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.4.0/conduit-v1.4.0.tbz"
+  checksum: "md5=204222b8a61692083b79c67c8967fb28"
+}


### PR DESCRIPTION
CHANGES:

* Use Ipaddr 3.0.0+ interfaces (mirage/ocaml-conduit#284 by @avsm).
* Update opam metadata files to the opam 2.0 format (mirage/ocaml-conduit#284 by @avsm)
* Hook in an introduction ocamldoc page to the `conduit` odoc (mirage/ocaml-conduit#284 by @avsm)