### PR TITLE
[new release] cstruct-async, ppx_cstruct, cstruct, cstruct-unix and cstruct-lwt (3.6.0)

### DIFF
--- a/packages/cstruct-async/cstruct-async.3.6.0/opam
+++ b/packages/cstruct-async/cstruct-async.3.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+doc: "https://mirage.github.io/ocaml-cstruct/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "async_kernel" {>= "v0.9.0" & < "v0.12"}
+  "async_unix" {>= "v0.9.0" & < "v0.12"}
+  "core_kernel" {>= "v0.9.0" & < "v0.12"}
+  "cstruct" {>= "3.2.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.6.0/cstruct-v3.6.0.tbz"
+  checksum: "md5=fa3ab5c5029dcab94fac95c3eceb4198"
+}

--- a/packages/cstruct-lwt/cstruct-lwt.3.6.0/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.3.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "lwt"
+  "cstruct" {>="3.2.0"}
+  "dune" {build & >= "1.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.6.0/cstruct-v3.6.0.tbz"
+  checksum: "md5=fa3ab5c5029dcab94fac95c3eceb4198"
+}

--- a/packages/cstruct-unix/cstruct-unix.3.6.0/opam
+++ b/packages/cstruct-unix/cstruct-unix.3.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build & >= "1.0"}
+  "base-unix"
+  "cstruct" {>="3.2.0"}
+]
+synopsis: "Access C-like structures directly from OCaml"
+
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.6.0/cstruct-v3.6.0.tbz"
+  checksum: "md5=fa3ab5c5029dcab94fac95c3eceb4198"
+}

--- a/packages/cstruct/cstruct.3.6.0/opam
+++ b/packages/cstruct/cstruct.3.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "sexplib" {< "v0.12"}
+  "alcotest" {with-test}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.6.0/cstruct-v3.6.0.tbz"
+  checksum: "md5=fa3ab5c5029dcab94fac95c3eceb4198"
+}

--- a/packages/ppx_cstruct/ppx_cstruct.3.6.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "3.1.1"}
+  "ounit" {with-test}
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_driver" {with-test & >= "v0.9.0"}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "cstruct-unix" {with-test}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v3.6.0/cstruct-v3.6.0.tbz"
+  checksum: "md5=fa3ab5c5029dcab94fac95c3eceb4198"
+}


### PR DESCRIPTION
Access C-like structures directly from OCaml

- Project page: <a href="https://github.com/mirage/ocaml-cstruct">https://github.com/mirage/ocaml-cstruct</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cstruct/">https://mirage.github.io/ocaml-cstruct/</a>

##### CHANGES:

- A `[%%cstruct type ...]` declaration generates many values that
  are potentially unused. The code generator in `ppx_cstruct` now
  guarantees that there will be no more "unused value" (warning 32)
  statements from use of the ppx form. (mirage/ocaml-cstruct#228 @emillon)
- Actually run the ppx tests instead of just building them.
  (mirage/ocaml-cstruct#227 @emillon to fix mirage/ocaml-cstruct#226 from @XVilka)
