### PR TITLE
2 packages from c-cube/calculon at 0.4

### DIFF
--- a/packages/calculon-web/calculon-web.0.2/opam
+++ b/packages/calculon-web/calculon-web.0.2/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build}
-  "calculon"
+  "calculon" { < "0.4" }
   "re"
   "uri"
   "cohttp"

--- a/packages/calculon-web/calculon-web.0.2/opam
+++ b/packages/calculon-web/calculon-web.0.2/opam
@@ -17,7 +17,7 @@ depends: [
   "re"
   "uri"
   "cohttp"
-  "irc-client-lwt"
+  "irc-client" {< "0.6.0"}
   "cohttp-lwt" {<"2.0.0"}
   "cohttp-lwt-unix" {<"2.0.0"}
   "atdgen"

--- a/packages/calculon-web/calculon-web.0.3/opam
+++ b/packages/calculon-web/calculon-web.0.3/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build}
-  "calculon"
+  "calculon" { < "0.4" }
   "re" {>= "1.7.2"}
   "uri"
   "cohttp"

--- a/packages/calculon-web/calculon-web.0.4/opam
+++ b/packages/calculon-web/calculon-web.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A collection of web plugins for Calculon"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+tags: ["irc" "bot" "factoids"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+depends: [
+  "dune" {build}
+  "calculon" {>= "0.4"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "atdgen"
+  "lambdasoup"
+  "sequence"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.4.tar.gz"
+  checksum: [
+    "md5=e53363833b7e3620a2ce7ffb9a27715d"
+    "sha512=c997fd52fd277e8a2d50f266f12182afa96f72bb2f161a6ac1b3372fc9ebbcc12c7593f90cbb5873456b8b96d3488e5c52d071723bbaa05097710d643241d70b"
+  ]
+}

--- a/packages/calculon-web/calculon-web.0.4/opam
+++ b/packages/calculon-web/calculon-web.0.4/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/c-cube/calculon"
 bug-reports: "https://github.com/c-cube/calculon/issues"
 depends: [
   "dune" {build}
-  "calculon" {>= "0.4"}
+  "calculon" {>= "0.4" & < "0.5" }
   "re" {>= "1.7.2"}
   "uri"
   "cohttp"

--- a/packages/calculon/calculon.0.4/opam
+++ b/packages/calculon/calculon.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Library for writing IRC bots in OCaml and a collection of plugins"
+maintainer: "c-cube"
+authors: ["Armael" "Enjolras" "c-cube"]
+tags: ["irc" "bot" "factoids"]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "result"
+  "lwt"
+  "irc-client" {>= "0.6.0"}
+  "irc-client-lwt"
+  "irc-client-tls"
+  "tls"
+  "yojson"
+  "containers" {>= "1.0"}
+  "ISO8601"
+  "stringext"
+  "re" {>= "1.7.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.4.tar.gz"
+  checksum: [
+    "md5=e53363833b7e3620a2ce7ffb9a27715d"
+    "sha512=c997fd52fd277e8a2d50f266f12182afa96f72bb2f161a6ac1b3372fc9ebbcc12c7593f90cbb5873456b8b96d3488e5c52d071723bbaa05097710d643241d70b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.4`: Library for writing IRC bots in OCaml and a collection of plugins
-`calculon-web.0.4`: A collection of web plugins for Calculon



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: git+https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---
:camel: Pull-request generated by opam-publish v2.0.0