### PR TITLE
release of OCamlbuild 0.14.0

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.14.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.14.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+license: "LGPL-2 with OCaml linking exception"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects."
+depends: [
+  "ocaml" {>= "4.03"}
+]
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/0.14.0.tar.gz"
+  checksum: "sha256=87b29ce96958096c0a1a8eeafeb6268077b2d11e1bf2b3de0f5ebc9cf8d42e78"
+}


### PR DESCRIPTION
OCamlbuild 0.13 contains a bugfix that breaks compatibility. 0.14.0 reverts this bugfix to restore compatibility. (The bug has a workaround in users `myocamlbuild.ml` if it hits them, and I decided that this is better than the compatibility-breaking cure.)

OCamlbuild 0.13.{0,1} saw a frustrating process of me tagging a release, preparing the release process, to find out thanks to the opam-repository CI that some revdeps are still broken. Even though I never formally released these tagged versions, I had users ask about them and, more frustrating, some package managers distribute them.
Instead, this time the PR is a [WIP] that corresponds only to a commit, not a tag -- so the `opam` file is garbage as is, please don't merge. I'll tag the release if revdeps testing looks fine.