### PR TITLE
Use conf-zstd in zstd.0.x

### DIFF
--- a/packages/zstd/zstd.0.1/opam
+++ b/packages/zstd/zstd.0.1/opam
@@ -29,10 +29,7 @@ depends: [
   "ctypes" {< "0.6.0"}
   ("extlib" {with-test} | "extlib-compat" {with-test})
   "base-unix" {with-test}
-]
-depexts: [
-  ["libzstd-dev"] {os-distribution = "debian"}
-  ["libzstd-dev"] {os-distribution = "ubuntu"}
+  "conf-zstd"
 ]
 synopsis: "Bindings to zstd compression library"
 description: """

--- a/packages/zstd/zstd.0.2/opam
+++ b/packages/zstd/zstd.0.2/opam
@@ -29,10 +29,7 @@ depends: [
   "ctypes"
   ("extlib" {with-test} | "extlib-compat" {with-test})
   "base-unix" {with-test}
-]
-depexts: [
-  ["libzstd-dev"] {os-distribution = "debian"}
-  ["libzstd-dev"] {os-distribution = "ubuntu"}
+  "conf-zstd"
 ]
 synopsis: "Bindings to zstd compression library"
 description: """


### PR DESCRIPTION
As a follow-up to https://github.com/ocaml/opam-repository/pull/13301, here is a pull request patching 
`packages/zstd/zstd.0.{1,2}/opam` to use the new
configuration package.

@ygrek 
