### PR TITLE
ocaml-migrate-parsetree is not compatible with OCaml 4.08

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "result"
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta18.1"}

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "result"
   "ocamlfind" {build}
   "dune" {build}

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "result"
   "dune" {build}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
 ]
 
 description: """

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "ppx_derivers"
   "dune" {build & >= "1.6.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """


### PR DESCRIPTION
Detected by [check.ocamllabs.io](http://check.ocamllabs.io)

cc @let-def 