### PR TITLE
[new release] fat-filesystem (0.13.0)

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.13.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.13.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-fat"
+doc: "https://mirage.github.io/ocaml-fat/"
+bug-reports: "https://github.com/mirage/ocaml-fat/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_cstruct"
+  "rresult"
+  "lwt" {>= "2.4.3"}
+  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs-lwt" {>= "1.0.0"}
+  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-block-unix" {>= "2.5.0"}
+  "io-page-unix" {>= "2.0.0"}
+  "re" {>= "1.7.2"}
+  "cmdliner"
+  "astring"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-fat.git"
+synopsis: "Pure OCaml implementation of the FAT filesystem"
+description: """
+This library has two purposes:
+1. to allow the easy preparation of bootable disk images
+     containing [mirage](https://mirage.io) kernels
+2. to provide a simple filesystem layer for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-fat/releases/download/v0.13.0/fat-filesystem-v0.13.0.tbz"
+  checksum: "md5=cf27d4f72b2bd194e09a97c387867601"
+}


### PR DESCRIPTION
Pure OCaml implementation of the FAT filesystem

- Project page: <a href="https://github.com/mirage/ocaml-fat">https://github.com/mirage/ocaml-fat</a>
- Documentation: <a href="https://mirage.github.io/ocaml-fat/">https://mirage.github.io/ocaml-fat/</a>

##### CHANGES:

- port to dune from jbuilder (mirage/ocaml-fat#79 @emillon)
- update opam metadata to 2.0 format (mirage/ocaml-fat#80 @avsm)
- test with OCaml 4.07 (mirage/ocaml-fat#80 @avsm)
- update opam metadata to 2.0 format (mirage/ocaml-fat#80 @avsm)
- work with cstruct 1.7.0 by not using leading underscores
  in prefix fields (mirage/ocaml-fat#80 @avsm)
