### PR TITLE
zlib: add depexts through conf-zlib

### DIFF
--- a/packages/zlib/zlib.0.4/opam
+++ b/packages/zlib/zlib.0.4/opam
@@ -17,6 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bigarray"
+  "conf-zlib"
 ]
 synopsis: "Bindings to the zlib compression library"
 description: """

--- a/packages/zlib/zlib.0.5/opam
+++ b/packages/zlib/zlib.0.5/opam
@@ -17,6 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bigarray"
+  "conf-zlib"
 ]
 synopsis: "Bindings to the zlib compression library"
 description: """


### PR DESCRIPTION
Currently zlib fails in the opam CI:

[0.4](https://ci.ocamllabs.io/log/saved/docker-run-f2592628a10c77a781ef1c4fea411cb0/f7f4f1be1f81ba76e1126e0bb63c3fdbc86e18fd)
[0.5](https://ci.ocamllabs.io/log/saved/docker-run-a308eceadaa1ccf0093b509e8c855e78/2ba36db7ecf68f5b1c7b8c1f46576939af8245e0)