### PR TITLE
[new release] hidapi (1.1)

### DIFF
--- a/packages/hidapi/hidapi.1.0-1/opam
+++ b/packages/hidapi/hidapi.1.0-1/opam
@@ -18,6 +18,6 @@ depends: [
 synopsis:
   "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac, and Windows."
 url {
-  src: "https://github.com/vbmithr/ocaml-hidapi/archive/1.0.tar.gz"
+  src: "https://github.com/vbmithr/ocaml-hidapi/releases/download/1.0/1.0.tar.gz"
   checksum: "md5=6197689cd0d5eae5316a4a2ba2a6f79f"
 }

--- a/packages/hidapi/hidapi.1.0/opam
+++ b/packages/hidapi/hidapi.1.0/opam
@@ -18,6 +18,6 @@ depends: [
 synopsis:
   "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac, and Windows."
 url {
-  src: "https://github.com/vbmithr/ocaml-hidapi/archive/1.0.tar.gz"
+  src: "https://github.com/vbmithr/ocaml-hidapi/releases/download/1.0/1.0.tar.gz"
   checksum: "md5=6197689cd0d5eae5316a4a2ba2a6f79f"
 }

--- a/packages/hidapi/hidapi.1.1/opam
+++ b/packages/hidapi/hidapi.1.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "hidapi"
+version: "1.1"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-hidapi"
+bug-reports: "https://github.com/vbmithr/ocaml-hidapi/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-hidapi"
+doc: "https://vbmithr.github.io/ocaml-hidapi/doc"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.8.2"}
+  "conf-hidapi" {build}
+  "bigstring" {>= "0.2"}
+]
+synopsis: "Bindings to Signal11's hidapi library"
+description: """
+A Simple library for communicating with USB and Bluetooth HID devices
+on Linux, Mac, and Windows."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-hidapi/releases/download/1.1/hidapi-1.1.tbz"
+  checksum: "md5=77a7bb40449df3b5ad5a138bdebc1d91"
+}


### PR DESCRIPTION
Bindings to Signal11's hidapi library

- Project page: <a href="https://github.com/vbmithr/ocaml-hidapi">https://github.com/vbmithr/ocaml-hidapi</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-hidapi/doc">https://vbmithr.github.io/ocaml-hidapi/doc</a>

##### CHANGES:

- Switch to dune.
- Fix build on some platforms (@dakk).
