### PR TITLE
[new release] ethernet (1.0.0)

### DIFF
--- a/packages/ethernet/ethernet.1.0.0/opam
+++ b/packages/ethernet/ethernet.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "mirageos-devel@lists.xenproject.org"
+homepage:     "https://github.com/mirage/ethernet"
+dev-repo:     "git+https://github.com/mirage/ethernet.git"
+bug-reports:  "https://github.com/mirage/ethernet/issues"
+doc:          "https://mirage.github.io/ethernet/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.04.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.0.2"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-protocols-lwt" {>= "1.4.0"}
+  "macaddr"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+]
+conflicts: [
+  "tcpip" {< "3.7.0"}
+]
+synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
+description: """
+`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
+(specified by IEEE 802.3) layer implementation for the
+[Mirage operating system](https://mirage.io).
+"""
+url {
+  src:
+    "https://github.com/mirage/ethernet/releases/download/v1.0.0/ethernet-v1.0.0.tbz"
+  checksum: "md5=60f90d97846928155713b0b5fdb0d4f7"
+}


### PR DESCRIPTION
OCaml Ethernet (IEEE 802.3) layer, used in MirageOS

- Project page: <a href="https://github.com/mirage/ethernet">https://github.com/mirage/ethernet</a>
- Documentation: <a href="https://mirage.github.io/ethernet/">https://mirage.github.io/ethernet/</a>

##### CHANGES:

* Minor ocamldoc improvements (@avsm).
* Initial import from mirage-tcpip (@hannesm).
  Based on source code from mirage-tcpip.3.6.0.
