### PR TITLE
New package iso639.0.0.4

### DIFF
--- a/packages/iso639/iso639.0.0.4/opam
+++ b/packages/iso639/iso639.0.0.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "iso639"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-iso639/"
+doc: "http://paurkedal.github.io/ocaml-iso639/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-iso639/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-iso639.git"
+synopsis: "Language Codes for OCaml"
+description: """
+This library implements a type to identify languages and macrolanguages from
+ISO 639-3 and language groups from ISO 639-5, and provides conversions to
+and from two- and three-letter codes defined by these and other parts of ISO
+639.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-iso639/releases/download/v0.0.4/iso639-v0.0.4.tbz"
+  checksum: "md5=79a0cdea5f5d9e000af8e3e2b4b201e8"
+}


### PR DESCRIPTION
This is a new package.  It provides a simple API to data files from the ISO-639 standard for language codes.  It's primary purpose is to supply a canonical representation of a language and conversions to and from 2- and 3-letter language codes.  The data files are packaged in the release tarballs.

API: https://paurkedal.github.io/ocaml-iso639/iso639/Iso639/index.html