### PR TITLE
Fix pkcs11 packages dependency over dune

### DIFF
--- a/packages/pkcs11-cli/pkcs11-cli.0.18.0/opam
+++ b/packages/pkcs11-cli/pkcs11-cli.0.18.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "cmdliner"
   "pkcs11" {>= "0.18.0"}
-  "dune" {>= "1.3.0"}
+  "dune" {build & >= "1.3.0"}
 ]
 tags: ["org:cryptosense"]
 synopsis: "Cmdliner arguments to initialize a PKCS#11 session"

--- a/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.0.18.0/opam
@@ -15,7 +15,7 @@ run-test: [
 depends: [
   "ctypes"
   "ctypes-foreign"
-  "dune" {>= "1.3.0"}
+  "dune" {build & >= "1.3.0"}
   "pkcs11" {>= "0.18.0"}
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }

--- a/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
+++ b/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ctypes"
   "ctypes-foreign"
-  "dune" {>= "1.3.0"}
+  "dune" {build & >= "1.3.0"}
   "pkcs11" {>= "0.18.0"}
   "pkcs11-driver"
 ]

--- a/packages/pkcs11/pkcs11.0.18.0/opam
+++ b/packages/pkcs11/pkcs11.0.18.0/opam
@@ -13,7 +13,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {>= "1.3.0"}
+  "dune" {build & >= "1.3.0"}
   "hex" { >= "1.0.0" }
   "integers"
   "ppx_deriving" { >= "4.0" }


### PR DESCRIPTION
Dune was registered as a regular dependency instead of a build dependency.