### PR TITLE
Package morbig.0.10.3

### DIFF
--- a/packages/morbig/morbig.0.10.3/opam
+++ b/packages/morbig/morbig.0.10.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+
+synopsis: "A trustworthy parser for POSIX shell"
+description: """
+Morbig is a parser for shell scripts written in the POSIX shell script
+language. It parses the scripts statically, that is without executing
+them, and constructs a concrete syntax tree for each of them. The
+concrete syntax trees are built using constructors according to the
+shell grammar of the POSIX standard.
+"""
+
+maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+authors: [
+  "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+  "Ralf Treinen <ralf.treinen@irif.fr>"
+  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+]
+license: "GPL3"
+
+homepage: "https://github.com/colis-anr/morbig"
+bug-reports: "https://github.com/colis-anr/morbig/issues"
+dev-repo: "git://github.com/colis-anr/morbig.git"
+
+available: [os != "macos"]
+depends: [
+  "dune"                 {build & >= "1.4.0"}
+  "menhir"               {>= "20170509"}
+  "ocaml"                {build & >= "4.04"}
+  "odoc"                 {with-doc}
+  "ppx_deriving_yojson"
+  "visitors"             {build & >= "20180513"}
+  "yojson"
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [make "check"]
+url {
+  src: "https://github.com/colis-anr/morbig/archive/0.10.3.tar.gz"
+  checksum: [
+    "md5=33186542556d300f590b64893d636bdc"
+    "sha512=8a3642ed9d78f9e1b24708e693de567baac01b37b6ec7c4e524fdf902453bffc89aeee03d5ae0e6455eabeca8497c0dcf16ce5a633c526107ec0f8853122ecbd"
+  ]
+}


### PR DESCRIPTION
### `morbig.0.10.3`
A trustworthy parser for POSIX shell
Morbig is a parser for shell scripts written in the POSIX shell script
language. It parses the scripts statically, that is without executing
them, and constructs a concrete syntax tree for each of them. The
concrete syntax trees are built using constructors according to the
shell grammar of the POSIX standard.



---
* Homepage: https://github.com/colis-anr/morbig
* Source repo: git://github.com/colis-anr/morbig.git
* Bug tracker: https://github.com/colis-anr/morbig/issues

---
:camel: Pull-request generated by opam-publish v2.0.0