### PR TITLE
use 4.07 on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
   - os: osx
     osx_image: xcode7.3
-    env: OCAML_VERSION=4.06 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.07 OPAM_VERSION=2.0.0
   - os: linux
     env: OCAML_VERSION=4.07 OPAM_VERSION=2.0.0
   - os: linux


### PR DESCRIPTION
as of now, travis uses brew to compile and install `ocaml 4.07.1`, just to return from brew (after ~25 minutes) and use opam to install ocaml 4.06 -- with this PR, the second compilation of ocaml is skipped, and 4.07 is used for CI.