### PR TITLE
[new release] vhd-format and vhd-format-lwt (0.12.0)

### DIFF
--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Jon Ludlam"]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-vhd"
+doc: "https://mirage.github.io/ocaml-vhd/"
+bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "cstruct"
+  "lwt" {>= "3.2.0"}
+  "mirage-block"
+  "mirage-types-lwt" {>= "3.0.0"}
+  "ounit"
+  "vhd-format"
+  "io-page-unix" {with-test}
+  "dune" {build & >= "1.0"}
+]
+available: os = "linux" | os = "macos"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+synopsis: "Lwt interface to read/write VHD format data"
+description: """
+A pure OCaml library to read and write
+[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
+simple command-line tool which allows vhd files to be interrogated,
+manipulated, format-converted and streamed to and from files and remote
+servers.
+
+This package provides an Lwt compatible interface to the library.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.0/vhd-format-v0.12.0.tbz"
+  checksum: "md5=73b88364f534dc0fcee23e6c4ceca8c7"
+}

--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "cstruct" {>= "1.9"}
   "io-page"
   "rresult"

--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Jon Ludlam"]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-vhd"
+doc: "https://mirage.github.io/ocaml-vhd/"
+bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "cstruct" {>= "1.9"}
+  "io-page"
+  "rresult"
+  "uuidm"
+  "dune" {build & >= "1.0"}
+  "ppx_cstruct" {build}
+]
+available: os = "linux" | os = "macos"
+build: ["dune" "build" "-p" name "-j" jobs]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+synopsis: "Pure OCaml library to read/write VHD format data"
+description: """
+A pure OCaml library to read and write
+[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
+simple command-line tool which allows vhd files to be interrogated,
+manipulated, format-converted and streamed to and from files and remote
+servers.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.0/vhd-format-v0.12.0.tbz"
+  checksum: "md5=73b88364f534dc0fcee23e6c4ceca8c7"
+}


### PR DESCRIPTION
Pure OCaml library to read/write VHD format data

- Project page: <a href="https://github.com/mirage/ocaml-vhd">https://github.com/mirage/ocaml-vhd</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vhd/">https://mirage.github.io/ocaml-vhd/</a>

##### CHANGES:

* Port to dune/dune-release (@avsm)
* Use modern cstruct ppx name (@avsm)
* Update Travis build matrix (@avsm)
