### PR TITLE
[new release] parse-argv (0.2.0)

### DIFF
--- a/packages/parse-argv/parse-argv.0.2.0/opam
+++ b/packages/parse-argv/parse-argv.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "parse-argv"
+maintainer: "Mindy Preston <mindy.preston@docker.com>"
+authors: ["Jon Ludlam" "Magnus Skjegstad" "Mindy Preston"]
+tags: "org:mirage"
+homepage: "https://github.com/mirage/parse-argv"
+doc: "https://mirage.github.io/parse-argv/"
+bug-reports: "https://github.com/mirage/parse-argv/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "ounit" {with-test}
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/parse-argv.git"
+synopsis: "Process strings into sets of command-line arguments"
+description: """
+parse-argv is a small implementation of a simple argv parser.
+"""
+url {
+  src:
+    "https://github.com/mirage/parse-argv/releases/download/v0.2.0/parse-argv-v0.2.0.tbz"
+  checksum: "md5=0621122768b81e089e5d5ebd7fd2c856"
+}

--- a/packages/parse-argv/parse-argv.0.2.0/opam
+++ b/packages/parse-argv/parse-argv.0.2.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "parse-argv"
 maintainer: "Mindy Preston <mindy.preston@docker.com>"
 authors: ["Jon Ludlam" "Magnus Skjegstad" "Mindy Preston"]
 tags: "org:mirage"


### PR DESCRIPTION
Process strings into sets of command-line arguments

- Project page: <a href="https://github.com/mirage/parse-argv">https://github.com/mirage/parse-argv</a>
- Documentation: <a href="https://mirage.github.io/parse-argv/">https://mirage.github.io/parse-argv/</a>

##### CHANGES:

* port to dune (mirage/parse-argv#7 @hannesm)
* do not use the Result module any more (mirage/parse-argv#5 @hannesm)
* update to opam 2 metadata (mirage/parse-argv#7 @hannesm)
