### PR TITLE
Package graphql-cohttp.0.12.0

### DIFF
--- a/packages/graphql-cohttp/graphql-cohttp.0.12.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.12.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "graphql" {>= "0.9.0"}
+  "cohttp" {>= "2.0.0"}
+  "crunch"
+  "astring" {>= "0.8.3"}
+  "base64" {>= "3.0.0"}
+  "ocplib-endian" {>= "1.0"}
+  "digestif" {>= "0.7.0"}
+]
+
+synopsis: "Run GraphQL servers with `cohttp`"
+
+description: """
+This package allows you to execute Cohttp HTTP requests against GraphQL schemas build with `graphql`. The package is agnostic to Lwt/Async."""
+
+url {
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.12.0/graphql-0.12.0.tbz"
+checksum: "bf7f3b66023e50d4ce7a6e485081f72f"
+}


### PR DESCRIPTION
### `graphql-cohttp.0.12.0`
Run GraphQL servers with `cohttp`
This package allows you to execute Cohttp HTTP requests against GraphQL schemas build with `graphql`. The package is agnostic to Lwt/Async.



---
* Homepage: https://github.com/andreas/ocaml-graphql-server
* Source repo: git+https://github.com/andreas/ocaml-graphql-server.git
* Bug tracker: https://github.com/andreas/ocaml-graphql-server/issues

---
0.12.0 2019-22-03
---------------------------------

- Remove Str from cohttp-graphql (#146)

---
:camel: Pull-request generated by opam-publish v2.0.0