### PR TITLE
Travis - always use latest release of opam 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,23 @@ matrix:
   include:
   - os: osx
     osx_image: xcode10.1
-    env: OCAML_VERSION=4.07 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.07 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.07 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.07 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.06 OPAM_VERSION=2.0.0 INSTALL_LOCAL=1
+    env: OCAML_VERSION=4.06 OPAM_VERSION=2.0 INSTALL_LOCAL=1
   - os: linux
-    env: OCAML_VERSION=4.05 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.05 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.04 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.04 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.03 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.03 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.02 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.02 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.01 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.01 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.00 OPAM_VERSION=2.0.0
+    env: OCAML_VERSION=4.00 OPAM_VERSION=2.0
 notifications:
   email:
   - opam-commits@lists.ocaml.org


### PR DESCRIPTION
After https://github.com/ocaml/ocaml-ci-scripts/pull/274/ was merged, the matrix should have been updated to specify `2.0`, rather than specifically `2.0.0`