### PR TITLE
[WIP] Package eigen.0.1.0

### DIFF
--- a/packages/eigen/eigen.0.1.0/opam
+++ b/packages/eigen/eigen.0.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+build: [
+  ["dune" "build" "eigen_cpp/libeigen_cpp_stubs.a"]
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "dune" {build & >= "0.4"}
+  "ocamlbuild" {build}
+]
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+"Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."


### PR DESCRIPTION
### `eigen.0.1.0`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0