### PR TITLE
[new release] vchan-xen, vchan-unix and vchan (4.0.1)

### DIFF
--- a/packages/vchan-unix/vchan-unix.4.0.1/opam
+++ b/packages/vchan-unix/vchan-unix.4.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan/"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "vchan" {>="4.0.0"}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "io-page-unix"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "xen-evtchn-unix"
+  "xen-gnt-unix"
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v4.0.1/vchan-v4.0.1.tbz"
+  checksum: "md5=e6c8304aeffe57dee7aec37511251b23"
+}

--- a/packages/vchan-xen/vchan-xen.4.0.1/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan/"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "vchan" {>="4.0.0"}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_cstruct" {build}
+  "io-page"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "mirage-xen"
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v4.0.1/vchan-v4.0.1.tbz"
+  checksum: "md5=e6c8304aeffe57dee7aec37511251b23"
+}

--- a/packages/vchan/vchan.4.0.1/opam
+++ b/packages/vchan/vchan.4.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+description: """
+This is an implementation of the Xen "libvchan" or "vchan" communication
+protocol in OCaml. It allows fast inter-domain communication using shared
+memory.
+"""
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan/"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v4.0.1/vchan-v4.0.1.tbz"
+  checksum: "md5=e6c8304aeffe57dee7aec37511251b23"
+}


### PR DESCRIPTION
CHANGES:

* Use `io-page-unix` dependency instead of the deprecated `io-page.unix` alias (@avsm)
* Correct doc url so that API docs are published (@avsm)