### PR TITLE
Fix liquidsoap.1.3.7 md5

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.3.7/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.7/opam
@@ -109,5 +109,5 @@ flags: light-uninstall
 url {
   src:
     "https://github.com/savonet/liquidsoap/releases/download/1.3.7/liquidsoap-1.3.7.tar.bz2"
-  checksum: "md5=ddc0924b46eaaaacca3d5aefd535efd7"
+  checksum: "md5=3445121b5171b34a96573485e46b6487"
 }


### PR DESCRIPTION
Hi,

Thanks for the quick merge earlier. Unfortunately, there was a small issue with the build tools in the released tarball. I have generated a new one and updated the `md5` signature here.