### PR TITLE
Patch ocamlfind to elimitate the check for awk 

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.3.1/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.3.1/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -49,7 +50,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+extra-files: [
+  ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.3.1.tar.gz"
   checksum: "md5=e632bad87f1c7be9414a6b754232ba01"

--- a/packages/ocamlfind/ocamlfind.1.3.2/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.3.2/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -49,7 +50,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+extra-files: [
+  ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.3.2.tar.gz"
   checksum: "md5=672e3a644015dda74daf89b7fcdec904"

--- a/packages/ocamlfind/ocamlfind.1.3.3/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.3.3/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -52,7 +53,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+extra-files: [
+  ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.3.3.tar.gz"
   checksum: "md5=a4c22ad5e0d38367a73cf58a25fcbebd"

--- a/packages/ocamlfind/ocamlfind.1.4.0/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.4.0/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -50,7 +51,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+extra-files: [
+  ["ocamlfind.install" "md5=aba2fbf5de8c723a190d49fbb46d0637"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src:
     "http://pkgs.fedoraproject.org/lookaside/extras/ocaml-findlib/findlib-1.4.tar.gz/5d1f8238c53964fdd14387b87b48b5d9/findlib-1.4.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.4.1/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.4.1/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -50,7 +51,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=d4e41653cf0d3ff8b9fe648d89a97273"]
+extra-files: [
+  ["ocamlfind.install" "md5=d4e41653cf0d3ff8b9fe648d89a97273"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.4.1.tar.gz"
   checksum: "md5=5d258142e9a7db98bb3553dbca739af8"

--- a/packages/ocamlfind/ocamlfind.1.5.1/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.5.1/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -51,7 +52,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.5.1.tar.gz"
   checksum: "md5=6bf0d0da66104bc8bdcb3018bd13a202"

--- a/packages/ocamlfind/ocamlfind.1.5.2/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.5.2/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -50,7 +51,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.5.2.tar.gz"
   checksum: "md5=b4939ea55f83e132794df17f8d176de9"

--- a/packages/ocamlfind/ocamlfind.1.5.3/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.5.3/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -50,7 +51,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.5.3.tar.gz"
   checksum: "md5=687b9dfee7d9d380d2eabe62bab67f09"

--- a/packages/ocamlfind/ocamlfind.1.5.4/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.5.4/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -3,7 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
-patches: [ "1.5.4-sed-bsd-compat.patch" ]
+patches: [ "1.5.4-sed-bsd-compat.patch" "no-awk-check.patch" ]
 build: [
   [
     "./configure"
@@ -54,6 +54,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 extra-files: [
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["1.5.4-sed-bsd-compat.patch" "md5=3d91c65a5214120838da38353619055f"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.5.4.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.5.5/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.5.5/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "mailto:gerd@gerd-stolpmann.de"
 dev-repo: "git+https://github.com/whitequark/ocaml-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -50,7 +51,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.5.5.tar.gz"
   checksum: "md5=703eae112f9e912507c3a2f8d8c48498"

--- a/packages/ocamlfind/ocamlfind.1.5.6/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.5.6/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "mailto:gerd@gerd-stolpmann.de"
 dev-repo: "git+https://github.com/whitequark/ocaml-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -50,7 +51,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.5.6.tar.gz"
   checksum: "md5=91585dd5459cb69bfd9a0689bf222403"

--- a/packages/ocamlfind/ocamlfind.1.6.1/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.6.1/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.6.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.1/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "mailto:gerd@gerd-stolpmann.de"
 dev-repo: "git+https://github.com/whitequark/ocaml-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -50,7 +51,10 @@ properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-extra-files: ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
 url {
   src: "http://download.camlcity.org/download/findlib-1.6.1.tar.gz"
   checksum: "md5=50a900451dbaa67c6985a09c905f94a7"

--- a/packages/ocamlfind/ocamlfind.1.6.2/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.6.2/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.6.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.2/opam
@@ -41,7 +41,7 @@ remove: [
   [make "uninstall"]
   ["rm" "-f" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "no-awk-check.patch" ]
 depends: [
   "ocaml" {>= "3.12.0" & < "4.07"}
   "conf-m4" {build}
@@ -59,6 +59,7 @@ extra-files: [
   ["termux.patch" "md5=453259e47f4c46e68db385d8a8a37699"]
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.6.2.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.7.1/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.7.1/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.7.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.1/opam
@@ -41,7 +41,7 @@ remove: [
   [make "uninstall"]
   ["rm" "-f" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
-patches: [ "termux.patch" ]
+patches: [ "termux.patch" "no-awk-check.patch" ]
 depends: [
   "ocaml" {>= "3.12.0" & < "4.07"}
   "conf-m4" {build}
@@ -59,6 +59,7 @@ extra-files: [
   ["termux.patch" "md5=d57f6e12d869926d1ec3301071e22d63"]
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.7.1.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.7.2/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.7.2/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.7.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.2/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -57,6 +58,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 extra-files: [
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.7.2.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/opam
@@ -6,6 +6,7 @@ dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
 patches: [
   "check-num-in-sitelib.patch"
   "threads.patch"
+  "no-awk-check.patch"
 ]
 build: [
   [
@@ -62,6 +63,7 @@ extra-files: [
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
   ["check-num-in-sitelib.patch" "md5=0ced9df5a3235cc6dbf0bb41b180e72d"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.7.3.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.7.3/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.7.3/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.7.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.3/opam
@@ -5,6 +5,7 @@ bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
 patches: [
   "check-num-in-sitelib.patch"
+  "no-awk-check.patch"
 ]
 build: [
   [
@@ -60,6 +61,7 @@ extra-files: [
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
   ["check-num-in-sitelib.patch" "md5=0ced9df5a3235cc6dbf0bb41b180e72d"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.7.3.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.8.0/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.8.0/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 40142bc941e6e308686e86be6fc2da92f346a22f
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index d9b587c..20e8dca 100755
+--- a/configure
++++ b/configure
+@@ -184,7 +184,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocaml ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocaml ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.8.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.0/opam
@@ -3,6 +3,7 @@ maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
 build: [
   [
     "./configure"
@@ -56,6 +57,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 extra-files: [
   ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
   ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
 ]
 url {
   src: "http://download.camlcity.org/download/findlib-1.8.0.tar.gz"


### PR DESCRIPTION
While testing the new opam-depext on Archlinux I encountered a problem while building `ocamlfind`: `awk` wasn't installed.

This PR adds a `conf-awk` package and adds the dependencies to it in all ocamlfind package as the dependency on awk has been there for at least the last 12 years (https://gitlab.camlcity.org/gerd/lib-findlib/commit/e400c8e6da02cd18343a321325e3d8f3314f19dd)

One thing I'm not sure about is how to name `conf-awk`. Is it fine like this or should we name it `conf-gawk`. I'm not sure of the differences between all the implementations.