### PR TITLE
Cstruct works with Jane Street 0.12 libs

### DIFF
--- a/packages/cstruct-async/cstruct-async.3.7.0/opam
+++ b/packages/cstruct-async/cstruct-async.3.7.0/opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
-  "async_kernel" {>= "v0.9.0" & < "v0.12"}
-  "async_unix" {>= "v0.9.0" & < "v0.12"}
-  "core_kernel" {>= "v0.9.0" & < "v0.12"}
+  "async_kernel" {>= "v0.9.0" & < "v0.13"}
+  "async_unix" {>= "v0.9.0" & < "v0.13"}
+  "core_kernel" {>= "v0.9.0" & < "v0.13"}
   "cstruct" {>= "3.2.0"}
 ]
 synopsis: "Access C-like structures directly from OCaml"

--- a/packages/ppx_cstruct/ppx_cstruct.3.7.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.3.7.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ppx_tools_versioned" {>= "5.0.1"}
   "ocaml-migrate-parsetree"
   "ppx_driver" {with-test & >= "v0.9.0"}
-  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "ppx_sexp_conv" {with-test & < "v0.13"}
   "cstruct-unix" {with-test}
 ]
 synopsis: "Access C-like structures directly from OCaml"


### PR DESCRIPTION
Apparently the restriction is not required, wasn't updated after the 0.12 libraries release.
See https://github.com/mirage/ocaml-cstruct/pull/243