### PR TITLE
Package mariadb.1.1.2

### DIFF
--- a/packages/mariadb/mariadb.1.1.2/opam
+++ b/packages/mariadb/mariadb.1.1.2/opam
@@ -27,6 +27,7 @@ depends: [
 depexts: [
   ["libmariadb-dev"] {os-distribution = "debian"}
   ["libmariadb-dev"] {os-distribution = "ubuntu"}
+  ["mariadb-dev"] {os-distribution = "alpine"}
 ]
 flags: light-uninstall
 url {

--- a/packages/mariadb/mariadb.1.1.2/opam
+++ b/packages/mariadb/mariadb.1.1.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/ocaml-mariadb"
+bug-reports: "https://github.com/andrenth/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/andrenth/ocaml-mariadb.git"
+synopsis: "OCaml bindings for MariaDB"
+description: "OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API."
+
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "mariadb"]
+  ["ocamlfind" "remove" "mariadb_bindings"]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.7.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+depexts: [
+  ["libmariadb-dev"] {os-distribution = "debian"}
+  ["libmariadb-dev"] {os-distribution = "ubuntu"}
+]
+flags: light-uninstall
+url {
+  src: "https://github.com/andrenth/ocaml-mariadb/archive/1.1.2.tar.gz"
+  checksum: [
+    "md5=2d39c1ad309bc43bf2d3ee8e7a367083"
+    "sha512=f9f7d4c2bd1d44ccda5171bdbffa577690def4714e6258c7addb128d1c5dd386199766841b92865e3be9efb6e96d77123fe9cbc7b54712762ae4a29c09be09e8"
+  ]
+}


### PR DESCRIPTION
### `mariadb.1.1.2`
OCaml bindings for MariaDB
OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API.



---
* Homepage: https://github.com/andrenth/ocaml-mariadb
* Source repo: git+https://github.com/andrenth/ocaml-mariadb.git
* Bug tracker: https://github.com/andrenth/ocaml-mariadb/issues

---
:camel: Pull-request generated by opam-publish v2.0.0