### PR TITLE
wasm.1.0 is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/wasm/wasm.1.0/opam
+++ b/packages/wasm/wasm.1.0/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "-C" "interpreter" "install"]
 remove: [make "-C" "interpreter" "uninstall"]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @protz there is no version of `wasm` compatible with OCaml >= 4.08. Also it would be sensible to avoid the use of `warnings-as-errors` for future releases.