### PR TITLE
Package uucp.12.0.0

### DIFF
--- a/packages/uucp/uucp.12.0.0/opam
+++ b/packages/uucp/uucp.12.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [
+  "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  "David Kaloper Meršinjak <david@numm.org>"
+]
+homepage: "https://erratique.ch/software/uucp"
+doc: "https://erratique.ch/software/uucp/doc/Uucp"
+dev-repo: "git+https://erratique.ch/repos/uucp.git"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+tags: [ "unicode" "text" "character" "org:erratique" ]
+license: "ISC"
+depends: [
+ "ocaml" {>= "4.01.0"}
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "uchar"
+ "uucd" {with-test} # dev really
+ "uunf" {with-test}
+ "uutf" {with-test}
+ ]
+depopts: [ "uunf" "uutf" "cmdliner" ]
+conflicts: [ "uutf" {< "1.0.1"}
+             "cmdliner" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-uutf" "%{uutf:installed}%"
+          "--with-uunf" "%{uunf:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+]]
+synopsis: """Unicode character properties for OCaml"""
+description: """\
+
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+"""
+url {
+archive: "https://erratique.ch/software/uucp/releases/uucp-12.0.0.tbz"
+checksum: "cf210ed43375b7f882c0540874e2cb81"
+}


### PR DESCRIPTION
### `uucp.12.0.0`
Unicode character properties for OCaml
Uucp is an OCaml library providing efficient access to a selection of
character properties of the [Unicode character database][1].

Uucp is independent from any Unicode text data structure and has no
dependencies. It is distributed under the ISC license.

[1]: http://www.unicode.org/reports/tr44/



---
* Homepage: https://erratique.ch/software/uucp
* Source repo: git+https://erratique.ch/repos/uucp.git
* Bug tracker: https://github.com/dbuenzli/uucp/issues

---
v12.0.0 2019-03-07 La Forclaz (VS)
----------------------------------

- Unicode 12.0.0 support.

---
:camel: Pull-request generated by opam-publish v2.0.0