### PR TITLE
[new release] netchannel and mirage-net-xen (v1.10.2)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.1.10.2/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.10.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "3.3.0"}
+  "netchannel" {>= "1.10.1"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.10.2/mirage-net-xen-v1.10.2.tbz"
+  checksum: "md5=d8c2360a8763debd56a2b70a264bc256"
+}

--- a/packages/netchannel/netchannel.1.10.2/opam
+++ b/packages/netchannel/netchannel.1.10.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "3.3.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "rresult"
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.10.2/mirage-net-xen-v1.10.2.tbz"
+  checksum: "md5=d8c2360a8763debd56a2b70a264bc256"
+}


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Use the new grant API provided by mirage-xen (@talex5 and @yomimono, mirage/mirage-net-xen#85).
