### PR TITLE
[new release] arp and arp-mirage (1.0.0)

### DIFF
--- a/packages/arp-mirage/arp-mirage.1.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+synopsis: "Address Resolution Protocol for MirageOS"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "mirage-protocols-lwt"
+  "mirage-time-lwt"
+  "mirage-protocols-lwt"
+  "ethernet"
+  "lwt"
+  "duration"
+  "arp" {>= "1.0.0"}
+  "logs"
+  "cstruct" {>= "2.2.0"}
+  "fmt" {with-test}
+  "mirage-vnetif" {with-test}
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "mirage-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v1.0.0/arp-v1.0.0.tbz"
+  checksum: "md5=40768ca09b10c6b91e8b3a420b075a0e"
+}

--- a/packages/arp/arp.1.0.0/opam
+++ b/packages/arp/arp.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "cstruct" {>= "2.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "ethernet"
+  "logs"
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+]
+conflicts: [
+  "arp-mirage" {< "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Address Resolution Protocol purely in OCaml"
+description: """
+ARP is an implementation of the address resolution protocol (RFC826) purely in
+OCaml.  It handles IPv4 protocol addresses and Ethernet hardware addresses only.
+"""
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v1.0.0/arp-v1.0.0.tbz"
+  checksum: "md5=40768ca09b10c6b91e8b3a420b075a0e"
+}

--- a/packages/arp/arp.1.0.0/opam
+++ b/packages/arp/arp.1.0.0/opam
@@ -12,7 +12,6 @@ depends: [
   "cstruct" {>= "2.2.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
-  "ethernet"
   "logs"
   "mirage-random" {with-test}
   "mirage-random-test" {with-test}


### PR DESCRIPTION
Address Resolution Protocol purely in OCaml

- Project page: <a href="https://github.com/mirage/arp">https://github.com/mirage/arp</a>
- Documentation: <a href="https://mirage.github.io/arp/">https://mirage.github.io/arp/</a>

##### CHANGES:

* split opam package into two separate ones: a core
  `arp` package and the `arp-mirage` implementation
  for MirageOS that has more dependencies.  This
  eliminates the use of depopts that was done previously
  to build the Mirage layer. (mirage/arp#7 @avsm)

* port build system to Dune (mirage/arp#7 @avsm). The `make coverage`
  and `make bench` targets will do the job of the previous
  topkg targets for those.

* minor fixes to ocamldoc comments to be compatible with
  odoc.

* use mirage-random and mirage-random-test instead of a
  nocrypto dependency in tests and bench (mirage/arp#7 @hannesm)

* import tests from mirage-tcpip (mirage/arp#8 @hannesm)

* depend on the ethernet opam package, no longer provided
  by tcpip >3.7.0 (mirage/arp#9 @hannesm)
