### PR TITLE
[new release] mirage-console-lwt, mirage-console-unix, mirage-console-xen-proto, mirage-console-xen, mirage-console-xen-backend and mirage-console (2.4.0)

### DIFF
--- a/packages/mirage-console-lwt/mirage-console-lwt.2.4.0/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console" {>= "2.2.0"}
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles using Lwt"
+description: """
+This implements a MirageOS console device using the Lwt
+concurrency libary for concurrency.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.0/mirage-console-v2.4.0.tbz"
+  checksum: "md5=d2ae5a712fe27c78d80b158ff99ac2e9"
+}

--- a/packages/mirage-console-unix/mirage-console-unix.2.4.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "lwt"
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt"
+  "mirage-console-lwt" {>= "2.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles for Unix"
+description: """
+This implements a MirageOS console device for use with
+Unix-based targets.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.0/mirage-console-v2.4.0.tbz"
+  checksum: "md5=d2ae5a712fe27c78d80b158ff99ac2e9"
+}

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.4.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "mirage-console-xen-proto"
+  "lwt"
+  "io-page-xen" {>= "2.0.0"}
+  "xenstore"
+  "xen-evtchn"
+  "xen-gnt"
+  "shared-memory-ring-lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console backend for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.0/mirage-console-v2.4.0.tbz"
+  checksum: "md5=d2ae5a712fe27c78d80b158ff99ac2e9"
+}

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.4.0/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.4.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "rresult"
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console protocol for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.0/mirage-console-v2.4.0.tbz"
+  checksum: "md5=d2ae5a712fe27c78d80b158ff99ac2e9"
+}

--- a/packages/mirage-console-xen/mirage-console-xen.2.4.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "mirage-console-xen-proto"
+  "xen-evtchn"
+  "xen-gnt"
+  "io-page-xen"
+  "mirage-xen" {>= "3.0.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.0/mirage-console-v2.4.0.tbz"
+  checksum: "md5=d2ae5a712fe27c78d80b158ff99ac2e9"
+}

--- a/packages/mirage-console/mirage-console.2.4.0/opam
+++ b/packages/mirage-console/mirage-console.2.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.0/mirage-console-v2.4.0.tbz"
+  checksum: "md5=d2ae5a712fe27c78d80b158ff99ac2e9"
+}


### PR DESCRIPTION
Implementation of Mirage consoles using Lwt

- Project page: <a href="https://github.com/mirage/mirage-console">https://github.com/mirage/mirage-console</a>
- Documentation: <a href="https://mirage.github.io/mirage-console/">https://mirage.github.io/mirage-console/</a>

##### CHANGES:

* Port build from jbuilder to Dune (@avsm)
* Use non-deprecated cstruct dependencies (cstruct-lwt) (@avsm)
* Upgrade opam metadata to 2.0 (@avsm)
* Remove mirage-xen-console-cli from the distribution until the
  upstream xenctrl library is more maintainable, since it doesnt
  build on the last four recent versions of xen (@avsm)
