### PR TITLE
[new release] gemini (0.2.0)

### DIFF
--- a/packages/gemini/gemini.0.2.0/opam
+++ b/packages/gemini/gemini.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Carmelo Piccione <carmelo.piccione@gmail.com>"
+synopsis: "OCaml bindings for Gemini Trading Exchange API"
+description: "This library implements the Gemini exchange v1 REST, Market
+Data, and Order events websockets services. It is backed by cohttp-async
+and websockets-async to do the heavy lifting. A provisional console interface
+is also provided using s-expressions to encode request parameters."
+authors: "Carmelo Piccione"
+homepage: "https://github.com/struktured/ocaml-gemini"
+license: "MIT"
+bug-reports: "https://github.com/struktured/ocaml-gemini/issues"
+dev-repo: "git+https://github.com/struktured/ocaml-gemini.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+doc: "https://struktured.github.io/ocaml-gemini/"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "async" {>= "v0.11.0"}
+  "core" {>= "v0.11.1"}
+  "async_ssl"
+  "cohttp-async"
+  "dune" {build}
+  "ppx_jane"
+  "uri"
+  "hex"
+  "yojson"
+  "zarith"
+  "nocrypto"
+  "ppx_deriving_yojson"
+  "ppx_csv_conv"
+  "csvfields"
+  "websocket-async"
+  "expect_test_helpers"
+]
+url {
+  src:
+    "https://github.com/struktured/ocaml-gemini/releases/download/0.2.0/gemini-0.2.0.tbz"
+  checksum: "md5=7c96b223bd0d3c82ca0eb602d96de3f4"
+}


### PR DESCRIPTION
OCaml bindings for Gemini Trading Exchange API

- Project page: <a href="https://github.com/struktured/ocaml-gemini">https://github.com/struktured/ocaml-gemini</a>
- Documentation: <a href="https://struktured.github.io/ocaml-gemini/">https://struktured.github.io/ocaml-gemini/</a>

##### CHANGES:

- Csv serialization support for web socket apis
- Added reject `reason` field to order event type
- Added block trade event type to market data api

