### PR TITLE
{gmp,zarith}-freestanding updates for Solo5 0.5.0+

### DIFF
--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0-1/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0-1/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding"
+  "ocaml-freestanding" { < "0.5.0" }
   "conf-m4" {build}
 ]
 available: arch = "x86_64" | arch = "x86_64"

--- a/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.0.0/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding"
+  "ocaml-freestanding" { < "0.5.0" }
   "conf-m4" {build}
 ]
 available: arch = "x86_64" | arch = "x86_64"

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-1/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.2.3"}
+  "ocaml-freestanding" {>= "0.2.3" & < "0.5.0"}
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"
 description: "Freestanding build of GNU GMP."

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/files/gmp-freestanding.pc
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/files/gmp-freestanding.pc
@@ -1,0 +1,9 @@
+libdir=${pcfiledir}/../gmp-freestanding
+includedir=${libdir}/include
+
+Name: gmp-freestanding
+Version: 6.1.2
+URL: https://gmplib.org
+Description: The GNU Multiple Precision Arithmetic Library
+Cflags: -I${includedir}
+Libs: -L${libdir} -lgmp-freestanding

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/files/mirage-build.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/files/mirage-build.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX="`opam config var prefix`/lib/gmp-freestanding"
+fi
+
+PKG_CONFIG_DEPS="ocaml-freestanding"
+check_deps () {
+  pkg-config --print-errors --exists ${PKG_CONFIG_DEPS}
+}
+
+if ! check_deps 2>/dev/null; then
+  # rely on `opam` if deps are unavailable
+  export PKG_CONFIG_PATH="`opam config var prefix`/lib/pkgconfig"
+fi
+check_deps || exit 1
+
+#
+# ocaml-freestanding does not provide a real cross compiler, so we fake it:
+# 
+# - set CC to stop configure trying to find a host compiler
+# - set CPPFLAGS to ocaml-freestanding CFLAGS, this prevents inclusion of
+#   system headers
+# - manually override tests for missing functions
+# - manually trim the components (SUBDIRS) of libgmp we build to the subset
+#   actually used by zarith-freestanding (our sole dependency)
+# - set -Werror=implicit-function-declaration at *build* time to catch any
+#   undefined symbols
+#
+# Further, with the introduction of -fstack-protector-strong in Solo5, override
+# this during './configure' to prevent it complaining that the compiler does not
+# work, and reinstate it again during 'make'.
+#
+FREESTANDING_CFLAGS="$(pkg-config --cflags ${PKG_CONFIG_DEPS})"
+ac_cv_func_obstack_vprintf=no \
+ac_cv_func_localeconv=no \
+./configure \
+    --host=$(uname -m)-unknown-none --enable-fat --disable-shared --with-pic=no \
+    CC=cc "CPPFLAGS=${FREESTANDING_CFLAGS} -fno-stack-protector"
+
+make SUBDIRS="mpn mpz mpq mpf" \
+    PRINTF_OBJECTS= SCANF_OBJECTS= \
+    CPPFLAGS="${FREESTANDING_CFLAGS}" \
+    CFLAGS+=-Werror=implicit-function-declaration

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/files/mirage-install.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/files/mirage-install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX=`opam config var prefix`
+fi
+PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+LIBDIR=${PREFIX}/lib/gmp-freestanding
+
+mkdir -p ${PKG_CONFIG_PATH}
+cp gmp-freestanding.pc ${PKG_CONFIG_PATH}
+mkdir -p ${LIBDIR}
+cp .libs/libgmp.a ${LIBDIR}/libgmp-freestanding.a
+touch ${LIBDIR}/META
+mkdir -p ${LIBDIR}/include
+cp gmp.h ${LIBDIR}/include

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.5.0"}
+  "ocaml-freestanding" {>= "0.4.1"}
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"
 description: "Freestanding build of GNU GMP."

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "Martin Lucina <martin@lucina.net>"
+homepage:     "https://gmplib.org/"
+license:      "GNU LGPL v3 and GNU GPL v2"
+authors:      "Torbjörn Granlund and contributors"
+bug-reports:  "mirageos-devel@lists.xenproject.org"
+
+build:   ["sh" "-ex" "./mirage-build.sh"]
+install: ["sh" "-ex" "./mirage-install.sh"]
+remove: [
+  "rm" "-rf"
+    "%{prefix}%/lib/pkgconfig/gmp-freestanding.pc"
+    "%{prefix}%/lib/gmp-freestanding"
+]
+depends: [
+  "ocaml"
+  "ocaml-freestanding" {>= "0.5.0"}
+]
+synopsis: "The GNU Multiple Precision Arithmetic Library"
+description: "Freestanding build of GNU GMP."
+flags: light-uninstall
+extra-files: [
+  ["mirage-install.sh" "md5=aca9a1c985326f95daa51aedef55b318"]
+  ["mirage-build.sh" "md5=c4b411f29867c13595470011d3b77f6c"]
+  ["gmp-freestanding.pc" "md5=391473dd7c6957fed3e9e485e456fb6c"]
+]
+url {
+  src: "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
+  checksum: "md5=f58fa8001d60c4c77595fbbb62b63c1d"
+}

--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.2.3"}
+  "ocaml-freestanding" {>= "0.2.3" & < "0.5.0"}
 ]
 available: arch = "x86_64" | arch = "x86_64"
 synopsis: "The GNU Multiple Precision Arithmetic Library"

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
@@ -7,8 +7,8 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding"
-  "gmp-freestanding"
+  "ocaml-freestanding" {< "0.5.0"}
+  "gmp-freestanding" {<= "6.1.2-1"}
   "zarith" {= "1.4.1"}
   "ocamlfind" {build}
 ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.4/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4/opam
@@ -7,8 +7,8 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding"
-  "gmp-freestanding"
+  "ocaml-freestanding" {< "0.5.0"}
+  "gmp-freestanding" {<= "6.1.2-1"}
   "zarith" {= "1.4"}
   "ocamlfind" {build}
 ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.6/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.6/opam
@@ -7,8 +7,8 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding"
-  "gmp-freestanding" {> "6.0.0"}
+  "ocaml-freestanding" {< "0.5.0"}
+  "gmp-freestanding" {> "6.0.0" & <= "6.1.2-1"}
   "zarith" {= "1.6"}
   "ocamlfind" {build}
 ]

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/mirage-build.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/mirage-build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+# WARNING: if you pass invalid cflags here, zarith will silently
+# fall back to compiling with the default flags instead!
+CFLAGS="$(pkg-config --cflags gmp-freestanding ocaml-freestanding)" \
+LDFLAGS="$(pkg-config --libs gmp-freestanding)" \
+./configure -nodynlink -gmp
+
+if [ `uname -s` = "FreeBSD" ] || [ `uname -s` = "OpenBSD" ]; then
+    gmake
+else
+    make
+fi

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/mirage-install.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/mirage-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+cp libzarith.a "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+# This is a hack to get freestanding_linkopts into the host 'zarith' package.
+cat >>"$PREFIX/lib/zarith/META" <<EOM
+freestanding_linkopts = "-lzarith-freestanding -L@gmp-freestanding -lgmp-freestanding"
+EOM

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/mirage-uninstall.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/mirage-uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+
+rm -f "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+mv "$PREFIX/lib/zarith/META" "$PREFIX/lib/zarith/META.tmp"
+cat "$PREFIX/lib/zarith/META.tmp" | grep -v freestanding_linkopts > "$PREFIX/lib/zarith/META"
+rm -f "$PREFIX/lib/zarith/META.tmp"

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/no-dynlink.patch
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/files/no-dynlink.patch
@@ -1,0 +1,85 @@
+This patch is required to build Zarith on an ocaml-freestanding type setup. It
+does three things:
+
+1. Add an option to configure to forcibly disable dynlink.
+2. Stop configure from adding a host -lgmp.
+3. In addition to (1), force project.mak to use "ocamlmklib -custom" instead of
+   "ocamlmklib -failsafe".
+
+We need all three because the Zarith build system is TOTALLY INSANE and has
+never even remotely heard of such a thing as cross compiling, and we need it to
+just shut up and build ONLY with the flags we pass it. KTHXBYE
+
+--- a/configure	2017-10-13 19:45:41.000000000 +0200
++++ b/configure	2018-11-30 19:12:36.809951317 +0100
+@@ -21,6 +21,7 @@
+ host='auto'
+ gmp='auto'
+ perf='no'
++nodynlink='no'
+ 
+ ar='ar'
+ ocaml='ocaml'
+@@ -59,6 +60,7 @@
+   -gmp                 use GMP library (default if found)
+   -mpir                use MPIR library instead of GMP
+   -perf                enable performance statistics
++  -nodynlink           disable dynamic linking
+ 
+ Environment variables that affect configuration:
+   CC                   C compiler to use (default: try gcc, then cc)
+@@ -99,6 +101,8 @@
+             gmp='mpir';;
+         -perf|--perf)
+             perf='yes';;
++        -nodynlink|--nodynlink)
++            nodynlink='yes';;
+         *)
+             echo "unknown option $1, try -help"
+             exit 2;;
+@@ -248,7 +252,7 @@
+ 
+ hasdynlink='no'
+ 
+-if test $hasocamlopt = yes
++if test $hasocamlopt = yes -a $nodynlink = no
+ then
+     checkcmxalib dynlink.cmxa
+     if test $? -eq 1; then hasdynlink='yes'; fi
+@@ -340,12 +344,8 @@
+ if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
+     checkinc gmp.h
+     if test $? -eq 1; then
+-        checklib gmp
+-        if test $? -eq 1; then 
+-            gmp='OK'
+-            cclib="$cclib -lgmp"
+-            ccdef="-DHAS_GMP $ccdef"
+-        fi
++        gmp='OK'
++        ccdef="-DHAS_GMP $ccdef"
+     fi
+ fi
+ if test "$gmp" = 'mpir' -o "$gmp" = 'auto'; then
+--- a/project.mak	2017-10-13 19:45:41.000000000 +0200
++++ b/project.mak	2018-11-30 19:11:16.205189144 +0100
+@@ -60,16 +60,16 @@
+ 	make -C tests test
+ 
+ zarith.cma: $(MLSRC:%.ml=%.cmo)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxa zarith.$(LIBSUFFIX): $(MLSRC:%.ml=%.cmx)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxs: zarith.cmxa libzarith.$(LIBSUFFIX)
+ 	$(OCAMLOPT) -shared -o $@ -I . zarith.cmxa -linkall
+ 
+ libzarith.$(LIBSUFFIX) dllzarith.$(DLLSUFFIX): $(SSRC:%.S=%.$(OBJSUFFIX)) $(CSRC:%.c=%.$(OBJSUFFIX)) 
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ doc: $(MLISRC)
+ 	mkdir -p html

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: "Xavier Leroy"
+maintainer: "mirageos-devel"
+homepage: "https://forge.ocamlcore.org/projects/zarith"
+bug-reports:  "mirageos-devel@lists.xenproject.org"
+build: ["sh" "-eux" "./mirage-build.sh"]
+install: ["sh" "-eux" "./mirage-install.sh"]
+remove: ["sh" "-eux" "./mirage-uninstall.sh"]
+depends: [
+  "ocaml"
+  "ocaml-freestanding" {>= "0.5.0"}
+  "gmp-freestanding" {>= "6.1.2-2"}
+  "zarith" {= "1.7"}
+  "ocamlfind" {build}
+]
+patches: [ "no-dynlink.patch" ]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+extra-files: [
+  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
+  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
+  ["mirage-build.sh" "md5=965e4b33ed871a73436223177d104876"]
+  ["no-dynlink.patch" "md5=eff128f04dd08b0e5a02e49c99dc518b"]
+]
+url {
+  src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
+  checksum: "md5=80944e2755ebb848451a77dc2ad0651b"
+}

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
@@ -8,7 +8,7 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.5.0"}
+  "ocaml-freestanding" {>= "0.4.1"}
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.7"}
   "ocamlfind" {build}

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/opam
@@ -7,8 +7,8 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding"
-  "gmp-freestanding" {> "6.0.0"}
+  "ocaml-freestanding" {< "0.5.0"}
+  "gmp-freestanding" {> "6.0.0" & <= "6.1.2-1"}
   "zarith" {= "1.7"}
   "ocamlfind" {build}
 ]


### PR DESCRIPTION
In preparation for updates to {gmp,zarith,ocaml}-freestanding:

1. Constrain existing releases of {gmp,zarith}-freestanding to ocaml-freestanding {<= "0.5.0"}.

2. Constrain existing releases of zarith-freestanding to gmp-freestanding {<= "6.1.2-1"}.

----

The SSP changes in Solo5/solo5#294 break gmp-freestanding and zarith-freestanding due to issues with the various cross-compiling hacks used to build these packages.

Publish updated versions, whose availability will be "gated" on an upcoming ocaml-freestanding 0.5.0 release, which itself will depend on Solo5 0.5.0+ bindings packages.

For details, see mirage/ocaml-freestanding#47.

----

@hannesm:

gmp-freestanding 6.1.2-2 should technically work with ocaml-freestanding / Solo5 < 0.5.0, but I don't want to "support" those combinations, so over and above what we discussed and you tested in mirage/ocaml-freestanding#47 I've added an explicit dependency on ocaml-freestanding {>= "0.5.0"} to the new gmp-freestanding.

/cc @emillon FYI/review, just so you're aware of the general horrible-ness of the cross-compiling hacks currently involved here.