### PR TITLE
[new release] ezxmlm (1.1.0)

### DIFF
--- a/packages/ezxmlm/ezxmlm.1.1.0/opam
+++ b/packages/ezxmlm/ezxmlm.1.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: "Anil Madhavapeddy"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezxmlm"
+bug-reports: "https://github.com/mirage/ezxmlm/issues"
+doc: "https://mirage.github.io/ezxmlm/"
+dev-repo: "git+https://github.com/mirage/ezxmlm.git"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.0"}
+  "xmlm" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Combinators for parsing and selection of XML structures"
+description: """
+An XML parser and serialisartion library written in pure OCaml.  Values can
+be converted to and from channels or strings, and combinators exist to
+query the XML values.
+"""
+url {
+  src:
+    "https://github.com/mirage/ezxmlm/releases/download/v1.1.0/ezxmlm-v1.1.0.tbz"
+  checksum: "md5=5d13d6c55cc1329b930b35eee2395731"
+}


### PR DESCRIPTION
Combinators for parsing and selection of XML structures

- Project page: <a href="https://github.com/mirage/ezxmlm">https://github.com/mirage/ezxmlm</a>
- Documentation: <a href="https://mirage.github.io/ezxmlm/">https://mirage.github.io/ezxmlm/</a>

##### CHANGES:

* Add optional XML declaration for `to_string` and `to_channel`
  (mirage/ezxmlm#8 by @gaborigloi and review by @mseri)
* Automatically install toplevel printer on modern utop (@avsm)
* Port to dune from jbuilder (@avsm and @Leonidas-from-XIV in mirage/ezxmlm#9)
* Port opam metadata to 2.0 format (@avsm)
* Move to the `mirage/` GitHub organisation (@avsm)
