### PR TITLE
2 packages from sapristi/easy_logging at 0.4

### DIFF
--- a/packages/easy_logging/easy_logging.0.4/opam
+++ b/packages/easy_logging/easy_logging.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Module to easily log messages"
+
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "examples"] {with-test}
+]
+
+description: """
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format and treat the message independantly.
+   * annotage log messages with tags
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.4"
+  checksum: [
+    "md5=dea0798a0e16c4c3adcd66284c78f02e"
+    "sha512=cec0646fac2c3ef0bca8991053fb0f8867737b6809cb0b191fb806d69df50ddd42fac8dc3147fb5c7f070a8156188fd7f168699189c10a3cbd3d880f81da0fbf"
+  ]
+}

--- a/packages/easy_logging_yojson/easy_logging_yojson.0.4/opam
+++ b/packages/easy_logging_yojson/easy_logging_yojson.0.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Configuration loader for easy_logging with yojson backend"
+
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.0"}
+  "ppx_deriving"{>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson"
+  "easy_logging" {= "0.4"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "conf_loader/yojson"] {with-test}
+]
+
+description: """
+     Provides deserialisation of logging configuration 
+(loggers instantation and handlers parameters) from json,
+using ppx_deriving_yojson.
+
+-------
+
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages are either [string] or [string lazy_t]
+   * log level adaptable at runtime from anywhere in the program
+   * handlers associated to each logger will format and treat the message independantly.
+   * annotage log messages with tags
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.4"
+  checksum: [
+    "md5=dea0798a0e16c4c3adcd66284c78f02e"
+    "sha512=cec0646fac2c3ef0bca8991053fb0f8867737b6809cb0b191fb806d69df50ddd42fac8dc3147fb5c7f070a8156188fd7f168699189c10a3cbd3d880f81da0fbf"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`easy_logging.0.4`: Module to easily log messages
-`easy_logging_yojson.0.4`: Configuration loader for easy_logging with yojson backend



---
* Homepage: https://sapristi.github.io/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.0.0