### PR TITLE
[new release] mirage-net-unix (2.6.0)

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.2.6.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "David Scott" "Thomas Gazagnaire" "Hannes Mehnert"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-net-unix"
+doc: "https://mirage.github.io/mirage-net-unix/"
+bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "1.7.1"}
+  "cstruct-lwt"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "tuntap" {>= "1.8.0"}
+  "alcotest" {with-test}
+  "logs"
+  "macaddr"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-net-unix.git"
+synopsis: "Unix implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using `ocaml-tuntap`,
+suitable for use with an OCaml network stack such as the one
+found at <https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-unix/releases/download/v2.6.0/mirage-net-unix-v2.6.0.tbz"
+  checksum: "md5=e8234f0fdd3e9211f3590b367130bf16"
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-net 2.0.0 changs (@hannesm)