### PR TITLE
[new release] charrua-unix, charrua-client-mirage, charrua-core, charrua-client and charrua-client-lwt (0.11.2)

### DIFF
--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.2/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua-core"
+bug-reports:  "https://github.com/mirage/charrua-core/issues"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "charrua-core" {>= "0.11.1"}
+  "charrua-client" {>= "0.11.1"}
+  "cstruct" {>="3.0.2"}
+  "ipaddr" {>="3.0.0"}
+  "rresult"
+  "mirage-random" {>= "1.0.0"}
+  "duration"
+  "mirage-time-lwt"
+  "mirage-net-lwt"
+  "logs"
+  "tcpip" {>= "3.6.0"}
+  "fmt"
+  "lwt"
+]
+synopsis: "A DHCP client using lwt as effectful layer"
+description: """
+`charrua-client-lwt` extends `charrua-client` with a functor `Dhcp_client_lwt`,
+using the provided modules for timing and networking logic,
+for convenient use by a program which might wish to implement a full client.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.11.2/charrua-core-v0.11.2.tbz"
+  checksum: "md5=c83ace0546e66ebe2b38e9685c7e9c55"
+}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua-core"
+bug-reports:  "https://github.com/mirage/charrua-core/issues"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "charrua-core" {>= "0.11.1"}
+  "charrua-client-lwt" {>= "0.11.1"}
+  "charrua-client" {>= "0.11.1"}
+  "cstruct" {>="3.0.2"}
+  "ipaddr" {>= "3.0.0"}
+  "rresult"
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock"
+  "mirage-time-lwt"
+  "mirage-net-lwt"
+  "mirage-protocols-lwt"
+  "duration"
+  "logs"
+  "tcpip" {>= "3.6.0"}
+  "fmt"
+  "lwt"
+]
+synopsis: "A DHCP client for MirageOS"
+description: """
+`charrua-client-mirage` exposes an additional `Dhcp_client_mirage` for direct use
+with the [MirageOS library operating system](https://github.com/mirage/mirage).
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.11.2/charrua-core-v0.11.2.tbz"
+  checksum: "md5=c83ace0546e66ebe2b38e9685c7e9c55"
+}

--- a/packages/charrua-client/charrua-client.0.11.2/opam
+++ b/packages/charrua-client/charrua-client.0.11.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua-core"
+bug-reports:  "https://github.com/mirage/charrua-core/issues"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-random-test" {with-test}
+  "charrua-core" {>= "0.11.1"}
+  "cstruct" {>="3.0.2"}
+  "ipaddr"
+  "macaddr"
+]
+synopsis: "DHCP client implementation"
+description: """
+charrua-client is a DHCP client powered by [charrua-core](https://github.com/haesbaert/charrua-core).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.11.2/charrua-core-v0.11.2.tbz"
+  checksum: "md5=c83ace0546e66ebe2b38e9685c7e9c55"
+}

--- a/packages/charrua-core/charrua-core.0.11.2/opam
+++ b/packages/charrua-core/charrua-core.0.11.2/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua-core"
+bug-reports: "https://github.com/mirage/charrua-core/issues"
+dev-repo: "git+https://github.com/mirage/charrua-core.git"
+doc: "https://mirage.github.io/charrua-core/api"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ppx_sexp_conv" {build}
+  "ppx_cstruct"   {build}
+  "menhir"        {build}
+  "ocaml"         {>= "4.0.3"}
+  "cstruct"       {>= "3.0.1"}
+  "sexplib"
+  "ipaddr"        {>= "3.0.0"}
+  "macaddr"
+  "ethernet"
+  "tcpip"         {>= "3.7.0"}
+  "rresult"
+  "io-page-unix"  {with-test}
+  "cstruct-unix"  {with-test}
+]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua-core consists of two modules, a `Dhcp_wire` responsible for parsing and
+constructing DHCP messages and a `Dhcp_server` module used for constructing DHCP
+servers.
+
+You can browse the API for [charrua-core](http://www.github.com/mirage/charrua-core) at
+http://mirage.github.io/charrua-core/api
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua-core, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP, it is the
+  base for `Dhcp_server`.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.11.2/charrua-core-v0.11.2.tbz"
+  checksum: "md5=c83ace0546e66ebe2b38e9685c7e9c55"
+}

--- a/packages/charrua-unix/charrua-unix.0.11.2/opam
+++ b/packages/charrua-unix/charrua-unix.0.11.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/haesbaert/charrua-unix"
+bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/haesbaert/charrua-unix.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.03.0"}
+  "lwt" {>="3.0.0"}
+  "lwt_log"
+  "charrua-core" {>= "0.11.0"}
+  "cstruct-unix"
+  "cmdliner"
+  "rawlink" {>= "1.0"}
+  "tuntap" {>= "1.2.0"}
+  "mtime" {>="1.0.0"}
+]
+synopsis: "Unix DHCP daemon"
+description: """
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua-core](http://www.github.com/mirage/charrua-core).
+"""
+url {
+  src:
+    "https://github.com/haesbaert/charrua-unix/releases/download/v0.11.2/charrua-core-v0.11.2.tbz"
+  checksum: "md5=c83ace0546e66ebe2b38e9685c7e9c55"
+}


### PR DESCRIPTION
CHANGES:

* build system ported to dune (haesbaert/charrua-unix#92, @hannesm)
* compatibility with tcpip 3.7.0 (haesbaert/charrua-unix#91, @hannesm)
* compatibility with rawlink 1.0 (haesbaert/charrua-unix#90, @hannesm)