### PR TITLE
Fix OCaml constraints on old versions of alcotest

### DIFF
--- a/packages/alcotest/alcotest.0.4.6/opam
+++ b/packages/alcotest/alcotest.0.4.6/opam
@@ -13,7 +13,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "alcotest"]
 depends: [
-  "ocaml" {>= "4.00.1" & < "4.06.0"}
+  "ocaml" {>= "4.00.1" & < "4.03.0"}
   "ocamlfind"
   "stringext"
   "result"

--- a/packages/alcotest/alcotest.0.4.7/opam
+++ b/packages/alcotest/alcotest.0.4.7/opam
@@ -13,7 +13,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "alcotest"]
 depends: [
-  "ocaml" {>= "4.00.1" & < "4.06.0"}
+  "ocaml" {>= "4.00.1" & < "4.03.0"}
   "ocamlfind"
   "stringext"
   "result"


### PR DESCRIPTION
Detected via http://check.ocamllabs.io/4.03.0/bad/alcotest.0.4.6 and http://check.ocamllabs.io/4.03.0/bad/alcotest.0.4.7