### PR TITLE
added packages/bst/bst.6.1.0

### DIFF
--- a/packages/bst/bst.6.1.0/opam
+++ b/packages/bst/bst.6.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "https://github.com/UnixJunkie/bisec-tree"
+bug-reports: "https://github.com/UnixJunkie/bisec-tree/issues"
+dev-repo: "git+https://github.com/UnixJunkie/bisec-tree.git"
+license: "BSD-3"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml"
+  "batteries"
+  "dune" {build}
+  "base-unix" {with-test}
+  "dolog" {with-test}
+  "minicli" {with-test}
+]
+synopsis: "Bisector tree implementation in OCaml"
+description: """
+A bisector tree allows to do fast but exact nearest neighbor searches
+in any space provided that you can measure the
+distance between any two points in that space.
+A bisector tree also allows fast neighbor searches (range queries/
+finding all points within a given tolerance from your query point).
+Cf. this article for details:
+'A Data Structure and an Algorithm for the Nearest Point Problem';
+Iraj Kalaranti and Gerard McDonald.
+ieeexplore.ieee.org/iel5/32/35936/01703102.pdf
+"""
+url {
+  src: "https://github.com/UnixJunkie/bisec-tree/archive/v6.1.0.tar.gz"
+  checksum: "md5=b630b52af052d34fdb9ed9de544fcd48"
+}


### PR DESCRIPTION
there is a new feature: you can partition the bisector tree
using a query point and a distance/tolerance to that point.
This is closely related to the already existing 'neighbors' query.