### PR TITLE
Add missing bound on the cmdliner->topkg dependency

### DIFF
--- a/packages/cmdliner/cmdliner.1.0.0/opam
+++ b/packages/cmdliner/cmdliner.1.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build}
+  "topkg" {>= "0.8.1" & build}
   "result"
 ]
 build: [[

--- a/packages/cmdliner/cmdliner.1.0.1/opam
+++ b/packages/cmdliner/cmdliner.1.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build}
+  "topkg" {>= "0.8.1" & build}
   "result"
 ]
 build: [[

--- a/packages/cmdliner/cmdliner.1.0.2/opam
+++ b/packages/cmdliner/cmdliner.1.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build}
+  "topkg" {>= "0.8.1" & build}
   "result"
 ]
 build: [[


### PR DESCRIPTION
This is needed because these versions of `cmdliner` use `Pkg.Flatten`.
