### PR TITLE
Fix conf-hidapi for FreeBSD

### DIFF
--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -5,8 +5,8 @@ homepage: "http://www.signal11.us/oss/hidapi/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD"
 build: [
-  ["pkg-config" "hidapi-libusb"] {os != "macos"}
-  ["pkg-config" "hidapi"] {os = "macos"}
+  ["pkg-config" "hidapi-libusb"] {os != "macos" & os != "freebsd"}
+  ["pkg-config" "hidapi"] {os = "macos" | os = "freebsd"}
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
@@ -14,6 +14,7 @@ depexts: [
   ["libhidapi-dev"] {os-distribution = "debian"}
   ["hidapi"] {os-distribution = "arch"}
   ["hidapi"] {os = "macos" & os-distribution = "homebrew"}
+  ["hidapi"] {os = "freebsd"}
   ["hidapi-dev"] {os-distribution = "alpine"}
   ["epel-release" "hidapi-devel"] {os-distribution = "centos"}
 ]


### PR DESCRIPTION
Like macos, also FreeBSD uses "hidapi.pc" as pkg-config file