### PR TITLE
[new release] mdx (1.3.0)

### DIFF
--- a/packages/mdx/mdx.1.3.0/opam
+++ b/packages/mdx/mdx.1.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org"]
+homepage:     "https://github.com/realworldocaml/mdx"
+license:      "ISC"
+dev-repo:     "git+https://github.com/realworldocaml/mdx.git"
+bug-reports:  "https://github.com/realworldocaml/mdx/issues"
+doc:          "https://realworldocaml.github.io/mdx/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "fmt"
+  "cppo" {build}
+  "astring"
+  "logs"
+  "cmdliner"
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "lwt" {with-test}
+  "conf-pandoc" {with-test}
+]
+
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility.
+"""
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.3.0/mdx-1.3.0.tbz"
+  checksum: "md5=c5551b5055dd071ab2b9ceb6258689b4"
+}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>
- Documentation: <a href="https://realworldocaml.github.io/mdx/">https://realworldocaml.github.io/mdx/</a>

##### CHANGES:

- Updated readme file with the new features: dune rules, named environment and
  ocaml versions, Some grammar correction too (@gpetiot, realworldocaml/mdx#101, aantron, realworldocaml/mdx#102)
- Better lexer error messages (@avsm, realworldocaml/mdx#103)
- Added cram syntax parsing (@trefis, realworldocaml/mdx#106)
- Renamed mdx to ocaml-mdx to avoid conflicts/for more precision (@clecat, realworldocaml/mdx#110, realworldocaml/mdx#115)
- Fix blank spaces causing parsing errors (@gpetiot, realworldocaml/mdx#97)
- Fix empty lines causing a String.sub (@clecat, realworldocaml/mdx#107)
