### PR TITLE
[new release] pkcs11-driver, pkcs11-cli, pkcs11-rev and pkcs11 (0.18.0)

### DIFF
--- a/packages/pkcs11-cli/pkcs11-cli.0.18.0/opam
+++ b/packages/pkcs11-cli/pkcs11-cli.0.18.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "cmdliner"
+  "pkcs11"
+  "dune" {>= "1.3.0"}
+]
+tags: ["org:cryptosense"]
+synopsis: "Cmdliner arguments to initialize a PKCS#11 session"
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v0.18.0/pkcs11-v0.18.0.tbz"
+  checksum: "md5=f1ec2b5c92bca1f4d156639c2409a5fe"
+}

--- a/packages/pkcs11-cli/pkcs11-cli.0.18.0/opam
+++ b/packages/pkcs11-cli/pkcs11-cli.0.18.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "cmdliner"
-  "pkcs11"
+  "pkcs11" {>= "0.18.0"}
   "dune" {>= "1.3.0"}
 ]
 tags: ["org:cryptosense"]

--- a/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
-  "pkcs11"
+  "pkcs11" {>= "0.18.0"}
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }
   "ocaml" {>= "4.04.0"}

--- a/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes"
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "pkcs11"
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "ounit" {with-test}
+]
+conflicts: [
+  "ctypes" { < "0.12.0" }
+]
+tags: ["org:cryptosense"]
+available: [os != "macos"]
+synopsis: "Bindings to the PKCS#11 cryptographic API"
+description: """
+This library contains ctypes bindings to the PKCS#11 API.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v0.18.0/pkcs11-v0.18.0.tbz"
+  checksum: "md5=f1ec2b5c92bca1f4d156639c2409a5fe"
+}

--- a/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
@@ -19,6 +19,7 @@ depends: [
   "pkcs11"
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }
+  "ocaml" {>= "4.04.0"}
   "ounit" {with-test}
 ]
 conflicts: [

--- a/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
+++ b/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
-  "pkcs11"
+  "pkcs11" {>= "0.18.0"}
   "pkcs11-driver"
 ]
 conflicts: [

--- a/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
+++ b/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes"
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "pkcs11"
+  "pkcs11-driver"
+]
+conflicts: [
+  "ctypes" { < "0.12.0" }
+]
+tags: ["org:cryptosense"]
+available: [os != "macos"]
+synopsis: "Reverse bindings to pkcs11"
+description: """
+This library contains helpers to write reverse PKCS#11 bindings.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v0.18.0/pkcs11-v0.18.0.tbz"
+  checksum: "md5=f1ec2b5c92bca1f4d156639c2409a5fe"
+}

--- a/packages/pkcs11/pkcs11.0.18.0/opam
+++ b/packages/pkcs11/pkcs11.0.18.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_deriving_yojson" { >= "3.0" }
   "ppx_variants_conv"
   "zarith"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.04.0"}
   "ounit" {with-test}
 ]
 tags: ["org:cryptosense"]

--- a/packages/pkcs11/pkcs11.0.18.0/opam
+++ b/packages/pkcs11/pkcs11.0.18.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.3.0"}
+  "hex" { >= "1.0.0" }
+  "integers"
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "ppx_variants_conv"
+  "zarith"
+  "ocaml" {>= "4.03.0"}
+  "ounit" {with-test}
+]
+tags: ["org:cryptosense"]
+available: [os != "macos"]
+synopsis: "PKCS#11 ocaml types"
+description: """
+This library contains type definitions for the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v0.18.0/pkcs11-v0.18.0.tbz"
+  checksum: "md5=f1ec2b5c92bca1f4d156639c2409a5fe"
+}


### PR DESCRIPTION
Bindings to the PKCS#11 cryptographic API

- Project page: <a href="https://github.com/cryptosense/pkcs11">https://github.com/cryptosense/pkcs11</a>
- Documentation: <a href="https://cryptosense.github.io/pkcs11/doc">https://cryptosense.github.io/pkcs11/doc</a>

##### CHANGES:

*2019-01-30*

## Changes

- Remove optional dependencies and split into `pkcs11`, `pkcs11-cli`, `pkcs11-driver` and
  `pkcs11-rev` packages.
