### PR TITLE
[new release] stdlib-shims (0.1.0)

### DIFF
--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
 tags: ["stdlib" "compatibility" "org:ocaml"]
 license: ["typeof OCaml system"]
 depends: [
-  "dune"
+  "dune" {build}
   "ocaml" {>= "4.02.3"}
 ]
 build: [ "dune" "build" "-p" name "-j" jobs ]

--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "The stdlib-shims programmers"
 authors: "The stdlib-shims programmers"
-homepage: "http://ocaml.org"
+homepage: "https://github.com/ocaml/stdlib-shims"
 doc: "https://ocaml.github.io/stdlib-shims/"
 dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
 bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
@@ -21,6 +21,7 @@ This allows projects that require compatibility with older compiler to
 use these new features in their code.
 """
 url {
-  src: "http://ocaml.org/releases/stdlib-shims-0.1.0.tbz"
-  checksum: "md5=7051d94575e62bfe38d62cef4738b633"
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
 }

--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "http://ocaml.org"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src: "http://ocaml.org/releases/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=7051d94575e62bfe38d62cef4738b633"
+}


### PR DESCRIPTION
Backport some of the new stdlib features to older compiler

- Project page: <a href="http://ocaml.org">http://ocaml.org</a>
- Documentation: <a href="https://ocaml.github.io/stdlib-shims/">https://ocaml.github.io/stdlib-shims/</a>

##### CHANGES:

First release. In this release, only the `Stdlib` module is backported
to older version of OCaml.
