### PR TITLE
Added the initial release of the mmdb package

### DIFF
--- a/packages/mmdb/mmdb.0.1.0/opam
+++ b/packages/mmdb/mmdb.0.1.0/opam
@@ -8,15 +8,15 @@ maintainer: "Team Platypus <platypus@issuu.com>"
 build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [["dune" "runtest" "-p" name "-j" jobs]]
 depends: [
-  "alcotest" {with-test & >= "0.8.5" < "0.9.0"}
-  "base" {>= "v0.10" < "v0.13"}
+  "alcotest" {with-test & >= "0.8.5"}
+  "base" {>= "v0.10"}
   "conf-libmaxminddb"
-  "ctypes" {>= "0.14" < "0.15"}
-  "ctypes-foreign" {>= "0.4" < "0.5"}
+  "ctypes" {>= "0.14"}
+  "ctypes-foreign" {>= "0.4"}
   "dune" {build & >= "1.6"}
   "ocaml" {>= "4.04.1"}
-  "ppx_deriving" {build & >= "4.2" < "5.0"}
-  "ppx_let" {build & >= "v0.10" < "v0.13"}
+  "ppx_deriving" {build & >= "4.2"}
+  "ppx_let" {build & >= "v0.10"}
 ]
 synopsis: "Binding to the MaxMind DB library for GeoIP lookups"
 description: """

--- a/packages/mmdb/mmdb.0.1.0/opam
+++ b/packages/mmdb/mmdb.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage: "https://issuu.github.io/ocaml-mmdb"
+dev-repo: "git+https://github.com/issuu/ocaml-mmdb.git"
+bug-reports: "https://github.com/issuu/ocaml-mmdb/issues"
+doc: "https://issuu.github.io/ocaml-mmdb/"
+license: "Apache-2.0"
+maintainer: "Team Platypus <platypus@issuu.com>"
+build: [["dune" "build" "-p" name "-j" jobs]]
+run-test: [["dune" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "alcotest" {with-test & >= "0.8.5" < "0.9.0"}
+  "base" {>= "v0.10" < "v0.13"}
+  "conf-libmaxminddb"
+  "ctypes" {>= "0.14" < "0.15"}
+  "ctypes-foreign" {>= "0.4" < "0.5"}
+  "dune" {build & >= "1.6"}
+  "ocaml" {>= "4.04.1"}
+  "ppx_deriving" {build & >= "4.2" < "5.0"}
+  "ppx_let" {build & >= "v0.10" < "v0.13"}
+]
+synopsis: "Binding to the MaxMind DB library for GeoIP lookups"
+description: """
+mmdb binds to the official MaxMind DB C library and allows looking up IPs to
+their location.
+
+It supports both the GeoLite2 dataset published by MaxMind under a permissive
+Creative Commons Attribution-ShareAlike 4.0 International License as well as
+the proprietary database offered by MaxMind.
+
+Unlike other bindings this one uses the ctypes stub generation so it should be
+less prone to leaking memory.
+"""
+authors: "Martin Slota <msl@issuu.com>"
+url {
+  src:
+    "https://github.com/issuu/ocaml-mmdb/releases/download/0.1.0/mmdb-0.1.0.tbz"
+  checksum: "md5=e879d2724eb996b372bc567014f8b18b"
+}


### PR DESCRIPTION
This package probably won't build on older Ubuntu because the corresponding `libmaxminddb` does not support `pkg-config`.