### PR TITLE
Restrict ppx_deriving_yojson dependency to yojson < 1.6

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.0/opam
@@ -4,8 +4,8 @@ authors: [ "Peter Zotov <whitequark@whitequark.org>" ]
 license: "MIT"
 homepage: "https://github.com/whitequark/ppx_deriving_yojson"
 doc: "http://whitequark.github.io/ppx_deriving_yojson"
-#bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
-#dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
 tags: [ "syntax" "json" ]
 build: [
   ["ocaml" "pkg/build.ml" "native=true" "native-dynlink=true"]
@@ -23,8 +23,8 @@ depends: [
   "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "0.2" & < "1.0"}
   "ocamlbuild" {build}
+  "ounit" {with-test & >= "2.0.0"}
 ]
-dev-repo: "git://github.com/whitequark/ppx_deriving_yojson"
 synopsis: "JSON codec generator for OCaml >=4.02"
 url {
   src:

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.0/opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "yojson"
+  "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "0.2" & < "1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ppx_deriving" {>= "0.2" & < "1.0"}
   "ocamlbuild" {build}
   "ounit" {with-test & >= "2.0.0"}
+  "ppx_import" {with-test & <= "1.5"}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"
 url {

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
@@ -4,8 +4,8 @@ authors: [ "Peter Zotov <whitequark@whitequark.org>" ]
 license: "MIT"
 homepage: "https://github.com/whitequark/ppx_deriving_yojson"
 doc: "http://whitequark.github.io/ppx_deriving_yojson"
-#bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
-#dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
 tags: [ "syntax" "json" ]
 build: [
   ["ocaml" "pkg/build.ml" "native=true" "native-dynlink=true"]
@@ -23,8 +23,8 @@ depends: [
   "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "0.2" & < "1.0"}
   "ocamlbuild" {build}
+  "ounit" {with-test & >= "2.0.0"}
 ]
-dev-repo: "git://github.com/whitequark/ppx_deriving_yojson"
 synopsis: "JSON codec generator for OCaml >=4.02"
 url {
   src:

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "yojson"
+  "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "0.2" & < "1.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
@@ -24,6 +24,7 @@ depends: [
   "ppx_deriving" {>= "0.2" & < "1.0"}
   "ocamlbuild" {build}
   "ounit" {with-test & >= "2.0.0"}
+  "ppx_import" {with-test & <= "1.5"}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"
 url {

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.1.1/opam
@@ -9,13 +9,6 @@ dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
 tags: [ "syntax" "json" ]
 build: [
   ["ocaml" "pkg/build.ml" "native=true" "native-dynlink=true"]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_ppx_yojson.byte"
-    "--"
-  ] {with-test}
   [make "doc"] {with-doc}
 ]
 depends: [

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.0/opam
@@ -25,7 +25,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "yojson"
+  "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "1.0" & < "2.0"}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_deriving" {>= "1.0" & < "2.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "1.0" & < "2.0"}
   "ocamlfind" {build}
-  "ounit" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
   "ppx_import" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.1/opam
@@ -31,7 +31,7 @@ depends: [
   "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "1.0" & < "2.0"}
   "ocamlfind" {build}
-  "ounit" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
   "ppx_import" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.1/opam
@@ -28,7 +28,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "yojson"
+  "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "1.0" & < "2.0"}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.1/opam
@@ -32,7 +32,7 @@ depends: [
   "ppx_deriving" {>= "1.0" & < "2.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
@@ -31,7 +31,7 @@ depends: [
   "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "2.0" & < "3.0"}
   "ocamlfind" {build}
-  "ounit" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
   "ppx_import" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
@@ -32,7 +32,7 @@ depends: [
   "ppx_deriving" {>= "2.0" & < "3.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
@@ -28,7 +28,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "yojson"
+  "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "2.0" & < "3.0"}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
@@ -32,7 +32,7 @@ depends: [
   "ppx_deriving" {>= "2.0" & < "3.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test <= "1.5"}
+  "ppx_import" {with-test & <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.2/opam
@@ -18,13 +18,6 @@ build: [
     "native=%{ocaml:native}%"
     "native-dynlink=%{ocaml:native-dynlink}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_ppx_yojson.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
@@ -28,7 +28,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.03.0"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "1.0"}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
@@ -32,7 +32,7 @@ depends: [
   "ppx_deriving" {>= "1.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test <= "1.5"}
+  "ppx_import" {with-test & <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
@@ -31,7 +31,7 @@ depends: [
   "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "1.0"}
   "ocamlfind" {build}
-  "ounit" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
   "ppx_import" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
@@ -18,13 +18,6 @@ build: [
     "native=%{ocaml:native}%"
     "native-dynlink=%{ocaml:native-dynlink}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_ppx_yojson.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {< "4.03.0"}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.3/opam
@@ -32,7 +32,7 @@ depends: [
   "ppx_deriving" {>= "1.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_deriving" {>= "2.0" & < "4.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
@@ -25,7 +25,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.03.0"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "2.0" & < "4.0"}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
@@ -28,7 +28,7 @@ depends: [
   "yojson" {< "1.6.0"}
   "ppx_deriving" {>= "2.0" & < "4.0"}
   "ocamlfind" {build}
-  "ounit" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
   "ppx_import" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
@@ -15,13 +15,6 @@ build: [
     "native=%{ocaml:native}%"
     "native-dynlink=%{ocaml:native-dynlink}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_ppx_yojson.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {< "4.03.0"}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.2.4/opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_deriving" {>= "2.0" & < "4.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test <= "1.5"}
+  "ppx_import" {with-test & <= "1.5"}
   "ocamlbuild" {build}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
@@ -32,7 +32,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & <= "1.5"}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
@@ -25,7 +25,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.05.0"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ocamlfind" {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
-  "ounit" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
   "ppx_import" {with-test & >= "1.1"}
 ]
 synopsis: "JSON codec generator for OCaml >=4.02"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
@@ -32,7 +32,7 @@ depends: [
   "ocamlbuild" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
-  "ounit" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
   "ppx_import" {with-test & >= "1.1"}
 ]
 conflicts: [

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
@@ -25,7 +25,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "yojson"
+  "yojson" {< "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ocamlfind" {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
@@ -33,7 +33,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ppx_import" {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & <= "1.5"}
 ]
 conflicts: [
   "ppx_deriving" {= "4.2"}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
@@ -21,7 +21,7 @@ depends: [
   "ppxfind"      {build}
   "dune"         {build & >= "1.2"}
   "cppo"         {build}
-  "ounit"        {with-test}
+  "ounit"        {with-test & >= "2.0.0"}
 ]
 conflicts: [
   "ppx_deriving" {= "4.2"}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ppx_tools"    {build}


### PR DESCRIPTION
Yojson 1.6 deprecates the type `json` in favor of the new type `t`.
This shouldn't be an issue but users of ppx_deriving_yojson and
dune are gonna have a hard time working with yojson 1.6 since warning 3
is fatal in the default dune profile and they can't change
ppx_deriving_yojson output.