### PR TITLE
[new release] rope (0.6.2)

### DIFF
--- a/packages/rope/rope.0.6.2/opam
+++ b/packages/rope/rope.0.6.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-rope"
+dev-repo: "git+https://github.com/Chris00/ocaml-rope.git"
+bug-reports: "https://github.com/Chris00/ocaml-rope/issues"
+doc: "https://Chris00.github.io/ocaml-rope/doc"
+tags: [ "datastructure" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "dune" {build}
+  "benchmark" {with-test}
+]
+synopsis: "Ropes (heavyweight strings)"
+description: """
+Ropes ("heavyweight strings") are a scalable string implementation:
+they are designed for efficient operation that involve the string as a
+whole.  Operations such as concatenation, and substring take time that
+is nearly independent of the length of the string.  Unlike strings,
+ropes are a reasonable representation for very long strings such as
+edit buffers or mail messages.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-rope/releases/download/0.6.2/rope-0.6.2.tbz"
+  checksum: "md5=b1bd36276f4556af2b208b70b92011d5"
+}


### PR DESCRIPTION
Ropes (heavyweight strings)

- Project page: <a href="https://github.com/Chris00/ocaml-rope">https://github.com/Chris00/ocaml-rope</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-rope/doc">https://Chris00.github.io/ocaml-rope/doc</a>

##### CHANGES:

- Improve the structure of the documentation.
- Use [dune](https://github.com/ocaml/dune) to compile.
- Upgrade to OPAM 2.
