### PR TITLE
Package tablecloth-native.0.0.2

### DIFF
--- a/packages/tablecloth-native/tablecloth-native.0.0.2/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis:
+  "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML"
+description: "Longer description"
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: "Paul Biggar <paul@darklang.com>"
+license: "MIT with some exceptions"
+homepage: "https://github.com/darklang/tablecloth"
+bug-reports: "https://github.com/darklang/tablecloth/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "base" {>= "v0.10.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/darklang/tablecloth"
+url {
+  src: "https://github.com/darklang/tablecloth/archive/0.0.2.tar.gz"
+  checksum: [
+    "md5=5671b9cd3aef00a767d2f7811065e68d"
+    "sha512=3330a63e0d828e3c891f4cd66922310747e89f666ecab7fd0c5b7564d4c32bce192cdb08293dace0a1255cd9da4e793e0c1f142cce7d25e260bd0b0649e88348"
+  ]
+}


### PR DESCRIPTION
### `tablecloth-native.0.0.2`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML
Longer description



---
* Homepage: https://github.com/darklang/tablecloth
* Source repo: git://github.com/darklang/tablecloth
* Bug tracker: https://github.com/darklang/tablecloth/issues

---
:camel: Pull-request generated by opam-publish v2.0.0