### PR TITLE
aws-s3.0.9.0: has warnings as errors on, so restrict yojson

### DIFF
--- a/packages/aws-s3/aws-s3.0.9.0/opam
+++ b/packages/aws-s3/aws-s3.0.9.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml-inifiles"
   "cryptokit"
   "nocrypto"
-  "yojson"
+  "yojson" {<"1.5.0"}
   "ppx_deriving_yojson"
   "xml-light"
 ]


### PR DESCRIPTION
it now issues deprecation warnings for the json type
cc @hcarty