### PR TITLE
conf-libX11: remove osx script - execvp not allowed in osx sanbox

### DIFF
--- a/packages/conf-libX11/conf-libX11.1/files/pkg-osx.sh
+++ b/packages/conf-libX11/conf-libX11.1/files/pkg-osx.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-if [ -n "$PKG_CONFIG_PATH" ] ; then
-  PKG_CONFIG_PATH=$PKG_CONFIG_PATH:
-fi
-
-PKG_CONFIG_PATH=$PKG_CONFIG_PATH/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig pkg-config x11

--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -6,7 +6,12 @@ homepage: "https://www.x.org"
 license: "MIT"
 build: [
   ["pkg-config" "x11"] {os != "macos"}
-  ["./pkg-osx.sh"] {os = "macos"}
+  [
+    "sh" "-exc"
+    """
+    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig" pkg-config --libs x11
+    """
+  ] {os = "macos"}
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
@@ -19,4 +24,3 @@ depexts: [
 synopsis: "Virtual package relying on an Xlib system installation"
 description:
   "This package can only install if Xlib (libX11) is installed on the system."
-extra-files: ["pkg-osx.sh" "md5=af634765ff5d52ee1b858b679f0e5c28"]


### PR DESCRIPTION
This should solve https://github.com/ocaml/opam-repository/issues/13686

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>