### PR TITLE
[new release] lazy-trie (1.2.0)

### DIFF
--- a/packages/lazy-trie/lazy-trie.1.2.0/opam
+++ b/packages/lazy-trie/lazy-trie.1.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [ "Louis Gesbert" "Thomas Gazagnaire" ]
+license: "ISC"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "dune" {build & >= "1.0"}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-lazy-trie"
+doc: "https://mirage.github.io/ocaml-lazy-trie/"
+homepage: "https://github.com/mirage/ocaml-lazy-trie"
+bug-reports: "https://github.com/mirage/ocaml-lazy-trie/issues"
+synopsis: "Implementation of lazy prefix trees"
+description: "Implementation of lazy prefix trees"
+url {
+  src:
+    "https://github.com/mirage/ocaml-lazy-trie/releases/download/v1.2.0/lazy-trie-v1.2.0.tbz"
+  checksum: "md5=480a4a13701392bd93bbd649afd7b9bb"
+}


### PR DESCRIPTION
Implementation of lazy prefix trees

- Project page: <a href="https://github.com/mirage/ocaml-lazy-trie">https://github.com/mirage/ocaml-lazy-trie</a>
- Documentation: <a href="https://mirage.github.io/ocaml-lazy-trie/">https://mirage.github.io/ocaml-lazy-trie/</a>

##### CHANGES:

* Use ppx instead of camlp4 for sexp converters (mirage/ocaml-lazy-trie#3 by @vasilisp)
* Build with dune (mirage/ocaml-lazy-trie#7 @verbosemode)
* Update CI matrix up to OCaml 4.07 (@avsm)
