### PR TITLE
[new release] base64 (3.1.0)

### DIFF
--- a/packages/base64/base64.3.1.0/opam
+++ b/packages/base64/base64.3.1.0/opam
@@ -15,6 +15,7 @@ binary data in an ASCII string format by translating it into a radix-64
 representation.  It is specified in RFC 4648.
 """
 depends: [
+  "ocaml" {>="4.03.0"}
   "base-bytes"
   "dune" {build & >= "1.0.1"}
   "bos" {with-test}

--- a/packages/base64/base64.3.1.0/opam
+++ b/packages/base64/base64.3.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "base-bytes"
+  "dune" {build & >= "1.0.1"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.1.0/base64-v3.1.0.tbz"
+  checksum: "md5=9847073feb4272e513d8c832904e1af7"
+}


### PR DESCRIPTION
Base64 encoding for OCaml

- Project page: <a href="https://github.com/mirage/ocaml-base64">https://github.com/mirage/ocaml-base64</a>
- Documentation: <a href="http://mirage.github.io/ocaml-base64/">http://mirage.github.io/ocaml-base64/</a>

##### CHANGES:

* Add `Base64.encode_string` that doesn't raise or return an error.
  This makes it easier to port pre-3.0 code to the new interface (mirage/ocaml-base64#26 @avsm)
