### PR TITLE
Package ocp-browser.1.1.8

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.1.8/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.8/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis: "Console browser for the documentation of installed OCaml libraries"
+description: """
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocp-pp" {build}
+  "jbuilder" {build}
+  "ocp-index" {= version}
+  "cmdliner"
+  "lambda-term"
+]
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/1.1.8.tar.gz"
+  checksum: [
+    "md5=f00f300d602e3e148e64d630d4f8a548"
+    "sha512=f743167890764d8ecad90a3925930210cf761a0534e08f57e547f0638705eb7ea4e38c48d45b8ebfe2a8d43a9e7b986bb69b5ed3624eb08911826a39ee0c0cef"
+  ]
+}

--- a/packages/ocp-browser/ocp-browser.1.1.8/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.8/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocp-pp" {build}
   "jbuilder" {build}
-  "ocp-index" {= version}
+  "ocp-index" {= "1.1.7" | = version}
   "cmdliner"
   "lambda-term"
 ]


### PR DESCRIPTION
### `ocp-browser.1.1.8`
Console browser for the documentation of installed OCaml libraries
ocp-browser is a ncurses-like interface that allows to easily browse the
interfaces and documentation of all installed OCaml modules.



---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: git+https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
:camel: Pull-request generated by opam-publish v2.0.0