### PR TITLE
Disable camlp4 detection on non-system switches

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -22,7 +22,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "3.08" & < "4.07"}
+  "ocaml" {>= "3.08" & < "4.02.0"}
   "conf-m4" {build}
   "num" {= "0"}
 ]

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -22,7 +22,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "3.08" & < "4.07"}
+  "ocaml" {>= "3.08" & < "4.02.0"}
   "conf-m4" {build}
   "num" {= "0"}
 ]

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -34,6 +35,7 @@ remove: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -15,6 +15,7 @@ build: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -33,6 +34,7 @@ remove: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -33,6 +34,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -15,6 +15,7 @@ build: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -33,6 +34,7 @@ remove: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -34,6 +35,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -34,6 +35,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.6.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.1/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -34,6 +35,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.6.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.2/opam
@@ -15,6 +15,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -36,6 +37,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.7.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.1/opam
@@ -15,6 +15,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -36,6 +37,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.7.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.2/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -37,6 +38,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/opam
@@ -20,6 +20,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -41,6 +42,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.7.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.3/opam
@@ -19,6 +19,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -40,6 +41,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/packages/ocamlfind/ocamlfind.1.8.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.0/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -37,6 +38,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]


### PR DESCRIPTION
ocamlfind will install camlp4 `META` files if it detects `camlp4` in `PATH`, but includes no detection for whether the `camlp4` binary corresponds to the compiler.

This is a problem for OCaml 4.02.0+, where `camlp4` ceased to be part of the distribution as it means that a system-installed `camlp4` gets registered, but won't work.

The change here is twofold:

1. Require ocamlfind 1.5 or greater on OCaml 4.02.0+ (this is when the `-no-camlp4` configure-time option was introduced)
2. For non-system switches, use `-no-camlp4` to prevent ocamlfind's detection of `camlp4`.