### PR TITLE
[new release] utop (2.3.0)

### DIFF
--- a/packages/utop/utop.2.3.0/opam
+++ b/packages/utop/utop.2.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: "Jérémie Dimino"
+license: "BSD3"
+homepage: "https://github.com/ocaml-community/utop"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+doc: "https://ocaml-community.github.io/utop/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "1.13"}
+  "lwt"
+  "lwt_react"
+  "camomile"
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.2"}
+  "dune" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+synopsis: "Universal toplevel for OCaml"
+description: """
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs.
+"""
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.3.0/utop-2.3.0.tbz"
+  checksum: "md5=5c9e6d4ca1bea263efb9967b7ad51393"
+}


### PR DESCRIPTION
Universal toplevel for OCaml

- Project page: <a href="https://github.com/ocaml-community/utop">https://github.com/ocaml-community/utop</a>
- Documentation: <a href="https://ocaml-community.github.io/utop/">https://ocaml-community.github.io/utop/</a>

##### CHANGES:

The new feature in this release is to automatically install
printers marked with `[@@ocaml.toplevel_printer]` (ocaml-community/utop#269 @diml).
Adding this annotation to your libraries will remove the need
to have a separate `top` package to install the printers.

For example, in the [uri](https://github.com/mirage/ocaml-uri)
library, the old printing function for `Uri.t` was:

```
val pp_hum : Format.formatter -> t -> unit
```

Just adding this annotation results in `Uri.t` values being automatically
pretty printed in this version of utop.

```
val pp_hum : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
```

* Add cool screenshot to README (ocaml-community/utop#259 @rizo) and update links (ocaml-community/utop#257 @bobot)
* Improve robustness by using more tail-recursive functions (ocaml-community/utop#251 @gpetiot)
* Remove deprecation warnings in newer compilers (ocaml-community/utop#246 @ncihnegn)
* Minimum OCaml version supported is now 4.03.0 (ocaml-community/utop#254 @XVilka)
* Publish API documentation online and add `doc:` entry to opam file (ocaml-community/utop#270 @avsm)
* Port build to dune from jbuilder (ocaml-community/utop#268 @avsm)
* Upgrade local opam metadata to opam 2.0 format (ocaml-community/utop#268 @avsm)
