### PR TITLE
Package datalog.0.6

### DIFF
--- a/packages/datalog/datalog.0.6/opam
+++ b/packages/datalog/datalog.0.6/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "An in-memory datalog implementation for OCaml"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+license: "BSD-2-Clause"
+tags: ["datalog" "relational" "query" "prolog"]
+homepage: "https://github.com/c-cube/datalog"
+doc: "https://c-cube.github.io/datalog"
+bug-reports: "https://github.com/c-cube/datalog/issues"
+depends: [
+  "dune"
+  "ocaml" {>= "4.03"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.3" & with-test}
+]
+depopts: ["num"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/c-cube/datalog"
+url {
+  src: "https://github.com/c-cube/datalog/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=4a2d12d630a5edd694968675a84a3ef5"
+    "sha512=685c0e186705837cb3ac66df6e8011d9f6a9629484b3a813b767df95348d5a41f37301f3e199ed6c91a42a87d1563e8355377269176785b123eb297a5ad022d7"
+  ]
+}


### PR DESCRIPTION
### `datalog.0.6`
An in-memory datalog implementation for OCaml



---
* Homepage: https://github.com/c-cube/datalog
* Source repo: git://github.com/c-cube/datalog
* Bug tracker: https://github.com/c-cube/datalog/issues

---
:camel: Pull-request generated by opam-publish v2.0.0