### PR TITLE
[new release] scrypt-kdf (1.0.0)

### DIFF
--- a/packages/scrypt-kdf/scrypt-kdf.1.0.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "scrypt-kdf"
+synopsis: "The scrypt Password-Based Key Derivation Function"
+description: """
+A pure OCaml implementation of [scrypt](https://en.wikipedia.org/wiki/Scrypt) password based key derivation function,
+as defined in [The scrypt Password-Based Key Derivation Function internet draft](https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-04),
+including test cases from the RFC.
+"""
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
+license: "BSD2"
+homepage: "https://github.com/abeaumont/ocaml-scrypt-kdf"
+bug-reports: "https://github.com/abeaumont/ocaml-scrypt-kdf/issues"
+dev-repo: "git+https://github.com/abeaumont/ocaml-scrypt-kdf.git"
+doc: "https://abeaumont.github.io/ocaml-scrypt-kdf/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "cstruct" {>= "1.7.0"}
+  "nocrypto" {>= "0.5.3"}
+  "pbkdf" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
+]
+url {
+  src:
+    "https://github.com/abeaumont/ocaml-scrypt-kdf/releases/download/1.0.0/scrypt-kdf-1.0.0.tbz"
+  checksum: [
+    "sha256=1d846369234a7cc618ce66cc1d9361a864f6fd9bca1035cd0664b4f6170b962f"
+    "sha512=57e2d8b3e4df97e0481db53c2d9061a32fc7891279dbdf44c2524944ab7cddc390d5186d7ca6e654760af7e5be7ede4656c84d5f7c6ea9e8340384807e2e0917"
+  ]
+}


### PR DESCRIPTION
The scrypt Password-Based Key Derivation Function

- Project page: <a href="https://github.com/abeaumont/ocaml-scrypt-kdf">https://github.com/abeaumont/ocaml-scrypt-kdf</a>
- Documentation: <a href="https://abeaumont.github.io/ocaml-scrypt-kdf/">https://abeaumont.github.io/ocaml-scrypt-kdf/</a>

##### CHANGES:

* Move to dune
* Upgrade to opam 2.0
