### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.4.1)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.4.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.4.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria-runtime"  {>= "2.2.2"}
+  "fmt"
+  "logs"
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.1/mirage-v3.4.1.tbz"
+  checksum: "md5=1937ea6740613991532af1cc8eb06b36"
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "lwt"
+  "cstruct" {>="3.2.1"}
+  "io-page" {>="2.0.1"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-types" {>= "3.4.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.5.0"}
+  "mirage-protocols-lwt" {>= "1.4.1"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-console-lwt" {>= "2.3.5"}
+  "mirage-block-lwt" {>= "1.1.0"}
+  "mirage-net-lwt" {>= "1.2.0"}
+  "mirage-fs-lwt" {>= "1.1.1"}
+  "mirage-kv-lwt" {>= "1.1.0"}
+  "mirage-channel-lwt" {>= "3.1.0"}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.1/mirage-v3.4.1.tbz"
+  checksum: "md5=1937ea6740613991532af1cc8eb06b36"
+}

--- a/packages/mirage-types/mirage-types.3.4.1/opam
+++ b/packages/mirage-types/mirage-types.3.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "mirage-device" {>= "1.1.0"}
+  "mirage-time" {>= "1.1.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow" {>= "1.5.0"}
+  "mirage-console" {>= "2.3.5"}
+  "mirage-protocols" {>= "1.4.1"}
+  "mirage-stack" {>= "1.3.0"}
+  "mirage-block" {>= "1.1.0"}
+  "mirage-net" {>= "1.2.0"}
+  "mirage-fs" {>= "1.1.1"}
+  "mirage-kv" {>= "1.1.1"}
+  "mirage-channel" {>= "3.1.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.1/mirage-v3.4.1.tbz"
+  checksum: "md5=1937ea6740613991532af1cc8eb06b36"
+}

--- a/packages/mirage/mirage.3.4.1/opam
+++ b/packages/mirage/mirage.3.4.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "2.2.3"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.4.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.4.1/mirage-v3.4.1.tbz"
+  checksum: "md5=1937ea6740613991532af1cc8eb06b36"
+}


### PR DESCRIPTION
…CHANGES:

* Provide a httpaf_server device, and a cohttp_server device (mirage/mirage#955, by @anmonteiro)
* There can only be a single prng device in a unikernel, due to entropy
  harvesting setup (mirage/mirage#959, by @hannesm)
* Cleanup zarith-freestanding / gmp-freestanding dependencies (mirage/mirage#964, by @hannesm)
* ethernet is now a separate package (mirage/mirage#965, by @hannesm)
* arp now uses the mirage/arp repository by default, the tcpip.arpv4
  implementation was removed in tcpip 3.7.0 (mirage/mirage#965, by @hannesm)