### PR TITLE
BAP 1.6 Release

### DIFF
--- a/packages/bap-abi/bap-abi.1.6.0/opam
+++ b/packages/bap-abi/bap-abi.1.6.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bap-abi"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-abi"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-abi"]
+         ["ocamlfind" "remove" "bap-abi"]
+         ["bapbundle" "remove" "abi.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "BAP ABI integration subsystem"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-api/bap-api.1.6.0/opam
+++ b/packages/bap-api/bap-api.1.6.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-api"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-api"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-api"]
+         ["ocamlfind" "remove" "bap-api"]
+         ["bapbundle" "remove" "api.plugin"]
+         ["rm" "-rf" "%{prefix}%/share/bap-api/c"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "A pass that adds parameters to subroutines based on known API"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-arm/bap-arm.1.6.0/opam
+++ b/packages/bap-arm/bap-arm.1.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-arm"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-arm"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-arm"]
+        ["ocamlfind" "remove" "bap-plugin-arm"]
+        ["bapbundle"   "remove" "arm.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-llvm"
+  "bap-abi"
+  "bap-c"
+]
+synopsis: "BAP ARM lifter and disassembler"
+description: """
+Provides semantics for ARM instructions, disassembler, and partial
+support for the gnueabi ABI"""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-beagle/bap-beagle.1.6.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-beagle"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-beagle"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
+         ["ocamlfind" "remove" "bap-beagle-prey"]
+         ["ocamlfind" "remove" "bap-plugin-strings"]
+         ["bapbundle" "remove" "beagle.plugin"]
+         ["bapbundle" "remove" "strings.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+  "bap-microx"
+  "bap-primus" {= "1.6.0"}
+]
+synopsis: "BAP obfuscated string solver"
+description: """
+Like strings on steroids - finds strings encoded in binaries,
+even if they are not truly static."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-bil/bap-bil.1.6.0/opam
+++ b/packages/bap-bil/bap-bil.1.6.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bap-bil"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bil"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-bil"]
+         ["bapbundle" "remove" "bil.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "Controls the BIL transformation pipeline"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.6.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-byteweight-frontend"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight-frontend"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-byteweight"
+  "cmdliner"
+  "ocurl"
+  "fileutils"
+  "re"
+]
+synopsis: "BAP Toolkit for training and controlling Byteweight algorithm"
+description: """
+A command line interface to the byteweight system that can train,
+test, download, and upload binary signatures."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-byteweight/bap-byteweight.1.6.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-byteweight"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-byteweight"]
+        ["ocamlfind" "remove" "bap-plugin-byteweight"]
+        [ "bapbundle" "remove" "byteweight.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-signatures"
+]
+synopsis: "BAP facility for indentifying code entry points"
+description: """
+Provides a library and a plugin that uses the Byteweigh algorithm for
+finding entry points (function strats) in stripped code."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-c/bap-c.1.6.0/opam
+++ b/packages/bap-c/bap-c.1.6.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bap-c"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-c"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-c"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-api"
+]
+synopsis: "A C language support library for BAP"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-cache/bap-cache.1.6.0/opam
+++ b/packages/bap-cache/bap-cache.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-cache"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-cache"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cache"]
+        [ "bapbundle" "remove" "cache.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "BAP caching service"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-callsites/bap-callsites.1.6.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-callsites"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-callsites"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-callsites"]
+        [ "bapbundle" "remove" "callsites.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "Inject data definition terms at callsites"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-constant-tracker/bap-constant-tracker.1.6.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.1.6.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-constant-tracker"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-constant-tracker"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-costant_tracker"]
+         ["bapbundle" "remove" "constant_tracker.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+]
+synopsis: "Constant Tracking Analysis based on Primus"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.6.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-cxxfilt"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-cxxfilt"
+                 "--cxxfilt-targets=%{conf-binutils:targets}%"
+                 "--cxxfilt-path=%{conf-binutils:cxxfilt}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cxxfilt"]
+        ["bapbundle" "remove" "cxxfilt.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-demangle"
+  "conf-binutils" {>= "0.2"}
+]
+synopsis: "A demangler that relies on a c++filt utility"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-demangle/bap-demangle.1.6.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-demangle"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-demangle"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-demangle"]
+        ["ocamlfind" "remove" "bap-plugin-demangle"]
+        ["bapbundle"   "remove" "demangle.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "Library for name demangling"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.6.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-dump-symbols"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dump-symbols"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-dump_symbols"]
+        ["bapbundle" "remove" "dump_symbols.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "BAP plugin that dumps symbols information from a binary"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-dwarf/bap-dwarf.1.6.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.1.6.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "bap-dwarf"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dwarf"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-dwarf"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+]
+synopsis: "BAP DWARF parsing library"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-elf/bap-elf.1.6.0/opam
+++ b/packages/bap-elf/bap-elf.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-elf"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-elf"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-elf"]
+        ["ocamlfind" "remove" "bap-plugin-elf_loader"]
+        ["bapbundle" "remove" "elf_loader.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-dwarf"
+  "bitstring" {>= "3.0.0"}
+]
+synopsis: "BAP ELF parser and loader written in native OCaml"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-frames/bap-frames.2.1.2/opam
+++ b/packages/bap-frames/bap-frames.2.1.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+name: "bap-frames"
+version: "2.1.2"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-frames"]
+        [ "ocamlfind" "remove" "bap-frames"]
+        [ "ocamlfind" "remove" "bfd"]
+        [ "bapbundle" "remove" "frames.plugin"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/*.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/exceptionframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/frame.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/keyframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/metaframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/modloadframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/stdframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/syscallframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/taintintroframe.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap-frames/types.piqi"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "bap-std" {>= "1.6.0"}
+  "bap-traces" {>= "1.6.0"}
+  "piqi" {>= "0.7.4"}
+]
+synopsis: "A data format for storing execution traces"
+url {
+  src:
+    "https://github.com/BinaryAnalysisPlatform/bap-frames/archive/v2.1.2.tar.gz"
+  checksum: "md5=4b443b65366933c7cf7c7f5d0da0039d"
+}

--- a/packages/bap-frontc/bap-frontc.1.6.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.6.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bap-frontc"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-frontc-parser"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
+        ["bapbundle" "remove" "frontc_parser.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-c"
+  "FrontC"
+]
+synopsis: "A C language frontend for based on FrontC library"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-frontend/bap-frontend.1.6.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-frontend"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-frontend"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+  "parsexp" {>= "v0.11" & < "v0.12"}
+]
+synopsis: "BAP frontend"
+description: "The command-line interface to the Binary Analysis Platform."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.6.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-fsi-benchmark"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-fsi-benchmark"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-ida"
+  "bap-byteweight-frontend"
+  "cmdliner"
+  "fileutils"
+  "re"
+]
+synopsis: "BAP function start identification benchmark game"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-future/bap-future.1.6.0/opam
+++ b/packages/bap-future/bap-future.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-future"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-future"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-future"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "monads"
+]
+synopsis: "A library for asynchronous values"
+description: """
+A library for reasoning about state based dynamic systems. This can
+be seen as a common denominator between Lwt and Async libraries."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.6.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.6.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-ida-plugin"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ida-plugin"]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-emit_ida_script"]
+        [ "bapbundle" "remove" "emit_ida_script.plugin"]
+
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap"
+  "cmdliner"
+]
+synopsis: "Plugins for IDA and BAP integration"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-ida-python/bap-ida-python.1.6.0/files/bap.cfg.in
+++ b/packages/bap-ida-python/bap-ida-python.1.6.0/files/bap.cfg.in
@@ -1,0 +1,2 @@
+.default
+bap_executable_path    %{bap:bin}%/bap

--- a/packages/bap-ida-python/bap-ida-python.1.6.0/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "bap-ida-python"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+license: "MIT"
+substs: [
+    "bap.cfg"
+]
+install: [
+    ["mkdir" "-p" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-v"  "plugins/plugin_loader_bap.py" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-rv" "plugins/bap" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-v"  "bap.cfg" "%{prefix}%/share/%{name}%/"]
+]
+remove: [
+    ["rm" "-rf" "%{prefix}%/share/%{name}%/"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap" {= "1.6.0"}
+  "conf-ida"
+]
+synopsis: "A BAP - IDA Pro integration library"
+flags: light-uninstall
+extra-files: ["bap.cfg.in" "md5=aec3a830555380469b523da74daef069"]
+url {
+src:
+    "https://github.com/BinaryAnalysisPlatform/bap-ida-python/archive/v1.6.0.tar.gz"
+checksum: "md5=df4822bfe901a5fb85a6328b2f4fccab"
+}
+
+post-messages: [
+  "In order to install bap-ida-python plugin:
+    $: rm -rf %{conf-ida:path}%/plugins/bap/
+    $: cp %{prefix}%/share/%{name}%/plugin_loader_bap.py %{conf-ida:path}%/plugins/
+    $: cp -r %{prefix}%/share/%{name}%/bap %{conf-ida:path}%/plugins/
+    $: cp %{prefix}%/share/%{name}%/bap.cfg %{conf-ida:path}%/cfg/
+ "
+]

--- a/packages/bap-ida/bap-ida.1.6.0/opam
+++ b/packages/bap-ida/bap-ida.1.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-ida"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+     "--prefix=%{prefix}%"
+     "--enable-ida"
+     "--ida-path=%{conf-ida:path}%"
+     "--ida-headless=%{conf-ida:headless}%"
+]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-ida"]
+        ["ocamlfind" "remove" "bap-plugin-ida"]
+        ["bapbundle" "remove" "ida.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "conf-ida"
+  "bap-ida-python" {>= "1.5.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "fileutils"
+  "re"
+  "bap-ida-plugin"
+]
+synopsis: "An IDA Pro integration library"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-llvm/bap-llvm.1.6.0/files/detect.travis
+++ b/packages/bap-llvm/bap-llvm.1.6.0/files/detect.travis
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > bap-llvm.config <<EOF
+ travis : ${TRAVIS:-false}
+EOF

--- a/packages/bap-llvm/bap-llvm.1.6.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.6.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+name: "bap-llvm"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+  "--prefix=%{prefix}%"
+  "--with-cxx=`which clang++`"
+  "--with-llvm-version=%{conf-bap-llvm:package-version}%"
+  "--with-llvm-config=%{conf-bap-llvm:config}%"
+  "--enable-llvm"]
+  [make]
+  ]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-llvm"]
+  ["ocamlfind" "remove" "bap-llvm"]
+  ["bapbundle" "remove" "llvm.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+  "conf-env-travis"
+  "conf-bap-llvm" {>= "1.1"}
+  "ogre"
+  "monads"
+]
+depexts: [
+  ["clang"] {os-distribution = "ubuntu"}
+  ["clang"] {os-distribution = "debian"}
+]
+synopsis: "BAP LLVM backend"
+description:
+  "Provides a loader and a disassembler, based on LLVM-MC library."
+extra-files: ["detect.travis" "md5=00e7b28719062d550dcd7813becf7396"]
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-mc/bap-mc.1.6.0/opam
+++ b/packages/bap-mc/bap-mc.1.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-mc"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-mc"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap-mc"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "BAP machine instruction playground"
+description: "A BAP version of llvm-mc tool."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-microx/bap-microx.1.6.0/opam
+++ b/packages/bap-microx/bap-microx.1.6.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "bap-microx"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-microx"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-microx"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+]
+synopsis: "A micro execution framework"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-mips/bap-mips.1.6.0/opam
+++ b/packages/bap-mips/bap-mips.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-mips"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-mips"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-mips"]
+         ["bapbundle" "remove" "mips.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-abi"
+  "bap-c"
+]
+synopsis: "BAP MIPS lifter"
+description: "Provides lifter for MIPS and MIPS32 architectures"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-objdump/bap-objdump.1.6.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-objdump"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-objdump"
+                 "--objdump-targets=%{conf-binutils:targets}%"
+                 "--objdump-path=%{conf-binutils:objdump}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
+	 ["bapbundle" "remove" "objdump.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "re"
+  "cmdliner"
+  "conf-binutils"
+]
+synopsis: "Extract symbols from binary, using binutils objdump"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-optimization/bap-optimization.1.6.0/opam
+++ b/packages/bap-optimization/bap-optimization.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-optimization"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-optimization"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-optimization"]
+         ["bapbundle" "remove" "optimization.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "A BAP plugin that removes dead IR code"
+description: """
+A pass that conservatively removes dead code in the generated IR. The
+removed dead code is usually produced by a lifter, though it might be
+possible that a binary indeed contains a dead code. The algorithm
+doesn't remove variables that are stored in memory, only registers are
+considered."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-phoenix/bap-phoenix.1.6.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "bap-phoenix"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-phoenix"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-phoenix"]
+        ["bapbundle" "remove" "phoenix.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+  "text-tags"
+  "ocamlgraph"
+  "ezjsonm"
+]
+synopsis: "BAP plugin that dumps information in a phoenix decompiler format"
+description: "Useful for visualization and project exploration"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-piqi/bap-piqi.1.6.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+name: "bap-piqi"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-piqi"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-piqi_printers"]
+        [ "ocamlfind" "remove" "bap-piqi"]
+        [ "bapbundle" "remove" "piqi_printers.plugin"]
+        [ "rm" "-f" "%{prefix}%/share/bap/exp.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/ir.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/stmt.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/type.piqi"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+  "piqi" {>= "0.7.4"}
+]
+synopsis: "BAP plugin for serialization based on piqi library"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-powerpc/bap-powerpc.1.6.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-powerpc"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-powerpc"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
+         ["bapbundle" "remove" "powerpc.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-abi"
+  "bap-c"
+  "bap-primus" {= "1.6.0"}
+  "zarith"
+]
+synopsis: "BAP PowerPC lifter"
+description: "Provides support for PPC and PPC64 architectures."
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.1.6.0/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.1.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-primus-dictionary"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-dictionary"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_dictionary"]
+        ["bapbundle" "remove" "primus_dictionary.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+]
+synopsis: "BAP Primus Lisp library that provides dictionaries"
+description: """
+Provides a key-value storage for Primus Lisp programs.  Dictionaries
+are represented with symbols and it is a responsibility of user to
+prevent name clashing between different dictionaries."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-primus-lisp/bap-primus-lisp.1.6.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.1.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-primus-lisp"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-lisp"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_lisp"]
+        ["bapbundle" "remove" "primus_lisp.plugin"]
+        ["rm" "-rf" "%{prefix}%/share/primus/site-lisp"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+]
+synopsis: "BAP Primus Lisp Runtime"
+description: """
+The default (and the only one so far) Primus Lisp runtime. The plugin
+provides Lisp primitives for manipulation program state, loads user
+specified libraries, and integrates Primus Lisp with BAP universe."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-primus-region/bap-primus-region.1.6.0/opam
+++ b/packages/bap-primus-region/bap-primus-region.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-primus-region"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-region"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_region"]
+        ["bapbundle" "remove" "primus_region.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+]
+synopsis:
+  "Provides a set of operations to store and manipulate interval trees"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-primus-support/bap-primus-support.1.6.0/opam
+++ b/packages/bap-primus-support/bap-primus-support.1.6.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+name: "bap-primus-support"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-support"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_exploring"]
+        ["ocamlfind" "remove" "bap-plugin-primus_greedy"]
+        ["ocamlfind" "remove" "bap-plugin-primus_limit"]
+        ["ocamlfind" "remove" "bap-plugin-primus_loader"]
+        ["ocamlfind" "remove" "bap-plugin-primus_mark_visited"]
+        ["ocamlfind" "remove" "bap-plugin-primus_print"]
+        ["ocamlfind" "remove" "bap-plugin-primus_promiscuous"]
+        ["ocamlfind" "remove" "bap-plugin-primus_round_robin"]
+        ["ocamlfind" "remove" "bap-plugin-primus_wandering"]
+        ["bapbundle" "remove" "primus_exploring.plugin"]
+        ["bapbundle" "remove" "primus_greedy.plugin"]
+        ["bapbundle" "remove" "primus_limit.plugin"]
+        ["bapbundle" "remove" "primus_loader.plugin"]
+        ["bapbundle" "remove" "primus_mark_visited.plugin"]
+        ["bapbundle" "remove" "primus_print.plugin"]
+        ["bapbundle" "remove" "primus_promiscuous.plugin"]
+        ["bapbundle" "remove" "primus_round_robin.plugin"]
+        ["bapbundle" "remove" "primus_wandering.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+  "bare"
+]
+synopsis: "Provides supporting components for Primus"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-primus-test/bap-primus-test.1.6.0/opam
+++ b/packages/bap-primus-test/bap-primus-test.1.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "bap-primus-test"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-test"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_test"]
+        ["bapbundle" "remove" "primus_test.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+]
+synopsis: "BAP Primus Testing and Program Verification module"
+description: """
+With Primus Test Framework program analysis could be implemented as a
+set of simple tests written in Primus Lisp language. The framework
+provides an unified incident reporting facility for generalized
+problem reporting. The framework comes with a couple of analysis on
+board as a showcase.
+
+Memcheck - a memory checker that detects vioalations of memory
+management discipline, such as use-after-free, double free, and
+corrupted free.
+
+Check Returned Value - verifies that a program is addressing all
+possible outcomes of certain API calls, e.g., checks return values,
+error codes, etc."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-primus-x86/bap-primus-x86.1.6.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-primus-x86"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_x86"]
+        ["bapbundle" "remove" "primus_x86.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+  "bap-x86"
+]
+synopsis: "The x86 CPU support package for BAP Primus CPU emulator"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-primus/bap-primus.1.6.0/opam
+++ b/packages/bap-primus/bap-primus.1.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+name: "bap-primus"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-primus"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-abi"
+  "bap-c"
+  "bap-future"
+  "bap-strings"
+  "monads"
+  "uuidm"
+  "graphlib" {> "1.3.0"}
+  "parsexp"  {>= "v0.11" & < "v0.12"}
+]
+synopsis: "The BAP Microexecution Framework"
+description: """
+BAP Primus is a Microexecutuin Framework. The Microexecution technique
+was pioneered by Patrice Godefroid from Microsoft Research. The idea
+is to execute a binary from any point, using random inputs for
+undefined values.
+
+The idea of Primus is very similiar. A program is lifted into the
+Intermediate Representation, that is interpreted using the Primus
+interpreter. The Framework allows users to customize the interpreter
+by implementing different machine components."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-print/bap-print.1.6.0/opam
+++ b/packages/bap-print/bap-print.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-print"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-print"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-print"]
+        ["bapbundle" "remove" "print.plugin"]
+
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-demangle"
+  "text-tags"
+]
+synopsis: "Print plugin - print project in various formats"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-relocatable/bap-relocatable.1.6.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-relocatable"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-relocatable"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-relocatable"]
+        ["bapbundle" "remove" "relocatable.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "ogre"
+]
+synopsis:
+  "Provides a brancher service for BAP that handles certain relocations"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-report/bap-report.1.6.0/opam
+++ b/packages/bap-report/bap-report.1.6.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bap-report"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-report"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-report"]
+         ["bapbundle" "remove" "report.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+]
+synopsis: "A BAP plugin that reports program status"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-run/bap-run.1.6.0/opam
+++ b/packages/bap-run/bap-run.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-run"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-run"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-run"]
+        ["bapbundle" "remove" "run.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+]
+synopsis: "A BAP plugin that executes a binary"
+description: "Uses the Primus Microexecution Framework to execute a binary."
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-saluki/bap-saluki.bap-1.6/opam
+++ b/packages/bap-saluki/bap-saluki.bap-1.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-saluki"
+version: "bap-1.6"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-plugins/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-plugins/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-plugins/"
+license: "MIT"
+
+build   : [make "-C" "saluki" "build"]
+install : [make "-C" "saluki" "install"]
+remove  : ["bapbundle" "remove" "saluki.plugin"]
+depends: [
+  "ocaml"
+  "bap-std"  {>= "1.6.0"}
+  "bap-callsites"
+  "bap-taint-propagator"
+]
+synopsis:
+  "A verification framework for detecting vulnerability patterns in binaries"
+description: """
+Saluki framework allows users to easily specify properties for de-
+tecting taint-style vulnerabilities automatically, drastically
+reducing the need for manual auditing of binaries. Prop- erties are
+formally verified over a program model which abstracts the concrete
+program."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap-plugins/archive/bap-1.6.tar.gz"
+  checksum: "md5=cde0acbbabfa8f8d9bf670c731434ebe"
+}

--- a/packages/bap-server/bap-server.0.3.0/opam
+++ b/packages/bap-server/bap-server.0.3.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+name: "bap-server"
+version: "0.3.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-server/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-server/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-server/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap-server"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core-lwt"
+  "regular"
+  "bap"
+  "cohttp" {>= "1.0.0" & < "2.0.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ezjsonm" {= "0.5.0"}
+  "lwt" {>= "4.0.0" & < "5.0.0"}
+  "lwt_log"
+  "oasis" {build & >= "0.4.7"}
+  "re"
+  "uri" {>= "2.0.0"}
+]
+conflicts: [
+    "tls" {< "0.7.1"}
+    "nocrypto" {< "0.5.3"}
+]
+
+synopsis: "BAP RPC server"
+description:
+  "Provides a small subset of BAP functionality via a JSON RPC server."
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/BinaryAnalysisPlatform/bap-server/archive/v0.3.0.tar.gz"
+  checksum: "md5=0fa424148d6802fdc151b76499833071"
+}

--- a/packages/bap-signatures/bap-signatures.1.6.0/opam
+++ b/packages/bap-signatures/bap-signatures.1.6.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+name: "bap-signatures"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+install: [
+  ["mkdir" "-p" "%{share}%/bap/"]
+  ["cp" "sigs.zip" "%{share}%/bap/sigs.zip"]
+]
+
+remove: [["rm" "%{share}%/bap/sigs.zip"]]
+synopsis: "A data package with binary signatures for bap"
+description: "A package contains signatures for Byteweight algorithm."
+depends: ["ocaml"]
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v1.6.0/sigs.tar.gz"
+  checksum: "md5=1099975bb3473f001f6d7b0dbda8b14a"
+}

--- a/packages/bap-ssa/bap-ssa.1.6.0/opam
+++ b/packages/bap-ssa/bap-ssa.1.6.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "bap-ssa"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ssa"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-ssa"]
+         ["bapbundle" "remove" "ssa.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+]
+synopsis: "A BAP plugin, that translates a program into the SSA form"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-std/bap-std.1.6.0/opam
+++ b/packages/bap-std/bap-std.1.6.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+name: "bap-std"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--with-cxx=`which clang++`"
+                 "--mandir=%{man}%"
+                 "--enable-bap-std"]
+  [make]
+]
+
+install: [
+  [make "reinstall"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap"]
+  ["ocamlfind" "remove" "bap-build"]
+  ["rm" "-f" "%{bin}%/baptop"]
+  ["rm" "-f" "%{bin}%/ppx-bap"]
+  ["rm" "-f" "%{bin}%/bapbuild"]
+  ["rm" "-f" "%{bin}%/bapbundle"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "base-unix"
+  "bap-future"
+  "camlzip" {>= "1.07"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "bin_prot" {>= "v0.11" & < "v0.12"}
+  "fileutils"
+  "graphlib"
+  "oasis" {build & >= "0.4.7"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "regular"
+  "uri"
+  "utop" {build & >= "2.0.0"}
+  "uuidm"
+  "zarith"
+  "cmdliner" {>= "0.9.8"}
+  "ogre"
+  "monads"
+]
+depexts: [
+  ["libgmp-dev" "libzip-dev" "clang"] {os-distribution = "ubuntu"}
+  ["gmp" "libzip"] {os = "macos" & os-distribution = "macports"}
+  ["clang"] {os-distribution = "debian"}
+]
+conflicts: [
+  "fileutils" {= "0.5.0"}
+  "jbuilder" {= "1.0+beta18"}
+]
+synopsis: "The Binary Analysis Platform Standard Library"
+description: "Provides the main BAP library."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-strings/bap-strings.1.6.0/opam
+++ b/packages/bap-strings/bap-strings.1.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "bap-strings"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-strings"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-strings"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "Text utilities useful in Binary Analysis and Reverse Engineering"
+description: """
+The library provides several algorithms:
+
+- Detector - that uses a maximum aposteriori likelihood estimator
+  (MAP) to detect code that operates with textual data (aka Bayesian
+  inference).
+
+- Unscrambler - that is capable of finding all possible words, that
+  can be built from a bag of letters in O(1).
+
+- Scanner - a generic algorithm for finding strings of characters (a
+  library variant of strings tool)"""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.6.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-symbol-reader"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-symbol-reader"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-read_symbols"]
+        [ "bapbundle" "remove" "read_symbols.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "BAP plugin that reads symbol information from files"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.6.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.6.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bap-taint-propagator"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-propagate-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
+         ["bapbundle" "remove" "propagate_taint.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+  "bap-microx"
+]
+synopsis: "BAP Taint propagation engine using based on microexecution"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-taint/bap-taint.1.6.0/opam
+++ b/packages/bap-taint/bap-taint.1.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-taint"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-taint"]
+  ["ocamlfind" "remove" "bap-plugin-taint"]
+  ["ocamlfind" "remove" "bap-plugin-primus_propagate_taint"]
+  ["ocamlfind" "remove" "bap-plugin-primus_taint"]
+  ["bapbundle" "remove" "taint.plugin"]
+  ["bapbundle" "remove" "primus_propagate_taint.plugin"]
+  ["bapbundle" "remove" "primus_taint.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+]
+synopsis: "BAP Taint Analysis Framework"
+description: """
+Provides a generic library for handling program taints, and plugins
+that integrate existing and new taint analysis tools with the new
+framework."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-term-mapper/bap-term-mapper.1.6.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-term-mapper"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-map-terms"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
+         [ "ocamlfind" "remove" "bap-bml"]
+         [ "bapbundle" "remove" "map_terms.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis: "A BAP DSL for mapping program terms"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-trace/bap-trace.1.6.0/opam
+++ b/packages/bap-trace/bap-trace.1.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-trace"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-trace"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-trace"]
+        ["bapbundle" "remove" "trace.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "bap-traces"
+  "cmdliner"
+]
+synopsis: "A plugin to load and run program execution traces"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-traces/bap-traces.1.6.0/opam
+++ b/packages/bap-traces/bap-traces.1.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-traces"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-traces"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-traces"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "uri" {>= "1.9.0"}
+  "uuidm"
+]
+synopsis: "BAP Library for loading and parsing execution traces"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.6.0/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-trivial-condition-form"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-trivial-condition-form"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-trivial_condition_form"]
+         ["bapbundle" "remove" "trivial_condition_form.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+]
+synopsis: "Eliminates complex conditionals in branches"
+description: """
+Ensures that all branching conditions are either a variable
+or a constant. We call such representation a Trivial Condition Form
+(TCF). During the translation all complex condition expressions are
+hoisted into the assignemnt section of a block."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-veri/bap-veri.0.2.3/opam
+++ b/packages/bap-veri/bap-veri.0.2.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "bap-veri"
+version: "0.2.3"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-veri/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-veri/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-veri/"
+license: "MIT"
+
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+  ["ocamlfind" "remove" "bap-veri"]
+  ["rm" "-f" "%{bin}%/bap-veri"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {>= "1.6.0"}
+  "bap-traces"
+  "cmdliner"
+  "oasis" {build}
+  "ounit"
+  "pcre"
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "textutils"   {>= "v0.11" & < "v0.12"}
+  "uri"
+]
+synopsis: "BAP Instruction Semantics Verification Tool"
+description: """
+Verifies that our understaning of instruction semantics is correct, or
+at least the same as in QEMU by checking if our execution bisimulates
+the QEMU."""
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/BinaryAnalysisPlatform/bap-veri/archive/v0.2.3.tar.gz"
+  checksum: "md5=161cae153274c7f8522feb886352f1d2"
+}

--- a/packages/bap-warn-unused/bap-warn-unused.1.6.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-warn-unused"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-warn-unused"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
+        ["bapbundle" "remove" "warn_unused.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "1.6.0"}
+  "cmdliner"
+]
+synopsis:
+  "Emit a warning if an unused result may cause a bug or security issue"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap-x86/bap-x86.1.6.0/opam
+++ b/packages/bap-x86/bap-x86.1.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-x86"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-x86-cpu"]
+        ["ocamlfind" "remove" "bap-plugin-x86"]
+        ["bapbundle" "remove" "x86.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-abi"
+  "bap-c"
+  "bap-llvm"
+  "cmdliner"
+]
+synopsis: "BAP x86 lifter"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bap/bap.1.6.0/opam
+++ b/packages/bap/bap.1.6.0/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+name: "bap"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-abi" {= "1.6.0"}
+  "bap-api" {= "1.6.0"}
+  "bap-arm" {= "1.6.0"}
+  "bap-beagle" {= "1.6.0"}
+  "bap-bil" {= "1.6.0"}
+  "bap-byteweight" {= "1.6.0"}
+  "bap-c" {= "1.6.0"}
+  "bap-cache" {= "1.6.0"}
+  "bap-cxxfilt" {= "1.6.0"}
+  "bap-callsites" {= "1.6.0"}
+  "bap-constant-tracker" {= "1.6.0"}
+  "bap-demangle" {= "1.6.0"}
+  "bap-dump-symbols" {= "1.6.0"}
+  "bap-elf" {= "1.6.0"}
+  "bap-frontend" {= "1.6.0"}
+  "bap-frontc" {= "1.6.0"}
+  "bap-llvm" {= "1.6.0"}
+  "bap-mc" {= "1.6.0"}
+  "bap-microx" {= "1.6.0"}
+  "bap-mips" {= "1.6.0"}
+  "bap-objdump" {= "1.6.0"}
+  "bap-optimization" {= "1.6.0"}
+  "bap-powerpc" {= "1.6.0"}
+  "bap-primus" {= "1.6.0"}
+  "bap-primus-dictionary" {= "1.6.0"}
+  "bap-primus-lisp" {= "1.6.0"}
+  "bap-primus-region" {= "1.6.0"}
+  "bap-primus-support" {= "1.6.0"}
+  "bap-primus-test" {= "1.6.0"}
+  "bap-primus-x86" {= "1.6.0"}
+  "bap-print" {= "1.6.0"}
+  "bap-relocatable" {= "1.6.0"}
+  "bap-report" {= "1.6.0"}
+  "bap-run" {= "1.6.0"}
+  "bap-ssa" {= "1.6.0"}
+  "bap-std" {= "1.6.0"}
+  "bap-strings" {= "1.6.0"}
+  "bap-symbol-reader" {= "1.6.0"}
+  "bap-taint" {= "1.6.0"}
+  "bap-taint-propagator" {= "1.6.0"}
+  "bap-term-mapper" {= "1.6.0"}
+  "bap-trace" {= "1.6.0"}
+  "bap-traces" {= "1.6.0"}
+  "bap-trivial-condition-form" {= "1.6.0"}
+  "bap-warn-unused" {= "1.6.0"}
+  "bap-x86" {= "1.6.0"}
+  "bap-emacs-goodies"
+]
+synopsis: "Binary Analysis Platform"
+description: """
+The Carnegie Mellon University Binary Analysis Platform (CMU BAP) is a
+reverse engineering and program analysis platform that works with
+binary code and doesn't require the source code. BAP supports multiple
+architectures: ARM, x86, x86-64, PowerPC, and MIPS. BAP disassembles
+and lifts binary code into the RISC-like BAP Instruction Language
+(BIL). Program analysis is performed using the BIL representation and
+is architecture independent in a sense that it will work equally well
+for all supported architectures. The main purpose of BAP is to provide
+a toolkit for implementing automated program analysis. BAP is written
+in OCaml and it is the preferred language to write analysis, but we
+have bindings to C, Python and Rust. The Primus Framework also provide
+a Lisp-like DSL for writing program analysis tools.
+
+This is a meta package that installs essential parts of BAP."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/bare/bare.1.6.0/opam
+++ b/packages/bare/bare.1.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bare"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bare"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bare"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build}
+  "parsexp" {>= "v0.11" & < "v0.12"}
+]
+synopsis: "BAP Rule Engine Library"
+description: """
+BARE is a library that provides non-linear pattern matching on streams
+of facts that are represented as s-expressions. We use BARE, in particular,
+to process Primus observations. Since Primus components use observations to
+convey their knowledge downstream it is very convenient to be able to query
+and join observations through the stream. In a sense, BARE could be seen as
+SQL select/join for streams."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.4/files/find-llvm.ml.in
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.4/files/find-llvm.ml.in
@@ -1,0 +1,148 @@
+#load "unix.cma"
+
+open Printf
+
+let read_all ch =
+  let buf = Buffer.create 16 in
+  let rec loop () =
+    match input_char ch with
+    | ch -> Buffer.add_char buf ch; loop ()
+    | exception End_of_file -> String.trim (Buffer.contents buf) in
+  loop ()
+
+exception Command_failed of Unix.process_status
+
+let process_status_to_string s =
+  let open Unix in
+  match s with
+  | WEXITED i -> sprintf "exit status %d" 1
+  | WSTOPPED i -> sprintf "proccess was stopped by signal %d" i
+  | WSIGNALED i -> sprintf "proccess was killed by signal %d" i
+
+let exn_to_string = function
+  | Command_failed s -> sprintf "%s" (process_status_to_string s)
+  | e -> Printexc.to_string e
+
+let cmd fmt =
+  let run c =
+    try
+      let inp = Unix.open_process_in c in
+      let res = read_all inp in
+      match Unix.close_process_in inp with
+      | Unix.WEXITED 0 -> Some res
+      | s -> raise (Command_failed s)
+    with e ->
+      eprintf "command %s failed: %s\n" c (exn_to_string e);
+      None in
+  ksprintf run fmt
+
+let of_opam_config () =
+  let cfg = "%{llvm-config}%" in
+  if cfg = "" then None
+  else Some cfg
+
+let of_env () =
+  try Some (Sys.getenv "LLVM_CONFIG")
+  with Not_found -> None
+
+let write path version =
+  let digest = Digest.to_hex (Digest.file path) in
+  let oc = open_out "%{_:name}%.config" in
+  fprintf oc {|
+opam-version: "2.0"
+file-depends: [ [ %S %S ] ]
+variables {
+  config: %S
+  package-version: "%s"
+}
+|} path digest path version;
+  close_out oc
+
+let (/) = Filename.concat
+
+let normalize ver =
+  let ver =
+    if String.length ver >= 3 then
+      String.sub ver 0 3
+    else ver in
+  if ver > "3.8" then String.sub ver 0 1
+  else ver
+
+let brew_config ver =
+  match cmd "brew --cellar" with
+  | None -> None
+  | Some cellar ->
+    match cmd "ls %s | grep %s" cellar (normalize ver) with
+    | None -> None
+    | Some p ->
+      cmd "find %s/%s -name \"llvm-config\"" cellar p
+
+let macports_config ver = sprintf "llvm-config-mp-%s" ver
+
+let index_opt str c =
+  try Some (String.index str '.')
+  with Not_found -> None
+
+let configs ver =
+  let ver' = match index_opt ver '.' with
+    | None -> ver
+    | Some i -> String.sub ver 0 i ^ String.sub ver (i + 1) 1 in
+  let configs = [
+    sprintf "llvm-config-%s" ver;
+    sprintf "llvm-config-%s" ver';
+    "llvm-config";
+  ] in
+  match "%{os}%" with
+  | "macos" ->
+    let configs = match brew_config ver with
+      | None -> configs
+      | Some b -> b :: configs in
+    macports_config ver :: configs
+  | _ -> configs
+
+let find_opt ~f xs =
+  try Some (List.find f xs)
+  with Not_found -> None
+
+let versions_equal v v' =
+  String.equal (normalize v) (normalize v')
+
+let locate () =
+  let versions = ["8.0"; "7.0"; "6.0"; "5.0"; "4.0"; "3.8"; "3.4"] in
+  List.fold_left (fun cfg ver ->
+      match cfg with
+      | Some _ -> cfg
+      | None ->
+        let configs = configs ver in
+        find_opt (fun cfg ->
+            match cmd "which %s" cfg with
+            | None -> false
+            | Some cfg ->
+              match cmd "%s --version" cfg with
+              | None -> false
+              | Some ver' ->
+                List.exists (versions_equal ver') versions) configs)
+    None versions
+
+let rec find_map fs =
+  match fs with
+  | [] -> None
+  | f :: fs ->
+    match f () with
+    | None -> find_map fs
+    | x -> x
+
+let () =
+  try
+    let path = match find_map [of_opam_config; of_env; locate] with
+      | Some cfg -> cmd "which %s" cfg
+      | None -> None in
+    match path with
+    | None -> eprintf "LLVM not found"; exit 1
+    | Some path ->
+      match cmd "%s --version" path with
+      | None -> eprintf "'%s --version' failed\n" path; exit 1
+      | Some version -> write path version
+  with e ->
+    eprintf "build failed: %s\n" (Printexc.to_string e);
+    exit 1

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.4/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+version: "1.4"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+homepage: "http://llvm.org"
+authors: "The LLVM Team"
+bug-reports: "https://llvm.org/bugs/"
+license: "BSD"
+build: [
+  ["ocaml" "find-llvm.ml"]
+]
+depends: [
+  "ocaml"
+  "base-unix"
+  "conf-which" {build}
+]
+depexts: [
+
+  # debian
+  ["llvm-4.0-dev"] {os-distribution = "debian"}
+
+  # ubuntu
+  ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty
+  ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "16.04"} #xenial
+  ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "18.04"} #bionic
+  ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "18.10"}
+
+  # fedora
+  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+
+  # macos
+  ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}
+  ["llvm@6"]   {os = "macos" & os-distribution = "homebrew"}
+]
+
+substs: [ "find-llvm.ml" ]
+flags: [ conf ]
+
+synopsis: "Checks that supported version of LLVM is installed"
+description: """
+Supported LLVM versions are: 3.4 3.8 4.0 5.0 6.0 7.0 8.0
+
+A preferred llvm-config can be choosen by setting opam config variable:
+$: opam config set llvm-config your-llvm-config
+OR by setting LLVM_CONFIG environment variable.
+"""

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -62,7 +62,17 @@ let string_of_targets targets =
   List.fold_left (fun acc x ->
       sprintf "%s\"%s\"; " acc x) "[" targets ^ "]"
 
+let is_none = function
+  | None -> true
+  | _ -> false
+
+let failed_to_find cmd =
+  eprintf "%s not found\n" cmd;
+  exit 1
+
 let write objdump cxxfilt targets =
+  if is_none objdump then failed_to_find "objdump";
+  if is_none cxxfilt then failed_to_find "cxxfilt";
   let digest path = Digest.to_hex (Digest.file path) in
   let depends = function
     | None -> ""

--- a/packages/conf-ida/conf-ida.0.2/files/find-ida.ml.in
+++ b/packages/conf-ida/conf-ida.0.2/files/find-ida.ml.in
@@ -1,0 +1,173 @@
+#load "unix.cma"
+
+open Printf
+
+type sys =
+  | MacOs
+  | Linux
+  | Other of string
+
+let os = match "linux" with
+  | "macos" -> MacOs
+  | "linux" -> Linux
+  | s -> Other s
+
+let (/) = Filename.concat
+
+let getenv_opt var =
+  try Some (Sys.getenv var)
+  with Not_found -> None
+
+let headless = os = Linux && getenv_opt "DISPLAY" = None
+
+let read_all ch =
+  let buf = Buffer.create 16 in
+  let rec loop () =
+    match input_char ch with
+    | ch -> Buffer.add_char buf ch; loop ()
+    | exception End_of_file -> String.trim (Buffer.contents buf) in
+  loop ()
+
+let split_on_char sep s =
+  let r = ref [] in
+  let j = ref (String.length s) in
+  for i = String.length s - 1 downto 0 do
+    if String.get s i = sep then begin
+      r := String.sub s (i + 1) (!j - i - 1) :: !r;
+      j := i
+    end
+  done;
+  String.sub s 0 !j :: !r
+
+let split str =
+  List.map String.trim (split_on_char '\n' str) |>
+  List.filter (fun s -> s <> "")
+
+exception Command_failed of Unix.process_status
+
+let process_status_to_string s =
+  let open Unix in
+  match s with
+  | WEXITED i -> sprintf "exit status %d" 1
+  | WSTOPPED i -> sprintf "proccess was stopped by signal %d" i
+  | WSIGNALED i -> sprintf "proccess was killed by signal %d" i
+
+let exn_to_string = function
+  | Command_failed s -> sprintf "%s" (process_status_to_string s)
+  | e -> Printexc.to_string e
+
+let cmd fmt =
+  let run c =
+    try
+      let inp = Unix.open_process_in c in
+      let res = read_all inp in
+      match Unix.close_process_in inp with
+      | Unix.WEXITED 0 -> Some res
+      | s -> raise (Command_failed s)
+    with e ->
+      eprintf "command %s failed: %s\n" c (exn_to_string e);
+      None in
+  ksprintf run fmt
+
+let find_map xs ~f =
+  let rec loop = function
+    | [] -> None
+    | hd :: tl ->
+      match f hd with
+      | None -> loop tl
+      | x -> x in
+  loop xs
+
+let known_names = ["ida"; "idaq"]
+
+let which_ida64 () = find_map known_names ~f:(cmd "which %s64")
+
+let find_ida64 path =
+  cmd
+    "find %s -executable -type f -name \"ida*64\" 2>/dev/null | sort -n -r"
+    path |> function
+  | None -> None
+  | Some idas ->
+    match split idas with
+    | [] -> None
+    | idas ->
+      let known = List.map (fun x -> x ^ "64") known_names in
+      find_map idas ~f:(fun file ->
+          if List.mem (Filename.basename file) known then
+            Some file
+          else None)
+
+let find_at_home () =
+  match getenv_opt "HOME" with
+  | None -> None
+  | Some home -> find_ida64 home
+
+let locate_linux () =
+  match find_at_home () with
+  | None -> find_ida64 "/"
+  | x -> x
+
+let locate_macos () =
+  find_map known_names ~f:(fun name ->
+      match cmd "mdfind -name %s | sort -n -r" name with
+      | None -> None
+      | Some result ->
+         let pathes = split result in
+         try
+           let path =
+             List.find (fun p -> Filename.basename p = name ^ ".app") pathes in
+           Some (sprintf "%s/Contents/MacOS/" path)
+         with Not_found -> None)
+
+let rec find fs =
+  match fs with
+  | [] -> None
+  | f :: fs ->
+    match f () with
+    | None -> find fs
+    | x -> x
+
+let locate () =
+  match os with
+  | MacOs -> find [which_ida64; locate_macos]
+  | Linux -> find [which_ida64; locate_linux]
+  | Other system ->
+    eprintf
+      "warning: we don't know how to find programs on %s!\n" system;
+    exit 1
+
+let write path =
+  let dir, file_depends =
+    if Sys.is_directory path then path, ""
+    else
+      Filename.dirname path,
+      sprintf "file-depends: [ [ %S %S ] ]\n"
+        path (Digest.to_hex (Digest.file path)) in
+  let oc = open_out "conf-ida.config" in
+  fprintf oc {|
+opam-version: "2.0"
+%s
+variables {
+  path: %S
+  headless: %b
+}
+|} file_depends dir headless;
+  close_out oc
+
+let of_config () =
+  let path = "" in
+  if path = "" then None
+  else Some path
+
+let of_env () = getenv_opt "IDA_PATH"
+
+let () =
+  try
+    match find [ of_config; of_env; locate; ] with
+    | Some path -> write path
+    | None ->
+      eprintf "failed to locate IDA Pro\n";
+      exit 1
+  with e ->
+    eprintf "build failed: %s\n" (Printexc.to_string e);
+    exit 1

--- a/packages/conf-ida/conf-ida.0.2/opam
+++ b/packages/conf-ida/conf-ida.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "conf-ida"
+version: "0.2"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["ocaml" "find-ida.ml"]
+]
+depends: [
+   "ocaml"
+   "base-unix"
+   "conf-which" {build}
+]
+substs: [ "find-ida.ml" ]
+flags: [ conf ]
+
+synopsis: "Checks that IDA Pro is installed"
+description: """
+A path to ida can be hinted by setting opam config variable:
+$: opam config set ida-path <path-to-ida>
+
+Also can be hinted with IDA_PATH environment variable, e.g.,
+$: IDA_PATH=<path-to-ida> opam install conf-ida
+"""

--- a/packages/core-lwt/core-lwt.0.3.0/opam
+++ b/packages/core-lwt/core-lwt.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "core-lwt"
+version: "0.3.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/core-lwt/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/core-lwt/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/core-lwt/"
+license: "MIT"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "core_lwt"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.0"}
+  "base-unix"
+  "base-threads"
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "lwt" {>= "4.0.0" & < "5.0.0"}
+]
+synopsis: "Lwt library wrapper in the Janestreet core style"
+description: """
+Provides an interface to Lwt library that follows the Janestreet
+coding standards."""
+flags: light-uninstall
+url {
+src:
+    "https://github.com/BinaryAnalysisPlatform/core-lwt/archive/v0.3.0.tar.gz"
+checksum: "md5=17c8ca7977a898c1d319a5141dbaccb0"
+}

--- a/packages/graphlib/graphlib.1.6.0/opam
+++ b/packages/graphlib/graphlib.1.6.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "graphlib"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-graphlib"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "graphlib"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "ocamlgraph"
+  "regular"
+]
+synopsis: "Generic Graph library"
+description: """
+Graphlib is a generic library that extends a well known OCamlGraph
+library. Graphlib uses its own, more reach, Graph interface that
+is isomorphic to OCamlGraph's `Sigs.P` signature for persistant
+graphs. Two functors witness the isomorphism of the interfaces:
+`Graphlib.To_ocamlgraph` and `Graphlib.Of_ocamlgraph`. Thanks to
+these functors, any algorithm written for OCamlGraph can be used on
+`Graphlibs` graph and vice verse."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/monads/monads.1.6.0/opam
+++ b/packages/monads/monads.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "monads"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-monads"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "monads"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "A missing monad library"
+description:
+  "Provides monad transformers for most (if not all) common monads."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/ogre/ogre.1.6.0/opam
+++ b/packages/ogre/ogre.1.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "ogre"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ogre"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "ogre"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "monads"
+]
+synopsis: "Open Generic REpresentation NoSQL Database"
+description: """
+OGRE is a NoSQL document-style database, that uses s-exp for data
+representation and provides a type safe monadic interface for quering
+and updating documents."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/regular/regular.1.6.0/opam
+++ b/packages/regular/regular.1.6.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+name: "regular"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-regular"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "regular"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+]
+synopsis: "Library for regular data types"
+description: """
+Provides functors and typeclasses implementing functionality expected
+for a regular data type, like i/o, containers, printing, etc.
+
+In particular, the library includes:
+
+- module Data that adds generic i/o routines for each regular data type.
+- module Cache that adds caching service for data types
+- module Regular that glues everything together
+- module Opaque for regular but opaque data types
+- module Seq that extends Core_kernel's sequence module
+- module Bytes that provides a rich core-like interface for Bytes data type."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}

--- a/packages/text-tags/text-tags.1.6.0/opam
+++ b/packages/text-tags/text-tags.1.6.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "text-tags"
+version: "1.6.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-text-tags"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "text-tags"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "A library for rich formatting using semantics tags"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.6.0.tar.gz"
+  checksum: "md5=0ccf6571613c0666a37d154c7f70af4f"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/1.6.0/v1.6.0.tar.gz"
+}


### PR DESCRIPTION
Release notes
=====

### Features

- PR#893  adds integration with ida 7
- PR#892  implements helper functions for creating and manipulating partitions
- PR#906  makes dead code elimination less conservative
- PR#914  preserves brancher information in the BIL code of an instruction
- PR#820  Jane Street 0.11.x library compatibility + minor fixes
- PR#922  few x86 enhancements
- PR#923  SSE XMM0 ABI
- PR#933  enables bap-elf
- PR#934  adds the compiler option to byteweight
- PR#932  enables memory sharing between instructions
- PR#938  removed upper bound for llvm version, compatibility with LLVM 8.0
- PR#926  enables functions with multiple entry

### Bug fixes

- PR#907  fixes the free-vars-by-dominators computation algorithm
- PR#915  fixed building on travis
- PR#920  fix the i64 import error
- PR#927  fixes ADT printer
- PR#939  fixes the order of arguments in the callsites plugin
- PR#937  fixes TOCTOU bug in bap log
- PR#941  fixes a dependency bug in primus lisp docs