### PR TITLE
plain -no-flat-float-array ocaml variants for 4.{06,07}.{0,1}

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Official 4.06.0 release, with -no-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.06.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+    "-cc"
+    "cc -O2 -pipe"
+    "-aspp"
+    "cc -O2 -pipe -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
+  checksum: "md5=4f3906e581181c5435078ffe3e485e3f"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Official 4.06.1 release, with -no-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.06.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+  checksum: "md5=d02eb67b828de22c3f97d94b3c46acba"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Official 4.07.0 release, with -no-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.07.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
+  checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.07.1, with -no-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.07.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-flat-float-array"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
+  checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
+}


### PR DESCRIPTION
The -no-flat-float-array switches currently available are only with
+flambda. To benchmark the performance impact this option, it is
better if non-flambda switches with the option are also available.

(-no-flat-float-array was made available in 4.06.0, so this commit
covers all possible versions)