### PR TITLE
[new release] hpack, h2-mirage, h2-lwt, h2 and h2-lwt-unix (0.2.0)

### DIFF
--- a/packages/h2-lwt-unix/h2-lwt-unix.0.2.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.2.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "faraday-lwt-unix"
-  "h2-lwt"
+  "h2-lwt" {>= "0.2.0"}
   "dune" {build}
   "lwt"
 ]

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.2.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "faraday-lwt-unix"
+  "h2-lwt"
+  "dune" {build}
+  "lwt"
+]
+depopts: ["tls" "lwt_ssl"]
+synopsis: "Lwt + UNIX support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX
+binaries.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/packages/h2-lwt/h2-lwt.0.1.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.1.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "h2"
+  "h2" {< "0.2.0"}
   "dune" {build}
   "lwt"
 ]

--- a/packages/h2-lwt/h2-lwt.0.2.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "h2"
+  "dune" {build}
+  "lwt"
+]
+synopsis: "Lwt support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt
+provides an Lwt runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/packages/h2-lwt/h2-lwt.0.2.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.2.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "h2"
+  "h2" {>= "0.2.0"}
   "dune" {build}
   "lwt"
 ]

--- a/packages/h2-mirage/h2-mirage.0.2.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "faraday-lwt"
+  "h2-lwt"
+  "dune" {build}
+  "lwt"
+  "mirage-conduit"
+  "cstruct"
+]
+synopsis: "Mirage support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS
+unikernels.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/packages/h2-mirage/h2-mirage.0.2.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.2.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "faraday-lwt"
-  "h2-lwt"
+  "h2-lwt" {>= "0.2.0"}
   "dune" {build}
   "lwt"
   "mirage-conduit"

--- a/packages/h2/h2.0.2.0/opam
+++ b/packages/h2/h2.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "bigstringaf" {>= "0.5.0"}
+  "angstrom" {>= "0.11.2"}
+  "faraday" {>= "0.5.0"}
+  "psq"
+  "hpack"
+  "httpaf"
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for for OCaml"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. It
+is based on the concepts in http/af, and therefore uses the Angstrom and
+Faraday libraries to implement the parsing and serialization layers of the
+HTTP/2 standard as a state machine that is agnostic to the underlying I/O
+specifics. It also preserves the same API as http/af wherever possible.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}

--- a/packages/hpack/hpack.0.2.0/opam
+++ b/packages/hpack/hpack.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Pieter Goetschalckx <3.14.e.ter@gmail.com>"
+           "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "angstrom"
+  "faraday"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis:
+  "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description: """
+hpack is an implementation of the HPACK: Header Compression for HTTP/2
+specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for
+parsing and serialization, respectively.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.2.0/h2-0.2.0.tbz"
+  checksum: "md5=c883927ce8a9f3f7159ef7b20988f051"
+}


### PR DESCRIPTION
An HTTP/2 implementation written in pure OCaml


- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>
- Documentation: <a href="https://anmonteiro.github.io/ocaml-h2/">https://anmonteiro.github.io/ocaml-h2/</a>

##### CHANGES:

- h2: Fix false negative related to receiving trailer headers with CONTINUATION frames ([#11](https://github.com/anmonteiro/ocaml-h2/pull/11))
- hpack: Fix bug where trying to add an entry to an HPACK dynamic table with 0 capacity resulted in an out-of-bounds array access ([#13](https://github.com/anmonteiro/ocaml-h2/pull/13), [#35](https://github.com/anmonteiro/ocaml-h2/pull/35))
- h2: Add support for the 421 (Misdirected Request) status code as per [RFC7540§9.1.2](https://tools.ietf.org/html/rfc7540#section-9.1.2) ([#15](https://github.com/anmonteiro/ocaml-h2/pull/15))
- h2, h2-lwt, h2-lwt-unix, h2-mirage: Add an HTTP/2 client implementation ([#16](https://github.com/anmonteiro/ocaml-h2/pull/16))
- h2: Remove dependency on the `result` package ([#18](https://github.com/anmonteiro/ocaml-h2/pull/18))
- h2: Track SETTINGS frames that haven't been acknowledged by the peer ([#22](https://github.com/anmonteiro/ocaml-h2/pull/22))
- h2: Don't treat `CONNECT` requests as malformed ([#32](https://github.com/anmonteiro/ocaml-h2/pull/32), [#34](https://github.com/anmonteiro/ocaml-h2/pull/34))
- h2: Respect the initial MAX\_FRAME\_SIZE setting when allocating the underlying buffer for the frame writer ([#34](https://github.com/anmonteiro/ocaml-h2/pull/34))

