### PR TITLE
[new release] mirage-block-xen (v1.6.1)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.1.6.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "cmdliner"
+  "logs"
+  "stringext"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "shared-memory-ring-lwt"
+  "mirage-block-lwt" {>= "1.0.0"}
+  "ipaddr"
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "3.3.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v1.6.1/mirage-block-xen-v1.6.1.tbz"
+  checksum: "md5=4854a1a68a721caa5561aff3fea4b4a9"
+}


### PR DESCRIPTION
CHANGES:

* use new grant API from mirage-xen (@yomimono, @talex5)
* several code cleanups and removals (@yomimono, @emillon)
* remove ppx_cstruct direct dependency (@TheLortex)