### PR TITLE
core-lwt.0.2 requires lwt >= 3.2.0

### DIFF
--- a/packages/core-lwt/core-lwt.0.2.0/opam
+++ b/packages/core-lwt/core-lwt.0.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base-unix"
   "base-threads"
   "core_kernel" {>= "v0.9.0" & < "v0.11"}
-  "lwt" {>= "3.0.0" & < "4.0.0"}
+  "lwt" {>= "3.2.0" & < "4.0.0"}
 ]
 synopsis: "Lwt library wrapper in the Janestreet core style"
 description: """


### PR DESCRIPTION
Detected by [check.ocamllabs.io](http://check.ocamllabs.io)