### PR TITLE
Package graphql_parser.0.12.2

### DIFF
--- a/packages/graphql_parser/graphql_parser.0.12.2/opam
+++ b/packages/graphql_parser/graphql_parser.0.12.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "menhir" {build}
+  "alcotest" {with-test & >= "0.8.1"}
+  "fmt"
+  "re" {>= "1.5.0"}
+]
+
+synopsis: "Library for parsing GraphQL queries"
+
+url {
+archive: "https://github.com/andreas/ocaml-graphql-server/releases/download/0.12.2/graphql-0.12.2.tbz"
+checksum: "d7c79e9527a57051b40c005c36cf236f"
+}


### PR DESCRIPTION
### `graphql_parser.0.12.2`
Library for parsing GraphQL queries



---
* Homepage: https://github.com/andreas/ocaml-graphql-server
* Source repo: git+https://github.com/andreas/ocaml-graphql-server.git
* Bug tracker: https://github.com/andreas/ocaml-graphql-server/issues

---
0.12.2 2019-04-02
---------------------------------

- Remove open of Result (#154)

---
:camel: Pull-request generated by opam-publish v2.0.0