### PR TITLE
[new release] ahrocksdb (0.2.2)

### DIFF
--- a/packages/ahrocksdb/ahrocksdb.0.2.2/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A binding to RocksDB"
+description: """
+This is a binding to Facebook's RocksDB.
+
+Early prototype of this library based on [orocksdb](https://github.com/domsj/orocksdb), we decided to rewrite our own binding to make use of Ctypes's stubs generators instead of the dynamic mode used in orocksdb.
+
+It is currently based and was tested against RocksDB 5.14fb, and should work with newer versions of this library.
+
+## API changes and contributions
+
+While we do not plan big changes in what is already implemented, we do not guarantee the stability of these APIs.
+
+Some APIs could definitely use improvements (moving the current configuration system to a builder-like pattern),
+and some breakage may or may-not happen.
+
+Pull requests to improve any parts of the library are however welcome, whether they are related to
+tests, binding coverage, or API improvements, feel free to open an issue to discuss changes."""
+maintainer: "Enguerrand Decorne <enguerrand.decorne@ahrefs.com>"
+authors: "Enguerrand Decorne <enguerrand.decorne@ahrefs.com>"
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ahrocksdb"
+doc: "https://ahrefs.github.io/ocaml-ahrocksdb/"
+bug-reports: "https://github.com/ahrefs/ocaml-ahrocksdb/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "ctypes" {>= "0.12.0"}
+  "astring"
+  "conf-rocksdb"
+  "rresult"
+  "bos" {with-test}
+  "cryptokit" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest"] {with-test}
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ahrocksdb.git"
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ahrocksdb/releases/download/0.2.2/ahrocksdb-0.2.2.tbz"
+  checksum: "md5=c44c39c979d1e066660c4550606a078e"
+}


### PR DESCRIPTION
A binding to RocksDB

- Project page: <a href="https://github.com/ahrefs/ocaml-ahrocksdb">https://github.com/ahrefs/ocaml-ahrocksdb</a>
- Documentation: <a href="https://ahrefs.github.io/ocaml-ahrocksdb/">https://ahrefs.github.io/ocaml-ahrocksdb/</a>

##### CHANGES:

Do not depend on base anymore.
Internal build system fixes.
rresult dependency was missing, thus added
