### PR TITLE
[new release] dune-release (1.2.0)

### DIFF
--- a/packages/dune-release/dune-release.1.2.0/opam
+++ b/packages/dune-release/dune-release.1.2.0/opam
@@ -8,11 +8,8 @@ bug-reports: "https://github.com/samoht/dune-release/issues"
 doc: "https://samoht.github.io/dune-release/"
 
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-]
-
-run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 

--- a/packages/dune-release/dune-release.1.2.0/opam
+++ b/packages/dune-release/dune-release.1.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire"]
+homepage: "https://github.com/samoht/dune-release"
+license: "ISC"
+dev-repo: "git+https://github.com/samoht/dune-release.git"
+bug-reports: "https://github.com/samoht/dune-release/issues"
+doc: "https://samoht.github.io/dune-release/"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "opam-format"
+  "opam-state"
+  "opam-core"
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+]
+
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com).
+"""
+url {
+  src:
+    "https://github.com/samoht/dune-release/releases/download/1.2.0/dune-release-1.2.0.tbz"
+  checksum: [
+    "sha256=aca8ed93a0cb471e1fb05c0d8a21bccac75b0cf3af500a4aa1a15cc787ab3cb8"
+    "sha512=078ec548796f33d5a004d49271db43db0a3fd4eae32ae3850c0e92a0ea6a5f9f3ec8104a65179386d9d9720941859fcaa8f64422a09e3b85069dd9f6d4cc935d"
+  ]
+}


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/samoht/dune-release">https://github.com/samoht/dune-release</a>
- Documentation: <a href="https://samoht.github.io/dune-release/">https://samoht.github.io/dune-release/</a>

##### CHANGES:

- Remove assert false in favor of error message. (samoht/dune-release#125, @ejgallego)
- Embed a 'version: "$release-version"' in each opam file of the current
  directory to get reproducible releases (samoht/dune-release#128, samoht/dune-release#129, @hannesm)
- Generate sha256 and sha512 checksums for release (samoht/dune-release#131, @hannesm)
- Grammar fixes (samoht/dune-release#132, @anmonteiro)
- Handle doc fields with no trailing slash (samoht/dune-release#133, @yomimono)
