### PR TITLE
conf-openssl: (macos) try `pkg-config openssl` first

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
+++ b/packages/conf-openssl/conf-openssl.1/files/osx-build.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Try just executing pkg-config openssl before looking
+# explicitly for Nix -> Homebrew -> MacPorts.
+# This handles the case where the user has set
+# PKG_CONFIG_PATH themselves.
+res=$(pkg-config openssl)
+if [ $? -eq 0 ]; then
+    echo $res
+    exit 0
+fi
+
 if [ -e "$HOME/.nix-profile/lib/pkgconfig/openssl.pc" ]; then
   # Nix on macOS
   res=$(env PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig pkg-config openssl)

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -26,5 +26,5 @@ depexts: [
 synopsis: "Virtual package relying on an OpenSSL system installation"
 description:
   "This package can only install if OpenSSL is installed on the system."
-extra-files: ["osx-build.sh" "md5=978504ca8c262cde48a71da6f11f2073"]
+extra-files: ["osx-build.sh" "md5=e216c6189d0dfb4185521c8ace09fe40"]
 flags: conf


### PR DESCRIPTION
Try just executing `pkg-config openssl` before looking explicitly for Nix -> Homebrew -> MacPorts.

This handles the case where the user has set `PKG_CONFIG_PATH` themselves.

In my case I'm actually using Nix, but rather than having `openssl` in my nix user profile I want to use `nix-shell` with the following `shell.nix` in my project directory:

```nix
{ pkgs ? import <nixpkgs> {} }:
  pkgs.mkShell {
    buildInputs = [
        pkgs.pkg-config
        pkgs.openssl
      ];
}
```

Then Nix sets `PKG_CONFIG_PATH` for me:

```shell
$ nix-shell

[nix-shell:~/code/project]$ echo $PKG_CONFIG_PATH
/nix/store/1zp3il13n33albk772nr3jrv8achkx09-openssl-1.0.2r-dev/lib/pkgconfig

```