### PR TITLE
bigstring-unix is incompatible with OCaml >= 4.08

### DIFF
--- a/packages/bigstring-unix/bigstring-unix.0.2/opam
+++ b/packages/bigstring-unix/bigstring-unix.0.2/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta19.1"}
   "bigstring"
   "base-bigarray"


### PR DESCRIPTION
Detected by [check.ocamllabs.io](http://check.ocamllabs.io)

cc @c-cube 