### PR TITLE
release tls 0.10.1

### DIFF
--- a/packages/tls/tls.0.10.1/opam
+++ b/packages/tls/tls.0.10.1/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+name:         "tls"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+author:       ["David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD2"
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+    "--with-lwt" "%{lwt+ptime:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+    "--with-lwt" "%{lwt+ptime+astring:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ] {with-test}
+  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02.2"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "ppx_cstruct" {>= "3.0.0"}
+  "result"
+  "cstruct" {>= "3.0.0"}
+  "sexplib"
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.6.1"}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit" {with-test}
+]
+depopts: [
+  "lwt"
+  "mirage-flow-lwt"
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "ptime"
+  "astring" {with-test}
+]
+conflicts: [
+  "lwt" {<"2.4.8"}
+  "mirage-net-xen" {<"1.3.0"}
+  "mirage-types" {<"3.0.0"}
+  "mirage-kv-lwt" {<"2.0.0"}
+  "sexplib" {= "v0.9.0"}
+  "ppx_sexp_conv" {= "v0.11.0"}
+  "ptime" {< "0.8.1"}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io)."""
+url {
+archive: "https://github.com/mirleft/ocaml-tls/releases/download/0.10.1/tls-0.10.1.tbz"
+checksum: "c7a963dae296fb1f7588c9b801e683c4"
+}


### PR DESCRIPTION
CHANGES:
* tls-mirage: fix compilation
* tls: fix extensions length (used to include the 2 byte extension length field) if padding is inserted (introduced on May 5, 2014)
* tls-mirage: adapt to mirage-kv 2.0.0 API (@samoht)
