### PR TITLE
Package resource-pooling.0.7

### DIFF
--- a/packages/resource-pooling/resource-pooling.0.7/opam
+++ b/packages/resource-pooling/resource-pooling.0.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jan Rochel <jan@besport.com>"
+authors: [ "Jan Rochel (BeSport)" ]
+synopsis: "Library for pooling resources like connections, threads, or similar"
+description: "This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool."
+license: "MIT"
+homepage: "https://github.com/ocsigen/resource-pooling"
+dev-repo: "git+https://github.com/ocsigen/resource-pooling.git"
+bug-reports: "https://github.com/ocsigen/resource-pooling/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "resource-pooling"]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "lwt" {>= "2.4.7"}
+  "lwt_log"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+flags: light-uninstall
+url {
+  src: "https://github.com/ocsigen/resource-pooling/archive/0.7.tar.gz"
+  checksum: [
+    "md5=9e59d90be170657b191460ec1cdb3519"
+    "sha512=8de716970b648e3e426d012b5182a6cce87300ac738d93b8d6f3bb03cabb667d328efccd5050bdb82a664052f8236bf76e6ee42fee93983f9cf087d14da51e60"
+  ]
+}


### PR DESCRIPTION
### `resource-pooling.0.7`
Library for pooling resources like connections, threads, or similar
This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool.



---
* Homepage: https://github.com/ocsigen/resource-pooling
* Source repo: git+https://github.com/ocsigen/resource-pooling.git
* Bug tracker: https://github.com/ocsigen/resource-pooling/issues

---
:camel: Pull-request generated by opam-publish v2.0.0