### PR TITLE
Package batsat.0.3.1

### DIFF
--- a/packages/batsat/batsat.0.3.1/opam
+++ b/packages/batsat/batsat.0.3.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for batsat, a SAT solver in rust"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+# TODO: add dependency on cargo?
+depends: [
+  "dune" {build & >= "1.3.0" }
+  "odoc" {with-doc}
+  "conf-rust" {build}
+]
+tags: [ "minisat" "solver" "SAT" ]
+homepage: "https://github.com/c-cube/batsat-ocaml/"
+dev-repo: "git+https://github.com/c-cube/batsat-ocaml.git"
+bug-reports: "https://github.com/c-cube/batsat-ocaml/issues"
+authors: "simon.cruanes.2007@m4x.org"
+url {
+  src: "https://github.com/c-cube/batsat-ocaml/archive/v0.3.1.tar.gz"
+  checksum: [
+    "md5=29728bf99be2407e85af67a83cbc20d2"
+    "sha512=914106d6f1b478741a14112df9ddf81706de6f68c2aa70f1d67cdc9a8da072582af596f9a88ea03f6dbed4a220a470367bb88d3332f7f4b844540e59ee40dbfa"
+  ]
+}


### PR DESCRIPTION
### `batsat.0.3.1`
OCaml bindings for batsat, a SAT solver in rust



---
* Homepage: https://github.com/c-cube/batsat-ocaml/
* Source repo: git+https://github.com/c-cube/batsat-ocaml.git
* Bug tracker: https://github.com/c-cube/batsat-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0