### PR TITLE
nocrypto: use the modern cstruct findlib packages

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/files/0005-use-modern-cstruct-findlib.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-1/files/0005-use-modern-cstruct-findlib.patch
@@ -1,0 +1,32 @@
+From 063b3496340fe4c3544b532ec0d27797b7917bb4 Mon Sep 17 00:00:00 2001
+From: Anil Madhavapeddy <anil@recoil.org>
+Date: Tue, 12 Mar 2019 09:07:13 +0000
+Subject: [PATCH 5/5] use modern cstruct findlib
+
+see https://discuss.ocaml.org/t/psa-cstruct-3-4-0-removes-old-ocamlfind-subpackage-aliases/3275
+
+--- a/_tags.orig        2019-03-12 09:03:58.000000000 +0000
++++ b/_tags     2019-03-12 09:04:12.000000000 +0000
+@@ -13,7 +13,7 @@
+ <unix/*.ml{,i}>: package(unix), package(bytes)
+
+ <lwt>: include
+-<lwt/*.ml{,i}>: package(lwt.unix), package(cstruct.lwt)
++<lwt/*.ml{,i}>: package(lwt.unix), package(cstruct-lwt)
+
+ <mirage>: include
+ <mirage/*.ml{,i}>: package(lwt), package(mirage-entropy)
+--- a/pkg/META.in.orig  2019-03-12 09:03:19.000000000 +0000
++++ b/pkg/META.in       2019-03-12 09:03:33.000000000 +0000
+@@ -23,7 +23,7 @@
+ package "lwt" (
+  version = "0.5.4"
+  description = "Simple crypto for the modern age"
+- requires = "nocrypto nocrypto.unix lwt.unix cstruct.lwt"
++ requires = "nocrypto nocrypto.unix lwt.unix cstruct-lwt"
+  archive(byte) = "nocrypto_lwt.cma"
+  archive(native) = "nocrypto_lwt.cmxa"
+  plugin(byte) = "nocrypto_lwt.cma"
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -23,7 +23,7 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv" {>= "113.33.01" & != "v0.11.0" & < "v0.12"}
   "ounit" {with-test}
-  "cstruct" {>= "2.4.0" & <"3.4.0"}
+  "cstruct" {>= "2.4.0"}
   "cstruct-lwt"
   "zarith"
   "lwt"
@@ -44,6 +44,7 @@ patches: [
     "0002-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch"
     "0003-Auto-detect-ppx_sexp_conv-runtime-library.patch"
     "0004-pack-package-workaround-ocamlbuild-272.patch"
+    "0005-use-modern-cstruct-findlib.patch"
 ]
 synopsis: "Simpler crypto"
 description: """
@@ -54,6 +55,10 @@ SHA1, SHA2), public-key primitives (RSA, DSA, DH) and a strong RNG (Fortuna).
 RSA timing attacks are countered by blinding. AES timing attacks are avoided by
 delegating to AES-NI."""
 extra-files: [
+  [
+    "0005-use-modern-cstruct-findlib.patch"
+    "md5=4d4aab890f0ca9327d83548c32d64efc"
+  ]
   [
     "0004-pack-package-workaround-ocamlbuild-272.patch"
     "md5=94615e4a8d5976e9e75c3b031d3484f1"


### PR DESCRIPTION
This removes an upper bound which is splitting the opam package universe around nocrypto.

Interim patch until upstream nocrypto has a release (this issue is fixed in trunk), as it's blocking a number of activities in opam-repository. cc @hannesm @copy @pqwy 