### PR TITLE
lazy-trie: add version constraint to ppx_sexp_conv

### DIFF
--- a/packages/lazy-trie/lazy-trie.1.2.0/opam
+++ b/packages/lazy-trie/lazy-trie.1.2.0/opam
@@ -9,7 +9,7 @@ build: [
 depends: [
   "ocaml" {>="4.03.0"}
   "sexplib"
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "dune" {build & >= "1.0"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-lazy-trie"


### PR DESCRIPTION
Fix:

```
 File "lib/dune", line 6, characters 2-21:
 6 |   (pps ppx_sexp_conv)))
       ^^^^^^^^^^^^^^^^^^^
 Error: No ppx driver were found.
 Hint: Try upgrading or reinstalling ppx_driver.
```