### PR TITLE
Package ocsigen-toolkit.2.1.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "calendar"
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.1.0.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.1.0.tar.gz"
   checksum: [
     "md5=7102b6a677340f9082e76464069462fc"
     "sha512=1d47d04b8eba6bcd07f8c7425b0afda759e3777aba49fb319e51f5591ef1ad22da4f0dd901a47c96783511959fec7d314b2902145eb9adb419bb645ba40e3bbe"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=7102b6a677340f9082e76464069462fc"
+    "sha512=1d47d04b8eba6bcd07f8c7425b0afda759e3777aba49fb319e51f5591ef1ad22da4f0dd901a47c96783511959fec7d314b2902145eb9adb419bb645ba40e3bbe"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.1.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0