### PR TITLE
js_of_ocaml-compiler is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.0/opam
@@ -10,7 +10,7 @@ name: "js_of_ocaml-compiler"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "cmdliner"
   "cppo" {>= "1.1.0"}

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.1/opam
@@ -10,7 +10,7 @@ name: "js_of_ocaml-compiler"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "cmdliner"
   "cppo" {>= "1.1.0"}

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.3.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.3.0/opam
@@ -10,7 +10,7 @@ name: "js_of_ocaml-compiler"
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "dune" {build & >= "1.2"}
   "cmdliner"
   "cppo" {>= "1.1.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @hhugo @vouillon there is no versions of `js_of_ocaml-compiler` compatible with OCaml >= 4.08