### PR TITLE
Patches to opam-publish released versions

### DIFF
--- a/packages/opam-publish/opam-publish.2.0.0/opam
+++ b/packages/opam-publish/opam-publish.2.0.0/opam
@@ -10,17 +10,18 @@ tags: "flags:plugin"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-core" {build & >= "2.0.0"}
   "opam-format" {build & >= "2.0.0"}
   "opam-state" {build & >= "2.0.0"}
-  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta19"}
   "cmdliner" {build}
   ("ssl" | "tls")
   ("github" {build & >= "2.0.0" & < "3.0.0"} |
    "github-unix" {build & >= "3.0.0"})
 ]
 build: ["jbuilder" "build" "-p" name]
-dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+dev-repo: "git+https://github.com/ocaml/opam-publish.git#2.0"
 synopsis: "A tool to ease contributions to opam repositories."
 description:
   "Opam-publish helps gather metadata to form an OPAM package and submit it to a remote repository."

--- a/packages/opam-publish/opam-publish.2.0.1/opam
+++ b/packages/opam-publish/opam-publish.2.0.1/opam
@@ -10,10 +10,11 @@ tags: "flags:plugin"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-core" {build & >= "2.0.0"}
   "opam-format" {build & >= "2.0.0"}
   "opam-state" {build & >= "2.0.0"}
-  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta19"}
   "cmdliner" {build}
   "lwt_ssl"
   ("ssl" {build & = "0.5.5"} | "tls")
@@ -22,6 +23,9 @@ depends: [
 ]
 build: ["jbuilder" "build" "-p" name]
 dev-repo: "git+https://github.com/ocaml/opam-publish.git#2.0"
+synopsis: "A tool to ease contributions to opam repositories."
+description:
+  "Opam-publish helps gather metadata to form an OPAM package and submit it to a remote repository."
 url {
   src: "https://github.com/ocaml/opam-publish/archive/2.0.1.tar.gz"
   checksum: [


### PR DESCRIPTION
While checking something else, I found that the latest versions of `opam-publish` were missing dependencies (not relevantly, obviously).

cc @rjbou, @AltGr - did the fields get lost because of the opam file in the main repo? This file used to have `flags: plugin` as well?