### PR TITLE
[new release] cstruct-async, ppx_cstruct, cstruct, cstruct-unix and cstruct-lwt (3.4.0)

### DIFF
--- a/packages/cstruct-async/cstruct-async.3.4.0/opam
+++ b/packages/cstruct-async/cstruct-async.3.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+doc: "https://mirage.github.io/ocaml-cstruct/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "async_kernel" {>= "v0.9.0" & < "v0.12"}
+  "async_unix" {>= "v0.9.0" & < "v0.12"}
+  "core_kernel" {>= "v0.9.0" & < "v0.12"}
+  "cstruct" {>= "3.2.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.4.0/cstruct-v3.4.0.tbz"
+  checksum: "md5=f32544c90e5f6212977473895166d55b"
+}

--- a/packages/cstruct-lwt/cstruct-lwt.3.4.0/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.3.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "lwt"
+  "cstruct" {>="3.2.0"}
+  "dune" {build & >= "1.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.4.0/cstruct-v3.4.0.tbz"
+  checksum: "md5=f32544c90e5f6212977473895166d55b"
+}

--- a/packages/cstruct-unix/cstruct-unix.3.4.0/opam
+++ b/packages/cstruct-unix/cstruct-unix.3.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "base-unix"
+  "cstruct" {>="3.2.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.4.0/cstruct-v3.4.0.tbz"
+  checksum: "md5=f32544c90e5f6212977473895166d55b"
+}

--- a/packages/cstruct/cstruct.3.4.0/opam
+++ b/packages/cstruct/cstruct.3.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "sexplib" {< "v0.12"}
+  "alcotest" {with-test}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.4.0/cstruct-v3.4.0.tbz"
+  checksum: "md5=f32544c90e5f6212977473895166d55b"
+}

--- a/packages/ppx_cstruct/ppx_cstruct.3.4.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "3.1.1"}
+  "ounit" {with-test}
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_driver" {with-test & >= "v0.9.0"}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "cstruct-unix" {with-test}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.4.0/cstruct-v3.4.0.tbz"
+  checksum: "md5=f32544c90e5f6212977473895166d55b"
+}


### PR DESCRIPTION
Access C-like structures directly from OCaml

- Project page: <a href="https://github.com/mirage/ocaml-cstruct">https://github.com/mirage/ocaml-cstruct</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cstruct/">https://mirage.github.io/ocaml-cstruct/</a>

##### CHANGES:

- Remove old compatibility packages for `cstruct.lwt`, `cstruct.async`,
  `cstruct.ppx` and `cstruct.unix`.  These were deprecated in
  cstruct.3.0.0 in favour of counter part libraries with a dash
  in the name (`cstruct-lwt`, `cstruct-async`, `cstruct.unix`)
  or `ppx_cstruct` for the PPX extension. (@avsm)
