### PR TITLE
Configuration package for zstd

### DIFF
--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -7,9 +7,9 @@ license: "BSD"
 depexts: [
   ["libzstd-dev"] {os-distribution = "debian"}
   ["libzstd-dev"] {os-distribution = "ubuntu"}
-  ["libzstd-devel"] {os-distribution = "centos"}
+  ["zstd"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
-  ["libzstd-devel"] {os-distribution = "fedora"}
+  ["zstd"] {os-distribution = "fedora"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}
 ]

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -4,12 +4,14 @@ homepage: "http://zstd.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]
 license: "BSD"
+build: [["pkg-config" "libzstd"]]
+depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libzstd-dev"] {os-distribution = "debian"}
   ["libzstd-dev"] {os-distribution = "ubuntu"}
-  ["zstd"] {os-distribution = "centos"}
+  ["libzstd-devel"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
-  ["zstd"] {os-distribution = "fedora"}
+  ["libzstd-devel"] {os-distribution = "fedora"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}
 ]

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+homepage: "http://zstd.net/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Facebook"]
+license: "BSD"
+depexts: [
+  ["libzstd-dev"] {os-distribution = "debian"}
+  ["libzstd-dev"] {os-distribution = "ubuntu"}
+  ["libzstd-devel"] {os-distribution = "centos"}
+  ["libzstd-devel"] {os-distribution = "rhel"}
+  ["libzstd-devel"] {os-distribution = "fedora"}
+  ["zstd-dev"] {os-distribution = "alpine"}
+  ["zstd"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on zstd"
+description:"
+This package can only install if the zstd library is installed on the system.
+"
+flags: conf


### PR DESCRIPTION
We have pushed a library depending on zstd [here](https://github.com/janestreet/zstandard), but
I was told that it would be better to have a configuration
package rather than embed the external dependencies
in the [opam file](https://github.com/janestreet/zstandard/blob/master/zstandard.opam).

(If this package is deemed correct / useful, I will then open
another pull request to make [other packages](https://github.com/ocaml/opam-repository/tree/master/packages/zstd) depending
on `zstd` use this configuration package.)