### PR TITLE
fix hg & darcs dev-repo format

### DIFF
--- a/packages/bindlib/bindlib.4.0.2/opam
+++ b/packages/bindlib/bindlib.4.0.2/opam
@@ -6,7 +6,7 @@ authors:
     "Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>" ]
 homepage: "http://lama.univ-savoie.fr/~raffalli/bindlib"
 license: "LGPL-3.0"
-dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/bindlib/repos"
+dev-repo: "darcs+https://lama.univ-savoie.fr/~raffalli/bindlib/repos"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "bindlib"]

--- a/packages/bindlib/bindlib.4.0.3/opam
+++ b/packages/bindlib/bindlib.4.0.3/opam
@@ -6,7 +6,7 @@ authors:
     "Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>" ]
 homepage: "http://lama.univ-savoie.fr/~raffalli/bindlib"
 license: "LGPL-3.0"
-dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/bindlib/repos"
+dev-repo: "darcs+https://lama.univ-savoie.fr/~raffalli/bindlib/repos"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "bindlib"]

--- a/packages/bindlib/bindlib.4.0/opam
+++ b/packages/bindlib/bindlib.4.0/opam
@@ -8,7 +8,7 @@ authors:
     "Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>" ]
 homepage: "http://lama.univ-savoie.fr/~raffalli/bindlib"
 license: "LGPL-3.0"
-dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/bindlib/repos"
+dev-repo: "darcs+https://lama.univ-savoie.fr/~raffalli/bindlib/repos"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "bindlib"]

--- a/packages/camlimages/camlimages.4.0.1/opam
+++ b/packages/camlimages/camlimages.4.0.1/opam
@@ -25,7 +25,7 @@ conflicts: [
   "lablgtk" { >= "2.18.6" }
 ]
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 homepage: "http://cristal.inria.fr/camlimages/"
 install: [
   [ "omake" "install" ]

--- a/packages/camlimages/camlimages.4.0.2/opam
+++ b/packages/camlimages/camlimages.4.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "omake" {build}
 ]
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 depopts: [
   "lablgtk"
 ]

--- a/packages/camlimages/camlimages.4.1.0/opam
+++ b/packages/camlimages/camlimages.4.1.0/opam
@@ -7,7 +7,7 @@ authors: [
   "Pierre Weis"
 ]
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 homepage: "http://cristal.inria.fr/camlimages/"
 license: "LGPL-2 with OCaml linking exception"
 build: [

--- a/packages/camlimages/camlimages.4.1.1/opam
+++ b/packages/camlimages/camlimages.4.1.1/opam
@@ -20,7 +20,7 @@ depends: [
   "omake" {build}
 ]
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 depopts: [
   "lablgtk"
 ]

--- a/packages/camlimages/camlimages.4.1.2/opam
+++ b/packages/camlimages/camlimages.4.1.2/opam
@@ -14,7 +14,7 @@ remove: [
   [ "ocamlfind" "remove" "camlimages" ]
 ]
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 depends: [
   "ocaml" {>= "4.00.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/camlimages/camlimages.4.2.0/opam
+++ b/packages/camlimages/camlimages.4.2.0/opam
@@ -21,7 +21,7 @@ conflicts: [
 homepage: "http://cristal.inria.fr/camlimages/"
 license: "LGPL-2 with OCaml linking exception"
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 authors: [
   "Jun Furuse"
   "Fran\195\167ois Pessaux"

--- a/packages/camlimages/camlimages.4.2.1/opam
+++ b/packages/camlimages/camlimages.4.2.1/opam
@@ -24,7 +24,7 @@ conflicts: [
 homepage: "http://cristal.inria.fr/camlimages/"
 license: "LGPL-2 with OCaml linking exception"
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 authors: [
   "Jun Furuse"
   "Fran\195\167ois Pessaux"

--- a/packages/camlimages/camlimages.4.2.2/opam
+++ b/packages/camlimages/camlimages.4.2.2/opam
@@ -8,7 +8,7 @@ authors: [
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://cristal.inria.fr/camlimages/"
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 build: [
   [ "omake" "--configure" ]
 ]

--- a/packages/camlimages/camlimages.4.2.3/opam
+++ b/packages/camlimages/camlimages.4.2.3/opam
@@ -8,7 +8,7 @@ authors: [
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://cristal.inria.fr/camlimages/"
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 build: [
   [ "omake" "--configure" ]
 ]

--- a/packages/camlimages/camlimages.4.2.4/opam
+++ b/packages/camlimages/camlimages.4.2.4/opam
@@ -8,7 +8,7 @@ authors: [
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://cristal.inria.fr/camlimages/"
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 build: [
   [ "omake" "--configure" ]
 ]

--- a/packages/camlimages/camlimages.4.2.6/opam
+++ b/packages/camlimages/camlimages.4.2.6/opam
@@ -8,7 +8,7 @@ authors: [
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/camlimages"
 bug-reports: "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 build: [
   [ "omake" "--configure" ]
 ]

--- a/packages/camlimages/camlimages.5.0.0/opam
+++ b/packages/camlimages/camlimages.5.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://bitbucket.org/camlspotter/camlimages"
 bug-reports:
   "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
 license: "LGPL-2 with OCaml linking exception"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06.0"}

--- a/packages/camlimages/camlimages.5.0.1/opam
+++ b/packages/camlimages/camlimages.5.0.1/opam
@@ -6,7 +6,7 @@ homepage: "https://bitbucket.org/camlspotter/camlimages"
 bug-reports:
   "https://bitbucket.org/camlspotter/camlimages/issues?status=new&status=open"
 license: "LGPL-2 with OCaml linking exception"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlimages"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlimages"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06.0"}

--- a/packages/camlon/camlon.1.0.0/opam
+++ b/packages/camlon/camlon.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/camlon"
 bug-reports: "https://bitbucket.org/camlspotter/camlon/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlon"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlon"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/camlon/camlon.1.0.1/opam
+++ b/packages/camlon/camlon.1.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/camlon"
 bug-reports: "https://bitbucket.org/camlspotter/camlon/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlon"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlon"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/camlon/camlon.1.0.2/opam
+++ b/packages/camlon/camlon.1.0.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/camlon"
 bug-reports: "https://bitbucket.org/camlspotter/camlon/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlon"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlon"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/camlon/camlon.2.0.0/opam
+++ b/packages/camlon/camlon.2.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/camlon"
 bug-reports: "https://bitbucket.org/camlspotter/camlon/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlon"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlon"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/camlon/camlon.2.0.1/opam
+++ b/packages/camlon/camlon.2.0.1/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/camlon"
 bug-reports:
   "https://bitbucket.org/camlspotter/camlon/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlon"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlon"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/camlon/camlon.2.0.2/opam
+++ b/packages/camlon/camlon.2.0.2/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/camlon"
 bug-reports:
   "https://bitbucket.org/camlspotter/camlon/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/camlon"
+dev-repo: "hg+https://bitbucket.org/camlspotter/camlon"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/charInfo_width/charInfo_width.0.1.0/opam
+++ b/packages/charInfo_width/charInfo_width.0.1.0/opam
@@ -4,7 +4,7 @@ authors: [ "ZAN DoYe" ]
 homepage: "https://bitbucket.org/zandoye/charinfo_width/"
 bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
 license: "MIT"
-dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
+dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/charInfo_width/charInfo_width.1.0.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.0.0/opam
@@ -4,7 +4,7 @@ authors: [ "ZAN DoYe" ]
 homepage: "https://bitbucket.org/zandoye/charinfo_width/"
 bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
 license: "MIT"
-dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
+dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}

--- a/packages/charInfo_width/charInfo_width.1.1.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.1.0/opam
@@ -4,7 +4,7 @@ authors: [ "ZAN DoYe" ]
 homepage: "https://bitbucket.org/zandoye/charinfo_width/"
 bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
 license: "MIT"
-dev-repo: "hg://https://bitbucket.org/zandoye/charinfo_width"
+dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}

--- a/packages/dune_watch/dune_watch.0.0.1/opam
+++ b/packages/dune_watch/dune_watch.0.0.1/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/dune_watch/"
 bug-reports:
   "https://bitbucket.org/camlspotter/dune_watch/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/dune_watch"
+dev-repo: "hg+https://bitbucket.org/camlspotter/dune_watch"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}

--- a/packages/dune_watch/dune_watch.0.1.0/opam
+++ b/packages/dune_watch/dune_watch.0.1.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/dune_watch/"
 bug-reports:
   "https://bitbucket.org/camlspotter/dune_watch/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/dune_watch"
+dev-repo: "hg+https://bitbucket.org/camlspotter/dune_watch"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}

--- a/packages/dune_watch/dune_watch.0.2.0/opam
+++ b/packages/dune_watch/dune_watch.0.2.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/dune_watch/"
 bug-reports:
   "https://bitbucket.org/camlspotter/dune_watch/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/dune_watch"
+dev-repo: "hg+https://bitbucket.org/camlspotter/dune_watch"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}

--- a/packages/gles3/gles3.20160307.alpha/opam
+++ b/packages/gles3/gles3.20160307.alpha/opam
@@ -8,7 +8,7 @@ authors:
 homepage: "http://lama.univ-savoie.fr/~raffalli/gles3"
 bug-reports: "raffalli@univ-savoie.fr"
 license: "LGPL-3.0"
-dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/gles3/repos"
+dev-repo: "darcs+https://lama.univ-savoie.fr/~raffalli/gles3/repos"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "gles3"]

--- a/packages/gles3/gles3.20160505.alpha/opam
+++ b/packages/gles3/gles3.20160505.alpha/opam
@@ -9,7 +9,7 @@ authors:
     "Alexandre Miquel<amiquel@fing.edu.uy>" ]
 homepage: "http://lama.univ-savoie.fr/~raffalli/gles3"
 license: "LGPL-3.0"
-dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/gles3/repos"
+dev-repo: "darcs+https://lama.univ-savoie.fr/~raffalli/gles3/repos"
 build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "gles3"]

--- a/packages/glsurf/glsurf.3.3.1/opam
+++ b/packages/glsurf/glsurf.3.3.1/opam
@@ -5,7 +5,7 @@ authors:
   [ "Christophe Raffalli <raffalli@univ-savoie.fr>" ]
 homepage: "http://lama.univ-savoie.fr/~raffalli/glsurf.html"
 license: "GPL-3.0"
-dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/glsurf/repos"
+dev-repo: "darcs+https://lama.univ-savoie.fr/~raffalli/glsurf/repos"
 build: [make]
 install: [make "install" "BINDIR=%{bin}%" "DOCDIR=%{doc}%"]
 remove: [

--- a/packages/glsurf/glsurf.3.3/opam
+++ b/packages/glsurf/glsurf.3.3/opam
@@ -7,7 +7,7 @@ authors:
   [ "Christophe Raffalli <raffalli@univ-savoie.fr>" ]
 homepage: "http://lama.univ-savoie.fr/~raffalli/glsurf.html"
 license: "GPL-3.0"
-dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/glsurf/repos"
+dev-repo: "darcs+https://lama.univ-savoie.fr/~raffalli/glsurf/repos"
 build: [make]
 install: [make "install" "BINDIR=%{bin}%"]
 remove: [rm "%{bin}%/glsurf"]

--- a/packages/imagelib/imagelib.20160413/opam
+++ b/packages/imagelib/imagelib.20160413/opam
@@ -4,7 +4,7 @@ authors: "Rodolphe Lepigre <rodolphe@lepigre.fr>"
 homepage: "http://patoline.org/tools.html"
 bug-reports: "Rodolphe Lepigre <rodolphe@lepigre.fr>"
 license: "LGPL-3.0"
-dev-repo: "darcs://patoline.org/darcs/imagelib"
+dev-repo: "darcs+https://patoline.org/darcs/imagelib"
 build: [make]
 install: [make "install"]
 remove: [make "uninstall"]

--- a/packages/levenshtein/levenshtein.1.0.0/opam
+++ b/packages/levenshtein/levenshtein.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocaml_levenshtein/"
 bug-reports: "https://bitbucket.org/camlspotter/ocaml_levenshtein/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocaml_levenshtein"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocaml_levenshtein"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/levenshtein/levenshtein.1.1.0/opam
+++ b/packages/levenshtein/levenshtein.1.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocaml_levenshtein/"
 bug-reports: "https://bitbucket.org/camlspotter/ocaml_levenshtein/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocaml_levenshtein"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocaml_levenshtein"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/levenshtein/levenshtein.1.1.1/opam
+++ b/packages/levenshtein/levenshtein.1.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocaml_levenshtein/"
 bug-reports: "https://bitbucket.org/camlspotter/ocaml_levenshtein/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocaml_levenshtein"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocaml_levenshtein"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/levenshtein/levenshtein.1.1.2/opam
+++ b/packages/levenshtein/levenshtein.1.1.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocaml_levenshtein/"
 bug-reports: "https://bitbucket.org/camlspotter/ocaml_levenshtein/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocaml_levenshtein"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocaml_levenshtein"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/levenshtein/levenshtein.1.1.3/opam
+++ b/packages/levenshtein/levenshtein.1.1.3/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/ocaml_levenshtein/"
 bug-reports:
   "https://bitbucket.org/camlspotter/ocaml_levenshtein/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocaml_levenshtein"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocaml_levenshtein"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.1"}

--- a/packages/meta_conv/meta_conv.1.1.5/opam
+++ b/packages/meta_conv/meta_conv.1.1.5/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/mmseg/mmseg.0.1.1/opam
+++ b/packages/mmseg/mmseg.0.1.1/opam
@@ -4,7 +4,7 @@ authors: [ "ZAN DoYe" ]
 homepage: "https://bitbucket.org/zandoye/mmseg/"
 bug-reports: "https://bitbucket.org/zandoye/mmseg/issues"
 license: "MIT"
-dev-repo: "hg://https://bitbucket.org/zandoye/mmseg"
+dev-repo: "hg+https://bitbucket.org/zandoye/mmseg"
 build: [
   [make]
   [make "doc"] {with-doc}

--- a/packages/objsize/objsize.0.16/opam
+++ b/packages/objsize/objsize.0.16/opam
@@ -3,7 +3,7 @@ maintainer: "ygrek@autistici.org"
 authors: [ "Dmitry Grebeniuk <gdsfh1@gmail.com>" "ygrek@autistici.org" ]
 homepage: "https://bitbucket.org/gds/objsize"
 bug-reports: "Dmitry Grebeniuk <gdsfh1@gmail.com>"
-dev-repo: "hg://https://bitbucket.org/gds/objsize"
+dev-repo: "hg+https://bitbucket.org/gds/objsize"
 build: [
   [make]
   [make "tests"] {with-test}

--- a/packages/objsize/objsize.0.17/opam
+++ b/packages/objsize/objsize.0.17/opam
@@ -3,7 +3,7 @@ maintainer: "ygrek@autistici.org"
 authors: [ "Dmitry Grebeniuk <gdsfh1@gmail.com>" "ygrek@autistici.org" ]
 homepage: "https://bitbucket.org/gds/objsize"
 bug-reports: "Dmitry Grebeniuk <gdsfh1@gmail.com>"
-dev-repo: "hg://https://bitbucket.org/gds/objsize"
+dev-repo: "hg+https://bitbucket.org/gds/objsize"
 build: [
   [make]
   [make "test"] {with-test}

--- a/packages/objsize/objsize.0.18/opam
+++ b/packages/objsize/objsize.0.18/opam
@@ -3,7 +3,7 @@ maintainer: "ygrek@autistici.org"
 authors: [ "Dmitry Grebeniuk <gdsfh1@gmail.com>" "ygrek@autistici.org" ]
 homepage: "https://bitbucket.org/gds/objsize"
 bug-reports: "Dmitry Grebeniuk <gdsfh1@gmail.com>"
-dev-repo: "hg://https://bitbucket.org/gds/objsize"
+dev-repo: "hg+https://bitbucket.org/gds/objsize"
 build: [
   [make]
   [make "test"] {with-test}

--- a/packages/ocamlmod/ocamlmod.0.0.7/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.7/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "opam-devel@lists.ocaml.org"
 homepage: "https://forge.ocamlcore.org/projects/ocamlmod/"
 bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=244"
-dev-repo: "darcs://https://forge.ocamlcore.org/anonscm/darcs/ocamlmod/ocamlmod"
+dev-repo: "darcs+https://forge.ocamlcore.org/anonscm/darcs/ocamlmod/ocamlmod"
 authors: [ "Sylvain Le Gall" ]
 license: "LGPL-2.1 with OCaml linking exception"
 build: [

--- a/packages/ocamlmod/ocamlmod.0.0.8/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.8/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "opam-devel@lists.ocaml.org"
 homepage: "https://forge.ocamlcore.org/projects/ocamlmod/"
 bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=244"
-dev-repo: "darcs://https://forge.ocamlcore.org/anonscm/darcs/ocamlmod/ocamlmod"
+dev-repo: "darcs+https://forge.ocamlcore.org/anonscm/darcs/ocamlmod/ocamlmod"
 authors: [ "Sylvain Le Gall" ]
 license: "LGPL-2.1 with OCaml linking exception"
 build: [

--- a/packages/ocamlmod/ocamlmod.0.0.9/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.9/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "opam-devel@lists.ocaml.org"
 homepage: "https://forge.ocamlcore.org/projects/ocamlmod/"
 bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=244"
-dev-repo: "darcs://https://forge.ocamlcore.org/anonscm/darcs/ocamlmod/ocamlmod"
+dev-repo: "darcs+https://forge.ocamlcore.org/anonscm/darcs/ocamlmod/ocamlmod"
 authors: [ "Sylvain Le Gall" ]
 license: "LGPL-2.1 with OCaml linking exception"
 build: [

--- a/packages/ocamlspot/ocamlspot.4.02.1.2.3.0/opam
+++ b/packages/ocamlspot/ocamlspot.4.02.1.2.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse <jun.furuse@gmail.com>"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocamlspot/"
 bug-reports: "https://bitbucket.org/camlspotter/ocamlspot/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocamlspot"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocamlspot"
 build: [
   [ make "all" "opt" "BINDIR=%{bin}%" "PREFIX=%{prefix}%" ]
 ]

--- a/packages/ocamlspot/ocamlspot.4.03.0.2.3.1/opam
+++ b/packages/ocamlspot/ocamlspot.4.03.0.2.3.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocamlspot/"
 bug-reports: "https://bitbucket.org/camlspotter/ocamlspot/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocamlspot"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocamlspot"
 build: [
   [ make "all" "opt" "BINDIR=%{bin}%" "PREFIX=%{prefix}%" ]
 ]

--- a/packages/ocamlspot/ocamlspot.4.04.0.2.3.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.04.0.2.3.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocamlspot/"
 bug-reports: "https://bitbucket.org/camlspotter/ocamlspot/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocamlspot"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocamlspot"
 build: [
   [ make "all" "opt" "BINDIR=%{bin}%" "PREFIX=%{prefix}%" ]
 ]

--- a/packages/ocamlspot/ocamlspot.4.05.0.2.3.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.05.0.2.3.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ocamlspot/"
 bug-reports: "https://bitbucket.org/camlspotter/ocamlspot/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocamlspot"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocamlspot"
 build: [
   [ make "all" "opt" "BINDIR=%{bin}%" "PREFIX=%{prefix}%" ]
 ]

--- a/packages/ocamlspot/ocamlspot.4.07.0.2.3.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.07.0.2.3.2/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/ocamlspot"
 bug-reports:
   "https://bitbucket.org/camlspotter/ocamlspot/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ocamlspot"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ocamlspot"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {= "4.07.0"}

--- a/packages/oni/oni.1.0.10/opam
+++ b/packages/oni/oni.1.0.10/opam
@@ -3,7 +3,7 @@ homepage: "https://bitbucket.org/jhw/oni"
 license: "BSD-2-Clause"
 authors: [ "james woodyatt <jhw@conjury.org>" ]
 maintainer: "james woodyatt <jhw@conjury.org>"
-dev-repo: "hg://https://bitbucket.org/jhw/oni"
+dev-repo: "hg+https://bitbucket.org/jhw/oni"
 bug-reports: "https://bitbucket.org/jhw/oni/issues"
 install: [["./etc/install.sh" "install"]]
 remove: [["./etc/install.sh" "remove"]]

--- a/packages/oni/oni.1.0.11/opam
+++ b/packages/oni/oni.1.0.11/opam
@@ -3,7 +3,7 @@ homepage: "https://bitbucket.org/jhw/oni"
 license: "BSD-2-Clause"
 authors: [ "james woodyatt <jhw@conjury.org>" ]
 maintainer: "james woodyatt <jhw@conjury.org>"
-dev-repo: "hg://https://bitbucket.org/jhw/oni"
+dev-repo: "hg+https://bitbucket.org/jhw/oni"
 bug-reports: "https://bitbucket.org/jhw/oni/issues"
 install: [["./etc/install.sh" "install"]]
 remove: [["./etc/install.sh" "remove"]]

--- a/packages/oni/oni.1.0.12/opam
+++ b/packages/oni/oni.1.0.12/opam
@@ -3,7 +3,7 @@ homepage: "https://bitbucket.org/jhw/oni"
 license: "BSD-2-Clause"
 authors: [ "james woodyatt <jhw@conjury.org>" ]
 maintainer: "james woodyatt <jhw@conjury.org>"
-dev-repo: "hg://https://bitbucket.org/jhw/oni"
+dev-repo: "hg+https://bitbucket.org/jhw/oni"
 bug-reports: "https://bitbucket.org/jhw/oni/issues"
 install: [["./etc/install.sh" "install"]]
 remove: [["./etc/install.sh" "remove"]]

--- a/packages/oni/oni.1.0.9/opam
+++ b/packages/oni/oni.1.0.9/opam
@@ -3,7 +3,7 @@ homepage: "https://bitbucket.org/jhw/oni"
 license: "BSD-2-Clause"
 authors: [ "james woodyatt <jhw@conjury.org>" ]
 maintainer: "james woodyatt <jhw@conjury.org>"
-dev-repo: "hg://https://bitbucket.org/jhw/oni"
+dev-repo: "hg+https://bitbucket.org/jhw/oni"
 bug-reports: "https://bitbucket.org/jhw/oni/issues"
 install: [["./etc/install.sh" "install"]]
 remove: [["./etc/install.sh" "remove"]]

--- a/packages/opamfind/opamfind.1.0.0/opam
+++ b/packages/opamfind/opamfind.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/opamfind/"
 bug-reports: "https://bitbucket.org/camlspotter/opamfind/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/opamfind"
+dev-repo: "hg+https://bitbucket.org/camlspotter/opamfind"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/opamfind/opamfind.1.1.0/opam
+++ b/packages/opamfind/opamfind.1.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/opamfind/"
 bug-reports: "https://bitbucket.org/camlspotter/opamfind/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/opamfind"
+dev-repo: "hg+https://bitbucket.org/camlspotter/opamfind"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/opamfind/opamfind.1.1.1/opam
+++ b/packages/opamfind/opamfind.1.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/opamfind/"
 bug-reports: "https://bitbucket.org/camlspotter/opamfind/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/opamfind"
+dev-repo: "hg+https://bitbucket.org/camlspotter/opamfind"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/opamfind/opamfind.1.1.2/opam
+++ b/packages/opamfind/opamfind.1.1.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/opamfind/"
 bug-reports: "https://bitbucket.org/camlspotter/opamfind/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/opamfind"
+dev-repo: "hg+https://bitbucket.org/camlspotter/opamfind"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/opamfind/opamfind.1.1.3/opam
+++ b/packages/opamfind/opamfind.1.1.3/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/opamfind/"
 bug-reports: "https://bitbucket.org/camlspotter/opamfind/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/opamfind"
+dev-repo: "hg+https://bitbucket.org/camlspotter/opamfind"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/opamfind/opamfind.1.2.0/opam
+++ b/packages/opamfind/opamfind.1.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/opamfind/"
 bug-reports: "https://bitbucket.org/camlspotter/opamfind/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/opamfind"
+dev-repo: "hg+https://bitbucket.org/camlspotter/opamfind"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/opencc/opencc.0.4.3-0.1.1/opam
+++ b/packages/opencc/opencc.0.4.3-0.1.1/opam
@@ -8,7 +8,7 @@ tags: [
   "opencc"
   "Chinese conversion"
 ]
-dev-repo: "hg://https://bitbucket.org/zandoye/ocaml-opencc"
+dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-opencc"
 build: [
   [make]
 ]

--- a/packages/opencc/opencc.transition/opam
+++ b/packages/opencc/opencc.transition/opam
@@ -8,7 +8,7 @@ tags: [
   "opencc"
   "Chinese conversion"
 ]
-dev-repo: "hg://https://bitbucket.org/zandoye/ocaml-opencc1"
+dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-opencc1"
 depends: [
   "ocaml"
   "opencc1"

--- a/packages/opencc0/opencc0.1.0.2/opam
+++ b/packages/opencc0/opencc0.1.0.2/opam
@@ -8,7 +8,7 @@ tags: [
   "opencc"
   "Chinese conversion"
 ]
-dev-repo: "hg://https://bitbucket.org/zandoye/ocaml-opencc0"
+dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-opencc0"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opencc1/opencc1.1.0.1/opam
+++ b/packages/opencc1/opencc1.1.0.1/opam
@@ -8,7 +8,7 @@ tags: [
   "opencc"
   "Chinese conversion"
 ]
-dev-repo: "hg://https://bitbucket.org/zandoye/ocaml-opencc1"
+dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-opencc1"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/orakuda/orakuda.1.0.1/opam
+++ b/packages/orakuda/orakuda.1.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/orakuda/orakuda.1.0.2/opam
+++ b/packages/orakuda/orakuda.1.0.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/orakuda/orakuda.1.1.0/opam
+++ b/packages/orakuda/orakuda.1.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/orakuda/orakuda.1.1.1/opam
+++ b/packages/orakuda/orakuda.1.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/orakuda/orakuda.1.2.0/opam
+++ b/packages/orakuda/orakuda.1.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/orakuda/orakuda.1.2.1/opam
+++ b/packages/orakuda/orakuda.1.2.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/orakuda/orakuda.1.2.2/opam
+++ b/packages/orakuda/orakuda.1.2.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/orakuda/orakuda.2.0.0/opam
+++ b/packages/orakuda/orakuda.2.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/planck/planck.1.0.1/opam
+++ b/packages/planck/planck.1.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/planck/"
 bug-reports: "https://bitbucket.org/camlspotter/planck/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/planck"
+dev-repo: "hg+https://bitbucket.org/camlspotter/planck"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/planck/planck.2.0.1/opam
+++ b/packages/planck/planck.2.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/planck/"
 bug-reports: "https://bitbucket.org/camlspotter/planck/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/planck"
+dev-repo: "hg+https://bitbucket.org/camlspotter/planck"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/planck/planck.2.1.0/opam
+++ b/packages/planck/planck.2.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/planck/"
 bug-reports: "https://bitbucket.org/camlspotter/planck/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/planck"
+dev-repo: "hg+https://bitbucket.org/camlspotter/planck"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/planck/planck.2.1.1/opam
+++ b/packages/planck/planck.2.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/planck/"
 bug-reports: "https://bitbucket.org/camlspotter/planck/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/planck"
+dev-repo: "hg+https://bitbucket.org/camlspotter/planck"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/planck/planck.2.2.0/opam
+++ b/packages/planck/planck.2.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/planck/"
 bug-reports: "https://bitbucket.org/camlspotter/planck/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/planck"
+dev-repo: "hg+https://bitbucket.org/camlspotter/planck"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_curried_constr/ppx_curried_constr.1.0.0/opam
+++ b/packages/ppx_curried_constr/ppx_curried_constr.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_curried_constr"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_curried_constr/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_curried_constr"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_curried_constr"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_dotbracket/ppx_dotbracket.1.0.0/opam
+++ b/packages/ppx_dotbracket/ppx_dotbracket.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_dotbracket"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_dotbracket/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_dotbracket"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_dotbracket"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_implicits/ppx_implicits.0.1.0/opam
+++ b/packages/ppx_implicits/ppx_implicits.0.1.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_implicits/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_implicits"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_implicits"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_implicits/ppx_implicits.0.2.0/opam
+++ b/packages/ppx_implicits/ppx_implicits.0.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_implicits"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_implicits/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_implicits"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_implicits"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_implicits/ppx_implicits.0.3.0/opam
+++ b/packages/ppx_implicits/ppx_implicits.0.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_implicits"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_implicits/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_implicits"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_implicits"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_integer/ppx_integer.0.1.0/opam
+++ b/packages/ppx_integer/ppx_integer.0.1.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/ppx_integer"
 bug-reports:
   "https://bitbucket.org/camlspotter/ppx_integer/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_integer"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_integer"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.0.2/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.0.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.1.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.2.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.2.0/opam
@@ -3,7 +3,7 @@ version: "2.2.0"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.3.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.4.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.4.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.4.1/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.4.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.5.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.5.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.5.1/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.5.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.6.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.6.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.7.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.7.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.8.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.8.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.3.0.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.3.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.4.0.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.4.0.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/ppx_meta_conv"
 bug-reports:
   "https://bitbucket.org/camlspotter/ppx_meta_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_meta_conv"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_meta_conv"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}

--- a/packages/ppx_monadic/ppx_monadic.1.0.4/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.4/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_monadic"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_monadic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_monadic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_monadic/ppx_monadic.1.0.5/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.5/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_monadic"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_monadic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_monadic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_monadic/ppx_monadic.1.0.6/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.6/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_monadic"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_monadic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_monadic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_monadic/ppx_monadic.1.1.0/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_monadic"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_monadic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_monadic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_monadic/ppx_monadic.2.2.1/opam
+++ b/packages/ppx_monadic/ppx_monadic.2.2.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_monadic"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_monadic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_monadic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_monadic/ppx_monadic.2.2.2/opam
+++ b/packages/ppx_monadic/ppx_monadic.2.2.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_monadic"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_monadic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_monadic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_monadic/ppx_monadic.2.3.0/opam
+++ b/packages/ppx_monadic/ppx_monadic.2.3.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/ppx_monadic"
 bug-reports:
   "https://bitbucket.org/camlspotter/ppx_monadic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_monadic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_orakuda/ppx_orakuda.2.0.1/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.2.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.1/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.2/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.3/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.3/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.1.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.1.1/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.2.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports: "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_orakuda/ppx_orakuda.3.3.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.3.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/orakuda/"
 bug-reports:
   "https://bitbucket.org/camlspotter/orakuda/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/orakuda"
+dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}

--- a/packages/ppx_overload/ppx_overload.1.0.0/opam
+++ b/packages/ppx_overload/ppx_overload.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/compiler-libs-hack"
 bug-reports: "https://bitbucket.org/camlspotter/compiler-libs-hack/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/compiler-libs-hack"
+dev-repo: "hg+https://bitbucket.org/camlspotter/compiler-libs-hack"
 build: [
   [ make "install" "BINDIR=%{bin}%" ]
 ]

--- a/packages/ppx_overload/ppx_overload.1.0.1/opam
+++ b/packages/ppx_overload/ppx_overload.1.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/compiler-libs-hack"
 bug-reports: "https://bitbucket.org/camlspotter/compiler-libs-hack/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/compiler-libs-hack"
+dev-repo: "hg+https://bitbucket.org/camlspotter/compiler-libs-hack"
 build: [
   [ make "BINDIR=%{bin}%" ]
 ]

--- a/packages/ppx_overload/ppx_overload.1.4/opam
+++ b/packages/ppx_overload/ppx_overload.1.4/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: ["ocamlfind" "query" "ppx_overload"]
 depends: [
   "ocaml" {>= "4.05.0"}

--- a/packages/ppx_poly_record/ppx_poly_record.1.0.1/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.0.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "jun.furuse@gmail.com"
 authors: "Jun Furuse"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.1/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.2/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.3/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.3/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.2.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.2.1/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.2.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.2.2/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.2.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_poly_record/ppx_poly_record.1.3.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.3.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/ppx_poly_record"
 bug-reports:
   "https://bitbucket.org/camlspotter/ppx_poly_record/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_poly_record"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_sexp/ppx_sexp.0.3.0/opam
+++ b/packages/ppx_sexp/ppx_sexp.0.3.0/opam
@@ -5,7 +5,7 @@ homepage: "https://bitbucket.org/jyc/ppx_sexp"
 bug-reports:
   "https://bitbucket.org/jyc/ppx_sexp/issues"
 license: "BSD 2-Clause"
-dev-repo: "hg://https://bitbucket.org/jyc/ppx_sexp"
+dev-repo: "hg+https://bitbucket.org/jyc/ppx_sexp"
 build: ["./build"]
 install: ["./install"]
 remove: ["./uninstall"]

--- a/packages/ppx_test/ppx_test.0.0.1/opam
+++ b/packages/ppx_test/ppx_test.0.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.0.1/opam
+++ b/packages/ppx_test/ppx_test.1.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.1.0/opam
+++ b/packages/ppx_test/ppx_test.1.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.2.0/opam
+++ b/packages/ppx_test/ppx_test.1.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.2.1/opam
+++ b/packages/ppx_test/ppx_test.1.2.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.3.0/opam
+++ b/packages/ppx_test/ppx_test.1.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.3.1/opam
+++ b/packages/ppx_test/ppx_test.1.3.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.4.0/opam
+++ b/packages/ppx_test/ppx_test.1.4.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.4.1/opam
+++ b/packages/ppx_test/ppx_test.1.4.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.4.2/opam
+++ b/packages/ppx_test/ppx_test.1.4.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.5.0/opam
+++ b/packages/ppx_test/ppx_test.1.5.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.5.1/opam
+++ b/packages/ppx_test/ppx_test.1.5.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.5.2/opam
+++ b/packages/ppx_test/ppx_test.1.5.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports: "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppx_test/ppx_test.1.6.0/opam
+++ b/packages/ppx_test/ppx_test.1.6.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "http://bitbucket.org/camlspotter/ppx_test"
 bug-reports:
   "https://bitbucket.org/camlspotter/ppx_test/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppx_test"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_test"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppxx/ppxx.1.0.0/opam
+++ b/packages/ppxx/ppxx.1.0.0/opam
@@ -3,7 +3,7 @@ version: "1.0.0"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.1.1.0/opam
+++ b/packages/ppxx/ppxx.1.1.0/opam
@@ -3,7 +3,7 @@ version: "1.1.0"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.1.2.0/opam
+++ b/packages/ppxx/ppxx.1.2.0/opam
@@ -3,7 +3,7 @@ version: "1.2.0"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.1.2.1/opam
+++ b/packages/ppxx/ppxx.1.2.1/opam
@@ -3,7 +3,7 @@ version: "1.2.1"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.1.3.0/opam
+++ b/packages/ppxx/ppxx.1.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.1.3.1/opam
+++ b/packages/ppxx/ppxx.1.3.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.1.3.2/opam
+++ b/packages/ppxx/ppxx.1.3.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.1.4.0/opam
+++ b/packages/ppxx/ppxx.1.4.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.2.0.0/opam
+++ b/packages/ppxx/ppxx.2.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.2.1.0/opam
+++ b/packages/ppxx/ppxx.2.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.2.2.0/opam
+++ b/packages/ppxx/ppxx.2.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.2.3.0/opam
+++ b/packages/ppxx/ppxx.2.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports: "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ppxx/ppxx.2.3.1/opam
+++ b/packages/ppxx/ppxx.2.3.1/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports:
   "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.07.0"}

--- a/packages/ppxx/ppxx.2.3.2/opam
+++ b/packages/ppxx/ppxx.2.3.2/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "http://bitbucket.org/camlspotter/ppxx"
 bug-reports:
   "https://bitbucket.org/camlspotter/ppxx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/ppxx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/ppxx"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/spotinstall/spotinstall.1.0.0/opam
+++ b/packages/spotinstall/spotinstall.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotinstall/"
 bug-reports: "https://bitbucket.org/camlspotter/spotinstall/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotinstall"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotinstall"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotinstall/spotinstall.1.0.1/opam
+++ b/packages/spotinstall/spotinstall.1.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotinstall/"
 bug-reports: "https://bitbucket.org/camlspotter/spotinstall/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotinstall"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotinstall"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotinstall/spotinstall.1.1.0/opam
+++ b/packages/spotinstall/spotinstall.1.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotinstall/"
 bug-reports: "https://bitbucket.org/camlspotter/spotinstall/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotinstall"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotinstall"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotinstall/spotinstall.1.1.1/opam
+++ b/packages/spotinstall/spotinstall.1.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotinstall/"
 bug-reports: "https://bitbucket.org/camlspotter/spotinstall/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotinstall"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotinstall"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotinstall/spotinstall.1.2.0/opam
+++ b/packages/spotinstall/spotinstall.1.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotinstall/"
 bug-reports: "https://bitbucket.org/camlspotter/spotinstall/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotinstall"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotinstall"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotinstall/spotinstall.1.2.1/opam
+++ b/packages/spotinstall/spotinstall.1.2.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotinstall/"
 bug-reports: "https://bitbucket.org/camlspotter/spotinstall/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotinstall"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotinstall"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.1.0.0/opam
+++ b/packages/spotlib/spotlib.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.0.1/opam
+++ b/packages/spotlib/spotlib.2.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.1.0/opam
+++ b/packages/spotlib/spotlib.2.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.1.1/opam
+++ b/packages/spotlib/spotlib.2.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.1.2/opam
+++ b/packages/spotlib/spotlib.2.1.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.2.0/opam
+++ b/packages/spotlib/spotlib.2.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.3.0/opam
+++ b/packages/spotlib/spotlib.2.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.4.0/opam
+++ b/packages/spotlib/spotlib.2.4.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.4.1/opam
+++ b/packages/spotlib/spotlib.2.4.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.5.0/opam
+++ b/packages/spotlib/spotlib.2.5.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.5.1/opam
+++ b/packages/spotlib/spotlib.2.5.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.5.2/opam
+++ b/packages/spotlib/spotlib.2.5.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.2.5.3/opam
+++ b/packages/spotlib/spotlib.2.5.3/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib/"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.3.0.0/opam
+++ b/packages/spotlib/spotlib.3.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.3.1.0/opam
+++ b/packages/spotlib/spotlib.3.1.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.3.1.2/opam
+++ b/packages/spotlib/spotlib.3.1.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.4.0.0/opam
+++ b/packages/spotlib/spotlib.4.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.4.0.1/opam
+++ b/packages/spotlib/spotlib.4.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.4.0.2/opam
+++ b/packages/spotlib/spotlib.4.0.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/spotlib"
 bug-reports: "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/spotlib/spotlib.4.0.3/opam
+++ b/packages/spotlib/spotlib.4.0.3/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/spotlib"
 bug-reports:
   "https://bitbucket.org/camlspotter/spotlib/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/spotlib"
+dev-repo: "hg+https://bitbucket.org/camlspotter/spotlib"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}

--- a/packages/tidy/tidy.0-2009-0.1.1/opam
+++ b/packages/tidy/tidy.0-2009-0.1.1/opam
@@ -9,7 +9,7 @@ tags: [
   "parse"
   "tidy"
 ]
-dev-repo: "hg://https://bitbucket.org/zandoye/ocaml-tidy"
+dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-tidy"
 available: opam-version >= "1.2.1"
 build: [
   [make]

--- a/packages/tidy/tidy.1-4.9.30-0.1.1/opam
+++ b/packages/tidy/tidy.1-4.9.30-0.1.1/opam
@@ -9,7 +9,7 @@ tags: [
   "parse"
   "tidy"
 ]
-dev-repo: "hg://https://bitbucket.org/zandoye/ocaml-tidy"
+dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-tidy"
 available: opam-version >= "1.2.1"
 build: [
   [make]

--- a/packages/tidy/tidy.5-0.2/opam
+++ b/packages/tidy/tidy.5-0.2/opam
@@ -4,7 +4,7 @@ authors: [ "ZAN DoYe" ]
 homepage: "https://bitbucket.org/zandoye/ocaml-tidy/"
 bug-reports: "https://bitbucket.org/zandoye/ocaml-tidy/issues"
 license: "MIT"
-dev-repo: "hg://https://bitbucket.org/zandoye/ocaml-tidy"
+dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-tidy"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/tiny_json/tiny_json.1.0.0/opam
+++ b/packages/tiny_json/tiny_json.1.0.0/opam
@@ -19,7 +19,7 @@ install: [
 authors: "Jun Furuse"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."

--- a/packages/tiny_json/tiny_json.1.0.1/opam
+++ b/packages/tiny_json/tiny_json.1.0.1/opam
@@ -19,7 +19,7 @@ install: [
 authors: "Jun Furuse"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."

--- a/packages/tiny_json/tiny_json.1.1.0/opam
+++ b/packages/tiny_json/tiny_json.1.1.0/opam
@@ -19,7 +19,7 @@ install: [
 authors: "Jun Furuse"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."

--- a/packages/tiny_json/tiny_json.1.1.1/opam
+++ b/packages/tiny_json/tiny_json.1.1.1/opam
@@ -19,7 +19,7 @@ install: [
 authors: "Jun Furuse"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."

--- a/packages/tiny_json/tiny_json.1.1.2/opam
+++ b/packages/tiny_json/tiny_json.1.1.2/opam
@@ -19,7 +19,7 @@ install: [
 authors: "Jun Furuse"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."

--- a/packages/tiny_json/tiny_json.1.1.3/opam
+++ b/packages/tiny_json/tiny_json.1.1.3/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/tiny_json/tiny_json.1.1.4/opam
+++ b/packages/tiny_json/tiny_json.1.1.4/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/tiny_json/tiny_json.1.1.5/opam
+++ b/packages/tiny_json/tiny_json.1.1.5/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports:
   "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.5.0"}

--- a/packages/tiny_json/tiny_json.1.1.6/opam
+++ b/packages/tiny_json/tiny_json.1.1.6/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://camlspotter@bitbucket.org/camlspotter/tiny_json"
 bug-reports:
   "https://bitbucket.org/camlspotter/tiny_json/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.05.0"}

--- a/packages/tiny_json_conv/tiny_json_conv.1.0.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.0.0/opam
@@ -3,7 +3,7 @@ version: "1.0.0"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/tiny_json_conv"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json_conv/"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json_conv/"
 authors: [
   "Jun Furuse"
 ]

--- a/packages/tiny_json_conv/tiny_json_conv.1.0.1/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.0.1/opam
@@ -3,7 +3,7 @@ version: "1.0.1"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/tiny_json_conv"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json_conv/"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json_conv/"
 authors: [
   "Jun Furuse"
 ]

--- a/packages/tiny_json_conv/tiny_json_conv.1.1.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.1.0/opam
@@ -3,7 +3,7 @@ version: "1.1.0"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/tiny_json_conv"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json_conv/"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json_conv/"
 authors: [
   "Jun Furuse"
 ]

--- a/packages/tiny_json_conv/tiny_json_conv.1.2.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.2.0/opam
@@ -3,7 +3,7 @@ version: "1.2.0"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/tiny_json_conv"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json_conv/"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json_conv/"
 authors: [
   "Jun Furuse"
 ]

--- a/packages/tiny_json_conv/tiny_json_conv.1.4.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.4.0/opam
@@ -3,7 +3,7 @@ version: "1.4.0"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/tiny_json_conv"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json_conv/"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json_conv/"
 authors: [ "Jun Furuse" ]
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]

--- a/packages/tiny_json_conv/tiny_json_conv.1.4.1/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.4.1/opam
@@ -3,7 +3,7 @@ version: "1.4.1"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/tiny_json_conv"
 bug-reports: "https://bitbucket.org/camlspotter/tiny_json_conv/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/tiny_json_conv/"
+dev-repo: "hg+https://bitbucket.org/camlspotter/tiny_json_conv/"
 authors: [ "Jun Furuse" ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/treeprint/treeprint.1.0.1/opam
+++ b/packages/treeprint/treeprint.1.0.1/opam
@@ -3,7 +3,7 @@ version: "1.0.1"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/treeprint"
+dev-repo: "hg+https://bitbucket.org/camlspotter/treeprint"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/treeprint/treeprint.1.0.2/opam
+++ b/packages/treeprint/treeprint.1.0.2/opam
@@ -3,7 +3,7 @@ version: "1.0.2"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/treeprint"
+dev-repo: "hg+https://bitbucket.org/camlspotter/treeprint"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/treeprint/treeprint.1.0.3/opam
+++ b/packages/treeprint/treeprint.1.0.3/opam
@@ -3,7 +3,7 @@ version: "1.0.3"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/treeprint"
+dev-repo: "hg+https://bitbucket.org/camlspotter/treeprint"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/treeprint/treeprint.2.0.0/opam
+++ b/packages/treeprint/treeprint.2.0.0/opam
@@ -3,7 +3,7 @@ version: "2.0.0"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/treeprint"
+dev-repo: "hg+https://bitbucket.org/camlspotter/treeprint"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/treeprint/treeprint.2.1.0/opam
+++ b/packages/treeprint/treeprint.2.1.0/opam
@@ -3,7 +3,7 @@ version: "2.1.0"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/treeprint"
+dev-repo: "hg+https://bitbucket.org/camlspotter/treeprint"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/treeprint/treeprint.2.1.1/opam
+++ b/packages/treeprint/treeprint.2.1.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/treeprint/"
 bug-reports: "https://bitbucket.org/camlspotter/treeprint/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/treeprint"
+dev-repo: "hg+https://bitbucket.org/camlspotter/treeprint"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/treeprint/treeprint.2.2.0/opam
+++ b/packages/treeprint/treeprint.2.2.0/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/treeprint/"
 bug-reports:
   "https://bitbucket.org/camlspotter/treeprint/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/treeprint"
+dev-repo: "hg+https://bitbucket.org/camlspotter/treeprint"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.1"}

--- a/packages/trie/trie.0.1.1/opam
+++ b/packages/trie/trie.0.1.1/opam
@@ -4,7 +4,7 @@ authors: [ "ZAN DoYe" ]
 homepage: "https://bitbucket.org/zandoye/trie/"
 bug-reports: "https://bitbucket.org/zandoye/trie/issues"
 license: "MIT"
-dev-repo: "hg://https://bitbucket.org/zandoye/trie"
+dev-repo: "hg+https://bitbucket.org/zandoye/trie"
 build: [
   [make]
   [make "doc"] {with-doc}

--- a/packages/typpx/typpx.1.0.2/opam
+++ b/packages/typpx/typpx.1.0.2/opam
@@ -3,7 +3,7 @@ version: "1.0.2"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "jun.furuse@gmail.com"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.1.1/opam
+++ b/packages/typpx/typpx.1.1.1/opam
@@ -3,7 +3,7 @@ version: "1.1.1"
 authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.1.2/opam
+++ b/packages/typpx/typpx.1.1.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.1.3/opam
+++ b/packages/typpx/typpx.1.1.3/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.2.0/opam
+++ b/packages/typpx/typpx.1.2.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.2.1/opam
+++ b/packages/typpx/typpx.1.2.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.2.2/opam
+++ b/packages/typpx/typpx.1.2.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.3.0/opam
+++ b/packages/typpx/typpx.1.3.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.4.0/opam
+++ b/packages/typpx/typpx.1.4.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.4.1/opam
+++ b/packages/typpx/typpx.1.4.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.4.2/opam
+++ b/packages/typpx/typpx.1.4.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports: "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/typpx/typpx.1.4.3/opam
+++ b/packages/typpx/typpx.1.4.3/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "http://bitbucket.org/camlspotter/typpx"
 bug-reports:
   "https://bitbucket.org/camlspotter/typpx/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/typpx"
+dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06.0" & < "4.07.0"}

--- a/packages/unmagic/unmagic.0.9.0/opam
+++ b/packages/unmagic/unmagic.0.9.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/unmagic/"
 bug-reports: "https://bitbucket.org/camlspotter/unmagic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/unmagic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/unmagic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/unmagic/unmagic.1.0.0/opam
+++ b/packages/unmagic/unmagic.1.0.0/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/unmagic/"
 bug-reports: "https://bitbucket.org/camlspotter/unmagic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/unmagic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/unmagic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/unmagic/unmagic.1.0.1/opam
+++ b/packages/unmagic/unmagic.1.0.1/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/unmagic/"
 bug-reports: "https://bitbucket.org/camlspotter/unmagic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/unmagic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/unmagic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/unmagic/unmagic.1.0.2/opam
+++ b/packages/unmagic/unmagic.1.0.2/opam
@@ -4,7 +4,7 @@ authors: "Jun Furuse"
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://bitbucket.org/camlspotter/unmagic/"
 bug-reports: "https://bitbucket.org/camlspotter/unmagic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/unmagic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/unmagic"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/unmagic/unmagic.1.0.3/opam
+++ b/packages/unmagic/unmagic.1.0.3/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/unmagic/"
 bug-reports:
   "https://bitbucket.org/camlspotter/unmagic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/unmagic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/unmagic"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06.0"}

--- a/packages/unmagic/unmagic.1.0.4/opam
+++ b/packages/unmagic/unmagic.1.0.4/opam
@@ -5,7 +5,7 @@ authors: "Jun Furuse"
 homepage: "https://bitbucket.org/camlspotter/unmagic/"
 bug-reports:
   "https://bitbucket.org/camlspotter/unmagic/issues?status=new&status=open"
-dev-repo: "hg://https://bitbucket.org/camlspotter/unmagic"
+dev-repo: "hg+https://bitbucket.org/camlspotter/unmagic"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06.0"}


### PR DESCRIPTION
There was a bug on parsing hg & darcs urls rom opam1.2 (fix in https://github.com/ocaml/opam/pull/3754).
Note that this PR contains only _sed-changes_.