### PR TITLE
[new release] mirage-block-unix (2.11.0)

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors:      "Dave Scott <dave@recoil.org>"
+maintainer:   "dave@recoil.org"
+homepage:     "https://github.com/mirage/mirage-block-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-block-unix.git"
+doc:          "https://mirage.github.io/mirage-block-unix/"
+bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
+tags:         "org:mirage"
+license:      "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >="1.0"}
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt"
+  "mirage-block-lwt" {>= "1.0.0"}
+  "rresult"
+  "io-page-unix" {>= "2.0.0"}
+  "uri" {>= "1.9.0"}
+  "logs"
+  "ounit" {with-test}
+  "diet" {with-test}
+  "fmt" {with-test}
+  "ppx_tools" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_type_conv" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+synopsis: "MirageOS disk block driver for Unix"
+description: """
+Unix implementation of the Mirage `BLOCK_DEVICE` interface.
+
+This module provides raw I/O to files and block devices with as little
+caching as possible.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-unix/releases/download/v2.11.0/mirage-block-unix-v2.11.0.tbz"
+  checksum: "md5=f2a55e7b98bb49ebcd886f1878b76797"
+}


### PR DESCRIPTION
MirageOS disk block driver for Unix

- Project page: <a href="https://github.com/mirage/mirage-block-unix">https://github.com/mirage/mirage-block-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-unix/">https://mirage.github.io/mirage-block-unix/</a>

##### CHANGES:

* Port build to Dune from jbuilder (mirage/mirage-block-unix#93 @avsm)
* Update opam metadata to 2.0 format (mirage/mirage-block-unix#92 @avsm @jonludlam)
* Use dune-release instead of topkg (mirage/mirage-block-unix#93 @avsm)
* Ocamldoc fixes for odoc support (mirage/mirage-block-unix#93 @avsm)
* Fix build on older macOS (mirage/mirage-block-unix#90 @djs55)
