### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.4.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.4.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria-runtime"  {>= "2.2.2"}
+  "fmt"
+  "logs"
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.0/mirage-v3.4.0.tbz"
+  checksum: "md5=ab44f3a3071feaef7c655ef0b952dc95"
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "lwt"
+  "cstruct" {>="3.2.1"}
+  "io-page" {>="2.0.1"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-types" {>= "3.4.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.5.0"}
+  "mirage-protocols-lwt" {>= "1.4.1"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-console-lwt" {>= "2.3.5"}
+  "mirage-block-lwt" {>= "1.1.0"}
+  "mirage-net-lwt" {>= "1.2.0"}
+  "mirage-fs-lwt" {>= "1.1.1"}
+  "mirage-kv-lwt" {>= "1.1.0"}
+  "mirage-channel-lwt" {>= "3.1.0"}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.0/mirage-v3.4.0.tbz"
+  checksum: "md5=ab44f3a3071feaef7c655ef0b952dc95"
+}

--- a/packages/mirage-types/mirage-types.3.4.0/opam
+++ b/packages/mirage-types/mirage-types.3.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "mirage-device" {>= "1.1.0"}
+  "mirage-time" {>= "1.1.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow" {>= "1.5.0"}
+  "mirage-console" {>= "2.3.5"}
+  "mirage-protocols" {>= "1.4.1"}
+  "mirage-stack" {>= "1.3.0"}
+  "mirage-block" {>= "1.1.0"}
+  "mirage-net" {>= "1.2.0"}
+  "mirage-fs" {>= "1.1.1"}
+  "mirage-kv" {>= "1.1.1"}
+  "mirage-channel" {>= "3.1.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.0/mirage-v3.4.0.tbz"
+  checksum: "md5=ab44f3a3071feaef7c655ef0b952dc95"
+}

--- a/packages/mirage/mirage.3.1.1/opam
+++ b/packages/mirage/mirage.3.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "bos"
   "astring"
   "logs"
-  "mirage-runtime" {>= "3.0.0"}
+  "mirage-runtime" {>= "3.0.0" & < "3.2.0"}
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}

--- a/packages/mirage/mirage.3.2.0/opam
+++ b/packages/mirage/mirage.3.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bos"
   "astring"
   "logs"
-  "mirage-runtime" {>= "3.2.0"}
+  "mirage-runtime" {>= "3.2.0" & < "3.3.0"}
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}

--- a/packages/mirage/mirage.3.3.0/opam
+++ b/packages/mirage/mirage.3.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bos"
   "astring"
   "logs"
-  "mirage-runtime"     {>= "3.3.0"}
+  "mirage-runtime"     {>= "3.3.0" & < "3.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.3.1/opam
+++ b/packages/mirage/mirage.3.3.1/opam
@@ -24,7 +24,7 @@ depends: [
   "bos"
   "astring"
   "logs"
-  "mirage-runtime"     {>= "3.3.0"}
+  "mirage-runtime"     {>= "3.3.0" & < "3.4.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.3.4.0/opam
+++ b/packages/mirage/mirage.3.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "2.2.3"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.4.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.0/mirage-v3.4.0.tbz"
+  checksum: "md5=ab44f3a3071feaef7c655ef0b952dc95"
+}


### PR DESCRIPTION
CHANGES:

* use ipaddr 3.0 without s-expression dependency (mirage/mirage#956, by @hannesm)
* use mirage-clock 2.x and tcpip 3.6.x libraries (mirage/mirage#960, mirage/mirage#962, by @hannesm)
* default to socket stack on unix and macos (mirage/mirage#958, by @hannesm)
* use String.split_on_char in mirage-runtime to avoid astring dependency (mirage/mirage#957, by @hannesm)
* add build-dependency on mirage to each unikernel (mirage/mirage#953, by @hannesm)