### PR TITLE
bytecode-only variants from 4.05.0 to 4.07.1

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Official 4.05.0 release, without the native-code compiler."
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.05.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-native-compiler"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
+  checksum: "md5=7e0079162134336a24b9028349c756bb"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Official 4.06.0 release, without the native-code compiler."
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.06.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-native-compiler"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
+  checksum: "md5=4f3906e581181c5435078ffe3e485e3f"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Official 4.06. release, without the native-code compiler."
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.06.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-native-compiler"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+  checksum: "md5=d02eb67b828de22c3f97d94b3c46acba"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Official 4.07.0 release, without the native-code compiler."
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.07.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-native-compiler"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
+  checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Official 4.07.1 release, without the native-code compiler."
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.07.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-no-native-compiler"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
+  checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
+}


### PR DESCRIPTION
As the name suggests, this PR adds `+bytecode-only` variants for:

- 4.05.0
- 4.06.0
- 4.06.1
- 4.07.0
- 4.07.1