### PR TITLE
datakit.0.10.1: fix an odd version constraint

### DIFF
--- a/packages/datakit/datakit.0.10.1/opam
+++ b/packages/datakit/datakit.0.10.1/opam
@@ -38,7 +38,7 @@ depends: [
   "mtime" {< "1.0.0"}
   "irmin-watcher" {>= "0.2.0"}
   "protocol-9p-unix" {>= "0.11.0"}
-  "protocol-9p" {>= "0.11.0"}
+  "protocol-9p" {>= "0.11.0" & < "0.12.1"}
   "prometheus-app"
   "datakit-server" {>= "0.10.0" & < "0.11.0"}
   "datakit-client" {with-test & >= "0.10.0" & < "0.11.0"}


### PR DESCRIPTION
Very weirdly, this fixes the following unrelated issue:

```
# File "src/datakit-conduit/datakit_conduit.ml", line 191, characters 17-46:
# Error: Unbound module Named_pipe_lwt
```