### PR TITLE
Fix mirage-bootvar-xen.0.3.2 dependencies

### DIFF
--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.2/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.3.2/opam
@@ -23,6 +23,7 @@ depends: [
   "mirage-types" {< "3.0.0"}
   "ipaddr"
   "astring"
+  "ounit"
 ]
 synopsis: "Library for reading MirageOS unikernel boot parameters in Xen"
 description: """


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)