### PR TITLE
digestif.0.6 is incompatible with OCaml >= 4.08

### DIFF
--- a/packages/digestif/digestif.0.6/opam
+++ b/packages/digestif/digestif.0.6/opam
@@ -12,7 +12,7 @@ license:      "MIT"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlbuild" {build & >= "0.11.0"}
   "ocamlfind" {build}
   "topkg" {build}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)