### PR TITLE
[ocaml-base-compiler]: fix the install section for old compilers

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -19,11 +19,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 patches: "ocaml-3.07-patch1.diffs"
 url {

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -19,11 +19,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 patches: "ocaml-3.07-patch2.diffs"
 url {

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -19,11 +19,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -18,11 +18,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -19,11 +19,11 @@ build: [
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world"]
   [make "world.opt"]
-  [make "install"]
-  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
 ]
 install: [
-  "cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"
+  [make "install"]
+  ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
+  ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"


### PR DESCRIPTION
move some install-related actions from the `build` section to the `install` section, otherwise they fail with sandboxing.

(tested with 3.09.3)