### PR TITLE
sequence.1.1 is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/sequence/sequence.1.1/opam
+++ b/packages/sequence/sequence.1.1/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "build" "@doc"] {with-doc}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "base-bytes"
   "result"
   "jbuilder" {build}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @c-cube only very old versions of sequence are compatible with OCaml >= 4.08