### PR TITLE
tyre.0.{1,2,3} are incompatible with re >= 1.9.0 (warnings-as-errors unabled)

### DIFF
--- a/packages/tyre/tyre.0.1.1/opam
+++ b/packages/tyre/tyre.0.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "re" {>= "1.6.0"}
+  "re" {>= "1.6.0" & < "1.9.0"}
   "alcotest" {with-test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]

--- a/packages/tyre/tyre.0.1/opam
+++ b/packages/tyre/tyre.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "re" {>= "1.6.0"}
+  "re" {>= "1.6.0" & < "1.9.0"}
   "alcotest" {with-test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]

--- a/packages/tyre/tyre.0.2/opam
+++ b/packages/tyre/tyre.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "re" {>= "1.7.0"}
+  "re" {>= "1.7.0" & < "1.9.0"}
   "alcotest" {with-test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]

--- a/packages/tyre/tyre.0.3/opam
+++ b/packages/tyre/tyre.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "re" {>= "1.7.0"}
+  "re" {>= "1.7.0" & < "1.9.0"}
   "alcotest" {with-test & >= "0.6.0" & < "0.8.0"}
   "result"
 ]


### PR DESCRIPTION
Detected by [check.ocamllabs.io](http://check.ocamllabs.io)

cc @samoht 