### PR TITLE
Add upper bounds to reverse dependencies of Jane Street packages

### DIFF
--- a/packages/biocaml/biocaml.0.9.0/opam
+++ b/packages/biocaml/biocaml.0.9.0/opam
@@ -41,8 +41,8 @@ depends: [
   "uri"
 ]
 depopts: [
-  "async" {< "v0.12"}
-  "core" {< "v0.12"}
+  "async"
+  "core"
   "lwt"
 ]
 conflicts: [

--- a/packages/biocaml/biocaml.0.9.0/opam
+++ b/packages/biocaml/biocaml.0.9.0/opam
@@ -41,8 +41,8 @@ depends: [
   "uri"
 ]
 depopts: [
-  "async"
-  "core"
+  "async" {< "v0.12"}
+  "core" {< "v0.12"}
   "lwt"
 ]
 conflicts: [

--- a/packages/charrua-core/charrua-core.0.11.2/opam
+++ b/packages/charrua-core/charrua-core.0.11.2/opam
@@ -15,12 +15,12 @@ build: [
 
 depends: [
   "dune" {build & >= "1.0"}
-  "ppx_sexp_conv"
-  "ppx_cstruct"  
+  "ppx_sexp_conv" {< "v0.12"}
+  "ppx_cstruct"
   "menhir"        {build}
   "ocaml"         {>= "4.0.3"}
   "cstruct"       {>= "3.0.1"}
-  "sexplib"
+  "sexplib"       {< "v0.12"}
   "ipaddr"        {>= "3.0.0"}
   "macaddr"
   "ethernet"

--- a/packages/cohttp-async/cohttp-async.2.0.0/opam
+++ b/packages/cohttp-async/cohttp-async.2.0.0/opam
@@ -25,18 +25,18 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {build & >= "1.1.0"}
-  "async_kernel" {>= "v0.11.0"}
-  "async_unix" {>= "v0.11.0"}
-  "async_extra" {>= "v0.11.0"}
-  "base" {>= "v0.11.0"}
-  "core" {with-test}
+  "async_kernel" {>= "v0.11.0" & < "v0.12"}
+  "async_unix" {>= "v0.11.0" & < "v0.12"}
+  "async_extra" {>= "v0.11.0" & < "v0.12"}
+  "base" {>= "v0.11.0" & < "v0.12"}
+  "core" {with-test & < "v0.12"}
   "cohttp"
   "conduit-async" {>="1.2.0"}
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
-  "sexplib0"
-  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0" {< "v0.12"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "ounit" {with-test}
   "uri" {>= "2.0.0"}
 ]

--- a/packages/cohttp-lwt/cohttp-lwt.2.0.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.2.0.0/opam
@@ -29,8 +29,8 @@ depends: [
   "dune" {build & >= "1.1.0"}
   "cohttp" {>= "1.0.0"}
   "lwt" {>= "2.5.0"}
-  "sexplib0"
-  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0" {< "v0.12"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "logs"
 ]
 build: [

--- a/packages/cohttp/cohttp.2.0.0/opam
+++ b/packages/cohttp/cohttp.2.0.0/opam
@@ -36,10 +36,10 @@ depends: [
   "dune" {build & >= "1.1.0"}
   "re" {>= "1.7.2"}
   "uri" {>= "2.0.0"}
-  "fieldslib"
-  "sexplib0"
-  "ppx_fields_conv" {>= "v0.9.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
+  "fieldslib" {< "v0.12"}
+  "sexplib0" {< "v0.12"}
+  "ppx_fields_conv" {>= "v0.9.0" & < "v0.12"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "stringext"
   "base64" {>= "3.1.0"}
   "fmt" {with-test}

--- a/packages/dns-async/dns-async.1.1.1/opam
+++ b/packages/dns-async/dns-async.1.1.1/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
   "dns"
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.12"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/dockerfile-cmd/dockerfile-cmd.6.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.1.0/opam
@@ -33,7 +33,7 @@ depends: [
   "fmt"
   "logs"
   "bos"
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/dockerfile/dockerfile.6.1.0/opam
+++ b/packages/dockerfile/dockerfile.6.1.0/opam
@@ -28,8 +28,8 @@ bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {build}
-  "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib"
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
+  "sexplib" {< "v0.12"}
   "fmt"
 ]
 build: [

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
@@ -12,10 +12,10 @@ depends: [
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "jsonm" {>= "0.9.1"}
-  "sexplib"
+  "sexplib" {< "v0.12"}
   "hex"
   "lwt" {>= "2.5.0"}
-  "ppx_sexp_conv" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ezjsonm/ezjsonm.1.0.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "jsonm" {>= "0.9.1"}
-  "sexplib"
+  "sexplib" {< "v0.12"}
   "hex"
 ]
 build: [

--- a/packages/faraday-async/faraday-async.0.7.0/opam
+++ b/packages/faraday-async/faraday-async.0.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "faraday" {>= "0.5.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.12"}
 ]
 synopsis: "Async support for Faraday"
 url {

--- a/packages/gemini/gemini.0.2.0/opam
+++ b/packages/gemini/gemini.0.2.0/opam
@@ -16,22 +16,22 @@ build: [
 doc: "https://struktured.github.io/ocaml-gemini/"
 depends: [
   "ocaml" {>= "4.06.1"}
-  "async" {>= "v0.11.0"}
-  "core" {>= "v0.11.1"}
-  "async_ssl"
+  "async" {>= "v0.11.0" & < "v0.12"}
+  "core" {>= "v0.11.1" & < "v0.12"}
+  "async_ssl" {< "v0.12"}
   "cohttp-async"
   "dune" {build}
-  "ppx_jane"
+  "ppx_jane" {< "v0.12"}
   "uri"
   "hex"
   "yojson"
   "zarith"
   "nocrypto"
   "ppx_deriving_yojson"
-  "ppx_csv_conv"
-  "csvfields"
+  "ppx_csv_conv" {< "v0.12"}
+  "csvfields" {< "v0.12"}
   "websocket-async"
-  "expect_test_helpers"
+  "expect_test_helpers" {< "v0.12"}
 ]
 url {
   src:

--- a/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "diet" {with-test}
   "fmt" {with-test}
   "ppx_tools" {with-test}
-  "ppx_sexp_conv" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
   "ppx_type_conv" {with-test}
 ]
 build: [

--- a/packages/mirage-net-macosx/mirage-net-macosx.1.5.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"  {build & >= "1.0"}
   "cstruct" {>= "1.4.0"}
   "macaddr"
-  "sexplib"
+  "sexplib" {< "v0.12"}
   "logs"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/netchannel/netchannel.1.9.0/opam
+++ b/packages/netchannel/netchannel.1.9.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune"  {build & >= "1.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
   "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
@@ -24,7 +24,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "mirage-profile" {>="0.3"}
   "shared-memory-ring" {>="3.0.0"}
-  "sexplib" {>= "113.01.00"}
+  "sexplib" {>= "113.01.00" & < "v0.12"}
   "logs" {>= "0.5.0"}
   "rresult"
 ]

--- a/packages/pcre/pcre.7.4.0/opam
+++ b/packages/pcre/pcre.7.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "dune" {build & >= "1.4.0"}
   "conf-libpcre" {build}
-  "base" {build}
+  "base" {build & < "v0.12"}
   "base-bytes"
 ]
 

--- a/packages/pkcs11/pkcs11.0.18.0/opam
+++ b/packages/pkcs11/pkcs11.0.18.0/opam
@@ -18,7 +18,7 @@ depends: [
   "integers"
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }
-  "ppx_variants_conv"
+  "ppx_variants_conv" {< "v0.12"}
   "zarith"
   "ocaml" {>= "4.04.0"}
   "ounit" {with-test}

--- a/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "base-bytes"
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt" {>= "3.0.0"}
-  "sexplib" {> "113.00.00"}
+  "sexplib" {> "113.00.00" & < "v0.12"}
   "prometheus"
   "rresult"
   "mirage-flow-lwt"
@@ -25,7 +25,7 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page-unix" {>= "2.0.0"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [

--- a/packages/protocol-9p-unix/protocol-9p-unix.1.0.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.1.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "base-bytes"
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt" {>= "3.0.0"}
-  "sexplib" {> "113.00.00"}
+  "sexplib" {> "113.00.00" & < "v0.12"}
   "prometheus"
   "rresult"
   "mirage-flow-lwt"
@@ -25,7 +25,7 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page-unix" {>= "2.0.0"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [

--- a/packages/protocol-9p/protocol-9p.1.0.0/opam
+++ b/packages/protocol-9p/protocol-9p.1.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "base-bytes"
   "cstruct" {>= "3.0.0"}
-  "sexplib" {> "113.00.00"}
+  "sexplib" {> "113.00.00" & < "v0.12"}
   "rresult"
   "mirage-flow-lwt"
   "mirage-kv-lwt"
@@ -20,7 +20,7 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [

--- a/packages/protocol-9p/protocol-9p.1.0.1/opam
+++ b/packages/protocol-9p/protocol-9p.1.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "base-bytes"
   "cstruct" {>= "3.0.0"}
-  "sexplib" {> "113.00.00"}
+  "sexplib" {> "113.00.00" & < "v0.12"}
   "rresult"
   "mirage-flow-lwt"
   "mirage-kv-lwt"
@@ -20,7 +20,7 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [

--- a/packages/satyrographos/satyrographos.0.0.1.4/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.4/opam
@@ -15,13 +15,13 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "cmdliner"
-  "core"
+  "core" {< "v0.12"}
   "dune" {build}
   "fileutils"
   "json-derivers"
   "ppx_deriving" {build}
-  "ppx_inline_test" {build}
-  "ppx_jane" {build}
+  "ppx_inline_test" {build & < "v0.12"}
+  "ppx_jane" {build & < "v0.12"}
   (* "satysfi" {>= "0.0.3" & < "0.0.4"} *)
   "uri" {>= "2.0.0"}
   "yojson"

--- a/packages/tensorflow/tensorflow.0.0.11/opam
+++ b/packages/tensorflow/tensorflow.0.0.11/opam
@@ -18,7 +18,7 @@ depends: [
   "libtensorflow"
   "ocaml" {>= "4.06"}
   "ocamlfind" {build}
-  "stdio"
+  "stdio" {< "v0.12"}
 ]
 
 depopts: [

--- a/packages/uri/uri.2.2.0/opam
+++ b/packages/uri/uri.2.2.0/opam
@@ -16,9 +16,9 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build & >= "1.2.0"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.12"}
   "re" {>= "1.7.2"}
-  "sexplib0"
+  "sexplib0" {< "v0.12"}
   "stringext" {>= "1.4.0"}
 ]
 build: [

--- a/packages/vchan-unix/vchan-unix.4.0.1/opam
+++ b/packages/vchan-unix/vchan-unix.4.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
   "ppx_cstruct"
   "io-page"
   "io-page-unix"
@@ -23,7 +23,7 @@ depends: [
   "xenstore_transport" {>= "1.0.0"}
   "xen-evtchn-unix"
   "xen-gnt-unix"
-  "sexplib"
+  "sexplib" {< "v0.12"}
   "cmdliner"
   "result"
   "ounit" {with-test}

--- a/packages/vchan-xen/vchan-xen.4.0.1/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.1/opam
@@ -14,14 +14,14 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.12"}
   "ppx_cstruct" {build}
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}
   "mirage-xen"
   "xenstore_transport" {>= "1.0.0"}
-  "sexplib"
+  "sexplib" {< "v0.12"}
   "cmdliner"
   "result"
   "ounit" {with-test}

--- a/packages/vchan/vchan.4.0.1/opam
+++ b/packages/vchan/vchan.4.0.1/opam
@@ -18,13 +18,13 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.12"}
   "ppx_cstruct"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport" {>= "1.0.0"}
-  "sexplib"
+  "sexplib" {< "v0.12"}
   "cmdliner"
   "result"
   "ounit" {with-test}


### PR DESCRIPTION
Follow-up to https://github.com/ocaml/opam-repository/pull/13010, https://github.com/ocaml/opam-repository/pull/13016, https://github.com/ocaml/opam-repository/pull/13107, and https://github.com/ocaml/opam-repository/pull/13344.