### PR TITLE
Package pgocaml.3.0

### DIFF
--- a/packages/pgocaml/pgocaml.3.0/opam
+++ b/packages/pgocaml/pgocaml.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Interface to PostgreSQL databases"
+description: "PG'OCaml provides an interface to PostgreSQL databases for OCaml applications. It uses Camlp4 to extend the OCaml syntax, enabling one to directly embed SQL statements inside the OCaml code. Moreover, it uses the describe feature of PostgreSQL to obtain type information about the database. This allows PG'OCaml to check at compile-time if the program is indeed consistent with the database structure. This type-safe database access is the primary advantage that PG'OCaml has over other PostgreSQL bindings for OCaml."
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "http://pgocaml.forge.ocamlcore.org/"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0 with OCaml linking exception"
+build: [
+  ["./configure" "--%{camlp4:enable}%-p4" "--prefix" prefix "--docdir" "%{doc}%/pgocaml"]
+  [make]
+  [make "doc"]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "pgocaml"]]
+depends: [
+  "ocaml" {>= "4.01"}
+  "base-bytes"
+  "calendar"
+  "csv"
+  "hex"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {with-test}
+  "re"
+]
+depopts: [ "camlp4" ]
+flags: light-uninstall
+url {
+  src: "https://github.com/jrochel/pgocaml/archive/v3.0.tar.gz"
+  checksum: [
+    "md5=d4944ff47c0605da0891ba683aba7ac2"
+    "sha512=e56e263a11c6246643feb51bcfa9409d198f402c32c1327786aac18e76e536bcb30183bddfa72768e69fedc7399517181d217772212eba4d53a97025066f3ef8"
+  ]
+}

--- a/packages/pgocaml/pgocaml.3.0/opam
+++ b/packages/pgocaml/pgocaml.3.0/opam
@@ -28,7 +28,7 @@ depends: [
 depopts: [ "camlp4" ]
 flags: light-uninstall
 url {
-  src: "https://github.com/jrochel/pgocaml/archive/v3.0.tar.gz"
+  src: "https://github.com/darioteixeira/pgocaml/archive/v3.0.tar.gz"
   checksum: [
     "md5=d4944ff47c0605da0891ba683aba7ac2"
     "sha512=e56e263a11c6246643feb51bcfa9409d198f402c32c1327786aac18e76e536bcb30183bddfa72768e69fedc7399517181d217772212eba4d53a97025066f3ef8"


### PR DESCRIPTION
### `pgocaml.3.0`
Interface to PostgreSQL databases
PG'OCaml provides an interface to PostgreSQL databases for OCaml applications. It uses Camlp4 to extend the OCaml syntax, enabling one to directly embed SQL statements inside the OCaml code. Moreover, it uses the describe feature of PostgreSQL to obtain type information about the database. This allows PG'OCaml to check at compile-time if the program is indeed consistent with the database structure. This type-safe database access is the primary advantage that PG'OCaml has over other PostgreSQL bindings for OCaml.



---
* Homepage: http://pgocaml.forge.ocamlcore.org/
* Source repo: git+https://github.com/darioteixeira/pgocaml.git
* Bug tracker: https://github.com/darioteixeira/pgocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0