### PR TITLE
Package easy_logging.0.2

### DIFF
--- a/packages/easy_logging/easy_logging.0.2/opam
+++ b/packages/easy_logging/easy_logging.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Module to easily log messages"
+
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.0"}
+  "ppx_deriving"{>= "4.0" & < "5.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+description: """
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages are either [string] or [string lazy_t]
+   * log level adaptable at runtime from anywhere in the program
+   * handlers associated to each logger will format and treat the message independantly.
+   * annotage log messages with tags
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.2"
+  checksum: [
+    "md5=16727b9601e8026716e3831b974fd5e0"
+    "sha512=ca6f6709624a0f96db4c1c99071d6758078c966b30f8952f41057c9dbce812bdbd4133ccf4ba579c98717d8353d1ce51bb6c84aee0980bd6455681415e9d62a3"
+  ]
+}


### PR DESCRIPTION
### `easy_logging.0.2`
Module to easily log messages
Logging infrastructure inspired by the Python logging module.
The aim of this module is to provide a quick and easy to use logging
infrastructure.

It has the following features :
   * one line logger creation
   * log messages are either [string] or [string lazy_t]
   * log level adaptable at runtime from anywhere in the program
   * handlers associated to each logger will format and treat the message independantly.
   * annotage log messages with tags



---
* Homepage: https://sapristi.github.io/easy_logging/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.0.0