### PR TITLE
iter.1.2 is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/iter/iter.1.2/opam
+++ b/packages/iter/iter.1.2/opam
@@ -11,6 +11,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test & ocaml:version >= "4.03.0"}
 ]
 depends: [
+  "ocaml" {< "4.08.0"}
   "base-bytes"
   "result"
   "dune" {build}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)