### PR TITLE
graphql_parser: really fix missing `result` dependency by constrainting fmt

### DIFF
--- a/packages/graphql_parser/graphql_parser.0.11.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.11.0/opam
@@ -16,8 +16,7 @@ depends: [
   "dune" {build}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
-  "result"
-  "fmt"
+  "fmt" {< "0.8.6"} # Due to implicit result constraint
   "re" {>= "1.5.0"}
 ]
 


### PR DESCRIPTION
The fix in a4d2989b5c7c41c3f is wrong.

See https://github.com/ocaml/opam-repository/pull/13803