### PR TITLE
Package b0.0.0.0

### DIFF
--- a/packages/b0/b0.0.0.0/opam
+++ b/packages/b0/b0.0.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The b0 programmers"]
+homepage: "https://erratique.ch/software/b0"
+doc: "https://erratique.ch/software/b0/doc"
+license: "ISC"
+dev-repo: "git+https://erratique.ch/repos/b0.git"
+bug-reports: "https://github.com/b0-system/b0/issues"
+tags: ["dev" "org:erratique" "org:b0-system" "build" ]
+depends:
+[
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "cmdliner" {build &>= "1.0.2"}
+]
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+]]
+
+synopsis: """Software construction care"""
+description: """\
+
+B0 is work in progress.
+
+B0 is distributed under the ISC license."""
+url {
+archive: "https://erratique.ch/software/b0/releases/b0-0.0.0.tbz"
+checksum: "f96ac96fb0182f2b97dbe9ded452544b"
+}


### PR DESCRIPTION
### `b0.0.0.0`
Software construction care
B0 is work in progress.

B0 is distributed under the ISC license.



---
* Homepage: https://erratique.ch/software/b0
* Source repo: git+https://erratique.ch/repos/b0.git
* Bug tracker: https://github.com/b0-system/b0/issues

---
v0.0.0 2019-03-08 La Forclaz (VS)
---------------------------------

First release to support `odig`.

---
:camel: Pull-request generated by opam-publish v2.0.0