### PR TITLE
[new release] hex (1.3.0)

### DIFF
--- a/packages/hex/hex.1.3.0/opam
+++ b/packages/hex/hex.1.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Trevor Summers Smith"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hex"
+doc: "https://mirage.github.io/ocaml-hex/"
+bug-reports: "https://github.com/mirage/ocaml-hex/issues"
+depends: [
+  "ocaml"
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "1.7.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-hex.git"
+synopsis: "Library providing hexadecimal converters"
+description: """
+```ocaml
+#require "hex";;
+# Hex.of_string "Hello world!";;
+- : Hex.t = "48656c6c6f20776f726c6421"
+# Hex.to_string "dead-beef";;
+- : string = "ޭ��"
+# Hex.hexdump (Hex.of_string "Hello world!\n")
+00000000: 4865 6c6c 6f20 776f 726c 6421 0a        Hello world!.
+- : unit = ()
+```
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-hex/releases/download/v1.3.0/hex-v1.3.0.tbz"
+  checksum: "md5=c0baa72c9d7495cd3c6646f9a50b03c7"
+}


### PR DESCRIPTION
Library providing hexadecimal converters

- Project page: <a href="https://github.com/mirage/ocaml-hex">https://github.com/mirage/ocaml-hex</a>
- Documentation: <a href="https://mirage.github.io/ocaml-hex/">https://mirage.github.io/ocaml-hex/</a>

##### CHANGES:

* Add `to/of_bytes/bigstring` functions. (mirage/ocaml-hex#27 @vbmithr)
* Install toplevel printers automatically in modern utop (@avsm)
* Port from jbuilder to dune (@avsm)
* Use `dune-release` instead of topkg (@avsm)
* Update opam metadata to 2.0 format (@avsm)
* Improve ocamldoc (@avsm)
