### PR TITLE
remove upper bound on base and stdio from configurator

### DIFF
--- a/packages/configurator/configurator.v0.11.0/opam
+++ b/packages/configurator/configurator.v0.11.0/opam
@@ -11,8 +11,8 @@ build: [
 conflicts: [ "jbuilder" { = "1.0+beta19" } ]
 depends: [
   "ocaml" {>= "4.04.1"}
-  "base" {>= "v0.11" & < "v0.12"}
-  "stdio" {>= "v0.11" & < "v0.12"}
+  "base" {>= "v0.11"}
+  "stdio" {>= "v0.11"}
   "jbuilder" {build & >= "1.0+beta18.1"}
 ]
 synopsis: "Helper library for gathering system configuration"


### PR DESCRIPTION
Builds locally with base v0.12, so seems ok to relax the upper bound.

I'm not sure if sending this PR contradicts the desired workflow for these upper bounds. If so, please just close this.