### PR TITLE
The gcc in OpenBSD base is too old(compilation fails), default to cc (aka clang)

### DIFF
--- a/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/mirage-build.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/mirage-build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+# WARNING: if you pass invalid cflags here, zarith will silently
+# fall back to compiling with the default flags instead!
+CFLAGS="$(pkg-config --cflags gmp-freestanding ocaml-freestanding)" \
+LDFLAGS="$(pkg-config --libs gmp-freestanding)" \
+CC=cc \
+./configure -nodynlink -gmp
+
+if [ `uname -s` = "FreeBSD" ] || [ `uname -s` = "OpenBSD" ]; then
+    gmake
+else
+    make
+fi

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/mirage-install.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/mirage-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+cp libzarith.a "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+# This is a hack to get freestanding_linkopts into the host 'zarith' package.
+cat >>"$PREFIX/lib/zarith/META" <<EOM
+freestanding_linkopts = "-lzarith-freestanding -L@gmp-freestanding -lgmp-freestanding"
+EOM

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/mirage-uninstall.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/mirage-uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+
+rm -f "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+mv "$PREFIX/lib/zarith/META" "$PREFIX/lib/zarith/META.tmp"
+cat "$PREFIX/lib/zarith/META.tmp" | grep -v freestanding_linkopts > "$PREFIX/lib/zarith/META"
+rm -f "$PREFIX/lib/zarith/META.tmp"

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/no-dynlink.patch
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-2/files/no-dynlink.patch
@@ -1,0 +1,85 @@
+This patch is required to build Zarith on an ocaml-freestanding type setup. It
+does three things:
+
+1. Add an option to configure to forcibly disable dynlink.
+2. Stop configure from adding a host -lgmp.
+3. In addition to (1), force project.mak to use "ocamlmklib -custom" instead of
+   "ocamlmklib -failsafe".
+
+We need all three because the Zarith build system is TOTALLY INSANE and has
+never even remotely heard of such a thing as cross compiling, and we need it to
+just shut up and build ONLY with the flags we pass it. KTHXBYE
+
+--- a/configure	2017-10-13 19:45:41.000000000 +0200
++++ b/configure	2018-11-30 19:12:36.809951317 +0100
+@@ -21,6 +21,7 @@
+ host='auto'
+ gmp='auto'
+ perf='no'
++nodynlink='no'
+ 
+ ar='ar'
+ ocaml='ocaml'
+@@ -59,6 +60,7 @@
+   -gmp                 use GMP library (default if found)
+   -mpir                use MPIR library instead of GMP
+   -perf                enable performance statistics
++  -nodynlink           disable dynamic linking
+ 
+ Environment variables that affect configuration:
+   CC                   C compiler to use (default: try gcc, then cc)
+@@ -99,6 +101,8 @@
+             gmp='mpir';;
+         -perf|--perf)
+             perf='yes';;
++        -nodynlink|--nodynlink)
++            nodynlink='yes';;
+         *)
+             echo "unknown option $1, try -help"
+             exit 2;;
+@@ -248,7 +252,7 @@
+ 
+ hasdynlink='no'
+ 
+-if test $hasocamlopt = yes
++if test $hasocamlopt = yes -a $nodynlink = no
+ then
+     checkcmxalib dynlink.cmxa
+     if test $? -eq 1; then hasdynlink='yes'; fi
+@@ -340,12 +344,8 @@
+ if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
+     checkinc gmp.h
+     if test $? -eq 1; then
+-        checklib gmp
+-        if test $? -eq 1; then 
+-            gmp='OK'
+-            cclib="$cclib -lgmp"
+-            ccdef="-DHAS_GMP $ccdef"
+-        fi
++        gmp='OK'
++        ccdef="-DHAS_GMP $ccdef"
+     fi
+ fi
+ if test "$gmp" = 'mpir' -o "$gmp" = 'auto'; then
+--- a/project.mak	2017-10-13 19:45:41.000000000 +0200
++++ b/project.mak	2018-11-30 19:11:16.205189144 +0100
+@@ -60,16 +60,16 @@
+ 	make -C tests test
+ 
+ zarith.cma: $(MLSRC:%.ml=%.cmo)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxa zarith.$(LIBSUFFIX): $(MLSRC:%.ml=%.cmx)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxs: zarith.cmxa libzarith.$(LIBSUFFIX)
+ 	$(OCAMLOPT) -shared -o $@ -I . zarith.cmxa -linkall
+ 
+ libzarith.$(LIBSUFFIX) dllzarith.$(DLLSUFFIX): $(SSRC:%.S=%.$(OBJSUFFIX)) $(CSRC:%.c=%.$(OBJSUFFIX)) 
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ doc: $(MLISRC)
+ 	mkdir -p html

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-2/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: "Xavier Leroy"
+maintainer: "mirageos-devel"
+homepage: "https://forge.ocamlcore.org/projects/zarith"
+bug-reports:  "mirageos-devel@lists.xenproject.org"
+build: ["sh" "-eux" "./mirage-build.sh"]
+install: ["sh" "-eux" "./mirage-install.sh"]
+remove: ["sh" "-eux" "./mirage-uninstall.sh"]
+depends: [
+  "ocaml"
+  "ocaml-freestanding" {>= "0.4.1"}
+  "gmp-freestanding" {>= "6.1.2-2"}
+  "zarith" {= "1.7"}
+  "ocamlfind" {build}
+]
+patches: [ "no-dynlink.patch" ]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+extra-files: [
+  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
+  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
+  ["mirage-build.sh" "md5=d8585e00ab3353746f2fc4c15abe7cfa"]
+  ["no-dynlink.patch" "md5=eff128f04dd08b0e5a02e49c99dc518b"]
+]
+url {
+  src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
+  checksum: "md5=80944e2755ebb848451a77dc2ad0651b"
+}


### PR DESCRIPTION
Compilation fails begining with

```
checking compilation with gcc -O3 -Wall -Wextra -I/home/asteen/.opam/default/lib/pkgconfig/../gmp-freestanding/include -I/home/asteen/.opam/default/lib/pkgconfig/../../include/ocaml-freestanding -ffreestanding -fstack-protector-strong -fno-stack-protector -nostdlibinc -mno-retpoline -mno-red-zone -isystem /home/asteen/.opam/default/lib/pkgconfig/../../include/solo5-bindings-hvt/crt -I/home/asteen/.opam/default/lib/pkgconfig/../../include/solo5-bindings-hvt/solo5 : not working
```

the build is halted when gmp.h is not found
```
include gmp.h: not found
cannot find GMP nor MPIR
```

the default cc (clang 7) should be used to compile zarith-freestanding.

more information
```
$ uname -a
OpenBSD x220.adamsteen.com.au 6.4 GENERIC.MP#748 amd64
```
```
$ gcc --version
gcc (GCC) 4.2.1 20070719
Copyright (C) 2007 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
```
$ cc --version
OpenBSD clang version 7.0.1 (tags/RELEASE_701/final) (based on LLVM 7.0.1)
Target: amd64-unknown-openbsd6.4
Thread model: posix
InstalledDir: /usr/bin
```