### PR TITLE
[new release] dune (1.7.2)

### DIFF
--- a/packages/dune/dune.1.7.2/opam
+++ b/packages/dune/dune.1.7.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-unix"
+  "base-threads"
+]
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+  "odoc" {< "1.3.0"}
+]
+
+synopsis: "Fast, portable and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+url {
+  src: "https://github.com/ocaml/dune/releases/download/1.7.2/dune-1.7.2.tbz"
+  checksum: "md5=41d273840f1edd9c4585e9e45d07c129"
+}


### PR DESCRIPTION
CHANGES:

- Add `${corrected-suffix}`, `${library-name}` and a few other
  variables to the list of variables to upgrade. This fixes the
  support for various framework producing corrections (ocaml/dune#1840, ocaml/dune#1853,
  @diml)

- Fix `$ dune subst` failing because the build directory wasn't set. (ocaml/dune#1854, fix
  ocaml/dune#1846, @rgrinberg)

- Configurator: Add warning to `Pkg_config.query` when a full package expression
  is used. Add `Pkg_config.query_expr` for cases when the full power of
  pkg-config's querying is needed (ocaml/dune#1842, fix ocaml/dune#1833, @rgrinberg)

- Fix unavailable, optional implementations eagerly breaking the build (ocaml/dune#1857,
  fix ocaml/dune#1856, @rgrinberg)