### PR TITLE
win-error.1.0: remove bad `version` field from metadata

### DIFF
--- a/packages/win-error/win-error.1.0/opam
+++ b/packages/win-error/win-error.1.0/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 name: "win-error"
-version: "0.2"
 maintainer: "dave@recoil.org"
 authors: "David Scott"
 license: "ISC"

--- a/packages/win-error/win-error.1.0/opam
+++ b/packages/win-error/win-error.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "win-error"
 maintainer: "dave@recoil.org"
 authors: "David Scott"
 license: "ISC"


### PR DESCRIPTION
See [mirage/ocaml-win-error#6]

Signed-off-by: David Scott <dave@recoil.org>