### PR TITLE
4 packages from nosman/Ocamlapi at 0.0.2

### DIFF
--- a/packages/ocamlapi/ocamlapi.0.0.2/opam
+++ b/packages/ocamlapi/ocamlapi.0.0.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "stephanos.tsoucas@gmail.com"
+authors: ["Stephanos Tsoucas"]
+license: "Apache-2.0"
+synopsis: "Path-based HTTP request routing for Ocaml"
+homepage: "https://github.com/nosman/Ocamlapi"
+bug-reports: "https://github.com/nosman/Ocamlapi/issues"
+dev-repo: "git+https://github.com/nosman/Ocamlapi.git"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "ounit" {with-test}
+  "dune" {build}
+  "core"
+  "re2"
+  "cohttp"
+]
+
+url {
+archive: "https://github.com/nosman/Ocamlapi/archive/0.0.2.tar.gz"
+checksum: "e1e7e9018092d9528c5ae60ef01e5246"
+}

--- a/packages/ocamlapi_async/ocamlapi_async.0.0.2/opam
+++ b/packages/ocamlapi_async/ocamlapi_async.0.0.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "stephanos.tsoucas@gmail.com"
+authors: ["Stephanos Tsoucas"]
+license: "Apache-2.0"
+synopsis: "Path-based HTTP request routing for Ocaml"
+homepage: "https://github.com/nosman/Ocamlapi"
+bug-reports: "https://github.com/nosman/Ocamlapi/issues"
+dev-repo: "git+https://github.com/nosman/Ocamlapi.git"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build}
+  "ocamlapi"
+  "cohttp-async"
+]
+url {
+archive: "https://github.com/nosman/Ocamlapi/archive/0.0.2.tar.gz"
+checksum: "e1e7e9018092d9528c5ae60ef01e5246"
+}

--- a/packages/ocamlapi_lwt_unix/ocamlapi_lwt_unix.0.0.2/opam
+++ b/packages/ocamlapi_lwt_unix/ocamlapi_lwt_unix.0.0.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "stephanos.tsoucas@gmail.com"
+authors: ["Stephanos Tsoucas"]
+license: "Apache-2.0"
+synopsis: "Path-based HTTP request routing for Ocaml"
+homepage: "https://github.com/nosman/Ocamlapi"
+bug-reports: "https://github.com/nosman/Ocamlapi/issues"
+dev-repo: "git+https://github.com/nosman/Ocamlapi.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+    ]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build}
+  "ocamlapi"
+  "cohttp-lwt-unix"
+]
+url {
+archive: "https://github.com/nosman/Ocamlapi/archive/0.0.2.tar.gz"
+checksum: "e1e7e9018092d9528c5ae60ef01e5246"
+}

--- a/packages/ocamlapi_ppx/ocamlapi_ppx.0.0.2/opam
+++ b/packages/ocamlapi_ppx/ocamlapi_ppx.0.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "stephanos.tsoucas@gmail.com"
+authors: ["Stephanos Tsoucas"]
+license: "Apache-2.0"
+homepage: "https://github.com/nosman/Ocamlapi"
+synopsis: "Path-based HTTP request routing for Ocaml"
+bug-reports: "https://github.com/nosman/Ocamlapi/issues"
+dev-repo: "git+https://github.com/nosman/Ocamlapi.git"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+ 
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build}
+  "ocamlapi"
+  "core"
+  "ppxlib"
+]
+url {
+archive: "https://github.com/nosman/Ocamlapi/archive/0.0.2.tar.gz"
+checksum: "e1e7e9018092d9528c5ae60ef01e5246"
+}


### PR DESCRIPTION
Path-based HTTP request routing for Ocaml

This pull-request concerns:
-`ocamlapi.0.0.2`
-`ocamlapi_async.0.0.2`
-`ocamlapi_lwt_unix.0.0.2`
-`ocamlapi_ppx.0.0.2`



---
* Homepage: https://github.com/nosman/Ocamlapi
* Source repo: git+https://github.com/nosman/Ocamlapi.git
* Bug tracker: https://github.com/nosman/Ocamlapi/issues

---
:camel: Pull-request generated by opam-publish v2.0.0