### PR TITLE
Fix base upper bound (pcre)

### DIFF
--- a/packages/pcre/pcre.7.4.1/opam
+++ b/packages/pcre/pcre.7.4.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "dune" {build & >= "1.4.0"}
   "conf-libpcre" {build}
-  "base" {build & < "v0.12"}
+  "base" {build & < "v0.13"}
   "base-bytes"
 ]
 


### PR DESCRIPTION
I made a small mistake when adding the upper bounds.
It is probably harmless, but certainly annoying; this PR
restore compatibility of the latest pcre with v0.12.0 of
the Jane Street packages.