### PR TITLE
6 packages from andersfugmann/ppx_protocol_conv at 3.1.3

### DIFF
--- a/packages/aws-s3/aws-s3.3.0.0/opam
+++ b/packages/aws-s3/aws-s3.3.0.0/opam
@@ -20,8 +20,8 @@ depends: [
   "digestif" {<= "0.5"}
   "xml-light"
   "yojson"
-  "ppx_protocol_conv_xml_light"
-  "ppx_protocol_conv_json"
+  "ppx_protocol_conv_xml_light" {<= "3.1.1"}
+  "ppx_protocol_conv_json" {<= "3.1.1"}
   "cmdliner"
 ]
 synopsis: "Ocaml library for accessing Amazon S3"

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
@@ -11,7 +11,7 @@ build: [
 version: "0.9.0"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "xml-light"
   "msgpck"
   "base" {< "v0.11"}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
@@ -11,7 +11,7 @@ build: [
 version: "1.0.0"
 depends: [
   "ocaml" {>= "4.04"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "xml-light"
   "msgpck"
   "base" {< "v0.11"}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.3/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "base" {< "v0.12"}
+  "dune" {build}
+  "ppxlib" {>= "0.3.0"}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis:
+  "Ppx for generating serialisation and de-serialisation functions of ocaml types"
+description: """
+Ppx_protocol_conv generates code to serialise and de-serialise
+types. The ppx itself does not contain any protocol specific code,
+but relies on 'drivers' that defines serialisation and
+de-serialisation of basic types and structures.
+
+Pre-defined drivers are available in separate packages:
+ppx_protocol_conv_json (Yojson.Safe.json)
+ppx_protocol_conv_msgpack (Msgpck.t)(Xml.xml)
+ppx_protocol_conv_xml-light (Xml.xml)
+ppx_protocol_conv_yaml (Yaml.t)"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/3.1.3.tar.gz"
+  checksum: [
+    "md5=891e1169b50d6ba3f08efea77e80ce3a"
+    "sha512=c1801c78dba94cd4c67aae5715c580e8a8d963bf064c1e45dffcebd50f13e1b2acf23a07e19231a22ed97970b1b42fb79dee27e6a14c9fc643815fddf6ceab6d"
+  ]
+}

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.2.0.0/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.2.0.0/opam
@@ -7,9 +7,9 @@ bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04"}
-  "ppx_protocol_conv" {>= "2.0.0"}
+  "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base" {< "v0.12"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "jbuilder" {build}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.0/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.0/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.0"}
-  "yojson"
+  "ppx_protocol_conv" {>= "3.1.0" & <= "3.1.1"}
+  "yojson" {< "1.6.0"}
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}
   "sexplib" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.1/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.1/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.1"}
-  "yojson"
+  "ppx_protocol_conv" {= "3.1.1"}
+  "yojson" {< "1.6.0"}
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}
   "sexplib" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.3/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {>= "3.1.3"}
+  "yojson" {>= "1.6.0"}
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Yojson.Safe.json)
+serialization and de-serialization using the yojson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/3.1.3.tar.gz"
+  checksum: [
+    "md5=891e1169b50d6ba3f08efea77e80ce3a"
+    "sha512=c1801c78dba94cd4c67aae5715c580e8a8d963bf064c1e45dffcebd50f13e1b2acf23a07e19231a22ed97970b1b42fb79dee27e6a14c9fc643815fddf6ceab6d"
+  ]
+}

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.0/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "ppx_protocol_conv" {>= "3.1.0"}
+  "ppx_protocol_conv" {>= "3.1.0" & <= "3.1.1"}
   "ezjsonm"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.1/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "ppx_protocol_conv" {>= "3.1.1"}
+  "ppx_protocol_conv" {= "3.1.1"}
   "ezjsonm"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.3/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "ppx_protocol_conv" {>= "3.1.3"}
+  "ezjsonm"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Jsonm driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Ezjson.value)
+serialization and de-serialization using the Ezjson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/3.1.3.tar.gz"
+  checksum: [
+    "md5=891e1169b50d6ba3f08efea77e80ce3a"
+    "sha512=c1801c78dba94cd4c67aae5715c580e8a8d963bf064c1e45dffcebd50f13e1b2acf23a07e19231a22ed97970b1b42fb79dee27e6a14c9fc643815fddf6ceab6d"
+  ]
+}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.2.0.0/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "2.0.0"}
+  "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base" {< "v0.12"}
   "msgpck"
   "jbuilder" {build}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.0/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.0"}
+  "ppx_protocol_conv" {>= "3.1.0" & <= "3.1.1"}
   "msgpck"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.1/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.1"}
+  "ppx_protocol_conv" {= "3.1.1"}
   "msgpck"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.3/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {>= "3.1.3"}
+  "msgpck"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "MessagePack driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for message pack (Msgpck.t)
+serialization and deserialization using the msgpck library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/3.1.3.tar.gz"
+  checksum: [
+    "md5=891e1169b50d6ba3f08efea77e80ce3a"
+    "sha512=c1801c78dba94cd4c67aae5715c580e8a8d963bf064c1e45dffcebd50f13e1b2acf23a07e19231a22ed97970b1b42fb79dee27e6a14c9fc643815fddf6ceab6d"
+  ]
+}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.2.0.0/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "2.0.0"}
+  "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base" {< "v0.12"}
   "xml-light"
   "jbuilder" {build}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.0/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.0"}
+  "ppx_protocol_conv" {>= "3.1.0" & <= "3.1.1"}
   "xml-light"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.1/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.1"}
+  "ppx_protocol_conv" {= "3.1.1"}
   "xml-light"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.3/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {>= "3.1.3"}
+  "xml-light"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Xml driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for xml (Xml.t) serialization and
+de-serialization using the xml-light library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/3.1.3.tar.gz"
+  checksum: [
+    "md5=891e1169b50d6ba3f08efea77e80ce3a"
+    "sha512=c1801c78dba94cd4c67aae5715c580e8a8d963bf064c1e45dffcebd50f13e1b2acf23a07e19231a22ed97970b1b42fb79dee27e6a14c9fc643815fddf6ceab6d"
+  ]
+}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.2.0.0/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.2.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "2.0.0"}
+  "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base" {< "v0.12"}
   "yaml"
   "jbuilder" {build}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.0/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.0"}
+  "ppx_protocol_conv" {>= "3.1.0" & <= "3.1.1"}
   "yaml"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.1/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.1"}
+  "ppx_protocol_conv" {= "3.1.1"}
   "yaml"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.3/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {>= "3.1.3"}
+  "yaml"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Yojson.Safe.json)
+serialization and de-serialization using the yojson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/3.1.3.tar.gz"
+  checksum: [
+    "md5=891e1169b50d6ba3f08efea77e80ce3a"
+    "sha512=c1801c78dba94cd4c67aae5715c580e8a8d963bf064c1e45dffcebd50f13e1b2acf23a07e19231a22ed97970b1b42fb79dee27e6a14c9fc643815fddf6ceab6d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ppx_protocol_conv.3.1.3`: Ppx for generating serialisation and de-serialisation functions of ocaml types
-`ppx_protocol_conv_json.3.1.3`: Json driver for Ppx_protocol_conv
-`ppx_protocol_conv_jsonm.3.1.3`: Jsonm driver for Ppx_protocol_conv
-`ppx_protocol_conv_msgpack.3.1.3`: MessagePack driver for Ppx_protocol_conv
-`ppx_protocol_conv_xml_light.3.1.3`: Xml driver for Ppx_protocol_conv
-`ppx_protocol_conv_yaml.3.1.3`: Json driver for Ppx_protocol_conv



---
* Homepage: https://github.com/andersfugmann/ppx_protocol_conv
* Source repo: git+https://github.com/andersfugmann/ppx_protocol_conv
* Bug tracker: https://github.com/andersfugmann/ppx_protocol_conv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0