### PR TITLE
3 packages from OCamlPro/ocplib-json-typed at 0.7.1

### DIFF
--- a/packages/ocplib-json-typed-browser/ocplib-json-typed-browser.0.7.1/opam
+++ b/packages/ocplib-json-typed-browser/ocplib-json-typed-browser.0.7.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Json_repr interface over JavaScript's objects"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
+
+build: [ "dune" "build" "-j" jobs "-p" name "@install" "@runtest" {with-test} ]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0.1"}
+  "ocplib-json-typed" {= "0.7.1" }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.7.1.tar.gz"
+  checksum: [
+    "md5=0166df7b74306cfeebaff2dc8ea533be"
+    "sha512=f1331ab4820546bc1bcae430888f9a7385030e62a133fb8606d0b134e921fe1bf3f730533ed4c99f683fe149e7aeafbc291b51fb20b173a543b380f948700c18"
+  ]
+}

--- a/packages/ocplib-json-typed-bson/ocplib-json-typed-bson.0.7.1/opam
+++ b/packages/ocplib-json-typed-bson/ocplib-json-typed-bson.0.7.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A Json_repr compatible implementation of the JSON compatible subset of BSON"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
+
+build: [ "dune" "build" "-j" jobs "-p" name "@install" "@runtest" {with-test} ]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0.1"}
+  "ocplib-json-typed" {= "0.7.1" }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.7.1.tar.gz"
+  checksum: [
+    "md5=0166df7b74306cfeebaff2dc8ea533be"
+    "sha512=f1331ab4820546bc1bcae430888f9a7385030e62a133fb8606d0b134e921fe1bf3f730533ed4c99f683fe149e7aeafbc291b51fb20b173a543b380f948700c18"
+  ]
+}

--- a/packages/ocplib-json-typed/ocplib-json-typed.0.7.1/opam
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.7.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Type-aware JSON and JSON schema utilities"
+maintainer: "Benjamin Canou <benjamin@ocamlpro.com>"
+authors: "Benjamin Canou <benjamin@ocamlpro.com>"
+homepage: "https://github.com/ocamlpro/ocplib-json-typed"
+bug-reports: "https://github.com/ocamlpro/ocplib-json-typed/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://github.com/ocamlpro/ocplib-json-typed.git"
+
+build: [ "dune" "build" "-j" jobs "-p" name "@install" "@runtest" {with-test} ]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0.1"}
+  "uri" {>= "1.9.0" }
+]
+url {
+  src: "https://github.com/OCamlPro/ocplib-json-typed/archive/v0.7.1.tar.gz"
+  checksum: [
+    "md5=0166df7b74306cfeebaff2dc8ea533be"
+    "sha512=f1331ab4820546bc1bcae430888f9a7385030e62a133fb8606d0b134e921fe1bf3f730533ed4c99f683fe149e7aeafbc291b51fb20b173a543b380f948700c18"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocplib-json-typed.0.7.1`: Type-aware JSON and JSON schema utilities
-`ocplib-json-typed-browser.0.7.1`: Json_repr interface over JavaScript's objects
-`ocplib-json-typed-bson.0.7.1`: A Json_repr compatible implementation of the JSON compatible subset of BSON



---
* Homepage: https://github.com/ocamlpro/ocplib-json-typed
* Source repo: git+https://github.com/ocamlpro/ocplib-json-typed.git
* Bug tracker: https://github.com/ocamlpro/ocplib-json-typed/issues

---
:camel: Pull-request generated by opam-publish v2.0.0