### PR TITLE
[new release] cstruct-async, ppx_cstruct, cstruct, cstruct-unix and cstruct-lwt (3.5.0)

### DIFF
--- a/packages/cstruct-async/cstruct-async.3.5.0/opam
+++ b/packages/cstruct-async/cstruct-async.3.5.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+doc: "https://mirage.github.io/ocaml-cstruct/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "async_kernel" {>= "v0.9.0" & < "v0.12"}
+  "async_unix" {>= "v0.9.0" & < "v0.12"}
+  "core_kernel" {>= "v0.9.0" & < "v0.12"}
+  "cstruct" {>= "3.2.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.5.0/cstruct-v3.5.0.tbz"
+  checksum: "md5=019c59aa18690fc05b80be1720efb6e5"
+}

--- a/packages/cstruct-lwt/cstruct-lwt.3.5.0/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.3.5.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "lwt"
+  "cstruct" {>="3.2.0"}
+  "dune" {build & >= "1.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.5.0/cstruct-v3.5.0.tbz"
+  checksum: "md5=019c59aa18690fc05b80be1720efb6e5"
+}

--- a/packages/cstruct-unix/cstruct-unix.3.5.0/opam
+++ b/packages/cstruct-unix/cstruct-unix.3.5.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build & >= "1.0"}
+  "base-unix"
+  "cstruct" {>="3.2.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.5.0/cstruct-v3.5.0.tbz"
+  checksum: "md5=019c59aa18690fc05b80be1720efb6e5"
+}

--- a/packages/cstruct/cstruct.3.5.0/opam
+++ b/packages/cstruct/cstruct.3.5.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "sexplib" {< "v0.12"}
+  "alcotest" {with-test}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.5.0/cstruct-v3.5.0.tbz"
+  checksum: "md5=019c59aa18690fc05b80be1720efb6e5"
+}

--- a/packages/ppx_cstruct/ppx_cstruct.3.5.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "3.1.1"}
+  "ounit" {with-test}
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_driver" {with-test & >= "v0.9.0"}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "cstruct-unix" {with-test}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.5.0/cstruct-v3.5.0.tbz"
+  checksum: "md5=019c59aa18690fc05b80be1720efb6e5"
+}


### PR DESCRIPTION
Access C-like structures directly from OCaml

- Project page: <a href="https://github.com/mirage/ocaml-cstruct">https://github.com/mirage/ocaml-cstruct</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cstruct/">https://mirage.github.io/ocaml-cstruct/</a>

##### CHANGES:

- Remove trailing spaces in hexdump output (mirage/ocaml-cstruct#219 @emillon)
- Add `Cstruct.rev` to allocate a reversed cstruct (mirage/ocaml-cstruct#221 @emillon)
- `Cstruct_unix` now uses the post-OCaml 4.06 `Unix.map_file`
  instead of the deprecated Bigarray `map_file` that was removed
  in OCaml 4.08 (@avsm, see ocaml/ocaml#2263)
- Remove unnecessary `(wrapped false)` in the build system (@avsm)
- Correct ocamldoc to the right `cstruct-ppx` package pointer (@avsm)
