### PR TITLE
Revert "introduce conflicts between base64 >=3.0.0 and extlib, both d…

### DIFF
--- a/packages/base64/base64.3.0.0/opam
+++ b/packages/base64/base64.3.0.0/opam
@@ -27,10 +27,6 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]
-conflicts: [
-  "extlib"
-  "extlib-compat"
-]
 url {
   src:
     "https://github.com/mirage/ocaml-base64/releases/download/v3.0.0/base64-v3.0.0.tbz"

--- a/packages/base64/base64.3.1.0/opam
+++ b/packages/base64/base64.3.1.0/opam
@@ -27,10 +27,6 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]
-conflicts: [
-  "extlib"
-  "extlib-compat"
-]
 url {
   src:
     "https://github.com/mirage/ocaml-base64/releases/download/v3.1.0/base64-v3.1.0.tbz"


### PR DESCRIPTION
…efine the base64 module"

This reverts commit 634a9973befd7c8be87082d862f5471da267b4a8.

as requested by @avsm and @jvillard in https://github.com/ocaml/opam-repository/pull/13552