### PR TITLE
Package containers.2.5

### DIFF
--- a/packages/containers/containers.2.5/opam
+++ b/packages/containers/containers.2.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "A modular, clean and powerful extension of the OCaml standard library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+depends: [
+  "dune" {build}
+  "result"
+  "uchar"
+  "qtest" {with-test}
+  "qcheck" {with-test}
+  "ounit" {with-test}
+  "sequence" {with-test}
+  "gen" {with-test}
+  "uutf" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.02.0"}
+]
+depopts: ["base-unix" "base-threads"]
+conflicts: [
+  "sequence" {< "0.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/2.5.tar.gz"
+  checksum: [
+    "md5=e769d484d7b8bfe499496533de21038c"
+    "sha512=441e86837efaea9a130db97abd136b6e1b155a8965116bcebbda30508cabe3dbae2656422247af6630c960a1576004253caf515858a5805828ee60f468746a07"
+  ]
+}


### PR DESCRIPTION
### `containers.2.5`
A modular, clean and powerful extension of the OCaml standard library



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0