### PR TITLE
Z3 package: build and install the static library

### DIFF
--- a/packages/z3/z3.4.8.4/opam
+++ b/packages/z3/z3.4.8.4/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/Z3prover/z3/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/Z3prover/z3.git"
 build: [
-  [ "python2.7" "scripts/mk_make.py" "--ml" ]
+  [ "python2.7" "scripts/mk_make.py" "--ml" "--staticlib" ]
   [ make "-C" "build" "-j" jobs ]
   [ "sh" "-c" "cp build/libz3* build/api/ml/" ]
 ]


### PR DESCRIPTION
by default, only the dynamic lib is installed (and that requires an
update to `LD_LIBRARY_PATH` for running linked binaries)