### PR TITLE
[new release] mirage-vnetif (0.4.2)

### DIFF
--- a/packages/mirage-vnetif/mirage-vnetif.0.4.2/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.4.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "mirage-vnetif"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"  {build & >= "1.0"}
+  "lwt"
+  "mirage-time-lwt" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "cstruct" {>="2.4.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "mirage-profile"
+  "duration"
+  "logs"
+]
+tags: ["org:mirage"]
+synopsis: "Virtual network interface and software switch for Mirage"
+description: """
+Provides the module `Vnetif` which can be used as a replacement for the regular
+`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
+connected to a software switch that allows the stacks to communicate as if they
+were connected to the same LAN.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.4.2/mirage-vnetif-v0.4.2.tbz"
+  checksum: "md5=196f5e1cadb53a16d29d3b9c89c65bc4"
+}


### PR DESCRIPTION
CHANGES:

- adjust to mirage-net 2.0.0 changes
- port build system to dune