### PR TITLE
[new release] websocket, websocket-lwt-unix and websocket-async (2.13)

### DIFF
--- a/packages/gemini/gemini.0.1/opam
+++ b/packages/gemini/gemini.0.1/opam
@@ -28,7 +28,7 @@ depends: [
   "zarith"
   "nocrypto"
   "ppx_deriving_yojson"
-  "websocket-async"
+  "websocket-async" {< "2.13"}
   "expect_test_helpers" {< "v0.13"}
 ]
 url {

--- a/packages/gemini/gemini.0.2.0/opam
+++ b/packages/gemini/gemini.0.2.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_csv_conv" {< "v0.13"}
   "csvfields" {< "v0.13"}
-  "websocket-async"
+  "websocket-async" {< "2.13"}
   "expect_test_helpers" {< "v0.13"}
 ]
 url {

--- a/packages/websocket-async/websocket-async.2.13/opam
+++ b/packages/websocket-async/websocket-async.2.13/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "websocket-async"
+version: "2.13"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-websocket"
+bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-websocket"
+doc: "https://vbmithr.github.io/ocaml-websocket/doc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build & >= "1.1.1"}
+  "websocket" {= version}
+  "cohttp-async" {>= "1.1.1"}
+  "logs-async" {>= "1.0"}
+  "logs-async-reporter" {>= "1.0"}
+]
+synopsis: "Websocket library (Async)"
+description: """
+The WebSocket Protocol enables two-way communication between a client
+running untrusted code in a controlled environment to a remote host
+that has opted-in to communications from that code.
+
+The security model used for this is the origin-based security model
+commonly used by web browsers. The protocol consists of an opening
+handshake followed by basic message framing, layered over TCP.
+
+The goal of this technology is to provide a mechanism for
+browser-based applications that need two-way communication with
+servers that does not rely on opening multiple HTTP connections (e.g.,
+using XMLHttpRequest or <iframe>s and long polling)."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-websocket/releases/download/2.13/websocket-2.13.tbz"
+  checksum: "md5=d0d07611c69250602c0ad9d7cddfae8e"
+}

--- a/packages/websocket-lwt-unix/websocket-lwt-unix.2.13/opam
+++ b/packages/websocket-lwt-unix/websocket-lwt-unix.2.13/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "websocket-lwt-unix"
+version: "2.13"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-websocket"
+bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-websocket"
+doc: "https://vbmithr.github.io/ocaml-websocket/doc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build & >= "1.1.1"}
+  "websocket" {= version}
+  "lwt_log" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "1.0.2"}
+]
+synopsis: "Websocket library (Lwt)"
+description: """
+The WebSocket Protocol enables two-way communication between a client
+running untrusted code in a controlled environment to a remote host
+that has opted-in to communications from that code.
+
+The security model used for this is the origin-based security model
+commonly used by web browsers. The protocol consists of an opening
+handshake followed by basic message framing, layered over TCP.
+
+The goal of this technology is to provide a mechanism for
+browser-based applications that need two-way communication with
+servers that does not rely on opening multiple HTTP connections (e.g.,
+using XMLHttpRequest or <iframe>s and long polling)."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-websocket/releases/download/2.13/websocket-2.13.tbz"
+  checksum: "md5=d0d07611c69250602c0ad9d7cddfae8e"
+}

--- a/packages/websocket/websocket.2.13/opam
+++ b/packages/websocket/websocket.2.13/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "websocket"
+version: "2.13"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-websocket"
+bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-websocket"
+doc: "https://vbmithr.github.io/ocaml-websocket/doc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build & >= "1.3.0"}
+  "base64" {>= "3.1.0"}
+  "conduit" {>= "1.1.0"}
+  "cohttp" {>= "1.1.0"}
+  "ocplib-endian" {>= "1.0"}
+  "astring" {>= "0.8.3"}
+]
+synopsis: "Websocket library"
+description: """
+The WebSocket Protocol enables two-way communication between a client
+running untrusted code in a controlled environment to a remote host
+that has opted-in to communications from that code.
+
+The security model used for this is the origin-based security model
+commonly used by web browsers. The protocol consists of an opening
+handshake followed by basic message framing, layered over TCP.
+
+The goal of this technology is to provide a mechanism for
+browser-based applications that need two-way communication with
+servers that does not rely on opening multiple HTTP connections (e.g.,
+using XMLHttpRequest or <iframe>s and long polling)."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-websocket/releases/download/2.13/websocket-2.13.tbz"
+  checksum: "md5=d0d07611c69250602c0ad9d7cddfae8e"
+}


### PR DESCRIPTION
Websocket library

- Project page: <a href="https://github.com/vbmithr/ocaml-websocket">https://github.com/vbmithr/ocaml-websocket</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-websocket/doc">https://vbmithr.github.io/ocaml-websocket/doc</a>

##### CHANGES:

- Async: use logs_async
- Async: upgrade_connection API (@kkazuo)
- Lwt: fix upgrade_connection for TLS (API change)
- Upgrade Base64 support to 3.1.0
