### PR TITLE
mirage-block-unix.2.7.0 requires cstruct.lwt

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
@@ -27,7 +27,7 @@ depends: [
   "logs"
   "rresult"
   "ounit" {with-test}
-  "cstruct-lwt"
+  "cstruct-lwt" {= "0"}
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 tags: "org:mirage"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)