### PR TITLE
Sqlite3 metadata fixes

### DIFF
--- a/packages/sqlite3/sqlite3.3.0.0/opam
+++ b/packages/sqlite3/sqlite3.3.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "ocaml" {>= "3.12"}
   "ocamlfind" {build & >= "1.3.1"}
   "ocamlbuild" {build}
+  "conf-pkg-config" {build}
 ]
 depexts: [
   ["libsqlite3-dev"] {os-distribution = "debian"}

--- a/packages/sqlite3/sqlite3.3.0.0/opam
+++ b/packages/sqlite3/sqlite3.3.0.0/opam
@@ -24,13 +24,7 @@ depends: [
   "ocamlfind" {build & >= "1.3.1"}
   "ocamlbuild" {build}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.3.0.0/opam
+++ b/packages/sqlite3/sqlite3.3.0.0/opam
@@ -10,9 +10,6 @@ tags: [ "clib:sqlite3"  ]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
-  ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/sqlite3/sqlite3.4.0.0/opam
+++ b/packages/sqlite3/sqlite3.4.0.0/opam
@@ -12,9 +12,6 @@ build: [
   ["ocaml" "setup.ml" "-build"] {os != "macos"}
   ["env" "SQLITE3_OCAML_BREWCHECK=1" "ocaml" "setup.ml" "-build"]
     {os = "macos"}
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
-  ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/sqlite3/sqlite3.4.0.0/opam
+++ b/packages/sqlite3/sqlite3.4.0.0/opam
@@ -26,18 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.0.1/opam
+++ b/packages/sqlite3/sqlite3.4.0.1/opam
@@ -12,9 +12,6 @@ build: [
   ["ocaml" "setup.ml" "-build"] {os != "macos"}
   ["env" "SQLITE3_OCAML_BREWCHECK=1" "ocaml" "setup.ml" "-build"]
     {os = "macos"}
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
-  ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/sqlite3/sqlite3.4.0.1/opam
+++ b/packages/sqlite3/sqlite3.4.0.1/opam
@@ -26,18 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.0.2/opam
+++ b/packages/sqlite3/sqlite3.4.0.2/opam
@@ -26,18 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.0.3/opam
+++ b/packages/sqlite3/sqlite3.4.0.3/opam
@@ -26,18 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.0.4/opam
+++ b/packages/sqlite3/sqlite3.4.0.4/opam
@@ -26,18 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.0.6/opam
+++ b/packages/sqlite3/sqlite3.4.0.6/opam
@@ -26,18 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.1.0/opam
+++ b/packages/sqlite3/sqlite3.4.1.0/opam
@@ -26,18 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.1.2/opam
+++ b/packages/sqlite3/sqlite3.4.1.2/opam
@@ -26,19 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-family = "suse"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.1.3/opam
+++ b/packages/sqlite3/sqlite3.4.1.3/opam
@@ -26,19 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-family = "suse"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings"
 description: """

--- a/packages/sqlite3/sqlite3.4.2.0/opam
+++ b/packages/sqlite3/sqlite3.4.2.0/opam
@@ -23,19 +23,7 @@ depends: [
   "stdio" {build & < "v0.12"}
   "configurator" {build & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta10"}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-family = "suse"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  "conf-sqlite3" {build}
 ]
 synopsis: "SQLite3 bindings for OCaml"
 description: """

--- a/packages/sqlite3/sqlite3.4.3.0/opam
+++ b/packages/sqlite3/sqlite3.4.3.0/opam
@@ -19,23 +19,11 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "conf-pkg-config" {build}
+  "conf-sqlite3" {build}
   "base" {build & < "v0.12"}
   "stdio" {build & < "v0.12"}
   "configurator" {build & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta10"}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-family = "suse"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "SQLite3 bindings for OCaml"
 description: """

--- a/packages/sqlite3/sqlite3.4.3.1/opam
+++ b/packages/sqlite3/sqlite3.4.3.1/opam
@@ -19,23 +19,11 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "conf-pkg-config" {build}
+  "conf-sqlite3" {build}
   "base" {build & < "v0.12"}
   "stdio" {build & < "v0.12"}
   "configurator" {build & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta10"}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-family = "suse"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "SQLite3 bindings for OCaml"
 description: """

--- a/packages/sqlite3/sqlite3.4.3.2/opam
+++ b/packages/sqlite3/sqlite3.4.3.2/opam
@@ -19,23 +19,11 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "conf-pkg-config" {build}
+  "conf-sqlite3" {build}
   "base" {build & < "v0.12"}
   "stdio" {build & < "v0.12"}
   "configurator" {build & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta10"}
-]
-depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
-  ["database/sqlite3"] {os = "freebsd"}
-  ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
-  ["sqlite-devel"] {os-distribution = "centos"}
-  ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
-  ["sqlite-dev"] {os-distribution = "alpine"}
-  ["sqlite3-devel"] {os-family = "suse"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
-  ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "SQLite3 bindings for OCaml"
 description: """


### PR DESCRIPTION
- fix a CI build failure with 3.0.0 due to a missing `pkg-config` dependency
- consistently use `conf-sqlite3` (already used in latter versions) to improve depext quality on older versions