### PR TITLE
[new release] mirage-net-macosx (1.6.0)

### DIFF
--- a/packages/mirage-net-macosx/mirage-net-macosx.1.6.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
+authors:     "Anil Madhavapeddy <anil@recoil.org>"
+homepage:    "https://github.com/mirage/mirage-net-macosx"
+bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
+dev-repo:    "git+https://github.com/mirage/mirage-net-macosx.git"
+doc:         "https://mirage.github.io/mirage-net-macosx/"
+
+license: "ISC"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "1.4.0"}
+  "macaddr"
+  "sexplib"
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "vmnet" {>= "1.5.0"}
+]
+tags: "org:mirage"
+
+synopsis: "MacOS implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-macosx/releases/download/v1.6.0/mirage-net-macosx-v1.6.0.tbz"
+  checksum: "md5=803f45581c13ac94f77024a3de822bab"
+}


### PR DESCRIPTION
CHANGES:

- adapt to mirage-net 2.0.0 change (@hannesm)
- use Vmnet.mtu (thanks to @avsm)