### PR TITLE
Package ocaml-crontab.0.1

### DIFF
--- a/packages/ocaml-crontab/ocaml-crontab.0.1/opam
+++ b/packages/ocaml-crontab/ocaml-crontab.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "Interacting with cron from OCaml"
+description: """
+With this library, an ocaml program can interact with cron:
+parse/print crontab and update installed crontabs.
+"""
+
+maintainer: "Yann Régis-Gianas <yrg@irif.fr>"
+authors: [
+  "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+]
+license: "MIT"
+
+homepage: "https://github.com/yurug/ocaml-crontab"
+bug-reports: "https://github.com/yurug/ocaml-crontab/issues"
+dev-repo: "git://github.com/yurug/ocaml-crontab.git"
+
+depends: [
+  "dune"                 {build & >= "1.4.0"}
+  "ocaml"
+  "odoc"                 {with-doc}
+  "ocamlfind"
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [make "check"]
+url {
+  src: "https://github.com/yurug/ocaml-crontab/archive/0.1.tar.gz"
+  checksum: [
+    "md5=dc40ebe9df53dc257d14bea5edc01f43"
+    "sha512=2197a4c5d513c32fab7eec4b182dd2d5154a66c816293d504b3bf5f5485ac3f8dad0fe98193495677d2c7c302df1bde0c0e4616bdb22b669dce2f58fc79f23da"
+  ]
+}


### PR DESCRIPTION
### `ocaml-crontab.0.1`
Interacting with cron from OCaml
With this library, an ocaml program can interact with cron:
parse/print crontab and update installed crontabs.



---
* Homepage: https://github.com/yurug/ocaml-crontab
* Source repo: git://github.com/yurug/ocaml-crontab.git
* Bug tracker: https://github.com/yurug/ocaml-crontab/issues

---
:camel: Pull-request generated by opam-publish v2.0.0