### PR TITLE
Release mirage-qubes mirage-qubes-ipv4 0.7.0

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-qubes" {>= "0.5"}
+  "mirage-qubes" {>= "0.5" & < "0.6"}
   "tcpip" {>= "3.0.0" & < "3.5.0"}
   "ipaddr" {< "3.0.0"}
   "mirage-protocols-lwt" {< "1.4.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-qubes" {>= "0.6"}
+  "mirage-qubes" {>= "0.6" & < "0.7.0"}
   "tcpip" {>= "3.5.0"}
   "ipaddr" {>= "3.0.0"}
   "mirage-random"

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-qubes" {>= "0.6"}
+  "mirage-qubes" {>= "0.6" & < "0.7.0"}
   "tcpip" {>= "3.5.0"}
   "ipaddr" {< "3.0.0"}
   "mirage-random"

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {build & >= "1.0"}
+  "mirage-qubes" { >= "0.6" }
+  "tcpip" { >= "3.5.0" }
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random"
+  "mirage-clock"
+  "mirage-protocols-lwt" { >= "2.0.0" }
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.03.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.7.0/mirage-qubes-v0.7.0.tbz"
+  checksum: "md5=0d9ed83062cbe806672f7c7c3c01b356"
+}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "dune"  {build & >= "1.0"}
-  "mirage-qubes" { >= "0.6" }
+  "mirage-qubes" { >= "0.7.0" }
   "tcpip" { >= "3.5.0" }
   "ipaddr" { >= "3.0.0" }
   "mirage-random"

--- a/packages/mirage-qubes/mirage-qubes.0.7.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.7.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {build & >= "1.0"}
+  "cstruct" { >= "1.9.0" }
+  "ppx_cstruct"
+  "vchan-xen"
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen" { >= "3.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.03.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.7.0/mirage-qubes-v0.7.0.tbz"
+  checksum: "md5=0d9ed83062cbe806672f7c7c3c01b356"
+}


### PR DESCRIPTION
CHANGES
- mirage-qubes-ipv4: compatibility with mirage-protocols 2.0.0 and mirage-net 2.0.0