### PR TITLE
[new release] alcotest, alcotest-lwt and alcotest-async (0.8.5)

### DIFF
--- a/packages/alcotest-async/alcotest-async.0.8.5/opam
+++ b/packages/alcotest-async/alcotest-async.0.8.5/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"  {build}
+  "ocaml" {>= "4.03.0"}
+  "alcotest"
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+
+synopsis: "Async-based helpers for Alcotest"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/0.8.5/alcotest-0.8.5.tbz"
+  checksum: "md5=2db36741c413ab93391ecc1f983aa804"
+}

--- a/packages/alcotest-lwt/alcotest-lwt.0.8.5/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.0.8.5/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"  {build}
+  "ocaml" {>= "4.02.3"}
+  "alcotest"
+  "lwt" "logs"
+]
+
+synopsis: "Lwt-based helpers for Alcotest"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/0.8.5/alcotest-0.8.5.tbz"
+  checksum: "md5=2db36741c413ab93391ecc1f983aa804"
+}

--- a/packages/alcotest/alcotest.0.8.5/opam
+++ b/packages/alcotest/alcotest.0.8.5/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"  {build & >= "1.1.0"}
+  "ocaml" {>= "4.02.3"}
+  "fmt"   {>= "0.8.0"}
+  "astring"
+  "result"
+  "cmdliner"
+  "uuidm"
+]
+
+synopsis: "Alcotest is a lightweight and colourful test framework"
+
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/0.8.5/alcotest-0.8.5.tbz"
+  checksum: "md5=2db36741c413ab93391ecc1f983aa804"
+}


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest/">https://github.com/mirage/alcotest/</a>
- Documentation: <a href="https://mirage.github.io/alcotest/">https://mirage.github.io/alcotest/</a>

##### CHANGES:

- Port build to Dune from jbuilder (mirage/alcotest#139 @samoht)
- Fix output path on Windows/Cygwin (mirage/alcotest#141 @kkirstein)
- Switch opam metadata to 2.0 format (mirage/alcotest#144 @samoht)
- Add nice screenshots to the README (mirage/alcotest#143 @rizo)
- Fix ocamldoc headings to work with odoc (mirage/alcotest#145 @avsm)
- Do not test on Debian-unstable, add Fedora (mirage/alcotest#145 @avsm)
