### PR TITLE
[new release] mirage-block and mirage-block-lwt (1.2.0)

### DIFF
--- a/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "2.0.0"}
+  "io-page"
+  "lwt"
+  "logs"
+  "mirage-block" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS using Lwt"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+This package is specialised to the Lwt concurrency library for IO.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v1.2.0/mirage-block-v1.2.0.tbz"
+  checksum: "md5=429022b9e477e8cd99b5906f073c59f4"
+}

--- a/packages/mirage-block/mirage-block.1.2.0/opam
+++ b/packages/mirage-block/mirage-block.1.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v1.2.0/mirage-block-v1.2.0.tbz"
+  checksum: "md5=429022b9e477e8cd99b5906f073c59f4"
+}


### PR DESCRIPTION
Block signatures and implementations for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-block">https://github.com/mirage/mirage-block</a>
- Documentation: <a href="https://mirage.github.io/mirage-block/">https://mirage.github.io/mirage-block/</a>

##### CHANGES:

- port to dune from jbuilder (@avsm)
- upgrade opam metadata to 2.0 (@avsm)
- switch to dune-release from topkg (@avsm)
- test OCaml 4.07 as well (@avsm)
