### PR TITLE
[new release] mirage-kv and mirage-kv-lwt (2.0.0)

### DIFF
--- a/packages/mirage-kv-lwt/mirage-kv-lwt.2.0.0/opam
+++ b/packages/mirage-kv-lwt/mirage-kv-lwt.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"     {>= "4.05.0"}
+  "dune"      {build}
+  "mirage-kv" {>= "1.0.0"}
+  "lwt"
+  "cstruct"
+]
+
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv-lwt provides the `Mirage_kv_lwt.RO` and `Mirage_kv_lwt.RW` signatures,
+which are the corresponding `Mirage_kv` signatures with `io` constrained to
+`Lwt.t` and `value` to `string`.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v2.0.0/mirage-kv-v2.0.0.tbz"
+  checksum: "md5=ae3aed9d16c93fc67a429ea1b5727dca"
+}

--- a/packages/mirage-kv/mirage-kv.2.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"     {build}
+  "mirage-device" {>= "1.0.0"}
+  "fmt"
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v2.0.0/mirage-kv-v2.0.0.tbz"
+  checksum: "md5=ae3aed9d16c93fc67a429ea1b5727dca"
+}


### PR DESCRIPTION
CHANGES:

* Major revision of the `RO` signature:
 - values are of type `string`
 - keys are segments instead of a string
 - `read` is now named `get`, and does no longer take an offset and length
 - the new function `list` is provided
 - the new functions `last_modified` and `digest` are provided
* A module `Key` is provided with convenience functions to build keys
* An `RW` signature is provided, extending `RO` with
 - a function `set` to replace a value
 - a function `remove` to remove a key
 - `batch` to batch operations

upper bounds for existing packages were added in #13497 