### PR TITLE
Package notty.0.2.2

### DIFF
--- a/packages/notty/notty.0.2.2/opam
+++ b/packages/notty/notty.0.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+homepage:     "https://github.com/pqwy/notty"
+dev-repo:     "git+https://github.com/pqwy/notty.git"
+bug-reports:  "https://github.com/pqwy/notty/issues"
+doc:          "http://pqwy.github.io/notty/doc"
+maintainer:   "David Kaloper <dk505@cam.ac.uk>"
+license:      "ISC"
+synopsis:     "Declaring terminals"
+description:
+  "Notty is a declarative terminal library for OCaml structured around a notion
+  of composable images. It tries to abstract away the basic terminal programming
+  model, providing something simpler and more expressive."
+
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+          "--with-lwt" "%{lwt:installed}%"
+]
+depends: [
+  "ocaml" { >= "4.05.0" }
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build & >="0.1.0"}
+  "uchar"
+  "uucp" {>= "2.0.0"}
+  "uuseg" {>= "1.0.0"}
+  "uutf" {>= "1.0.0"}
+]
+depopts: [ "lwt" ]
+conflicts: [
+  "ocb-stubblr" {<"0.1.0"}
+  "lwt" {<"2.5.2"}
+]
+
+url {
+archive: "https://github.com/pqwy/notty/releases/download/v0.2.2/notty-0.2.2.tbz"
+checksum: "ed22e6958f9e98cc5cee5eab54290735"
+}
+authors: "David Kaloper <dk505@cam.ac.uk>"


### PR DESCRIPTION
### `notty.0.2.2`
Declaring terminals
Notty is a declarative terminal library for OCaml structured around a notion
  of composable images. It tries to abstract away the basic terminal programming
  model, providing something simpler and more expressive.



---
* Homepage: https://github.com/pqwy/notty
* Source repo: git+https://github.com/pqwy/notty.git
* Bug tracker: https://github.com/pqwy/notty/issues

---
## v0.2.2 (2019-02-19)

* Fix a long-standing terminal cleanup bug. Reported by @ttamttam, fix by @cfcs.

---
:camel: Pull-request generated by opam-publish v2.0.0