### PR TITLE
[new release] xen-gnt-unix and xen-gnt (4.0.0)

### DIFF
--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "john.else@citrix.com"
+authors: [
+  "Anil Madhavapeddy"
+  "John Else"
+  "Thomas Leonard"
+  "Andrew Cooper"
+  "David Scott"
+]
+homepage: "https://github.com/mirage/ocaml-gnt"
+doc: "https://mirage.github.io/ocaml-gnt/"
+bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "xen-gnt"
+  "io-page-unix" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: [
+  ["xen-dev"] {os-distribution = "alpine"}
+  ["libxen-dev"] {os-distribution = "debian"}
+  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["xen-devel"] {os-distribution = "centos"}
+  ["xen-devel"] {os-distribution = "fedora"}
+  ["xenstore"] {os-distribution = "archlinux"}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-gnt.git"
+synopsis: "Xen grant table bindings for OCaml"
+description: """
+These are used to create Xen device driver "backends" (servers)
+and "frontends" (clients).
+
+This library can be used in both kernelspace (via Mirage) or in userspace
+(on Linux). To see a concrete example, have a look at [mirage/ocaml-vchan]
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gnt/releases/download/v4.0.0/xen-gnt-v4.0.0.tbz"
+  checksum: "md5=3d64522c82c663546ebb0904f52d7c05"
+}

--- a/packages/xen-gnt/xen-gnt.4.0.0/opam
+++ b/packages/xen-gnt/xen-gnt.4.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "john.else@citrix.com"
+authors: [
+  "Anil Madhavapeddy"
+  "John Else"
+  "Thomas Leonard"
+  "Andrew Cooper"
+  "David Scott"
+]
+homepage: "https://github.com/mirage/ocaml-gnt"
+doc: "https://mirage.github.io/ocaml-gnt/"
+bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "1.0.1"}
+  "io-page"
+  "lwt" {>= "2.4.3"}
+  "lwt-dllist"
+  "cmdliner"
+  "mirage-profile" {>= "0.3"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-gnt.git"
+synopsis: "Xen grant table bindings for OCaml"
+description: """
+These are used to create Xen device driver "backends" (servers)
+and "frontends" (clients).
+
+This library can be used in both kernelspace (via Mirage) or in userspace
+(on Linux) via the xen-gnt-unix library.
+To see a concrete example, have a look at [mirage/ocaml-vchan]
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gnt/releases/download/v4.0.0/xen-gnt-v4.0.0.tbz"
+  checksum: "md5=3d64522c82c663546ebb0904f52d7c05"
+}


### PR DESCRIPTION
Xen grant table bindings for OCaml

- Project page: <a href="https://github.com/mirage/ocaml-gnt">https://github.com/mirage/ocaml-gnt</a>
- Documentation: <a href="https://mirage.github.io/ocaml-gnt/">https://mirage.github.io/ocaml-gnt/</a>

##### CHANGES:

- Mark all unikernel-only APIs as deprecated. These functions
  fail at runtime if called from Unix. A newer low-level API
  is provided by mirage-xen. (mirage/ocaml-gnt#36, by @talex5)
