### PR TITLE
New clangml release: 4.0.0beta1

### DIFF
--- a/packages/clangml-transforms/clangml-transforms.0.19/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.19/opam
@@ -11,7 +11,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml" {< "4.06"}
+  "ocaml" {< "4.05"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml-transforms/clangml-transforms.0.19/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.19/opam
@@ -9,7 +9,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml-transforms/clangml-transforms.0.19/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.19/opam
@@ -11,7 +11,7 @@ remove: [
 depends: [
   "ocaml"
   "deriving"
-  "clangml"
+  "clangml" {< "4.0.0"}
   "batteries"
   "dolog"
   "obuild" {> "0.0.7"}

--- a/packages/clangml-transforms/clangml-transforms.0.19/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.19/opam
@@ -1,6 +1,8 @@
 opam-version: "2.0"
+authors: ["Pippijn van Steenhoven" "Francois Berenger"]
 maintainer: "https://github.com/Antique-team/clangml-transforms/issues"
 homepage: "https://github.com/Antique-team/clangml-transforms"
+bug-reports: "https://github.com/Antique-team/clangml-transforms/issues"
 build: [
   ["obuild" "configure"]
   ["obuild" "build"]

--- a/packages/clangml-transforms/clangml-transforms.0.20/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.20/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml-transforms/clangml-transforms.0.20/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.20/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "ocaml"
   "deriving"
-  "clangml"
+  "clangml" {< "4.0.0"}
   "batteries"
   "dolog"
   "obuild" {> "0.0.7"}

--- a/packages/clangml-transforms/clangml-transforms.0.20/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.20/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml" {< "4.06"}
+  "ocaml" {< "4.05"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml-transforms/clangml-transforms.0.21/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.21/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml-transforms/clangml-transforms.0.21/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.21/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "ocaml"
   "deriving"
-  "clangml"
+  "clangml" {< "4.0.0"}
   "batteries"
   "dolog"
   "obuild" {> "0.0.7"}

--- a/packages/clangml-transforms/clangml-transforms.0.21/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.21/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml" {< "4.06"}
+  "ocaml" {< "4.05"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml-transforms/clangml-transforms.0.23/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.23/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml-transforms/clangml-transforms.0.23/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.23/opam
@@ -17,7 +17,7 @@ remove: [
 depends: [
   "ocaml"
   "deriving"
-  "clangml"
+  "clangml" {< "4.0.0"}
   "batteries"
   "dolog"
   "obuild" {> "0.0.7"}

--- a/packages/clangml-transforms/clangml-transforms.0.23/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.23/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "-remove" "clangml-transforms"]
 ]
 depends: [
-  "ocaml" {< "4.06"}
+  "ocaml" {< "4.05"}
   "deriving"
   "clangml" {< "4.0.0"}
   "batteries"

--- a/packages/clangml/clangml.3.9.1.2/opam
+++ b/packages/clangml/clangml.3.9.1.2/opam
@@ -23,7 +23,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0" & < "4.06.0"}
+  "ocaml" {>= "4.03.0" & < "4.05.0"}
   "dolog"
   "batteries"
   "deriving"

--- a/packages/clangml/clangml.3.9.1.2/opam
+++ b/packages/clangml/clangml.3.9.1.2/opam
@@ -38,10 +38,12 @@ depends: [
 ]
 depexts: [
   ["boost"] {os-distribution = "archlinux"}
-  ["clang-3.9" "libboost-dev" "libclang-3.9-dev" "llvm-3.9-dev"]
+  ["binutils-dev" "clang-3.9" "libboost-dev" "libclang-3.9-dev" "llvm-3.9-dev"
+   "libncurses-dev"]
     {os-distribution = "debian"}
   ["dev-libs/boost"] {os-distribution = "gentoo"}
-  ["libboost-dev"] {os-distribution = "ubuntu"}
+  ["binutils-dev" "clang-3.9" "libboost-dev" "libclang-3.9-dev" "llvm-3.9-dev"
+   "libncurses-dev"] {os-distribution = "ubuntu"}
   ["boost160"] {os = "macos" & os-distribution = "homebrew"}
 ]
 available: os != "alpine" & os != "centos"

--- a/packages/clangml/clangml.3.9.1.2/opam
+++ b/packages/clangml/clangml.3.9.1.2/opam
@@ -23,7 +23,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "dolog"
   "batteries"
   "deriving"

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -17,8 +17,8 @@ depends: [
   "ppx_deriving"
   "visitors"
   "dune" {>= "1.2"}
-  "ocaml" {>= "4.02.0" & < "4.08.0"}]
+  "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=47630f9fc99676f85e5b940cbea27b61"
+  checksum: "md5=d6e62fadc5b0eac266cbb35c3ac898ed"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://gitlab.inria.fr/tmartine/clangml/issues"
 license: "BSD"
 dev-repo: "git+https://gitlab.inria.fr/tmartine/clangml.git"
 build: [
-  ["./configure_with_log.sh %{prefix}%"]
+  ["./configure_with_log.sh" "%{prefix}%"]
   ["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "stdcompat"
@@ -21,5 +21,5 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=920d2ac42c762bbed9f45101efda7c3a"
+  checksum: "md5=6cb09cfefd8500e755b8417d601090ab"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Clang API"
+description: "clangml provides bindings to call the Clang API from OCaml."
+maintainer: "Thierry Martinez <Thierry.Martinez@inria.fr>"
+authors: "Thierry Martinez <Thierry.Martinez@inria.fr>"
+homepage: "https://gitlab.inria.fr/tmartine/clangml"
+bug-reports: "https://gitlab.inria.fr/tmartine/clangml/issues"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/clangml.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  ["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "stdcompat"
+  "conf-libclang"
+  "ppx_deriving"
+  "visitors"
+  "dune" {>= "1.2"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}]
+url {
+  src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
+  checksum: "md5=205fab1b9daaee5fafb4d888c8ff701a"
+}

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -17,7 +17,7 @@ depends: [
   "conf-zlib"
   "ppx_deriving"
   "visitors"
-  "dune" {>= "1.2"}
+  "dune" {build & >= "1.2"}
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -21,5 +21,5 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=391d506c54e64e95578726e5e11626fb"
+  checksum: "md5=b168532766944f04ec630bb4f4feaebd"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -13,11 +13,12 @@ build: [
 depends: [
   "stdcompat"
   "conf-libclang"
+  "conf-ncurses"
   "ppx_deriving"
   "visitors"
   "dune" {>= "1.2"}
   "ocaml" {>= "4.02.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=ac8dd2ff3894c316eefb171911a7f90f"
+  checksum: "md5=47630f9fc99676f85e5b940cbea27b61"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -19,5 +19,5 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=205fab1b9daaee5fafb4d888c8ff701a"
+  checksum: "md5=ac8dd2ff3894c316eefb171911a7f90f"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -21,5 +21,5 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=6cb09cfefd8500e755b8417d601090ab"
+  checksum: "md5=391d506c54e64e95578726e5e11626fb"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -21,5 +21,5 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=070116c90ec5b0e92cd400a194750dda"
+  checksum: "md5=f82c29bca8a8a9bd3f18aab574746ceb"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://gitlab.inria.fr/tmartine/clangml/issues"
 license: "BSD"
 dev-repo: "git+https://gitlab.inria.fr/tmartine/clangml.git"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
+  ["./configure_with_log.sh %{prefix}%"]
   ["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "stdcompat"
@@ -21,5 +21,5 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=f82c29bca8a8a9bd3f18aab574746ceb"
+  checksum: "md5=920d2ac42c762bbed9f45101efda7c3a"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://gitlab.inria.fr/tmartine/clangml/issues"
 license: "BSD"
 dev-repo: "git+https://gitlab.inria.fr/tmartine/clangml.git"
 build: [
-  ["./configure_with_log.sh" "%{prefix}%"]
+  ["./configure" "--prefix=%{prefix}%"]
   ["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "stdcompat"
@@ -21,5 +21,5 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=b168532766944f04ec630bb4f4feaebd"
+  checksum: "md5=fb83a82368b127ec7391a4ec7170511c"
 }

--- a/packages/clangml/clangml.4.0.0beta1/opam
+++ b/packages/clangml/clangml.4.0.0beta1/opam
@@ -14,11 +14,12 @@ depends: [
   "stdcompat"
   "conf-libclang"
   "conf-ncurses"
+  "conf-zlib"
   "ppx_deriving"
   "visitors"
   "dune" {>= "1.2"}
   "ocaml" {>= "4.04.0" & < "4.08.0"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/clangml/-/archive/v4.0.0beta1/clangml-v4.0.0beta1.tar.gz"
-  checksum: "md5=d6e62fadc5b0eac266cbb35c3ac898ed"
+  checksum: "md5=070116c90ec5b0e92cd400a194750dda"
 }

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["llvm"] {os-distribution = "macports" & os = "macos"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "debian"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
-  ["clang-dev" "llvm-dev"] {os-distribution = "alpine"}
+  ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
     {os-distribution = "fedora"}

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libclang-dev" "llvm-dev"] {os-distribution = "debian"}
   ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
-  ["clang-devel" "llvm-devel" "zlib-devel"] {os-distribution = "centos"}
+  ["clang-devel" "llvm-static" "zlib-devel"] {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
     {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}


### PR DESCRIPTION
First public release: complete rewriting of the library.
Bindings now call directly the libclang API by a C/OCaml interface.
Compatible with all versions of clang from 3.8.0 to 8.0.0(rc1).
**Edit:** Compatible with all versions of clang from 3.4 to 8.0.0(rc1). (Added compatibility for old versions to be able to compile on CentOS)