### PR TITLE
fix coqide authors

### DIFF
--- a/packages/coqide/coqide.8.9.0/opam
+++ b/packages/coqide/coqide.8.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "coqdev@inria.fr"
-authors: "The Coq development team, INRIA, CNRS, University Paris Sud, University Paris 7, Ecole Polytechnique."
+authors: "The Coq development team, INRIA, CNRS, and contributors."
 homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"


### PR DESCRIPTION
This makes the `coqide` authors consistent with `coq`.

Cc @mattam82 