### PR TITLE
fix cohttp-mirage revdeps

### DIFF
--- a/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
@@ -13,6 +13,7 @@ depends: [
   "mirage-channel-lwt" {>= "3.0.0"}
   "conduit" {>= "0.99"}
   "mirage-conduit" {>= "3.0.0"}
+  "mirage-kv-lwt" {<"2.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp"
   "cohttp-lwt"

--- a/packages/cohttp-mirage/cohttp-mirage.1.2.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.2.0/opam
@@ -40,6 +40,7 @@ depends: [
   "mirage-channel-lwt" {>= "3.0.0"}
   "conduit" {>= "0.99"}
   "mirage-conduit" {>= "3.0.0"}
+  "mirage-kv-lwt" {<"2.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp"
   "cohttp-lwt"

--- a/packages/cohttp-mirage/cohttp-mirage.2.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.0.0/opam
@@ -22,6 +22,7 @@ depends: [
   "dune" {build & >= "1.1.0"}
   "result"
   "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-kv-lwt" {<"2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "conduit" {>= "0.99"}
   "mirage-conduit" {>= "3.0.0"}


### PR DESCRIPTION
looking for FS.size which is gone in newer kv-lwt