### PR TITLE
[new release] shared-memory-ring-lwt and shared-memory-ring (3.1.0)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
@@ -25,6 +25,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
   "shared-memory-ring" {>= "0.4.1"}
+  "shared-memory-ring-lwt"
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}

--- a/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
@@ -24,8 +24,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
-  "shared-memory-ring" {>= "0.4.1"}
-  "shared-memory-ring-lwt"
+  "shared-memory-ring" {>= "0.4.1" & < "2.0.0"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
+  "mirage-types-lwt" {>="1.1.0" & <"3.0.0"}
   "io-page" {>= "1.5.0"}
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
@@ -23,8 +23,8 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
-  "mirage-types" {>= "1.1.0" & < "3.0.0"}
-  "mirage-types-lwt" {>="1.1.0" & <"3.0.0"}
+  "mirage-types" {>= "1.1.0" & < "2.8.0"}
+  "mirage-types-lwt" {>="1.1.0" & <"2.8.0"}
   "io-page" {>= "1.5.0"}
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "netchannel"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.04.0"} 
   "ocamlfind"
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
@@ -23,8 +23,8 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
-  "mirage-types" {>= "1.1.0" & < "2.8.0"}
-  "mirage-types-lwt" {>="1.1.0" & <"2.8.0"}
+  "mirage-types" {>= "1.1.0" & < "3.0.0"}
+  "mirage-types-lwt" {>="1.1.0" & <"3.0.0"}
   "io-page" {>= "1.5.0"}
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
+  "mirage-types-lwt" {>="1.1.0" & <"3.0.0"}
   "io-page" {>= "1.5.0"}
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
@@ -23,8 +23,8 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
-  "mirage-types" {>= "1.1.0" & < "3.0.0"}
-  "mirage-types-lwt" {>="1.1.0" & <"3.0.0"}
+  "mirage-types" {>= "1.1.0" & < "2.8.0"}
+  "mirage-types-lwt" {>="1.1.0" & <"2.8.0"}
   "io-page" {>= "1.5.0"}
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0" & < "3.0.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "netchannel"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & <"4.04.0"}
   "ocamlfind"
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
@@ -23,8 +23,8 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "ocamlbuild" {build}
   "lwt" {>= "2.4.3"}
-  "mirage-types" {>= "1.1.0" & < "2.8.0"}
-  "mirage-types-lwt" {>="1.1.0" & <"2.8.0"}
+  "mirage-types" {>="1.1.0" & <"3.0.0"}
+  "mirage-types-lwt" {>="1.1.0" & <"3.0.0"}
   "io-page" {>= "1.5.0"}
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0" & < "3.0.0"}

--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.1.0/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/shared-memory-ring"
+doc: "https://mirage.github.io/shared-memory-ring/"
+bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "cstruct" {>= "2.4.1"}
+  "ppx_cstruct"
+  "shared-memory-ring"
+  "lwt"
+  "lwt-dllist"
+  "mirage-profile"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/shared-memory-ring.git"
+synopsis: "Shared memory rings for RPC and bytestream communications using Lwt"
+description: """
+This package contains a set of libraries for creating shared memory
+producer/consumer rings, using the Lwt concurrency library to handle blocking.
+The rings follow the Xen ABI and may be used to create or implement Xen virtual
+devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/shared-memory-ring/releases/download/v3.1.0/shared-memory-ring-v3.1.0.tbz"
+  checksum: "md5=dba58a2c1da945028df10d34332ca7fe"
+}

--- a/packages/shared-memory-ring/shared-memory-ring.3.1.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.3.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/shared-memory-ring"
+doc: "https://mirage.github.io/shared-memory-ring/"
+bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "cstruct" {>= "2.4.1"}
+  "ppx_cstruct" {>= "3.2.0"}
+  "mirage-profile"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/shared-memory-ring.git"
+synopsis: "Shared memory rings for RPC and bytestream communications"
+description: """
+This package contains a set of libraries for creating shared memory
+producer/consumer rings. The rings follow the Xen ABI and may be used
+to create or implement Xen virtual devices.
+
+Example use:
+
+One program wishes to create data records and push them efficiently
+to a second process on the same physical machine for
+sampling/analysis/archiving.
+
+Example use:
+
+A Xen virtual machine wishes to send and receive network packets to
+and from a backend driver domain.
+"""
+url {
+  src:
+    "https://github.com/mirage/shared-memory-ring/releases/download/v3.1.0/shared-memory-ring-v3.1.0.tbz"
+  checksum: "md5=dba58a2c1da945028df10d34332ca7fe"
+}


### PR DESCRIPTION
Shared memory rings for RPC and bytestream communications using Lwt

- Project page: <a href="https://github.com/mirage/shared-memory-ring">https://github.com/mirage/shared-memory-ring</a>
- Documentation: <a href="https://mirage.github.io/shared-memory-ring/">https://mirage.github.io/shared-memory-ring/</a>

##### CHANGES:

* Port build from jbuilder to Dune (@avsm).
* Update opam metadata to the 2.0 format (@avsm). 
* Removed deprecated use of `Lwt_sequence` and depend
  on the equivalent `lwt-dllist` package instead (@avsm)
* Use `noalloc` attribute in external declarations (@avsm)
* Fix ocamldoc formatting with odoc (@avsm)
* Travis: test up to OCaml 4.07 (@avsm)
