### PR TITLE
Prevent yojson 1.4.x from building with dune > 1.7

### DIFF
--- a/packages/yojson/yojson.1.4.0/opam
+++ b/packages/yojson/yojson.1.4.0/opam
@@ -15,6 +15,9 @@ depends: [
   "easy-format"
   "biniou" {>= "1.2.0"}
 ]
+conflicts: [
+  "dune" {>= "1.7.0"}
+]
 synopsis:
   "Yojson is an optimized parsing and printing library for the JSON format"
 description: """

--- a/packages/yojson/yojson.1.4.1/opam
+++ b/packages/yojson/yojson.1.4.1/opam
@@ -15,6 +15,9 @@ depends: [
   "easy-format"
   "biniou" {>= "1.2.0"}
 ]
+conflicts: [
+  "dune" {>= "1.7.0"}
+]
 synopsis:
   "Yojson is an optimized parsing and printing library for the JSON format"
 description: """


### PR DESCRIPTION
The deprecations in dune 1.7 cause failures to build in yojson 1.4 (though not older versions, 1.3.0 works fine). It also works with newer versions, like 1.5 or 1.6.

Here's a Dockerfile + output which reproduces the issue: https://gist.github.com/Leonidas-from-XIV/ad89a093ded4835f96707ec382bee96f