### PR TITLE
Specify depopts for h2-lwt-unix

### DIFF
--- a/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
@@ -17,6 +17,7 @@ depends: [
   "dune" {build}
   "lwt"
 ]
+depopts: ["tls" "lwt_ssl"]
 synopsis: "Lwt + UNIX support for h2"
 description: """
 h2 is an implementation of the HTTP/2 specification entirely in OCaml.


### PR DESCRIPTION
I forgot to include this in the original release and users were seeing build failures with e.g. esy which needs to track this information.