### PR TITLE
[new release] tcpip (3.7.0)

### DIFF
--- a/packages/arp/arp.0.2.3/opam
+++ b/packages/arp/arp.0.2.3/opam
@@ -31,6 +31,7 @@ depopts: [
 ]
 conflicts: [
   "tcpip" {<"2.8.0"}
+  "tcpip" {>="3.7.0"}
   "mirage-types-lwt" {<"3.0.0"}
 ]
 build: [

--- a/packages/charrua-core/charrua-core.0.11.1/opam
+++ b/packages/charrua-core/charrua-core.0.11.1/opam
@@ -23,7 +23,7 @@ depends: [
   "sexplib"       {< "v0.12"}
   "ipaddr"        {>= "3.0.0"}
   "macaddr"
-  "tcpip"         {>= "3.6.0"}
+  "tcpip"         {>= "3.6.0" & <"3.7.0"}
   "rresult"
   "io-page-unix"  {with-test}
   "cstruct-unix"  {with-test}

--- a/packages/mirage-nat/mirage-nat.1.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lru"
   "ppx_deriving" {>= "4.2"}
   "jbuilder" {build}
-  "tcpip" {>= "3.0.0"}
+  "tcpip" {>= "3.0.0" & <"3.7.0"}
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}
 ]

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"     {build & >= "1.0"}
+  "configurator" {build}
+  "ocaml" {>= "4.03.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.0.2"}
+  "cstruct-lwt"
+  "mirage-net" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-protocols" {>= "1.4.0"}
+  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "io-page-unix"
+  "randomconv"
+  "ethernet"
+  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-vnetif" {with-test & >= "0.4.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-random-test" {with-test}
+  "arp-mirage" {with-test}
+  "lru"
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v3.7.0/tcpip-v3.7.0.tbz"
+  checksum: "md5=21ec267e2d1f4a30c45c4f052159b03d"
+}


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* Use `Lwt_dllist` instead of `Lwt_sequence`, due to the latter being deprecated
  upstream in Lwt (ocsigen/lwt#361) (mirage/mirage-tcpip#388 by @avsm).
* Remove arpv4 and ethif sublibraries, now provided by ethernet and arp-mirage
  opam packages (mirage/mirage-tcpip#380 by @hannesm).
* Upgrade from jbuilder to dune (mirage/mirage-tcpip#391 @avsm)
* Switch from topkg to dune-release (mirage/mirage-tcpip#391 @avsm)

