### PR TITLE
Package papi.0.1.0

### DIFF
--- a/packages/papi/papi.0.1.0/opam
+++ b/packages/papi/papi.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer:   ["David Kaloper Meršinjak <dk505@cam.ac.uk>"]
+authors:      ["David Kaloper Meršinjak <dk505@cam.ac.uk>"]
+license:      "ISC"
+homepage:     "https://github.com/pqwy/ocaml-papi"
+doc:          "https://pqwy.github.io/ocaml-papi/doc"
+dev-repo:     "git+https://github.com/pqwy/ocaml-papi.git"
+bug-reports:  "https://github.com/pqwy/ocaml-papi/issues"
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "fmt" {with-test} ]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+synopsis: """Performance Application Programming Interface for OCaml"""
+description: """\
+Papi provides OCaml bindings to
+[PAPI (Performance Application Programming Interface)][papi-home], a C library
+for portable access to hardware performance counters."""
+
+url {
+archive: "https://github.com/pqwy/ocaml-papi/releases/download/v0.1.0/papi-0.1.0.tbz"
+checksum: "bc1bf7f2a3768857723061e510d7adec"
+}


### PR DESCRIPTION
### `papi.0.1.0`
Performance Application Programming Interface for OCaml
Papi provides OCaml bindings to
[PAPI (Performance Application Programming Interface)][papi-home], a C library
for portable access to hardware performance counters.



---
* Homepage: https://github.com/pqwy/ocaml-papi
* Source repo: git+https://github.com/pqwy/ocaml-papi.git
* Bug tracker: https://github.com/pqwy/ocaml-papi/issues

---
## v0.1.0 2019-03-05

First release.

---
:camel: Pull-request generated by opam-publish v2.0.0