### PR TITLE
graphql, graphql_parser, graphql-lwt, graphql-async, graphql-cohttp 0.9.0

### DIFF
--- a/packages/graphql-async/graphql-async.0.9.0/opam
+++ b/packages/graphql-async/graphql-async.0.9.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "graphql" {= "0.8.0"}
+  "graphql" {>= "0.9.0"}
   "async_kernel" {>= "v0.9.0" & < "v0.12"}
   "alcotest" {with-test}
   "async_unix" {with-test & >= "v0.9.0" & < "v0.12"}
@@ -26,6 +26,6 @@ description: """
 `graphql-async` adds support for Async to `graphql`, so you can use Async in your GraphQL schema resolver functions."""
 
 url {
-archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.8.0/graphql-0.8.0.tbz"
-checksum: "582564e3de2095ce7512cee28b406920"
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.9.0/graphql-0.9.0.tbz"
+checksum: "2385ce2f537413e9466d13acb11ae7e4"
 }

--- a/packages/graphql-cohttp/graphql-cohttp.0.9.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.9.0/opam
@@ -14,18 +14,21 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "graphql" {= "0.8.0"}
-  "async_kernel" {>= "v0.9.0" & < "v0.12"}
-  "alcotest" {with-test}
-  "async_unix" {with-test & >= "v0.9.0" & < "v0.12"}
+  "graphql" {>= "0.9.0"}
+  "cohttp" {>= "2.0.0"}
+  "crunch"
+  "astring" {>= "0.8.3"}
+  "base64" {>= "3.0.0"}
+  "ocplib-endian" {>= "1.0"}
+  "digestif" {>= "0.7.0"}
 ]
 
-synopsis: "Build GraphQL schemas with Async support"
+synopsis: "Run GraphQL servers with `cohttp`"
 
 description: """
-`graphql-async` adds support for Async to `graphql`, so you can use Async in your GraphQL schema resolver functions."""
+This package allows you to execute Cohttp HTTP requests against GraphQL schemas build with `graphql`. The package is agnostic to Lwt/Async."""
 
 url {
-archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.8.0/graphql-0.8.0.tbz"
-checksum: "582564e3de2095ce7512cee28b406920"
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.9.0/graphql-0.9.0.tbz"
+checksum: "2385ce2f537413e9466d13acb11ae7e4"
 }

--- a/packages/graphql-lwt/graphql-lwt.0.8.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.8.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "graphql" {>= "0.8.0"}
+  "graphql" {= "0.8.0"}
   "alcotest" {with-test}
   "lwt"
 ]

--- a/packages/graphql-lwt/graphql-lwt.0.9.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.9.0/opam
@@ -14,18 +14,17 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "graphql" {= "0.8.0"}
-  "async_kernel" {>= "v0.9.0" & < "v0.12"}
+  "graphql" {>= "0.9.0"}
   "alcotest" {with-test}
-  "async_unix" {with-test & >= "v0.9.0" & < "v0.12"}
+  "lwt"
 ]
 
-synopsis: "Build GraphQL schemas with Async support"
+synopsis: "Build GraphQL schemas with Lwt support"
 
 description: """
-`graphql-async` adds support for Async to `graphql`, so you can use Async in your GraphQL schema resolver functions."""
+`graphql-lwt` adds support for Lwt to `graphql`, so you can use Lwt in your GraphQL schema resolver functions."""
 
 url {
-archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.8.0/graphql-0.8.0.tbz"
-checksum: "582564e3de2095ce7512cee28b406920"
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.9.0/graphql-0.9.0.tbz"
+checksum: "2385ce2f537413e9466d13acb11ae7e4"
 }

--- a/packages/graphql/graphql.0.9.0/opam
+++ b/packages/graphql/graphql.0.9.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "graphql_parser" {>= "0.9.0"}
+  "yojson"
+  "rresult"
+  "seq"
+  "alcotest" {with-test}
+]
+
+synopsis: "Build GraphQL schemas and execute queries against them"
+
+description: """
+`graphql` is a package for creating GraphQL servers. Current feature set includes:
+
+- Type-safe schema design
+- GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- Query execution
+- Introspection of schemas
+- Arguments for fields
+- Allows variables in queries
+- Subscriptions
+
+Supporting packages:
+
+- Use `graphql-lwt` for Lwt support.
+- Use `graphql-async` for Async support.
+- Use `graphql-cohttp` to run a GraphQL server with `cohttp`."""
+
+url {
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.9.0/graphql-0.9.0.tbz"
+checksum: "2385ce2f537413e9466d13acb11ae7e4"
+}

--- a/packages/graphql_parser/graphql_parser.0.9.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.9.0/opam
@@ -14,18 +14,15 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "graphql" {= "0.8.0"}
-  "async_kernel" {>= "v0.9.0" & < "v0.12"}
-  "alcotest" {with-test}
-  "async_unix" {with-test & >= "v0.9.0" & < "v0.12"}
+  "menhir" {build}
+  "alcotest" {with-test & >= "0.8.1"}
+  "result"
+  "fmt"
 ]
 
-synopsis: "Build GraphQL schemas with Async support"
-
-description: """
-`graphql-async` adds support for Async to `graphql`, so you can use Async in your GraphQL schema resolver functions."""
+synopsis: "Library for parsing GraphQL queries"
 
 url {
-archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.8.0/graphql-0.8.0.tbz"
-checksum: "582564e3de2095ce7512cee28b406920"
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.9.0/graphql-0.9.0.tbz"
+checksum: "2385ce2f537413e9466d13acb11ae7e4"
 }


### PR DESCRIPTION
# 0.9.0 2019-02-08
Skip and include directives (andreas/ocaml-graphql-server#117)
Expose more data to resolvers (andreas/ocaml-graphql-server#127)
Add the errors key first in the response JSON (andreas/ocaml-graphql-server#131)
Rewrite parser to Menhir and replace sexp with fmt (andreas/ocaml-graphql-server#132)
Support for websockets as transport (andreas/ocaml-graphql-server#133)