### PR TITLE
vmnet: upper bounds of ipaddr to < 3.0.0

### DIFF
--- a/packages/vmnet/vmnet.1.0.0/opam
+++ b/packages/vmnet/vmnet.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "camlp4" {build}
   "type_conv" {build}
   "sexplib" {< "113.24.00"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.4.0" & <= "1.9.0"}
   "ocamlbuild" {build}

--- a/packages/vmnet/vmnet.1.0.1/opam
+++ b/packages/vmnet/vmnet.1.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "camlp4" {build}
   "type_conv" {build}
   "sexplib" {< "113.24.00"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.4.0" & <= "1.9.0"}
   "ocamlbuild" {build}

--- a/packages/vmnet/vmnet.1.0.2/opam
+++ b/packages/vmnet/vmnet.1.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "camlp4" {build}
   "type_conv" {build}
   "sexplib" {< "113.24.00"}
-  "ipaddr" {>= "2.5.0"}
+  "ipaddr" {>= "2.5.0" & < "3.0.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.4.0" & <= "1.9.0"}
   "ocamlbuild" {build}

--- a/packages/vmnet/vmnet.1.1.0/opam
+++ b/packages/vmnet/vmnet.1.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "ppx_cstruct"
   "sexplib" {>= "113.24.00" & < "v0.12"}
-  "ipaddr" {>= "1.4.0"}
+  "ipaddr" {>= "1.4.0" & < "3.0.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.9.0"}
   "cstruct-unix"

--- a/packages/vmnet/vmnet.1.2.0/opam
+++ b/packages/vmnet/vmnet.1.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_tools"
   "ppx_sexp_conv" {< "v0.12"}
   "sexplib" {>= "113.24.00" & < "v0.12"}
-  "ipaddr" {>= "1.4.0"}
+  "ipaddr" {>= "1.4.0" & < "3.0.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.9.0"}
   "cstruct-unix"

--- a/packages/vmnet/vmnet.1.3.0/opam
+++ b/packages/vmnet/vmnet.1.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "ocaml-migrate-parsetree" {build}
   "sexplib" {>= "113.24.00" & < "v0.12"}
-  "ipaddr" {>= "1.4.0"}
+  "ipaddr" {>= "1.4.0" & < "3.0.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.9.0"}
   "cstruct-unix"

--- a/packages/vmnet/vmnet.1.3.1/opam
+++ b/packages/vmnet/vmnet.1.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.12"}
   "ocaml-migrate-parsetree" {build}
   "sexplib" {>= "113.24.00" & < "v0.12"}
-  "ipaddr" {>= "1.4.0"}
+  "ipaddr" {>= "1.4.0" & < "3.0.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "cstruct" {>= "1.9.0"}
   "cstruct-unix"

--- a/packages/vmnet/vmnet.1.3.2/opam
+++ b/packages/vmnet/vmnet.1.3.2/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {build}
   "ppx_sexp_conv"
   "sexplib" {>= "113.24.00"}
-  "ipaddr" {>="1.4.0"}
+  "ipaddr" {>="1.4.0" & < "3.0.0"}
   "lwt" {>="2.4.3"}
   "cstruct" {>="1.9.0"}
   "cstruct-unix"


### PR DESCRIPTION
see https://github.com/mirage/ocaml-vmnet/pull/25 for an upstream fix to support newer ipaddr (well, rather macaddr).