### PR TITLE
graphql_parser.0.11.0: fix missing `result` dependency.

### DIFF
--- a/packages/graphql_parser/graphql_parser.0.11.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.11.0/opam
@@ -16,6 +16,7 @@ depends: [
   "dune" {build}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
+  "result"
   "fmt"
   "re" {>= "1.5.0"}
 ]


### PR DESCRIPTION
It seems graphql_parser.0.11.0 is getting its `result` dependency indirectly through `fmt`. But the latest release of `fmt` drops the `result` dependency which results in a [build failure](https://ci.ocamllabs.io/log/saved/docker-run-f5501ba2891862ebca2f3088e59459a6/23bf11a4c8a0535463c58a64ab76cfa9e404f8b7).

This PR adds a dependency on `result` (note that e.g. `0.9.0` has the dependency on `result).

/cc @andreas