### PR TITLE
tls uses cstruct_sexp, which has been removed from cstruct 4.0.0 -- r…

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -23,7 +23,7 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv" {>= "113.33.01" & != "v0.11.0"}
   "ounit" {with-test}
-  "cstruct" {>= "2.4.0"}
+  "cstruct" {>= "3.0.0"}
   "cstruct-lwt"
   "zarith"
   "lwt"

--- a/packages/tls/tls.0.7.1/opam
+++ b/packages/tls/tls.0.7.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlbuild" {build}
   "result"
   "ppx_tools"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "4.0.0"}
   "ppx_cstruct"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}

--- a/packages/tls/tls.0.7.1/opam
+++ b/packages/tls/tls.0.7.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlbuild" {build}
   "result"
   "ppx_tools"
-  "cstruct" {>= "1.9.0" & < "4.0.0"}
+  "cstruct" {>= "1.9.0" & < "3.0.0"}
   "ppx_cstruct"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}

--- a/packages/tls/tls.0.8.0/opam
+++ b/packages/tls/tls.0.8.0/opam
@@ -46,7 +46,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.11.0"}
   "result"
   "ppx_cstruct"
-  "cstruct" {>= "1.9.0" & < "4.0.0"}
+  "cstruct" {>= "1.9.0" & < "3.0.0"}
   "sexplib" {< "v0.13"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.5.0" & < "0.6.0"}

--- a/packages/tls/tls.0.8.0/opam
+++ b/packages/tls/tls.0.8.0/opam
@@ -46,7 +46,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.11.0"}
   "result"
   "ppx_cstruct"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.5.0" & < "0.6.0"}

--- a/packages/tls/tls.0.9.0/opam
+++ b/packages/tls/tls.0.9.0/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
   "result"
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.6.1"}

--- a/packages/tls/tls.0.9.1/opam
+++ b/packages/tls/tls.0.9.1/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
   "result"
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.6.1"}

--- a/packages/tls/tls.0.9.2/opam
+++ b/packages/tls/tls.0.9.2/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
   "result"
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.6.1"}

--- a/packages/tls/tls.0.9.3/opam
+++ b/packages/tls/tls.0.9.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
   "result"
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "4.0.0"}
   "sexplib" {< "v0.13"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.6.1"}


### PR DESCRIPTION
…estrict released tls versions to cstruct < 4.0.0