### PR TITLE
fix influxdb constraints

### DIFF
--- a/packages/influxdb-async/influxdb-async.0.1.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build}
   "base" {< "v0.12"}
   "alcotest" {with-test}
-  "influxdb"
+  "influxdb" {<"0.2.0"}
   "async" {< "v0.12"}
   "cohttp"
   "cohttp-async"

--- a/packages/influxdb-async/influxdb-async.0.2.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build}
   "base" {< "v0.12"}
   "alcotest" {with-test}
-  "influxdb"
+  "influxdb" {>= "0.2.0"}
   "async" {< "v0.12"}
   "cohttp"
   "cohttp-async"

--- a/packages/influxdb-lwt/influxdb-lwt.0.1.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build}
   "base" {< "v0.12"}
   "alcotest" {with-test}
-  "influxdb"
+  "influxdb" {<"0.2.0"}
   "lwt"
   "cohttp"
   "cohttp-lwt-unix"

--- a/packages/influxdb-lwt/influxdb-lwt.0.2.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build}
   "base" {< "v0.12"}
   "alcotest" {with-test}
-  "influxdb"
+  "influxdb" {>="0.2.0"}
   "lwt"
   "cohttp"
   "cohttp-lwt-unix"


### PR DESCRIPTION
cc @ryanslade and #12810 -- the older packages may be selected
by the opam solver, so these constraints ensure the 'gang' of packages
are selected together

fixes build failure observed in #13620