### PR TITLE
x509: constrain to cstruct<4

### DIFF
--- a/packages/x509/x509.0.1.0/opam
+++ b/packages/x509/x509.0.1.0/opam
@@ -12,7 +12,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
-  "cstruct" {>= "1.2.0"}
+  "cstruct" {>= "1.2.0" & < "4.0.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
   "nocrypto" {= "0.1.0"}

--- a/packages/x509/x509.0.2.0/opam
+++ b/packages/x509/x509.0.2.0/opam
@@ -18,7 +18,7 @@ remove: ["ocamlfind" "remove" "x509"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
-  "cstruct" {>= "1.2.0"}
+  "cstruct" {>= "1.2.0" & < "4.0.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.2.1/opam
+++ b/packages/x509/x509.0.2.1/opam
@@ -18,7 +18,7 @@ remove: ["ocamlfind" "remove" "x509"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
-  "cstruct" {>= "1.2.0"}
+  "cstruct" {>= "1.2.0" & < "4.0.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.3.0/opam
+++ b/packages/x509/x509.0.3.0/opam
@@ -18,7 +18,7 @@ remove: ["ocamlfind" "remove" "x509"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
-  "cstruct" {>= "1.2.0"}
+  "cstruct" {>= "1.2.0" & < "4.0.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.3.1/opam
+++ b/packages/x509/x509.0.3.1/opam
@@ -16,7 +16,7 @@ remove: ["ocamlfind" "remove" "x509"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
-  "cstruct" {>= "1.2.0"}
+  "cstruct" {>= "1.2.0" & < "4.0.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.4.0/opam
+++ b/packages/x509/x509.0.4.0/opam
@@ -19,7 +19,7 @@ remove: [ "ocamlfind" "remove" "x509" ]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
-  "cstruct" {>= "1.2.0"}
+  "cstruct" {>= "1.2.0" & < "4.0.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.5.0/opam
+++ b/packages/x509/x509.0.5.0/opam
@@ -19,7 +19,7 @@ remove: [ "ocamlfind" "remove" "x509" ]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "4.0.0"}
   "type_conv"
   "sexplib" {< "113.01.00"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}

--- a/packages/x509/x509.0.5.1/opam
+++ b/packages/x509/x509.0.5.1/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.3"}

--- a/packages/x509/x509.0.5.2/opam
+++ b/packages/x509/x509.0.5.2/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.3"}

--- a/packages/x509/x509.0.5.3/opam
+++ b/packages/x509/x509.0.5.3/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.3"}

--- a/packages/x509/x509.0.6.0/opam
+++ b/packages/x509/x509.0.6.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.11.0"}
   "topkg" {build}
   "result"
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "asn1-combinators" {>= "0.2.0"}
   "ptime"

--- a/packages/x509/x509.0.6.1/opam
+++ b/packages/x509/x509.0.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.11.0"}
   "topkg" {build}
   "result"
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "asn1-combinators" {>= "0.2.0"}
   "ptime"

--- a/packages/x509/x509.0.6.2/opam
+++ b/packages/x509/x509.0.6.2/opam
@@ -20,7 +20,7 @@ depends: [
   "topkg" {build}
   "ppx_sexp_conv" {< "v0.13"}
   "result"
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "asn1-combinators" {>= "0.2.0"}
   "ptime"


### PR DESCRIPTION
due to making sexp optional in cstruct, see #13748