### PR TITLE
[new release] io-page-xen, io-page and io-page-unix (2.1.0)

### DIFF
--- a/packages/io-page-unix/io-page-unix.2.1.0/opam
+++ b/packages/io-page-unix/io-page-unix.2.1.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/io-page"
 bug-reports: "https://github.com/mirage/io-page/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "io-page"
+  "io-page" {>="2.1.0"}
   "dune" {build & >= "1.0"}
   "cstruct" {>= "2.0.0"}
   "ounit" {with-test}

--- a/packages/io-page-unix/io-page-unix.2.1.0/opam
+++ b/packages/io-page-unix/io-page-unix.2.1.0/opam
@@ -9,7 +9,6 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "io-page"
   "dune" {build & >= "1.0"}
-  "configurator" {build}
   "cstruct" {>= "2.0.0"}
   "ounit" {with-test}
 ]

--- a/packages/io-page-unix/io-page-unix.2.1.0/opam
+++ b/packages/io-page-unix/io-page-unix.2.1.0/opam
@@ -15,7 +15,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/io-page.git"
 synopsis: "Support for efficient handling of I/O memory pages on Unix"

--- a/packages/io-page-unix/io-page-unix.2.1.0/opam
+++ b/packages/io-page-unix/io-page-unix.2.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "io-page"
+  "dune" {build & >= "1.0"}
+  "configurator" {build}
+  "cstruct" {>= "2.0.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages on Unix"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.1.0/io-page-v2.1.0.tbz"
+  checksum: "md5=b0d25561552d3d7067f57337c5527c54"
+}

--- a/packages/io-page-xen/io-page-xen.2.1.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/io-page/issues"
 doc: "https://mirage.github.io/io-page/"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "io-page"
+  "io-page" {>="2.1.0"}
   "dune" {build & >= "1.0"}
   "cstruct" {>= "2.0.0"}
   "mirage-xen-ocaml"

--- a/packages/io-page-xen/io-page-xen.2.1.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "io-page"
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "2.0.0"}
+  "mirage-xen-ocaml"
+]
+build: [
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst"] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig"
+    "dune" "build" "-p" name "-j" jobs ]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages on Xen"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.1.0/io-page-v2.1.0.tbz"
+  checksum: "md5=b0d25561552d3d7067f57337c5527c54"
+}

--- a/packages/io-page/io-page.2.1.0/opam
+++ b/packages/io-page/io-page.2.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.1.0/io-page-v2.1.0.tbz"
+  checksum: "md5=b0d25561552d3d7067f57337c5527c54"
+}

--- a/packages/mirage-console-xen/mirage-console-xen.1.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "mirage-types" {= "0.4.0"}
   "mirage-xen" {>= "0.9.9" & < "2.0.0"}
   "mirage-unix" {>= "0.9.9" & < "2.0.0"}
-  "io-page-xen" {>= "0.9.9"}
+  "io-page-xen" {>= "0.9.9" & < "1.2.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"
 install: [make "xen-install"]

--- a/packages/mirage-console-xen/mirage-console-xen.1.0.1/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.1.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "mirage-types" {= "0.4.0"}
   "mirage-xen" {>= "0.9.9" & < "2.0.0"}
   "mirage-unix" {>= "0.9.9" & < "2.0.0"}
-  "io-page-xen" {>= "0.9.9"}
+  "io-page-xen" {>= "0.9.9" & <"1.2.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"
 install: [make "xen-install"]

--- a/packages/mirage-console-xen/mirage-console-xen.1.0.2/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.1.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind"
   "mirage-types" {>= "1.1.0" & < "2.0.0"}
   "mirage-xen" {>= "1.1.0"}
-  "io-page-xen" {>= "0.9.9"}
+  "io-page-xen" {>= "0.9.9" & <"1.3.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"
 install: [make "xen-install"]

--- a/packages/shared-memory-ring/shared-memory-ring.1.2.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.2.0/opam
@@ -17,7 +17,7 @@ remove:  ["ocamlfind" "remove" "shared-memory-ring"]
 
 depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "3.4.0"}
   "ppx_tools"
   "lwt"
   "ocamlfind"

--- a/packages/shared-memory-ring/shared-memory-ring.1.3.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.1.3.0/opam
@@ -17,7 +17,7 @@ remove:  ["ocamlfind" "remove" "shared-memory-ring"]
 
 depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "3.4.0"}
   "ppx_tools"
   "lwt"
   "ocamlfind"

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
-  "cstruct" {>= "2.4.1"}
+  "cstruct" {>= "2.4.1" & < "3.4.0"}
   "ppx_cstruct"
   "mirage-profile"
   "ounit" {with-test}

--- a/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.2.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
-  "cstruct" {>= "2.4.1"}
+  "cstruct" {>= "2.4.1" & < "3.4.0"}
   "ppx_cstruct"
   "mirage-profile"
   "ounit" {with-test}

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
@@ -15,6 +15,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "xen-gnt"
   "io-page"
+  "io-page-unix"
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
Support for efficient handling of I/O memory pages on Xen

- Project page: <a href="https://github.com/mirage/io-page">https://github.com/mirage/io-page</a>
- Documentation: <a href="https://mirage.github.io/io-page/">https://mirage.github.io/io-page/</a>

##### CHANGES:

* Port to Dune and configurator (@avsm)
* Upgrade opam metadata to 2.0 (@avsm)
