### PR TITLE
Package eigen.0.1.3

### DIFF
--- a/packages/eigen/eigen.0.1.3/opam
+++ b/packages/eigen/eigen.0.1.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+doc: "https://owlbarn.github.io/eigen/eigen"
+build: [
+  ["dune" "build" "-p" name "eigen_cpp/libeigen_cpp_stubs.a"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "dune" {build & >= "1.1.0"}
+]
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+"Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."
+url {
+  src: "https://github.com/owlbarn/eigen/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=a3e9a83a291ec1d1f57a3913a4d30e10"
+    "sha512=bf978f27d28fdac370ce71380c40bfa3e70387452cc2284f56fb6728d1af0443d064063a92d6c23e6cfe11820f1f4efb6e52a07b572453ea928133548a82bec0"
+  ]
+}


### PR DESCRIPTION
### `eigen.0.1.3`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0