### PR TITLE
[new release] mirage-block-unix (2.11.1)

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.11.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors:      "Dave Scott <dave@recoil.org>"
+maintainer:   "dave@recoil.org"
+homepage:     "https://github.com/mirage/mirage-block-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-block-unix.git"
+doc:          "https://mirage.github.io/mirage-block-unix/"
+bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
+tags:         "org:mirage"
+license:      "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >="1.0"}
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt"
+  "mirage-block-lwt" {>= "1.0.0"}
+  "rresult"
+  "io-page-unix" {>= "2.0.0"}
+  "uri" {>= "1.9.0"}
+  "logs"
+  "ounit" {with-test}
+  "diet" {with-test}
+  "fmt" {with-test}
+  "ppx_tools" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_type_conv" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+synopsis: "MirageOS disk block driver for Unix"
+description: """
+Unix implementation of the Mirage `BLOCK_DEVICE` interface.
+
+This module provides raw I/O to files and block devices with as little
+caching as possible.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-unix/releases/download/v2.11.1/mirage-block-unix-v2.11.1.tbz"
+  checksum: "md5=95d3b8e9bd3c44c35ef454d38727afbd"
+}


### PR DESCRIPTION
MirageOS disk block driver for Unix

- Project page: <a href="https://github.com/mirage/mirage-block-unix">https://github.com/mirage/mirage-block-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-unix/">https://mirage.github.io/mirage-block-unix/</a>

##### CHANGES:

* Fix some warnings in dev mode (mirage/mirage-block-unix#94 @emillon)
* Clarify documentation about behaviour of `discard` (mirage/mirage-block-unix#95 @g2p)
* Use modern cstruct-lwt ocamlfind name (mirage/mirage-block-unix#96 @g2p)
