### PR TITLE
Package eigen.0.1.2

### DIFF
--- a/packages/eigen/eigen.0.1.2/opam
+++ b/packages/eigen/eigen.0.1.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/owlbarn/eigen.git"
 bug-reports: "https://github.com/owlbarn/eigen/issues"
 doc: "https://owlbarn.github.io/eigen/eigen"
 build: [
-  ["dune" "build" "eigen_cpp/libeigen_cpp_stubs.a"]
+  ["dune" "build" "-p" name "eigen_cpp/libeigen_cpp_stubs.a"]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/eigen/eigen.0.1.2/opam
+++ b/packages/eigen/eigen.0.1.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+doc: "https://owlbarn.github.io/eigen/eigen"
+build: [
+  ["dune" "build" "eigen_cpp/libeigen_cpp_stubs.a"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "dune" {build & >= "1.1.0"}
+]
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+"Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."
+url {
+  src: "https://github.com/owlbarn/eigen/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=be1551426fd260b6b585f287a1a9f173"
+    "sha512=237bdcee521617db9041983e6e067b728d272a352c59e70c83d28911fa8dbe0dc24fff9729f1e031f3552a6ca33d0038e352df4231a378b1e5e2a942f74374de"
+  ]
+}


### PR DESCRIPTION
### `eigen.0.1.2`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0