### PR TITLE
biocaml.0.{5,6,7}.0 is incompatible with re >= 1.8.0 which uses seq (incompatible interface)

### DIFF
--- a/packages/biocaml/biocaml.0.5.0/opam
+++ b/packages/biocaml/biocaml.0.5.0/opam
@@ -33,7 +33,7 @@ depends: [
   "ppx_compare" {< "v0.13"}
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.13"}
-  "re"
+  "re" {< "1.8.0"}
   "rresult"
   "uri"
 ]

--- a/packages/biocaml/biocaml.0.6.0/opam
+++ b/packages/biocaml/biocaml.0.6.0/opam
@@ -32,7 +32,7 @@ depends: [
   "ppx_compare" {< "v0.13"}
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.13"}
-  "re"
+  "re" {< "1.8.0"}
   "rresult"
   "uri"
 ]

--- a/packages/biocaml/biocaml.0.7.0/opam
+++ b/packages/biocaml/biocaml.0.7.0/opam
@@ -33,7 +33,7 @@ depends: [
   "cfstream"
   "ppx_compare" {< "v0.13"}
   "ppx_sexp_conv" {< "v0.13"}
-  "re"
+  "re" {< "1.8.0"}
   "rresult"
   "uri"
 ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @pveber I'm not sure why recent versions are not affected but those 3 at least are (maybe more ancient ones too but I don't know)