### PR TITLE
Package learn-ocaml.0.10

### DIFF
--- a/packages/learn-ocaml/learn-ocaml.0.10/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.10/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+maintainer: "Louis Gesbert"
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "base" {= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "cohttp" {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "dune" {build & >= "1.1.1"}
+  "easy-format" {>= "1.3.0" }
+  "ipaddr" {= "2.8.0" }
+  "ezjsonm"
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "3.2.0" & < "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "magic-mime"
+  "markup"
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {= "0.4"}
+  "ocplib-json-typed" {= "0.6"}
+  "odoc" {build & = "1.3.0"}
+  "omd"
+  "pprint"
+  "ppx_cstruct"
+  "ppx_tools"
+  "uutf" {>= "1.0" }
+  "yojson" {>= "1.4.0" }
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name]
+]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+synopsis: "The learn-ocaml online platform (engine)"
+description: """
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example.
+"""
+url {
+  src: "https://github.com/ocaml-sf/learn-ocaml/archive/0.10.tar.gz"
+  checksum: [
+    "md5=a3893e313a385169d0f26ae46901f6f4"
+    "sha512=730d563c9c82a031baa3ddc79b174168e5b1e4cf8d9bb8b56d54708985085a1ebbe9e4fd2e163639a2580b89217fc536e6fdc95546dd5b06b6fba7e93cc5866a"
+  ]
+}


### PR DESCRIPTION
### `learn-ocaml.0.10`
The learn-ocaml online platform (engine)
This contains the binaries forming the engine for the learn-ocaml platform, and
the common files. A demo exercise repository is also provided as example.



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0