### PR TITLE
ocp-index does not build with dune >=1.7

### DIFF
--- a/packages/ocp-index/ocp-index.1.1.6/opam
+++ b/packages/ocp-index/ocp-index.1.1.6/opam
@@ -15,6 +15,9 @@ depends: [
   "re"
   "cmdliner"
 ]
+conflicts: [
+  "dune" {>= "1.7.0"}
+]
 post-messages: [
   "
 This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:

--- a/packages/ocp-index/ocp-index.1.1.7/opam
+++ b/packages/ocp-index/ocp-index.1.1.7/opam
@@ -28,6 +28,9 @@ depends: [
   "re" {>= "1.7.2"}
   "cmdliner"
 ]
+conflicts: [
+  "dune" {>= "1.7.0"}
+]
 post-messages:
   "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
 


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/13459

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>