### PR TITLE
Package easy_logging.0.3

### DIFF
--- a/packages/easy_logging/easy_logging.0.3/opam
+++ b/packages/easy_logging/easy_logging.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Module to easily log messages"
+
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.0"}
+  "ppx_deriving"{>= "4.0" & < "5.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+description: """
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages are either [string] or [string lazy_t]
+   * log level adaptable at runtime from anywhere in the program
+   * handlers associated to each logger will format and treat the message independantly.
+   * annotage log messages with tags
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.3"
+  checksum: [
+    "md5=f2c40e821571792fc46dce2e97b2154b"
+    "sha512=15bbf841d4a7c5ff7c7d0af60176e6479a2ea1bf97e882d1c5bcf0adc7ccf990d947999705e63717353a86c8e87aa473e830629631b75501894389ca99b9f273"
+  ]
+}


### PR DESCRIPTION
### `easy_logging.0.3`
Module to easily log messages
Logging infrastructure inspired by the Python logging module.
The aim of this module is to provide a quick and easy to use logging
infrastructure.

It has the following features :
   * one line logger creation
   * log messages are either [string] or [string lazy_t]
   * log level adaptable at runtime from anywhere in the program
   * handlers associated to each logger will format and treat the message independantly.
   * annotage log messages with tags



---
* Homepage: https://sapristi.github.io/easy_logging/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.0.0