### PR TITLE
charrua-unix.0.{5,6} requires cstruct < 3.0.0

### DIFF
--- a/packages/charrua-unix/charrua-unix.0.5/opam
+++ b/packages/charrua-unix/charrua-unix.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "rawlink" {< "1.0"}
   "tuntap" {>= "1.2.0"}
   "mtime" {< "1.0.0"}
-  "cstruct-unix"
+  "cstruct-unix" {= "0"}
 ]
 synopsis: "Charrua DHCP Unix Server"
 description: """

--- a/packages/charrua-unix/charrua-unix.0.6/opam
+++ b/packages/charrua-unix/charrua-unix.0.6/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06.0"}
   "ocamlfind" {build}
   "cstruct"
-  "cstruct-unix"
+  "cstruct-unix" {= "0"}
   "ipaddr"
   "lwt"
   "charrua-core" {>= "0.5"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)