### PR TITLE
Package crontab.0.1

### DIFF
--- a/packages/crontab/crontab.0.1/opam
+++ b/packages/crontab/crontab.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+
+synopsis: "Interacting with cron from OCaml"
+description: """
+With this library, an ocaml program can interact with cron:
+parse/print crontab and update installed crontabs.
+"""
+
+maintainer: "Yann Régis-Gianas <yrg@irif.fr>"
+authors: [
+  "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+]
+license: "MIT"
+
+homepage: "https://github.com/yurug/ocaml-crontab"
+bug-reports: "https://github.com/yurug/ocaml-crontab/issues"
+dev-repo: "git://github.com/yurug/ocaml-crontab.git"
+
+depends: [
+  "dune"                 {build & >= "1.4.0"}
+  "ocaml"
+  "odoc"                 {with-doc}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/yurug/ocaml-crontab/archive/0.1.tar.gz"
+  checksum: [
+    "md5=0bea4f8de63112ad92706e985e431ed0"
+    "sha512=a7a4a4f70625bd8222bd2f66dee524e54634d3a5915cab140c114228d02b0e7c598bd7675c584a05c240fbf92070c2d198fb4a1b92631eb83c333fd3e58c080b"
+  ]
+}


### PR DESCRIPTION
### `crontab.0.1`
Interacting with cron from OCaml
With this library, an ocaml program can interact with cron:
parse/print crontab and update installed crontabs.



---
* Homepage: https://github.com/yurug/ocaml-crontab
* Source repo: git://github.com/yurug/ocaml-crontab.git
* Bug tracker: https://github.com/yurug/ocaml-crontab/issues

---
:camel: Pull-request generated by opam-publish v2.0.0