### PR TITLE
+mirage-platform.3.3.0

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+depends: [
+  "ocaml" {>= "4.04.2" & < "4.09.0"}
+  "mirage-xen-posix" {>= "2.6.0"}
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src"
+]
+substs: [
+  "xen-ocaml/flags/cflags.tmp"
+  "xen-ocaml/flags/libs.tmp"
+  ]
+available: os = "linux"
+build: [make "xen-ocaml-build"]
+install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+dev-repo: "git+https://github.com/mirage/mirage-platform.git"
+synopsis: "MirageOS headers for the OCaml runtime"
+description:
+  "The package contains the OCaml runtime patches and build system."
+url {
+  src: "https://github.com/mirage/mirage-platform/archive/v3.3.0.tar.gz"
+  checksum: "md5=25b42ec49cdd2c4503eb994d0279ef35"
+}

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
@@ -15,6 +15,7 @@ substs: [
   "xen-ocaml/flags/cflags.tmp"
   "xen-ocaml/flags/libs.tmp"
   ]
+conflicts: ["ocaml-system"]
 available: os = "linux"
 build: [make "xen-ocaml-build"]
 install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.3.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.3.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "conf-pkg-config"
+]
+substs: [
+  "xen-posix/flags/posix-cflags.tmp"
+  "xen-posix/flags/posix-libs.tmp"
+  "xen-posix/flags/minios-cflags.tmp"
+  "xen-posix/flags/minios-libs.tmp"
+  ]
+available: os = "linux"
+build: [make "xen-posix-build"]
+install: [make "xen-posix-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-posix-uninstall" "PREFIX=%{prefix}%"]
+dev-repo: "git+https://github.com/mirage/mirage-platform.git"
+synopsis: "MirageOS library for posix headers"
+description: """
+This package contains the header files to pretend a posix
+system (required to compile the OCaml runtime), plus minilibc and
+float formating."""
+url {
+  src: "https://github.com/mirage/mirage-platform/archive/v3.3.0.tar.gz"
+  checksum: "md5=25b42ec49cdd2c4503eb994d0279ef35"
+}


### PR DESCRIPTION
supports forthcoming dune support as part of mirage/mirage#969:

* Add support for OCaml 4.08 (mirage/mirage-platform#206 by @anmonteiro)
* `libxenasmrun.a` is symlinked in the ocaml directory in order to be able to use ocamlopt's `-runtime-variant` option.
* Expose flags through files as well as pkg-config (mirage/mirage-platform#205 by @TheLortex).  Instead of pkg-config, one can use the following files to get compilation flags:
  * mirage-xen-ocaml/libs
  * mirage-xen-ocaml/cflags
  * mirage-xen-posix/minios-cflags
  * mirage-xen-posix/minios-libs
  * mirage-xen-posix/posix-cflags
  * mirage-xen-posix/posix-libs
  With dune this allows us to write `%{lib:mirage-xen-posix:posix-libs}` to get the flags instead of having a script invoking `pkg-config mirage-xen-posix --libs`.