### PR TITLE
[new release] mirage-net-macosx (1.5.0)

### DIFF
--- a/packages/mirage-net-macosx/mirage-net-macosx.1.5.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
+authors:     "Anil Madhavapeddy <anil@recoil.org>"
+homepage:    "https://github.com/mirage/mirage-net-macosx"
+bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
+dev-repo:    "git+https://github.com/mirage/mirage-net-macosx.git"
+doc:         "https://mirage.github.io/mirage-net-macosx/"
+
+license: "ISC"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "1.4.0"}
+  "macaddr"
+  "sexplib"
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "io-page" {>= "2.0.0"}
+  "io-page-unix" {>= "2.0.0"}
+  "vmnet"
+]
+tags: "org:mirage"
+
+synopsis: "MacOS implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-macosx/releases/download/v1.5.0/mirage-net-macosx-v1.5.0.tbz"
+  checksum: "md5=8e75987dfc35f8b149b7339f2e2aea26"
+}


### PR DESCRIPTION
MacOS implementation of the Mirage_net_lwt interface

- Project page: <a href="https://github.com/mirage/mirage-net-macosx">https://github.com/mirage/mirage-net-macosx</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-macosx/">https://mirage.github.io/mirage-net-macosx/</a>

##### CHANGES:

- Switch to Dune from jbuilder (@avsm)
- Remove topkg in favour of dune-release (@avsm)
- Upgrade opam metadata to 2.0 (@hannesm @avsm)
