### PR TITLE
New package: conf-libclang

### DIFF
--- a/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
@@ -63,10 +63,10 @@ main(int argc, char *argv[])
 }
 EOF
 CC=clang
-$(CC) -o "$tempdir/test_libclang.o" -c $LLVM_CFLAGS \
+"$CC" -o "$tempdir/test_libclang.o" -c $LLVM_CFLAGS \
     "$tempdir/test_libclang.c" || \
     ( clean_tempdir; echo "Error: cannot compile libclang test."; exit 1 )
-$(CC) -o "$tempdir/test_libclang" \
+"$CC" -o "$tempdir/test_libclang" \
     $LLVM_LDFLAGS "$tempdir/test_libclang.o" \
     "-lclang" "-Wl,-rpath,$LLVM_LIBDIR" || \
     ( clean_tempdir; echo "Error: cannot link libclang test."; exit 1 )

--- a/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
@@ -29,18 +29,16 @@ LLVM_LDFLAGS="`\"$llvm_config\" --ldflags`"
 LLVM_LIBDIR="`\"$llvm_config\" --libdir`"
 
 # These filters enable compilation with gcc.
-# We will use clang instead in the test below.
-#
-## Filter -Wstring-conversion for OpenSUSE
-#LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Wstring-conversion\\ //`"
-#
-## Filter -Werror=unguarded-availability-new and -Wcovered-switch-default
-## (which appear with LLVM 7)
-#LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Werror=unguarded-availability-new\\ //`"
-#LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Wcovered-switch-default\\ //`"
-#
-## Filter "-Wdelete-non-virtual-dtor" (warning only)
-#LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Wdelete-non-virtual-dtor\\ //`"
+# Filter -Wstring-conversion for OpenSUSE
+LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Wstring-conversion\\ //`"
+
+# Filter -Werror=unguarded-availability-new and -Wcovered-switch-default
+# (which appear with LLVM 7)
+LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Werror=unguarded-availability-new\\ //`"
+LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Wcovered-switch-default\\ //`"
+
+# Filter "-Wdelete-non-virtual-dtor" (warning only)
+LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Wdelete-non-virtual-dtor\\ //`"
 
 tempdir="`mktemp -d`"
 
@@ -62,7 +60,7 @@ main(int argc, char *argv[])
   return EXIT_SUCCESS;
 }
 EOF
-CC=clang
+CC=cc
 "$CC" -o "$tempdir/test_libclang.o" -c $LLVM_CFLAGS \
     "$tempdir/test_libclang.c" || \
     ( clean_tempdir; echo "Error: cannot compile libclang test."; exit 1 )

--- a/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
@@ -28,6 +28,9 @@ LLVM_CFLAGS="`\"$llvm_config\" --cflags`"
 LLVM_LDFLAGS="`\"$llvm_config\" --ldflags`"
 LLVM_LIBDIR="`\"$llvm_config\" --libdir`"
 
+# Filter -Wstring-conversion for OpenSUSE
+LLVM_CFLAGS="`echo $LLVM_CFLAGS | sed s/-Wstring-conversion\\ //`"
+
 tempdir="`mktemp -d`"
 
 clean_tempdir () {

--- a/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -ex
+
+find_llvm_config () {
+    # Locate llvm-config (taken from conf-llvm's configure.sh file)
+
+    shopt -s nullglob
+    for version in 7 6 5 4 3; do
+        if hash brew 2>/dev/null; then
+           brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
+        fi
+        for llvm_config in \
+            llvm-config-$version llvm-config-${version}.0 \
+            llvm-config${version}0 llvm-config-mp-$version \
+            llvm-config-mp-${version}.0 $brew_llvm_config \
+            llvm-config; do
+            llvm_version="`$llvm_config --version`" || continue
+            return
+        done
+    done
+
+    echo "Error: LLVM is not installed."
+    exit 1
+}
+
+find_llvm_config
+
+LLVM_CFLAGS="`\"$llvm_config\" --cflags`"
+LLVM_LDFLAGS="`\"$llvm_config\" --ldflags`"
+LLVM_LIBDIR="`\"$llvm_config\" --libdir`"
+
+tempdir="`mktemp -d`"
+
+clean_tempdir () {
+    rm -f "$tempdir/test_libclang.c" "$tempdir/test_libclang.o" \
+       "$tempdir/test_libclang"
+    rmdir "$tempdir"
+}
+
+cat >"$tempdir/test_libclang.c" <<EOF
+#include <clang-c/Index.h>
+#include <stdlib.h>
+
+int
+main(int argc, char *argv[])
+{
+  CXIndex idx = clang_createIndex(1, 1);
+  clang_disposeIndex(idx);
+  return EXIT_SUCCESS;
+}
+EOF
+cc -o "$tempdir/test_libclang.o" -c $LLVM_CFLAGS "$tempdir/test_libclang.c" || \
+    ( clean_tempdir; echo "Error: cannot compile libclang test."; exit 1 )
+cc -o "$tempdir/test_libclang" \
+    $LLVM_LDFLAGS "$tempdir/test_libclang.o" \
+    "-lclang" "-Wl,-rpath,$LLVM_LIBDIR" || \
+    ( clean_tempdir; echo "Error: cannot link libclang test."; exit 1 )
+"$tempdir/test_libclang" || \
+    ( clean_tempdir; echo "Error: cannot execute libclang test."; exit 1 )
+clean_tempdir

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -19,5 +19,8 @@ depexts: [
   ["llvm-clang-devel"] {os-family = "suse"}
   ["devel/clang" "devel/llvm"] {os = "freebsd"}
 ]
+extra-files: [[
+  "configure.sh" "md5=2980f60a8c38e9a85352e4afb6a11fd3"
+]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (any version)"
 flags: conf

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -8,8 +8,8 @@ build: [
   ["bash" "-ex" "configure.sh" version]
 ]
 depexts: [
-  ["clang" "llvm"] {os-distribution = "homebrew" & os = "macos"}
-  ["clang" "llvm"] {os-distribution = "macports" & os = "macos"}
+  ["llvm"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm"] {os-distribution = "macports" & os = "macos"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "debian"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
   ["clang-dev" "llvm-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libclang-dev" "llvm-dev"] {os-distribution = "debian"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
   ["clang-dev" "llvm-dev"] {os-distribution = "alpine"}
-  ["clang-devel" "llvm-devel"] {os-distribution = "centos"}
+  ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "centos"}
   ["llvm-clang-devel"] {os-distribution = "opensuse"}
   ["devel/clang" "devel/llvm"] {os = "freebsd"}
 ]

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
   ["clang-dev" "llvm-dev"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "centos"}
-  ["llvm-clang-devel"] {os-distribution = "opensuse"}
+  ["llvm-clang-devel"] {os-family = "suse"}
   ["devel/clang" "devel/llvm"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (any version)"

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "-ex" "configure.sh" version]
+]
+depexts: [
+  ["clang" "llvm"] {os-distribution = "homebrew" & os = "macos"}
+  ["clang" "llvm"] {os-distribution = "macports" & os = "macos"}
+  ["libclang-dev" "llvm-dev"] {os-distribution = "debian"}
+  ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
+  ["clang" "llvm"] {os-distribution = "alpine"}
+  ["clang" "llvm"] {os-distribution = "opensuse"}
+  ["devel/clang" "devel/llvm"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on the installation of llvm and clang libraries (any version)"
+flags: conf

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -14,6 +14,7 @@ depexts: [
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
   ["clang-dev" "llvm-dev"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "centos"}
+  ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}
   ["devel/clang" "devel/llvm"] {os = "freebsd"}
 ]

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -14,7 +14,8 @@ depexts: [
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
   ["clang-dev" "llvm-dev"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "centos"}
-  ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "fedora"}
+  ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
+    {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}
   ["devel/clang" "devel/llvm"] {os = "freebsd"}
 ]

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -12,8 +12,9 @@ depexts: [
   ["clang" "llvm"] {os-distribution = "macports" & os = "macos"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "debian"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
-  ["clang" "llvm"] {os-distribution = "alpine"}
-  ["clang" "llvm"] {os-distribution = "opensuse"}
+  ["clang-dev" "llvm-dev"] {os-distribution = "alpine"}
+  ["clang-devel" "llvm-devel"] {os-distribution = "centos"}
+  ["llvm-clang-devel"] {os-distribution = "opensuse"}
   ["devel/clang" "devel/llvm"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (any version)"


### PR DESCRIPTION
This configuration package will enable the release of the next version
of clangml.

This package checks whether there exists one working version of
libclang and llvm (by opposition to conf-llvm, that checks whether one
specific version is available). This behaviour is linked to the fact
that the next version of clangml will be able to compile with any
version of libclang.