### PR TITLE
Package tablecloth-native.0.0.4

### DIFF
--- a/packages/tablecloth-native/tablecloth-native.0.0.4/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.4/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis:
+  "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML"
+description: "Longer description"
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: "Paul Biggar <paul@darklang.com>"
+license: "MIT with some exceptions"
+homepage: "https://github.com/darklang/tablecloth"
+bug-reports: "https://github.com/darklang/tablecloth/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "base" {>= "v0.10.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/darklang/tablecloth"
+url {
+  src: "https://github.com/darklang/tablecloth/archive/0.0.4.tar.gz"
+  checksum: [
+    "md5=81fbeeab1aaafa91193358bcb5427c7e"
+    "sha512=ed428886d942fc9dbef740e8086af15f905406525cfc17a57264732eaedca43b3e96f98e0a1bfe2270ab107db83da60d5688d6843a8481e2219c8bc60ce88a0b"
+  ]
+}


### PR DESCRIPTION
### `tablecloth-native.0.0.4`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML
Longer description



---
* Homepage: https://github.com/darklang/tablecloth
* Source repo: git://github.com/darklang/tablecloth
* Bug tracker: https://github.com/darklang/tablecloth/issues

---
:camel: Pull-request generated by opam-publish v2.0.0