### PR TITLE
[new release] syndic (1.6.0)

### DIFF
--- a/packages/syndic/syndic.1.6.0/opam
+++ b/packages/syndic/syndic.1.6.0/opam
@@ -21,7 +21,7 @@ build: [
 
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.04.0"}
   "dune"
   "ptime"
   "uri" {>= "1.9"}

--- a/packages/syndic/syndic.1.6.0/opam
+++ b/packages/syndic/syndic.1.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name:         "syndic"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      [ "Romain Calascibetta"
+                "Christophe Troestler" ]
+license:      "MIT"
+homepage:     "https://github.com/Cumulus/Syndic"
+dev-repo:     "git+https://github.com/Cumulus/Syndic.git"
+bug-reports:  "https://github.com/Cumulus/Syndic/issues"
+doc:          "https://cumulus.github.io/Syndic/"
+synopsis:     "RSS1, RSS2, Atom and OPML1 parsing"
+description: """
+Pure OCaml Library for parsing and writing various types of
+feeds and subscriber lists."""
+
+build: [
+  [ "dune" "subst" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+]
+
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ptime"
+  "uri" {>= "1.9"}
+  "xmlm" {>= "1.2.0"}
+  "fmt" {with-test}
+  "ocurl" {with-test}
+  "fpath" {with-test}
+  "ocplib-json-typed" {with-test}
+  "base-unix" {with-test}
+  "jsonm" {with-test}
+]
+url {
+  src:
+    "https://github.com/Cumulus/Syndic/releases/download/v1.6.0/syndic-v1.6.0.tbz"
+  checksum: "md5=b587da170bfa5b5d2d931ce0105b22a4"
+}

--- a/packages/syndic/syndic.1.6.0/opam
+++ b/packages/syndic/syndic.1.6.0/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
+  "dune" {build}
   "ptime"
   "uri" {>= "1.9"}
   "xmlm" {>= "1.2.0"}

--- a/packages/syndic/syndic.1.6.0/opam
+++ b/packages/syndic/syndic.1.6.0/opam
@@ -14,7 +14,7 @@ Pure OCaml Library for parsing and writing various types of
 feeds and subscriber lists."""
 
 build: [
-  [ "dune" "subst" ]
+  [ "dune" "subst" ] {pinned}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name ] {with-test}
 ]


### PR DESCRIPTION
RSS1, RSS2, Atom and OPML1 parsing

- Project page: <a href="https://github.com/Cumulus/Syndic">https://github.com/Cumulus/Syndic</a>
- Documentation: <a href="https://cumulus.github.io/Syndic/">https://cumulus.github.io/Syndic/</a>

##### CHANGES:

* Lost support of OCaml 4.03.0
* Support of OCaml 4.07.0
* Fix tests
 * Move to `ocurl`
 * Add materials to test in distribution
* Accept entries with empty author (@thomas-huet)
* Dunify project
* Added Z timezone to comply with RFC 822 and reality (@wictory)
* Accept empty CDATA in copyright field (@sgrove, @dinosaure)
