### PR TITLE
Package satyrographos.0.0.1.6

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.1.6/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.6/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL3+"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "cmdliner"
+  "core" {< "v0.12"}
+  "dune" {build}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving"
+  "ppx_jane" {< "v0.12"}
+  "uri" {>= "2.0.0"}
+  "yojson"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.1.6.tar.gz"
+  checksum: [
+    "md5=09e78ceb85c43a757d59b4d773e58485"
+    "sha512=86d05d6a3a8d30249773e3d04cbb4e58a6b8524bc2592229515ab1c4ed3aaaf4d4b3f622ce4854dca64f440cf4a6dc4bd7a82ac31aa5b28899bd012851089393"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.1.6`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.0