### PR TITLE
Add libtorch 1.0.1

### DIFF
--- a/packages/libtorch/libtorch.1.0.1/opam
+++ b/packages/libtorch/libtorch.1.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-torch"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-torch/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    """
+test -d %{lib}%/libtorch/lib/libtorch.so ||
+  ( unzip libtorch-linux.zip &&
+    mv -f libtorch %{lib}%/
+  )
+    """
+  ] { os = "linux" }
+  [
+    "sh"
+    "-c"
+    """
+test -d %{lib}%/libtorch/lib/libtorch.so ||
+  ( unzip libtorch-macos.zip &&
+    mv -f libtorch %{lib}%/ &&
+    tar xzf mklml-macos.tgz &&
+    mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ &&
+    mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/
+  )
+    """
+  ] { os = "macos" }
+]
+remove: [
+  [ "rm" "-Rf" "%{lib}%/libtorch" ]
+]
+synopsis: "LibTorch library package"
+description: """
+This is used by the torch package to trigger the install of the
+libtorch library."""
+extra-source "libtorch-linux.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.0.0.zip"
+  checksum: "md5=0b9e7a3da5da473760709dbf84c292dc"
+}
+extra-source "libtorch-macos.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip"
+  checksum: "md5=82f52647daa39c189a573115d440d09d"
+}
+extra-source "mklml-macos.tgz" {
+  src: "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz"
+  checksum: "md5=a8b4b158dc8e7aad13c0d594a9a8d241"
+}


### PR DESCRIPTION
The difference with 1.0.0 is that mklml gets downloaded and installed for macos. This seems necessary in order to have the `torch` package working on macos.