### PR TITLE
3 packages from OCamlPro/ocplib-json-typed at 0.7

### DIFF
--- a/packages/ocplib-json-typed-browser/ocplib-json-typed-browser.0.7/opam
+++ b/packages/ocplib-json-typed-browser/ocplib-json-typed-browser.0.7/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Json_repr interface over JavaScript's objects"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
+
+build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0.1"}
+  "ocplib-json-typed" {= "0.7" }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=afa5aed32fcd7ff3ffae7c0adfb5de58"
+    "sha512=e564518999e3b88c4d734d783ba4ea3bdcf7c2b6f408db70d662a989e97a50192ef1c75ad9621505779609372bce0e765a5ceb4536a24c66deb359c37fc967f8"
+  ]
+}

--- a/packages/ocplib-json-typed-browser/ocplib-json-typed-browser.0.7/opam
+++ b/packages/ocplib-json-typed-browser/ocplib-json-typed-browser.0.7/opam
@@ -7,8 +7,7 @@ bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
 license: "LGPLv3 w/ linking exception"
 dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
 
-build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+build: [ "dune" "build" "-j" jobs "-p" name "@install" "@runtest" {with-test} ]
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0.1"}

--- a/packages/ocplib-json-typed-bson/ocplib-json-typed-bson.0.7/opam
+++ b/packages/ocplib-json-typed-bson/ocplib-json-typed-bson.0.7/opam
@@ -7,8 +7,7 @@ bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
 license: "LGPLv3 w/ linking exception"
 dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
 
-build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+build: [ "dune" "build" "-j" jobs "-p" name "@install" "@runtest" {with-test} ]
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0.1"}

--- a/packages/ocplib-json-typed-bson/ocplib-json-typed-bson.0.7/opam
+++ b/packages/ocplib-json-typed-bson/ocplib-json-typed-bson.0.7/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "A Json_repr compatible implementation of the JSON compatible subset of BSON"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
+
+build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0.1"}
+  "ocplib-json-typed" {= "0.7" }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=afa5aed32fcd7ff3ffae7c0adfb5de58"
+    "sha512=e564518999e3b88c4d734d783ba4ea3bdcf7c2b6f408db70d662a989e97a50192ef1c75ad9621505779609372bce0e765a5ceb4536a24c66deb359c37fc967f8"
+  ]
+}

--- a/packages/ocplib-json-typed/ocplib-json-typed.0.7/opam
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.7/opam
@@ -7,8 +7,7 @@ bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
 license: "LGPLv3 w/ linking exception"
 dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
 
-build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+build: [ "dune" "build" "-j" jobs "-p" name "@install" "@runtest" {with-test} ]
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0.1"}

--- a/packages/ocplib-json-typed/ocplib-json-typed.0.7/opam
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.7/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Type-aware JSON and JSON schema utilities"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
+
+build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0.1"}
+  "uri" {>= "1.9.0" }
+]
+url {
+  src: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=afa5aed32fcd7ff3ffae7c0adfb5de58"
+    "sha512=e564518999e3b88c4d734d783ba4ea3bdcf7c2b6f408db70d662a989e97a50192ef1c75ad9621505779609372bce0e765a5ceb4536a24c66deb359c37fc967f8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocplib-json-typed.0.7`: Type-aware JSON and JSON schema utilities
-`ocplib-json-typed-browser.0.7`: Json_repr interface over JavaScript's objects
-`ocplib-json-typed-bson.0.7`: A Json_repr compatible implementation of the JSON compatible subset of BSON



---
* Homepage: https://github.com/ocamlpro/ocplib-json-typed
* Source repo: git+https://github.com/ocamlpro/ocplib-json-typed.git
* Bug tracker: https://github.com/ocamlpro/ocplib-json-typed/issues

---
:camel: Pull-request generated by opam-publish v2.0.0