### PR TITLE
[new release] yojson (1.6.0)

### DIFF
--- a/packages/yojson/yojson.1.6.0/opam
+++ b/packages/yojson/yojson.1.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "https://github.com/ocaml-community/yojson"
+bug-reports: "https://github.com/ocaml-community/yojson/issues"
+dev-repo: "git+https://github.com/ocaml-community/yojson.git"
+doc: "https://ocaml-community.github.io/yojson/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [["dune" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "cppo" {build}
+  "easy-format"
+  "biniou" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.8.5"}
+]
+synopsis:
+  "Yojson is an optimized parsing and printing library for the JSON format"
+description: """
+Yojson is an optimized parsing and printing library for the JSON format.
+
+It addresses a few shortcomings of json-wheel including 2x speedup,
+polymorphic variants and optional syntax for tuples and variants.
+
+ydump is a pretty-printing command-line program provided with the
+yojson package.
+
+The program atdgen can be used to derive OCaml-JSON serializers and
+deserializers from type definitions."""
+url {
+  src:
+    "https://github.com/ocaml-community/yojson/releases/download/1.6.0/yojson-1.6.0.tbz"
+  checksum: "md5=8ca16557d3068253cc375452af3bde96"
+}


### PR DESCRIPTION
Yojson is an optimized parsing and printing library for the JSON format

- Project page: <a href="https://github.com/ocaml-community/yojson">https://github.com/ocaml-community/yojson</a>
- Documentation: <a href="https://ocaml-community.github.io/yojson/">https://ocaml-community.github.io/yojson/</a>

##### CHANGES:

*2019-01-30*

### Deprecate

- `json` types are deprecated in favor of their new `t` aliases, ahead of their removal in the next
  major release (ocaml-community/yojson#73, @Leonidas-from-XIV)

### Add

- Add a type `t` and monomorphic `equal`, `pp` and `show` (ocaml-community/yojson#73, @Leonidas-from-XIV)
