### PR TITLE
[new release] tcpip (3.7.1)

### DIFF
--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"     {build & >= "1.0"}
+  "configurator" {build}
+  "ocaml" {>= "4.03.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.0.2"}
+  "cstruct-lwt"
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-protocols" {>= "2.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-vnetif" {with-test & >= "0.4.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-random-test" {with-test}
+  "arp-mirage" {with-test & >= "2.0.0"}
+  "lru"
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v3.7.1/tcpip-v3.7.1.tbz"
+  checksum: "md5=b4fa7d7c9cbf205e14e271486a1d652a"
+}

--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -23,7 +23,7 @@ depends: [
   "configurator" {build}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
-  "cstruct" {>= "3.0.2"}
+  "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
   "mirage-clock" {>= "1.2.0"}


### PR DESCRIPTION
CHANGES:

* Adjust to mirage-protocols 2.0.0 changes (mirage/mirage-tcpip#394 by @hannesm)
* Ethif is now Ethernet (mirage/mirage-tcpip#394 by @hannesm)
* IPv4 write now fragments if payload exceeds MTU (and the optional labeled
  fragment argument is not false) (mirage/mirage-tcpip#394 by @hannesm)