### PR TITLE
Export extra libs in labltk META

### DIFF
--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -9,6 +9,8 @@ depexts: [
   ["tcl-dev"] {os-distribution = "debian"}
   ["tcl-dev"] {os-distribution = "ubuntu"}
   ["tcl"] {os-distribution = "nixos"}
+  ["tcl-dev"] {os-family = "alpine"}
+  ["tcl-devel"] {os-family = "rhel"}
 ]
 synopsis: "Virtual package relying on tcl"
 description:

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -11,6 +11,8 @@ depexts: [
   ["tcl"] {os-distribution = "nixos"}
   ["tcl-dev"] {os-family = "alpine"}
   ["tcl-devel"] {os-family = "rhel"}
+  ["tcl-devel"] {os-family = "fedora"}
+  ["tcl-devel"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on tcl"
 description:

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -9,6 +9,8 @@ depexts: [
   ["tk-dev"] {os-distribution = "debian"}
   ["tk-dev"] {os-distribution = "ubuntu"}
   ["tk"] {os-distribution = "nixos"}
+  ["tk-dev"] {os-family = "alpine"}
+  ["tk-devel"] {os-family = "rhel"}
 ]
 synopsis: "Virtual package relying on tk"
 description:

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -9,6 +9,7 @@ depexts: [
   ["tk-dev"] {os-distribution = "debian"}
   ["tk-dev"] {os-distribution = "ubuntu"}
   ["tk"] {os-distribution = "nixos"}
+  ["tk"] {os-family = "alpine"}
   ["tk-dev"] {os-family = "alpine"}
   ["tk-devel"] {os-family = "rhel"}
 ]

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -12,6 +12,8 @@ depexts: [
   ["tk"] {os-family = "alpine"}
   ["tk-dev"] {os-family = "alpine"}
   ["tk-devel"] {os-family = "rhel"}
+  ["tk-devel"] {os-family = "fedora"}
+  ["tk-devel"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on tk"
 description:

--- a/packages/labltk/labltk.8.06.5/files/auxlibs-in-META.patch
+++ b/packages/labltk/labltk.8.06.5/files/auxlibs-in-META.patch
@@ -1,0 +1,20 @@
+diff --git b/support/META a/support/META
+index 195448a..cc9881f 100644
+--- b/support/META
++++ a/support/META
+@@ -7,3 +7,15 @@ archive(byte) = "labltk.cma"
+ archive(native) = "labltk.cmxa"
+ linkopts = ""
+ 
++package "jpf" (
++description = "a 'file selector' and 'balloon help' support for labltk"
++requires = "unix,labltk"
++archive(byte) = "jpflib.cma"
++archive(native) = "jpflib.cmxa"
++)
++package "frx" (
++description = "Francois Rouaix's widget set library"
++requires = "unix,labltk"
++archive(byte) = "frxlib.cma"
++archive(native) = "frxlib.cmxa"
++)

--- a/packages/labltk/labltk.8.06.5/opam
+++ b/packages/labltk/labltk.8.06.5/opam
@@ -5,6 +5,7 @@ homepage: "http://labltk.forge.ocamlcore.org/"
 bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=343"
 dev-repo: "git+https://github.com/garrigue/labltk.git"
 license: "LGPL with linking exception"
+patches: [ "auxlibs-in-META.patch" ]
 build: [
   ["./configure" "-use-findlib" "-installbindir" bin]
   [make "all" "opt"]


### PR DESCRIPTION
Labltk installs some extra libraries without advertising them in the META file. This patch makes the advertisement.

I' sorry and sad to work at the opam level. I tried to modify that upstream 4 years ago: https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1444&group_id=343&atid=1353 without any reaction.

It is fully backward compatible (it simply add opportinuties). It would have make my life so easier 4 years ago when I moved the build system of KaSim to ocamlbuild and it simplifies so much the migration to dune today that I'm considering this non optimal solution.