### PR TITLE
decompress: older versions do not compile on ocaml 4.08

### DIFF
--- a/packages/decompress/decompress.0.3/opam
+++ b/packages/decompress/decompress.0.3/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "decompress"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/decompress/decompress.0.4/opam
+++ b/packages/decompress/decompress.0.4/opam
@@ -18,7 +18,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "decompress"]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/decompress/decompress.0.5/opam
+++ b/packages/decompress/decompress.0.5/opam
@@ -10,7 +10,7 @@ build: [
   "--with-cmdliner" "%{cmdliner:installed}%"
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/decompress/decompress.0.6/opam
+++ b/packages/decompress/decompress.0.6/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/decompress/decompress.0.7/opam
+++ b/packages/decompress/decompress.0.7/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}


### PR DESCRIPTION
cc @dinosaure  (from check.ocamllabs.io)