### PR TITLE
Package eliom.6.7

### DIFF
--- a/packages/eliom/eliom.6.7/opam
+++ b/packages/eliom/eliom.6.7/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "deriving" {>= "0.6"}
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml" {>= "3.3"}
+  "js_of_ocaml-lwt" {>= "3.3"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
+  "js_of_ocaml-tyxml" {>= "3.3"}
+  "lwt_log"
+  "lwt_ppx"
+  "lwt_camlp4"
+  "tyxml" {>= "4.3.0"}
+  "ocsigenserver" {>= "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/jrochel/eliom/archive/6.7.tar.gz"
+  checksum: [
+    "md5=f578af9fd7b7286dce520147e435b67c"
+    "sha512=ac072ee740afc4816fbe0bed864f69df4c9bca6893a70f285d87ebecced779325c8e391d509feb3fdad26d26ec29a691bdb1fa56b979e2a1169e6e1e1da295f7"
+  ]
+}

--- a/packages/eliom/eliom.6.7/opam
+++ b/packages/eliom/eliom.6.7/opam
@@ -31,7 +31,7 @@ depends: [
   "base-bytes"
 ]
 url {
-  src: "https://github.com/jrochel/eliom/archive/6.7.tar.gz"
+  src: "https://github.com/ocsigen/eliom/archive/6.7.tar.gz"
   checksum: [
     "md5=f578af9fd7b7286dce520147e435b67c"
     "sha512=ac072ee740afc4816fbe0bed864f69df4c9bca6893a70f285d87ebecced779325c8e391d509feb3fdad26d26ec29a691bdb1fa56b979e2a1169e6e1e1da295f7"


### PR DESCRIPTION
### `eliom.6.7`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0