### PR TITLE
[new release] hpack, h2-mirage, h2-lwt, h2 and h2-lwt-unix (0.1.0)

### DIFF
--- a/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "h2-lwt-unix"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/h2"
+bug-reports: "https://github.com/anmonteiro/h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/h2.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "faraday-lwt-unix"
+  "h2"
+  "dune" {build}
+  "lwt"
+]
+synopsis: "Lwt + UNIX support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX
+binaries.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/h2/releases/download/0.1.0/h2-0.1.0.tbz"
+  checksum: "md5=f3e52be5e2b4e93bc15ed2f0d3420718"
+}

--- a/packages/h2-lwt/h2-lwt.0.1.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "h2-lwt"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/h2"
+bug-reports: "https://github.com/anmonteiro/h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/h2.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "h2"
+  "dune" {build}
+  "lwt"
+]
+synopsis: "Lwt support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt
+provides an Lwt runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/h2/releases/download/0.1.0/h2-0.1.0.tbz"
+  checksum: "md5=f3e52be5e2b4e93bc15ed2f0d3420718"
+}

--- a/packages/h2-mirage/h2-mirage.0.1.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "h2-mirage"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/h2"
+dev-repo: "git+https://github.com/anmonteiro/h2.git"
+bug-reports: "https://github.com/anmonteiro/h2/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "faraday-lwt"
+  "h2-lwt"
+  "dune" {build}
+  "lwt"
+  "mirage-conduit"
+  "cstruct"
+]
+synopsis: "Mirage support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS
+unikernels.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/h2/releases/download/0.1.0/h2-0.1.0.tbz"
+  checksum: "md5=f3e52be5e2b4e93bc15ed2f0d3420718"
+}

--- a/packages/h2/h2.0.1.0/opam
+++ b/packages/h2/h2.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/h2"
+bug-reports: "https://github.com/anmonteiro/h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/h2.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "bigstringaf" {>= "0.5.0"}
+  "angstrom" {>= "0.11.2"}
+  "faraday" {>= "0.5.0"}
+  "result"
+  "psq"
+  "hpack"
+  "httpaf"
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for for OCaml"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. It
+is based on the concepts in http/af, and therefore uses the Angstrom and
+Faraday libraries to implement the parsing and serialization layers of the
+HTTP/2 standard as a state machine that is agnostic to the underlying I/O
+specifics. It also preserves the same API as http/af wherever possible.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/h2/releases/download/0.1.0/h2-0.1.0.tbz"
+  checksum: "md5=f3e52be5e2b4e93bc15ed2f0d3420718"
+}

--- a/packages/hpack/hpack.0.1.0/opam
+++ b/packages/hpack/hpack.0.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "hpack"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+homepage: "https://github.com/anmonteiro/h2"
+license: "MIT"
+dev-repo: "git+https://github.com/anmonteiro/h2.git"
+bug-reports: "https://github.com/anmonteiro/h2/issues"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "angstrom"
+  "faraday"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis:
+  "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description: """
+hpack is an implementation of the HPACK: Header Compression for HTTP/2
+specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for
+parsing and serialization, respectively.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/h2/releases/download/0.1.0/h2-0.1.0.tbz"
+  checksum: "md5=f3e52be5e2b4e93bc15ed2f0d3420718"
+}


### PR DESCRIPTION
### hpack

An HPACK (Header Compression for HTTP/2) implementation in OCaml

### h2

An HTTP/2 implementation in OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>

##### CHANGES:

- Initial public release
