### PR TITLE
Camldiets.0.2 is incompatible with OCaml >= 4.05

### DIFF
--- a/packages/Camldiets/Camldiets.0.2/opam
+++ b/packages/Camldiets/Camldiets.0.2/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "Camldiets"]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.05.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]


### PR DESCRIPTION
Detected by [check.ocamllabs.io](http://check.ocamllabs.io)