### PR TITLE
Package learn-ocaml.0.10

### DIFF
--- a/packages/learn-ocaml/learn-ocaml.0.10/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.10/opam
@@ -10,6 +10,7 @@ maintainer: "Louis Gesbert"
 license: "MIT"
 homepage: "https://github.com/ocaml-sf/learn-ocaml"
 bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
 depends: [
   "base" {= "v0.9.4"}
   "base64"


### PR DESCRIPTION
### `learn-ocaml.0.10`
The learn-ocaml online platform (engine)
This contains the binaries forming the engine for the learn-ocaml platform, and
the common files. A demo exercise repository is also provided as example.



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0