### PR TITLE
depyt: old version doesn't work on 4.08

### DIFF
--- a/packages/depyt/depyt.0.1.0/opam
+++ b/packages/depyt/depyt.0.1.0/opam
@@ -10,7 +10,7 @@ tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
(because of use of Pervasives + warn-errors)