### PR TITLE
Package py.1.2

### DIFF
--- a/packages/py/py.1.2/opam
+++ b/packages/py/py.1.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-py"
+doc: "https://zshipko.github.io/ocaml-py/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-py.git"
+bug-reports: "https://github.com/zshipko/ocaml-py/issues"
+tags: ["python"]
+
+depends:
+[
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "ctypes" {>= "0.13.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+  "conf-python-3-dev"
+]
+
+build:
+[
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+post-messages: [
+    "Py requires Python 3.5 or greater"
+]
+
+synopsis: "Ctypes bindings to Python 3.5 or greater"
+url {
+  src: "https://github.com/zshipko/ocaml-py/archive/v1.2.tar.gz"
+  checksum: [
+    "md5=2c6774d3156e994182753394a7ad624d"
+    "sha512=94f06d73d079d7c715b596de73eab884560dca98e36a5b6257b41d51d58b99aa724edd43ea1e17e33d4fe007b2926be0b5e0b8ebc882297014b46602adb21c30"
+  ]
+}


### PR DESCRIPTION
### `py.1.2`
Ctypes bindings to Python 3.5 or greater



---
* Homepage: https://github.com/zshipko/ocaml-py
* Source repo: git+https://github.com/zshipko/ocaml-py.git
* Bug tracker: https://github.com/zshipko/ocaml-py/issues

---
:camel: Pull-request generated by opam-publish v2.0.0