### PR TITLE
Package ocsigen-start.1.1.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -35,7 +35,7 @@ depexts: [
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-start/archive/1.1.0.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-start/archive/1.1.0.tar.gz"
   checksum: [
     "md5=543cd2feaddcb98937b19465fb832ea4"
     "sha512=3f02accee1c1f5c82e21f739ed0f320874fcfea08f05f3df768799f4d9b96f0014e5bbb69a989922780af39a9c26c2f42efc6bcbb908304dc2eff3812bf904f2"

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -1,10 +1,13 @@
 opam-version: "2.0"
 authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
+synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"
+description: "Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management."
 homepage: "https://ocsigen.org/ocsigen-start/"
 bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
-build: [ make ]
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 remove: [ make "uninstall" ]
 depends: [
@@ -13,11 +16,11 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass"
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.3"}
-  "ocsigen-toolkit" {>= "1.1"}
+  "eliom" {>= "6.3.1" < "6.4"}
+  "ocsigen-toolkit" {>= "1.1.1" < "2.0"}
   "js_of_ocaml-camlp4"
   "yojson"
-  "lwt" {< "4.0.0"}
+  "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
   ["imagemagick"] {os-distribution = "debian"}
@@ -31,9 +34,10 @@ depexts: [
   ["npm"] {os-distribution = "ubuntu"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
-synopsis: "Skeleton for building client-server Eliom applications"
-description: "(with users, notifications, etc.)"
 url {
-  src: "https://github.com/ocsigen/ocsigen-start/archive/1.1.0.tar.gz"
-  checksum: "md5=cff1cd532de67dd4e5f8792c95bc4bac"
+  src: "https://github.com/jrochel/ocsigen-start/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=543cd2feaddcb98937b19465fb832ea4"
+    "sha512=3f02accee1c1f5c82e21f739ed0f320874fcfea08f05f3df768799f4d9b96f0014e5bbb69a989922780af39a9c26c2f42efc6bcbb908304dc2eff3812bf904f2"
+  ]
 }


### PR DESCRIPTION
### `ocsigen-start.1.1.0`
An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.0.0