### PR TITLE
General.0.6.0 is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/General/General.0.6.0/opam
+++ b/packages/General/General.0.6.0/opam
@@ -7,7 +7,7 @@ homepage: "https://jacquev6.github.io/General/"
 doc: "https://jacquev6.github.io/General/"
 bug-reports: "http://github.com/jacquev6/General/issues/"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
   "dune" {build}
   "js_of_ocaml-compiler" {with-test}
   "cppo" {build & >= "1.3.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @jacquev6 