### PR TITLE
[new release] cow (2.4.0)

### DIFF
--- a/packages/cow/cow.2.4.0/opam
+++ b/packages/cow/cow.2.4.0/opam
@@ -15,7 +15,7 @@ homepage: "https://github.com/mirage/ocaml-cow"
 doc: "http://mirage.github.io/ocaml-cow/"
 bug-reports: "https://github.com/mirage/ocaml-cow/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.1.0"}
   "uri" {>= "1.3.9"}
   "xmlm" {>= "1.1.1"}

--- a/packages/cow/cow.2.4.0/opam
+++ b/packages/cow/cow.2.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Gazagnaire"
+  "David Sheets"
+  "Rudi Grinberg"
+  "Timothy Bourke"
+]
+license: "ISC"
+tags: [
+  "org:mirage" "org:xapi-project" "www" "html" "xml" "css" "json" "markdown"
+]
+homepage: "https://github.com/mirage/ocaml-cow"
+doc: "http://mirage.github.io/ocaml-cow/"
+bug-reports: "https://github.com/mirage/ocaml-cow/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.1.0"}
+  "uri" {>= "1.3.9"}
+  "xmlm" {>= "1.1.1"}
+  "omd" {>= "0.8.2"}
+  "ezjsonm" {>= "0.4.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cow.git"
+synopsis: "Caml on the Web"
+description: """
+Writing web-applications requires a lot of skills: HTML, XML, JSON and
+Markdown, to name but a few!  This library provides OCaml combinators
+for these web formats.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cow/releases/download/v2.4.0/cow-v2.4.0.tbz"
+  checksum: "md5=7d3d672aeca0dc551b9b408210dc0b9d"
+}


### PR DESCRIPTION
Caml on the Web

- Project page: <a href="https://github.com/mirage/ocaml-cow">https://github.com/mirage/ocaml-cow</a>
- Documentation: <a href="http://mirage.github.io/ocaml-cow/">http://mirage.github.io/ocaml-cow/</a>

##### CHANGES:

* Port to dune fully (mirage/ocaml-cow#105 @emillon)
* Upgrade opam metadata to 2.0 (@avsm)
