### PR TITLE
[coq] blacklist incompatible versions of ocaml 4.05.0

### DIFF
--- a/packages/coq/coq.8.7.2/opam
+++ b/packages/coq/coq.8.7.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & != "4.05.0"}
   "ocamlfind" {build}
   "camlp5"
   "num"

--- a/packages/coq/coq.8.8.0/opam
+++ b/packages/coq/coq.8.8.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & != "4.05.0"}
   "ocamlfind" {build}
   "camlp5"
   "num"

--- a/packages/coq/coq.8.8.1/opam
+++ b/packages/coq/coq.8.8.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & != "4.05.0"}
   "ocamlfind" {build}
   "camlp5"
   "num"

--- a/packages/coq/coq.8.8.2/opam
+++ b/packages/coq/coq.8.8.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & != "4.05.0"}
   "ocamlfind" {build}
   "camlp5"
   "num"

--- a/packages/coq/coq.8.9.0/opam
+++ b/packages/coq/coq.8.9.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & != "4.05.0"}
   "ocamlfind" {build}
   "camlp5"
   "num"


### PR DESCRIPTION
OCaml 4.05.0 seems incompatible with all versions of Coq >= 8.7.2 (8.7.1 compiles fine).

When I try to compile any of them, I get an error similar to the following:

```
[ERROR] The compilation of coq failed at "$HOME/.opam/opam-init/hooks/sandbox.sh build make -j11".

#=== ERROR while compiling coq.8.7.2 ==========================================#
# context     2.0.3 | linux/x86_64 | ocaml-base-compiler.4.05.0 | https://opam.ocaml.org#68919f95
# path        ~/.opam/4.05.0/.opam-switch/build/coq.8.7.2
# command     ~/.opam/opam-init/hooks/sandbox.sh build make -j11
# exit-code   2
# env-file    ~/.opam/log/coq-17688-6d07ae.env
# output-file ~/.opam/log/coq-17688-6d07ae.out
### output ###
# [...]
# OCAMLC    kernel/byterun/coq_interp.c
# OCAMLC    plugins/ltac/tauto.mli
# OCAMLC    plugins/fourier/fourier.ml
# OCAMLC    plugins/micromega/sos_types.mli
# OCAMLC    plugins/micromega/micromega.mli
# ocamlfind: Package `num' not found
# make[1]: *** [Makefile.build:605: plugins/micromega/sos_types.cmi] Error 2
# make[1]: *** Waiting for unfinished jobs....
# ocamlfind: Package `num' not found
# make[1]: *** [Makefile.build:605: plugins/micromega/micromega.cmi] Error 2
# make[1]: Leaving directory '$HOME/.opam/4.05.0/.opam-switch/build/coq.8.7.2'
```

OCaml 4.05.0 does have a `num` package (version 0), but apparently `ocamlfind` cannot find it. `opam install num` results in "package already installed".

Anyway, given the age of OCaml 4.05.0, I think trying to fix the issue is not worth the time, but blacklisting it should help save time, if in the future others try to compile it. In particular, future users of Frama-C which will use 4.05.0 as minimum version.