### PR TITLE
Package stdcompat.9

### DIFF
--- a/packages/ocamlcodoc/ocamlcodoc.1.0.0/opam
+++ b/packages/ocamlcodoc/ocamlcodoc.1.0.0/opam
@@ -10,7 +10,8 @@ dev-repo: "git+https://gitlab.inria.fr/tmartine/ocamlcodoc.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
-  "stdcompat" "cmdliner"
+  "stdcompat" { <= "8" }
+  "cmdliner"
   "dune" {>= "1.3"}]
 url {
   src: "https://gitlab.inria.fr/tmartine/ocamlcodoc/-/archive/v1.0.0/ocamlcodoc-v1.0.0.tar.gz"

--- a/packages/stdcompat/stdcompat.9/opam
+++ b/packages/stdcompat/stdcompat.9/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.07" & < "4.09.0"}
+]
+depopts: ["result" "seq" "uchar" "ocamlfind"]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/9/stdcompat-9.tar.gz"
+  checksum: [
+    "md5=fff903b5c06cd7116240419691963419"
+    "sha512=4b8548c5741714c59fe8d0bb865bf9facf83af98a94189faa35494867fe4b03e71a9e5f59e299f07b54469a94b62a058ced2edbe87518af33aba549d1de00aca"
+  ]
+}


### PR DESCRIPTION
### `stdcompat.9`
Compatibility module for OCaml standard library
Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml.



---
* Homepage: https://github.com/thierry-martinez/stdcompat
* Source repo: git+https://github.com/thierry-martinez/stdcompat.git
* Bug tracker: https://github.com/thierry-martinez/stdcompat/issues

---
:camel: Pull-request generated by opam-publish v2.0.0