### PR TITLE
[new release] moss (0.1.1)

### DIFF
--- a/packages/moss/moss.0.1.1/opam
+++ b/packages/moss/moss.0.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["MOSS"]
+license: "ISC"
+homepage: "https://github.com/Chris00/ocaml-moss"
+dev-repo: "git+https://github.com/Chris00/ocaml-moss.git"
+bug-reports: "https://github.com/Chris00/ocaml-moss/issues"
+doc: "https://Chris00.github.io/ocaml-moss/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {build}
+  "base-unix"
+  "base-bytes"
+  "uri"
+]
+synopsis: "A client for the MOSS plagiarism detection service"
+description: """
+This package provides an OCaml client for the MOSS (Measure Of
+Software Similarity) plagiarism detection service.  It is based on the
+original submission script.  The MOSS system only runs on Stanford's
+servers — you cannot run your own instance — so you need to obtain an
+account first.
+
+MOSS: http://theory.stanford.edu/~aiken/moss/
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-moss/releases/download/0.1.1/moss-0.1.1.tbz"
+  checksum: "md5=a399194cff33f8f8e957b89f6cbd22c0"
+}


### PR DESCRIPTION
A client for the MOSS plagiarism detection service

- Project page: <a href="https://github.com/Chris00/ocaml-moss">https://github.com/Chris00/ocaml-moss</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-moss/doc">https://Chris00.github.io/ocaml-moss/doc</a>

##### CHANGES:

- Use `dune`.
- Upgrade to OPAM 2.
