### PR TITLE
Package eliom.6.6.0

### DIFF
--- a/packages/eliom/eliom.6.6.0/opam
+++ b/packages/eliom/eliom.6.6.0/opam
@@ -31,7 +31,7 @@ depends: [
   "base-bytes"
 ]
 url {
-  src: "https://github.com/jrochel/eliom/archive/6.6.0.tar.gz"
+  src: "https://github.com/ocsigen/eliom/archive/6.6.0.tar.gz"
   checksum: [
     "md5=ac3881422095f709a12209eeb4921742"
     "sha512=fef515c36c0663e553d83e14f0a38e2af84c7bc5707a39d23a107d69287dfdebc63145f6c97e5a3d86ea2d762af98c501725b71d4e28bff8ae4af83b928c59e6"

--- a/packages/eliom/eliom.6.6.0/opam
+++ b/packages/eliom/eliom.6.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "deriving" {>= "0.6"}
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml" {>= "3.3"}
+  "js_of_ocaml-lwt" {>= "3.3"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
+  "js_of_ocaml-tyxml" {>= "3.3"}
+  "lwt_log"
+  "lwt_ppx"
+  "lwt_camlp4"
+  "tyxml" {>= "4.3.0"}
+  "ocsigenserver" {>= "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/jrochel/eliom/archive/6.6.0.tar.gz"
+  checksum: [
+    "md5=ac3881422095f709a12209eeb4921742"
+    "sha512=fef515c36c0663e553d83e14f0a38e2af84c7bc5707a39d23a107d69287dfdebc63145f6c97e5a3d86ea2d762af98c501725b71d4e28bff8ae4af83b928c59e6"
+  ]
+}


### PR DESCRIPTION
### `eliom.6.6.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0