### PR TITLE
git.1: add cmdliner version constraint

### DIFF
--- a/packages/git/git.1.0.0/opam
+++ b/packages/git/git.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "core_kernel" {>= "109.55.02" & < "v0.13"}
   "cryptokit"
   "uri" {>= "1.3.12"}
-  "cmdliner"
+  "cmdliner" {< "1.0.0"}
   "lazy-trie"
   "re"
   "ocamlgraph"

--- a/packages/git/git.1.0.1/opam
+++ b/packages/git/git.1.0.1/opam
@@ -23,7 +23,7 @@ depends: [
   "core_kernel" {>= "109.55.02" & < "v0.13"}
   "cryptokit"
   "uri" {>= "1.3.12"}
-  "cmdliner"
+  "cmdliner" {< "1.0.0"}
   "lazy-trie"
   "re"
   "ocamlgraph"

--- a/packages/git/git.1.0.2/opam
+++ b/packages/git/git.1.0.2/opam
@@ -23,7 +23,7 @@ depends: [
   "core_kernel" {>= "109.55.02" & < "v0.13"}
   "cryptokit"
   "uri" {>= "1.3.12"}
-  "cmdliner"
+  "cmdliner" {< "1.0.0"}
   "lazy-trie"
   "re"
   "ocamlgraph"

--- a/packages/git/git.1.1.0/opam
+++ b/packages/git/git.1.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "core_kernel" {>= "109.55.02" & < "v0.13"}
   "cryptokit"
   "uri" {>= "1.3.12"}
-  "cmdliner"
+  "cmdliner" {< "1.0.0"}
   "lazy-trie"
   "re"
   "ocamlgraph"

--- a/packages/git/git.1.2.0/opam
+++ b/packages/git/git.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "core_kernel" {>= "109.55.02" & < "v0.13"}
   "sha"
   "uri" {>= "1.3.12"}
-  "cmdliner"
+  "cmdliner" {< "1.0.0"}
   "re"
   "ocamlgraph"
   "lwt"


### PR DESCRIPTION
Fix:

```
 File "bin/ogit.ml", line 102, characters 19-23:
 Error: This expression has type
          ?docv:string ->
          (string -> ('a, [ `Msg of string ]) Result.result) *
          'a Cmdliner.Arg.printer -> 'a Cmdliner.Arg.conv
        but an expression was expected of type
          'b Cmdliner.Arg.conv =
            'b Cmdliner.Arg.parser * 'b Cmdliner.Arg.printer
 Command exited with code 2.
```