### PR TITLE
parmap is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/parmap/parmap.1.0-rc10/opam
+++ b/packages/parmap/parmap.1.0-rc10/opam
@@ -16,7 +16,7 @@ remove: [
   [make "uninstall" "DESTDIR=%{prefix}%" "OCAMLLIBDIR=lib"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/parmap/parmap.1.0-rc9/opam
+++ b/packages/parmap/parmap.1.0-rc9/opam
@@ -22,7 +22,7 @@ remove: [
   [make "uninstall" "DESTDIR=%{prefix}%" "OCAMLLIBDIR=lib"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-autoconf"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @rdicosmo there is no versions of parmap compatible with OCaml 4.08