### PR TITLE
cohttp: add conditional bounds

### DIFF
--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
@@ -20,7 +20,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & ( ! with-test | < "4.06.0" )}
   "jbuilder" {build & >= "1.0+beta10"}
   "conduit-lwt-unix"
   "cmdliner"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
@@ -17,10 +17,10 @@ dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.06.0"}
 ]
 depends: [
-  "ocaml" {>= "4.03.0" & ( ! with-test | < "4.06.0" )}
+  "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "conduit-lwt-unix"
   "cmdliner"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
@@ -25,6 +25,7 @@ depends: [
   "lwt" {>= "3.0.0"}
   "base-unix"
   "ounit" {with-test}
+  "cohttp" {! with-test | = "1.1.1"}
 ]
 conflicts: [
   "lwt" {< "2.5.0"}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
@@ -25,10 +25,10 @@ depends: [
   "lwt" {>= "3.0.0"}
   "base-unix"
   "ounit" {with-test}
-  "cohttp" {! with-test | = "1.1.1"}
 ]
 conflicts: [
   "lwt" {< "2.5.0"}
+  "cohttp" {= "1.1.1" & with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
`cohttp-lwt-unix.1.0.0` : the test needs unsafe-string
`cohttp-lwt-unix.1.1.1` : the test fails when compiled with `cohttp.1.1.0`
