### PR TITLE
Package odig.0.0.4

### DIFF
--- a/packages/odig/odig.0.0.4/opam
+++ b/packages/odig/odig.0.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The odig programmers"]
+homepage: "https://erratique.ch/software/odig"
+doc: "https://erratique.ch/software/odig/doc"
+license: ["ISC" "PT-Sans-fonts" "DejaVu-fonts" ]
+dev-repo: "git+https://erratique.ch/repos/odig.git"
+bug-reports: "https://github.com/b0-system/odig/issues"
+tags: [ "org:erratique" "org:b0-system" "build" "dev" "meta" "doc" "packaging" ]
+depends: [
+  "ocaml" {>= "4.03"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.1"}
+  "cmdliner" {>= "1.0.0"}
+  "odoc" {>= "1.4.0"}
+  "b0"
+]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+
+synopsis: """Lookup documentation of installed OCaml packages"""
+description: """\
+
+odig is a command line tool to lookup documentation of installed OCaml
+packages. It shows package metadata, readmes, change logs, licenses,
+cross-referenced `odoc` API documentation and manuals.
+
+odig is distributed under the ISC license. The theme fonts have their
+own [licenses](LICENSE.md).
+"""
+url {
+archive: "https://erratique.ch/software/odig/releases/odig-0.0.4.tbz"
+checksum: "cea6608b4d0a62df5c358d771fd1a148"
+}


### PR DESCRIPTION
### `odig.0.0.4`
Lookup documentation of installed OCaml packages
odig is a command line tool to lookup documentation of installed OCaml
packages. It shows package metadata, readmes, change logs, licenses,
cross-referenced `odoc` API documentation and manuals.

odig is distributed under the ISC license. The theme fonts have their
own [licenses](LICENSE.md).



---
* Homepage: https://erratique.ch/software/odig
* Source repo: git+https://erratique.ch/repos/odig.git
* Bug tracker: https://github.com/b0-system/odig/issues

---
v0.0.4 2019-03-08 La Forclaz (VS)
---------------------------------

- Support for odoc manuals (`.mld` files) and package page customization
  (`index.mld` file) (#31, #18). See the packaging conventions; if you are
  using `dune` and already authoring `.mld` files the right thing should
  be done automatically install-wise.
- Support for odoc themes (#21). Themes can be distributed via `opam`, see
  command `odig odoc-theme` and the packaging conventions in `odig doc odig`.
- Support for best-effort OCaml manual theming. Themes can provide a stylesheet
  to style the local manual installed by the `ocaml-manual` package and linked
  from the generated documentation sets.
- Support for customizing the title and introduction of the package list
  page (#19). See the `--index-title` and `--index-intro` options of
  `odig odoc`.
- Add `gh-pages-amend` a tool to easily push documentation sets on
  GitHub pages (see the odig manual and `--help` for details).
- The `opam` metadata support needs an `opam` v2 binary in your `PATH`.
- The odoc API documentation generation support needs an `odoc` v1.4.0
  binary in your `PATH`.
- `odig doc` exit with non-zero on unknown package (#34).
- `odig doc` add `-u` option to guarantee docset freshness (#4).
- Depend only on `cmdliner` and `b0`. Drop dependency on `compiler-libs`,
  `rresult`, `asetmap`, `fpath`, `logs`, `mtime`, `bos`, `webbrowser` and
  `opam-format`.

---
:camel: Pull-request generated by opam-publish v2.0.0