### PR TITLE
octavius.1.2.0 is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/octavius/octavius.1.2.0/opam
+++ b/packages/octavius/octavius.1.2.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml-doc/octavius/issues"
 tags: ["doc" "ocamldoc" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta7"}
 ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @lpw25 the previous versions work but the latest doesn't