### PR TITLE
Fix menhir dependency

### DIFF
--- a/packages/dolmen/dolmen.0.4/opam
+++ b/packages/dolmen/dolmen.0.4/opam
@@ -7,7 +7,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "menhir" {>= "20151005"}
+  "menhir" {>= "20180523"}
   "dune" {build}
 ]
 tags: [ "parser" "tptp" "logic" "smtlib" "dimacs" ]


### PR DESCRIPTION
Dolmen has recently switched to dune, which seems to use menhir options introduced very recently, thus the version bound on menhir actually need to be updated.