### PR TITLE
[new release] travesty (0.3.0)

### DIFF
--- a/packages/travesty/travesty.0.3.0/opam
+++ b/packages/travesty/travesty.0.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Monadically traversable containers"
+description:
+  "'Travesty' is a library for defining containers with monadic traversals,
+   inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
+   Core library ecosystem."
+maintainer: "Matt Windsor <m.windsor@imperial.ac.uk>"
+authors: "Matt Windsor <m.windsor@imperial.ac.uk>"
+license: "MIT"
+doc: "https://MattWindsor91.github.io/travesty/"
+homepage: "https://MattWindsor91.github.io/travesty"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {build}
+  "ppx_deriving"
+  "ppx_expect"
+  "ppx_jane"
+  "ppx_sexp_message"
+  "core_kernel" {>= "v0.12" & < "v0.13"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/MattWindsor91/travesty"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.3.0/travesty-v0.3.0.tbz"
+  checksum: "md5=dc818d6b232f13edb388d25781cd99a2"
+}


### PR DESCRIPTION
Monadically traversable containers

- Project page: <a href="https://MattWindsor91.github.io/travesty">https://MattWindsor91.github.io/travesty</a>
- Documentation: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>

##### CHANGES:

## Breaking changes

- Now targeting v0.12 of Jane Street's upstream libraries.  This release of
  travesty no longer supports v0.11.
- As a result, travesty no longer supports OCaml 4.06; please use 4.07+.
- Traversable signature names have changed: `Basic_container0` is now `Basic0`,
  and `Basic_container1` is now `Basic1`.  The original names are now used for
  stronger interfaces that include implementations of `Container.S*`; see
  'new features' below for information.
