### PR TITLE
git-http.1.11.4: add missing sexplib dependency

### DIFF
--- a/packages/git-http/git-http.1.11.4/opam
+++ b/packages/git-http/git-http.1.11.4/opam
@@ -12,6 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build}
+  "sexplib"
   "git" {>= "1.11.0" & < "2.0.0"}
   "cohttp-lwt" {>= "1.0.0"}
 ]


### PR DESCRIPTION
Fix:

```
File "src/git-http/jbuild", line 6, characters 35-42:
6 |   (libraries   (git cohttp-lwt uri sexplib))))
```