### PR TITLE
[new releases] x509 (0.6.3) tls (0.10.2)

### DIFF
--- a/packages/tls/tls.0.10.1/opam
+++ b/packages/tls/tls.0.10.1/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
   "result"
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "4.0.0"}
   "sexplib"
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.6.1"}

--- a/packages/tls/tls.0.10.2/opam
+++ b/packages/tls/tls.0.10.2/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+name:         "tls"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+author:       ["David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD2"
+
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+    "--with-lwt" "%{lwt+ptime:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+    "--with-lwt" "%{lwt+ptime+astring:installed}%"
+    "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ] {with-test}
+  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.6.1"}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit" {with-test}
+]
+depopts: [
+  "lwt"
+  "mirage-flow-lwt"
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "ptime"
+  "astring" {with-test}
+]
+conflicts: [
+  "lwt" {<"2.4.8"}
+  "mirage-net-xen" {<"1.3.0"}
+  "mirage-types" {<"3.0.0"}
+  "mirage-kv-lwt" {<"2.0.0"}
+  "sexplib" {= "v0.9.0"}
+  "ppx_sexp_conv" {= "v0.11.0"}
+  "ptime" {< "0.8.1"}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io)."""
+url {
+archive: "https://github.com/mirleft/ocaml-tls/releases/download/0.10.2/tls-0.10.2.tbz"
+checksum: "3d7dfafe777c20cf9314eef704c3650b"
+}

--- a/packages/x509/x509.0.6.3/opam
+++ b/packages/x509/x509.0.6.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+name: "x509"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"
+]
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "BSD2"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.2"}
+  "ppx_sexp_conv"
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "nocrypto" {>= "0.5.3"}
+  "astring"
+  "ounit" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+]
+conflicts: [
+  "ppx_sexp_conv" {= "v0.11.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding,
+which is also partially implemented by this library - namely PKCS 1, PKCS 7,
+PKCS 8, PKCS 9 and PKCS 10.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/0.6.3/x509-0.6.3.tbz"
+  checksum: "md5=52fbcf55fd7fe775c0b33a81f04a92cf"
+}

--- a/packages/x509/x509.0.6.3/opam
+++ b/packages/x509/x509.0.6.3/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.2"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {>="v0.11.0"}
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
   "sexplib"


### PR DESCRIPTION
X509 CHANGES:

* provide X509.Encoding.distinguished_name_of_cs -- similar to mirleft/ocaml-x509#87 which provided distinguished_name_to_cs
* provide X509.Encoding.{public_key_of_cstruct,public_key_to_cstruct}, as requested by @dinosaure
* support of cstruct 4.0.0, which split up the sexp de&encoders
* removes result dependency (now requires >= 4.04.2)
* upgrades opam file to version 2.0
* build system is now dune

TLS CHANGES:

* support for cstruct 4.0.0+
* remove support for < 4.04.2 (same as x509 in master)
* remove result (part of 4.03.0)
* enhance mirage/example2 to work on more platforms than unix