### PR TITLE
[new release] mirage-console-lwt, mirage-console-xen-backend, mirage-console-xen, mirage-console, mirage-console-xen-proto and mirage-console-unix (v2.4.2)

### DIFF
--- a/packages/mirage-console-lwt/mirage-console-lwt.v2.4.2/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.v2.4.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console" {>= "2.2.0"}
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles using Lwt"
+description: """
+This implements a MirageOS console device using the Lwt
+concurrency libary for concurrency.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.2/mirage-console-v2.4.2.tbz"
+  checksum: "md5=78bdb8d509f2c3576e69e49cd191896a"
+}

--- a/packages/mirage-console-unix/mirage-console-unix.v2.4.2/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.v2.4.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "lwt"
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt"
+  "mirage-console-lwt" {>= "2.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles for Unix"
+description: """
+This implements a MirageOS console device for use with
+Unix-based targets.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.2/mirage-console-v2.4.2.tbz"
+  checksum: "md5=78bdb8d509f2c3576e69e49cd191896a"
+}

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.v2.4.2/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.v2.4.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "mirage-console-xen-proto"
+  "mirage-xen" {>= "3.3.0"}
+  "lwt"
+  "io-page-xen" {>= "2.0.0"}
+  "xenstore"
+  "xen-evtchn"
+  "shared-memory-ring-lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console backend for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.2/mirage-console-v2.4.2.tbz"
+  checksum: "md5=78bdb8d509f2c3576e69e49cd191896a"
+}

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.v2.4.2/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.v2.4.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "rresult"
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console protocol for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.2/mirage-console-v2.4.2.tbz"
+  checksum: "md5=78bdb8d509f2c3576e69e49cd191896a"
+}

--- a/packages/mirage-console-xen/mirage-console-xen.v2.4.2/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.v2.4.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "mirage-console-xen-proto"
+  "xen-evtchn"
+  "io-page-xen"
+  "mirage-xen" {>= "3.3.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.2/mirage-console-v2.4.2.tbz"
+  checksum: "md5=78bdb8d509f2c3576e69e49cd191896a"
+}

--- a/packages/mirage-console/mirage-console.v2.4.2/opam
+++ b/packages/mirage-console/mirage-console.v2.4.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.2/mirage-console-v2.4.2.tbz"
+  checksum: "md5=78bdb8d509f2c3576e69e49cd191896a"
+}


### PR DESCRIPTION
Implementation of Mirage consoles using Lwt

- Project page: <a href="https://github.com/mirage/mirage-console">https://github.com/mirage/mirage-console</a>
- Documentation: <a href="https://mirage.github.io/mirage-console/">https://mirage.github.io/mirage-console/</a>

##### CHANGES:

* Use new grant API from mirage-xen instead of xen-gnt (mirage/mirage-console#75 @yomimono)
