### PR TITLE
Package uucd.12.0.0

### DIFF
--- a/packages/uucd/uucd.12.0.0/opam
+++ b/packages/uucd/uucd.12.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "https://erratique.ch/software/uucd"
+dev-repo: "git+https://erratique.ch/repos/uucd.git"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+doc: "https://erratique.ch/software/uucd/doc/Uucd"
+tags: [ "unicode" "database" "decoder" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "xmlm"
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]]
+synopsis: """Unicode character database decoder for OCaml"""
+description: """\
+
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[xmlm]: http://erratique.ch/software/xmlm 
+"""
+url {
+archive: "https://erratique.ch/software/uucd/releases/uucd-12.0.0.tbz"
+checksum: "1fa4405f863a5b05a6701d024eb40eb2"
+}


### PR DESCRIPTION
### `uucd.12.0.0`
Unicode character database decoder for OCaml
Uucd is an OCaml module to decode the data of the [Unicode character 
database][1] from its XML [representation][2]. It provides high-level 
(but not necessarily efficient) access to the data so that efficient 
representations can be extracted.

Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
under the ISC license.

[1]: http://www.unicode.org/reports/tr44/
[2]: http://www.unicode.org/reports/tr42/
[xmlm]: http://erratique.ch/software/xmlm



---
* Homepage: https://erratique.ch/software/uucd
* Source repo: git+https://erratique.ch/repos/uucd.git
* Bug tracker: https://github.com/dbuenzli/uucd/issues

---
v12.0.0 2019-03-07 La Forclaz (VS)
----------------------------------

- Support for Unicode 12.0.0

---
:camel: Pull-request generated by opam-publish v2.0.0