### PR TITLE
Lwt 4.2.0: promises and concurrent I/O, also Lwt_ppx 1.2.2 and Lwt_react 1.1.2

### DIFF
--- a/packages/lwt/lwt.4.2.0/opam
+++ b/packages/lwt/lwt.4.2.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {build}
+  "mmap"
+  "ocaml" {>= "4.02.0"}
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.2.0.tar.gz"
+  checksum: "md5=2ce7827948adc611319f9449e4519070"
+}

--- a/packages/lwt_ppx/lwt_ppx.1.2.2/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.2.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Gabriel Radanne"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {build}
+  "lwt"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0.1"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.2.0.tar.gz"
+  checksum: "md5=2ce7827948adc611319f9449e4519070"
+}

--- a/packages/lwt_react/lwt_react.1.1.2/opam
+++ b/packages/lwt_react/lwt_react.1.1.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using React with Lwt"
+
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_react"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {build}
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "react" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.2.0.tar.gz"
+  checksum: "md5=2ce7827948adc611319f9449e4519070"
+}


### PR DESCRIPTION
From the changelog:

> Additions
>
> - [`Lwt.both`](http://ocsigen.org/lwt/dev/api/Lwt#VALboth) (ocsigen/lwt#668, Brendan Long, Jeremy Yallop).
> - ppx_let support with `open Lwt.Infix` (ocsigen/lwt#667, Brendan Long).
> - [`Lwt_stream.of_seq`](http://ocsigen.org/lwt/dev/api/Lwt_stream#VALof_seq) (ocsigen/lwt#646, Hezekiah Carty).
> - [`Lwt_io.is_closed`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALis_closed) (ocsigen/lwt#635, Andreas Garnaes).
> - [`Lwt_unix.IO_vectors.byte_count`](http://ocsigen.org/lwt/dev/api/Lwt_unix.IO_vectors#VALbyte_count) (ocsigen/lwt#645, Raphaël Proust).
> - Support for higher baud rates in [`Lwt_unix.tcgetattr`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALtcgetaddr) and [`Lwt_unix.tcsetattr`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALtcsetaddr) (ocsigen/lwt#678, Frédéric Fortier).
> - Replacement functions in [`Lwt_main`](http://ocsigen.org/lwt/dev/api/Lwt_main) for deprecated functions based on `Lwt_sequence` (ocsigen/lwt#660).
>
> Bugs fixed
>
> - 4.08 compatibility (ocsigen/lwt#658).
> - Stack overflow in [`Lwt_stream.iter_p`](http://ocsigen.org/lwt/dev/api/Lwt_stream#VALiter_p) (ocsigen/lwt#432, Varun Kohli).
> - Incorrect bounds check in [`Lwt_bytes.mincore`](http://ocsigen.org/lwt/dev/api/Lwt_bytes#VALmincore) (ocsigen/lwt#627, Cédric Le Moigne).
> - [`Lwt_bytes.mincore`](http://ocsigen.org/lwt/dev/api/Lwt_bytes#VALmincore) will not be available in future releases of OpenBSD (ocsigen/lwt#663, Kenneth Westerback).
> - Missing header in the Android build (ocsigen/lwt#652, Justus Matthiesen).
> - Build broken on MSVC (ocsigen/lwt@98303de, ocsigen/lwt@85535f7, Dmitry Bely).
> - Build broken on OpenBSD (ocsigen/lwt#672, Christopher Zimmermann).
> - [`Lwt_io.of_bytes`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALof_bytes) produces a channel with inaccurate positions (ocsigen/lwt#636, Nathan Rebours).
> - [`Lwt_io._.read_int`](http://ocsigen.org/lwt/dev/api/Lwt_io.LE#VALread_int) behaves incorrectly on 32-bit systems (ocsigen/lwt#671, reported Dmitry Bely).
> - Inaccurate locations for errors related to `;%lwt` (ocsigen/lwt#602, @kandu).
> - `(_ : t)` not recognized as a catch-all pattern by the PPX (ocsigen/lwt#640, Florian Angeletti).
> - Race condition in [`Lwt_react.E.limit`](http://ocsigen.org/lwt/dev/api/Lwt_react.E#VALlimit) (ocsigen/lwt#606, Avni Fatehpuria).
> - Premature deallocation in [`Lwt_react.E.with_finaliser`](http://ocsigen.org/lwt/dev/api/Lwt_react.E#VALwith_finaliser) and [`Lwt_react.S.with_finaliser`](http://ocsigen.org/lwt/dev/api/Lwt_react.S#VALwith_finaliser) (ocsigen/lwt#626, El-Hassan Wanas).
>
> Miscellaneous
>
> - New tests for [`Lwt_bytes`](http://ocsigen.org/lwt/dev/api/Lwt_bytes), portions of [`Lwt_unix`](http://ocsigen.org/lwt/dev/api/Lwt_unix) (ocsigen/lwt#619, ocsigen/lwt#621, ocsigen/lwt#628, ocsigen/lwt#630, ocsigen/lwt#673, Cédric Le Moigne, Anurag Soni).
> - Test suite improvements (ocsigen/lwt#656, Dave Parfitt).
> - Clarifications for documentation of [`Lwt.try_bind`](http://ocsigen.org/lwt/dev/api/Lwt#VALtry_bind), [`Lwt.pick`](http://ocsigen.org/lwt/dev/api/Lwt#VALpick) (ocsigen/lwt#648, ocsigen/lwt#650, Bikal Lem).
> - Fixed documentation of [`Lwt_io.read_line`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALread_line) (ocsigen/lwt#657, Yoni Levy).
> - Fixed some typos (ocsigen/lwt#611, ocsigen/lwt#613, Rich Neswold).

<br/>

Resolves ocsigen/lwt#675.
