### PR TITLE
[new release] yaml (1.0.0)

### DIFF
--- a/packages/yaml/yaml.1.0.0/opam
+++ b/packages/yaml/yaml.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >="1.3"}
+  "ctypes" {>= "0.12.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "rresult"
+  "fmt"
+  "logs"
+  "bos"
+  "mdx" {with-test}
+  "alcotest" {with-test}
+  "junit_alcotest" {with-test}
+  "ezjsonm" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+synopsis: "Parse and generate YAML 1.1 files"
+description: """
+This is an OCaml library to parse and generate the YAML file
+format.  It is intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
+JSON handling library, if the simple common subset of Yaml 
+is used.  Anchors and other advanced Yaml features are not
+implemented in the JSON compatibility layer.
+
+The [Yaml module docs](http://anil-code.recoil.org/ocaml-yaml/yaml/Yaml/index.html) are browseable online.
+"""
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v1.0.0/yaml-v1.0.0.tbz"
+  checksum: "md5=17e1d206e8b47092864163afb616ebeb"
+}


### PR DESCRIPTION
Parse and generate YAML 1.1 files

- Project page: <a href="https://github.com/avsm/ocaml-yaml">https://github.com/avsm/ocaml-yaml</a>
- Documentation: <a href="https://avsm.github.io/ocaml-yaml/">https://avsm.github.io/ocaml-yaml/</a>

##### CHANGES:

* Support parsing of canonical Yaml null, float and bool
  values (@avsm, fixes avsm/ocaml-yaml#15 avsm/ocaml-yaml#16).
* Port from jbuilder to dune (avsm/ocaml-yaml#2 @rgrinberg)
* Use dune.configurator for config probing (avsm/ocaml-yaml#18 @emillon)
* Upgrade opam metadata to 2.0 format (@avsm)
* Suppress some C warnings on build due to ctypes autogen
  until ctypes gains support for unsigned char types (@avsm)
* Add Windows build support (@avsm avsm/ocaml-yaml#11)
* Refresh libyaml to upstream changeset 85d1f168ef39f4 (@avsm)
* Switch CI to Azure Pipelines and test Windows, Linux and
  macOS (@avsm)
* Add Junit output to the Alcotest (@avsm)
