### PR TITLE
nsq breaks with Lwt_log being separate, so upper bound on lwt

### DIFF
--- a/packages/nsq/nsq.0.2.4/opam
+++ b/packages/nsq/nsq.0.2.4/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {build}
   "containers"
-  "lwt" {>= "3.2.0"}
+  "lwt" {>= "3.2.0" & <"4.0.0"}
   "ocplib-endian"
   "integers"
   "cohttp"

--- a/packages/nsq/nsq.0.2.5/opam
+++ b/packages/nsq/nsq.0.2.5/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {build}
   "base" {< "v0.12"}
-  "lwt" {>= "3.2.0"}
+  "lwt" {>= "3.2.0" & <"4.0.0"}
   "ocplib-endian"
   "integers"
   "cohttp"

--- a/packages/nsq/nsq.0.3.0/opam
+++ b/packages/nsq/nsq.0.3.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {build}
   "base" {< "v0.12"}
-  "lwt" {>= "3.2.0"}
+  "lwt" {>= "3.2.0" & <"4.0.0"}
   "ocplib-endian"
   "integers"
   "cohttp"

--- a/packages/opium/opium.0.16.0/opam
+++ b/packages/opium/opium.0.16.0/opam
@@ -17,7 +17,7 @@ depends: [
   "opium_kernel"
   "cohttp-lwt-unix" {>= "0.99.0"}
   "base-unix"
-  "lwt"
+  "lwt" {<"4.0.0"}
   "cmdliner"
   "ppx_fields_conv" {>= "v0.9.0" & < "v0.12"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}


### PR DESCRIPTION
revdeps for #13388