### PR TITLE
Package jupyter-kernel.0.4

### DIFF
--- a/packages/jupyter-kernel/jupyter-kernel.0.4/opam
+++ b/packages/jupyter-kernel/jupyter-kernel.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Library to write jupyter kernels (interactive notebooks)"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Andrew Ray"]
+tags: ["jupyter" "ipython"]
+homepage: "https://github.com/ocaml-jupyter/jupyter-kernel"
+bug-reports: "https://github.com/ocaml-jupyter/jupyter-kernel/issues"
+depends: [
+  "dune" {build}
+  "odoc" {with-doc}
+  "base-bytes"
+  "result"
+  "base-unix"
+  "zmq"
+  "atdgen"
+  "yojson"
+  "uuidm"
+  "lwt"
+  "lwt_ppx"
+  "lwt-zmq"
+  "digestif"
+  "ISO8601"
+  "uutf"
+  "ocaml" {>= "4.02.0"}
+]
+depopts: ["tyxml"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml-jupyter/jupyter-kernel.git"
+url {
+  src: "https://github.com/ocaml-jupyter/jupyter-kernel/archive/v0.4.tar.gz"
+  checksum: [
+    "md5=75e5f27182c5b714385ade2ba5e88f59"
+    "sha512=d933c7c105bd1ab0533e389a07a3bbf2391ed3adf11045bd84c9ebf022570440d322303ef629f2bbb207591be19f60b91fad074fa90e1f0fc9f8d73e454d9914"
+  ]
+}


### PR DESCRIPTION
### `jupyter-kernel.0.4`
Library to write jupyter kernels (interactive notebooks)



---
* Homepage: https://github.com/ocaml-jupyter/jupyter-kernel
* Source repo: git+https://github.com/ocaml-jupyter/jupyter-kernel.git
* Bug tracker: https://github.com/ocaml-jupyter/jupyter-kernel/issues

---
:camel: Pull-request generated by opam-publish v2.0.0