### PR TITLE
[new release] protocol-9p, protocol-9p-unix and protocol-9p-tool (1.0.0)

### DIFF
--- a/packages/protocol-9p-tool/protocol-9p-tool.1.0.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.1.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard" "Anil Madhavapeddy"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-9p"
+doc: "https://mirage.github.io/ocaml-9p/"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "protocol-9p"
+  "protocol-9p-unix"
+  "base-bytes"
+  "rresult"
+  "logs" {>= "0.5.0"}
+  "fmt"
+  "lambda-term"
+  "win-error"
+  "cmdliner"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-9p.git"
+synopsis: "An implementation of the 9p protocol in pure OCaml"
+description: """
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style. This opam package contains the Unix
+client.
+
+Example of the CLI program is:
+```
+o9p ls --username vagrant   /var
+drwxr-xr-x ? root root 4096 Feb 2  2015 lib
+drwxr-xr-x ? root root 4096 Mar 15 2015 cache
+-rwxrwxrwx ? root root 9    May 10 2014 lock
+drwxrwxrwx ? root root 4096 Jul 6  2015 tmp
+drwxr-xr-x ? root root 4096 May 11 2014 spool
+drwxrwxr-x ? root sshd 4096 Sep 28 2015 log
+drwxr-xr-x ? root root 4096 Sep 21 2015 backups
+drwxrwxr-x ? root mail 4096 Apr 16 2014 mail
+drwxr-xr-x ? root root 4096 Apr 16 2014 opt
+drwxrwxr-x ? root 50   4096 Apr 10 2014 local
+-rwxrwxrwx ? root root 4    May 10 2014 run
+```
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-9p/releases/download/v1.0.0/protocol-9p-v1.0.0.tbz"
+  checksum: "md5=61542ca258532b913b6b40e12160cee2"
+}

--- a/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard" "Anil Madhavapeddy"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-9p"
+doc: "https://mirage.github.io/ocaml-9p/"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "protocol-9p"
+  "base-bytes"
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt" {>= "3.0.0"}
+  "sexplib" {> "113.00.00"}
+  "prometheus"
+  "rresult"
+  "mirage-flow-lwt"
+  "mirage-kv-lwt"
+  "mirage-channel-lwt"
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "astring"
+  "fmt"
+  "logs" {>= "0.5.0"}
+  "win-error"
+  "io-page-unix" {>= "2.0.0"}
+  "ppx_sexp_conv"
+  "alcotest" {with-test & >= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-9p.git"
+synopsis: "A Unix implementation of the 9p protocol in pure OCaml"
+description: """
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style.  This package supports the Unix socket
+library.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-9p/releases/download/v1.0.0/protocol-9p-v1.0.0.tbz"
+  checksum: "md5=61542ca258532b913b6b40e12160cee2"
+}

--- a/packages/protocol-9p/protocol-9p.1.0.0/opam
+++ b/packages/protocol-9p/protocol-9p.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard" "Anil Madhavapeddy"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-9p"
+doc: "https://mirage.github.io/ocaml-9p/"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "base-bytes"
+  "cstruct" {>= "3.0.0"}
+  "sexplib" {> "113.00.00"}
+  "rresult"
+  "mirage-flow-lwt"
+  "mirage-kv-lwt"
+  "mirage-channel-lwt"
+  "lwt" {>= "3.0.0"}
+  "astring"
+  "fmt"
+  "logs" {>= "0.5.0"}
+  "win-error"
+  "ppx_sexp_conv"
+  "alcotest" {with-test & >= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-9p.git"
+synopsis: "An implementation of the 9p protocol in pure OCaml"
+description: """
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style.  This library supports the
+[9P2000.u extension](http://ericvh.github.io/9p-rfc/rfc9p2000.u.html).
+Please also refer to the `protocol-9p-unix` package for a
+Unix/Windows implementation, and to `protocol-9p-tool` for a
+CLI interface.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-9p/releases/download/v1.0.0/protocol-9p-v1.0.0.tbz"
+  checksum: "md5=61542ca258532b913b6b40e12160cee2"
+}


### PR DESCRIPTION
An implementation of the 9p protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-9p">https://github.com/mirage/ocaml-9p</a>
- Documentation: <a href="https://mirage.github.io/ocaml-9p/">https://mirage.github.io/ocaml-9p/</a>

##### CHANGES:

* Upgrade metadata to opam 2.0 format (@avsm)
* Port to dune (@avsm)
* Fix warnings for unused variables and opens and record binds (@avsm)
