### PR TITLE
stdcompat.{6,8} are incompatible with OCaml 4.08

### DIFF
--- a/packages/stdcompat/stdcompat.6/opam
+++ b/packages/stdcompat/stdcompat.6/opam
@@ -16,7 +16,7 @@ depopts : [ "result" "seq" "uchar" ]
 synopsis:
   "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
 depends: [
-  "ocaml" {>= "3.07" & < "4.09.0"}
+  "ocaml" {>= "3.07" & < "4.08.0"}
 ]
 url {
   src:

--- a/packages/stdcompat/stdcompat.8/opam
+++ b/packages/stdcompat/stdcompat.8/opam
@@ -15,7 +15,7 @@ depopts: [ "result" "seq" "uchar" ]
 synopsis: "Compatibility module for OCaml standard library"
 description: "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
 depends: [
-  "ocaml" {>= "3.07" & < "4.09.0"}
+  "ocaml" {>= "3.07" & < "4.08.0"}
 ]
 url {
   src:


### PR DESCRIPTION
Detected by [check.ocamllabs.io](http://check.ocamllabs.io)