### PR TITLE
Package uritemplate.0.1.0

### DIFF
--- a/packages/uritemplate/uritemplate.0.1.0/opam
+++ b/packages/uritemplate/uritemplate.0.1.0/opam
@@ -17,8 +17,8 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03.0"}
 ]
-run-test: [["dune" "runtest" "-p" name "-j" jobs]]
 dev-repo: "git+https://https://github.com/CorinChappy/uritemplate-ocaml.git"
 url {
   src:

--- a/packages/uritemplate/uritemplate.0.1.0/opam
+++ b/packages/uritemplate/uritemplate.0.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of URI templates (RFC6570)"
+tags: "uri url templates RFC6570"
+maintainer: "Corin Chaplin <git@corinchaplin.co.uk>"
+authors: "Corin Chaplin <git@corinchaplin.co.uk>"
+license: "MIT"
+homepage: "https://github.com/CorinChappy/uritemplate-ocaml"
+bug-reports: "https://github.com/CorinChappy/uritemplate-ocaml/issues"
+doc: "https://corinchappy.github.io/uritemplate-ocaml/"
+depends: [
+  "dune" {build}
+  "stdcompat" {>= "5"}
+  "ounit" {with-test}
+  "atdgen" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [["dune" "runtest" "-p" name "-j" jobs]]
+dev-repo: "git+https://https://github.com/CorinChappy/uritemplate-ocaml.git"
+url {
+  src:
+    "https://github.com/CorinChappy/uritemplate-ocaml/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=4ea0e98cddffe645e9f3e9618933bb28"
+    "sha512=a552128dfe54552c8fb6f5dab5a402775de96a825876c34ec8ee12fc280e31c87f7252e73d7973a4a1b716721d98ad5b74ed7de1995007f62e9b3d3a8063d9f3"
+  ]
+}


### PR DESCRIPTION
### `uritemplate.0.1.0`
OCaml implementation of URI templates (RFC6570)



---
* Homepage: https://github.com/CorinChappy/uritemplate-ocaml
* Source repo: git+https://https://github.com/CorinChappy/uritemplate-ocaml.git
* Bug tracker: https://github.com/CorinChappy/uritemplate-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0