### PR TITLE
[new release] dns-lwt, dns, dns-async, dns-lwt-unix and mirage-dns (1.1.1)

### DIFF
--- a/packages/dns-async/dns-async.1.1.1/opam
+++ b/packages/dns-async/dns-async.1.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+synopsis: "DNS implementation using the Async concurrency framework"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the Jane Street Async library.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns"
+  "async" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.1/dns-v1.1.1.tbz"
+  checksum: "md5=42a49a41d3b53567e074b864926d4411"
+}

--- a/packages/dns-async/dns-async.1.1.1/opam
+++ b/packages/dns-async/dns-async.1.1.1/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
   "dns"
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.10.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.1.1/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+synopsis: "DNS implementation for Unix and Windows using Lwt_unix"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the `Lwt_unix` concurrency framework.
+Despite the name, the library should work on both Unix and Windows
+(as supported by Lwt_unix upstream).
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns-lwt"
+  "base-unix"
+  "cmdliner"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.1/dns-v1.1.1.tbz"
+  checksum: "md5=42a49a41d3b53567e074b864926d4411"
+}

--- a/packages/dns-lwt/dns-lwt.1.1.1/opam
+++ b/packages/dns-lwt/dns-lwt.1.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS implementation in portable Lwt"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the portable Lwt concurrency framework.
+You can find a Unix version of this library in the `dns-lwt-unix`
+opam package, and in theory you could compile this one to JavaScript
+as well using js_of_ocaml.
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "mirage-profile" {>= "0.8.0"}
+  "lwt" {>= "3.0.0"}
+  "dns"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.1/dns-v1.1.1.tbz"
+  checksum: "md5=42a49a41d3b53567e074b864926d4411"
+}

--- a/packages/dns/dns.1.1.1/opam
+++ b/packages/dns/dns.1.1.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS client and server implementation in pure OCaml"
+description: """
+This is a pure OCaml implementation of the DNS protocol.  It is intended to be
+a reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.
+
+There are several concrete implementations using this package that you probably
+want to use for practical purposes:
+
+- dns-lwt for the Lwt concurrency library
+- dns-lwt-unix using the Lwt_unix bindings
+- dns-async using the Jane Street Async library
+- mirage-dns for the MirageOS unikernel framework
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "cstruct" {>= "3.0.2"}
+  "ppx_cstruct"
+  "re" {>="1.7.2"}
+  "ipaddr" {>= "2.6.0"}
+  "uri" {>= "1.7.0"}
+  "base64" {>= "3.0.0"}
+  "hashcons"
+  "result"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.1/dns-v1.1.1.tbz"
+  checksum: "md5=42a49a41d3b53567e074b864926d4411"
+}

--- a/packages/mirage-dns/mirage-dns.1.1.1/opam
+++ b/packages/mirage-dns/mirage-dns.1.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+synopsis: "DNS implementation for the MirageOS unikernel framework"
+description: """
+This is an implementation of a DNS server and client resolver
+for the [MirageOS unikernel framework](https://mirage.io).
+"""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns-lwt"
+  "duration"
+  "mirage-stack-lwt"
+  "mirage-kv-lwt"
+  "mirage-time-lwt"
+  "mirage-profile" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.1/dns-v1.1.1.tbz"
+  checksum: "md5=42a49a41d3b53567e074b864926d4411"
+}


### PR DESCRIPTION
DNS implementation in portable Lwt

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* Support Base64.3.0.0 interface (@avsm)
