### PR TITLE
Package opam-ed.0.3

### DIFF
--- a/packages/opam-ed/opam-ed.0.3/opam
+++ b/packages/opam-ed/opam-ed.0.3/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/AltGr/opam-ed"
 bug-reports: "https://github.com/AltGr/opam-ed/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "cmdliner" {>= "1.0.0"}
   "opam-file-format" {>= "2.0.0" & < "2.1"}
 ]

--- a/packages/opam-ed/opam-ed.0.3/opam
+++ b/packages/opam-ed/opam-ed.0.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/AltGr/opam-ed"
+bug-reports: "https://github.com/AltGr/opam-ed/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind"
+  "cmdliner" {>= "1.0.0"}
+  "opam-file-format" {>= "2.0.0" & < "2.1"}
+]
+build: [
+  make "COMP=ocamlc" {!ocaml:native}
+]
+dev-repo: "git+https://github.com/AltGr/opam-ed.git"
+synopsis: "Command-line edition tool for handling the opam file syntax"
+description: """
+opam-ed can read and write files in the general opam syntax. It provides a small CLI with some useful commands for mechanically extracting or modifying the file contents.
+
+The specification for the syntax itself is available at:
+    http://opam.ocaml.org/doc/Manual.html#Common-file-format
+"""
+url {
+  src: "https://github.com/AltGr/opam-ed/archive/0.3.tar.gz"
+  checksum: [
+    "md5=29757044dec336ceed80b528a5d5717e"
+    "sha512=97ab5404a6b3c69628626232544069030cafb9daac85a1a6342f878e69678972180667613778c508ef87f19c2477938333eda41f713cca40af5376900dda7360"
+  ]
+}


### PR DESCRIPTION
### `opam-ed.0.3`
Command-line edition tool for handling the opam file syntax
opam-ed can read and write files in the general opam syntax. It provides a small CLI with some useful commands for mechanically extracting or modifying the file contents.

The specification for the syntax itself is available at:
    http://opam.ocaml.org/doc/Manual.html#Common-file-format



---
* Homepage: https://github.com/AltGr/opam-ed
* Source repo: git+https://github.com/AltGr/opam-ed.git
* Bug tracker: https://github.com/AltGr/opam-ed/issues

---
:camel: Pull-request generated by opam-publish v2.0.0