### PR TITLE
datakit-ci: depend on cstruct<4 due to sexp fix

### DIFF
--- a/packages/datakit-ci/datakit-ci.0.10.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.10.0/opam
@@ -25,6 +25,7 @@ depends: [
   "logs"
   "tyxml" {>= "4.0.0"}
   "tls" {< "0.9.0"}
+  "cstruct" {<"4.0.0"}
   "conduit"
   "io-page"
   "pbkdf"

--- a/packages/datakit-ci/datakit-ci.0.10.1/opam
+++ b/packages/datakit-ci/datakit-ci.0.10.1/opam
@@ -23,6 +23,7 @@ depends: [
   "cmdliner"
   "fmt"
   "logs"
+  "cstruct" {<"4.0.0"}
   "tyxml" {>= "4.0.0"}
   "tls" {< "0.9.0"}
   "conduit"

--- a/packages/datakit-ci/datakit-ci.0.11.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.11.0/opam
@@ -22,6 +22,7 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "astring"
   "cmdliner"
+  "cstruct" {<"4.0.0"}
   "fmt"
   "logs"
   "tyxml" {>= "4.0.0"}

--- a/packages/datakit-ci/datakit-ci.0.12.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.0/opam
@@ -23,6 +23,7 @@ depends: [
   "yojson" {<= "1.5.0"}
   "astring"
   "cmdliner"
+  "cstruct" {<"4.0.0"}
   "fmt"
   "logs"
   "tyxml" {>= "4.0.0" & < "4.3.0"}

--- a/packages/datakit-ci/datakit-ci.0.12.1/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.1/opam
@@ -22,6 +22,7 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "astring"
   "cmdliner"
+  "cstruct" {<"4.0.0"}
   "fmt"
   "logs"
   "tyxml" {>= "4.0.0"}

--- a/packages/datakit-ci/datakit-ci.0.12.2/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.2/opam
@@ -17,6 +17,7 @@ depends: [
   "protocol-9p-unix" {>= "0.11.0"}
   "astring"
   "cmdliner"
+  "cstruct" {<"4.0.0"}
   "fmt"
   "logs"
   "tyxml" {>= "4.0.0"}


### PR DESCRIPTION
found in revdeps for #13947