### PR TITLE
stop old jupyter-kernel from being selected

### DIFF
--- a/packages/jupyter-kernel/jupyter-kernel.0.1/opam
+++ b/packages/jupyter-kernel/jupyter-kernel.0.1/opam
@@ -25,6 +25,7 @@ depends: [
   "hex"
   "ISO8601"
 ]
+available: [ false ] # lwt.ppx failure
 synopsis:
   "A library for writing [Jupyter](https://jupyter.org) kernels in OCaml"
 url {

--- a/packages/jupyter-kernel/jupyter-kernel.0.2/opam
+++ b/packages/jupyter-kernel/jupyter-kernel.0.2/opam
@@ -25,6 +25,7 @@ depends: [
   "hex"
   "ISO8601"
 ]
+available: [ false ] # lwt.ppx failure
 depopts: "tyxml"
 synopsis:
   "A library for writing [Jupyter](https://jupyter.org) kernels in OCaml"

--- a/packages/jupyter-kernel/jupyter-kernel.0.3/opam
+++ b/packages/jupyter-kernel/jupyter-kernel.0.3/opam
@@ -26,6 +26,7 @@ depends: [
   "ISO8601"
   "uutf"
 ]
+available: [ false ] # lwt.ppx failure
 depopts: "tyxml"
 synopsis:
   "A library for writing [Jupyter](https://jupyter.org) kernels in OCaml"


### PR DESCRIPTION
these all fail with some lwt ppx error, so stop them from trying
to build (especially in revdeps) until debugged

cc @c-cube 