### PR TITLE
5 packages from zshipko/resp at 0.9

### DIFF
--- a/packages/resp-client/resp-client.0.9/opam
+++ b/packages/resp-client/resp-client.0.9/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+tags: ["redis" "protocol"]
+
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9"}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Redis serialization protocol client
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=a616b371a8813cfc312ecdaf55c991c7"
+    "sha512=a819f5ce682ba4450303e02bf3599b6ddd99271c00365d409a5874e389005a504073efcea59391faa82b0c3dfbbf3b724babe4ffd5e6ca0a12e1ad4c02798dfc"
+  ]
+}

--- a/packages/resp-mirage/resp-mirage.0.9/opam
+++ b/packages/resp-mirage/resp-mirage.0.9/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9"}
+    "resp-client" {>= "0.9"}
+    "resp-server" {>= "0.9"}
+    "mirage-conduit" {>= "3.01"}
+]
+
+build:
+[
+    ["dune" "build" "-p" name]
+]
+
+synopsis: """
+Redis serialization protocol tools for MirageOS
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=a616b371a8813cfc312ecdaf55c991c7"
+    "sha512=a819f5ce682ba4450303e02bf3599b6ddd99271c00365d409a5874e389005a504073efcea59391faa82b0c3dfbbf3b724babe4ffd5e6ca0a12e1ad4c02798dfc"
+  ]
+}

--- a/packages/resp-server/resp-server.0.9/opam
+++ b/packages/resp-server/resp-server.0.9/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9"}
+    "resp-client" {>= "0.9"}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Redis serialization protocol server
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=a616b371a8813cfc312ecdaf55c991c7"
+    "sha512=a819f5ce682ba4450303e02bf3599b6ddd99271c00365d409a5874e389005a504073efcea59391faa82b0c3dfbbf3b724babe4ffd5e6ca0a12e1ad4c02798dfc"
+  ]
+}

--- a/packages/resp-unix/resp-unix.0.9/opam
+++ b/packages/resp-unix/resp-unix.0.9/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9"}
+    "resp-client" {>= "0.9"}
+    "resp-server" {>= "0.9"}
+    "conduit-lwt-unix" {>= "1.3"}
+    "alcotest" {with-test}
+    "alcotest-lwt" {with-test}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Redis serialization protocol library for Unix
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=a616b371a8813cfc312ecdaf55c991c7"
+    "sha512=a819f5ce682ba4450303e02bf3599b6ddd99271c00365d409a5874e389005a504073efcea59391faa82b0c3dfbbf3b724babe4ffd5e6ca0a12e1ad4c02798dfc"
+  ]
+}

--- a/packages/resp/resp.0.9/opam
+++ b/packages/resp/resp.0.9/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "lwt" {>= "4.1"}
+    "alcotest" {with-test}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Redis serialization protocol library
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=a616b371a8813cfc312ecdaf55c991c7"
+    "sha512=a819f5ce682ba4450303e02bf3599b6ddd99271c00365d409a5874e389005a504073efcea59391faa82b0c3dfbbf3b724babe4ffd5e6ca0a12e1ad4c02798dfc"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`resp.0.9`: Redis serialization protocol library
-`resp-client.0.9`: Redis serialization protocol client
-`resp-mirage.0.9`: Redis serialization protocol tools for MirageOS
-`resp-server.0.9`: Redis serialization protocol server
-`resp-unix.0.9`: Redis serialization protocol library for Unix



---
* Homepage: https://github.com/zshipko/resp
* Source repo: git+https://github.com/zshipko/resp.git
* Bug tracker: https://github.com/zshipko/resp/issues

---
:camel: Pull-request generated by opam-publish v2.0.0