### PR TITLE
[new release] tar-mirage, tar and tar-unix (1.0.0)

### DIFF
--- a/packages/tar-mirage/tar-mirage.1.0.0/opam
+++ b/packages/tar-mirage/tar-mirage.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "tar"
+  "cstruct" {>= "1.9.0"}
+  "re" {>="1.7.2"}
+  "result"
+  "mirage-block-unix" {with-test & >= "2.5.0"}
+  "mirage-types-lwt" {>= "3.0.0"}
+  "lwt"
+  "io-page"
+  "mirage-block-unix" {with-test}
+  "io-page-unix" {with-test}
+  "ounit" {with-test}
+  "tar-unix" {with-test}
+]
+conflicts: [
+  "mirage-types-lwt" {< "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v1.0.0/tar-v1.0.0.tbz"
+  checksum: "md5=160d445644541224aa6b8ee0da7df939"
+}

--- a/packages/tar-unix/tar-unix.1.0.0/opam
+++ b/packages/tar-unix/tar-unix.1.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "tar"
+  "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
+  "re"
+  "result"
+  "lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v1.0.0/tar-v1.0.0.tbz"
+  checksum: "md5=160d445644541224aa6b8ee0da7df939"
+}

--- a/packages/tar/tar.1.0.0/opam
+++ b/packages/tar/tar.1.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "ppx_tools" {build}
+  "ppx_cstruct" {>= "3.1.0"}
+  "cstruct" {>= "1.9.0"}
+  "re"
+  "result"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v1.0.0/tar-v1.0.0.tbz"
+  checksum: "md5=160d445644541224aa6b8ee0da7df939"
+}


### PR DESCRIPTION
Read and write tar format files via MirageOS interfaces

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- port build to dune from builder (@avsm)
- upgrade opam metadata to 2.0 (@avsm)
- remove topkg in favour of dune-release (@avsm)
- use modern `ppx_cstruct` instead of `cstruct.ppx` (mirage/ocaml-tar#65 @avsm @djs55)
- test with OCaml 4.07 as well (@avsm)
