### PR TITLE
merlin-extend.0.3 is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/merlin-extend/merlin-extend.0.3/opam
+++ b/packages/merlin-extend/merlin-extend.0.3/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "merlin_extend"]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
   "cppo" {build}
 ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @let-def 