### PR TITLE
[new release] dune (1.8.1)

### DIFF
--- a/packages/dune/dune.1.8.1/opam
+++ b/packages/dune/dune.1.8.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-unix"
+  "base-threads"
+]
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+  "odoc" {< "1.3.0"}
+]
+
+synopsis: "Fast, portable and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+url {
+  src: "https://github.com/ocaml/dune/releases/download/1.8.1/dune-1.8.1.tbz"
+  checksum: "md5=ea21600b365082e1baf15aab165452da"
+}


### PR DESCRIPTION
CHANGES:

- Correctly write `dune-package` when version is empty string (ocaml/dune#1919, fix ocaml/dune#1918,
  @rgrinberg)