### PR TITLE
[new release] mindstorm and mindstorm-lwt (0.8)

### DIFF
--- a/packages/mindstorm-lwt/mindstorm-lwt.0.8/opam
+++ b/packages/mindstorm-lwt/mindstorm-lwt.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler"
+           "Julie De Pril"
+           "Marc Ducobu"
+           "Dany Maslowski" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-mindstorm"
+dev-repo: "git+https://github.com/Chris00/ocaml-mindstorm.git"
+bug-reports: "https://github.com/Chris00/ocaml-mindstorm/issues"
+doc: "https://Chris00.github.io/ocaml-mindstorm/doc"
+tags: [ "lego" "robotics" "mindstorms"
+        "clib:usb" "clib:bluetooth" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "mindstorm" {= version}
+  "base-threads"
+  "lwt"
+  "dune" {build}
+  "cppo" {build}
+  "base-bytes"
+  "base-unix"
+]
+synopsis: "Drive Lego Mindstorms bricks from OCaml (LWT version)"
+description: """
+This library allows you to communicate with your Lego Mindstorms brick
+via bluetooth, enable the motors and retrieve data from various
+sensors.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-mindstorm/releases/download/0.8/mindstorm-0.8.tbz"
+  checksum: "md5=f6763a1883455ce615fdc12cb6bf3ef7"
+}

--- a/packages/mindstorm/mindstorm.0.8/opam
+++ b/packages/mindstorm/mindstorm.0.8/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler"
+           "Julie De Pril"
+           "Marc Ducobu"
+           "Dany Maslowski" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-mindstorm"
+dev-repo: "git+https://github.com/Chris00/ocaml-mindstorm.git"
+bug-reports: "https://github.com/Chris00/ocaml-mindstorm/issues"
+doc: "https://Chris00.github.io/ocaml-mindstorm/doc"
+tags: [ "lego" "robotics" "mindstorms"
+        "clib:usb" "clib:bluetooth" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {build}
+  "cppo" {build}
+  "base-bytes"
+  "base-unix"
+  "conf-bluetooth" {os = "linux"}
+]
+synopsis: "Drive Lego Mindstorms bricks from OCaml"
+description: """
+This library allows you to communicate with your Lego Mindstorms brick
+via bluetooth, enable the motors and retrieve data from various
+sensors.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-mindstorm/releases/download/0.8/mindstorm-0.8.tbz"
+  checksum: "md5=f6763a1883455ce615fdc12cb6bf3ef7"
+}


### PR DESCRIPTION
CHANGES:

- In addition to the package `mindstorm`, a version of the interface
  using LWT promises has been developed in the package `mindstorm-lwt`.
- LWT: transactions with the LEGO© brick are atomic.
- Use [dune][] and `dune.configurator`.
- Improve the documentation

[dune]: https://github.com/ocaml/dune