### PR TITLE
mirage-console-xen-proto.2.2.0 requires OCaml >= 4.03

### DIFF
--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.2.0/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.2.0/opam
@@ -11,7 +11,7 @@ license:       "ISC"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)