### PR TITLE
Package uuseg.12.0.0

### DIFF
--- a/packages/uuseg/uuseg.12.0.0/opam
+++ b/packages/uuseg/uuseg.12.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+depends: [ "ocaml" {>= "4.01.0"}
+           "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uchar"
+           "uucp" {>= "12.0.0" & < "13.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {with-test}
+           "cmdliner" {with-test} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """Unicode text segmentation for OCaml"""
+description: """\
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+"""
+url {
+archive: "https://erratique.ch/software/uuseg/releases/uuseg-12.0.0.tbz"
+checksum: "1d4487ddf5154e3477e55021b978d58a"
+}


### PR DESCRIPTION
### `uuseg.12.0.0`
Unicode text segmentation for OCaml
Uuseg is an OCaml library for segmenting Unicode text. It implements
the locale independent [Unicode text segmentation algorithms][1] to
detect grapheme cluster, word and sentence boundaries and the
[Unicode line breaking algorithm][2] to detect line break
opportunities.

The library is independent from any IO mechanism or Unicode text data
structure and it can process text without a complete in-memory
representation.

Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
optionally on [Uutf](http://erratique.ch/software/uutf) for support on
OCaml UTF-X encoded strings. It is distributed under the ISC license.

[1]: http://www.unicode.org/reports/tr29/
[2]: http://www.unicode.org/reports/tr14/



---
* Homepage: https://erratique.ch/software/uuseg
* Source repo: git+https://erratique.ch/repos/uuseg.git
* Bug tracker: https://github.com/dbuenzli/uuseg/issues

---
v12.0.0 2019-03-08 La Forclaz (VS)
----------------------------------

- Unicode 12.0.0 support. Grapheme cluster and word boundaries
  w.r.t. are still only partially according to the specification
  see issue #5 for details.

---
:camel: Pull-request generated by opam-publish v2.0.0