### PR TITLE
datakit-bridge-github: use a fix version of datakit-github

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {build & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "3.0.0"}
-  "datakit-github" {>= "0.11.0"}
+  "datakit-github" {>= "0.11.0" & < "0.12.0"}
   "datakit-client-9p" {>= "0.11.0"}
   "datakit-client-git"
   "logs"


### PR DESCRIPTION
See http://check.ocamllabs.io/4.03.0/bad/datakit-bridge-github.0.11.0