### PR TITLE
containers: fix deps in with-test mode

### DIFF
--- a/packages/containers/containers.2.2/opam
+++ b/packages/containers/containers.2.2/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.7"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.2/opam
+++ b/packages/containers/containers.2.2/opam
@@ -12,7 +12,7 @@ build: [
   ["jbuilder" "build" "@doc"] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.02.0" & < "4.08.0"}
+  "ocaml" {>= "4.02.0" & < "4.07.0"}
   "jbuilder" {build & >= "1.0+beta12"}
   "result"
   "uchar"

--- a/packages/containers/containers.2.3/opam
+++ b/packages/containers/containers.2.3/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.7"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.4.1/opam
+++ b/packages/containers/containers.2.4.1/opam
@@ -12,7 +12,7 @@ depends: [
   "result"
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.7"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.4/opam
+++ b/packages/containers/containers.2.4/opam
@@ -12,7 +12,7 @@ depends: [
   "result"
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.7"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.5/opam
+++ b/packages/containers/containers.2.5/opam
@@ -12,7 +12,7 @@ depends: [
   "result"
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.7"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}


### PR DESCRIPTION
The tests in these versions of `containers` need `qcheck` >= 0.7.
