### PR TITLE
[new release] xenstore (2.1.0)

### DIFF
--- a/packages/xenstore/xenstore.2.1.0/opam
+++ b/packages/xenstore/xenstore.2.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage: "https://github.com/mirage/ocaml-xenstore"
+doc: "https://mirage.github.io/ocaml-xenstore/"
+bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "3.2.0"}
+  "ppx_cstruct" {>= "3.2.0"}
+  "lwt"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-xenstore.git"
+synopsis: "Xenstore protocol in pure OCaml"
+description: """
+This repo contains:
+1. a xenstore client library, a merge of the Mirage and XCP ones
+2. a xenstore server library
+3. a xenstore server instance which runs under Unix with libxc
+4. a xenstore server instance which runs on mirage.
+
+The client and the server libraries have sets of unit-tests.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-xenstore/releases/download/2.1.0/xenstore-2.1.0.tbz"
+  checksum: "md5=c3d52b5956e764434f19afb7f6f27f98"
+}


### PR DESCRIPTION
Xenstore protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-xenstore">https://github.com/mirage/ocaml-xenstore</a>
- Documentation: <a href="https://mirage.github.io/ocaml-xenstore/">https://mirage.github.io/ocaml-xenstore/</a>

##### CHANGES:

* Upgrade opam metadata to 2.0 format (@avsm)
* Port build from jbuilder to Dune (@avsm)
* Test on OCaml 4.07 (@avsm)
* Remove topkg metadata in favour of dune-release (@avsm)
