### PR TITLE
6 packages from andersfugmann/ppx_protocol_conv at 4.0.0

### DIFF
--- a/packages/ppx_protocol_conv/ppx_protocol_conv.4.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.4.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "base" {< "v0.12"}
+  "dune" {build}
+  "ppxlib" {>= "0.3.0"}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis:
+  "Ppx for generating serialisation and de-serialisation functions of ocaml types"
+description: """
+Ppx_protocol_conv generates code to serialise and de-serialise
+types. The ppx itself does not contain any protocol specific code,
+but relies on 'drivers' that defines serialisation and
+de-serialisation of basic types and structures.
+
+Pre-defined drivers are available in separate packages:
+ppx_protocol_conv_json (Yojson.Safe.json)
+ppx_protocol_conv_jsonm (Ezjson.value)
+ppx_protocol_conv_msgpack (Msgpck.t)(Xml.xml)
+ppx_protocol_conv_xml-light (Xml.xml)
+ppx_protocol_conv_yaml (Yaml.t)"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/4.0.0.tar.gz"
+  checksum: [
+    "md5=fea7b25f51a02d5170ed52146f151c6f"
+    "sha512=f9bffcac11fd7b690d924b204747783bc912e655c36f5be00dc9bd63a781e0c9f4723f6c4a732566c6b1760375ccc53098de0119958223c4293fd0c714b2bf5f"
+  ]
+}

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.3/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.3.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.3"}
+  "ppx_protocol_conv" {= "3.1.3"}
   "yojson" {>= "1.6.0"}
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.4.0.0/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.4.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= "4.0.0"}
+  "yojson" {>= "1.5.0" & < "2.0.0"}
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "ppx_expect" {< "v0.12"}
+  "ppx_inline_test" {< "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Yojson.Safe.json)
+serialization and de-serialization using the yojson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/4.0.0.tar.gz"
+  checksum: [
+    "md5=fea7b25f51a02d5170ed52146f151c6f"
+    "sha512=f9bffcac11fd7b690d924b204747783bc912e655c36f5be00dc9bd63a781e0c9f4723f6c4a732566c6b1760375ccc53098de0119958223c4293fd0c714b2bf5f"
+  ]
+}

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.3/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.3.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "ppx_protocol_conv" {>= "3.1.3"}
+  "ppx_protocol_conv" {= "3.1.3"}
   "ezjsonm"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.4.0.0/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.4.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "ppx_protocol_conv" {= "4.0.0"}
+  "ezjsonm"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Jsonm driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Ezjson.value)
+serialization and de-serialization using the Ezjson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/4.0.0.tar.gz"
+  checksum: [
+    "md5=fea7b25f51a02d5170ed52146f151c6f"
+    "sha512=f9bffcac11fd7b690d924b204747783bc912e655c36f5be00dc9bd63a781e0c9f4723f6c4a732566c6b1760375ccc53098de0119958223c4293fd0c714b2bf5f"
+  ]
+}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.3/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.3.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.3"}
+  "ppx_protocol_conv" {= "3.1.3"}
   "msgpck"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.4.0.0/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.4.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= "4.0.0"}
+  "msgpck"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "MessagePack driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for message pack (Msgpck.t)
+serialization and deserialization using the msgpck library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/4.0.0.tar.gz"
+  checksum: [
+    "md5=fea7b25f51a02d5170ed52146f151c6f"
+    "sha512=f9bffcac11fd7b690d924b204747783bc912e655c36f5be00dc9bd63a781e0c9f4723f6c4a732566c6b1760375ccc53098de0119958223c4293fd0c714b2bf5f"
+  ]
+}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.3/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.3.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.3"}
+  "ppx_protocol_conv" {= "3.1.3"}
   "xml-light"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.4.0.0/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.4.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= "4.0.0"}
+  "xml-light"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Xml driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for xml (Xml.t) serialization and
+de-serialization using the xml-light library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/4.0.0.tar.gz"
+  checksum: [
+    "md5=fea7b25f51a02d5170ed52146f151c6f"
+    "sha512=f9bffcac11fd7b690d924b204747783bc912e655c36f5be00dc9bd63a781e0c9f4723f6c4a732566c6b1760375ccc53098de0119958223c4293fd0c714b2bf5f"
+  ]
+}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.3/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.3.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_protocol_conv" {>= "3.1.3"}
+  "ppx_protocol_conv" {= "3.1.3"}
   "yaml"
   "dune" {build}
   "ppx_sexp_conv" {with-test & < "v0.12"}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.4.0.0/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.4.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= "4.0.0"}
+  "yaml"
+  "dune" {build}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "sexplib" {with-test & < "v0.12"}
+  "ounit" {with-test}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Yojson.Safe.json)
+serialization and de-serialization using the yojson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/4.0.0.tar.gz"
+  checksum: [
+    "md5=fea7b25f51a02d5170ed52146f151c6f"
+    "sha512=f9bffcac11fd7b690d924b204747783bc912e655c36f5be00dc9bd63a781e0c9f4723f6c4a732566c6b1760375ccc53098de0119958223c4293fd0c714b2bf5f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ppx_protocol_conv.4.0.0`: Ppx for generating serialisation and de-serialisation functions of ocaml types
-`ppx_protocol_conv_json.4.0.0`: Json driver for Ppx_protocol_conv
-`ppx_protocol_conv_jsonm.4.0.0`: Jsonm driver for Ppx_protocol_conv
-`ppx_protocol_conv_msgpack.4.0.0`: MessagePack driver for Ppx_protocol_conv
-`ppx_protocol_conv_xml_light.4.0.0`: Xml driver for Ppx_protocol_conv
-`ppx_protocol_conv_yaml.4.0.0`: Json driver for Ppx_protocol_conv



---
* Homepage: https://github.com/andersfugmann/ppx_protocol_conv
* Source repo: git+https://github.com/andersfugmann/ppx_protocol_conv
* Bug tracker: https://github.com/andersfugmann/ppx_protocol_conv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0