### PR TITLE
ppx_ast.v0.9.2 is incompatible with OCaml >= 4.08

### DIFF
--- a/packages/ppx_ast/ppx_ast.v0.9.2/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.2/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs "@install"]
 ]
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta2"}
   "ocaml-compiler-libs" {>= "v0.9" & < "v0.10"}
   "ocaml-migrate-parsetree" {>= "1.0.5"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)