### PR TITLE
mirage-net-lwt: restrict to ipaddr <3.0.0 (requires Macaddr.t which i…

### DIFF
--- a/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "topkg" {build & >= "0.8.0"}
   "mirage-net" {= "1.0.0"}
   "lwt"
-  "ipaddr" {>= "1.0.0"}
+  "ipaddr" {>= "1.0.0" & < "3.0.0"}
   "cstruct"
   "io-page"
 ]

--- a/packages/mirage-net-lwt/mirage-net-lwt.1.1.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.1.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "topkg" {build & >= "0.8.0"}
   "mirage-net" {>= "1.0.0"}
   "lwt"
-  "ipaddr" {>= "1.0.0"}
+  "ipaddr" {>= "1.0.0" & < "3.0.0"}
   "cstruct"
   "io-page"
   "result"


### PR DESCRIPTION
…s now longer part of ipaddr 3.0.0 API)