### PR TITLE
[new release] hex (1.4.0)

### DIFF
--- a/packages/hex/hex.1.4.0/opam
+++ b/packages/hex/hex.1.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Trevor Summers Smith"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hex"
+doc: "https://mirage.github.io/ocaml-hex/"
+bug-reports: "https://github.com/mirage/ocaml-hex/issues"
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "1.7.0"}
+  "bigarray-compat" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-hex.git"
+synopsis: "Library providing hexadecimal converters"
+description: """
+```ocaml
+#require "hex";;
+# Hex.of_string "Hello world!";;
+- : Hex.t = "48656c6c6f20776f726c6421"
+# Hex.to_string "dead-beef";;
+- : string = "ޭ��"
+# Hex.hexdump (Hex.of_string "Hello world!\n")
+00000000: 4865 6c6c 6f20 776f 726c 6421 0a        Hello world!.
+- : unit = ()
+```
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-hex/releases/download/v1.4.0/hex-v1.4.0.tbz"
+  checksum: "md5=57103ff33e70f14171c46d88f5452d11"
+}


### PR DESCRIPTION
Library providing hexadecimal converters

- Project page: <a href="https://github.com/mirage/ocaml-hex">https://github.com/mirage/ocaml-hex</a>
- Documentation: <a href="https://mirage.github.io/ocaml-hex/">https://mirage.github.io/ocaml-hex/</a>

##### CHANGES:

* Drop the hard dependency on `unix` that is transitively
  brought in by cstruct/bigarray.  This is done by using
  the new `bigarray-compat` opam package that does the
  right thing on OCaml 4.07+ to not depend on unix.
  On older OCaml compilers the dependency will still be
  there and must be manually dropped with `-dontlink`, but
  we encourage users to use a newer compiler (mirage/ocaml-hex#29 @TheLortex)
