### PR TITLE
mastodon-archive-viewer.0.1 requires ezjsonm >= 0.4.0

### DIFF
--- a/packages/mastodon-archive-viewer/mastodon-archive-viewer.0.1/opam
+++ b/packages/mastodon-archive-viewer/mastodon-archive-viewer.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build}
   "containers"
-  "ezjsonm"
+  "ezjsonm" {>= "0.4.0"}
   "ptime"
   "tyxml"
   "cmdliner"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)