### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.1.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL and distribution support"
+description: """
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile-opam" {>= "3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.1.0/dockerfile-v6.1.0.tbz"
+  checksum: "md5=b278021bc9f093fc831364eb0a66df52"
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.1.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL and distribution support"
+description: """
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile" {>= "3.0.0"}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.1.0/dockerfile-v6.1.0.tbz"
+  checksum: "md5=b278021bc9f093fc831364eb0a66df52"
+}

--- a/packages/dockerfile/dockerfile.6.1.0/opam
+++ b/packages/dockerfile/dockerfile.6.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL and distribution support"
+description: """
+[Docker](http://docker.com) is a container manager that can build images
+automatically by reading the instructions from a `Dockerfile`. A Dockerfile is
+a text document that contains all the commands you would normally execute
+manually in order to build a Docker image. By calling `docker build` from your
+terminal, you can have Docker build your image step-by-step, executing the
+instructions successively.  Read more at <http://docker.com>
+
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+ocaml-dockerfile is distributed under the ISC license.
+
+- **HTML Documentation**: <http://anil-code.recoil.org/ocaml-dockerfile>
+- **Source:**: <https://github.com/avsm/ocaml-dockerfile>
+- **Issues**: <https://github.com/avsm/ocaml-dockerfile/issues>
+- **Email**: <anil@recoil.org>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.1.0/dockerfile-v6.1.0.tbz"
+  checksum: "md5=b278021bc9f093fc831364eb0a66df52"
+}


### PR DESCRIPTION
Dockerfile eDSL and distribution support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/doc">https://avsm.github.io/ocaml-dockerfile/doc</a>

##### CHANGES:

- Add support for Fedora 29 and OpenSUSE Leap 15.0 and Alpine 3.9.
- Demote some releases to Tier 2 from Tier 1.
- Add functions to calculate base distro tags in `Dockerfile_distro`.
- Install bzip2 and rsync on OpenSUSE distros.
- Add a `Dockerfile_opam.deprecated` container for being able to turn off older distros. 
- Install `which` into OpenSUSE containers by default.
- Use `+trunk` suffix for dev versions of compiler.
- Remove unused GNU Parallel wrapper in `dockerfile_cmd`.
