### PR TITLE
ocamlclean is incompatible with OCaml >= 4.08

### DIFF
--- a/packages/ocamlclean/ocamlclean.2.1/opam
+++ b/packages/ocamlclean/ocamlclean.2.1/opam
@@ -13,7 +13,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlbuild"
 ]
 install: [make "install"]

--- a/packages/ocamlclean/ocamlclean.2.2/opam
+++ b/packages/ocamlclean/ocamlclean.2.2/opam
@@ -13,7 +13,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "4.08.0"}
   "ocamlbuild" { build }
 ]
 install: [make "install"]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @bvaugon there is no version of `ocamlclean` compatible with OCaml 4.08. Also, it might be sensible to avoid using warnings-as-errors for future releases