### PR TITLE
added package funbits v0.02

### DIFF
--- a/packages/funbits/funbits.0.02/opam
+++ b/packages/funbits/funbits.0.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "Florent Monnier <monnier.florent@gmail.com>"
 
 homepage: "http://www.linux-nantes.org/~fmonnier/ocaml/funbits/"
 dev-repo: "git+https://github.com/fccm/ocaml-funbits.git"

--- a/packages/funbits/funbits.0.02/opam
+++ b/packages/funbits/funbits.0.02/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+
+homepage: "http://www.linux-nantes.org/~fmonnier/ocaml/funbits/"
+dev-repo: "git+https://github.com/fccm/ocaml-funbits.git"
+bug-reports: "https://github.com/fccm/ocaml-funbits/issues"
+doc: "http://www.linux-nantes.org/~fmonnier/ocaml/funbits/doc/"
+
+authors: ["Florent Monnier"]
+license: "restrictionless Zlib"
+synopsis: "Functional bit field library"
+tags: [ "bit-field" "bits" "functional" ]
+
+build: [
+  [make]
+]
+install: [
+  [make "findinstall"]
+]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
+run-test: [
+  [make "test" "LIB_DIR=../src"]
+]
+
+url {
+  src: "https://github.com/fccm/ocaml-funbits/archive/v0.02.tar.gz"
+  checksum: "md5=f15aac7eb612de2837a550342ff5b6e7"
+}


### PR DESCRIPTION
Funbits is a bit-field library similar to the package "bitv" except that bitv is imperative and funbits is functional.