### PR TITLE
Release Caqti 1.1.0 core package and two drivers.

### DIFF
--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.1.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.1.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+name: "caqti-driver-mariadb"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
 license: "LGPL-3 with OCaml linking exception"
@@ -9,19 +10,19 @@ depends: [
   "ocaml"
   "caqti" {>= "1.0.0" & < "1.2.0~"}
   "dune" {build}
-  "sqlite3"
+  "mariadb" {>= "1.1.1"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
-synopsis: "Sqlite3 driver for Caqti using C bindings"
+synopsis: "MariaDB driver for Caqti using C bindings"
 url {
   src:
-    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.1.0/caqti-v1.1.0.tbz"
   checksum: [
-    "md5=6fb535971d307094a9f0bfb05ddc711c"
-    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+    "md5=1dbae4092760be0813823a1936dec1c6"
+    "sha256=9635da1efb377fc4477a573f8292d4afd781e20dae17e2da7250dc7fbfec5170"
   ]
 }

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.1.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.1.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+name: "caqti-driver-postgresql"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
 license: "LGPL-3 with OCaml linking exception"
@@ -7,21 +8,21 @@ doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.0.0" & < "1.2.0~"}
+  "caqti" {>= "1.1.0" & < "1.2.0~"}
   "dune" {build}
-  "sqlite3"
+  "postgresql"
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
-synopsis: "Sqlite3 driver for Caqti using C bindings"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
 url {
   src:
-    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.0.0/caqti-1.0.0.tbz"
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.1.0/caqti-v1.1.0.tbz"
   checksum: [
-    "md5=6fb535971d307094a9f0bfb05ddc711c"
-    "sha256=016e4649710b8ba530642aa706fa62ae65224f18d6791df63554451a430eb3dd"
+    "md5=1dbae4092760be0813823a1936dec1c6"
+    "sha256=9635da1efb377fc4477a573f8292d4afd781e20dae17e2da7250dc7fbfec5170"
   ]
 }

--- a/packages/caqti-dynload/caqti-dynload.1.0.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.0.0/opam
@@ -7,7 +7,7 @@ doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "caqti"
+  "caqti" {>= "1.0.0" & < "2.0.0~"}
   "dune" {build}
   "ocamlfind"
 ]

--- a/packages/caqti/caqti.1.1.0/opam
+++ b/packages/caqti/caqti.1.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "caqti"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "logs"
+  "ptime"
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.1.0/caqti-v1.1.0.tbz"
+  checksum: [
+    "md5=1dbae4092760be0813823a1936dec1c6"
+    "sha256=9635da1efb377fc4477a573f8292d4afd781e20dae17e2da7250dc7fbfec5170"
+  ]
+}


### PR DESCRIPTION
This is a bugfix and minor feature update of the core package and two of the drivers, an adjustment of the constraints of two more packages.  From the release notes:

- Add pretty printer for requests.
- Add variance to `'a future` declarations.
- Add blocking instance of API.
- Generalize `$.` to `$<var>.` in queries.
- Infer the expansion of `$(<var>.)` from `$(<var>)` if not provided.
- Fix connection recovery for PostgreSQL (issue paurkedal/ocaml-caqti#19, Dave Aitken).
- Fix unhandled exceptions for PostgreSQL.
- Fix connection validation for MariaDB.
