### PR TITLE
coqide.8.7.0 is incompatible with OCaml >= 4.05

### DIFF
--- a/packages/coqide/coqide.8.7.0/opam
+++ b/packages/coqide/coqide.8.7.0/opam
@@ -24,7 +24,7 @@ build: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 depends: [
-  "ocaml" {>= "4.02.3" & < "4.06.0"}
+  "ocaml" {>= "4.02.3" & < "4.05.0"}
   "camlp5"
   "coq" {= "8.7.0"}
   "lablgtk"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)