### PR TITLE
[new release] ezjsonm-lwt and ezjsonm (1.0.0)

### DIFF
--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml"
+  "ezjsonm"
+  "dune" {build & >= "1.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "jsonm" {>= "0.9.1"}
+  "sexplib"
+  "hex"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple Lwt-based interface to the Jsonm JSON library"
+description: """
+This simple interface over the Jsonm library provides an
+Lwt variant of the serialisation functions.
+"""
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.0.0/ezjsonm-v1.0.0.tbz"
+  checksum: "md5=bb8655912d114e093d7b5382df7f843a"
+}

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
@@ -15,6 +15,7 @@ depends: [
   "sexplib"
   "hex"
   "lwt" {>= "2.5.0"}
+  "ppx_sexp_conv" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ezjsonm"
 doc: "https://mirage.github.io/ezjsonm"
 bug-reports: "https://github.com/mirage/ezjsonm/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>="4.03.0"}
   "ezjsonm"
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}

--- a/packages/ezjsonm/ezjsonm.1.0.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.0.0/opam
@@ -13,7 +13,6 @@ depends: [
   "jsonm" {>= "0.9.1"}
   "sexplib"
   "hex"
-  "ppx_sexp_conv" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ezjsonm/ezjsonm.1.0.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.0.0/opam
@@ -13,6 +13,7 @@ depends: [
   "jsonm" {>= "0.9.1"}
   "sexplib"
   "hex"
+  "ppx_sexp_conv" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ezjsonm/ezjsonm.1.0.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm/"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml"
+  "dune" {build & >= "1.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "jsonm" {>= "0.9.1"}
+  "sexplib"
+  "hex"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple interface on top of the Jsonm JSON library"
+description: """
+Ezjsonm provides more convenient (but far less flexible)
+input and output functions that go to and from `string` values.
+This avoids the need to write signal code, which is useful for
+quick scripts that manipulate JSON.
+
+More advanced users should go straight to the Jsonm library and
+use it directly, rather than be saddled with the Ezjsonm interface.
+"""
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.0.0/ezjsonm-v1.0.0.tbz"
+  checksum: "md5=bb8655912d114e093d7b5382df7f843a"
+}


### PR DESCRIPTION
Simple Lwt-based interface to the Jsonm JSON library

- Project page: <a href="https://github.com/mirage/ezjsonm">https://github.com/mirage/ezjsonm</a>
- Documentation: <a href="https://mirage.github.io/ezjsonm">https://mirage.github.io/ezjsonm</a>

##### CHANGES:

* Upgrade opam metadata to 2.0 format (@avsm)
* Update build from jbuilder to dune (@avsm)
* Support dune-release (@avsm)
