### PR TITLE
Restrict ocaml-migrate-parsetree.1.3.0 to 4.08.0+beta2

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
@@ -18,6 +18,7 @@ depends: [
   "ppx_derivers"
   "dune" {build & >= "1.6.0"}
   "ocaml" {>= "4.08.0" & < "4.09.0"}
+  "ocaml-variants" {= "4.08.0+beta2"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """


### PR DESCRIPTION
This is needed because of #8535: `ocaml-migrate-parsetree.1.3.0` doesn't work with the latest 4.08.

See #13722