### PR TITLE
Package py.1.1

### DIFF
--- a/packages/py/py.1.1/opam
+++ b/packages/py/py.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-py"
+doc: "https://zshipko.github.io/ocaml-py/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-py.git"
+bug-reports: "https://github.com/zshipko/ocaml-py/issues"
+tags: ["python"]
+
+depends:
+[
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "ctypes" {>= "0.13.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+
+depexts: [
+	[["debian"] ["python3-dev"]]
+	[["ubuntu"] ["python3-dev"]]
+	[["fedora"] ["python3-devel"]]
+	[["alpine"] ["python3-dev"]]
+  [["macos"] ["python3"]]
+]
+
+build:
+[
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+post-messages: [
+    "Py requires Python 3.5 or greater"
+]
+
+synopsis: "Ctypes bindings to Python 3.5 or greater"
+url {
+  src: "https://github.com/zshipko/ocaml-py/archive/v1.1.tar.gz"
+  checksum: [
+    "md5=875243748662383fbeaaf647e1e9693a"
+    "sha512=55bdbc41ed4a31140bb43cb1499706eec3bf94ac49fa1ef70e2c178110a42b205812fd5d48211dd76140ba55dda76c23291dbdd4e5ffb35085cc933f0a0234f0"
+  ]
+}


### PR DESCRIPTION
### `py.1.1`
Ctypes bindings to Python 3.5 or greater



---
* Homepage: https://github.com/zshipko/ocaml-py
* Source repo: git+https://github.com/zshipko/ocaml-py.git
* Bug tracker: https://github.com/zshipko/ocaml-py/issues

---
:camel: Pull-request generated by opam-publish v2.0.0