### PR TITLE
[new release] uri (2.1.0)

### DIFF
--- a/packages/uri/uri.2.1.0/opam
+++ b/packages/uri/uri.2.1.0/opam
@@ -29,5 +29,5 @@ build: [
 url {
   src:
     "https://github.com/mirage/ocaml-uri/releases/download/v2.1.0/uri-v2.1.0.tbz"
-  checksum: "md5=36b973b283cce2f3b31b121eccc5c2d1"
+  checksum: "md5=a5d9ed86f9f26d7936523afecd623d61"
 }


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* Expose a `compare` function in `Uri_sexp` so that it will work
  with `deriving compare,sexp`.
* Upgrade the opam metadata to the 2.0 format.
* Update Travis to test OCaml 4.03->4.07.
* Minimum OCaml version is now 4.04.0+ due to sexplib0 dependency.
