### PR TITLE
Package headache.1.04

### DIFF
--- a/packages/headache/headache.1.04/files/headache.install
+++ b/packages/headache/headache.1.04/files/headache.install
@@ -1,2 +1,0 @@
-bin: ["headache"]
-doc: ["?doc/headache.pdf" "?doc/headache.ps.gz" "?doc/headache.html" "?doc/headache.txt"]

--- a/packages/headache/headache.1.04/files/headache.install
+++ b/packages/headache/headache.1.04/files/headache.install
@@ -1,0 +1,2 @@
+bin: ["headache"]
+doc: ["?doc/headache.pdf" "?doc/headache.ps.gz" "?doc/headache.html" "?doc/headache.txt"]

--- a/packages/headache/headache.1.04/opam
+++ b/packages/headache/headache.1.04/opam
@@ -23,25 +23,23 @@ authors: [
 maintainer: "Patrick Baudin"
 homepage: "https://github.com/Frama-C/headache/"
 bug-reports: "https://github.com/Frama-C/headache/issues"
-dev-repo: "https://github.com/Frama-C/headache.git"
+dev-repo: "git+https://github.com/Frama-C/headache.git"
 
 depends: [
   "camomile"
-  "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "dune" {build}
 ]
 
 build: [
-  [make]
+  [ "dune" "build" "-p" "headache" ]
 ]
 
-install: [
+install:  [
   [make "INSTALLDIR=%{prefix}%/bin" "install"]
   [make "DOC_INSTALLDIR=%{prefix}%/doc/headache" "install-doc"] {with-doc}
 ]
 
-extra-files: ["headache.install" "md5=698fde7c6498aa82223d679fae952d69"]
 url {
   src: "https://github.com/Frama-C/headache/archive/v1.04.tar.gz"
-  checksum: "md5=35d75338793d1f17de6de504909221ae"
+  checksum: "md5=d551319dcb2616d660f2cb04021602aa"
 }

--- a/packages/headache/headache.1.04/opam
+++ b/packages/headache/headache.1.04/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "headache"
+version: "1.04"
+
+license: "GNU Library General Public License"
+
+synopsis: "Automatic generation of files headers"
+description: """
+Lightweight tool for managing headers in source code files. It can
+update in any source code files (OCaml, C, XML et al).
+"""
+
+authors: [
+  "Vincent Simonet"
+  # contributors
+  "Patrick Baudin"
+  "Mehdi Dogguy"
+  "François Pottier"
+  "Virgile Prevosto"
+  "Ralf Treinen"
+]
+
+maintainer: "Patrick Baudin"
+homepage: "https://github.com/Frama-C/headache/"
+bug-reports: "https://github.com/Frama-C/headache/issues"
+
+depends: [
+  "camomile"
+  "ocamlbuild" {build}
+]
+
+build: [
+  [make]
+]
+
+install: [
+  [make "INSTALLDIR=%{prefix}%/bin" "install"]
+  [make "DOC_INSTALLDIR=%{prefix}%/doc/headache" "install-doc"] {with-doc}
+]
+
+extra-files: ["headache.install" "md5=698fde7c6498aa82223d679fae952d69"]
+url {
+  src: "https://github.com/Frama-C/headache/archive/v1.04.tar.gz"
+  checksum: "md5=35d75338793d1f17de6de504909221ae"
+}

--- a/packages/headache/headache.1.04/opam
+++ b/packages/headache/headache.1.04/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "headache"
-version: "1.04"
 
 license: "GNU Library General Public License"
 
@@ -31,12 +29,7 @@ depends: [
 ]
 
 build: [
-  [ "dune" "build" "-p" "headache" ]
-]
-
-install:  [
-  [make "INSTALLDIR=%{prefix}%/bin" "install"]
-  [make "DOC_INSTALLDIR=%{prefix}%/doc/headache" "install-doc"] {with-doc}
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
 url {

--- a/packages/headache/headache.1.04/opam
+++ b/packages/headache/headache.1.04/opam
@@ -23,9 +23,11 @@ authors: [
 maintainer: "Patrick Baudin"
 homepage: "https://github.com/Frama-C/headache/"
 bug-reports: "https://github.com/Frama-C/headache/issues"
+dev-repo: "https://github.com/Frama-C/headache.git"
 
 depends: [
   "camomile"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
 


### PR DESCRIPTION
New version for `headache` package including patches for UTF-8 encoding.

As said at Ocaml forge https://forge.ocamlcore.org/projects/headache, the project as migrated to https://github.com/Frama-C/headache.