### PR TITLE
[new release] hkdf (1.0.3)

### DIFF
--- a/packages/hkdf/hkdf.1.0.3/opam
+++ b/packages/hkdf/hkdf.1.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "hkdf"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD2"
+homepage: "https://github.com/hannesm/ocaml-hkdf"
+doc: "https://hannesm.github.io/ocaml-hkdf/doc"
+bug-reports: "https://github.com/hannesm/ocaml-hkdf/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "cstruct" {>= "3.2.0"}
+  "nocrypto" {>= "0.5.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/ocaml-hkdf.git"
+synopsis: "HMAC-based Extract-and-Expand Key Derivation Function (RFC 5869)"
+description: """
+An implementation of [HKDF](https://tools.ietf.org/html/rfc5869) using
+[nocrypto](https://github.com/mirleft/ocaml-nocrypto).
+"""
+url {
+  src:
+    "https://github.com/hannesm/ocaml-hkdf/releases/download/1.0.3/hkdf-1.0.3.tbz"
+  checksum: "md5=a92cf45193a8f2f5429da0590a8e808c"
+}


### PR DESCRIPTION
HMAC-based Extract-and-Expand Key Derivation Function (RFC 5869)

- Project page: <a href="https://github.com/hannesm/ocaml-hkdf">https://github.com/hannesm/ocaml-hkdf</a>
- Documentation: <a href="https://hannesm.github.io/ocaml-hkdf/doc">https://hannesm.github.io/ocaml-hkdf/doc</a>

##### CHANGES:

* move to dune
