### PR TITLE
constrain qcow to cstruct<4

### DIFF
--- a/packages/qcow/qcow.0.10.0/opam
+++ b/packages/qcow/qcow.0.10.0/opam
@@ -12,7 +12,7 @@ tags: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "astring"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
   "mirage-types-lwt" {>= "3.0.0"}

--- a/packages/qcow/qcow.0.10.2/opam
+++ b/packages/qcow/qcow.0.10.2/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "astring"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
   "mirage-types-lwt" {>= "3.0.0"}

--- a/packages/qcow/qcow.0.10.3/opam
+++ b/packages/qcow/qcow.0.10.3/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "astring"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
   "mirage-types-lwt" {>= "3.0.0"}

--- a/packages/qcow/qcow.0.10.4/opam
+++ b/packages/qcow/qcow.0.10.4/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "astring"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
   "mirage-types-lwt" {>= "3.0.0"}

--- a/packages/qcow/qcow.0.6.0/opam
+++ b/packages/qcow/qcow.0.6.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "astring"
   "cmdliner"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "mirage-types-lwt" {>= "2.6.0" & < "3.0.0"}
   "lwt" {< "4.0.0"}

--- a/packages/qcow/qcow.0.7.0/opam
+++ b/packages/qcow/qcow.0.7.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "astring"
   "cmdliner"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "mirage-types-lwt" {>= "2.6.0" & < "3.0.0"}
   "lwt" {< "4.0.0"}

--- a/packages/qcow/qcow.0.8.1/opam
+++ b/packages/qcow/qcow.0.8.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "astring"
   "cmdliner"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "mirage-types-lwt" {>= "3.0.0"}
   "lwt"

--- a/packages/qcow/qcow.0.9.0/opam
+++ b/packages/qcow/qcow.0.9.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "astring"
   "cmdliner"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "mirage-types-lwt" {>= "3.0.0"}
   "lwt"

--- a/packages/qcow/qcow.0.9.4/opam
+++ b/packages/qcow/qcow.0.9.4/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "astring"
   "cmdliner"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "mirage-types-lwt" {>= "3.0.0"}
   "lwt"

--- a/packages/qcow/qcow.0.9.5/opam
+++ b/packages/qcow/qcow.0.9.5/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "astring"
   "cmdliner"
-  "cstruct"
+  "cstruct" {< "4.0.0"}
   "result"
   "mirage-types-lwt" {>= "3.0.0"}
   "lwt"


### PR DESCRIPTION
due to making sexp optional in cstruct, see #13748