### PR TITLE
travis: update osx version to xcode 10.1 and macOS 10.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: required
 matrix:
   include:
   - os: osx
-    osx_image: xcode7.3
+    osx_image: xcode10.1
     env: OCAML_VERSION=4.07 OPAM_VERSION=2.0.0
   - os: linux
     env: OCAML_VERSION=4.07 OPAM_VERSION=2.0.0


### PR DESCRIPTION
The previous version is macOS 10.11 which is ancient and let to
breakage in e.g. #13375