### PR TITLE
[new release] coq-serapi (8.9.0+0.6.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.9.0+0.6.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.9.0+0.6.0/opam
@@ -1,0 +1,30 @@
+synopsis:     "Sexp-based serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  "Sexp-based serialization library and protocol for machine interaction with the Coq proof assistant"
+name:         "coq-serapi"
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+authors:      "Emilio Jesús Gallego Arias"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL 3"
+doc:          "https://ejgallego.github.io/coq-serapi/doc"
+
+depends: [
+  "ocaml"         { >= "4.06.0"           }
+  "coq"           { >= "8.9.0" & < "8.10" }
+  "cmdliner"      { >= "1.0.0"            }
+  "ocamlfind"     { >= "1.8.0"            }
+  "sexplib"       { >= "v0.11.0"          }
+  "dune"          { build & >= "1.2.0"    }
+  "ppx_import"    { build & >= "1.5-3"    }
+  "ppx_deriving"  { build & >= "4.2.1"    }
+  "ppx_sexp_conv" { build & >= "v0.11.0"  }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/archive/8.9.0+0.6.0.tar.gz"
+  checksum: "md5=8b52f643a3c9019c551e0757e1b3b569"
+}


### PR DESCRIPTION
CHANGES:

* [general] support Coq 8.9,
 * [general] SerAPI now uses Dune as a build system,
 * [opam]   install `sertop.el`,
 * [serlib] support to serialize kernel environments,
 * [serapi] new query `Env` that tries to print the current kernel environment,
 * [serlib] correct field names for `CAst`,
 * [serlib] more robust support for opaque / non-serializable types (ejgallego/coq-serapi#61, ejgallego/coq-serapi#68).
            Thanks to @palmskog,
 * [serlib] new option `--exn_on_opaque` to raise an exception on
            non-serializable types; closes ejgallego/coq-serapi#68, thanks to @palmskog,
 * [serlib] serialization test-suite from
            https://github.com/proofengineering/serapi-tests, thanks to
            @palmskog,
 * [sercomp] add `--mode` option to better control output,
 * [sercomp] add `compser` for deserialization (inverse of `sercomp`)
             (@palmskog),
 * [serapi]  Allow custom document creation using the `NewDoc` call.
             Use the `--no_init` option to avoid automatic creation
             on init. (@ejgallego)
 * [sercomp] Allow compilers to output `.vo` (@ejgallego , suggested by
             @palmskog)
 * [sercomp] Serialize top-level vernaculars with their syntactic
             attributes (such as location) (@ejallego)
 * [serapi]  Add `Assumptions` query, at the suggestion of @Armael
             (@ejgallego)
 * [sercomp] Disable error resilience mode in compilers; semantics are
             a bit dubious see coq/coq#9204 also ejgallego/coq-serapi#94.
             (@ejgallego, report by @palmskog)
 * [sercomp] Add `check` mode to compilers to check all proofs without
             outputting `.vo`. (@palmskog)
 * [sercomp] Add "hacky" `--quick` option to skip checking of opaque
             proofs. (@ejgallego, request by @palmskog)
 * [sercomp] Add `--async_workers` option to set maximum number
             of parallel async workers. (@palmskog)
 * [sertop] Stop linking Coq plugins statically and load `serlib`
            plugins when Coq plugins are loaded instead (@ejgallego,
            review by @palmskog)
