### PR TITLE
[new release] diet (0.3)

### DIFF
--- a/packages/diet/diet.0.3/opam
+++ b/packages/diet/diet.0.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-diet"
+doc: "https://mirage.github.io/ocaml-diet/"
+bug-reports: "https://github.com/mirage/ocaml-diet/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "sexplib"
+  "dune" {build}
+  "ppx_sexp_conv"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-diet.git"
+synopsis: "Discrete Interval Encoding Trees"
+description: """
+This data structure is based on the
+[Functional Pearls: Diets for Fat Sets](https://web.engr.oregonstate.edu/~erwig/papers/Diet_JFP98.pdf)
+by Martin Erwig."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-diet/releases/download/v0.3/diet-v0.3.tbz"
+  checksum: "md5=198de585f888bedc2b85f555250ce6d5"
+}


### PR DESCRIPTION
Discrete Interval Encoding Trees

- Project page: <a href="https://github.com/mirage/ocaml-diet">https://github.com/mirage/ocaml-diet</a>
- Documentation: <a href="https://mirage.github.io/ocaml-diet/">https://mirage.github.io/ocaml-diet/</a>

##### CHANGES:

- Add `find_next_gap` function (mirage/ocaml-diet#9 @g2p)
- switch to `dune-release` (mirage/ocaml-diet#10 @avsm)
- run the tests as well as build them (mirage/ocaml-diet#10 @avsm)
- update metadata to opam 2.0 format (mirage/ocaml-diet#10 @avsm)
