### PR TITLE
[new release] mirage-fs-unix (1.6.0)

### DIFF
--- a/packages/mirage-fs-unix/mirage-fs-unix.1.6.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
+                "Thomas Gazagnaire" ]
+maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org"]
+homepage:     "https://github.com/mirage/mirage-fs-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-fs-unix.git"
+bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
+doc:          "https://mirage.github.io/mirage-fs-unix/"
+tags:         [ "org:mirage" ]
+build: [
+  ["dune" "subst" ] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-fs-lwt" {>= "1.0.0"}
+  "lwt"
+  "rresult" {with-test}
+  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "alcotest" {with-test & >= "0.7.1"}
+  "ptime" {with-test}
+]
+synopsis: "Passthrough filesystem for MirageOS on Unix"
+description: """
+This is a pass-through Mirage filesystem to an underlying Unix directory.  The
+interface is intended to support eventual privilege separation (e.g. via the
+Casper daemon in FreeBSD 11).
+
+The current version supports the `Mirage_fs.S` and `Mirage_fs_lwt.S` signatures
+defined in the `mirage-fs` package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-fs-unix/releases/download/v1.6.0/mirage-fs-unix-v1.6.0.tbz"
+  checksum: "md5=7111e1367e6a94663a8ddb3861d948a5"
+}


### PR DESCRIPTION
Passthrough filesystem for MirageOS on Unix

- Project page: <a href="https://github.com/mirage/mirage-fs-unix">https://github.com/mirage/mirage-fs-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-fs-unix/">https://mirage.github.io/mirage-fs-unix/</a>

##### CHANGES:

* upgrade to dune from jbuilder (@avsm)
* test OCaml 4.07 as well (@avsm)
* use latest cstruct-lwt package name (@avsm)
