### PR TITLE
[new release] mirage-net-unix (2.5.0)

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.2.5.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.5.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "David Scott" "Thomas Gazagnaire" "Hannes Mehnert"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-net-unix"
+doc: "https://mirage.github.io/mirage-net-unix/"
+bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "1.7.1"}
+  "cstruct-lwt"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "io-page-unix" {>= "2.0.0"}
+  "tuntap" {>= "1.3.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-net-unix.git"
+synopsis: "Unix implementation of the Mirage NETWORK interface"
+description: """
+This interface exposes raw Ethernet frames using `ocaml-tuntap`,
+suitable for use with an OCaml network stack such as the one
+found at <https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-unix/releases/download/v2.5.0/mirage-net-unix-v2.5.0.tbz"
+  checksum: "md5=d4f929a33a0c68b9613c6f3c30b44ca8"
+}


### PR DESCRIPTION
Unix implementation of the Mirage NETWORK interface

- Project page: <a href="https://github.com/mirage/mirage-net-unix">https://github.com/mirage/mirage-net-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-unix/">https://mirage.github.io/mirage-net-unix/</a>

##### CHANGES:

* Build with dune instead of jbuilder (@avsm)
* Upgrade opam metadata to 2.0 (@avsm)
* Refresh Travis matrix to 4.07 as well (@avsm)
