### PR TITLE
[new releases] mirage-net, mirage-net-lwt, mirage-protocols, mirage-protocols-lwt, ethernet, arp, arp-mirage (2.0.0), mirage-vnetif (0.4.2)

### DIFF
--- a/packages/arp-mirage/arp-mirage.1.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ethernet" {< "2.0.0"}
   "lwt"
   "duration"
-  "arp" {>= "1.0.0"}
+  "arp" {>= "1.0.0" & < "2.0.0"}
   "logs"
   "cstruct" {>= "2.2.0"}
   "fmt" {with-test}

--- a/packages/arp-mirage/arp-mirage.1.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "mirage-protocols-lwt"
   "mirage-time-lwt"
   "mirage-protocols-lwt"
-  "ethernet"
+  "ethernet" {< "2.0.0"}
   "lwt"
   "duration"
   "arp" {>= "1.0.0"}

--- a/packages/arp-mirage/arp-mirage.1.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.1.0.0/opam
@@ -9,9 +9,8 @@ license: "ISC"
 synopsis: "Address Resolution Protocol for MirageOS"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "mirage-protocols-lwt"
   "mirage-time-lwt"
-  "mirage-protocols-lwt"
+  "mirage-protocols-lwt" {< "2.0.0"}
   "ethernet" {< "2.0.0"}
   "lwt"
   "duration"

--- a/packages/arp-mirage/arp-mirage.2.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+synopsis: "Address Resolution Protocol for MirageOS"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "mirage-time-lwt"
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "lwt"
+  "duration"
+  "arp" {>= "2.0.0"}
+  "mirage-profile" {>= "0.5"}
+  "logs"
+  "cstruct" {>= "2.2.0"}
+  "ethernet" {with-test & >= "2.0.0"}
+  "fmt" {with-test}
+  "mirage-vnetif" {with-test}
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "mirage-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.0.0/arp-v2.0.0.tbz"
+  checksum: "md5=50bbe0aba0ee6527d56306f04402accf"
+}

--- a/packages/arp/arp.2.0.0/opam
+++ b/packages/arp/arp.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "cstruct" {>= "2.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "logs"
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+]
+conflicts: [
+  "arp-mirage" {< "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Address Resolution Protocol purely in OCaml"
+description: """
+ARP is an implementation of the address resolution protocol (RFC826) purely in
+OCaml.  It handles IPv4 protocol addresses and Ethernet hardware addresses only.
+"""
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.0.0/arp-v2.0.0.tbz"
+  checksum: "md5=50bbe0aba0ee6527d56306f04402accf"
+}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.1/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.1/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-clock"
   "mirage-time-lwt"
   "mirage-net-lwt" {< "2.0.0"}
-  "mirage-protocols-lwt"
+  "mirage-protocols-lwt" {< "2.0.0"}
   "duration"
   "logs"
   "tcpip" {>= "3.6.0"}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-clock"
   "mirage-time-lwt"
   "mirage-net-lwt" {< "2.0.0"}
-  "mirage-protocols-lwt"
+  "mirage-protocols-lwt" {< "2.0.0"}
   "duration"
   "logs"
   "tcpip" {>= "3.6.0"}

--- a/packages/charrua-core/charrua-core.0.11.2/opam
+++ b/packages/charrua-core/charrua-core.0.11.2/opam
@@ -17,17 +17,17 @@ depends: [
   "dune" {build & >= "1.0"}
   "ppx_sexp_conv" {< "v0.12"}
   "ppx_cstruct"
-  "menhir"        {build}
-  "ocaml"         {>= "4.0.3"}
-  "cstruct"       {>= "3.0.1"}
-  "sexplib"       {< "v0.12"}
-  "ipaddr"        {>= "3.0.0"}
+  "menhir" {build}
+  "ocaml" {>= "4.0.3"}
+  "cstruct" {>= "3.0.1"}
+  "sexplib" {< "v0.12"}
+  "ipaddr" {>= "3.0.0"}
   "macaddr"
-  "ethernet"
-  "tcpip"         {>= "3.7.0"}
+  "ethernet" {< "2.0.0"}
+  "tcpip" {>= "3.7.0"}
   "rresult"
-  "io-page-unix"  {with-test}
-  "cstruct-unix"  {with-test}
+  "io-page-unix" {with-test}
+  "cstruct-unix" {with-test}
 ]
 synopsis: "DHCP wire frame encoder and decoder"
 description: """

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -70,7 +70,7 @@ depends: [
   "lwt" {with-test}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-protocols" {with-test}
+  "mirage-protocols" {with-test & < "2.0.0"}
   "mirage-stack-lwt" {with-test}
   "mirage-time-lwt" {with-test}
   "mirage-kv" {with-test & < "2.0.0"}

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -70,7 +70,7 @@ depends: [
   "lwt" {with-test}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-protocols" {with-test & >= "1.1.0"}
+  "mirage-protocols" {with-test & >= "1.1.0" & < "2.0.0"}
   "mirage-stack-lwt" {with-test}
   "mirage-time-lwt" {with-test}
   "mirage-kv" {with-test & < "2.0.0"}

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -72,7 +72,7 @@ depends: [
   "lwt" {with-test & < "4.0.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-protocols" {with-test & >= "1.1.0"}
+  "mirage-protocols" {with-test & >= "1.1.0" & < "2.0.0"}
   "mirage-stack-lwt" {with-test}
   "mirage-time-lwt" {with-test}
   "mirage-kv" {with-test & < "2.0.0"}

--- a/packages/ethernet/ethernet.1.0.0/opam
+++ b/packages/ethernet/ethernet.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.0.2"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "macaddr"
   "mirage-profile" {>= "0.5"}
   "fmt"

--- a/packages/ethernet/ethernet.2.0.0/opam
+++ b/packages/ethernet/ethernet.2.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "mirageos-devel@lists.xenproject.org"
+homepage:     "https://github.com/mirage/ethernet"
+dev-repo:     "git+https://github.com/mirage/ethernet.git"
+bug-reports:  "https://github.com/mirage/ethernet/issues"
+doc:          "https://mirage.github.io/ethernet/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.04.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.0.2"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "macaddr"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+]
+conflicts: [
+  "tcpip" {< "3.7.0"}
+]
+synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
+description: """
+`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
+(specified by IEEE 802.3) layer implementation for the
+[Mirage operating system](https://mirage.io).
+"""
+url {
+  src:
+    "https://github.com/mirage/ethernet/releases/download/v2.0.0/ethernet-v2.0.0.tbz"
+  checksum: "md5=547520508219768cb0011f1e18fc6b05"
+}

--- a/packages/mirage-net-lwt/mirage-net-lwt.2.0.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.2.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-net" {>= "2.0.0"}
+  "lwt"
+  "macaddr"
+  "cstruct"
+]
+synopsis: "Network signatures for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v2.0.0/mirage-net-v2.0.0.tbz"
+  checksum: "md5=8eab9b0aa56d8d98e578f90de5dc41c2"
+}

--- a/packages/mirage-net/mirage-net.2.0.0/opam
+++ b/packages/mirage-net/mirage-net.2.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "fmt"
+]
+synopsis: "Network signatures for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v2.0.0/mirage-net-v2.0.0.tbz"
+  checksum: "md5=8eab9b0aa56d8d98e578f90de5dc41c2"
+}

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.4.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.4.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-protocols" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
   "ipaddr" {>= "2.0.0" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.4.1/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.4.1/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-protocols" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
   "lwt"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.2.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-protocols" {>= "2.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols-lwt provides a set of module types specialized to lwt which
+libraries intended to be used as MirageOS network implementations should
+implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v2.0.0/mirage-protocols-v2.0.0.tbz"
+  checksum: "md5=7f9de3a8a966a2d78f664290cc231649"
+}

--- a/packages/mirage-protocols/mirage-protocols.2.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.2.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-net" {>= "2.0.0"}
+  "fmt"
+  "duration"
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v2.0.0/mirage-protocols-v2.0.0.tbz"
+  checksum: "md5=7f9de3a8a966a2d78f664290cc231649"
+}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
@@ -13,18 +13,18 @@ build: [
 ]
 
 depends: [
-  "jbuilder"  {build & >="1.0+beta9"}
-  "mirage-qubes" { >= "0.6" }
-  "tcpip" { >= "3.5.0" }
-  "ipaddr" { >= "3.0.0" }
+  "jbuilder" {build & >= "1.0+beta9"}
+  "mirage-qubes" {>= "0.6"}
+  "tcpip" {>= "3.5.0"}
+  "ipaddr" {>= "3.0.0"}
   "mirage-random"
   "mirage-clock"
-  "mirage-protocols-lwt"
-  "cstruct" { >= "1.9.0" }
+  "mirage-protocols-lwt" {< "2.0.0"}
+  "cstruct" {>= "1.9.0"}
   "lwt"
-  "mirage-types-lwt" { >= "3.0.0" }
-  "logs" { >= "0.5.0" }
-  "ocaml" { >= "4.03.0" }
+  "mirage-types-lwt" {>= "3.0.0"}
+  "logs" {>= "0.5.0"}
+  "ocaml" {>= "4.03.0"}
 ]
 synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
 description: """\

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
@@ -21,7 +21,7 @@ depends: [
   "ipaddr" {< "3.0.0"}
   "mirage-random"
   "mirage-clock"
-  "mirage-protocols-lwt"
+  "mirage-protocols-lwt" {< "2.0.0"}
   "cstruct" {>= "1.9.0"}
   "lwt"
   "mirage-types-lwt" {>= "3.0.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-random" {>= "1.2.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
-  "mirage-protocols-lwt" {>= "1.4.1"}
+  "mirage-protocols-lwt" {>= "1.4.1" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-console-lwt" {>= "2.3.5"}
   "mirage-block-lwt" {>= "1.1.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-random" {>= "1.2.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
-  "mirage-protocols-lwt" {>= "1.4.1"}
+  "mirage-protocols-lwt" {>= "1.4.1" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-console-lwt" {>= "2.3.5"}
   "mirage-block-lwt" {>= "1.1.0"}

--- a/packages/mirage-types/mirage-types.3.2.0/opam
+++ b/packages/mirage-types/mirage-types.3.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}
-  "mirage-protocols" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
   "mirage-stack" {>= "1.3.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}

--- a/packages/mirage-types/mirage-types.3.3.0/opam
+++ b/packages/mirage-types/mirage-types.3.3.0/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}
-  "mirage-protocols" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
   "mirage-stack" {>= "1.3.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}

--- a/packages/mirage-types/mirage-types.3.4.0/opam
+++ b/packages/mirage-types/mirage-types.3.4.0/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-random" {>= "1.2.0"}
   "mirage-flow" {>= "1.5.0"}
   "mirage-console" {>= "2.3.5"}
-  "mirage-protocols" {>= "1.4.1"}
+  "mirage-protocols" {>= "1.4.1" & < "2.0.0"}
   "mirage-stack" {>= "1.3.0"}
   "mirage-block" {>= "1.1.0"}
   "mirage-net" {>= "1.2.0" & < "2.0.0"}

--- a/packages/mirage-types/mirage-types.3.4.1/opam
+++ b/packages/mirage-types/mirage-types.3.4.1/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-random" {>= "1.2.0"}
   "mirage-flow" {>= "1.5.0"}
   "mirage-console" {>= "2.3.5"}
-  "mirage-protocols" {>= "1.4.1"}
+  "mirage-protocols" {>= "1.4.1" & < "2.0.0"}
   "mirage-stack" {>= "1.3.0"}
   "mirage-block" {>= "1.1.0"}
   "mirage-net" {>= "1.2.0" & < "2.0.0"}

--- a/packages/mirage-vnetif/mirage-vnetif.0.4.2/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.4.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "mirage-vnetif"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"  {build & >= "1.0"}
+  "lwt"
+  "mirage-time-lwt" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "cstruct" {>="2.4.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "mirage-profile"
+  "duration"
+  "logs"
+]
+tags: ["org:mirage"]
+synopsis: "Virtual network interface and software switch for Mirage"
+description: """
+Provides the module `Vnetif` which can be used as a replacement for the regular
+`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
+connected to a software switch that allows the stacks to communicate as if they
+were connected to the same LAN.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.4.2/mirage-vnetif-v0.4.2.tbz"
+  checksum: "md5=196f5e1cadb53a16d29d3b9c89c65bc4"
+}

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -49,8 +49,8 @@ depends: [
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
-  "mirage-protocols" {= "1.0.0" & < "1.3.0"}
-  "mirage-protocols-lwt" {= "1.0.0" & < "1.3.0"}
+  "mirage-protocols" {= "1.0.0"}
+  "mirage-protocols-lwt" {= "1.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5" & < "0.8.0"}

--- a/packages/tcpip/tcpip.3.5.0/opam
+++ b/packages/tcpip/tcpip.3.5.0/opam
@@ -30,8 +30,8 @@ depends: [
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "1.4.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
+  "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5"}

--- a/packages/tcpip/tcpip.3.5.1/opam
+++ b/packages/tcpip/tcpip.3.5.1/opam
@@ -31,8 +31,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "1.4.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
+  "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5"}

--- a/packages/tcpip/tcpip.3.6.0/opam
+++ b/packages/tcpip/tcpip.3.6.0/opam
@@ -31,8 +31,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "1.4.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
+  "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -51,7 +51,7 @@ depends: [
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}
-  "arp-mirage" {with-test}
+  "arp-mirage" {with-test & < "2.0.0"}
   "lru"
 ]
 synopsis: "OCaml TCP/IP networking stack, used in MirageOS"

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -31,8 +31,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "1.4.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
+  "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "ethernet"
+  "ethernet" {< "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}


### PR DESCRIPTION
CHANGES:

- Improvements to the write path (mirage/mirage-net#15, mirage/mirage-net#18 @hannesm)
  * remove `page_aligned_buffer` and `io-page` dependency
  * remove `writev`
  * provide `mtu : t -> int`
  * adjust `write : t -> size:int -> (buffer -> int) -> (unit, error) result io`
   -> allocation is done by the mirage-net implementation, and the buffer is
      filled by the upper layers. once filled, it is send out.
- Port build to dune from jbuilder (mirage/mirage-net#16 @avsm)
- Switch to dune-release instead of topkg (mirage/mirage-net#16 @avsm)