### PR TITLE
[new release] mirage-stack and mirage-stack-lwt (1.4.0)

### DIFF
--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.4.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-stack"
+doc: "https://mirage.github.io/mirage-stack/"
+bug-reports: "https://github.com/mirage/mirage-stack/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-stack" {>= "1.3.0"}
+  "ipaddr"
+  "lwt"
+  "cstruct" {>= "2.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-stack.git"
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack-lwt provides a set of module types which libraries intended to be
+used as MirageOS network stacks should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-stack/releases/download/v1.4.0/mirage-stack-v1.4.0.tbz"
+  checksum: "md5=6a21f64c2eb015464b53e0ad9410bfa6"
+}

--- a/packages/mirage-stack/mirage-stack.1.4.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-stack"
+doc: "https://mirage.github.io/mirage-stack/"
+bug-reports: "https://github.com/mirage/mirage-stack/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.4.0"}
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-stack.git"
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used
+as MirageOS network stacks should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-stack/releases/download/v1.4.0/mirage-stack-v1.4.0.tbz"
+  checksum: "md5=6a21f64c2eb015464b53e0ad9410bfa6"
+}


### PR DESCRIPTION
CHANGES:

- port build system to dune
- adjuust to opam2 metadata