### PR TITLE
[new release] interval_intel, interval_base, interval and interval_crlibm (1.5)

### DIFF
--- a/packages/interval/interval.1.5/opam
+++ b/packages/interval/interval.1.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0"
+tags: ["interval" "science"]
+build: [
+  [make "test-speed"] {with-test}
+  [make "tests"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "interval_base" {= version}
+  "interval_intel" {= version}
+  "interval_crlibm" {= version}
+]
+synopsis: "An interval arithmetic library for OCaml (meta package)"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.5/interval-1.5.tbz"
+  checksum: "md5=f44dd2c998cd3389cb63a56d676cb665"
+}

--- a/packages/interval_base/interval_base.1.5/opam
+++ b/packages/interval_base/interval_base.1.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0"
+tags: ["interval" "science"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {build}
+]
+synopsis: "An interval library for OCaml (base package)"
+description: "
+This library define basic interval operations.  It is supported on
+all platforms.
+"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.5/interval-1.5.tbz"
+  checksum: "md5=f44dd2c998cd3389cb63a56d676cb665"
+}

--- a/packages/interval_crlibm/interval_crlibm.1.5/opam
+++ b/packages/interval_crlibm/interval_crlibm.1.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0"
+tags: ["interval" "science"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "interval_base" {= version}
+  "dune" {build}
+  "crlibm"
+]
+synopsis: "An interval library for OCaml (crlibm version)"
+description: "
+This library uses assembly code to compute all operations with proper
+roundings, and currently ONLY works on intel processors.
+
+This package uses CRlibm (a proved correctly rounded mathematical
+library) to provide enclosures of transcendental functions.  It may be
+slower than the version using the implementation in the CPU but
+the bounds are proved correct.  It also provides *pi versions of the
+trigonometric functions and their inverse.
+"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.5/interval-1.5.tbz"
+  checksum: "md5=f44dd2c998cd3389cb63a56d676cb665"
+}

--- a/packages/interval_intel/interval_intel.1.5/opam
+++ b/packages/interval_intel/interval_intel.1.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0"
+tags: ["interval" "science"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "interval_base" {= version}
+  "dune" {build}
+]
+available: [ arch = "x86_64" ]
+synopsis: "An interval library for OCaml"
+description: "
+This library uses assembly code to compute all operations with proper
+roundings, and currently ONLY works on intel processors.  It supports
+Linux, Windows and MacOs, with gcc and clang.  Unfortunately, the Intel
+processor does not properly round trigonometric functions so this library
+cannot be used whenever proved correct enclosures are needed.
+
+More information is given in the paper presented in the OCaml meeting
+2012: http://www.alliot.fr/papers/oud2012.pdf
+"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.5/interval-1.5.tbz"
+  checksum: "md5=f44dd2c998cd3389cb63a56d676cb665"
+}


### PR DESCRIPTION
CHANGES:

- The library is now organized as 4 packages:
  - `interval_base` defines the module `Interval` that groups the
    functions that work on any IEEE-754 processor and offers
	basic module signatures;
  - `interval_intel`: defines a module `Interval_intel` using assembly
    instructions on Intel Processors;
  - `interval_crlibm`: defines a module `Interval_crlibm` using the
    library CRlibm to evaluate standard functions (sometimes a bit
    slower but proved enclosures in contrast to the Intel package for
    which enclosures are not always 100% correct).
  - `interval`: a meta-package that install all above three.
- `Interval.T` is a module signature to form the base of what is
  expected of any interval package.
- New functions: `invx` (extended inverse), `cancelminus`,
  `cancelplus`, `inter` `inter_exn`, `low`, `high`.
- New binary relations `equal`, `=`, `subset`, `<=`, `>=`, `precedes`,
  `interior`, `<`, `>`, `strict_precedes`, `disjoint`.
- New predicates `is_bounded`, `is_entire`.
- New constants `I.half_pi` ∋ π/2 and `I.entire` for [-∞, +∞].
- `Interval_crlibm`: functions `expm1`, `log1p`, `log2`, `log10`,
  `cospi`, `sinpi`, `tanpi`, `acospi`, `asinpi`, `atanpi`, not present
  in the Intel version.
- The module `I.U` also restores inequality relations.
- Speed and documentation improvements.