### PR TITLE
Add missing bound on the mirage-kv->fmt dependency

### DIFF
--- a/packages/mirage-kv/mirage-kv.2.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune"     {build}
   "mirage-device" {>= "1.0.0"}
-  "fmt"
+  "fmt" {>= "0.8.4"}
   "alcotest" {with-test}
 ]
 synopsis: "MirageOS signatures for key/value devices"


### PR DESCRIPTION
This is needed because `mirage-kv` needs `Fmt.failwith`.
