### PR TITLE
[new release] mirage-device (1.2.0)

### DIFF
--- a/packages/mirage-device/mirage-device.1.2.0/opam
+++ b/packages/mirage-device/mirage-device.1.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-device"
+doc: "https://mirage.github.io/mirage-device/"
+bug-reports: "https://github.com/mirage/mirage-device/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-device.git"
+synopsis: "Abstract devices for MirageOS"
+description: """
+mirage-device defines [Mirage_device.S][1], the signature for
+basic abstract devices for MirageOS and a pretty-printing function
+for device errors.
+
+[1]: https://mirage.github.io/mirage-device/Mirage_device.S.html
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-device/releases/download/v1.2.0/mirage-device-v1.2.0.tbz"
+  checksum: "md5=dac8ccb8064a728fbf55790f02d36b0d"
+}


### PR DESCRIPTION
Abstract devices for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-device">https://github.com/mirage/mirage-device</a>
- Documentation: <a href="https://mirage.github.io/mirage-device/">https://mirage.github.io/mirage-device/</a>

##### CHANGES:

- Port build to dune (@avsm)
- Upgrade opam metadata to 2.0 (@avsm)
- ocamldoc improvements (@avsm)
