### PR TITLE
5 packages from zshipko/resp at 0.9.1

### DIFF
--- a/packages/resp-client/resp-client.0.9.1/opam
+++ b/packages/resp-client/resp-client.0.9.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+tags: ["redis" "protocol"]
+
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9.1"}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Redis serialization protocol client
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=1e52d65e20b229f18e0d009473afb5cb"
+    "sha512=7a2c31c7e83c285408ac39aa29c002a6c074e0d8be18cf7cb5f29b7499440071d49e037a8bca1536ec5742a0058d77069c1ffe8c6b05176aecd94c2377538ae5"
+  ]
+}

--- a/packages/resp-mirage/resp-mirage.0.9.1/opam
+++ b/packages/resp-mirage/resp-mirage.0.9.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9.1"}
+    "resp-client" {>= "0.9.1"}
+    "resp-server" {>= "0.9.1"}
+    "mirage-conduit" {>= "3.01"}
+]
+
+build:
+[
+    ["dune" "build" "-p" name]
+]
+
+synopsis: """
+Redis serialization protocol tools for MirageOS
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=1e52d65e20b229f18e0d009473afb5cb"
+    "sha512=7a2c31c7e83c285408ac39aa29c002a6c074e0d8be18cf7cb5f29b7499440071d49e037a8bca1536ec5742a0058d77069c1ffe8c6b05176aecd94c2377538ae5"
+  ]
+}

--- a/packages/resp-server/resp-server.0.9.1/opam
+++ b/packages/resp-server/resp-server.0.9.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9.1"}
+    "resp-client" {>= "0.9.1"}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Redis serialization protocol server
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=1e52d65e20b229f18e0d009473afb5cb"
+    "sha512=7a2c31c7e83c285408ac39aa29c002a6c074e0d8be18cf7cb5f29b7499440071d49e037a8bca1536ec5742a0058d77069c1ffe8c6b05176aecd94c2377538ae5"
+  ]
+}

--- a/packages/resp-unix/resp-unix.0.9.1/opam
+++ b/packages/resp-unix/resp-unix.0.9.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "resp" {>= "0.9.1"}
+    "resp-client" {>= "0.9.1"}
+    "resp-server" {>= "0.9.1"}
+    "conduit-lwt-unix" {>= "1.3"}
+    "alcotest" {with-test}
+    "alcotest-lwt" {with-test}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Redis serialization protocol library for Unix
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=1e52d65e20b229f18e0d009473afb5cb"
+    "sha512=7a2c31c7e83c285408ac39aa29c002a6c074e0d8be18cf7cb5f29b7499440071d49e037a8bca1536ec5742a0058d77069c1ffe8c6b05176aecd94c2377538ae5"
+  ]
+}

--- a/packages/resp/resp.0.9.1/opam
+++ b/packages/resp/resp.0.9.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/resp"
+doc: "https://zshipko.github.io/resp/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/resp.git"
+bug-reports: "https://github.com/zshipko/resp/issues"
+depends:
+[
+    "ocaml" {>= "4.05.0"}
+    "dune" {build}
+    "lwt" {>= "4.1"}
+    "alcotest" {with-test}
+]
+
+build:
+[
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Redis serialization protocol library
+"""
+url {
+  src: "https://github.com/zshipko/resp/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=1e52d65e20b229f18e0d009473afb5cb"
+    "sha512=7a2c31c7e83c285408ac39aa29c002a6c074e0d8be18cf7cb5f29b7499440071d49e037a8bca1536ec5742a0058d77069c1ffe8c6b05176aecd94c2377538ae5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`resp.0.9.1`: Redis serialization protocol library
-`resp-client.0.9.1`: Redis serialization protocol client
-`resp-mirage.0.9.1`: Redis serialization protocol tools for MirageOS
-`resp-server.0.9.1`: Redis serialization protocol server
-`resp-unix.0.9.1`: Redis serialization protocol library for Unix



---
* Homepage: https://github.com/zshipko/resp
* Source repo: git+https://github.com/zshipko/resp.git
* Bug tracker: https://github.com/zshipko/resp/issues

---
:camel: Pull-request generated by opam-publish v2.0.0