### PR TITLE
[new release] crlibm (0.4)

### DIFF
--- a/packages/crlibm/crlibm.0.4/opam
+++ b/packages/crlibm/crlibm.0.4/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["libm" "math" "science"]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-crlibm"
+dev-repo: "git+https://github.com/Chris00/ocaml-crlibm.git"
+bug-reports: "https://github.com/Chris00/ocaml-crlibm/issues"
+doc: "https://Chris00.github.io/ocaml-crlibm/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {build}
+  "base-bytes" {build}
+  "benchmark" {with-test}
+]
+synopsis: "Binding to CRlibm, a correctly rounded math lib"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-crlibm/releases/download/0.4/crlibm-0.4.tbz"
+  checksum: "md5=d050a60185c69f58665a170ec2a7d973"
+}


### PR DESCRIPTION
CHANGES:

- Fix undeclared symbol un CRlibm for Windows MinGW.
- Fix warning about extraneous parentheses in CRlibm code.
- Automatically execute `crlibm_init` and `crlibm_exit`.
- Add some tests.