### PR TITLE
mirage-xen 3.2.0/3.3.0: dune 1.9.0/1.9.1 is a bad version here

### DIFF
--- a/packages/mirage-xen/mirage-xen.3.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.2.0/opam
@@ -14,6 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
   "shared-memory-ring-lwt"
@@ -27,6 +28,10 @@ depends: [
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen-minios" {>= "0.7.0"}
   "logs"
+]
+conflicts: [
+  "dune" {= "1.9.0"}
+  "dune" {= "1.9.1"}
 ]
 available: [ os = "linux" ]
 synopsis: "Xen core platform libraries for MirageOS"

--- a/packages/mirage-xen/mirage-xen.3.3.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.3.0/opam
@@ -8,13 +8,14 @@ doc:          "https://mirage.github.io/mirage-xen/"
 license:      "ISC"
 tags:         ["org:mirage"]
 
-build: [ 
+build: [
   [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst" ] {pinned}
   [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml" {>= "4.04.2"}
   "cstruct" {>= "1.0.1"}
+  "dune" {build}
   "lwt" {>= "2.4.3"}
   "shared-memory-ring-lwt"
   "xenstore" {>= "1.2.5"}
@@ -28,6 +29,10 @@ depends: [
   "mirage-xen-minios" {>= "0.7.0"}
   "logs"
   "fmt"
+]
+conflicts: [
+  "dune" {= "1.9.0"}
+  "dune" {= "1.9.1"}
 ]
 available: [ os = "linux" ]
 synopsis: "Xen core platform libraries for MirageOS"


### PR DESCRIPTION
this hopefully fixes:
```
#=== ERROR while compiling mirage-xen.3.3.0 ===================================#
# context     2.0.3 | linux/x86_64 | ocaml-base-compiler.4.05.0 | git://github.com/ocaml/opam-repository
# path        ~/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/mirage-xen.3.3.0
# command     ~/.opam/opam-init/hooks/sandbox.sh build env OPAM_PKG_CONFIG_PATH=/home/travis/.opam/ocaml-base-compiler.4.05.0/lib/pkgconfig dune build -p mirage-xen -j 1
# exit-code   1
# env-file    ~/.opam/log/mirage-xen-11109-4ad119.env
# output-file ~/.opam/log/mirage-xen-11109-4ad119.out
### output ###
# Path outside the workspace: ../pkgconfig/mirage-xen.pc from .
```

according to @rgrinberg https://github.com/mirage/mirage/issues/969#issuecomment-482547099 this is likely a dune bug.