### PR TITLE
Older version of sexplib are not coinstallable with sexplib0.

### DIFF
--- a/packages/sexplib/sexplib.v0.10.0/opam
+++ b/packages/sexplib/sexplib.v0.10.0/opam
@@ -13,6 +13,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta12"}
   "num"
 ]
+conflicts: [
+  "sexplib0" 
+]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street's Core library

--- a/packages/sexplib/sexplib.v0.9.0/opam
+++ b/packages/sexplib/sexplib.v0.9.0/opam
@@ -14,6 +14,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta4" & < "1.0+beta12"}
   "num"
 ]
+conflicts: [
+  "sexplib0"
+]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street's Core library

--- a/packages/sexplib/sexplib.v0.9.1/opam
+++ b/packages/sexplib/sexplib.v0.9.1/opam
@@ -13,6 +13,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta2" & < "1.0+beta12"}
   "num"
 ]
+conflicts: [
+  "sexplib0" 
+]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street's Core library

--- a/packages/sexplib/sexplib.v0.9.2/opam
+++ b/packages/sexplib/sexplib.v0.9.2/opam
@@ -13,6 +13,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "num"
 ]
+conflicts: [
+  "sexplib0" 
+]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street's Core library

--- a/packages/sexplib/sexplib.v0.9.3/opam
+++ b/packages/sexplib/sexplib.v0.9.3/opam
@@ -13,6 +13,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "num"
 ]
+conflicts: [
+  "sexplib0" 
+]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street's Core library


### PR DESCRIPTION
The `sexplib0` package appeared as a split from `sexplib`
in `v0.11.0`. Previous versions of `sexplib` cannot coexist
with `sexplib0` because both contain a module named
`Sexplib0`.