### PR TITLE
Bisect_ppx 1.4.1: code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.1.4.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+license: "MPL2"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "dune" {build}
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.1.0"}
+  "ppx_tools_versioned"
+
+  "ocamlfind" {dev}
+  "ounit" {dev}
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/1.4.1.tar.gz"
+  checksum: "md5=05d514706646adc947ed21e7e69a1cf1"
+}


### PR DESCRIPTION
From the changelog:

> Additions
>
> - PPX `-no-comment-parsing` option, to work around Bisect_ppx trying to parse `(*BISECT-IGNORE*)` comments (aantron/bisect_ppx#187, reported Ben Anderson).
>
> Bugs fixed
>
> - Bisect_ppx should run after other PPXs (aantron/bisect_ppx#186, reported Brian Caine).
> - Round displayed coverage percentages down (aantron/bisect_ppx#172, reported Iago Abal).
