### PR TITLE
[new release] crunch (2.2.0)

### DIFF
--- a/packages/crunch/crunch.2.2.0/opam
+++ b/packages/crunch/crunch.2.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+homepage:     "https://github.com/mirage/ocaml-crunch"
+bug-reports:  "https://github.com/mirage/ocaml-crunch/issues"
+doc:          "https://mirage.github.io/ocaml-crunch/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/ocaml-crunch.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "cmdliner"
+  "dune" {build & >= "1.0"}
+  "cstruct" {with-test}
+  "lwt" {with-test}
+  "mirage-kv-lwt" {with-test & >= "1.0.0"}
+  "io-page-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Convert a filesystem into a static OCaml module"
+description: """
+`ocaml-crunch` takes a directory of files and compiles them into a standalone
+OCaml module which serves the contents directly from memory.  This can be
+convenient for libraries that need a few embedded files (such as a web server)
+and do not want to deal with all the trouble of file configuration.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-crunch/releases/download/v2.2.0/crunch-v2.2.0.tbz"
+  checksum: "md5=2abd598ffe1b6e84d0a75ba708caab79"
+}


### PR DESCRIPTION
Convert a filesystem into a static OCaml module

- Project page: <a href="https://github.com/mirage/ocaml-crunch">https://github.com/mirage/ocaml-crunch</a>
- Documentation: <a href="https://mirage.github.io/ocaml-crunch/">https://mirage.github.io/ocaml-crunch/</a>

##### CHANGES:

* Port to dune from jbuilder (mirage/ocaml-crunch#46 @hannesm)
* use `SOURCE_DATE_EPOCH` instead of gettimeofday if set to
  support reproducible builds (mirage/ocaml-crunch#45 @xclerc)
