### PR TITLE
lablgtk is incompatible with OCaml >= 4.08

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk2"]]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "4.08"}
   "ocamlfind" {>= "1.2.1"}
 ]
 depopts: [

--- a/packages/lablgtk/lablgtk.2.18.7/opam
+++ b/packages/lablgtk/lablgtk.2.18.7/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk2"]]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "4.08"}
   "ocamlfind" {>= "1.2.1"}
 ]
 depopts: [


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @garrigue None of the releases work with OCaml 4.08. It would be sensible to remove any `-warn-error` for the next releases.