### PR TITLE
constrain existing packages to mirage-kv{-lwt} <2.0.0 for an upcoming…

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "asetmap"
   "mirage-flow-lwt"
   "tls" {>= "0.8.0" & < "0.9.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-clock"
   "base64" {< "3.0.0"}
   "uri" {>= "1.6.0"}

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "asetmap"
   "mirage-flow-lwt"
   "tls" {>= "0.8.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-clock"
   "base64" {< "3.0.0"}
   "uri" {>= "1.6.0"}

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
@@ -21,7 +21,7 @@ depends: [
   "asetmap"
   "mirage-flow-lwt"
   "tls" {>= "0.8.0" & < "0.9.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-clock"
   "base64" {< "3.0.0"}
   "uri" {>= "1.6.0"}

--- a/packages/crunch/crunch.2.0.0/opam
+++ b/packages/crunch/crunch.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "bos" {with-test}
   "cstruct" {with-test}
   "lwt" {with-test}
-  "mirage-kv-lwt" {with-test & >= "1.0.0"}
+  "mirage-kv-lwt" {with-test & >= "1.0.0" & < "2.0.0"}
   "io-page" {with-test}
   "rresult" {with-test}
 ]

--- a/packages/crunch/crunch.2.1.0/opam
+++ b/packages/crunch/crunch.2.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "cstruct" {with-test}
   "lwt" {with-test}
-  "mirage-kv-lwt" {with-test & >= "1.0.0"}
+  "mirage-kv-lwt" {with-test & >= "1.0.0" & < "2.0.0"}
   "io-page-unix" {with-test}
 ]
 build: [

--- a/packages/crunch/crunch.2.2.0/opam
+++ b/packages/crunch/crunch.2.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "cstruct" {with-test}
   "lwt" {with-test}
-  "mirage-kv-lwt" {with-test & >= "1.0.0"}
+  "mirage-kv-lwt" {with-test & >= "1.0.0" & < "2.0.0"}
   "io-page-unix" {with-test}
 ]
 build: [

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -73,8 +73,8 @@ depends: [
   "mirage-protocols" {with-test}
   "mirage-stack-lwt" {with-test}
   "mirage-time-lwt" {with-test}
-  "mirage-kv" {with-test}
-  "mirage-kv-lwt" {with-test}
+  "mirage-kv" {with-test & < "2.0.0"}
+  "mirage-kv-lwt" {with-test & < "2.0.0"}
   "mirage-profile" {with-test}
   "duration" {with-test}
   "io-page" {with-test}

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -73,8 +73,8 @@ depends: [
   "mirage-protocols" {with-test & >= "1.1.0"}
   "mirage-stack-lwt" {with-test}
   "mirage-time-lwt" {with-test}
-  "mirage-kv" {with-test}
-  "mirage-kv-lwt" {with-test}
+  "mirage-kv" {with-test & < "2.0.0"}
+  "mirage-kv-lwt" {with-test & < "2.0.0"}
   "mirage-profile" {with-test}
   "duration" {with-test}
 ]

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -75,8 +75,8 @@ depends: [
   "mirage-protocols" {with-test & >= "1.1.0"}
   "mirage-stack-lwt" {with-test}
   "mirage-time-lwt" {with-test}
-  "mirage-kv" {with-test}
-  "mirage-kv-lwt" {with-test}
+  "mirage-kv" {with-test & < "2.0.0"}
+  "mirage-kv-lwt" {with-test & < "2.0.0"}
   "mirage-profile" {with-test}
   "duration" {with-test}
 ]

--- a/packages/irmin-mirage/irmin-mirage.1.0.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "irmin-git" {>= "1.0.0"}
   "git-mirage" {>= "1.10.0"}
   "ptime"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-clock"
   "result"
 ]

--- a/packages/irmin-mirage/irmin-mirage.1.2.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "irmin-mem" {>= "1.2.0"}
   "git-mirage" {>= "1.11.0"}
   "ptime"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-clock"
   "result"
 ]

--- a/packages/irmin-mirage/irmin-mirage.1.3.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin-mem" {>= "1.3.0"}
   "git-mirage" {>= "1.11.0"}
   "ptime"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-clock"
   "result"
 ]

--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dns" {>= "0.15.3" & < "1.0"}
   "mirage-time"
   "mirage-stack-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "duration"
   "mirage-profile"
   "xenstore" {<= "1.3.0"}

--- a/packages/jitsu/jitsu.0.3.0/opam
+++ b/packages/jitsu/jitsu.0.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dns" {>= "0.15.3" & < "1.0.0"}
   "mirage-time"
   "mirage-stack-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "duration"
   "mirage-profile"
   "xenstore" {<= "1.3.0"}

--- a/packages/mirage-dns/mirage-dns.1.1.1/opam
+++ b/packages/mirage-dns/mirage-dns.1.1.1/opam
@@ -23,7 +23,7 @@ depends: [
   "dns-lwt"
   "duration"
   "mirage-stack-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-time-lwt"
   "mirage-profile" {>= "0.8.0"}
 ]

--- a/packages/mirage-dns/mirage-dns.2.6.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.6.0/opam
@@ -21,7 +21,7 @@ depends: [
   "cmdliner"
   "dns" {>= "0.19.0" & < "1.0.0"}
   "mirage-stack-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "duration"
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-dns/mirage-dns.2.6.1/opam
+++ b/packages/mirage-dns/mirage-dns.2.6.1/opam
@@ -21,7 +21,7 @@ depends: [
   "cmdliner"
   "dns" {>= "0.19.0" & < "1.0.0"}
   "mirage-stack-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "duration"
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-dns/mirage-dns.2.7.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.7.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dns" {>= "0.20.0" & < "1.0.0"}
   "cmdliner"
   "mirage-stack-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-time-lwt"
   "duration"
   "io-page"

--- a/packages/mirage-dns/mirage-dns.3.0.0/opam
+++ b/packages/mirage-dns/mirage-dns.3.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-lwt"
   "duration"
   "mirage-stack-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-time-lwt"
   "mirage-profile" {>= "0.8.0"}
 ]

--- a/packages/mirage-dns/mirage-dns.3.0.1/opam
+++ b/packages/mirage-dns/mirage-dns.3.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-lwt"
   "duration"
   "mirage-stack-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-time-lwt"
   "mirage-profile" {>= "0.8.0"}
 ]

--- a/packages/mirage-dns/mirage-dns.3.1.0/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.0/opam
@@ -20,10 +20,10 @@ for the [MirageOS unikernel framework](https://mirage.io).
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "dns-lwt" {>="1.1.0"}
+  "dns-lwt" {>= "1.1.0"}
   "duration"
   "mirage-stack-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-time-lwt"
   "mirage-profile" {>= "0.8.0"}
 ]

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.1.1/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
@@ -17,12 +17,11 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"
 ]
-
 synopsis: "MirageOS signatures for filesystem devices using Lwt"
 description: """
 mirage-fs-lwt provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.3.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "cstruct" {>= "1.4.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "result"

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.4.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.4.0/opam
@@ -16,8 +16,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
   "jbuilder" {build & >= "1.0+beta7"}
   "cstruct" {>= "1.4.0"}
-  "cstruct-lwt" {<"3.4.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "cstruct-lwt" {< "3.4.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "result"

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/opam
@@ -15,8 +15,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta7"}
   "cstruct" {>= "3.2.0"}
-  "cstruct-lwt" {<"3.4.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "cstruct-lwt" {< "3.4.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "rresult" {with-test}

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.5.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.5.0/opam
@@ -14,11 +14,11 @@ build: [
 ]
 
 depends: [
-  "jbuilder" {build & >="1.0+beta7"}
+  "jbuilder" {build & >= "1.0+beta7"}
   "ocaml" {>= "4.04.2"}
-  "cstruct" {>= "3.2.0" & <"3.4.0"}
-  "cstruct-lwt" {<"3.4.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "cstruct" {>= "3.2.0" & < "3.4.0"}
+  "cstruct-lwt" {< "3.4.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "rresult" {with-test}

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.6.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "rresult" {with-test}

--- a/packages/mirage-kv-lwt/mirage-kv-lwt.1.1.0/opam
+++ b/packages/mirage-kv-lwt/mirage-kv-lwt.1.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.01.0"}
   "jbuilder" {build & >= "1.0+beta7"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
 ]
 synopsis: "Lwt module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
 ]
 synopsis: "Lwt module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
 ]
 synopsis: "Lwt module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
 ]
 synopsis: "Lwt module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
 ]
 synopsis: "Lwt module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
 ]
 build: [

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
 ]
 synopsis: "Lwt module type definitions for MirageOS applications"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-block-lwt" {>= "1.1.0"}
   "mirage-net-lwt" {>= "1.2.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.1.1"}
-  "mirage-kv-lwt" {>= "1.1.0"}
+  "mirage-kv-lwt" {>= "1.1.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.1.0"}
 ]
 synopsis: "Lwt module type definitions for MirageOS applications"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-block-lwt" {>= "1.1.0"}
   "mirage-net-lwt" {>= "1.2.0" & < "2.0.0"}
   "mirage-fs-lwt" {>= "1.1.1"}
-  "mirage-kv-lwt" {>= "1.1.0"}
+  "mirage-kv-lwt" {>= "1.1.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.1.0"}
 ]
 synopsis: "Lwt module type definitions for MirageOS applications"

--- a/packages/mirage-types/mirage-types.3.0.0/opam
+++ b/packages/mirage-types/mirage-types.3.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel" {>= "3.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types/mirage-types.3.0.5/opam
+++ b/packages/mirage-types/mirage-types.3.0.5/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel" {>= "3.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types/mirage-types.3.0.7/opam
+++ b/packages/mirage-types/mirage-types.3.0.7/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel" {>= "3.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types/mirage-types.3.1.0/opam
+++ b/packages/mirage-types/mirage-types.3.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel" {>= "3.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types/mirage-types.3.1.1/opam
+++ b/packages/mirage-types/mirage-types.3.1.1/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel" {>= "3.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"

--- a/packages/mirage-types/mirage-types.3.2.0/opam
+++ b/packages/mirage-types/mirage-types.3.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel" {>= "3.0.0"}
 ]
 build: [

--- a/packages/mirage-types/mirage-types.3.3.0/opam
+++ b/packages/mirage-types/mirage-types.3.3.0/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv" {>= "1.0.0"}
+  "mirage-kv" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel" {>= "3.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"

--- a/packages/mirage-types/mirage-types.3.4.0/opam
+++ b/packages/mirage-types/mirage-types.3.4.0/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-block" {>= "1.1.0"}
   "mirage-net" {>= "1.2.0" & < "2.0.0"}
   "mirage-fs" {>= "1.1.1"}
-  "mirage-kv" {>= "1.1.1"}
+  "mirage-kv" {>= "1.1.1" & < "2.0.0"}
   "mirage-channel" {>= "3.1.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"

--- a/packages/mirage-types/mirage-types.3.4.1/opam
+++ b/packages/mirage-types/mirage-types.3.4.1/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-block" {>= "1.1.0"}
   "mirage-net" {>= "1.2.0" & < "2.0.0"}
   "mirage-fs" {>= "1.1.1"}
-  "mirage-kv" {>= "1.1.1"}
+  "mirage-kv" {>= "1.1.1" & < "2.0.0"}
   "mirage-channel" {>= "3.1.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
@@ -20,7 +20,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.0/opam
@@ -23,7 +23,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.1/opam
@@ -23,7 +23,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.2/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.2/opam
@@ -24,7 +24,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.3/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.3/opam
@@ -23,7 +23,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
@@ -23,7 +23,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
@@ -23,7 +23,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "prometheus"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p-unix/protocol-9p-unix.1.0.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.1.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "prometheus"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p/protocol-9p.0.10.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.10.0/opam
@@ -15,12 +15,12 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
   "cstruct" {>= "1.9.0"}
-  "cstruct-lwt" {<"3.4.0"}
+  "cstruct-lwt" {< "3.4.0"}
   "sexplib" {> "113.00.00" & < "v0.12"}
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p/protocol-9p.0.11.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.0/opam
@@ -18,15 +18,15 @@ depends: [
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "ocamlfind" {build}
   "ppx_tools"
-  "ppx_cstruct" {<"3.4.0"}
+  "ppx_cstruct" {< "3.4.0"}
   "base-bytes"
   "cstruct" {>= "1.9.0"}
-  "cstruct-lwt" {<"3.4.0"}
+  "cstruct-lwt" {< "3.4.0"}
   "sexplib" {> "113.00.00" & < "v0.12"}
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p/protocol-9p.0.11.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.1/opam
@@ -17,15 +17,15 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "ppx_tools"
-  "ppx_cstruct" {<"3.4.0"}
+  "ppx_cstruct" {< "3.4.0"}
   "base-bytes"
   "cstruct" {>= "1.9.0"}
-  "cstruct-lwt" {<"3.4.0"}
+  "cstruct-lwt" {< "3.4.0"}
   "sexplib" {> "113.00.00" & < "v0.12"}
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p/protocol-9p.0.11.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.2/opam
@@ -21,7 +21,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p/protocol-9p.0.11.3/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.3/opam
@@ -20,7 +20,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "cmdliner"

--- a/packages/protocol-9p/protocol-9p.0.12.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.12.0/opam
@@ -20,7 +20,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "cmdliner"

--- a/packages/protocol-9p/protocol-9p.0.12.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.12.1/opam
@@ -20,7 +20,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "astring"

--- a/packages/protocol-9p/protocol-9p.0.9.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.9.0/opam
@@ -40,7 +40,7 @@ depends: [
   "result"
   "rresult"
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-kv-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "base-unix"

--- a/packages/protocol-9p/protocol-9p.1.0.0/opam
+++ b/packages/protocol-9p/protocol-9p.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "sexplib" {> "113.00.00" & < "v0.12"}
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "astring"

--- a/packages/protocol-9p/protocol-9p.1.0.1/opam
+++ b/packages/protocol-9p/protocol-9p.1.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "sexplib" {> "113.00.00" & < "v0.12"}
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {< "2.0.0"}
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "astring"


### PR DESCRIPTION
… breaking release (https://github.com/mirage/mirage-kv/pull/14)