### PR TITLE
merlin.3.1.0 is not compatible with OCaml >= 4.07

### DIFF
--- a/packages/merlin/merlin.3.1.0/opam
+++ b/packages/merlin/merlin.3.1.0/opam
@@ -14,7 +14,7 @@ build: [
 #build-test: [make "tests"]
 
 depends: [
-  "ocaml" {>= "4.02.1" & < "4.08"}
+  "ocaml" {>= "4.02.1" & < "4.07"}
   "ocamlfind" {>= "1.5.2"}
   "yojson"
 ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)