### PR TITLE
The great Iter migration.

### DIFF
--- a/packages/sequence/sequence.0.1/opam
+++ b/packages/sequence/sequence.0.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -17,6 +17,6 @@ It is intented to transfer a finite number of elements from one data structure
 to another, perhaps with some intermediate transformations."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.1.tar.gz"
-  checksum: "md5=967d9d96332effb340f96c86c6a6bb12"
+  src: "https://github.com/c-cube/iter/archive/0.1.tar.gz"
+  checksum: "sha256=f393291cfaaea7a56dcddb96dca5e9385109bf4338460f33de5717ada704411a"
 }

--- a/packages/sequence/sequence.0.10/opam
+++ b/packages/sequence/sequence.0.10/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-bug-reports: "https://github.com/c-cube/sequence/issues"
+homepage: "https://github.com/c-cube/iter/"
+bug-reports: "https://github.com/c-cube/iter/issues"
 license: "BSD-2-clauses"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
 tags: ["sequence" "iterator" "iter" "fold"]
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 build: [
   [
     "./configure"
@@ -37,6 +37,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.10.tar.gz"
-  checksum: "md5=da3ce107161a663d00ae674c2e51a120"
+  src: "https://github.com/c-cube/iter/archive/0.10.tar.gz"
+  checksum: "sha256=803a6522e3676b3507638fd96c82c8c34f6de8b05536989019ab3d9f9f55e6c4"
 }

--- a/packages/sequence/sequence.0.11/opam
+++ b/packages/sequence/sequence.0.11/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-bug-reports: "https://github.com/c-cube/sequence/issues"
+homepage: "https://github.com/c-cube/iter/"
+bug-reports: "https://github.com/c-cube/iter/issues"
 license: "BSD-2-clauses"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
 tags: ["sequence" "iterator" "iter" "fold"]
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 build: [
   [
     "./configure"
@@ -37,6 +37,6 @@ Simple sequence abstract datatype, intended to iterate efficiently
 on collections while performing some transformations."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.11.tar.gz"
-  checksum: "md5=b7edb3a8570964ed2bc3cb5036cfb18f"
+  src: "https://github.com/c-cube/iter/archive/0.11.tar.gz"
+  checksum: "sha256=87302cf384adcafe1e4cc13683b2aa06c01fa7b1c44a6314af48e93baa1cbcdd"
 }

--- a/packages/sequence/sequence.0.2/opam
+++ b/packages/sequence/sequence.0.2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -18,6 +18,6 @@ to another, perhaps with some intermediate transformations. It also provides a t
 library for S-expressions, convertible to streams of tokens, and conversely."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.2.tar.gz"
-  checksum: "md5=c8271ba96afcc07f590a2586e96a7eef"
+  src: "https://github.com/c-cube/iter/archive/0.2.tar.gz"
+  checksum: "sha256=a612283ab5dfedaa8469d5174a438e75398ac24262a9398fe6b4f00a0bbd602d"
 }

--- a/packages/sequence/sequence.0.3.1/opam
+++ b/packages/sequence/sequence.0.3.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -19,6 +19,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.1.tar.gz"
-  checksum: "md5=3cd7643874d7174aa05440e16ff48aec"
+  src: "https://github.com/c-cube/iter/archive/0.3.1.tar.gz"
+  checksum: "sha256=6754673c897725bd582e034eb25a223f5dada656283dfe212b158eb390d5e1d1"
 }

--- a/packages/sequence/sequence.0.3.2/opam
+++ b/packages/sequence/sequence.0.3.2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -19,6 +19,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.2.tar.gz"
-  checksum: "md5=2e8e14237f71dd4f423f0d935d0d34da"
+  src: "https://github.com/c-cube/iter/archive/0.3.2.tar.gz"
+  checksum: "sha256=c6da0e28587310a72f06fd9f4a481ab449a730940179aff4a9ef79424b532a51"
 }

--- a/packages/sequence/sequence.0.3.3/opam
+++ b/packages/sequence/sequence.0.3.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -19,6 +19,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.3.tar.gz"
-  checksum: "md5=2f6edd79a4ea7fe83762eeb01c5f3109"
+  src: "https://github.com/c-cube/iter/archive/0.3.3.tar.gz"
+  checksum: "sha256=44e347f6943b15d0ef088181a4dc9c127f6357a5b24b20f03c73081faafb3e6b"
 }

--- a/packages/sequence/sequence.0.3.4/opam
+++ b/packages/sequence/sequence.0.3.4/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -19,6 +19,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.4.tar.gz"
-  checksum: "md5=4bd7a98b2f29815d033a849cefd531e7"
+  src: "https://github.com/c-cube/iter/archive/0.3.4.tar.gz"
+  checksum: "sha256=dc3be7bc720028750b1deb240b2ea89b4b3f01e716c195e7ecb8113c61cea9ee"
 }

--- a/packages/sequence/sequence.0.3.5/opam
+++ b/packages/sequence/sequence.0.3.5/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -19,6 +19,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.5.tar.gz"
-  checksum: "md5=3cd04feac1febcdda41ac907229fd059"
+  src: "https://github.com/c-cube/iter/archive/0.3.5.tar.gz"
+  checksum: "sha256=7555a97baea1273fef50db97aa29b3b4b68d4ad5b6267deb14190bc10db304d3"
 }

--- a/packages/sequence/sequence.0.3.6.1/opam
+++ b/packages/sequence/sequence.0.3.6.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-doc: ["http://cedeela.fr/~simon/software/sequence/Sequence.html"]
+homepage: "https://github.com/c-cube/iter/"
+doc: ["http://cedeela.fr/~simon/software/iter/Sequence.html"]
 tags: [
   "sequence"
   "iterator"
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -26,6 +26,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.6.1.tar.gz"
-  checksum: "md5=c781cbacef0751c45e41e07928ae86df"
+  src: "https://github.com/c-cube/iter/archive/0.3.6.1.tar.gz"
+  checksum: "sha256=7b19d08f0a926abdbcc64fa21af7d682a5c34135de7f051b2cccd4110ddc1db2"
 }

--- a/packages/sequence/sequence.0.3.6/opam
+++ b/packages/sequence/sequence.0.3.6/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-doc: ["http://cedeela.fr/~simon/software/sequence/Sequence.html"]
+homepage: "https://github.com/c-cube/iter/"
+doc: ["http://cedeela.fr/~simon/software/iter/Sequence.html"]
 tags: [
   "sequence"
   "iterator"
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -26,6 +26,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.6.tar.gz"
-  checksum: "md5=d4eb0d26b1a634e7983c62d085f82729"
+  src: "https://github.com/c-cube/iter/archive/0.3.6.tar.gz"
+  checksum: "sha256=eb03db075a1fea9f228ce497723240eeb63c399bb30cb6061824d97ad3027127"
 }

--- a/packages/sequence/sequence.0.3.7/opam
+++ b/packages/sequence/sequence.0.3.7/opam
@@ -11,9 +11,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-dev-repo: "git://github.com/c-cube/sequence"
+homepage: "https://github.com/c-cube/iter/"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -23,6 +23,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.7.tar.gz"
-  checksum: "md5=c633e1395ac987ae430949f74f911203"
+  src: "https://github.com/c-cube/iter/archive/0.3.7.tar.gz"
+  checksum: "sha256=532944d0962141a1d1d10e4e226e3877b95aa05c93b662f21bce886482b8456f"
 }

--- a/packages/sequence/sequence.0.3/opam
+++ b/packages/sequence/sequence.0.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
@@ -9,7 +9,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/c-cube/sequence"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple sequence abstract datatype."
 description: """
@@ -19,6 +19,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.3.tar.gz"
-  checksum: "md5=ef3ed3bf67ca728b1c957a5e520f1c96"
+  src: "https://github.com/c-cube/iter/archive/0.3.tar.gz"
+  checksum: "sha256=d26227c33e212c7c484835672206a2cf268e63714ce20940f0e8a1b28c1b673f"
 }

--- a/packages/sequence/sequence.0.4.1/opam
+++ b/packages/sequence/sequence.0.4.1/opam
@@ -14,9 +14,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-dev-repo: "git://github.com/c-cube/sequence"
+homepage: "https://github.com/c-cube/iter/"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -26,6 +26,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.4.1.tar.gz"
-  checksum: "md5=0f641e4ae3f09d490e3ca05ae0520a23"
+  src: "https://github.com/c-cube/iter/archive/0.4.1.tar.gz"
+  checksum: "sha256=20f29d94ae50643ce0cab2a0e0cd55354ebc3a8479cc0e289bd1a426dafae87c"
 }

--- a/packages/sequence/sequence.0.4/opam
+++ b/packages/sequence/sequence.0.4/opam
@@ -14,9 +14,9 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-dev-repo: "git://github.com/c-cube/sequence"
+homepage: "https://github.com/c-cube/iter/"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -26,6 +26,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.4.tar.gz"
-  checksum: "md5=55f3d4d198502c38347c6e2aa5299e50"
+  src: "https://github.com/c-cube/iter/archive/0.4.tar.gz"
+  checksum: "sha256=f117505b8a7e3702711c4d63619027267979cac7704a541a6189496ecb5fc1a7"
 }

--- a/packages/sequence/sequence.0.5.1/opam
+++ b/packages/sequence/sequence.0.5.1/opam
@@ -14,10 +14,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 depopts: ["delimcc"]
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-dev-repo: "git://github.com/c-cube/sequence"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -27,6 +27,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.5.1.tar.gz"
-  checksum: "md5=1eb4b9d6fb1f8a7fd5ce279818bdcfe0"
+  src: "https://github.com/c-cube/iter/archive/0.5.1.tar.gz"
+  checksum: "sha256=eb44882cd7e9acf6cc9f5e123c5c2bb531cfeca8799df058c104e53ac9377f01"
 }

--- a/packages/sequence/sequence.0.5.2/opam
+++ b/packages/sequence/sequence.0.5.2/opam
@@ -14,10 +14,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 depopts: ["delimcc"]
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-dev-repo: "git://github.com/c-cube/sequence"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -27,6 +27,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.5.2.tar.gz"
-  checksum: "md5=8477834a1f49f522eeffaa5f837ea68e"
+  src: "https://github.com/c-cube/iter/archive/0.5.2.tar.gz"
+  checksum: "sha256=a0b0c7417faff4e1ec728cbdc368431f5447f3d92aac92282d8f84e9e5aa2579"
 }

--- a/packages/sequence/sequence.0.5.3/opam
+++ b/packages/sequence/sequence.0.5.3/opam
@@ -14,10 +14,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 depopts: ["delimcc"]
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-dev-repo: "git://github.com/c-cube/sequence"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -27,6 +27,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.5.3.tar.gz"
-  checksum: "md5=1bcbf1efed1d9aa9422a1401a81b2598"
+  src: "https://github.com/c-cube/iter/archive/0.5.3.tar.gz"
+  checksum: "sha256=40303d84e271434b7b38a47ecc0e54b127a5497757e4646e896af88abf1b13a8"
 }

--- a/packages/sequence/sequence.0.5.4/opam
+++ b/packages/sequence/sequence.0.5.4/opam
@@ -15,11 +15,11 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 depopts: ["delimcc"]
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-bug-reports: "https://github.com/c-cube/sequence/issues"
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+bug-reports: "https://github.com/c-cube/iter/issues"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
 Simple sequence abstract data type, intended to transfer a finite number of
@@ -28,6 +28,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.5.4.tar.gz"
-  checksum: "md5=e7041f75add746c3aaef1840825df180"
+  src: "https://github.com/c-cube/iter/archive/0.5.4.tar.gz"
+  checksum: "sha256=8091673c988bf752035846993e3f65baf2154b38c29992343f2bdfab12f7a350"
 }

--- a/packages/sequence/sequence.0.5.5/opam
+++ b/packages/sequence/sequence.0.5.5/opam
@@ -19,11 +19,11 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 depopts: ["delimcc" "base-bigarray"]
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-bug-reports: "https://github.com/c-cube/sequence/issues"
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+bug-reports: "https://github.com/c-cube/iter/issues"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
 Simple sequence abstract data type, intended to transfer a finite number of
@@ -32,6 +32,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.5.5.2.tar.gz"
-  checksum: "md5=5df331503f005790fba5674baa693ea6"
+  src: "https://github.com/c-cube/iter/archive/0.5.5.2.tar.gz"
+  checksum: "sha256=1174bd9d8d8f4b3acb4ee3639a71525d5b3a35fa1e28f248fa538d49e9a070b6"
 }

--- a/packages/sequence/sequence.0.5/opam
+++ b/packages/sequence/sequence.0.5/opam
@@ -14,10 +14,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 depopts: ["delimcc"]
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-dev-repo: "git://github.com/c-cube/sequence"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+dev-repo: "git://github.com/c-cube/iter"
 install: [make "install"]
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
@@ -27,6 +27,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.5.tar.gz"
-  checksum: "md5=809d29163439763031d78506b6787864"
+  src: "https://github.com/c-cube/iter/archive/0.5.tar.gz"
+  checksum: "sha256=014b20f6e4e15df3d418939fa0776b5712d2ae79fa1f61355d375dd8be3f4aef"
 }

--- a/packages/sequence/sequence.0.6/opam
+++ b/packages/sequence/sequence.0.6/opam
@@ -19,11 +19,11 @@ depends: [
   "ocamlbuild" {build}
 ]
 tags: [ "sequence" "iterator" "iter" "fold" ]
-homepage: "https://github.com/c-cube/sequence/"
+homepage: "https://github.com/c-cube/iter/"
 depopts: ["delimcc" "base-bigarray"]
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
-bug-reports: "https://github.com/c-cube/sequence/issues"
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
+bug-reports: "https://github.com/c-cube/iter/issues"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 synopsis: "Simple and lightweight sequence abstract data type."
 description: """
 Simple sequence abstract data type, intended to transfer a finite number of
@@ -32,6 +32,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.6.tar.gz"
-  checksum: "md5=5ebfa57dda39e30fe28dd474a04ccacb"
+  src: "https://github.com/c-cube/iter/archive/0.6.tar.gz"
+  checksum: "sha256=a0d725f44fa618f9d3363ad316ec8ba3592fc1b6f40df3da0bcf0c7019995b4c"
 }

--- a/packages/sequence/sequence.0.7/opam
+++ b/packages/sequence/sequence.0.7/opam
@@ -1,11 +1,11 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-bug-reports: "https://github.com/c-cube/sequence/issues"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
+homepage: "https://github.com/c-cube/iter/"
+bug-reports: "https://github.com/c-cube/iter/issues"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
 tags: ["sequence" "iterator" "iter" "fold"]
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 build: [
   [
     "./configure"
@@ -32,6 +32,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.7.tar.gz"
-  checksum: "md5=8147da28cb5680ef68133442f51abf0e"
+  src: "https://github.com/c-cube/iter/archive/0.7.tar.gz"
+  checksum: "sha256=280fb9528d36d18cf68f3e65007195b6a5a495ea12b1dfb8ae74b32a1afb7769"
 }

--- a/packages/sequence/sequence.0.8/opam
+++ b/packages/sequence/sequence.0.8/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-bug-reports: "https://github.com/c-cube/sequence/issues"
+homepage: "https://github.com/c-cube/iter/"
+bug-reports: "https://github.com/c-cube/iter/issues"
 license: "BSD-2-clauses"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
 tags: ["sequence" "iterator" "iter" "fold"]
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 build: [
   [
     "./configure"
@@ -33,6 +33,6 @@ like `filter`, `map`, `take`, `drop` and `append` can be performed before the
 sequence is iterated/folded on."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.8.tar.gz"
-  checksum: "md5=2501d15e53088fdf2663bde9c274985a"
+  src: "https://github.com/c-cube/iter/archive/0.8.tar.gz"
+  checksum: "sha256=48d1afa46c861be7e5c33fc369ed45160c1d3e0a5cf1a05496a234c56c8fc4e9"
 }

--- a/packages/sequence/sequence.0.9/opam
+++ b/packages/sequence/sequence.0.9/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-bug-reports: "https://github.com/c-cube/sequence/issues"
+homepage: "https://github.com/c-cube/iter/"
+bug-reports: "https://github.com/c-cube/iter/issues"
 license: "BSD-2-clauses"
-doc: "http://cedeela.fr/~simon/software/sequence/Sequence.html"
+doc: "http://cedeela.fr/~simon/software/iter/Sequence.html"
 tags: ["sequence" "iterator" "iter" "fold"]
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 build: [
   [
     "./configure"
@@ -31,6 +31,6 @@ Simple sequence abstract datatype, intended to iterate efficiently
 on collections while performing some transformations."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/sequence/archive/0.9.tar.gz"
-  checksum: "md5=d8304c09a19ff45b925d6193d60477e7"
+  src: "https://github.com/c-cube/iter/archive/0.9.tar.gz"
+  checksum: "sha256=0358430d467731b8d57fa36814f3c956d9084b21e23b553b9bd86b0aa271a01c"
 }

--- a/packages/sequence/sequence.1.0/opam
+++ b/packages/sequence/sequence.1.0/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-bug-reports: "https://github.com/c-cube/sequence/issues"
+homepage: "https://github.com/c-cube/iter/"
+bug-reports: "https://github.com/c-cube/iter/issues"
 license: "BSD-2-clauses"
-doc: "https://c-cube.github.io/sequence/"
+doc: "https://c-cube.github.io/iter/"
 tags: ["sequence" "iterator" "iter" "fold"]
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
@@ -26,6 +26,6 @@ description: """
 Simple sequence abstract datatype, intended to iterate efficiently
 on collections while performing some transformations."""
 url {
-  src: "https://github.com/c-cube/sequence/archive/1.0.tar.gz"
-  checksum: "md5=3022b30b9406fcaeebbf5756f1fa51fa"
+  src: "https://github.com/c-cube/iter/archive/1.0.tar.gz"
+  checksum: "sha256=42005610cb518a11cdce0384e8f43e3124e8212af8e4132b4b16bfb2b46c5e11"
 }

--- a/packages/sequence/sequence.1.1/opam
+++ b/packages/sequence/sequence.1.1/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "Simon Cruanes"
-homepage: "https://github.com/c-cube/sequence/"
-bug-reports: "https://github.com/c-cube/sequence/issues"
+homepage: "https://github.com/c-cube/iter/"
+bug-reports: "https://github.com/c-cube/iter/issues"
 license: "BSD-2-clauses"
-doc: "https://c-cube.github.io/sequence/"
+doc: "https://c-cube.github.io/iter/"
 tags: ["sequence" "iterator" "iter" "fold"]
-dev-repo: "git+https://github.com/c-cube/sequence.git"
+dev-repo: "git+https://github.com/c-cube/iter.git"
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
@@ -27,6 +27,6 @@ description: """
 Simple sequence abstract datatype, intended to iterate efficiently
 on collections while performing some transformations."""
 url {
-  src: "https://github.com/c-cube/sequence/archive/1.1.tar.gz"
-  checksum: "md5=081416d37ef8bc0ee124d03b082ed00b"
+  src: "https://github.com/c-cube/iter/archive/1.1.tar.gz"
+  checksum: "sha256=30d534e2be90ca511b19f83938631f22966b5a7c959515c0b247c8726c9c61aa"
 }


### PR DESCRIPTION
Following the addition of `Seq` to the standard library, @c-cube and I decided to rename `Sequence` to `Iter`. Unfortunately, due to github tarballs being obnoxious, this breaks all the checksums

So this commit fixes them all, and rewrite the path on the way. I also upgraded the hashing algorithm. :)

For the curious, and due to https://github.com/ocaml/opam/issues/3767 , I had to use the following script:
```zsh
#!/usr/bin/zsh -f
for i in *(/); do
    url="$(opam show -f "url.src:" "./${i}/opam")"
    url="${(Q)url}"
    tarball="/tmp/bla/${i}.tar.gz"
    wget -O "${tarball}" "${url}";
    checksum="$(sha256sum ${tarball} | cut -d " " -f 1 -)"
    sub="s/checksum:.*/checksum: \"sha256=${checksum}\"/" 
    sed -i -e $sub ./$i/opam
    sed -i -e "s/\/sequence/\/iter/g" ./$i/opam
done
```