### PR TITLE
mirage-unix: ensure older versions use older lwt

### DIFF
--- a/packages/mirage-unix/mirage-unix.0.9.1/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.1/opam
@@ -6,7 +6,7 @@ depends: [
   "ocaml"
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
-  "lwt" {>= "2.4.0"}
+  "lwt" {>= "2.4.0" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.0"}
   "tuntap" {= "0.5"}
   "fd-send-recv"

--- a/packages/mirage-unix/mirage-unix.0.9.2/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.2/opam
@@ -6,7 +6,7 @@ depends: [
   "ocaml"
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
-  "lwt" {>= "2.4.0"}
+  "lwt" {>= "2.4.0" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.0"}
   "tuntap" {= "0.5"}
   "fd-send-recv"

--- a/packages/mirage-unix/mirage-unix.0.9.3/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.3/opam
@@ -6,7 +6,7 @@ depends: [
   "ocaml"
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
-  "lwt" {>= "2.4.0"}
+  "lwt" {>= "2.4.0" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.0"}
   "tuntap" {= "0.5"}
   "fd-send-recv"

--- a/packages/mirage-unix/mirage-unix.0.9.4/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.4/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.0"}
+  "lwt" {>= "2.4.0" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.1"}
   "tuntap" {>= "0.6"}
   "ipaddr"

--- a/packages/mirage-unix/mirage-unix.0.9.5/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.5/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.0"}
+  "lwt" {>= "2.4.0" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.1"}
   "tuntap" {>= "0.6"}
   "ipaddr" {>= "0.2.2"}

--- a/packages/mirage-unix/mirage-unix.0.9.6/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.6/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.0"}
+  "lwt" {>= "2.4.0" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.1"}
   "tuntap" {>= "0.6"}
   "ipaddr" {>= "0.2.2"}

--- a/packages/mirage-unix/mirage-unix.0.9.7/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.7/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.0"}
+  "lwt" {>= "2.4.0" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.3"}
   "tuntap" {>= "0.6"}
   "ipaddr" {>= "0.2.2"}

--- a/packages/mirage-unix/mirage-unix.0.9.8/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.8/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "cstruct" {>= "0.8.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "shared-memory-ring" {>= "0.4.3"}
   "tuntap" {>= "0.7.0"}
   "ipaddr" {>= "0.2.3"}

--- a/packages/mirage-unix/mirage-unix.0.9.9/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.9/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page-unix" {>= "0.9.9"}
   "mirage-clock-unix" {>= "1.0.0"}
   "shared-memory-ring" {>= "0.4.3"}

--- a/packages/mirage-unix/mirage-unix.1.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.0.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page-unix" {>= "0.9.9"}
   "mirage-clock-unix" {>= "1.0.0"}
   "shared-memory-ring" {>= "0.4.3"}

--- a/packages/mirage-unix/mirage-unix.1.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.0.1" & <= "1.4.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.3/opam
@@ -12,7 +12,7 @@ depends: [
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"
   "ocamlfind" {build}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.3.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.3.1/opam
@@ -13,7 +13,7 @@ depends: [
   "type_conv"
   "conf-which" {build}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.4.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-which" {build}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.4.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.1/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-which" {build}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.5.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.5.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-which" {build}
   "cstruct" {>= "1.0.1"}
   "ocamlfind"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.6.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-which" {build}
   "cstruct" {>= "1.0.1"}
   "ocamlfind" {build}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "4.0.0"}
   "io-page" {>= "1.5.0" & < "2.0.0"}
   "mirage-clock-unix" {>= "1.0.0" & < "1.1"}
   "shared-memory-ring" {>= "1.0.0"}


### PR DESCRIPTION
to get camlp4