### PR TITLE
Package jwto.0.1.6

### DIFF
--- a/packages/jwto/jwto.0.1.6/opam
+++ b/packages/jwto/jwto.0.1.6/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "JWT encoding, decoding and verification"
+authors: "Sebastian Porto"
+maintainer: "Sebastian Porto <s@porto5.com>"
+license: "MIT"
+homepage: "https://github.com/sporto/jwto"
+bug-reports: "https://github.com/sporto/jwto"
+dev-repo: "git://github.com/sporto/jwto"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "cryptokit"
+  "yojson"
+  "base64"
+  "re"
+  "ppx_deriving"
+]
+url {
+  src: "https://github.com/sporto/jwto/archive/0.1.6.tar.gz"
+  checksum: [
+    "md5=c20f3597b2376074048c1d828d3103d2"
+    "sha512=e36994b52e942722f15026ae9f009b78ec979d2b4bef3f3ae1f80f906c053de145fe85e823b6f37b9e99e4b7d6c2a7aa7c05b0d0a6942fa69a2dabacc178311f"
+  ]
+}


### PR DESCRIPTION
### `jwto.0.1.6`
JWT encoding, decoding and verification



---
* Homepage: https://github.com/sporto/jwto
* Source repo: git://github.com/sporto/jwto
* Bug tracker: https://github.com/sporto/jwto

---
:camel: Pull-request generated by opam-publish v2.0.0