### PR TITLE
ocsigen-start.1.1.0: correct wrong md5 checksum

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -35,5 +35,5 @@ synopsis: "Skeleton for building client-server Eliom applications"
 description: "(with users, notifications, etc.)"
 url {
   src: "https://github.com/ocsigen/ocsigen-start/archive/1.1.0.tar.gz"
-  checksum: "md5=cff1cd532de67dd4e5f8792c95bc4bac"
+  checksum: "md5=543cd2feaddcb98937b19465fb832ea4"
 }

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass"
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {= "6.3"}
+  "eliom" {= "6.3.0"}
   "ocsigen-toolkit" {>= "1.1"}
   "js_of_ocaml-camlp4"
   "yojson"

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -19,6 +19,7 @@ depends: [
   "yojson"
   "lwt" {< "4.0.0"}
   "lwt_log"
+  "js_of_ocaml" {< "3.3.0"}
 ]
 depexts: [
   ["imagemagick"] {os-distribution = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -18,6 +18,7 @@ depends: [
   "js_of_ocaml-camlp4"
   "yojson"
   "lwt" {< "4.0.0"}
+  "lwt_log"
 ]
 depexts: [
   ["imagemagick"] {os-distribution = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass"
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.3"}
+  "eliom" {= "6.3"}
   "ocsigen-toolkit" {>= "1.1"}
   "js_of_ocaml-camlp4"
   "yojson"


### PR DESCRIPTION
I'm not sure whether what I'm doing is considered bad practise, but
it seems that version does not compile anymore. As far as I can see,
there is no-one willing to maintain a pretty outdated version of that
package, nor anyone depending on it.