### PR TITLE
[new release] codept 0.10.3

### DIFF
--- a/packages/codept/codept.0.10.3/opam
+++ b/packages/codept/codept.0.10.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "codept"
+version: "0.10.3"
+author: "octachron <octa@polychoron.fr>"
+maintainer: "octachron <octa@polychoron.fr>"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+license: "gpl-3"
+dev-repo: "git+https://github.com/Octachron/codept.git"
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "build" "@private-docs" {with-doc}]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+depends: ["dune" {build} "menhir" {build} "ocaml" {>="4.03" & < "4.09"} "odoc"{with-doc}]
+synopsis: "Alternative ocaml dependency analyzer"
+description:"""
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+  when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis."""
+url {
+  src: "https://github.com/Octachron/codept/archive/0.10.3.tar.gz"
+  checksum: "md5=84188eac5808667399e6b296b0b9d348"
+}

--- a/packages/codept/codept.0.10.3/opam
+++ b/packages/codept/codept.0.10.3/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "codept"
-version: "0.10.3"
 author: "octachron <octa@polychoron.fr>"
 maintainer: "octachron <octa@polychoron.fr>"
 homepage: "https://github.com/Octachron/codept"
@@ -8,13 +6,16 @@ bug-reports: "https://github.com/Octachron/codept/issues"
 license: "gpl-3"
 dev-repo: "git+https://github.com/Octachron/codept.git"
 build: [
-  ["dune" "build" "-p" name]
-  ["dune" "build" "@private-docs" {with-doc}]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@private-docs"] {with-doc}
 ]
-run-test: [
-  ["dune" "runtest"]
+depends: [
+  "dune" {build}
+  "menhir" {build}
+  "ocaml" {>="4.03" & < "4.09"}
+  "odoc"{with-doc}
 ]
-depends: ["dune" {build} "menhir" {build} "ocaml" {>="4.03" & < "4.09"} "odoc"{with-doc}]
 synopsis: "Alternative ocaml dependency analyzer"
 description:"""
 Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:

--- a/packages/codept/codept.0.10.3/opam
+++ b/packages/codept/codept.0.10.3/opam
@@ -8,13 +8,11 @@ dev-repo: "git+https://github.com/Octachron/codept.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-  ["dune" "build" "@private-docs"] {with-doc}
 ]
 depends: [
   "dune" {build}
   "menhir" {build}
   "ocaml" {>="4.03" & < "4.09"}
-  "odoc"{with-doc}
 ]
 synopsis: "Alternative ocaml dependency analyzer"
 description:"""


### PR DESCRIPTION
 Codept 0.10.3 - Alternative ocaml dependency analyzer
-------
This is essentially a 4.08 compatibility release with a compiler upper bound on 4.09 since available data points show that codept generally breaks on new compiler releases.  

## Changes
### Support

  * OCaml 4.08

### Features

* Flatter json and sexp output
* Less noisy ambiguous module warning

### Bug fixes

  * Missing dependencies while matching first-class modules


