### PR TITLE
Package satyrographos.0.0.1.5

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.1.5/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL3+"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "cmdliner"
+  "core"
+  "dune" {build}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving" {build}
+  "ppx_inline_test" {build}
+  "ppx_jane" {build}
+  (* "satysfi" {>= "0.0.3" & < "0.0.4"} *)
+  "uri" {>= "2.0.0"}
+  "yojson"
+]
+synopsis: "A naive package manager for SATySFi"
+description: """
+Satyrographos is a naive package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.1.5.tar.gz"
+  checksum: [
+    "md5=98ed1796c908c3522d985818878a0368"
+    "sha512=5cc32c8d39975914946e5f427157e7e001c0f1abe6840cd7f7374e9770b0953f979c39eba68fceb1ba7e96d747fec954575c01c5f898be452c866622b9529a81"
+  ]
+}

--- a/packages/satyrographos/satyrographos.0.0.1.5/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.5/opam
@@ -19,10 +19,8 @@ depends: [
   "dune" {build}
   "fileutils"
   "json-derivers"
-  "ppx_deriving" {build}
-  "ppx_inline_test" {build}
-  "ppx_jane" {build}
-  (* "satysfi" {>= "0.0.3" & < "0.0.4"} *)
+  "ppx_deriving"
+  "ppx_jane"
   "uri" {>= "2.0.0"}
   "yojson"
 ]

--- a/packages/satyrographos/satyrographos.0.0.1.5/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.5/opam
@@ -15,12 +15,12 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "cmdliner"
-  "core"
+  "core" {< "v0.12"}
   "dune" {build}
   "fileutils"
   "json-derivers"
   "ppx_deriving"
-  "ppx_jane"
+  "ppx_jane" {< "v0.12"}
   "uri" {>= "2.0.0"}
   "yojson"
 ]


### PR DESCRIPTION
### `satyrographos.0.0.1.5`
A naive package manager for SATySFi
Satyrographos is a naive package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.0