### PR TITLE
[new release] xen-evtchn-unix and xen-evtchn (2.1.0)

### DIFF
--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Vincent Hanquez" "Anil Madhavapeddy" "David Scott" "Jonathan Ludlam"
+]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-evtchn"
+bug-reports: "https://github.com/mirage/ocaml-evtchn/issues"
+doc: "https://mirage.github.io/ocaml-evtchn/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "xen-evtchn" {>="2.0.0"}
+  "lwt-dllist"
+  "lwt"
+  "cmdliner"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: [
+  ["xen-dev"] {os-distribution = "alpine"}
+  ["libxen-dev"] {os-distribution = "debian"}
+  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["xen-devel"] {os-distribution = "centos"}
+  ["xen-devel"] {os-distribution = "fedora"}
+  ["xenstore"] {os-distribution = "archlinux"}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-evtchn.git"
+synopsis: "Xen event channel interface for Linux"
+description: """
+Event channels are the Xen equivalent of interrupts, used to signal
+when data (or space) is available for processing. This implementation
+is a binding to a set of libxc functions which access `/dev/xen/evtchn`
+for userspace.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-evtchn/releases/download/v2.1.0/xen-evtchn-v2.1.0.tbz"
+  checksum: "md5=5df050f2aaca4cc9d006042633277dbd"
+}

--- a/packages/xen-evtchn/xen-evtchn.2.1.0/opam
+++ b/packages/xen-evtchn/xen-evtchn.2.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Vincent Hanquez" "Anil Madhavapeddy" "David Scott" "Jonathan Ludlam"
+]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-evtchn"
+doc: "https://mirage.github.io/ocaml-evtchn/"
+bug-reports: "https://github.com/mirage/ocaml-evtchn/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "lwt"
+  "lwt-dllist"
+  "cmdliner"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-evtchn.git"
+synopsis: "Xen event channel interface for MirageOS"
+description: """
+Event channels are the Xen equivalent of interrupts, used to signal
+when data (or space) is available for processing. There are 2 distinct
+implementations:
+
+  1. a Xen shared-memory + hypercall protocol for kernelspace
+  2. a binding to a set of libxc functions which access /dev/xen/evtchn
+     for userspace (see `xen-evtchn-unix` opam package).
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-evtchn/releases/download/v2.1.0/xen-evtchn-v2.1.0.tbz"
+  checksum: "md5=5df050f2aaca4cc9d006042633277dbd"
+}


### PR DESCRIPTION
Xen event channel interface for Linux

- Project page: <a href="https://github.com/mirage/ocaml-evtchn">https://github.com/mirage/ocaml-evtchn</a>
- Documentation: <a href="https://mirage.github.io/ocaml-evtchn/">https://mirage.github.io/ocaml-evtchn/</a>

##### CHANGES:

* Port to dune from jbuilder (@avsm)
* Use `lwt-dllist` instead of deprecated `Lwt_sequence` (@avsm)
* Upgrade opam metadata to 2.0 format (@avsm)
