### PR TITLE
[new release] charrua-unix, charrua-client-mirage, charrua-core, charrua-client and charrua-client-lwt (0.12.0)

### DIFF
--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
-  "charrua-core" {>= "0.11.0"}
-  "charrua-client" {>= "0.11.0"}
+  "charrua-core" {>= "0.11.0" & < "0.12.0"}
+  "charrua-client" {>= "0.11.0" & < "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr" {< "3.0.0"}
   "rresult"

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.1/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.1/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test}
-  "charrua-core" {>= "0.11.1"}
-  "charrua-client" {>= "0.11.1"}
+  "charrua-core" {>= "0.11.1" & < "0.12.0"}
+  "charrua-client" {>= "0.11.1" & < "0.12.0"}
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.2/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.2/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test}
-  "charrua-core" {>= "0.11.1"}
-  "charrua-client" {>= "0.11.1"}
+  "charrua-core" {>= "0.11.1" & < "0.12.0"}
+  "charrua-client" {>= "0.11.1" & < "0.12.0"}
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.12.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.12.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua-core"
+bug-reports:  "https://github.com/mirage/charrua-core/issues"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "charrua-core" {>= "0.12.0"}
+  "charrua-client" {>= "0.12.0"}
+  "cstruct" {>="3.0.2"}
+  "ipaddr" {>="3.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "duration"
+  "mirage-time-lwt"
+  "mirage-net-lwt" {>= "2.0.0"}
+  "logs"
+  "fmt"
+  "lwt"
+]
+synopsis: "A DHCP client using lwt as effectful layer"
+description: """
+`charrua-client-lwt` extends `charrua-client` with a functor `Dhcp_client_lwt`,
+using the provided modules for timing and networking logic,
+for convenient use by a program which might wish to implement a full client.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.12.0/charrua-core-v0.12.0.tbz"
+  checksum: "md5=a1edfeeaea6d9ed079efec4514f0e44c"
+}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.0/opam
@@ -15,9 +15,9 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "ocaml" {>= "4.04.2"}
-  "charrua-core" {>= "0.11.0"}
-  "charrua-client-lwt" {>= "0.11.0"}
-  "charrua-client" {>= "0.11.0"}
+  "charrua-core" {>= "0.11.0" & < "0.12.0"}
+  "charrua-client-lwt" {>= "0.11.0" & < "0.12.0"}
+  "charrua-client" {>= "0.11.0" & < "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
   "rresult"

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.1/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.1/opam
@@ -15,9 +15,9 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "ocaml" {>= "4.04.2"}
-  "charrua-core" {>= "0.11.1"}
-  "charrua-client-lwt" {>= "0.11.1"}
-  "charrua-client" {>= "0.11.1"}
+  "charrua-core" {>= "0.11.1" & < "0.12.0"}
+  "charrua-client-lwt" {>= "0.11.1" & < "0.12.0"}
+  "charrua-client" {>= "0.11.1" & < "0.12.0"}
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
@@ -15,9 +15,9 @@ build: [
 depends: [
   "dune" {build & >= "1.0"}
   "ocaml" {>= "4.04.2"}
-  "charrua-core" {>= "0.11.1"}
-  "charrua-client-lwt" {>= "0.11.1"}
-  "charrua-client" {>= "0.11.1"}
+  "charrua-core" {>= "0.11.1" & < "0.12.0"}
+  "charrua-client-lwt" {>= "0.11.1" & < "0.12.0"}
+  "charrua-client" {>= "0.11.1" & < "0.12.0"}
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.12.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.12.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua-core"
+bug-reports:  "https://github.com/mirage/charrua-core/issues"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "charrua-client-lwt" {>= "0.12.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock"
+  "mirage-time-lwt"
+  "mirage-net-lwt"
+  "mirage-protocols-lwt"
+  "logs"
+  "lwt"
+]
+synopsis: "A DHCP client for MirageOS"
+description: """
+`charrua-client-mirage` exposes an additional `Dhcp_client_mirage` for direct use
+with the [MirageOS library operating system](https://github.com/mirage/mirage).
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.12.0/charrua-core-v0.12.0.tbz"
+  checksum: "md5=a1edfeeaea6d9ed079efec4514f0e44c"
+}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.12.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.12.0/opam
@@ -20,8 +20,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock"
   "mirage-time-lwt"
-  "mirage-net-lwt"
-  "mirage-protocols-lwt"
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
   "logs"
   "lwt"
 ]

--- a/packages/charrua-client/charrua-client.0.11.0/opam
+++ b/packages/charrua-client/charrua-client.0.11.0/opam
@@ -19,7 +19,7 @@ depends: [
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
   "mirage-random-test" {with-test}
-  "charrua-core" {>= "0.11.0"}
+  "charrua-core" {>= "0.11.0" & < "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
 ]

--- a/packages/charrua-client/charrua-client.0.11.1/opam
+++ b/packages/charrua-client/charrua-client.0.11.1/opam
@@ -19,7 +19,7 @@ depends: [
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
   "mirage-random-test" {with-test}
-  "charrua-core" {>= "0.11.1"}
+  "charrua-core" {>= "0.11.1" & < "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
   "macaddr"

--- a/packages/charrua-client/charrua-client.0.11.2/opam
+++ b/packages/charrua-client/charrua-client.0.11.2/opam
@@ -19,7 +19,7 @@ depends: [
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
   "mirage-random-test" {with-test}
-  "charrua-core" {>= "0.11.1"}
+  "charrua-core" {>= "0.11.1" & < "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
   "macaddr"

--- a/packages/charrua-client/charrua-client.0.12.0/opam
+++ b/packages/charrua-client/charrua-client.0.12.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua-core"
+bug-reports:  "https://github.com/mirage/charrua-core/issues"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-random-test" {with-test}
+  "charrua-core" {>= "0.12.0"}
+  "cstruct" {>="3.0.2"}
+  "ipaddr"
+  "macaddr"
+]
+synopsis: "DHCP client implementation"
+description: """
+charrua-client is a DHCP client powered by [charrua-core](https://github.com/mirage/charrua-core).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.12.0/charrua-core-v0.12.0.tbz"
+  checksum: "md5=a1edfeeaea6d9ed079efec4514f0e44c"
+}

--- a/packages/charrua-core/charrua-core.0.12.0/opam
+++ b/packages/charrua-core/charrua-core.0.12.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua-core"
+bug-reports: "https://github.com/mirage/charrua-core/issues"
+dev-repo: "git+https://github.com/mirage/charrua-core.git"
+doc: "https://mirage.github.io/charrua-core/api"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "menhir"        {build}
+  "ocaml"         {>= "4.0.3"}
+  "cstruct"       {>= "3.0.1"}
+  "sexplib"
+  "ipaddr"        {>= "3.0.0"}
+  "macaddr"
+  "ethernet"
+  "tcpip"         {>= "3.7.0"}
+  "rresult"
+  "cstruct-unix"  {with-test}
+]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua-core consists of two modules, a `Dhcp_wire` responsible for parsing and
+constructing DHCP messages and a `Dhcp_server` module used for constructing DHCP
+servers.
+
+You can browse the API for [charrua-core](http://www.github.com/mirage/charrua-core) at
+http://mirage.github.io/charrua-core/api
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua-core, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP, it is the
+  base for `Dhcp_server`.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-core/releases/download/v0.12.0/charrua-core-v0.12.0.tbz"
+  checksum: "md5=a1edfeeaea6d9ed079efec4514f0e44c"
+}

--- a/packages/charrua-unix/charrua-unix.0.10/opam
+++ b/packages/charrua-unix/charrua-unix.0.10/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
   "lwt" {>= "3.0.0" & < "4.0.0"}
-  "charrua-core" {>= "0.10"}
+  "charrua-core" {= "0.10"}
   "cstruct-unix"
   "cmdliner"
   "rawlink" {<"1.0"}

--- a/packages/charrua-unix/charrua-unix.0.11.0/opam
+++ b/packages/charrua-unix/charrua-unix.0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "lwt" {>= "3.0.0"}
   "lwt_log"
-  "charrua-core" {>= "0.11.0"}
+  "charrua-core" {>= "0.11.0" & < "0.12.0"}
   "cstruct-unix"
   "cmdliner"
   "rawlink" {< "1.0"}

--- a/packages/charrua-unix/charrua-unix.0.11.1/opam
+++ b/packages/charrua-unix/charrua-unix.0.11.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "lwt" {>= "3.0.0"}
   "lwt_log"
-  "charrua-core" {>= "0.11.0"}
+  "charrua-core" {>= "0.11.0" & < "0.12.0"}
   "cstruct-unix"
   "cmdliner"
   "rawlink" {< "1.0"}

--- a/packages/charrua-unix/charrua-unix.0.11.2/opam
+++ b/packages/charrua-unix/charrua-unix.0.11.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "lwt" {>="3.0.0"}
   "lwt_log"
-  "charrua-core" {>= "0.11.0"}
+  "charrua-core" {>= "0.11.0" & < "0.12.0"}
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}

--- a/packages/charrua-unix/charrua-unix.0.12.0/opam
+++ b/packages/charrua-unix/charrua-unix.0.12.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/mirage/charrua-unix"
+bug-reports: "https://github.com/mirage/charrua-unix/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/charrua-unix.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.03.0"}
+  "lwt" {>="3.0.0"}
+  "lwt_log"
+  "charrua-core" {>= "0.12.0"}
+  "cstruct-unix"
+  "cmdliner"
+  "rawlink" {>= "1.0"}
+  "tuntap" {>= "1.2.0"}
+  "mtime" {>="1.0.0"}
+]
+synopsis: "Unix DHCP daemon"
+description: """
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua-core](http://www.github.com/mirage/charrua-core).
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua-unix/releases/download/v0.12.0/charrua-core-v0.12.0.tbz"
+  checksum: "md5=a1edfeeaea6d9ed079efec4514f0e44c"
+}


### PR DESCRIPTION
CHANGES:

* Adjust to mirage-net 2.0.0 and mirage-protocols 2.0.0 changes (mirage/charrua-unix#94, @hannesm)