### PR TITLE
Packages Morbig 0.10.3 and Morsmall 0.2.0

### DIFF
--- a/packages/morbig/morbig.0.10.3/opam
+++ b/packages/morbig/morbig.0.10.3/opam
@@ -24,7 +24,7 @@ dev-repo: "git://github.com/colis-anr/morbig.git"
 depends: [
   "dune"                 {build & >= "1.4.0"}
   "menhir"               {>= "20170509"}
-  "ocaml"                {build & >= "4.04"}
+  "ocaml"                {>= "4.04"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
   "visitors"             {>= "20180513"}

--- a/packages/morbig/morbig.0.10.3/opam
+++ b/packages/morbig/morbig.0.10.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"                {build & >= "4.04"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
-  "visitors"             {build & >= "20180513"}
+  "visitors"             {>= "20180513"}
   "yojson"
 ]
 

--- a/packages/morbig/morbig.0.10.3/opam
+++ b/packages/morbig/morbig.0.10.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+
+synopsis: "A trustworthy parser for POSIX shell"
+description: """
+Morbig is a parser for shell scripts written in the POSIX shell script
+language. It parses the scripts statically, that is without executing
+them, and constructs a concrete syntax tree for each of them. The
+concrete syntax trees are built using constructors according to the
+shell grammar of the POSIX standard.
+"""
+
+maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+authors: [
+  "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+  "Ralf Treinen <ralf.treinen@irif.fr>"
+  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+]
+license: "GPL3"
+
+homepage: "https://github.com/colis-anr/morbig"
+bug-reports: "https://github.com/colis-anr/morbig/issues"
+dev-repo: "git://github.com/colis-anr/morbig.git"
+
+depends: [
+  "dune"                 {build & >= "1.4.0"}
+  "menhir"               {>= "20170509"}
+  "ocaml"                {build & >= "4.04"}
+  "odoc"                 {with-doc}
+  "ppx_deriving_yojson"
+  "visitors"             {build & >= "20180513"}
+  "yojson"
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [make "check"]
+
+url {
+  src: "https://github.com/colis-anr/morbig/archive/0.10.3.tar.gz"
+  checksum: [
+    "md5=93ad6f7e3e112e8ffc1b838250085a11"
+    "sha512=ee51f1b257b14a780c28bee0190f58c7af9e9bb7393f2a2a47d5b5a02fcb24ca0fb37e8cc51408eafe977e7ea2ee53b1570e3b5345ed74975973c909acdc3507"
+  ]
+}

--- a/packages/morsmall/morsmall.0.1/opam
+++ b/packages/morsmall/morsmall.0.1/opam
@@ -16,7 +16,7 @@ dev-repo: "git+ssh://git@github.com/colis-anr/morsmall.git"
 
 depends: [
   "dune"    {build}
-  "morbig"
+  "morbig"  {< "0.10.0"}
   "ocaml"   {>= "4.04"}
 ]
 

--- a/packages/morsmall/morsmall.0.2.0/opam
+++ b/packages/morsmall/morsmall.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "A concise AST for POSIX shell"
+description: """
+A concise AST for POSIX shell
+"""
+
+maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+authors: [ "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>" ]
+license: "GPL3"
+
+homepage: "https://github.com/colis-anr/morsmall"
+bug-reports: "https://github.com/colis-anr/morsmall/issues"
+dev-repo: "git+ssh://git@github.com/colis-anr/morsmall.git"
+
+depends: [
+  "dune"          {build}
+  "morbig"        {>= "0.10.0"}
+  "ocaml"         {>= "4.04"}
+  "ppx_deriving"  {build}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/colis-anr/morsmall/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=0882ae5bb8e4ade3749c1d3f45df85ff"
+    "sha512=f0aeac41022b06879e92bf864217f7fa1e63deb8815d8bb98bac89ae2146fdeb1eeb118049c143aac0ec2cdddffe8a7038f5042385ef786c9228be0bda3c1b18"
+  ]
+}

--- a/packages/morsmall/morsmall.0.2.0/opam
+++ b/packages/morsmall/morsmall.0.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"          {build}
   "morbig"        {>= "0.10.0"}
   "ocaml"         {>= "4.04"}
-  "ppx_deriving"  {build}
+  "ppx_deriving"
 ]
 
 build: [


### PR DESCRIPTION
### Morbig 0.10.3

Morbig is a parser for shell scripts written in the POSIX shell script
language. It parses the scripts statically, that is without executing
them, and constructs a concrete syntax tree for each of them. The
concrete syntax trees are built using constructors according to the
shell grammar of the POSIX standard.

### Morsmall 0.2.0

A concise AST for POSIX shell.
