### PR TITLE
Package ocamlformat.0.9

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.9/opam
+++ b/packages/ocamlformat/ocamlformat.0.9/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src: "https://github.com/ocaml-ppx/ocamlformat/archive/0.9.tar.gz"
+  checksum: [
+    "md5=4e5e4df8687f2f2e820bebe1a55c0f6d"
+    "sha512=6bedb60073239867caa57171d2537a77e8857a00ce3d8280850a163baf1c4bc8625d6e6bd79cdf8a3d603241224aac5485f1e148d0c0d4144469080cf41fbc6a"
+  ]
+}
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.ml" "src/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {build & >= "1.1.1"}
+  "fpath"
+  "ocaml-migrate-parsetree" {>= "1.0.10"}
+  "octavius" {>= "1.2.0"}
+  "stdio"
+  "uutf"
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."


### PR DESCRIPTION
### `ocamlformat.0.9`
Auto-formatter for OCaml code
OCamlFormat is a tool to automatically format OCaml code in a uniform style.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat
* Source repo: git+https://github.com/ocaml-ppx/ocamlformat.git
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---
:camel: Pull-request generated by opam-publish v2.0.0