### PR TITLE
Package msat.0.7

### DIFF
--- a/packages/msat/msat.0.7/opam
+++ b/packages/msat/msat.0.7/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+license: "Apache"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes@inria.fr"]
+build: [
+    [make "disable_log"]
+    [make "doc"] { with-doc }
+    [make "test"] { with-test }
+    [make "lib"]
+]
+install: [
+    [make "DOCDIR=%{msat:doc}%" "install"]
+]
+remove: [
+    [make "DOCDIR=%{msat:doc}%" "uninstall"]
+]
+depends: [
+  "ocaml" { >= "4.00.1" }
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "dolmen" {with-test & >= "0.4" }
+]
+tags: [ "sat" "smt" ]
+homepage: "https://github.com/Gbury/mSAT"
+dev-repo: "git+https://github.com/Gbury/mSAT.git"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+synopsis: "A library to create SAT/SMT/McSat solvers"
+description:
+"mSAT is a library intended to make creating new SMT/McSat solvers easier.
+
+mSAT implements a SAT solver core functorized over a theory. It thus provides
+functors that take an arbitrary theory (either for SMT or McSat), and returns
+a functionning SMT or McSat solver.
+
+mSAT solvers support arbitrarily nested local assumptions. Solvers created
+using mSAT functors can additionally provide formal proofs whenever the
+solver answers UNSAT on a problem.
+"
+authors: [
+  "Sylvain Conchon"
+  "Alain Mebsout"
+  "Stephane Lecuyer"
+  "Simon Cruanes"
+  "Guillaume Bury"
+]
+url {
+  src: "https://github.com/Gbury/mSAT/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=c921093f88fcf2cfe2e9a4787ffb24f3"
+    "sha512=3b8fb33996840dfbe56943a57c4c8cb5ad4684af89a0e67c3e9f10fdde9a4a508069e082f9489d058b30d3d345718bab190f9d55fe2d06d91eafa9296a0b1e30"
+  ]
+}


### PR DESCRIPTION
### `msat.0.7`
A library to create SAT/SMT/McSat solvers
mSAT is a library intended to make creating new SMT/McSat solvers easier.

mSAT implements a SAT solver core functorized over a theory. It thus provides
functors that take an arbitrary theory (either for SMT or McSat), and returns
a functionning SMT or McSat solver.

mSAT solvers support arbitrarily nested local assumptions. Solvers created
using mSAT functors can additionally provide formal proofs whenever the
solver answers UNSAT on a problem.



---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: git+https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0