### PR TITLE
Cstruct 4.0.0 works with JS 0.12 libs

### DIFF
--- a/packages/ppx_cstruct/ppx_cstruct.4.0.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.4.0.0/opam
@@ -23,8 +23,8 @@ depends: [
   "ppx_tools_versioned" {>= "5.0.1"}
   "ocaml-migrate-parsetree"
   "ppx_driver" {with-test & >= "v0.9.0"}
-  "ppx_sexp_conv" {with-test & < "v0.12"}
-  "sexplib" {< "v0.12"}
+  "ppx_sexp_conv" {with-test & < "v0.13"}
+  "sexplib" {< "v0.13"}
   "cstruct-sexp" {with-test}
   "cstruct-unix" {with-test & =version}
 ]


### PR DESCRIPTION
Sorry, it was forgotten to be included in the 4.0.0 release opam files:
- https://github.com/ocaml/opam-repository/commit/04f5a5b7c78843a7d6ed8951ac19e63849d3c15c
- https://github.com/mirage/ocaml-cstruct/commit/f7a44df8617d1ce9808091b551b24fb21f36ae91
