### PR TITLE
Package glfw-ocaml (3.2.1-1)

### DIFF
--- a/packages/glfw-ocaml/glfw-ocaml.3.2.1-1/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.2.1-1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "A GLFW binding for OCaml"
+maintainer: "Sylvain BOILARD <boilard@crans.org>"
+authors: "Sylvain BOILARD <boilard@crans.org>"
+license: "Zlib"
+homepage: "https://github.com/SylvainBoilard/GLFW-OCaml"
+bug-reports: "https://github.com/SylvainBoilard/GLFW-OCaml/issues"
+depends: [
+  "conf-glfw3"
+  "base-bigarray"
+  "dune" {build & >= "1.0"}
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.02.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/SylvainBoilard/GLFW-OCaml.git"
+url {
+  src:
+    "https://github.com/SylvainBoilard/GLFW-OCaml/archive/3.2.1-1.tar.gz"
+  checksum: [
+    "md5=69bc25389d41f5041f373f5aca41fc71"
+    "sha512=bc98ff18534397273e7e385ccedbd9c691562d97cd1afb3e3e45d6f58122a1831605866dbf102f1203c64ca1d1f57d373cd598cbc154261321b57e3f68eed256"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Fixed build when the GLFW headers are not in /usr/include.