### PR TITLE
conf-openssl: macos: look for openssl until it is found

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
+++ b/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -d "$HOME/.nix-profile/lib/pkgconfig/" ]; then
+if [ -e "$HOME/.nix-profile/lib/pkgconfig/openssl.pc" ]; then
   # Nix on macOS
   res=$(env PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig pkg-config openssl)
   if [ $? -eq 0 ]; then
@@ -9,7 +9,7 @@ if [ -d "$HOME/.nix-profile/lib/pkgconfig/" ]; then
   fi
 fi
 
-if [ -d "/usr/local/opt/openssl/" ]; then
+if [ -e "/usr/local/opt/openssl/lib/pkgconfig/openssl.pc" ]; then
   # Homebrew
   res=$(env PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl)
   if [ $? -eq 0 ]; then

--- a/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
+++ b/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
@@ -2,11 +2,21 @@
 
 if [ -d "$HOME/.nix-profile/lib/pkgconfig/" ]; then
   # Nix on macOS
-  PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig pkg-config openssl
-elif [ -d "/usr/local/opt/openssl/" ]; then
-  # Homebrew
-  PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl
-else
-  # MacPorts
-  PKG_CONFIG_PATH=/opt/local/lib/pkgconfig pkg-config openssl
+  res=$(env PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig pkg-config openssl)
+  if [ $? -eq 0 ]; then
+    echo $res
+    exit 0
+  fi
 fi
+
+if [ -d "/usr/local/opt/openssl/" ]; then
+  # Homebrew
+  res=$(env PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig pkg-config openssl)
+  if [ $? -eq 0 ]; then
+    echo $res
+    exit 0
+  fi
+fi
+
+# MacPorts
+PKG_CONFIG_PATH=/opt/local/lib/pkgconfig pkg-config openssl

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -26,5 +26,5 @@ depexts: [
 synopsis: "Virtual package relying on an OpenSSL system installation"
 description:
   "This package can only install if OpenSSL is installed on the system."
-extra-files: ["osx-build.sh" "md5=3c1a4b3be6890300af26aa4802f4f836"]
+extra-files: ["osx-build.sh" "md5=855921ee6d80b1e85589e8be6a72b81b"]
 flags: conf

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -26,5 +26,5 @@ depexts: [
 synopsis: "Virtual package relying on an OpenSSL system installation"
 description:
   "This package can only install if OpenSSL is installed on the system."
-extra-files: ["osx-build.sh" "md5=855921ee6d80b1e85589e8be6a72b81b"]
+extra-files: ["osx-build.sh" "md5=978504ca8c262cde48a71da6f11f2073"]
 flags: conf


### PR DESCRIPTION
Right now, on a machine with both nix and homebrew configured, the conf-openssl osx script will only look at nix for the openssl pkg-config files. This changes it to look in nix, and if it isn't found, also look in homebrew, and if it isn't found there, finally look in macports.