### PR TITLE
[new release] pbkdf (1.0.0)

### DIFF
--- a/packages/pbkdf/pbkdf.1.0.0/opam
+++ b/packages/pbkdf/pbkdf.1.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "pbkdf"
+synopsis: "Password based key derivation functions (PBKDF) from PKCS#5"
+description: """
+An implementation of PBKDF 1 and 2 as defined by [PKCS#5](https://tools.ietf.org/html/rfc2898) using
+ [nocrypto](https://github.com/mirleft/ocaml-nocrypto)
+"""
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
+license: "BSD2"
+homepage: "https://github.com/abeaumont/ocaml-pbkdf"
+bug-reports: "https://github.com/abeaumont/ocaml-pbkdf/issues"
+dev-repo: "git+https://github.com/abeaumont/ocaml-pbkdf.git"
+doc: "https://abeaumont.github.io/ocaml-pbkdf/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "nocrypto" {>= "0.5.4"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+url {
+  src:
+    "https://github.com/abeaumont/ocaml-pbkdf/releases/download/1.0.0/pbkdf-1.0.0.tbz"
+  checksum: [
+    "sha256=a04f9e9961a458563c95666fd8f3b0818d8b439b3a98f5aaaa86abe039d50a46"
+    "sha512=2f5961c3fb53b6e98ad5677cfa993886b1a6dbe633eb9155c908035e60da56a2558d6792b64f5636ab2c9f72a4fde02ae1a20d5a5f8cf434874d571efb466e72"
+  ]
+}

--- a/packages/pbkdf/pbkdf.1.0.0/opam
+++ b/packages/pbkdf/pbkdf.1.0.0/opam
@@ -14,7 +14,7 @@ dev-repo: "git+https://github.com/abeaumont/ocaml-pbkdf.git"
 doc: "https://abeaumont.github.io/ocaml-pbkdf/"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {build & >= "1.0+beta17"}
+  "dune" {build}
   "nocrypto" {>= "0.5.4"}
   "alcotest" {with-test & >= "0.8.1"}
 ]
@@ -27,7 +27,7 @@ url {
   src:
     "https://github.com/abeaumont/ocaml-pbkdf/releases/download/1.0.0/pbkdf-1.0.0.tbz"
   checksum: [
-    "sha256=a04f9e9961a458563c95666fd8f3b0818d8b439b3a98f5aaaa86abe039d50a46"
-    "sha512=2f5961c3fb53b6e98ad5677cfa993886b1a6dbe633eb9155c908035e60da56a2558d6792b64f5636ab2c9f72a4fde02ae1a20d5a5f8cf434874d571efb466e72"
+    "sha256=6e858fee2759a80b8284cd828c34b5e44324de820854aade31d5564276227f58"
+    "sha512=ad04dd5409334d453abfbe3dc0be0dc57e60185838f7935e6d501b4a58b9c326098c49b9a7176b76b7ba54557bb6d697fa81627e1ccc32aaa2a35fe50aa3df06"
   ]
 }


### PR DESCRIPTION
Password based key derivation functions (PBKDF) from PKCS#5

- Project page: <a href="https://github.com/abeaumont/ocaml-pbkdf">https://github.com/abeaumont/ocaml-pbkdf</a>
- Documentation: <a href="https://abeaumont.github.io/ocaml-pbkdf/">https://abeaumont.github.io/ocaml-pbkdf/</a>

##### CHANGES:

* Move to dune
* Upgrade to opam 2.0
* Reimplement `cdiv`, no longer available in `nocrypto`.
