### PR TITLE
[DRAFT] ocaml-migrate-parsetree for OCaml 4.08.0

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ppx_derivers"
+  "dune" {build & >= "1.6.0"}
+  "ocaml" {>= "4.08.0" & < "4.09.0"}
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+url {
+  src: "https://github.com/xclerc/ocaml-migrate-parsetree/archive/1.3.tar.gz"
+  checksum: "md5=04465020b5534d8b13b6fa69eb9a7666"
+}


### PR DESCRIPTION
This version is expected to be used with the current beta
(*i.e.* ocaml-variants.4.08.0+beta2), another version will
be needed due to https://github.com/ocaml/ocaml/pull/8535.