### PR TITLE
Package prepare.0.0.1

### DIFF
--- a/packages/prepare/prepare.0.0.1/opam
+++ b/packages/prepare/prepare.0.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of URI templates (RFC6570"
+maintainer: "Corin Chaplin <git@corinchaplin.co.uk>"
+authors: "Corin Chaplin <git@corinchaplin.co.uk>"
+license: "MIT"
+homepage: "https://github.com/CorinChappy/uritemplate-ocaml"
+bug-reports: "https://github.com/CorinChappy/uritemplate-ocaml/issues"
+depends: [
+  "dune" {build}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: ["dune" "runtest"]
+dev-repo: "git+https://https://github.com/CorinChappy/uritemplate-ocaml.git"
+url {
+  src:
+    "https://github.com/CorinChappy/uritemplate-ocaml/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=0f80621298643e82f8ff616798381141"
+    "sha512=08ba46b69c40314108808f5b86cfabe699f196357f6f26597ccd1f18e4905ae5b5c22aa9113b8f9a8f4041498bbc806152440972a77c0a41ea5899d66abf789d"
+  ]
+}


### PR DESCRIPTION
### `prepare.0.0.1`
OCaml implementation of URI templates (RFC6570



---
* Homepage: https://github.com/CorinChappy/uritemplate-ocaml
* Source repo: git+https://https://github.com/CorinChappy/uritemplate-ocaml.git
* Bug tracker: https://github.com/CorinChappy/uritemplate-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0