### PR TITLE
Package uritemplate.0.0.1

### DIFF
--- a/packages/uritemplate/uritemplate.0.0.1/opam
+++ b/packages/uritemplate/uritemplate.0.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of URI templates (RFC6570)"
+maintainer: "Corin Chaplin <git@corinchaplin.co.uk>"
+authors: "Corin Chaplin <git@corinchaplin.co.uk>"
+license: "MIT"
+homepage: "https://github.com/CorinChappy/uritemplate-ocaml"
+bug-reports: "https://github.com/CorinChappy/uritemplate-ocaml/issues"
+depends: [
+  "dune" {build}
+  "stdcompat" {>= "5"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: ["dune" "runtest"]
+dev-repo: "git+https://https://github.com/CorinChappy/uritemplate-ocaml.git"
+url {
+  src:
+    "https://github.com/CorinChappy/uritemplate-ocaml/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=add517c628e4db4f582d7fea7303f6f2"
+    "sha512=ac64467eb2c21f7f5a12fbbcdd4b14f1a3df7adecdd58e9adaf3ea3b8a6f4967a35f3973eb4387b4dd21c73da6dc4a6ac3000e865c56bf9c5110dadd54843861"
+  ]
+}


### PR DESCRIPTION
### `uritemplate.0.0.1`
OCaml implementation of URI templates (RFC6570)



---
* Homepage: https://github.com/CorinChappy/uritemplate-ocaml
* Source repo: git+https://https://github.com/CorinChappy/uritemplate-ocaml.git
* Bug tracker: https://github.com/CorinChappy/uritemplate-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0