### PR TITLE
[new release] iter (1.2)

### DIFF
--- a/packages/iter/iter.1.2/opam
+++ b/packages/iter/iter.1.2/opam
@@ -8,7 +8,7 @@ synopsis: "Simple abstraction over `iter` functions, intended to iterate efficie
 build: [
   ["dune" "build" "@install" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name] {with-doc}
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name] {with-test & ocaml:version >= "4.03.0"}
 ]
 depends: [
   "base-bytes"

--- a/packages/iter/iter.1.2/opam
+++ b/packages/iter/iter.1.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "iter"
+version: "1.2"
+authors: ["Simon Cruanes" "Gabriel Radanne"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-clauses"
+synopsis: "Simple abstraction over `iter` functions, intended to iterate efficiently on collections while performing some transformations"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "base-bytes"
+  "result"
+  "dune" {build}
+  "qcheck" {with-test}
+  "qtest" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+tags: [ "iter" "iterator" "iter" "fold" ]
+homepage: "https://github.com/c-cube/iter/"
+depopts: [
+  "base-bigarray"
+]
+doc: "https://c-cube.github.io/iter/doc/1.2"
+bug-reports: "https://github.com/c-cube/iter/issues"
+dev-repo: "git+https://github.com/c-cube/iter.git"
+url {
+  src: "https://github.com/c-cube/iter/releases/download/1.2/iter-1.2.tbz"
+  checksum: "md5=f98c61e37fc009aaca1d1dd401927dfd"
+}


### PR DESCRIPTION
## 1.2

- Rename the library to Iter.
- Add `from_labeled_iter`.
- Use `raise_notrace` for internal exceptions.
