### PR TITLE
Package tablecloth-native.0.0.5

### DIFF
--- a/packages/tablecloth-native/tablecloth-native.0.0.5/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.5/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis:
+  "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML"
+description: "Longer description"
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: "Paul Biggar <paul@darklang.com>"
+license: "MIT with some exceptions"
+homepage: "https://github.com/darklang/tablecloth"
+bug-reports: "https://github.com/darklang/tablecloth/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "base" {>= "v0.10.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/darklang/tablecloth"
+url {
+  src: "https://github.com/darklang/tablecloth/archive/0.0.5.tar.gz"
+  checksum: [
+    "md5=4d2519440a096b0af2d9e1987fb7bb33"
+    "sha512=63f7db5a0dfcc6144e6cc52a4fe8a54074c23bf1d9a4ccb3209a5fa329b2df265999531caf6e68d02f8c2fae17edc7a0d5659fe1861413bb9d5ebf0823ad4e43"
+  ]
+}

--- a/packages/tablecloth-native/tablecloth-native.0.0.5/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.5/opam
@@ -1,7 +1,6 @@
 opam-version: "2.0"
 synopsis:
   "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML"
-description: "Longer description"
 maintainer: "Paul Biggar <paul@darklang.com>"
 authors: "Paul Biggar <paul@darklang.com>"
 license: "MIT with some exceptions"


### PR DESCRIPTION
### `tablecloth-native.0.0.5`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML
Longer description



---
* Homepage: https://github.com/darklang/tablecloth
* Source repo: git://github.com/darklang/tablecloth
* Bug tracker: https://github.com/darklang/tablecloth/issues

---
:camel: Pull-request generated by opam-publish v2.0.0