### PR TITLE
Package tablecloth-native.0.0.3

### DIFF
--- a/packages/tablecloth-native/tablecloth-native.0.0.3/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.3/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis:
+  "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML"
+description: "Longer description"
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: "Paul Biggar <paul@darklang.com>"
+license: "MIT with some exceptions"
+homepage: "https://github.com/darklang/tablecloth"
+bug-reports: "https://github.com/darklang/tablecloth/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "base" {>= "v0.10.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/darklang/tablecloth"
+url {
+  src: "https://github.com/darklang/tablecloth/archive/0.0.3.tar.gz"
+  checksum: [
+    "md5=913df426e14adb5fc85bb2eded4a083a"
+    "sha512=8a01a254fabd4c0ba2b00e41c0a802cc89834542e9a625e823841e57cdb22cf4885125fed9861a9ad594bd60821ebc0431fda2298e7b273d6852cad1a0ebd0e7"
+  ]
+}

--- a/packages/tablecloth-native/tablecloth-native.0.0.3/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis:
   "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML"
-description: "Longer description"
+
 maintainer: "Paul Biggar <paul@darklang.com>"
 authors: "Paul Biggar <paul@darklang.com>"
 license: "MIT with some exceptions"


### PR DESCRIPTION
### `tablecloth-native.0.0.3`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML
Longer description



---
* Homepage: https://github.com/darklang/tablecloth
* Source repo: git://github.com/darklang/tablecloth
* Bug tracker: https://github.com/darklang/tablecloth/issues

---
:camel: Pull-request generated by opam-publish v2.0.0