### PR TITLE
[new release] hidapi (1.1.1)

### DIFF
--- a/packages/hidapi/hidapi.1.1.1/opam
+++ b/packages/hidapi/hidapi.1.1.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+name: "hidapi"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-hidapi"
+bug-reports: "https://github.com/vbmithr/ocaml-hidapi/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-hidapi"
+doc: "https://vbmithr.github.io/ocaml-hidapi/doc"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.8.2"}
+  "conf-hidapi" {build}
+  "bigstring" {>= "0.2"}
+]
+synopsis: "Bindings to Signal11's hidapi library"
+description: """
+A Simple library for communicating with USB and Bluetooth HID devices
+on Linux, Mac, and Windows."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-hidapi/releases/download/1.1.1/hidapi-1.1.1.tbz"
+  checksum: "md5=c23dfb12312d54738949bc1b7e87ecdb"
+}


### PR DESCRIPTION
Bindings to Signal11's hidapi library

- Project page: <a href="https://github.com/vbmithr/ocaml-hidapi">https://github.com/vbmithr/ocaml-hidapi</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-hidapi/doc">https://vbmithr.github.io/ocaml-hidapi/doc</a>

##### CHANGES:

- Switch to dune.
- Fix build on some platforms (@dakk).
