### PR TITLE
[new release] mirage-fs and mirage-fs-lwt (1.2.0)

### DIFF
--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/mirage/mirage-fs"
+doc:          "https://mirage.github.io/mirage-fs/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-fs.git"
+bug-reports:  "https://github.com/mirage/mirage-fs/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "mirage-fs" {>= "1.0.0"}
+  "mirage-kv-lwt"
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
+]
+
+synopsis: "MirageOS signatures for filesystem devices using Lwt"
+description: """
+mirage-fs-lwt provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures
+the MirageOS filesystem devices should implement.  These are specialised to
+the Lwt concurrency library in this package.
+
+[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
+[fslwt]: http://mirage.github.io/mirage-fs/Mirage_fs_lwt.html
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-fs/releases/download/v1.2.0/mirage-fs-v1.2.0.tbz"
+  checksum: "md5=eb6f213e61d3d7f7552b269b457d8f2b"
+}

--- a/packages/mirage-fs/mirage-fs.1.2.0/opam
+++ b/packages/mirage-fs/mirage-fs.1.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/mirage/mirage-fs"
+doc:          "https://mirage.github.io/mirage-fs/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-fs.git"
+bug-reports:  "https://github.com/mirage/mirage-fs/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "fmt"
+  "mirage-device" {>= "1.0.0"}
+]
+
+synopsis: "MirageOS signatures for filesystem devices"
+description: """
+mirage-fs provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures
+the MirageOS filesystem devices should implement.
+
+[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
+[fslwt]: http://mirage.github.io/mirage-fs/Mirage_fs_lwt.html
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-fs/releases/download/v1.2.0/mirage-fs-v1.2.0.tbz"
+  checksum: "md5=eb6f213e61d3d7f7552b269b457d8f2b"
+}


### PR DESCRIPTION
MirageOS signatures for filesystem devices

- Project page: <a href="https://github.com/mirage/mirage-fs">https://github.com/mirage/mirage-fs</a>
- Documentation: <a href="https://mirage.github.io/mirage-fs/">https://mirage.github.io/mirage-fs/</a>

##### CHANGES:

* Port to dune (@dinosaure)
* Test more OCaml versions (@hannesm)
* Fix doc urls (@dinosaure)
* Upgrade opam metadata to 2.0 (@hannesm)
