### PR TITLE
Package satyrographos.0.0.1.4

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.1.4/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL3+"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "cmdliner"
+  "core"
+  "dune" {build}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving" {build}
+  "ppx_inline_test" {build}
+  "ppx_jane" {build}
+  (* "satysfi" {>= "0.0.3" & < "0.0.4"} *)
+  "uri" {>= "2.0.0"}
+  "yojson"
+]
+synopsis: "A naive package manager for SATySFi"
+description: """
+Satyrographos is a naive package manager for [SATySFi].
+It does nothing but compose installed files with OPAM.
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.1.4.tar.gz"
+  checksum: [
+    "md5=8a82e1ebae8c63014519c834fce1b27a"
+    "sha512=76615b62b14408cb2f00c08c82bd7e987d784355c2f6352a236d620161f7439e10ab3e48b33cf57aab2521a9a91f6fa27c0f2d74d25d2c48895c47d88499d353"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.1.4`
A naive package manager for SATySFi
Satyrographos is a naive package manager for [SATySFi].
It does nothing but compose installed files with OPAM.

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.0