### PR TITLE
[new release] lru (0.3.0)

### DIFF
--- a/packages/lru/lru.0.3.0/opam
+++ b/packages/lru/lru.0.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+authors: ["David Kaloper Meršinjak <dk505@cam.ac.uk>"]
+homepage: "https://github.com/pqwy/lru"
+doc: "https://pqwy.github.io/lru/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/pqwy/lru.git"
+bug-reports: "https://github.com/pqwy/lru/issues"
+synopsis: "Scalable LRU caches"
+build: [ [ "dune" "subst" ] {pinned}
+         [ "dune" "build" "-p" name "-j" jobs ]
+         [ "dune" "runtest" "-p" name ] {with-test} ]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {build & >= "1.7"}
+  "psq"   {>="0.2.0"}
+  "qcheck-core"     {with-test}
+  "qcheck-alcotest" {with-test}
+  "alcotest"        {with-test}
+]
+description: """
+Lru provides weight-bounded finite maps that can remove the least-recently-used
+(LRU) bindings in order to maintain a weight constraint.
+"""
+url {
+  src: "https://github.com/pqwy/lru/releases/download/v0.3.0/lru-v0.3.0.tbz"
+  checksum: "md5=ecaa8c9f5f708879140961ce35bcdba4"
+}


### PR DESCRIPTION
Scalable LRU caches

- Project page: <a href="https://github.com/pqwy/lru">https://github.com/pqwy/lru</a>
- Documentation: <a href="https://pqwy.github.io/lru/doc">https://pqwy.github.io/lru/doc</a>

##### CHANGES:

Semantics cleanup.

Breaking:

- `find` drops `?promote` and never changes the ordering.
- `add` drops `?trim` and never drops bindings.
- `size` -> `weight`
- `items` -> `size`
- `unadd` -> `pop`
- `F.S.fold` and `F.S.iter` iterate in LRU order.
- `F.M.fold` and `F.M.iter` drop `?dir` and always iterate in LRU order.

Other:

- add `F.S.fold_k` and `F.S.iter_k`

To fix client code:

- replace `find ~promote:false` with `find`;
- replace `find` and `find ~promote:true` with `find` and `promote`;
- replace `add ~trim:false` with `add`;
- replace `add` and `add ~trim:true` with `add` and `trim`;
- `s/size/weight/g`, `s/items/size/g`, `s/unadd/pop/g`;
- audit uses of `fold` and `iter` for order-sensitivity.
