### PR TITLE
nocrypto: support cstruct 4.0.0

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/files/0006-explicit-dependency-on-sexplib.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-1/files/0006-explicit-dependency-on-sexplib.patch
@@ -1,0 +1,24 @@
+From 063b3496340fe4c3544b532ec0d27797b7917bb4 Mon Sep 17 00:00:00 2001
+From: Anil Madhavapeddy <anil@recoil.org>
+Date: Tue, 26 Mar 2019 20:07:13 +0000
+Subject: [PATCH 6/6] explicitly depend on sexplib
+
+Need to explicitly depend on sexplib rather than hope
+it is a transitive dependency of cstruct. This lets
+cstruct.4.0.0 work which makes sexplib optional.
+
+--- a/_tags.orig	2019-03-26 20:33:33.000000000 +0000
++++ b/_tags	2019-03-26 20:33:42.000000000 +0000
+@@ -1,7 +1,7 @@
+ true: color(always)
+ true: bin_annot, safe_string
+ true: warn(A-4-29-33-40-41-42-43-34-44-48)
+-true: package(bytes), package(cstruct)
++true: package(bytes), package(sexplib), package(cstruct)
+
+ <src>: include
+ <src/*.ml{,i}>: package(zarith), package(sexplib), package(ppx_sexp_conv)
+
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -45,6 +45,7 @@ patches: [
     "0003-Auto-detect-ppx_sexp_conv-runtime-library.patch"
     "0004-pack-package-workaround-ocamlbuild-272.patch"
     "0005-use-modern-cstruct-findlib.patch"
+    "0006-explicit-dependency-on-sexplib.patch"
 ]
 synopsis: "Simpler crypto"
 description: """
@@ -55,6 +56,10 @@ SHA1, SHA2), public-key primitives (RSA, DSA, DH) and a strong RNG (Fortuna).
 RSA timing attacks are countered by blinding. AES timing attacks are avoided by
 delegating to AES-NI."""
 extra-files: [
+  [
+    "0006-explicit-dependency-on-sexplib.patch"
+    "md5=7f552e18ba304eb4e1e19d66d19b7888"
+  ]
   [
     "0005-use-modern-cstruct-findlib.patch"
     "md5=4d4aab890f0ca9327d83548c32d64efc"


### PR DESCRIPTION
add an explicit sexplib dependency rather than assuming it is transitive. This should work with all cstruct releases including 4.0.0

cc @hannesm
fixes build failure in #13748 