### PR TITLE
constrains the upper bounds of old bap packages

### DIFF
--- a/packages/bap-demangle/bap-demangle.1.0.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.0.0/opam
@@ -22,7 +22,7 @@ remove: [
 
 depends: [
   "ocaml"
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9.0"}
   "oasis" {build & = "0.4.7"}
   "bap-std"
   "cmdliner"

--- a/packages/bap-demangle/bap-demangle.1.1.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.1.0/opam
@@ -22,7 +22,7 @@ remove: [
 
 depends: [
   "ocaml"
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
   "bap-std"
   "cmdliner"

--- a/packages/bap-demangle/bap-demangle.1.2.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.2.0/opam
@@ -22,7 +22,7 @@ remove: [
 
 depends: [
   "ocaml"
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
   "bap-std"
   "cmdliner"

--- a/packages/bap-demangle/bap-demangle.1.3.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.3.0/opam
@@ -22,7 +22,7 @@ remove: [
 
 depends: [
   "ocaml"
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
   "bap-std"
   "cmdliner"

--- a/packages/bap-demangle/bap-demangle.1.4.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.4.0/opam
@@ -22,7 +22,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "oasis" {build & = "0.4.7"}
   "bap-std" {= "1.4.0"}
   "cmdliner"

--- a/packages/bap-frontend/bap-frontend.1.4.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "oasis" {build & = "0.4.7"}
   "bap-std" {= "1.4.0"}
   "cmdliner"
-  "parsexp" {< "v0.13"}
+  "parsexp" {>= "v0.9.0" & < "v0.10"}
 ]
 synopsis: "BAP frontend"
 description: "The command-line interface to the Binary Analysis Platform."

--- a/packages/bap-frontend/bap-frontend.1.5.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.5.0/opam
@@ -28,7 +28,7 @@ depends: [
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "1.5.0"}
   "cmdliner"
-  "parsexp" {< "v0.13"}
+  "parsexp" {>= "v0.9.0" & < "v0.10"}
 ]
 synopsis: "BAP frontend"
 description: "The command-line interface to the Binary Analysis Platform."

--- a/packages/bap-ida/bap-ida.1.0.0/opam
+++ b/packages/bap-ida/bap-ida.1.0.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml"
   "conf-ida"
   "bap-ida-python" {= "1.0.0"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-ida/bap-ida.1.1.0/opam
+++ b/packages/bap-ida/bap-ida.1.1.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml"
   "conf-ida"
   "bap-ida-python" {= "1.1.0"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-ida/bap-ida.1.2.0/opam
+++ b/packages/bap-ida/bap-ida.1.2.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml"
   "conf-ida"
   "bap-ida-python" {= "1.2.0"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-ida/bap-ida.1.3.0/opam
+++ b/packages/bap-ida/bap-ida.1.3.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml"
   "conf-ida"
   "bap-ida-python" {= "1.3.0"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-ida/bap-ida.1.4.0/opam
+++ b/packages/bap-ida/bap-ida.1.4.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "conf-ida"
   "bap-ida-python"
-  "core_kernel" {>= "113.24.00" & < "v0.9"}
+  "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.9"}
+  "ppx_jane" {>= "v0.9.0" & < "v0.10"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-ida/bap-ida.1.4.0/opam
+++ b/packages/bap-ida/bap-ida.1.4.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "conf-ida"
   "bap-ida-python"
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-ida/bap-ida.1.5.0/opam
+++ b/packages/bap-ida/bap-ida.1.5.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "conf-ida"
   "bap-ida-python" {>= "1.5.0"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-ida/bap-ida.1.5.0/opam
+++ b/packages/bap-ida/bap-ida.1.5.0/opam
@@ -26,9 +26,9 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "conf-ida"
   "bap-ida-python" {>= "1.5.0"}
-  "core_kernel" {>= "113.24.00" & < "v0.9"}
+  "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.9"}
+  "ppx_jane" {>= "v0.9.0" & < "v0.10"}
   "fileutils"
   "re"
   "bap-ida-plugin"

--- a/packages/bap-primus/bap-primus.1.4.0/opam
+++ b/packages/bap-primus/bap-primus.1.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "monads"
   "uuidm"
   "graphlib" {> "1.3.0"}
-  "parsexp" {< "v0.13"}
+  "parsexp" {>= "v0.9.0" & < "v0.10"}
 ]
 synopsis: "The BAP Microexecution Framework"
 description: """

--- a/packages/bap-primus/bap-primus.1.5.0/opam
+++ b/packages/bap-primus/bap-primus.1.5.0/opam
@@ -26,7 +26,7 @@ depends: [
   "monads"
   "uuidm"
   "graphlib" {> "1.3.0"}
-  "parsexp" {< "v0.13"}
+  "parsexp" {>= "v0.9.0" & < "v0.10"}
 ]
 synopsis: "The BAP Microexecution Framework"
 description: """

--- a/packages/bap-server/bap-server.0.1.0/opam
+++ b/packages/bap-server/bap-server.0.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "bap-std"
   "bap-arm"
   "cohttp" {>= "0.20.0" & <= "0.21.0"}
-  "core_kernel" {>= "113.33.00" & < "v0.13"}
+  "core_kernel" {>= "113.33.00" & < "v0.9"}
   "ezjsonm" {>= "0.4.0" & < "0.4.4"}
   "lwt"
   "oasis" {build & = "0.4.7"}

--- a/packages/bap-std/bap-std.1.0.0/opam
+++ b/packages/bap-std/bap-std.1.0.0/opam
@@ -34,12 +34,12 @@ depends: [
   "base-unix"
   "bap-future"
   "camlzip"
-  "core_kernel" {>= "113.33.00" & < "v0.13"}
+  "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"
   "graphlib"
   "oasis" {build & = "0.4.7"}
   "ocamlfind" {>= "1.5.6" & < "2.0"}
-  "ppx_jane" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane" {>= "113.33.00" & < "v0.9"}
   "regular"
   "uri"
   "utop"

--- a/packages/bap-std/bap-std.1.1.0/opam
+++ b/packages/bap-std/bap-std.1.1.0/opam
@@ -34,12 +34,12 @@ depends: [
   "base-unix"
   "bap-future"
   "camlzip"
-  "core_kernel" {>= "113.33.00" & < "v0.13"}
+  "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"
   "graphlib"
   "oasis" {build & = "0.4.7"}
   "ocamlfind" {>= "1.5.6" & < "2.0"}
-  "ppx_jane" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane" {>= "113.33.00" & < "v0.9"}
   "regular"
   "uri"
   "utop"

--- a/packages/bap-std/bap-std.1.2.0/opam
+++ b/packages/bap-std/bap-std.1.2.0/opam
@@ -34,12 +34,12 @@ depends: [
   "base-unix"
   "bap-future"
   "camlzip" {>= "1.07"}
-  "core_kernel" {>= "113.33.00" & < "v0.13"}
+  "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"
   "graphlib"
   "oasis" {build & = "0.4.7"}
   "ocamlfind" {>= "1.5.6" & < "2.0"}
-  "ppx_jane" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane" {>= "113.33.00" & < "v0.9"}
   "regular"
   "uri"
   "utop"

--- a/packages/bap-std/bap-std.1.3.0/opam
+++ b/packages/bap-std/bap-std.1.3.0/opam
@@ -34,12 +34,12 @@ depends: [
   "base-unix"
   "bap-future"
   "camlzip" {>= "1.07"}
-  "core_kernel" {>= "113.33.00" & < "v0.13"}
+  "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"
   "graphlib"
   "oasis" {build & = "0.4.7"}
   "ocamlfind" {>= "1.5.6" & < "2.0"}
-  "ppx_jane" {>= "113.33.00" & < "113.34.00"}
+  "ppx_jane" {>= "113.33.00" & < "v0.9"}
   "regular"
   "uri"
   "utop"

--- a/packages/bap-veri/bap-veri.0.2.1/opam
+++ b/packages/bap-veri/bap-veri.0.2.1/opam
@@ -29,7 +29,7 @@ depends: [
   "oasis" {build}
   "ounit"
   "pcre"
-  "textutils" {< "v0.13"}
+  "textutils" {< "v0.9"}
   "uri"
 ]
 synopsis: "BAP verification tool"

--- a/packages/bap-veri/bap-veri.0.2.2/opam
+++ b/packages/bap-veri/bap-veri.0.2.2/opam
@@ -29,7 +29,7 @@ depends: [
   "oasis" {build}
   "ounit"
   "pcre"
-  "textutils" {< "v0.13"}
+  "textutils" {< "v0.9"}
   "uri"
 ]
 synopsis: "BAP Instruction Semantics Verification Tool"

--- a/packages/bap-veri/bap-veri.0.2/opam
+++ b/packages/bap-veri/bap-veri.0.2/opam
@@ -29,7 +29,7 @@ depends: [
   "oasis" {build}
   "ounit"
   "pcre"
-  "textutils" {< "v0.13"}
+  "textutils" {< "v0.9"}
   "uri"
 ]
 synopsis: "BAP verification tool"

--- a/packages/bare/bare.1.4.0/opam
+++ b/packages/bare/bare.1.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "oasis" {build}
-  "parsexp" {< "v0.13"}
+  "parsexp" {>= "v0.9.0" & < "v0.10"}
 ]
 synopsis: "BAP Rule Engine Library"
 description: """

--- a/packages/bare/bare.1.5.0/opam
+++ b/packages/bare/bare.1.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "oasis" {build}
-  "parsexp" {< "v0.13"}
+  "parsexp" {>= "v0.9.0" & < "v0.10"}
 ]
 synopsis: "BAP Rule Engine Library"
 description: """

--- a/packages/graphlib/graphlib.1.0.0/opam
+++ b/packages/graphlib/graphlib.1.0.0/opam
@@ -25,9 +25,9 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "ocamlgraph"
   "regular"
 ]

--- a/packages/graphlib/graphlib.1.1.0/opam
+++ b/packages/graphlib/graphlib.1.1.0/opam
@@ -25,9 +25,9 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "ocamlgraph"
   "regular"
 ]

--- a/packages/graphlib/graphlib.1.2.0/opam
+++ b/packages/graphlib/graphlib.1.2.0/opam
@@ -25,9 +25,9 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "ocamlgraph"
   "regular"
 ]

--- a/packages/graphlib/graphlib.1.4.0/opam
+++ b/packages/graphlib/graphlib.1.4.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "core_kernel" {>= "v0.9.0" & < "v0.10"}
-  "oasis" {bxuild & >= "0.4.7"}
+  "oasis" {build & >= "0.4.7"}
   "ppx_jane" {>= "v0.9.0" & < "v0.10"}
   "ocamlgraph"
   "regular"

--- a/packages/graphlib/graphlib.1.4.0/opam
+++ b/packages/graphlib/graphlib.1.4.0/opam
@@ -25,9 +25,9 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "core_kernel" {>= "113.24.00" & < "v0.13"}
+  "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "ocamlgraph"
   "regular"
 ]

--- a/packages/graphlib/graphlib.1.4.0/opam
+++ b/packages/graphlib/graphlib.1.4.0/opam
@@ -25,9 +25,9 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "core_kernel" {>= "113.24.00" & < "v0.9"}
-  "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.9"}
+  "core_kernel" {>= "v0.9.0" & < "v0.10"}
+  "oasis" {bxuild & >= "0.4.7"}
+  "ppx_jane" {>= "v0.9.0" & < "v0.10"}
   "ocamlgraph"
   "regular"
 ]

--- a/packages/regular/regular.1.0.0/opam
+++ b/packages/regular/regular.1.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.04"}
   "core_kernel" {>= "113.24.00" & < "v0.9.0"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
 ]
 synopsis: "Library for regular data types"
 description: """

--- a/packages/regular/regular.1.1.0/opam
+++ b/packages/regular/regular.1.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.04"}
   "core_kernel" {>= "113.24.00" & < "v0.9.0"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
 ]
 synopsis: "Library for regular data types"
 description: """

--- a/packages/regular/regular.1.2.0/opam
+++ b/packages/regular/regular.1.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "core_kernel" {>= "113.24.00" & < "v0.9.0"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
 ]
 synopsis: "Library for regular data types"
 description: """

--- a/packages/regular/regular.1.3.0/opam
+++ b/packages/regular/regular.1.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "core_kernel" {>= "113.24.00" & < "v0.9.0"}
   "oasis" {build & = "0.4.7"}
-  "ppx_jane" {>= "113.24.01" & < "v0.13"}
+  "ppx_jane" {>= "113.24.01" & < "v0.9"}
 ]
 synopsis: "Library for regular data types"
 description: """


### PR DESCRIPTION
Since the old versions of bap weren't properly constrained (they didn't have the upper bounds), the https://github.com/ocaml/opam-repository/pull/13010 PR added the upper bounds, and https://github.com/ocaml/opam-repository/pull/13716/ relaxed them a litte bit. However, neither upper bounds were actually right (nor were the absence of them, therefore the introduced upper bounds were still a closer approximation of truth). This PR adds proper constraints to those old versions of bap. 
