### PR TITLE
Bump ppx_jsobject_conv to v0.6.0:

### DIFF
--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.6.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Roma Sokolov <sokolov.r.v@gmail.com>"
+authors: [ "Roma Sokolov <sokolov.r.v@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/little-arhat/ppx_jsobject_conv"
+bug-reports: "https://github.com/little-arhat/ppx_jsobject_conv/issues"
+dev-repo: "git://github.com/little-arhat/ppx_jsobject_conv.git"
+tags: [ "syntax" "jsoo" "javascript" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "js_of_ocaml" {>= "2.8"}
+  "ppxlib" {>= "0.5.0"}
+  "ocaml-migrate-parsetree" {>= "0.4"}
+  "dune" {build & >= "1.0"}
+  "webtest" {with-test}
+]
+synopsis:
+  "Ppx plugin for Typeconv to derive conversion from ocaml types to js objects to use with js_of_ocaml."
+description: """
+For types annotated with [@@deriving jsobject], plugin will generate pair of functions: *_of_jsobject/jsobject_of_*
+to convert from/to JavaScript objects. This allows one to use clean OCaml types to describe their logic, while having ability
+to easy go down to js types. Easy conversion from js objects to OCaml types means also, one can use fast native JSON.parse to
+convert JSON to OCaml types.
+
+Plugin supports number of customizations."""
+url {
+  src:
+    "https://github.com/little-arhat/ppx_jsobject_conv/archive/v0.6.0.tar.gz"
+  checksum: "md5=0b281ee22fd3fe2e2e01339cc0473298"
+}


### PR DESCRIPTION
Now uses dune, ppxlib.
Deprecation warnings are removed.

Thanks @copy for https://github.com/little-arhat/ppx_jsobject_conv/pull/5 