### PR TITLE
Package uutf.1.0.2

### DIFF
--- a/packages/uutf/uutf.1.0.2/opam
+++ b/packages/uutf/uutf.1.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/uutf"
+doc: "http://erratique.ch/software/uutf/doc/Uutf"
+dev-repo: "git+http://erratique.ch/repos/uutf.git"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "uchar"
+]
+depopts: ["cmdliner"]
+conflicts: ["cmdliner" { < "0.9.6"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+synopsis: """Non-blocking streaming Unicode codec for OCaml"""
+description: """\
+
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values.
+
+Uutf has no dependency and is distributed under the ISC license.
+"""
+url {
+archive: "http://erratique.ch/software/uutf/releases/uutf-1.0.2.tbz"
+checksum: "a7c542405a39630c689a82bd7ef2292c"
+}


### PR DESCRIPTION
### `uutf.1.0.2`
Non-blocking streaming Unicode codec for OCaml
Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
work character by character without blocking on IO. Decoders perform
character position tracking and support newline normalization.

Functions are also provided to fold over the characters of UTF encoded
OCaml string values and to directly encode characters in OCaml
Buffer.t values.

Uutf has no dependency and is distributed under the ISC license.



---
* Homepage: http://erratique.ch/software/uutf
* Source repo: git+http://erratique.ch/repos/uutf.git
* Bug tracker: https://github.com/dbuenzli/uutf/issues

---
v1.0.2 2019-02-05 La Forclaz (VS)
---------------------------------

- Fix the substring folding functionality introduced in v1.0.0.
  It never worked correctly.

---
:camel: Pull-request generated by opam-publish v2.0.0