### PR TITLE
conf-maxminddb

### DIFF
--- a/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
+++ b/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
@@ -11,11 +11,12 @@ license: "Apache-2.0"
 build: [["pkg-config" "libmaxminddb"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libmaxminddb-dev"] {os-distribution = "debian"}
-  ["libmaxminddb-dev"] {os-distribution = "ubuntu"}
+  ["libmaxminddb-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
   ["net/libmaxminddb"] {os = "freebsd"}
   ["libmaxminddb"] {os-distribution = "homebrew" & os = "macos"}
   ["libmaxminddb-dev"] {os-distribution = "alpine"}
+  ["libmaxminddb-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "mageia"}
+  ["libmaxminddb-devel"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on a libmaxminddb system installation"
 description:

--- a/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
+++ b/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Marek Kubica <marek@xivilization.net>"
+authors: [
+  "Dave Rolsky"
+  "Boris Zentner"
+  "Gregory Oschwald"
+  "Will Storey"
+]
+homepage: "http://maxmind.github.io/libmaxminddb/"
+license: "Apache-2.0"
+build: [["pkg-config" "libmaxminddb"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["libmaxminddb-dev"] {os-distribution = "debian"}
+  ["libmaxminddb-dev"] {os-distribution = "ubuntu"}
+  ["net/libmaxminddb"] {os = "freebsd"}
+  ["libmaxminddb"] {os-distribution = "homebrew" & os = "macos"}
+  ["libmaxminddb-dev"] {os-distribution = "alpine"}
+]
+synopsis: "Virtual package relying on a libmaxminddb system installation"
+description:
+  "This package can only install if the libmaxminddb is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/maxminddb/maxminddb.0.3/opam
+++ b/packages/maxminddb/maxminddb.0.3/opam
@@ -23,6 +23,7 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "conf-libmaxminddb"
 ]
 synopsis: "Bindings to Maxmind.com's libmaxminddb library, think geoip2"
 description: """

--- a/packages/maxminddb/maxminddb.0.4/opam
+++ b/packages/maxminddb/maxminddb.0.4/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
+  "conf-libmaxminddb"
 ]
 synopsis: "Bindings to Maxmind.com's libmaxminddb library, like geoip2"
 description: """

--- a/packages/maxminddb/maxminddb.0.5/opam
+++ b/packages/maxminddb/maxminddb.0.5/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
+  "conf-libmaxminddb"
 ]
 synopsis: "Bindings to Maxmind.com's libmaxminddb library, like geoip2"
 description: """

--- a/packages/maxminddb/maxminddb.0.6/opam
+++ b/packages/maxminddb/maxminddb.0.6/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
+  "conf-libmaxminddb"
 ]
 synopsis: "Bindings to Maxmind.com's libmaxminddb library, like geoip2"
 description: """


### PR DESCRIPTION
Added libmaxminddb as `conf` package because we're working on a `ctypes`-based binding to it so it made sense to us to not just make `depexts` but rather a true `conf-libmaxminddb` package.