### PR TITLE
base-unsafe-string

### DIFF
--- a/packages/base-unsafe-string/base-unsafe-string.base/opam
+++ b/packages/base-unsafe-string/base-unsafe-string.base/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+synopsis: "A pseudo-library to indicate OCaml versions that equate 'string' and 'bytes' (by default)"
+depends: [
+  "ocaml" {< "4.06.0"}
+]
+


### PR DESCRIPTION
We can use a dependency on the base-unsafe-string package to mark
packages that fail to build when -safe-string is enabled. This is
easier to do, and clearer in the metadata, than remember which version
of OCaml made -safe-string the default (4.06).

Note: this package is currently *not* available under >=4.06 switches
that explicitly enable -unsafe-string (they should in theory support
this flag), as I'm not sure how to do this and whether it is worth the
effort.