### PR TITLE
abella.2.0.{3,4,5,6} are not compatible with OCaml >= 4.08

### DIFF
--- a/packages/abella/abella.2.0.3/opam
+++ b/packages/abella/abella.2.0.3/opam
@@ -9,7 +9,7 @@ homepage: "http://abella-prover.org"
 license: "GPL 3"
 build: [[make]]
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "4.08.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/abella/abella.2.0.4/opam
+++ b/packages/abella/abella.2.0.4/opam
@@ -9,7 +9,7 @@ homepage: "http://abella-prover.org"
 license: "GPL 3"
 build: [[make]]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/abella/abella.2.0.5/opam
+++ b/packages/abella/abella.2.0.5/opam
@@ -9,7 +9,7 @@ homepage: "http://abella-prover.org"
 license: "GPL 3"
 build: [[make]]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/abella/abella.2.0.6/opam
+++ b/packages/abella/abella.2.0.6/opam
@@ -12,7 +12,7 @@ build: [
   [make "all" "abella.install"]
 ]
 depends: [
-  "ocaml" { >= "4.02.3" }
+  "ocaml" { >= "4.02.3" & < "4.08.0" }
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @chaudhuri the recent versions are incompatible. It would be sensible to avoid using warnings-as-errors for future releases.