### PR TITLE
[new release] base64 (3.2.0)

### DIFF
--- a/packages/base64/base64.3.2.0/opam
+++ b/packages/base64/base64.3.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>="4.03.0"}
+  "base-bytes"
+  "dune" {build & >= "1.0.1"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.2.0/base64-v3.2.0.tbz"
+  checksum: "md5=8ac1d6145277cee57d36611d1c420f05"
+}


### PR DESCRIPTION
Base64 encoding for OCaml

- Project page: <a href="https://github.com/mirage/ocaml-base64">https://github.com/mirage/ocaml-base64</a>
- Documentation: <a href="http://mirage.github.io/ocaml-base64/">http://mirage.github.io/ocaml-base64/</a>

##### CHANGES:

* `Base64_rfc2045.decode` can now progress on many input errors, allowing
  clients to make forward progress by discarding a single character and
  trying to continue.  This allows, for example, newlines and other invalid
  characters to be discarded. (mirage/ocaml-base64#34 @tiash, review by @dinosaure @avsm)
* Add more test cases for RFC2045 (mirage/ocaml-base64#34 @dinosaure)
* Improve README toplevel output example (mirage/ocaml-base64#28 @djs55)
