### PR TITLE
odoc 1.4.0 — documentation generator

### DIFF
--- a/packages/odoc/odoc.1.4.0/opam
+++ b/packages/odoc/odoc.1.4.0/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 
-version: "1.4.0"
 homepage: "http://github.com/ocaml/odoc"
 doc: "https://github.com/ocaml/odoc#readme"
 bug-reports: "https://github.com/ocaml/odoc/issues"

--- a/packages/odoc/odoc.1.4.0/opam
+++ b/packages/odoc/odoc.1.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+version: "1.4.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://github.com/ocaml/odoc#readme"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+
+depends: [
+  "astring" {build}
+  "cmdliner" {build & >= "1.0.0"}
+  "cppo" {build}
+  "dune" {build}
+  "fpath" {build}
+  "ocaml" {>= "4.02.0"}
+  "result" {build}
+  "tyxml" {build & >= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocaml/odoc/archive/1.4.0.tar.gz"
+  checksum: "md5=8fec61a88813b2295a16298fc6daedf1"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/ocaml/odoc/releases/tag/1.4.0):

> Changes
>
> - All parsing errors are now recoverable warnings (ocaml/odoc#238).
> - Page titles are now level-0 headings (`{0 ...}`), and top-level sections within a page are level-1 headings (`{1 ...}`) (ocaml/odoc#217, Rizo Isrof).
> - Don't render definitions of externals (ocaml/odoc#275, Nik Graf).
> - Disable programming ligatures (ocaml/odoc#248).
> - Rename `--root-uri` option to `--xref-base-uri` (ocaml/odoc#223, Rizo Isrof).
> - Deprecate redundant reference kind annotations (ocaml/odoc#246).
>
> Additions
>
> - Preliminary compatibility with the current 4.08 beta releases (ocaml/odoc#309, Jon Ludlam).
> - Paragraph headings (`{4 ...}`) and subparagraph headings (`{5 ...}`) (ocaml/odoc#217, Rizo Isrof).
> - `odoc support-files-targets` command (ocaml/odoc#232).
> - Recommend [`bsdoc`](https://ostera.github.io/bsdoc/docs/BsDoc/) for using odoc with BuckleScript (ocaml/odoc#269, Leandro Ostera).
>
> Bugs fixed
>
> - Improve breadcrumbs on `.mld` pages (ocaml/odoc#293, Daniel Buenzli).
> - Display tables of contents in nested module and class pages (ocaml/odoc#261, Rizo Isrof).
> - Uncaught exception when parsing references to operators with `-` in them, such as `@->` (ocaml/odoc#178).
> - Incorrect parsing of references to operators with `.` in them, such as `*.` (ocaml/odoc#237).
> - Assertion failure when processing optional arguments in an `.ml` file with a type annotation, when that type annotation uses an alias of `'a option` (ocaml/odoc#101).
> - Assertion failure when two modules with the same name are found by odoc (ocaml/odoc#148, Jon Ludlam).
> - Verbatim blocks (`{v ... v}`) can now only be terminated if the `v}` is immediately preceded by whitespace (ocaml/odoc#71, reported Daniel Buenzli).
> - Wrong column numbers for errors reported in comments (ocaml/odoc#227, ocaml/odoc#253).
> - Restore parsing of ocamldoc-style reference kind annotations (ocaml/odoc#244).
> - Ordinary `type` keyword instead of `and` rendered in HTML for mutually-recursive types (ocaml/odoc#105, reported Fourchaux).
> - `nonrec` keyword not rendered (ocaml/odoc#249).
> - `and` not rendered for mutually-recursive modules, classes, and class types (ocaml/odoc#251).
> - Outer comment attached to a module rendered when the module is included (ocaml/odoc#87, Jon Ludlam).
> - Polymorphic variant constructor documentation not rendered (ocaml/odoc#176, reported steinuil).
> - Variant constructor and record field documentation styled differently (ocaml/odoc#260, Jon Ludlam).
> - Sloppy keyword markup in HTML output (ocaml/odoc#319).
> - Rendering of multiple `constraint` clauses (ocaml/odoc#321).
> - Incorrect order of functor arguments (ocaml/odoc#261, Rizo Isrof).
> - `odoc html` option `-o` now creates the output directory if it does not exist ocaml/odoc#171, ocaml/odoc#264 Rizo Isrof).
> - `odoc html-targets` output now includes path prefix given through `-o` option (ocaml/odoc#173, Rizo Isrof).
> - Allow `-I` and `-o` options to refer to non-existent directories (ocaml/odoc#32, ocaml/odoc#170, Daniel Buenzli).
> - Make `odoc compile-targets` match `odoc compile` (ocaml/odoc#273, Daniel Buenzli).
> - `odoc compile-deps` does not work on `.cmt` files (ocaml/odoc#162, Daniel Buenzli).
> - `odoc html-deps` now scans for `.odoc` files recursively (ocaml/odoc#307, Daniel Buenzli).
> - `odoc html-targets` ignores stop comments (ocaml/odoc#276, Daniel Buenzli).
> - `odoc html-targets` and `odoc html-deps` segfault on `.mld` pages (ocaml/odoc#277, ocaml/odoc#282, Daneil Buenzli).
> - `--theme-uri` option not propagated to some subpages (ocaml/odoc#318, Thomas Refis).
> - Binary files not opened in binary mode (ocaml/odoc#281, Ulrik Strid).
>
> Build and development
>
> - Always print backtraces for unhandled exceptions (ocaml/odoc@3d10feb).
> - CI on macOS (ocaml/odoc#216, Leandro Ostera).
> - Test runner improvements (ocaml/odoc#266, Rizo Isrof).
> - Fix esy builds in Travis (ocaml/odoc#301, Jon Ludlam).
> - Don't require `make` in the esy build (ocaml/odoc#308, Leandro Ostera).
> - Get rid of some large GADTs (ocaml/odoc#292, Jon Ludlam).
> - Remove dependency on `bos` (ocaml/odoc#305, Daniel Buenzli).
> - Remove dependency on `rresult` (ocaml/odoc#306, Daniel Buenzli).
> - Remove dependency on `bisect_ppx`, previously present in development checkouts (ocaml/odoc#316).