### PR TITLE
mirage-entropy-xen.0.1.6 requires cstruct.lwt

### DIFF
--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.1.6/opam
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.1.6/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0"}
-  "cstruct-lwt"
+  "cstruct-lwt" {= "0"}
   "lwt" {< "4.0.0"}
   "io-page"
   "ipaddr"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)