### PR TITLE
3 packages from zshipko/ocaml-bimage at 0.1

### DIFF
--- a/packages/bimage-gtk/bimage-gtk.0.1/opam
+++ b/packages/bimage-gtk/bimage-gtk.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git://github.com:zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing" "gtk"]
+
+depends:
+[
+    "ocaml" {>= "4.03.0"}
+    "dune" {build}
+    "bimage" {>= "0.1"}
+    "lablgtk" {>= "2.18"}
+    "cairo2" {>= "0.6"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+
+synopsis: """
+Bimage_gtk allows images to be displayed in GTK windows
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src: "https://github.com/zshipko/ocaml-bimage/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=d99320389cab8e85c6021c96cc98cb7c"
+    "sha512=d98d334eff3f077b9aadc5c082809976b79902d2d31788d8e40e9773687d0c8678030cb8efc71581822a46afeac92d34ab8933f5507bceea6cd7e38e78456334"
+  ]
+}

--- a/packages/bimage-unix/bimage-unix.0.1/opam
+++ b/packages/bimage-unix/bimage-unix.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git://github.com:zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.06.0"}
+    "dune" {build}
+    "bimage" {>= "0.1"}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/Ffmpeg/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src: "https://github.com/zshipko/ocaml-bimage/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=d99320389cab8e85c6021c96cc98cb7c"
+    "sha512=d98d334eff3f077b9aadc5c082809976b79902d2d31788d8e40e9773687d0c8678030cb8efc71581822a46afeac92d34ab8933f5507bceea6cd7e38e78456334"
+  ]
+}

--- a/packages/bimage/bimage.0.1/opam
+++ b/packages/bimage/bimage.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git://github.com:zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.03.0"}
+    "dune" {build}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src: "https://github.com/zshipko/ocaml-bimage/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=d99320389cab8e85c6021c96cc98cb7c"
+    "sha512=d98d334eff3f077b9aadc5c082809976b79902d2d31788d8e40e9773687d0c8678030cb8efc71581822a46afeac92d34ab8933f5507bceea6cd7e38e78456334"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bimage.0.1`: A simple, efficient image-processing library
-`bimage-gtk.0.1`: Bimage_gtk allows images to be displayed in GTK windows
-`bimage-unix.0.1`: Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/Ffmpeg/stb_image



---
* Homepage: https://github.com/zshipko/ocaml-bimage
* Source repo: git+ssh://github.com/zshipko/ocaml-bimage.git
* Bug tracker: https://github.com/zshipko/ocaml-bimage/issues

---
:camel: Pull-request generated by opam-publish v2.0.0