### PR TITLE
sexplib: older sexplib should conflict with sexplib0

### DIFF
--- a/packages/sexplib/sexplib.113.33.00+4.03/opam
+++ b/packages/sexplib/sexplib.113.33.00+4.03/opam
@@ -14,6 +14,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
 ]
+conflicts: [ "sexplib0" ]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street’s Core library

--- a/packages/sexplib/sexplib.113.33.00/opam
+++ b/packages/sexplib/sexplib.113.33.00/opam
@@ -14,6 +14,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
 ]
+conflicts: ["sexplib0"]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street’s Core library

--- a/packages/sexplib/sexplib.113.33.03/opam
+++ b/packages/sexplib/sexplib.113.33.03/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {build & >= "1.5.1"}
   "js-build-tools" {build & >= "113.33.04" & < "113.34.00"}
 ]
+conflicts: ["sexplib0"]
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: """
 Part of Jane Street’s Core library


### PR DESCRIPTION
otherwise sexplib0.v0.12.0 is getting selected with
sexplib.113.33.00+4.03 on ocaml 4.04 switches, with the
results not going well...

cc @xclerc