### PR TITLE
[new release] ezjsonm-lwt and ezjsonm (1.1.0)

### DIFF
--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "hex"
   "lwt" {>= "2.5.0"}
-  "ppx_sexp_conv" {with-test & < "v0.13" & > "v0.9.0"}
+  "ppx_sexp_conv" {with-test & < "v0.13" & >= "v0.9.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.0.0/opam
@@ -8,14 +8,14 @@ doc: "https://mirage.github.io/ezjsonm"
 bug-reports: "https://github.com/mirage/ezjsonm/issues"
 depends: [
   "ocaml" {>="4.03.0"}
-  "ezjsonm"
+  "ezjsonm" {=version}
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "jsonm" {>= "0.9.1"}
   "sexplib" {< "v0.13"}
   "hex"
   "lwt" {>= "2.5.0"}
-  "ppx_sexp_conv" {with-test & < "v0.13"}
+  "ppx_sexp_conv" {with-test & < "v0.13" & > "v0.9.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.1.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.1.0/opam
@@ -8,10 +8,10 @@ doc: "https://mirage.github.io/ezjsonm"
 bug-reports: "https://github.com/mirage/ezjsonm/issues"
 depends: [
   "ocaml"
-  "ezjsonm"
+  "ezjsonm" {=version}
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
-  "ppx_sexp_conv" {with-test}
+  "ppx_sexp_conv" {with-test & >"v0.9.0"}
   "jsonm" {>= "1.0.0"}
   "sexplib"
   "hex"

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.1.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml"
+  "ezjsonm"
+  "dune" {build & >= "1.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "ppx_sexp_conv" {with-test}
+  "jsonm" {>= "1.0.0"}
+  "sexplib"
+  "hex"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple Lwt-based interface to the Jsonm JSON library"
+description: """
+This simple interface over the Jsonm library provides an
+Lwt variant of the serialisation functions.
+"""
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.1.0/ezjsonm-v1.1.0.tbz"
+  checksum: "md5=e8f207c6cd2226b2c4784b1e56556797"
+}

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.1.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ezjsonm" {=version}
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
-  "ppx_sexp_conv" {with-test & >"v0.9.0"}
+  "ppx_sexp_conv" {with-test & >="v0.9.0"}
   "jsonm" {>= "1.0.0"}
   "sexplib"
   "hex"

--- a/packages/ezjsonm/ezjsonm.1.1.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm/"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune" {build & >= "1.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "jsonm" {>= "1.0.0"}
+  "sexplib"
+  "hex"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple interface on top of the Jsonm JSON library"
+description: """
+Ezjsonm provides more convenient (but far less flexible)
+input and output functions that go to and from `string` values.
+This avoids the need to write signal code, which is useful for
+quick scripts that manipulate JSON.
+
+More advanced users should go straight to the Jsonm library and
+use it directly, rather than be saddled with the Ezjsonm interface.
+"""
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.1.0/ezjsonm-v1.1.0.tbz"
+  checksum: "md5=e8f207c6cd2226b2c4784b1e56556797"
+}


### PR DESCRIPTION
Simple Lwt-based interface to the Jsonm JSON library

- Project page: <a href="https://github.com/mirage/ezjsonm">https://github.com/mirage/ezjsonm</a>
- Documentation: <a href="https://mirage.github.io/ezjsonm">https://mirage.github.io/ezjsonm</a>

##### CHANGES:

* Add `value_to_*` and `value_from_*` methods to support
  RFC 7159/ECMA-404 (mirage/ezjsonm#34 @jaredly)
