### PR TITLE
Better zstd dependencies

### DIFF
--- a/packages/conf-zstd/conf-zstd.1.3.8/files/main.c
+++ b/packages/conf-zstd/conf-zstd.1.3.8/files/main.c
@@ -1,0 +1,5 @@
+#include "zstd.h"
+#if ZSTD_VERSION_NUMBER < 10308
+# error "zstd it too old (should be at least 1.3.8)"
+#endif
+int main() { return 0; }

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -4,7 +4,10 @@ homepage: "http://zstd.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]
 license: "BSD"
-build: [["pkg-config" "libzstd"]]
+build: [
+  ["pkg-config" "libzstd"]
+  ["cc" "main.c"]
+]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libzstd-dev"] {os-distribution = "debian"}
@@ -14,9 +17,6 @@ depexts: [
   ["libzstd-devel"] {os-distribution = "fedora"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}
-]
-build: [
-  ["cc" "main.c"]
 ]
 synopsis: "Virtual package relying on zstd"
 description:"

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+homepage: "http://zstd.net/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Facebook"]
+license: "BSD"
+build: [["pkg-config" "libzstd"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["libzstd-dev"] {os-distribution = "debian"}
+  ["libzstd-dev"] {os-distribution = "ubuntu"}
+  ["libzstd-devel"] {os-distribution = "centos"}
+  ["libzstd-devel"] {os-distribution = "rhel"}
+  ["libzstd-devel"] {os-distribution = "fedora"}
+  ["zstd-dev"] {os-distribution = "alpine"}
+  ["zstd"] {os-distribution = "homebrew" & os = "macos"}
+]
+build: [
+  ["cc" "main.c"]
+]
+synopsis: "Virtual package relying on zstd"
+description:"
+This package can only install if the zstd library is installed on the system,
+and its version is at least 1.3.8
+"
+extra-files: ["main.c" "md5=fa8e42b5b9b928730ce53849767f2233"]

--- a/packages/zstandard/zstandard.v0.12.0/opam
+++ b/packages/zstandard/zstandard.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"       {>= "4.07.0"}
   "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
-  "conf-zstd"   {>= "1.3.8"}
+  "conf-zstd"   {= "1.3.8"}
   "ctypes"
   "dune"        {build & >= "1.5.1"}
 ]

--- a/packages/zstandard/zstandard.v0.12.0/opam
+++ b/packages/zstandard/zstandard.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"       {>= "4.07.0"}
   "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
-  "conf-zstd"
+  "conf-zstd-1.3.8"
   "ctypes"
   "dune"        {build & >= "1.5.1"}
 ]

--- a/packages/zstandard/zstandard.v0.12.0/opam
+++ b/packages/zstandard/zstandard.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"       {>= "4.07.0"}
   "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
-  "conf-zstd-1.3.8"
+  "conf-zstd"   {>= "1.3.8"}
   "ctypes"
   "dune"        {build & >= "1.5.1"}
 ]


### PR DESCRIPTION
The `zstandard` package fails to build if the version of
Zstandard installed on the system is too old (I have
seen this *e.g.* on Debian Stretch).

This pull request adds a revised version of the
`conf-zstd` package that ensures that at least 1.3.8
is present, and make `zstandard` depend on it.

However, I am not certain it is the best (or even a
correct) way to achieve that; feedback more than
welcome.