### PR TITLE
[new release] pcre (7.4.0)

### DIFF
--- a/packages/pcre/pcre.7.4.0/opam
+++ b/packages/pcre/pcre.7.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build & >= "1.4.0"}
+  "conf-libpcre" {build}
+  "base" {build}
+  "base-bytes"
+]
+
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.4.0/pcre-7.4.0.tbz"
+  checksum: "md5=986d1391e926b559d8db42273679bbc0"
+}


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

* Added DFA support

    New functions:

      * pcre_dfa_exec
      * unsafe_pcre_dfa_exec

    Thanks to Chas Emerick <chas@cemerick.com> for this contribution!
