### PR TITLE
[new release] io-page, io-page-unix and io-page-xen (2.2.0)

### DIFF
--- a/packages/io-page-unix/io-page-unix.2.2.0/opam
+++ b/packages/io-page-unix/io-page-unix.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "io-page"
+  "dune" {build & >= "1.0"}
+  "configurator" {build}
+  "cstruct" {>= "2.0.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages on Unix"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.2.0/io-page-v2.2.0.tbz"
+  checksum: [
+    "sha256=f51ad9b96dd1378aae1474ee2929b56ddedaca5c5dc49459e291e5476c1ee047"
+    "sha512=4240bbc0c7b6c8c1bc0b628fcde51c73bc7f6e49b2cd7157e32d3277d1fe31f0604829a1ae49c84524922d3954ead870e02d215768310b21a0b1f57ee7344294"
+  ]
+}

--- a/packages/io-page-xen/io-page-xen.2.2.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "io-page"
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "2.0.0"}
+  "mirage-xen-ocaml"
+]
+build: [
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst"] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig"
+    "dune" "build" "-p" name "-j" jobs ]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages on Xen"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.2.0/io-page-v2.2.0.tbz"
+  checksum: [
+    "sha256=f51ad9b96dd1378aae1474ee2929b56ddedaca5c5dc49459e291e5476c1ee047"
+    "sha512=4240bbc0c7b6c8c1bc0b628fcde51c73bc7f6e49b2cd7157e32d3277d1fe31f0604829a1ae49c84524922d3954ead870e02d215768310b21a0b1f57ee7344294"
+  ]
+}

--- a/packages/io-page-xen/io-page-xen.2.2.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.2.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/io-page"
 bug-reports: "https://github.com/mirage/io-page/issues"
 doc: "https://mirage.github.io/io-page/"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "io-page"
   "dune" {build & >= "1.0"}
   "cstruct" {>= "2.0.0"}

--- a/packages/io-page/io-page.2.2.0/opam
+++ b/packages/io-page/io-page.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "2.0.0"}
+  "bigarray-compat" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.2.0/io-page-v2.2.0.tbz"
+  checksum: [
+    "sha256=f51ad9b96dd1378aae1474ee2929b56ddedaca5c5dc49459e291e5476c1ee047"
+    "sha512=4240bbc0c7b6c8c1bc0b628fcde51c73bc7f6e49b2cd7157e32d3277d1fe31f0604829a1ae49c84524922d3954ead870e02d215768310b21a0b1f57ee7344294"
+  ]
+}


### PR DESCRIPTION
Support for efficient handling of I/O memory pages

- Project page: <a href="https://github.com/mirage/io-page">https://github.com/mirage/io-page</a>
- Documentation: <a href="https://mirage.github.io/io-page/">https://mirage.github.io/io-page/</a>

##### CHANGES:

* Use bigarray_compat (mirage/io-page#56, @TheLortex)
