### PR TITLE
Package obelisk.0.4.0

### DIFF
--- a/packages/obelisk/obelisk.0.4.0/opam
+++ b/packages/obelisk/obelisk.0.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Pretty-printing for Menhir files"
+description: """
+Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly).
+It is inspired from yacc2latex and is also written in OCaml, but is aimed at supporting features from Menhir instead of only those of ocamlyacc.
+"""
+maintainer: "Lélio Brun <lelio.brun@inria.fr>"
+authors: "Lélio Brun <lelio.brun@inria.fr>"
+license: "MIT"
+homepage: "https://github.com/Lelio-Brun/Obelisk"
+bug-reports: "https://github.com/Lelio-Brun/Obelisk/issues"
+doc: "https://github.com/Lelio-Brun/Obelisk/blob/v0.4.0/README.md"
+dev-repo: "git+https://github.com/Lelio-Brun/Obelisk.git"
+build: [make]
+install: [make "install" "BINDIR=%{bin}%"]
+run-test: [make "tests"]
+depends: [
+  "ocaml" {build & >= "4.03"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "menhir" {build}
+]
+url {
+  src: "https://github.com/Lelio-Brun/Obelisk/archive/v0.4.0.tar.gz"
+  checksum: [
+    "md5=7901f47c113c9a2a4c105a7b8c764279"
+    "sha512=6a706b090c96b34f70f624949a463068031c9c2c2587d8eccd459612c35677b9b9b0de3b3fd91edc66ed9fc714c2a8a773287ff399ac170752faec968f80fac8"
+  ]
+}


### PR DESCRIPTION
### `obelisk.0.4.0`
Pretty-printing for Menhir files
Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly).
It is inspired from yacc2latex and is also written in OCaml, but is aimed at supporting features from Menhir instead of only those of ocamlyacc.



---
* Homepage: https://github.com/Lelio-Brun/Obelisk
* Source repo: git+https://github.com/Lelio-Brun/Obelisk.git
* Bug tracker: https://github.com/Lelio-Brun/Obelisk/issues

---
:camel: Pull-request generated by opam-publish v2.0.0