### PR TITLE
extlib: add conditional bound on ocaml version

### DIFF
--- a/packages/extlib/extlib.1.7.0/opam
+++ b/packages/extlib/extlib.1.7.0/opam
@@ -21,7 +21,7 @@ authors: [
 ]
 build: [
   [make "minimal=1" "build"]
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "4.06.0"}
   [make "doc"] {with-doc}
 ]
 install: [ [make "minimal=1" "install"] ]
@@ -29,7 +29,7 @@ remove: [
   ["ocamlfind" "remove" "extlib"]
 ]
 depends: [
-  "ocaml" {! with-test | < "4.06.0"}
+  "ocaml"
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}

--- a/packages/extlib/extlib.1.7.0/opam
+++ b/packages/extlib/extlib.1.7.0/opam
@@ -29,7 +29,7 @@ remove: [
   ["ocamlfind" "remove" "extlib"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {! with-test | < "4.06.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}


### PR DESCRIPTION
`extlib.1.7.0` can be compiled but not tested in safe-string mode because its test suite is not compatible, so add a conditional bound on OCaml's version (with-test => ocaml < 4.06.0).
