### PR TITLE
[new release] mirage-net and mirage-net-lwt (2.0.0)

### DIFF
--- a/packages/mirage-net-lwt/mirage-net-lwt.2.0.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.2.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-net" {>= "2.0.0"}
+  "lwt"
+  "macaddr"
+  "cstruct"
+]
+synopsis: "Network signatures for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v2.0.0/mirage-net-v2.0.0.tbz"
+  checksum: "md5=8eab9b0aa56d8d98e578f90de5dc41c2"
+}

--- a/packages/mirage-net/mirage-net.2.0.0/opam
+++ b/packages/mirage-net/mirage-net.2.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "fmt"
+]
+synopsis: "Network signatures for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v2.0.0/mirage-net-v2.0.0.tbz"
+  checksum: "md5=8eab9b0aa56d8d98e578f90de5dc41c2"
+}


### PR DESCRIPTION
CHANGES:

- Improvements to the write path (mirage/mirage-net#15, mirage/mirage-net#18 @hannesm)
  * remove `page_aligned_buffer` and `io-page` dependency
  * remove `writev`
  * provide `mtu : t -> int`
  * adjust `write : t -> size:int -> (buffer -> int) -> (unit, error) result io`
   -> allocation is done by the mirage-net implementation, and the buffer is
      filled by the upper layers. once filled, it is send out.
- Port build to dune from jbuilder (mirage/mirage-net#16 @avsm)
- Switch to dune-release instead of topkg (mirage/mirage-net#16 @avsm)