### PR TITLE
[new release] uri (2.1.0)

### DIFF
--- a/packages/uri/uri.2.1.0/opam
+++ b/packages/uri/uri.2.1.0/opam
@@ -29,5 +29,5 @@ build: [
 url {
   src:
     "https://github.com/mirage/ocaml-uri/releases/download/v2.1.0/uri-v2.1.0.tbz"
-  checksum: "md5=36b973b283cce2f3b31b121eccc5c2d1"
+  checksum: "md5=3e8fa185dcdae13caad3f64a3eff419b"
 }


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* Add `Uri.pp` as an alias to `Uri.pp_hum`, as the `pp` form
  is more commonly used. (mirage/ocaml-uri#133 @avsm)
* Add an `[@@ocaml.toplevel_printer]` attribute to Uri.pp
  so that it will be automatically loaded on modern Utop versions. (mirage/ocaml-uri#133 @avsm)
* Upgrade last remaining `jbuild` file to `dune` (mirage/ocaml-uri#133 @avsm)
* OCamldoc improvements in section headers (@avsm)
