### PR TITLE
[new release] odepack (0.7)

### DIFF
--- a/packages/odepack/odepack.0.7/opam
+++ b/packages/odepack/odepack.0.7/opam
@@ -11,8 +11,6 @@ build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc"] {with-doc}
-]
-run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [

--- a/packages/odepack/odepack.0.7/opam
+++ b/packages/odepack/odepack.0.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-odepack"
+dev-repo: "git+https://github.com/Chris00/ocaml-odepack.git"
+bug-reports: "https://github.com/Chris00/ocaml-odepack/issues"
+doc: "https://chris00.github.io/ocaml-odepack/doc/"
+tags: [ "ODE" "scientific-computing"  ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {build}
+  "base-bytes" {build}
+  "conf-gfortran" {build}
+]
+synopsis: "Binding to ODEPACK"
+description: """
+This is a collection of solvers for the initial value problem for
+ordinary differential equation systems."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-odepack/releases/download/0.7/odepack-0.7.tbz"
+  checksum: "md5=8ea18c4c07ca934ddd09a1f911683f4d"
+}


### PR DESCRIPTION
Binding to ODEPACK

- Project page: <a href="https://github.com/Chris00/ocaml-odepack">https://github.com/Chris00/ocaml-odepack</a>
- Documentation: <a href="https://chris00.github.io/ocaml-odepack/doc/">https://chris00.github.io/ocaml-odepack/doc/</a>

##### CHANGES:

- Set the `-custom` flag for bytecode because `libgfortan` is not
  compiled with `-fPIC`.
- Fix package name in configure script.
- Use `conf-gfortran`.
