### PR TITLE
Package tip-parser.0.6

### DIFF
--- a/packages/tip-parser/tip-parser.0.6/opam
+++ b/packages/tip-parser/tip-parser.0.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Parser for https://tip-org.github.io/format.html"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+tags: ["TIP" "parse" "inductive" "logic"]
+homepage: "https://github.com/c-cube/tip-parser/"
+bug-reports: "https://github.com/c-cube/tip-parser/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/tip-parser.git"
+url {
+  src: "https://github.com/c-cube/tip-parser/archive/0.6.tar.gz"
+  checksum: [
+    "md5=67037b4d8b95c661cab061a5686be2d1"
+    "sha512=696154e0b1ab5f28b39889dec1f877b48087652be2f5706010a9b9645f577f7a5f58b61e241e29837923fb691d7963a7487bce1331b973f03ba0785464b60175"
+  ]
+}


### PR DESCRIPTION
### `tip-parser.0.6`
Parser for https://tip-org.github.io/format.html



---
* Homepage: https://github.com/c-cube/tip-parser/
* Source repo: git+https://github.com/c-cube/tip-parser.git
* Bug tracker: https://github.com/c-cube/tip-parser/issues

---
:camel: Pull-request generated by opam-publish v2.0.0