### PR TITLE
[new release] ocaml-version (2.0.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.2.0.0/opam
+++ b/packages/ocaml-version/ocaml-version.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/avsm/ocaml-version"
+doc: "https://avsm.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/avsm/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+Browse the [API documentation](http://anil-code.recoil.org/ocaml-version/ocaml-version/Ocaml_version/index.html) for more
+details.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/avsm/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/avsm/ocaml-version/releases/download/v2.0.0/ocaml-version-v2.0.0.tbz"
+  checksum: "md5=c019c3c1891d7127d59b031504b040a0"
+}


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/avsm/ocaml-version">https://github.com/avsm/ocaml-version</a>
- Documentation: <a href="https://avsm.github.io/ocaml-version/doc">https://avsm.github.io/ocaml-version/doc</a>

##### CHANGES:

* Reinstate OCaml 4.02 to the "recent" list after a request
  from @dra27.  This means that all the supported OCaml compilers
  for Dune will be present in a single container.
* Add support for 4.09 now that 4.08 has branched.
* Use `+trunk` in the suffix for opam dev version packages.
* Add `Releases.is_dev` to make it easier to spot a dev release.
