### PR TITLE
[new release] mirage-protocols and mirage-protocols-lwt (2.0.0)

### DIFF
--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.2.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-protocols" {>= "2.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols-lwt provides a set of module types specialized to lwt which
+libraries intended to be used as MirageOS network implementations should
+implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v2.0.0/mirage-protocols-v2.0.0.tbz"
+  checksum: "md5=7f9de3a8a966a2d78f664290cc231649"
+}

--- a/packages/mirage-protocols/mirage-protocols.2.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.2.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-net" {>= "2.0.0"}
+  "fmt"
+  "duration"
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v2.0.0/mirage-protocols-v2.0.0.tbz"
+  checksum: "md5=7f9de3a8a966a2d78f664290cc231649"
+}


### PR DESCRIPTION
CHANGES:

- Ethif/ETHIF renamed to Ethernet/ETHERNET (mirage/mirage-protocols#16)
- Ethernet.proto defines a polymorphic variant of ethernet types (mirage/mirage-protocols#15)
- Ip.proto defines a polymorphic variant of ip types (mirage/mirage-protocols#15)
- Ethernet.writev is removed (mirage/mirage-protocols#15)
- Ethernet.write expects an optional source mac address, a destination mac
  address, a protocol, an optional size and a fill function. Ethernet writes
  the Ethernet header to the buffer. (mirage/mirage-protocols#15)
- Ip.writev and Ip.checksum are removed (mirage/mirage-protocols#15)
- Ip.write expects an optional fragment, ttl, src, and a size and fill function,
  as well as a list of payload buffers. Size default to MTU. (mirage/mirage-protocols#15)
- migrated build system to dune