### PR TITLE
[new release] mirage-xen (3.2.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.3.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [ 
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst" ] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "xen-gnt" {>= "2.0.0"}
+  "conf-pkg-config"
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "mirage-xen-ocaml" {>= "2.6.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "logs"
+]
+available: [ os = "linux" ]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v3.2.0/mirage-xen-v3.2.0.tbz"
+  checksum: "md5=654d9339ee74204e7833c4121c7903cb"
+}


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Port build to dune from ocamlbuild (mirage/mirage-xen#8 @avsm)
