### PR TITLE
alcotest: old versions do not work on OCaml 4.08

### DIFF
--- a/packages/alcotest-async/alcotest-async.0.8.2/opam
+++ b/packages/alcotest-async/alcotest-async.0.8.2/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "alcotest"
+  "alcotest" {>= "0.8.0"}
   "async_unix" {>= "v0.9.0" & < "v0.12"}
   "core_kernel" {>= "v0.9.0" & < "v0.12"}
 ]

--- a/packages/alcotest-async/alcotest-async.0.8.5/opam
+++ b/packages/alcotest-async/alcotest-async.0.8.5/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"  {build}
   "ocaml" {>= "4.03.0"}
-  "alcotest"
+  "alcotest" {>= "0.8.0"}
   "async_unix" {>= "v0.9.0" & < "v0.12"}
   "core_kernel" {>= "v0.9.0" & < "v0.12"}
 ]

--- a/packages/alcotest-lwt/alcotest-lwt.0.8.5/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.0.8.5/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"  {build}
   "ocaml" {>= "4.02.3"}
-  "alcotest"
+  "alcotest" {>= "0.8.0"}
   "lwt" "logs"
 ]
 

--- a/packages/alcotest/alcotest.0.5.0/opam
+++ b/packages/alcotest/alcotest.0.5.0/opam
@@ -14,7 +14,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/alcotest/alcotest.0.6.0/opam
+++ b/packages/alcotest/alcotest.0.6.0/opam
@@ -14,7 +14,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/alcotest/alcotest.0.7.0/opam
+++ b/packages/alcotest/alcotest.0.7.0/opam
@@ -14,7 +14,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/alcotest/alcotest.0.7.1/opam
+++ b/packages/alcotest/alcotest.0.7.1/opam
@@ -14,7 +14,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/alcotest/alcotest.0.7.2/opam
+++ b/packages/alcotest/alcotest.0.7.2/opam
@@ -14,7 +14,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/junit_alcotest/junit_alcotest.2.0.1/opam
+++ b/packages/junit_alcotest/junit_alcotest.2.0.1/opam
@@ -10,7 +10,7 @@ tags: ["junit" "jenkins" "alcotest"]
 depends: [
   "dune" {build & >= "1.0"}
   "odoc" {with-doc & >= "1.1.1"}
-  "alcotest"
+  "alcotest" {>= "0.8.0"}
   "junit"
 ]
 build: [

--- a/packages/junit_alcotest/junit_alcotest.2.0/opam
+++ b/packages/junit_alcotest/junit_alcotest.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
   "odoc" {with-doc & >= "1.1.1"}
-  "alcotest"
+  "alcotest" {>= "0.8.0"}
   "junit"
 ]
 build: [

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -11,7 +11,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "qcheck-core" {>= "0.9"}
-  "alcotest"
+  "alcotest" {>= "0.8.0"}
   "odoc" {doc}
 ]
 build:[


### PR DESCRIPTION
Because Pervasives is used directly and warning-as-errors is enabled.