### PR TITLE
Make archlinux depexts work

### DIFF
--- a/packages/aacplus/aacplus.0.2.1/opam
+++ b/packages/aacplus/aacplus.0.2.1/opam
@@ -8,7 +8,7 @@ build: [
 remove: [["ocamlfind" "remove" "aacplus"]]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
-  ["libaacplus"] {os-distribution = "archlinux"}
+  ["libaacplus"] {os-distribution = "arch"}
   ["libaacplus"] {os-distribution = "gentoo"}
   ["libaacplus"] {os = "freebsd"}
 ]

--- a/packages/aacplus/aacplus.0.2.2/opam
+++ b/packages/aacplus/aacplus.0.2.2/opam
@@ -12,7 +12,7 @@ install: [
 remove: ["ocamlfind" "remove" "aacplus"]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
-  ["libaacplus"] {os-distribution = "archlinux"}
+  ["libaacplus"] {os-distribution = "arch"}
   ["libaacplus"] {os-distribution = "gentoo"}
   ["libaacplus"] {os = "freebsd"}
 ]

--- a/packages/clangml/clangml.0.5.1/opam
+++ b/packages/clangml/clangml.0.5.1/opam
@@ -46,7 +46,7 @@ depexts: [
     "sys-devel/clang-3.4.0-r100"
     "sys-devel/binutils"
   ] {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.0.5.2/opam
+++ b/packages/clangml/clangml.0.5.2/opam
@@ -44,7 +44,7 @@ depexts: [
     "sys-devel/clang-3.4.0-r100"
     "sys-devel/binutils"
   ] {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.5.0.1/opam
+++ b/packages/clangml/clangml.3.5.0.1/opam
@@ -41,7 +41,7 @@ depexts: [
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.5.0.2/opam
+++ b/packages/clangml/clangml.3.5.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["binutils" "boost"] {os-distribution = "archlinux"}
+  ["binutils" "boost"] {os-distribution = "arch"}
   [
     "binutils-dev"
     "clang-3.5"

--- a/packages/clangml/clangml.3.5.0/opam
+++ b/packages/clangml/clangml.3.5.0/opam
@@ -39,7 +39,7 @@ depexts: [
     "binutils-dev"
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.6.0.1/opam
+++ b/packages/clangml/clangml.3.6.0.1/opam
@@ -39,7 +39,7 @@ depexts: [
     "binutils-dev"
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.6.0.2/opam
+++ b/packages/clangml/clangml.3.6.0.2/opam
@@ -40,7 +40,7 @@ depexts: [
     "binutils-dev"
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.6.0.4/opam
+++ b/packages/clangml/clangml.3.6.0.4/opam
@@ -41,7 +41,7 @@ depexts: [
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.6.0.5/opam
+++ b/packages/clangml/clangml.3.6.0.5/opam
@@ -41,7 +41,7 @@ depexts: [
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.6.0.6/opam
+++ b/packages/clangml/clangml.3.6.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["binutils" "boost"] {os-distribution = "archlinux"}
+  ["binutils" "boost"] {os-distribution = "arch"}
   [
     "binutils-dev"
     "clang-3.6"

--- a/packages/clangml/clangml.3.6.0/opam
+++ b/packages/clangml/clangml.3.6.0/opam
@@ -39,7 +39,7 @@ depexts: [
     "binutils-dev"
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.7.0.1/opam
+++ b/packages/clangml/clangml.3.7.0.1/opam
@@ -41,7 +41,7 @@ depexts: [
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.7.0.2/opam
+++ b/packages/clangml/clangml.3.7.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["binutils" "boost"] {os-distribution = "archlinux"}
+  ["binutils" "boost"] {os-distribution = "arch"}
   [
     "binutils-dev"
     "clang-3.7"

--- a/packages/clangml/clangml.3.7.0/opam
+++ b/packages/clangml/clangml.3.7.0/opam
@@ -41,7 +41,7 @@ depexts: [
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.8.0.1/opam
+++ b/packages/clangml/clangml.3.8.0.1/opam
@@ -41,7 +41,7 @@ depexts: [
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.8.0/opam
+++ b/packages/clangml/clangml.3.8.0/opam
@@ -41,7 +41,7 @@ depexts: [
   ] {os-distribution = "ubuntu"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  ["boost" "binutils"] {os-distribution = "archlinux"}
+  ["boost" "binutils"] {os-distribution = "arch"}
 ]
 available: os != "macos"
 post-messages: [

--- a/packages/clangml/clangml.3.9.1.2/opam
+++ b/packages/clangml/clangml.3.9.1.2/opam
@@ -37,7 +37,7 @@ depends: [
   "conf-wget" {build}
 ]
 depexts: [
-  ["boost"] {os-distribution = "archlinux"}
+  ["boost"] {os-distribution = "arch"}
   ["binutils-dev" "clang-3.9" "libboost-dev" "libclang-3.9-dev" "llvm-3.9-dev"
    "libncurses-dev"]
     {os-distribution = "debian"}

--- a/packages/clangml/clangml.3.9.1/opam
+++ b/packages/clangml/clangml.3.9.1/opam
@@ -31,7 +31,7 @@ depends: [
   "conf-wget" {build}
 ]
 depexts: [
-  ["binutils" "boost"] {os-distribution = "archlinux"}
+  ["binutils" "boost"] {os-distribution = "arch"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   [

--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["automake"] {os-distribution = "debian"}
   ["automake"] {os-distribution = "ubuntu"}
   ["automake"] {os-distribution = "nixos"}
-  ["automake"] {os-distribution = "archlinux"}
+  ["automake"] {os-distribution = "arch"}
 ]
 depends: ["conf-which" {build}]
 synopsis: "Virtual package relying on aclocal"

--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["autoconf"] {os-distribution = "ubuntu"}
   ["autoconf"] {os-distribution = "centos"}
   ["autoconf"] {os-distribution = "fedora"}
-  ["autoconf"] {os-distribution = "archlinux"}
+  ["autoconf"] {os-distribution = "arch"}
   ["sys-devel/autoconf"] {os-distribution = "gentoo"}
   ["autoconf"] {os-distribution = "nixos"}
   ["autoconf"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-bmake/conf-bmake.1.0/opam
+++ b/packages/conf-bmake/conf-bmake.1.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["bmake"] {os-distribution = "ubuntu"}
   ["bmake"] {os-distribution = "centos"}
   ["bmake"] {os-distribution = "fedora"}
-  ["bmake"] {os-distribution = "archlinux"}
+  ["bmake"] {os-distribution = "arch"}
   ["sys-devel/bmake"] {os-distribution = "gentoo"}
   ["bmake"] {os-distribution = "nixos"}
   ["bmake"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["boost-devel"] {os-distribution = "centos"}
   ["boost-devel"] {os-distribution = "rhel"}
   ["boost-devel"] {os-family = "suse"}
-  ["boost"] {os-distribution = "archlinux"}
+  ["boost"] {os-distribution = "arch"}
   ["boost"] {os = "macos" & os-distribution = "homebrew"}
   ["boost-all"] {os = "freebsd"}
   ["boost"] {os = "netbsd"}

--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -13,7 +13,7 @@ build: [
   ["capnpc" "--version"]
 ]
 depexts: [
-  ["capnproto"] {os-distribution = "archlinux"}
+  ["capnproto"] {os-distribution = "arch"}
   ["capnproto"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-distribution = "debian"}
   ["capnproto"] {os-distribution = "fedora"}

--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -23,7 +23,7 @@ depexts: [
   ["gdbm-devel"] {os-distribution = "fedora"}
   ["gdbm-dev"] {os-distribution = "alpine"}
   ["gdbm"] {os-distribution = "homebrew"}
-  ["gdbm"] {os-distribution = "archlinux"}
+  ["gdbm"] {os-distribution = "arch"}
   ["sys-libs/gdbm"] {os-distribution = "gentoo"}
 ]
 synopsis: "Virtual package relying on gdbm"

--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -6,7 +6,7 @@ license: "various"
 build: [["pkg-config" "elementary" "--atleast-version=1.8"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["efl"] {os-distribution = "archlinux" & os = "linux"}
+  ["efl"] {os-distribution = "arch" & os = "linux"}
   ["libelementary-dev"] {os-distribution = "debian" & os = "linux"}
   ["elementary-devel"] {os-distribution = "fedora" & os = "linux"}
   ["efl"] {os = "freebsd"}

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["g++"] {os-distribution = "debian"}
   ["g++"] {os-distribution = "ubuntu"}
   ["gcc"] {os-distribution = "nixos"}
-  ["gcc"] {os-distribution = "archlinux"}
+  ["gcc"] {os-distribution = "arch"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on the g++ compiler (for C++)"

--- a/packages/conf-gd/conf-gd.1/opam
+++ b/packages/conf-gd/conf-gd.1/opam
@@ -6,7 +6,7 @@ license: "MIT"
 build: [["pkg-config" "gdlib"]]
 depexts: [
   ["gd-dev" "libpng-dev" "libjpeg-turbo-dev" "freetype-dev" "zlib-dev"] {os-distribution = "alpine"}
-  ["gd"] {os-distribution = "archlinux"}
+  ["gd"] {os-distribution = "arch"}
   ["libgd3-devel"] {os-distribution = "centos"}
   ["libgd3-devel"] {os-distribution = "fedora"}
   ["libgd3-devel"] {os-family = "suse"}

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -15,7 +15,7 @@ depexts: [
   ["git"] {os-distribution = "debian"}
   ["git"] {os-distribution = "ubuntu"}
   ["git"] {os-distribution = "nixos"}
-  ["git"] {os-distribution = "archlinux"}
+  ["git"] {os-distribution = "arch"}
   ["git"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on git"

--- a/packages/conf-gles2/conf-gles2.1/opam
+++ b/packages/conf-gles2/conf-gles2.1/opam
@@ -9,7 +9,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libgles2-mesa-dev"] {os-distribution = "debian"}
   ["libgles2-mesa-dev"] {os-distribution = "ubuntu"}
-  ["mesa"] {os-distribution = "archlinux"}
+  ["mesa"] {os-distribution = "arch"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["mesa-libGLES-devel"] {os-distribution = "centos"}
 ]

--- a/packages/conf-glpk/conf-glpk.1/opam
+++ b/packages/conf-glpk/conf-glpk.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["glpk"] {os-distribution = "centos"}
   ["glpk"] {os-distribution = "rhel"}
   ["glpk"] {os-family = "suse"}
-  ["glpk"] {os-distribution = "archlinux"}
+  ["glpk"] {os-distribution = "arch"}
   ["glpk"] {os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package for GLPK (GNU Linear Programming Kit)"

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -9,7 +9,7 @@ depexts: [
   ["libgnomecanvas2-dev"] {os-distribution = "ubuntu"}
   ["libgnomecanvas-devel"] {os-distribution = "fedora"}
   ["libgnomecanvas"] {os = "macos" & os-distribution = "homebrew"}
-  ["libgnomecanvas"] {os-distribution = "archlinux"}
+  ["libgnomecanvas"] {os-distribution = "arch"}
   ["libgnomecanvas"] {os = "openbsd"}
 ]
 synopsis: "Virtual package relying on a Gnomecanvas system installation"

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["graphviz"] {os-distribution = "ubuntu"}
   ["graphviz"] {os-distribution = "fedora"}
   ["graphviz"] {os-distribution = "centos"}
-  ["graphviz"] {os-distribution = "archlinux"}
+  ["graphviz"] {os-distribution = "arch"}
   ["graphviz"] {os-distribution = "alpine"}
   ["media-gfx/graphviz"] {os-distribution = "gentoo"}
   ["graphviz"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -8,7 +8,7 @@ build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-2.0"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["gtksourceview2-dev"] {os-distribution = "alpine"}
-  ["gtksourceview2"] {os-distribution = "archlinux"}
+  ["gtksourceview2"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview2-devel"] {os-distribution = "centos"}
   ["libgtksourceview2.0-dev"] {os-distribution = "debian"}
   ["gtksourceview2-devel"] {os-distribution = "fedora"}

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -8,7 +8,7 @@ build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["gtksourceview-dev"] {os-distribution = "alpine"}
-  ["gtksourceview3"] {os-distribution = "archlinux"}
+  ["gtksourceview3"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
   ["libgtksourceview-3.0-dev"] {os-distribution = "debian"}
   ["gtksourceview3-devel"] {os-distribution = "fedora"}

--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -12,7 +12,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libhidapi-dev"] {os-distribution = "ubuntu"}
   ["libhidapi-dev"] {os-distribution = "debian"}
-  ["hidapi"] {os-distribution = "archlinux"}
+  ["hidapi"] {os-distribution = "arch"}
   ["hidapi"] {os = "macos" & os-distribution = "homebrew"}
   ["hidapi-dev"] {os-distribution = "alpine"}
   ["epel-release" "hidapi-devel"] {os-distribution = "centos"}

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
   ["curl"] {os-distribution = "nixos"}
-  ["curl"] {os-distribution = "archlinux"}
+  ["curl"] {os-distribution = "arch"}
   ["curl-dev"] {os-distribution = "alpine"}
   ["libcurl-devel"] {os-family = "suse"}
   ["libcurl-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -8,14 +8,14 @@ depexts: [
   ["libev-dev"] {os-distribution = "ubuntu"}
   ["libev"] {os = "macos" & os-distribution = "homebrew"}
   ["libev-dev"] {os-distribution = "alpine"}
-  ["libev"] {os-distribution = "archlinux"}
+  ["libev"] {os-distribution = "arch"}
   ["libev-devel"] {os-distribution = "fedora"}
   ["libev-devel"] {os-distribution = "rhel"}
   ["libev-devel"] {os-distribution = "centos"}
   ["libev-devel"] {os-family = "suse"}
   ["libev"] {os = "freebsd"}
   ["libev"] {os = "openbsd"}
-  ["libev"] {os-distribution = "archlinux"}
+  ["libev"] {os-distribution = "arch"}
 ]
 synopsis: "High-performance event loop/event model with lots of features"
 description: """

--- a/packages/conf-libsvm/conf-libsvm.3/opam
+++ b/packages/conf-libsvm/conf-libsvm.3/opam
@@ -11,7 +11,7 @@ build: [
 depexts: [
   ["libsvm-dev"] {os-distribution = "ubuntu"}
   ["libsvm-dev"] {os-distribution = "debian"}
-  ["libsvm"] {os-distribution = "archlinux"}
+  ["libsvm"] {os-distribution = "arch"}
   ["sci-libs/libsvm"] {os-distribution = "gentoo"}
   ["libsvm-devel"] {os-distribution = "fedora"}
   ["libsvm-devel"] {os-distribution = "centos"}

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["m4"] {os-distribution = "nixos"}
   ["m4"] {os-family = "suse"}
   ["m4"] {os-distribution = "oraclelinux"}
-  ["m4"] {os-distribution = "archlinux"}
+  ["m4"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on m4"
 description:

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["openmpi-devel"] {os-distribution = "centos"}
   ["openmpi-devel"] {os-distribution = "fedora"}
   ["openmpi"] {os-family = "suse"}
-  ["openmpi"] {os-distribution = "archlinux"}
+  ["openmpi"] {os-distribution = "arch"}
   ["openmpi-dev"] {os-distribution = "alpine"}
   ["openmpi"] {os = "freebsd"}
   ["devel/openmpi"] {os = "openbsd"}

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -7,7 +7,7 @@ build: [["pkg-config" "nanomsg"]]
 depexts: [
   ["libnanomsg-dev"] {os-distribution = "ubuntu"}
   ["libnanomsg-dev"] {os-distribution = "debian"}
-  ["nanomsg"] {os-distribution = "archlinux"}
+  ["nanomsg"] {os-distribution = "arch"}
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a nanomsg system installation"

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["ncurses-devel"] {os-distribution = "centos"}
   ["ncurses-devel"] {os-distribution = "rhel"}
   ["ncurses-devel"] {os-family = "suse"}
-  ["ncurses"] {os-distribution = "archlinux"}
+  ["ncurses"] {os-distribution = "arch"}
 ]
 available: os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"
 synopsis: "Virtual package relying on ncurses"

--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["nekovm-devel"] {os-distribution = "fedora"}
   ["neko"] {os-distribution = "nixos"}
   ["neko"] {os-distribution = "homebrew" & os = "macos"}
-  ["neko"] {os-distribution = "archlinux"}
+  ["neko"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on a Neko system installation"
 description:

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depexts: [
   ["nodejs"] {os-distribution = "alpine"}
-  ["npm"] {os-distribution = "archlinux"}
+  ["npm"] {os-distribution = "arch"}
   ["npm"] {os-distribution = "centos"}
   ["npm"] {os-distribution = "debian"}
   ["npm"] {os-distribution = "fedora"}

--- a/packages/conf-opencc1/conf-opencc1.1/opam
+++ b/packages/conf-opencc1/conf-opencc1.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libopencc2"] {os-distribution = "debian"}
   ["libopencc2"] {os-distribution = "ubuntu"}
   ["libopencc2"] {os-family = "suse"}
-  ["opencc"] {os-distribution = "archlinux"}
+  ["opencc"] {os-distribution = "arch"}
   ["app-i18n/opencc"] {os-distribution = "gentoo"}
   ["opencc"] {os-distribution = "fedora"}
   ["opencc"] {os-distribution = "centos"}

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -20,7 +20,7 @@ depexts: [
   ["openssl"] {os = "macos" & os-distribution = "macports"}
   ["libressl-dev"] {os-distribution = "alpine"}
   ["openssl"] {os-distribution = "nixos"}
-  ["openssl"] {os-distribution = "archlinux"}
+  ["openssl"] {os-distribution = "arch"}
   ["libopenssl-devel"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on an OpenSSL system installation"

--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["perl"] {os-distribution = "ubuntu"}
   ["perl"] {os-distribution = "alpine"}
   ["perl"] {os-distribution = "nixos"}
-  ["perl"] {os-distribution = "archlinux"}
+  ["perl"] {os-distribution = "arch"}
   ["perl-Pod-Html"] {os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on perl"

--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -10,7 +10,7 @@ build: [
 depexts: [
   ["pkg-config"] {os-distribution = "debian"}
   ["pkg-config"] {os-distribution = "ubuntu"}
-  ["pkg-config"] {os-distribution = "archlinux"}
+  ["pkg-config"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}
   ["pkgconfig"] {os-distribution = "mageia"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -19,7 +19,7 @@ post-messages: [
 depexts: [
   ["pkg-config"] {os-distribution = "debian"}
   ["pkg-config"] {os-distribution = "ubuntu"}
-  ["pkg-config"] {os-distribution = "archlinux"}
+  ["pkg-config"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}
   ["pkgconfig"] {os-distribution = "mageia"}

--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -11,7 +11,7 @@ build: [
 depexts: [
   ["libppl-dev"] {os-distribution = "debian"}
   ["libppl-dev"] {os-distribution = "ubuntu"}
-  ["ppl"] {os-distribution = "archlinux"}
+  ["ppl"] {os-distribution = "arch"}
   ["dev-libs/ppl"] {os-distribution = "gentoo"}
   ["libppl" "libppl-devel"] {os-distribution = "centos"}
   ["ppl"] {os = "freebsd"}

--- a/packages/conf-python-2-7/conf-python-2-7.1.0/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["python"] {os-distribution = "alpine"}
   ["python"] {os-distribution = "centos"}
   ["python2"] {os-distribution = "fedora"}
-  ["python2"] {os-distribution = "archlinux"}
+  ["python2"] {os-distribution = "arch"}
   ["python"] {os-family = "suse"}
   ["dev-lang/python:2.7"] {os-distribution = "gentoo"}
   ["python/2.7"] {os = "openbsd"}

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["R-base"] {os-family = "suse"}
   ["libRmath"] {os = "freebsd"}
   ["r"] {os = "macos" & os-distribution = "homebrew"}
-  ["r"] {os-distribution = "archlinux"}
+  ["r"] {os-distribution = "arch"}
 ]
 synopsis:
   "Virtual package relying on a system installation of R Standalone Mathlib"

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -7,7 +7,7 @@ license: "GPL-2+"
 build: ["R" "CMD" "BATCH" "check.r"]
 depexts: [
   ["r"] {os = "macos" & os-distribution = "homebrew"}
-  ["r"] {os-distribution = "archlinux"}
+  ["r"] {os-distribution = "arch"}
   ["r-base-core"] {os-distribution = "debian"}
   ["r-base-core"] {os-distribution = "ubuntu"}
   ["R-core"] {os-family = "suse"}

--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depexts: [
   ["ruby"] {os-distribution = "alpine"}
-  ["ruby"] {os-distribution = "archlinux"}
+  ["ruby"] {os-distribution = "arch"}
   ["ruby"] {os-distribution = "centos"}
   ["ruby"] {os-distribution = "debian"}
   ["ruby"] {os-distribution = "fedora"}

--- a/packages/conf-rust-2018/conf-rust-2018.1/opam
+++ b/packages/conf-rust-2018/conf-rust-2018.1/opam
@@ -19,7 +19,7 @@ depexts: [
   ["cargo"] {os-distribution = "ubuntu"}
   ["cargo"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}
-  ["rust"] {os-distribution = "archlinux"}
+  ["rust"] {os-distribution = "arch"}
   ["rust"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on cargo (rust build system)"

--- a/packages/conf-rust/conf-rust.0.1/opam
+++ b/packages/conf-rust/conf-rust.0.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["cargo"] {os-distribution = "ubuntu"}
   ["cargo"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}
-  ["rust"] {os-distribution = "archlinux"}
+  ["rust"] {os-distribution = "arch"}
   ["rust"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on cargo (rust build system)"

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -7,7 +7,7 @@ license: "Zlib"
 build: [["pkg-config" "sdl2"]]
 depexts: [
   ["sdl2-dev"] {os-distribution = "alpine"}
-  ["sdl2"] {os-distribution = "archlinux"}
+  ["sdl2"] {os-distribution = "arch"}
   ["libsdl2-dev"] {os-distribution = "debian"}
   ["SDL2-devel"] {os-distribution = "fedora"}
   ["sdl2"] {os = "freebsd"}

--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libsecp256k1-0" "libsecp256k1-dev"] {os-distribution = "debian"}
   ["dev-libs/libsecp256k1"] {os-distribution = "gentoo"}
   ["secp256k1"] {os-distribution = "homebrew" & os = "macos"}
-  ["libsecp256k1-git"] {os-distribution = "archlinux"}
+  ["libsecp256k1-git"] {os-distribution = "arch"}
   ["libsecp256k1-0" "libsecp256k1-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a secp256k1 lib system installation"

--- a/packages/conf-tidy/conf-tidy.1/opam
+++ b/packages/conf-tidy/conf-tidy.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libtidy-dev"] {os-distribution = "debian"}
   ["libtidy-dev"] {os-distribution = "ubuntu"}
   ["libtidy-devel"] {os-distribution = "opensuse"}
-  ["tidy"] {os-distribution = "archlinux"}
+  ["tidy"] {os-distribution = "arch"}
   ["app-text/tidy-html5"] {os-distribution = "gentoo"}
   ["libtidy-devel"] {os-distribution = "fedora"}
   ["libtidy-devel"] {os-distribution = "centos"}

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["time"] {os-distribution = "ubuntu"}
   ["time"] {os-distribution = "centos"}
   ["time"] {os-distribution = "fedora"}
-  ["time"] {os-distribution = "archlinux"}
+  ["time"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on the \"time\" command"
 description:

--- a/packages/conf-wget/conf-wget.1/opam
+++ b/packages/conf-wget/conf-wget.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["wget"] {os-distribution = "debian"}
   ["wget"] {os-distribution = "ubuntu"}
   ["wget"] {os-distribution = "fedora"}
-  ["wget"] {os-distribution = "archlinux"}
+  ["wget"] {os-distribution = "arch"}
   ["wget"] {os-distribution = "nixos"}
   ["net-misc/wget"] {os-distribution = "gentoo"}
   ["wget"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["debianutils"] {os-distribution = "debian"}
   ["debianutils"] {os-distribution = "ubuntu"}
   ["which"] {os-distribution = "nixos"}
-  ["which"] {os-distribution = "archlinux"}
+  ["which"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on which"
 description:

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["zlib-devel"] {os-distribution = "fedora"}
   ["zlib"] {os-distribution = "nixos"}
   ["lzlib"] {os-distribution = "homebrew" & os = "macos"}
-  ["zlib"] {os-distribution = "archlinux"}
+  ["zlib"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on zlib"
 description:

--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -22,7 +22,7 @@ depexts: [
   ["gdbm-devel"] {os-distribution = "rhel"}
   ["gdbm-devel"] {os-distribution = "fedora"}
   ["gdbm-dev"] {os-distribution = "alpine"}
-  ["gdbm"] {os-distribution = "archlinux"}
+  ["gdbm"] {os-distribution = "arch"}
 ]
 patches: [
   "hasgotfix.patch"

--- a/packages/dbm/dbm.1.1/opam
+++ b/packages/dbm/dbm.1.1/opam
@@ -23,7 +23,7 @@ depexts: [
   ["gdbm-devel"] {os-distribution = "fedora"}
   ["gdbm-dev"] {os-distribution = "alpine"}
   ["gdbm"] {os = "macos" & os-distribution = "homebrew"}
-  ["gdbm"] {os-distribution = "archlinux"}
+  ["gdbm"] {os-distribution = "arch"}
 ]
 patches: [
   "include_local_fix.patch"

--- a/packages/dlm/dlm.0.3.0/opam
+++ b/packages/dlm/dlm.0.3.0/opam
@@ -26,7 +26,7 @@ depexts: [
   ["dlm-devel"] {os-distribution = "centos"}
   ["dlm-devel"] {os-distribution = "fedora"}
   ["dlm-devel"] {os-distribution = "oraclelinux"}
-  ["dlm-git"] {os-distribution = "archlinux"}
+  ["dlm-git"] {os-distribution = "arch"}
   ["libdlm-devel"] {os-family = "suse"}
 ]
 available: [ os = "linux" & os != "alpine" ]

--- a/packages/dssi/dssi.0.1.2/opam
+++ b/packages/dssi/dssi.0.1.2/opam
@@ -18,7 +18,7 @@ depexts: [
   ["dssi-devel"] {os-distribution = "fedora"}
   ["dssi-devel"] {os-family = "suse"}
   ["dssi"] {os-distribution = "nixos"}
-  ["dssi"] {os-distribution = "archlinux"}
+  ["dssi"] {os-distribution = "arch"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-dssi/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-dssi.git"

--- a/packages/faad/faad.0.4.0/opam
+++ b/packages/faad/faad.0.4.0/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depexts: [
   ["faad2-dev"] {os-distribution = "alpine"}
-  ["faad2"] {os-distribution = "archlinux"}
+  ["faad2"] {os-distribution = "arch"}
   ["faad2-devel"] {os-distribution = "centos"}
   ["faad2-devel"] {os-distribution = "fedora"}
   ["faad2-devel"] {os-family = "suse"}

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -19,7 +19,7 @@ depends: [
 ]
 depexts: [
   ["fdk-aac-dev"] {os-distribution = "alpine"}
-  ["libfdk-aac"] {os-distribution = "archlinux"}
+  ["libfdk-aac"] {os-distribution = "arch"}
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse"}

--- a/packages/ffmpeg/ffmpeg.0.1.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libavutil-dev" "libswscale-dev"] {os-distribution = "debian"}
   ["libavutil-dev" "libswscale-dev"] {os-distribution = "ubuntu"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
-  ["ffmpeg"] {os-distribution = "archlinux"}
+  ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}

--- a/packages/ffmpeg/ffmpeg.0.1.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.2/opam
@@ -19,7 +19,7 @@ depexts: [
   ["libavutil-dev" "libswscale-dev"] {os-distribution = "debian"}
   ["libavutil-dev" "libswscale-dev"] {os-distribution = "ubuntu"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
-  ["ffmpeg"] {os-distribution = "archlinux"}
+  ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}

--- a/packages/ffmpeg/ffmpeg.0.2.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.0/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libavutil-dev" "libswscale-dev" "libavformat-dev"]
     {os-distribution = "ubuntu"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
-  ["ffmpeg"] {os-distribution = "archlinux"}
+  ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}

--- a/packages/ffmpeg/ffmpeg.0.2.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.1/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
     {os-distribution = "ubuntu"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
-  ["ffmpeg"] {os-distribution = "archlinux"}
+  ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}

--- a/packages/flac/flac.0.1.3/opam
+++ b/packages/flac/flac.0.1.3/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depexts: [
   ["flac-dev"] {os-distribution = "alpine"}
-  ["flac"] {os-distribution = "archlinux"}
+  ["flac"] {os-distribution = "arch"}
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}

--- a/packages/flac/flac.0.1.4/opam
+++ b/packages/flac/flac.0.1.4/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depexts: [
   ["flac-dev"] {os-distribution = "alpine"}
-  ["flac"] {os-distribution = "archlinux"}
+  ["flac"] {os-distribution = "arch"}
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}

--- a/packages/gavl/gavl.0.1.6/opam
+++ b/packages/gavl/gavl.0.1.6/opam
@@ -19,7 +19,7 @@ depexts: [
   ["libgavl-dev"] {os-distribution = "debian"}
   ["libgavl-dev"] {os-distribution = "ubuntu"}
   ["drfill/liquidsoap/libgavl"] {os = "macos" & os-distribution = "homebrew"}
-  ["gavl"] {os-distribution = "archlinux"}
+  ["gavl"] {os-distribution = "arch"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-gavl/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-gavl.git"

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}
-  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
   ["gtkspell3-devel"] {os-distribution = "fedora"}

--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -29,7 +29,7 @@ depexts: [
   ["gc-devel"] {os-distribution = "centos"}
   ["gc-devel"] {os-distribution = "fedora"}
   ["gc-devel"] {os-family = "suse"}
-  ["gc"] {os-distribution = "archlinux"}
+  ["gc"] {os-distribution = "arch"}
   ["gc-dev"] {os-distribution = "alpine"}
   ["boehmgc"] {os-distribution = "macports" & os = "macos"}
   ["bdw-gc"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/lmdb/lmdb.0.1/opam
+++ b/packages/lmdb/lmdb.0.1/opam
@@ -32,7 +32,7 @@ depexts: [
   ["lmdb"] {os = "macos" & os-distribution = "macports"}
   ["lmdb-devel"] {os-distribution = "fedora"}
   ["lmdb-devel"] {os-family = "suse"}
-  ["lmdb"] {os-distribution = "archlinux"}
+  ["lmdb"] {os-distribution = "arch"}
 ]
 url {
   src: "https://github.com/Drup/ocaml-lmdb/archive/0.1.tar.gz"

--- a/packages/mad/mad.0.4.5/opam
+++ b/packages/mad/mad.0.4.5/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "mad"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["libmad-dev"] {os-distribution = "alpine"}
-  ["libmad"] {os-distribution = "archlinux"}
+  ["libmad"] {os-distribution = "arch"}
   ["libmad-devel"] {os-distribution = "centos"}
   ["libmad-devel"] {os-distribution = "fedora"}
   ["libmad-devel"] {os-family = "suse"}

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 depexts: [
   ["libmilter-dev"] {os-distribution = "alpine"}
-  ["libmilter"] {os-distribution = "archlinux"}
+  ["libmilter"] {os-distribution = "arch"}
   ["sendmail-devel"] {os-distribution = "centos"}
   ["sendmail-milter-devel"] {os-distribution = "fedora"}
   ["libmilter"] {os = "freebsd"}

--- a/packages/ogg/ogg.0.5.0/opam
+++ b/packages/ogg/ogg.0.5.0/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "ogg"]
 depends: ["ocaml" {< "4.06.0"} "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["libogg-dev"] {os-distribution = "alpine"}
-  ["libogg"] {os-distribution = "archlinux"}
+  ["libogg"] {os-distribution = "arch"}
   ["libogg-dev"] {os-distribution = "debian"}
   ["libogg-dev"] {os-distribution = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}

--- a/packages/ogg/ogg.0.5.1/opam
+++ b/packages/ogg/ogg.0.5.1/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "ogg"]
 depends: ["ocaml" {< "4.06.0"} "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["libogg-dev"] {os-distribution = "alpine"}
-  ["libogg"] {os-distribution = "archlinux"}
+  ["libogg"] {os-distribution = "arch"}
   ["libogg-dev"] {os-distribution = "debian"}
   ["libogg-dev"] {os-distribution = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}

--- a/packages/ogg/ogg.0.5.2/opam
+++ b/packages/ogg/ogg.0.5.2/opam
@@ -17,7 +17,7 @@ depends: [
 ]
 depexts: [
   ["libogg-dev"] {os-distribution = "alpine"}
-  ["libogg"] {os-distribution = "archlinux"}
+  ["libogg"] {os-distribution = "arch"}
   ["libogg-dev"] {os-distribution = "debian"}
   ["libogg-dev"] {os-distribution = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}

--- a/packages/opencc/opencc.0.4.3-0.1.1/opam
+++ b/packages/opencc/opencc.0.4.3-0.1.1/opam
@@ -23,7 +23,7 @@ depends: [
 depexts: [
   ["libopencc-dev"] {os-distribution = "debian"}
   ["libopencc-dev"] {os-distribution = "ubuntu"}
-  ["opencc"] {os-distribution = "archlinux"}
+  ["opencc"] {os-distribution = "arch"}
 ]
 post-messages: [
   "This package requires installation of libopencc-dev (>= 0.4.3)" {failure & os = "debian"}

--- a/packages/opus/opus.0.1.2/opam
+++ b/packages/opus/opus.0.1.2/opam
@@ -17,7 +17,7 @@ depends: [
 ]
 depexts: [
   ["opus-dev"] {os-distribution = "alpine"}
-  ["opus"] {os-distribution = "archlinux"}
+  ["opus"] {os-distribution = "arch"}
   ["libopus-dev"] {os-distribution = "debian"}
   ["libopus-dev"] {os-distribution = "ubuntu"}
   ["opus-devel"] {os-distribution = "centos"}

--- a/packages/postgresql/postgresql.3.2.1/opam
+++ b/packages/postgresql/postgresql.3.2.1/opam
@@ -48,7 +48,7 @@ depexts: [
   ["libpq-dev"] {os-distribution = "debian"}
   ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "fedora"}
-  ["postgresql-libs"] {os-distribution = "archlinux"}
+  ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}

--- a/packages/postgresql/postgresql.4.0.0/opam
+++ b/packages/postgresql/postgresql.4.0.0/opam
@@ -48,7 +48,7 @@ depexts: [
   ["libpq-dev"] {os-distribution = "debian"}
   ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "fedora"}
-  ["postgresql-libs"] {os-distribution = "archlinux"}
+  ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}

--- a/packages/postgresql/postgresql.4.0.1/opam
+++ b/packages/postgresql/postgresql.4.0.1/opam
@@ -48,7 +48,7 @@ depexts: [
   ["libpq-dev"] {os-distribution = "debian"}
   ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "fedora"}
-  ["postgresql-libs"] {os-distribution = "archlinux"}
+  ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}

--- a/packages/postgresql/postgresql.4.1.0/opam
+++ b/packages/postgresql/postgresql.4.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 depexts: [
-  ["postgresql-libs"] {os-distribution = "archlinux"}
+  ["postgresql-libs"] {os-distribution = "arch"}
   ["libpq-dev"] {os-distribution = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}

--- a/packages/postgresql/postgresql.4.2.0/opam
+++ b/packages/postgresql/postgresql.4.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 depexts: [
-  ["postgresql-libs"] {os-distribution = "archlinux"}
+  ["postgresql-libs"] {os-distribution = "arch"}
   ["libpq-dev"] {os-distribution = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}

--- a/packages/postgresql/postgresql.4.2.1/opam
+++ b/packages/postgresql/postgresql.4.2.1/opam
@@ -25,7 +25,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 depexts: [
-  ["postgresql-libs"] {os-distribution = "archlinux"}
+  ["postgresql-libs"] {os-distribution = "arch"}
   ["libpq-dev"] {os-distribution = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}

--- a/packages/postgresql/postgresql.4.3.0/opam
+++ b/packages/postgresql/postgresql.4.3.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 depexts: [
-  ["postgresql-libs"] {os-distribution = "archlinux"}
+  ["postgresql-libs"] {os-distribution = "arch"}
   ["libpq-dev"] {os-distribution = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}

--- a/packages/radare2/radare2.0.0.2/opam
+++ b/packages/radare2/radare2.0.0.2/opam
@@ -15,7 +15,7 @@ depexts: [
   ["radare2"] {os-distribution = "debian"}
   ["radare2"] {os-distribution = "ubuntu"}
   ["radare2"] {os-distribution = "fedora"}
-  ["radare2"] {os-distribution = "archlinux"}
+  ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "gentoo"}
   ["radare2"] {os-distribution = "homebrew" & os = "macos"}
 ]

--- a/packages/spf/spf.2.0.2/opam
+++ b/packages/spf/spf.2.0.2/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 depexts: [
   ["libspf2-dev"] {os-distribution = "alpine"}
-  ["libspf2"] {os-distribution = "archlinux"}
+  ["libspf2"] {os-distribution = "arch"}
   ["epel-release" "libspf2-devel"] {os-distribution = "centos"}
   ["libspf2-dev"] {os-distribution = "debian"}
   ["libspf2-devel"] {os-distribution = "fedora"}

--- a/packages/tidy/tidy.0-2009-0.1.1/opam
+++ b/packages/tidy/tidy.0-2009-0.1.1/opam
@@ -24,7 +24,7 @@ depends: [
 depexts: [
   ["libtidy-dev"] {os-distribution = "debian"}
   ["libtidy-dev"] {os-distribution = "ubuntu"}
-  ["tidyhtml"] {os-distribution = "archlinux"}
+  ["tidyhtml"] {os-distribution = "arch"}
 ]
 post-messages: [
   "This package requires installation of libtidy (>= 20090501)" {failure & (os = "ubuntu" | os = "debian")}

--- a/packages/tidy/tidy.1-4.9.30-0.1.1/opam
+++ b/packages/tidy/tidy.1-4.9.30-0.1.1/opam
@@ -24,7 +24,7 @@ depends: [
 depexts: [
   ["libtidy-dev"] {os-distribution = "debian"}
   ["libtidy-dev"] {os-distribution = "ubuntu"}
-  ["tidyhtml"] {os-distribution = "archlinux"}
+  ["tidyhtml"] {os-distribution = "arch"}
 ]
 post-messages: [
   "This package requires installation of libtidy5. You can download and install it from https://github.com/htacg/tidy-html5 and here is a sample install script: https://gist.githubusercontent.com/kandu/b88c1f4631e6c5a3bbac/raw" {failure}

--- a/packages/tsdl-image/tsdl-image.0.1.1/opam
+++ b/packages/tsdl-image/tsdl-image.0.1.1/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libsdl2-image-dev"] {os-distribution = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
   ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
-  ["sdl2_image"] {os-distribution = "archlinux"}
+  ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"
 description: """

--- a/packages/tsdl-image/tsdl-image.0.1.2/opam
+++ b/packages/tsdl-image/tsdl-image.0.1.2/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libsdl2-image-dev"] {os-distribution = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
   ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
-  ["sdl2_image"] {os-distribution = "archlinux"}
+  ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"
 description: """

--- a/packages/tsdl-image/tsdl-image.0.1/opam
+++ b/packages/tsdl-image/tsdl-image.0.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libsdl2-image-dev"] {os-distribution = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
   ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
-  ["sdl2_image"] {os-distribution = "archlinux"}
+  ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"
 description: """

--- a/packages/tsdl-image/tsdl-image.0.2.0/opam
+++ b/packages/tsdl-image/tsdl-image.0.2.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libsdl2-image-dev"] {os-distribution = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
   ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
-  ["sdl2_image"] {os-distribution = "archlinux"}
+  ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"
 description: """

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -52,7 +52,7 @@ depopts: [
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
   ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 tags: "org:mirage"
 synopsis: "Xen Vchan implementation"

--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."
 description:

--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-evtchn.git"
 synopsis: "Xen event channel interface for Linux"

--- a/packages/xen-evtchn/xen-evtchn.1.0.1/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.1/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."
 description:

--- a/packages/xen-evtchn/xen-evtchn.1.0.3/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.3/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."
 description:

--- a/packages/xen-evtchn/xen-evtchn.1.0.4/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.4/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."
 description:

--- a/packages/xen-evtchn/xen-evtchn.1.0.5/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.5/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."
 description:

--- a/packages/xen-evtchn/xen-evtchn.1.0.6/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.6/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."
 description:

--- a/packages/xen-evtchn/xen-evtchn.1.0.7/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.7/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."
 description:

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
@@ -23,7 +23,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen grant table bindings"
 description: """

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
@@ -23,7 +23,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Grant table bindings for OCaml."
 description: """

--- a/packages/yara/yara.0.1/opam
+++ b/packages/yara/yara.0.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libyara-dev"] {os-distribution = "ubuntu"}
   ["epel-release" "yara-devel"] {os-distribution = "centos"}
   ["yara-devel"] {os-distribution = "fedora"}
-  ["yara"] {os-distribution = "archlinux"}
+  ["yara"] {os-distribution = "arch"}
   ["yara"] {os-distribution = "gentoo"}
   ["yara"] {os = "macos" & os-distribution = "homebrew"}
 ]


### PR DESCRIPTION
Turns out depexts never worked on archlinux with opam 2.0 because os-distribution is `"arch"` on archlinux, not `"archlinux"`