### PR TITLE
[new release] dns-lwt, dns, dns-async, dns-lwt-unix (1.1.0) and mirag…

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
@@ -16,6 +16,7 @@ depends: [
   "astring"
   "fmt"
   "logs"
+  "ipaddr" {<"3.0.0"}
   "mirage-dns"
   "mirage-stack-lwt"
   "alcotest-lwt" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
@@ -17,6 +17,7 @@ depends: [
   "fmt"
   "logs"
   "mirage-dns"
+  "ipaddr" {<"3.0.0"}
   "mirage-stack-lwt"
   "alcotest-lwt" {with-test}
   "io-page-unix" {with-test}

--- a/packages/dns-async/dns-async.1.1.0/opam
+++ b/packages/dns-async/dns-async.1.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+synopsis: "DNS implementation using the Async concurrency framework"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the Jane Street Async library.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns" {>="1.1.0"}
+  "async" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.0/dns-v1.1.0.tbz"
+  checksum: "md5=62230d2f85de4646d029cde7d1c3a55d"
+}

--- a/packages/dns-async/dns-async.1.1.0/opam
+++ b/packages/dns-async/dns-async.1.1.0/opam
@@ -29,7 +29,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
 url {

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.1.0/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.1.0/opam
@@ -32,7 +32,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
 url {

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.1.0/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+synopsis: "DNS implementation for Unix and Windows using Lwt_unix"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the `Lwt_unix` concurrency framework.
+Despite the name, the library should work on both Unix and Windows
+(as supported by Lwt_unix upstream).
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns-lwt" {>="1.1.0"}
+  "base-unix"
+  "cmdliner"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.0/dns-v1.1.0.tbz"
+  checksum: "md5=62230d2f85de4646d029cde7d1c3a55d"
+}

--- a/packages/dns-lwt/dns-lwt.1.1.0/opam
+++ b/packages/dns-lwt/dns-lwt.1.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS implementation in portable Lwt"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the portable Lwt concurrency framework.
+You can find a Unix version of this library in the `dns-lwt-unix`
+opam package, and in theory you could compile this one to JavaScript
+as well using js_of_ocaml.
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "mirage-profile" {>= "0.8.0"}
+  "lwt" {>= "3.0.0"}
+  "dns" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.0/dns-v1.1.0.tbz"
+  checksum: "md5=62230d2f85de4646d029cde7d1c3a55d"
+}

--- a/packages/dns/dns.1.1.0/opam
+++ b/packages/dns/dns.1.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS client and server implementation in pure OCaml"
+description: """
+This is a pure OCaml implementation of the DNS protocol.  It is intended to be
+a reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.
+
+There are several concrete implementations using this package that you probably
+want to use for practical purposes:
+
+- dns-lwt for the Lwt concurrency library
+- dns-lwt-unix using the Lwt_unix bindings
+- dns-async using the Jane Street Async library
+- mirage-dns for the MirageOS unikernel framework
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "cstruct" {>= "3.0.2"}
+  "ppx_cstruct"
+  "re" {>="1.7.2"}
+  "ipaddr" {>= "2.6.0"}
+  "uri" {>= "1.7.0"}
+  "base64" {>= "2.0.0"}
+  "hashcons"
+  "result"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.0/dns-v1.1.0.tbz"
+  checksum: "md5=62230d2f85de4646d029cde7d1c3a55d"
+}

--- a/packages/mirage-dns/mirage-dns.3.1.0/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+synopsis: "DNS implementation for the MirageOS unikernel framework"
+description: """
+This is an implementation of a DNS server and client resolver
+for the [MirageOS unikernel framework](https://mirage.io).
+"""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns-lwt" {>="1.1.0"}
+  "duration"
+  "mirage-stack-lwt"
+  "mirage-kv-lwt"
+  "mirage-time-lwt"
+  "mirage-profile" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.0/dns-v1.1.0.tbz"
+  checksum: "md5=62230d2f85de4646d029cde7d1c3a55d"
+}


### PR DESCRIPTION
…e-dns (3.1.0)

CHANGES:

* Improve parsing robustness with:
  - invalid pointers in packets
  - taking total packet size limitations into account
  - handling unknown opcodes gracefully without an exception
  Work done by @Willy-Tan in mirage/ocaml-dns#154.
* Port build from jbuilder to Dune (mirage/ocaml-dns#155 mirage/ocaml-dns#152 mirage/ocaml-dns#153 by @paurkedal @samoht)
* Update opam metadata to the 2.0 format.