### PR TITLE
Package MUTF8 v0.1

### DIFF
--- a/packages/mutf8/mutf8.0.1/opam
+++ b/packages/mutf8/mutf8.0.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+name: "mutf8"
+version: "0.1"
+synopsis: "The Modified UTF-8 encoding used by Java and related systems"
+maintainer: "Wim Lewis <wiml@hhhh.org>"
+authors: "Wim Lewis <wiml@hhhh.org>"
+license: "BSD"
+depends: [
+  "ocaml" { >= "4.07.0" }
+  "dune" { build & >= "1.0.0" }
+  "batteries" { >= "2.0.0" }
+]
+build: [ "dune" "build" "-p" "mutf8" ]
+dev-repo: "git+https://github.com/wiml/ocaml-mutf8.git"
+bug-reports: "https://github.com/wiml/ocaml-mutf8/issues"
+homepage: "https://github.com/wiml/ocaml-mutf8"
+url {
+  src: "http://github.com/wiml/ocaml-mutf8/archive/v0.1.tar.gz"
+  checksum: "sha512=261561d7ae178ce3b0e2eac35070f13e1eedb7b41a801f1ce5604dd3d134be0613a4a03caa9889e69b6f4d3410402652eb60ed8608cb20bb1bc4931c299f879c"
+}


### PR DESCRIPTION
This is a package to manipulate strings in the oddball MUTF-8 encoding used by Java-related software. There is an existing WTF-8 package in opam, but MUTF-8 and WTF-8 differ slightly.