### PR TITLE
Update the pprint package description so as to use Makefile.

### DIFF
--- a/packages/pprint/pprint.20180528/opam
+++ b/packages/pprint/pprint.20180528/opam
@@ -5,22 +5,21 @@ authors: [
   "Nicolas Pouillard <np@nicolaspouillard.fr>"
 ]
 homepage: "https://github.com/fpottier/pprint"
-bug-reports: "francois.pottier@inria.fr"
 dev-repo: "git+ssh://git@github.com/fpottier/pprint.git"
-build: [make "all"]
-install: [make "install"]
-remove: [make "uninstall"]
+bug-reports: "francois.pottier@inria.fr"
+build: [make "-f" "Makefile" "all"]
+install: [make "-f" "Makefile" "install"]
+remove: [make "-f" "Makefile" "uninstall"]
 depends: [
   "ocaml" {>= "4.02"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-synopsis: "A pretty-printing combinator library and rendering engine."
-description: """
-This library offers a set of combinators for building so-called "documents" as
+synopsis: "A pretty-printing combinator library and rendering engine"
+description: "This library offers a set of combinators for building so-called documents as
 well as an efficient engine for converting documents to a textual, fixed-width
 format. The engine takes care of indentation and line breaks, while respecting
-the constraints imposed by the structure of the document and by the text width."""
+the constraints imposed by the structure of the document and by the text width."
 url {
   src: "https://github.com/fpottier/pprint/archive/20180528.tar.gz"
   checksum: "md5=a75651b51ba6668cd6121799986a1ca2"


### PR DESCRIPTION
Update the pprint package description so as to use Makefile, not GNUmakefile. This should fix a build failure on systems that do not have bash.