### PR TITLE
why.2.35 requires camlp4

### DIFF
--- a/packages/why/why.2.35/opam
+++ b/packages/why/why.2.35/opam
@@ -39,6 +39,7 @@ depends: [
   "why3" {>= "0.84" & <= "0.85"}
   "frama-c" {= "11.0"}
   "conf-autoconf"
+  "camlp4"
 ]
 conflicts: [
   "ocaml" {>= "4.03.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)