### PR TITLE
Package eigen.0.1.1

### DIFF
--- a/packages/eigen/eigen.0.1.1/opam
+++ b/packages/eigen/eigen.0.1.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+doc: "https://owlbarn.github.io/eigen/eigen"
+build: [
+  ["dune" "build" "eigen_cpp/libeigen_cpp_stubs.a"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "dune" {build & >= "1.1.0"}
+]
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+"Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."
+url {
+  src: "https://github.com/owlbarn/eigen/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=94ee716f2156c988539144fdec2260ce"
+    "sha512=f81164df63a9505c37cdcd25e6dd3f467c6a26c995fb0970604a55dae962007855b9dfb555316515d66b2dec6140a62c85a0f7e6d2db51a160cef0083f042e1d"
+  ]
+}


### PR DESCRIPTION
### `eigen.0.1.1`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0