### PR TITLE
vhd-format-lwt: only builds with lwt.3.1.0 or less

### DIFF
--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build}
   "cstruct"
-  "lwt" {>= "2.4.3" & < "4.0.0"}
+  "lwt" {>= "2.4.3" & <= "3.1.0"}
   "mirage-block"
   "mirage-types-lwt" {>= "3.0.0"}
   "ounit"

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {build}
   "cstruct"
-  "lwt" {>= "2.4.3" & < "4.0.0"}
+  "lwt" {>= "2.4.3" & <= "3.1.0"}
   "mirage-block"
   "mirage-types-lwt" {>= "3.0.0"}
   "ounit"


### PR DESCRIPTION
due to lwt.preemptive meta change