### PR TITLE
utop is incompatible with OCaml >= 4.08

### DIFF
--- a/packages/utop/utop.2.2.0/opam
+++ b/packages/utop/utop.2.2.0/opam
@@ -11,7 +11,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.3.0/opam
+++ b/packages/utop/utop.2.3.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/ocaml-community/utop"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 doc: "https://ocaml-community.github.io/utop/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @diml, there is no release compatible with OCaml 4.08