### PR TITLE
[new release] tar-mirage, tar and tar-unix (1.1.0)

### DIFF
--- a/packages/tar-mirage/tar-mirage.1.1.0/opam
+++ b/packages/tar-mirage/tar-mirage.1.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.0"}
+  "tar"
+  "cstruct" {>= "1.9.0"}
+  "re" {>="1.7.2"}
+  "mirage-block"
+  "mirage-block-lwt"
+  "mirage-kv" {>= "2.0.0"}
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "lwt"
+  "io-page"
+  "ptime"
+  "mirage-block-unix" {with-test & >= "2.5.0"}
+  "io-page-unix" {with-test}
+  "ounit" {with-test}
+  "tar-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v1.1.0/tar-v1.1.0.tbz"
+  checksum: [
+    "sha256=c48e4ce128058fac4ae1a0f3d2d49f42d9a736a3bf166b59f086e6e6f926018d"
+    "sha512=ea273a8fefab42624c42da9d1a02557d1c51d4d8c0d032e8d8a17e0f6866c56b3ab0b32eacb8ad788bbf6983bff36ac072353af08a730b6b26f9c45d4d4f521a"
+  ]
+}

--- a/packages/tar-unix/tar-unix.1.1.0/opam
+++ b/packages/tar-unix/tar-unix.1.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "tar"
+  "cstruct" {>= "1.9.0"}
+  "cstruct-lwt"
+  "re"
+  "lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v1.1.0/tar-v1.1.0.tbz"
+  checksum: [
+    "sha256=c48e4ce128058fac4ae1a0f3d2d49f42d9a736a3bf166b59f086e6e6f926018d"
+    "sha512=ea273a8fefab42624c42da9d1a02557d1c51d4d8c0d032e8d8a17e0f6866c56b3ab0b32eacb8ad788bbf6983bff36ac072353af08a730b6b26f9c45d4d4f521a"
+  ]
+}

--- a/packages/tar/tar.1.1.0/opam
+++ b/packages/tar/tar.1.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "ppx_tools" {build}
+  "ppx_cstruct" {>= "3.6.0"}
+  "cstruct" {>= "1.9.0"}
+  "re"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v1.1.0/tar-v1.1.0.tbz"
+  checksum: [
+    "sha256=c48e4ce128058fac4ae1a0f3d2d49f42d9a736a3bf166b59f086e6e6f926018d"
+    "sha512=ea273a8fefab42624c42da9d1a02557d1c51d4d8c0d032e8d8a17e0f6866c56b3ab0b32eacb8ad788bbf6983bff36ac072353af08a730b6b26f9c45d4d4f521a"
+  ]
+}


### PR DESCRIPTION
Read and write tar format files via MirageOS interfaces

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Do not depend on mirage-types, use mirage-kv instead (@hannesm)
- Support mirage-kv 2.0.0 (@hannesm)
- Do not suppress "unused value" warning (@emillon)
- Represent link indicator as a char. This transforms comments into actual code
  (@emillon)
