### PR TITLE
Fix bap packages: fix their dependencies to use the same version as the package version

### DIFF
--- a/packages/bap-abi/bap-abi.1.0.0/opam
+++ b/packages/bap-abi/bap-abi.1.0.0/opam
@@ -16,7 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["ocamlfind" "remove" "bap-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "cmdliner"
+]
 synopsis: "A pass that applies ABI specific information"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-abi/bap-abi.1.1.0/opam
+++ b/packages/bap-abi/bap-abi.1.1.0/opam
@@ -16,7 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["ocamlfind" "remove" "bap-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "cmdliner"
+]
 synopsis: "A pass that applies ABI specific information"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-abi/bap-abi.1.2.0/opam
+++ b/packages/bap-abi/bap-abi.1.2.0/opam
@@ -16,7 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["ocamlfind" "remove" "bap-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "cmdliner"
+]
 synopsis: "A pass that applies ABI specific information"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-abi/bap-abi.1.3.0/opam
+++ b/packages/bap-abi/bap-abi.1.3.0/opam
@@ -16,7 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["ocamlfind" "remove" "bap-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "cmdliner"
+]
 synopsis: "A pass that applies ABI specific information"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-api/bap-api.1.0.0/opam
+++ b/packages/bap-api/bap-api.1.0.0/opam
@@ -16,7 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["ocamlfind" "remove" "bap-api"]
          [ "bapbundle" "remove" "api.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "cmdliner"
+]
 synopsis: "A pass that adds parameters to subroutines based on known API"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-api/bap-api.1.1.0/opam
+++ b/packages/bap-api/bap-api.1.1.0/opam
@@ -16,7 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["ocamlfind" "remove" "bap-api"]
          [ "bapbundle" "remove" "api.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "cmdliner"
+]
 synopsis: "A pass that adds parameters to subroutines based on known API"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-api/bap-api.1.2.0/opam
+++ b/packages/bap-api/bap-api.1.2.0/opam
@@ -16,7 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["ocamlfind" "remove" "bap-api"]
          [ "bapbundle" "remove" "api.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "cmdliner"
+]
 synopsis: "A pass that adds parameters to subroutines based on known API"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-api/bap-api.1.3.0/opam
+++ b/packages/bap-api/bap-api.1.3.0/opam
@@ -17,7 +17,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["bapbundle" "remove" "api.plugin"]
          ["rm" "-rf" "%{prefix}%/share/bap-api/c"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "cmdliner"
+]
 synopsis: "A pass that adds parameters to subroutines based on known API"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-arm/bap-arm.1.0.0/opam
+++ b/packages/bap-arm/bap-arm.1.0.0/opam
@@ -21,7 +21,13 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-llvm" "bap-abi" "bap-c"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "bap-llvm" {= "1.0.0"}
+  "bap-abi" {= "1.0.0"}
+  "bap-c" {= "1.0.0"}
+]
 synopsis: "BAP ARM lifter"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-arm/bap-arm.1.1.0/opam
+++ b/packages/bap-arm/bap-arm.1.1.0/opam
@@ -21,7 +21,13 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-llvm" "bap-abi" "bap-c"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "bap-llvm" {= "1.1.0"}
+  "bap-abi" {= "1.1.0"}
+  "bap-c" {= "1.1.0"}
+]
 synopsis: "BAP ARM lifter"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-arm/bap-arm.1.2.0/opam
+++ b/packages/bap-arm/bap-arm.1.2.0/opam
@@ -21,7 +21,13 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-llvm" "bap-abi" "bap-c"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "bap-llvm" {= "1.2.0"}
+  "bap-abi" {= "1.2.0"}
+  "bap-c" {= "1.2.0"}
+]
 synopsis: "BAP ARM lifter"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-arm/bap-arm.1.3.0/opam
+++ b/packages/bap-arm/bap-arm.1.3.0/opam
@@ -21,7 +21,13 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-llvm" "bap-abi" "bap-c"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-llvm" {= "1.3.0"}
+  "bap-abi" {= "1.3.0"}
+  "bap-c" {= "1.3.0"}
+]
 synopsis: "BAP ARM lifter"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-arm/bap-arm.1.4.0/opam
+++ b/packages/bap-arm/bap-arm.1.4.0/opam
@@ -24,9 +24,9 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-llvm"
-  "bap-abi"
-  "bap-c"
+  "bap-llvm" {= "1.4.0"}
+  "bap-abi" {= "1.4.0"}
+  "bap-c" {= "1.4.0"}
 ]
 synopsis: "BAP ARM lifter and disassembler"
 description: """

--- a/packages/bap-arm/bap-arm.1.5.0/opam
+++ b/packages/bap-arm/bap-arm.1.5.0/opam
@@ -24,9 +24,9 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-llvm"
-  "bap-abi"
-  "bap-c"
+  "bap-llvm" {= "1.5.0"}
+  "bap-abi" {= "1.5.0"}
+  "bap-c" {= "1.5.0"}
 ]
 synopsis: "BAP ARM lifter and disassembler"
 description: """

--- a/packages/bap-arm/bap-arm.1.6.0/opam
+++ b/packages/bap-arm/bap-arm.1.6.0/opam
@@ -24,9 +24,9 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-llvm"
-  "bap-abi"
-  "bap-c"
+  "bap-llvm" {= "1.6.0"}
+  "bap-abi" {= "1.6.0"}
+  "bap-c" {= "1.6.0"}
 ]
 synopsis: "BAP ARM lifter and disassembler"
 description: """

--- a/packages/bap-beagle/bap-beagle.1.2.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.2.0/opam
@@ -16,7 +16,12 @@ remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
          ["ocamlfind" "remove" "bap-beagle-prey"]
          ["bapbundle" "remove" "beagle.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner" "bap-microx"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "cmdliner"
+  "bap-microx" {= "1.2.0"}
+]
 synopsis: "An obfuscated string solver"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-beagle/bap-beagle.1.3.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.3.0/opam
@@ -18,7 +18,13 @@ remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
          ["bapbundle" "remove" "beagle.plugin"]
          ["bapbundle" "remove" "strings.plugin"]
          ]
-depends: ["ocaml" "bap-std" "cmdliner" "bap-microx" "bap-primus"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "cmdliner"
+  "bap-microx" {= "1.3.0"}
+  "bap-primus" {= "1.3.0"}
+]
 synopsis: "An obfuscated string solver"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-beagle/bap-beagle.1.4.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
   "cmdliner"
-  "bap-microx"
+  "bap-microx" {= "1.4.0"}
   "bap-primus" {= "1.4.0"}
 ]
 synopsis: "BAP obfuscated string solver"

--- a/packages/bap-beagle/bap-beagle.1.5.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
   "cmdliner"
-  "bap-microx"
+  "bap-microx" {= "1.5.0"}
   "bap-primus" {= "1.5.0"}
 ]
 synopsis: "BAP obfuscated string solver"

--- a/packages/bap-beagle/bap-beagle.1.6.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
   "cmdliner"
-  "bap-microx"
+  "bap-microx" {= "1.6.0"}
   "bap-primus" {= "1.6.0"}
 ]
 synopsis: "BAP obfuscated string solver"

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.0.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.0.0/opam
@@ -17,7 +17,13 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" "bap-std" "bap-byteweight" "cmdliner" "ocurl" "fileutils" "re"
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "bap-byteweight" {= "1.0.0"}
+  "cmdliner"
+  "ocurl"
+  "fileutils"
+  "re"
 ]
 synopsis: "A frontend for the Byteweight library"
 flags: light-uninstall

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/opam
@@ -17,7 +17,13 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" "bap-std" "bap-byteweight" "cmdliner" "ocurl" "fileutils" "re"
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "bap-byteweight" {= "1.1.0"}
+  "cmdliner"
+  "ocurl"
+  "fileutils"
+  "re"
 ]
 synopsis: "A frontend for the Byteweight library"
 flags: light-uninstall

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.2.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.2.0/opam
@@ -17,7 +17,13 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" "bap-std" "bap-byteweight" "cmdliner" "ocurl" "fileutils" "re"
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "bap-byteweight" {= "1.2.0"}
+  "cmdliner"
+  "ocurl"
+  "fileutils"
+  "re"
 ]
 synopsis: "A frontend for the Byteweight library"
 flags: light-uninstall

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.3.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.3.0/opam
@@ -17,7 +17,13 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" "bap-std" "bap-byteweight" "cmdliner" "ocurl" "fileutils" "re"
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-byteweight" {= "1.3.0"}
+  "cmdliner"
+  "ocurl"
+  "fileutils"
+  "re"
 ]
 synopsis: "A frontend for the Byteweight library"
 flags: light-uninstall

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.4.0/opam
@@ -19,7 +19,7 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-byteweight"
+  "bap-byteweight" {= "1.4.0"}
   "cmdliner"
   "ocurl"
   "fileutils"

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.5.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.5.0/opam
@@ -19,7 +19,7 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-byteweight"
+  "bap-byteweight" {= "1.5.0"}
   "cmdliner"
   "ocurl"
   "fileutils"

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.6.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.6.0/opam
@@ -19,7 +19,7 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-byteweight"
+  "bap-byteweight" {= "1.6.0"}
   "cmdliner"
   "ocurl"
   "fileutils"

--- a/packages/bap-byteweight/bap-byteweight.1.0.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.0.0/opam
@@ -23,7 +23,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-signatures"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "bap-signatures" {= "1.0.0"}
+]
 synopsis: "A library and a plugin for finding function starts"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-byteweight/bap-byteweight.1.1.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.1.0/opam
@@ -23,7 +23,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-signatures"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "bap-signatures" {= "1.1.0"}
+]
 synopsis: "A library and a plugin for finding function starts"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-byteweight/bap-byteweight.1.2.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.2.0/opam
@@ -23,7 +23,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-signatures"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "bap-signatures" {= "1.2.0"}
+]
 synopsis: "A library and a plugin for finding function starts"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-byteweight/bap-byteweight.1.3.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.3.0/opam
@@ -23,7 +23,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-signatures"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-signatures" {= "1.3.0"}
+]
 synopsis: "A library and a plugin for finding function starts"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-byteweight/bap-byteweight.1.4.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.4.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-signatures"
+  "bap-signatures" {= "1.4.0"}
 ]
 synopsis: "BAP facility for indentifying code entry points"
 description: """

--- a/packages/bap-byteweight/bap-byteweight.1.5.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.5.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-signatures"
+  "bap-signatures" {= "1.5.0"}
 ]
 synopsis: "BAP facility for indentifying code entry points"
 description: """

--- a/packages/bap-byteweight/bap-byteweight.1.6.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.1.6.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-signatures"
+  "bap-signatures" {= "1.6.0"}
 ]
 synopsis: "BAP facility for indentifying code entry points"
 description: """

--- a/packages/bap-c/bap-c.1.0.0/opam
+++ b/packages/bap-c/bap-c.1.0.0/opam
@@ -13,7 +13,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-c"]]
-depends: ["ocaml" "bap-std" "bap-api"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "bap-api" {= "1.0.0"}
+]
 synopsis: "A C language support library for BAP"
 flags: light-uninstall
 url {

--- a/packages/bap-c/bap-c.1.1.0/opam
+++ b/packages/bap-c/bap-c.1.1.0/opam
@@ -13,7 +13,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-c"]]
-depends: ["ocaml" "bap-std" "bap-api"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "bap-api" {= "1.1.0"}
+]
 synopsis: "A C language support library for BAP"
 flags: light-uninstall
 url {

--- a/packages/bap-c/bap-c.1.2.0/opam
+++ b/packages/bap-c/bap-c.1.2.0/opam
@@ -13,7 +13,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-c"]]
-depends: ["ocaml" "bap-std" "bap-api"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "bap-api" {= "1.2.0"}
+]
 synopsis: "A C language support library for BAP"
 flags: light-uninstall
 url {

--- a/packages/bap-c/bap-c.1.3.0/opam
+++ b/packages/bap-c/bap-c.1.3.0/opam
@@ -13,7 +13,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-c"]]
-depends: ["ocaml" "bap-std" "bap-api"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-api" {= "1.3.0"}
+]
 synopsis: "A C language support library for BAP"
 flags: light-uninstall
 url {

--- a/packages/bap-c/bap-c.1.4.0/opam
+++ b/packages/bap-c/bap-c.1.4.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-c"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-api"
+  "bap-api" {= "1.4.0"}
 ]
 synopsis: "A C language support library for BAP"
 flags: light-uninstall

--- a/packages/bap-c/bap-c.1.5.0/opam
+++ b/packages/bap-c/bap-c.1.5.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-c"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-api"
+  "bap-api" {= "1.5.0"}
 ]
 synopsis: "A C language support library for BAP"
 flags: light-uninstall

--- a/packages/bap-c/bap-c.1.6.0/opam
+++ b/packages/bap-c/bap-c.1.6.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-c"]]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-api"
+  "bap-api" {= "1.6.0"}
 ]
 synopsis: "A C language support library for BAP"
 flags: light-uninstall

--- a/packages/bap-cache/bap-cache.1.0.0/opam
+++ b/packages/bap-cache/bap-cache.1.0.0/opam
@@ -20,7 +20,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "cmdliner"
+]
 synopsis: "BAP caching service"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-cache/bap-cache.1.1.0/opam
+++ b/packages/bap-cache/bap-cache.1.1.0/opam
@@ -20,7 +20,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "cmdliner"
+]
 synopsis: "BAP caching service"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-cache/bap-cache.1.2.0/opam
+++ b/packages/bap-cache/bap-cache.1.2.0/opam
@@ -20,7 +20,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "cmdliner"
+]
 synopsis: "BAP caching service"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-cache/bap-cache.1.3.0/opam
+++ b/packages/bap-cache/bap-cache.1.3.0/opam
@@ -20,7 +20,11 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "cmdliner"
+]
 synopsis: "BAP caching service"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-callsites/bap-callsites.1.0.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.0.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis: "Inject data definition terms at callsites"

--- a/packages/bap-callsites/bap-callsites.1.1.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.1.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis: "Inject data definition terms at callsites"

--- a/packages/bap-callsites/bap-callsites.1.2.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.2.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis: "Inject data definition terms at callsites"

--- a/packages/bap-callsites/bap-callsites.1.3.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.3.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis: "Inject data definition terms at callsites"

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.0.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.0.0/opam
@@ -23,8 +23,8 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-demangle"
+  "bap-std" {= "1.0.0"}
+  "bap-demangle" {= "1.0.0"}
   "conf-binutils" {>= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.1.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.1.0/opam
@@ -23,8 +23,8 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-demangle"
+  "bap-std" {= "1.1.0"}
+  "bap-demangle" {= "1.1.0"}
   "conf-binutils" {>= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.2.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.2.0/opam
@@ -23,8 +23,8 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-demangle"
+  "bap-std" {= "1.2.0"}
+  "bap-demangle" {= "1.2.0"}
   "conf-binutils" {>= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.3.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.3.0/opam
@@ -22,8 +22,8 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-demangle"
+  "bap-std" {= "1.3.0"}
+  "bap-demangle" {= "1.3.0"}
   "conf-binutils" {>= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-demangle"
+  "bap-demangle" {= "1.4.0"}
   "conf-binutils" {>= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.5.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.5.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-demangle"
+  "bap-demangle" {= "1.5.0"}
   "conf-binutils" {>= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.6.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.6.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-demangle"
+  "bap-demangle" {= "1.6.0"}
   "conf-binutils" {>= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"

--- a/packages/bap-demangle/bap-demangle.1.0.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml"
   "core_kernel" {>= "113.24.00" & < "v0.9.0"}
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis: "Library for name demangling"

--- a/packages/bap-demangle/bap-demangle.1.1.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml"
   "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis: "Library for name demangling"

--- a/packages/bap-demangle/bap-demangle.1.2.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml"
   "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis: "Library for name demangling"

--- a/packages/bap-demangle/bap-demangle.1.3.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml"
   "core_kernel" {>= "113.24.00" & < "v0.9"}
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis: "Library for name demangling"

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.0.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.0.0/opam
@@ -19,7 +19,11 @@ remove: [
         ["bapbundle" "remove" "dump_symbols.plugin"]
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "cmdliner"
+]
 synopsis: "BAP plugin that dumps symbols information from a binary"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/opam
@@ -19,7 +19,11 @@ remove: [
         ["bapbundle" "remove" "dump_symbols.plugin"]
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "cmdliner"
+]
 synopsis: "BAP plugin that dumps symbols information from a binary"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.2.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.2.0/opam
@@ -19,7 +19,11 @@ remove: [
         ["bapbundle" "remove" "dump_symbols.plugin"]
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "cmdliner"
+]
 synopsis: "BAP plugin that dumps symbols information from a binary"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.3.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.3.0/opam
@@ -19,7 +19,11 @@ remove: [
         ["bapbundle" "remove" "dump_symbols.plugin"]
 ]
 
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "cmdliner"
+]
 synopsis: "BAP plugin that dumps symbols information from a binary"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-dwarf/bap-dwarf.1.0.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.1.0.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-dwarf"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+]
 synopsis: "BAP DWARF parsing library"
 flags: light-uninstall
 url {

--- a/packages/bap-dwarf/bap-dwarf.1.1.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.1.1.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-dwarf"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+]
 synopsis: "BAP DWARF parsing library"
 flags: light-uninstall
 url {

--- a/packages/bap-dwarf/bap-dwarf.1.2.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.1.2.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-dwarf"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+]
 synopsis: "BAP DWARF parsing library"
 flags: light-uninstall
 url {

--- a/packages/bap-dwarf/bap-dwarf.1.3.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.1.3.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-dwarf"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+]
 synopsis: "BAP DWARF parsing library"
 flags: light-uninstall
 url {

--- a/packages/bap-elf/bap-elf.1.0.0/opam
+++ b/packages/bap-elf/bap-elf.1.0.0/opam
@@ -22,8 +22,8 @@ remove: [
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-dwarf"
+  "bap-std" {= "1.0.0"}
+  "bap-dwarf" {= "1.0.0"}
   "camlp4"
   "bitstring" {< "3.0.0"}
 ]

--- a/packages/bap-elf/bap-elf.1.1.0/opam
+++ b/packages/bap-elf/bap-elf.1.1.0/opam
@@ -22,8 +22,8 @@ remove: [
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-dwarf"
+  "bap-std" {= "1.1.0"}
+  "bap-dwarf" {= "1.1.0"}
   "camlp4"
   "bitstring" {< "3.0.0"}
 ]

--- a/packages/bap-elf/bap-elf.1.2.0/opam
+++ b/packages/bap-elf/bap-elf.1.2.0/opam
@@ -22,8 +22,8 @@ remove: [
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-dwarf"
+  "bap-std" {= "1.2.0"}
+  "bap-dwarf" {= "1.2.0"}
   "camlp4"
   "bitstring" {< "3.0.0"}
 ]

--- a/packages/bap-elf/bap-elf.1.3.0/opam
+++ b/packages/bap-elf/bap-elf.1.3.0/opam
@@ -22,8 +22,8 @@ remove: [
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-dwarf"
+  "bap-std" {= "1.3.0"}
+  "bap-dwarf" {= "1.3.0"}
   "camlp4"
   "bitstring" {< "3.0.0"}
 ]

--- a/packages/bap-elf/bap-elf.1.5.0/opam
+++ b/packages/bap-elf/bap-elf.1.5.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.05.0" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-dwarf"
+  "bap-dwarf" {= "1.5.0"}
   "bitstring" {>= "3.0.0"}
 ]
 synopsis: "BAP ELF parser and loader written in native OCaml"

--- a/packages/bap-elf/bap-elf.1.6.0/opam
+++ b/packages/bap-elf/bap-elf.1.6.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-dwarf"
+  "bap-dwarf" {= "1.6.0"}
   "bitstring" {>= "3.0.0"}
 ]
 synopsis: "BAP ELF parser and loader written in native OCaml"

--- a/packages/bap-frontc/bap-frontc.1.0.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.0.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
         ["bapbundle" "remove" "frontc_parser.plugin"]]
-depends: ["ocaml" "bap-std" "bap-c" "FrontC"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "bap-c" {= "1.0.0"}
+  "FrontC"
+]
 synopsis: "A C language frontend for based on FrontC library"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-frontc/bap-frontc.1.1.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.1.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
         ["bapbundle" "remove" "frontc_parser.plugin"]]
-depends: ["ocaml" "bap-std" "bap-c" "FrontC"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "bap-c" {= "1.1.0"}
+  "FrontC"
+]
 synopsis: "A C language frontend for based on FrontC library"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-frontc/bap-frontc.1.2.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.2.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
         ["bapbundle" "remove" "frontc_parser.plugin"]]
-depends: ["ocaml" "bap-std" "bap-c" "FrontC"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "bap-c" {= "1.2.0"}
+  "FrontC"
+]
 synopsis: "A C language frontend for based on FrontC library"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-frontc/bap-frontc.1.3.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.3.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
         ["bapbundle" "remove" "frontc_parser.plugin"]]
-depends: ["ocaml" "bap-std" "bap-c" "FrontC"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-c" {= "1.3.0"}
+  "FrontC"
+]
 synopsis: "A C language frontend for based on FrontC library"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-frontc/bap-frontc.1.4.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.4.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-c"
+  "bap-c" {= "1.4.0"}
   "FrontC"
 ]
 synopsis: "A C language frontend for based on FrontC library"

--- a/packages/bap-frontc/bap-frontc.1.5.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.5.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-c"
+  "bap-c" {= "1.5.0"}
   "FrontC"
 ]
 synopsis: "A C language frontend for based on FrontC library"

--- a/packages/bap-frontc/bap-frontc.1.6.0/opam
+++ b/packages/bap-frontc/bap-frontc.1.6.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-c"
+  "bap-c" {= "1.6.0"}
   "FrontC"
 ]
 synopsis: "A C language frontend for based on FrontC library"

--- a/packages/bap-frontend/bap-frontend.1.0.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.0.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis: "BAP frontend"

--- a/packages/bap-frontend/bap-frontend.1.1.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.1.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis: "BAP frontend"

--- a/packages/bap-frontend/bap-frontend.1.2.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis: "BAP frontend"

--- a/packages/bap-frontend/bap-frontend.1.3.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.3.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis: "BAP frontend"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.0.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.0.0/opam
@@ -18,9 +18,9 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-ida"
-  "bap-byteweight-frontend"
+  "bap-std" {= "1.0.0"}
+  "bap-ida" {= "1.0.0"}
+  "bap-byteweight-frontend" {= "1.0.0"}
   "cmdliner"
   "fileutils"
   "re"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/opam
@@ -18,9 +18,9 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-ida"
-  "bap-byteweight-frontend"
+  "bap-std" {= "1.1.0"}
+  "bap-ida" {= "1.1.0"}
+  "bap-byteweight-frontend" {= "1.1.0"}
   "cmdliner"
   "fileutils"
   "re"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.2.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.2.0/opam
@@ -18,9 +18,9 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-ida"
-  "bap-byteweight-frontend"
+  "bap-std" {= "1.2.0"}
+  "bap-ida" {= "1.2.0"}
+  "bap-byteweight-frontend" {= "1.2.0"}
   "cmdliner"
   "fileutils"
   "re"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.3.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.3.0/opam
@@ -18,9 +18,9 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
   "ocaml"
-  "bap-std"
-  "bap-ida"
-  "bap-byteweight-frontend"
+  "bap-std" {= "1.3.0"}
+  "bap-ida" {= "1.3.0"}
+  "bap-byteweight-frontend" {= "1.3.0"}
   "cmdliner"
   "fileutils"
   "re"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.4.0/opam
@@ -19,8 +19,8 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-ida"
-  "bap-byteweight-frontend"
+  "bap-ida" {= "1.4.0"}
+  "bap-byteweight-frontend" {= "1.4.0"}
   "cmdliner"
   "fileutils"
   "re"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.5.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.5.0/opam
@@ -19,8 +19,8 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-ida"
-  "bap-byteweight-frontend"
+  "bap-ida" {= "1.5.0"}
+  "bap-byteweight-frontend" {= "1.5.0"}
   "cmdliner"
   "fileutils"
   "re"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.6.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.6.0/opam
@@ -19,8 +19,8 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-ida"
-  "bap-byteweight-frontend"
+  "bap-ida" {= "1.6.0"}
+  "bap-byteweight-frontend" {= "1.6.0"}
   "cmdliner"
   "fileutils"
   "re"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.0.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.0.0/opam
@@ -17,7 +17,11 @@ remove: [
         [ "bapbundle" "remove" "emit_ida_script.plugin"]
 
 ]
-depends: ["ocaml" "bap" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap" {= "1.0.0"}
+  "cmdliner"
+]
 synopsis: "Plugins for IDA and BAP integration"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/opam
@@ -17,7 +17,11 @@ remove: [
         [ "bapbundle" "remove" "emit_ida_script.plugin"]
 
 ]
-depends: ["ocaml" "bap" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap" {= "1.1.0"}
+  "cmdliner"
+]
 synopsis: "Plugins for IDA and BAP integration"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.2.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.2.0/opam
@@ -17,7 +17,11 @@ remove: [
         [ "bapbundle" "remove" "emit_ida_script.plugin"]
 
 ]
-depends: ["ocaml" "bap" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap" {= "1.2.0"}
+  "cmdliner"
+]
 synopsis: "Plugins for IDA and BAP integration"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.3.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.3.0/opam
@@ -17,7 +17,11 @@ remove: [
         [ "bapbundle" "remove" "emit_ida_script.plugin"]
 
 ]
-depends: ["ocaml" "bap" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap" {= "1.3.0"}
+  "cmdliner"
+]
 synopsis: "Plugins for IDA and BAP integration"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.4.0/opam
@@ -19,7 +19,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "bap"
+  "bap" {= "1.4.0"}
   "cmdliner"
 ]
 synopsis: "Plugins for IDA and BAP integration"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.5.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.5.0/opam
@@ -19,7 +19,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "bap"
+  "bap" {= "1.5.0"}
   "cmdliner"
 ]
 synopsis: "Plugins for IDA and BAP integration"

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.6.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.6.0/opam
@@ -19,7 +19,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "bap"
+  "bap" {= "1.6.0"}
   "cmdliner"
 ]
 synopsis: "Plugins for IDA and BAP integration"

--- a/packages/bap-ida-python/bap-ida-python.1.3.0/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.3.0/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "bap" {>= "1.3.0"}
+  "bap" {= "1.3.0"}
   "conf-ida"
 ]
 synopsis: "A BAP - IDA Pro integration library"

--- a/packages/bap-ida/bap-ida.1.0.0/opam
+++ b/packages/bap-ida/bap-ida.1.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
-  "bap-ida-plugin"
+  "bap-ida-plugin" {= "1.0.0"}
 ]
 synopsis: "An IDA Pro integration library"
 url {

--- a/packages/bap-ida/bap-ida.1.1.0/opam
+++ b/packages/bap-ida/bap-ida.1.1.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
-  "bap-ida-plugin"
+  "bap-ida-plugin" {= "1.1.0"}
 ]
 synopsis: "An IDA Pro integration library"
 url {

--- a/packages/bap-ida/bap-ida.1.2.0/opam
+++ b/packages/bap-ida/bap-ida.1.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
-  "bap-ida-plugin"
+  "bap-ida-plugin" {= "1.2.0"}
 ]
 synopsis: "An IDA Pro integration library"
 url {

--- a/packages/bap-ida/bap-ida.1.3.0/opam
+++ b/packages/bap-ida/bap-ida.1.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_jane" {>= "113.24.01" & < "v0.9"}
   "fileutils"
   "re"
-  "bap-ida-plugin"
+  "bap-ida-plugin" {= "1.3.0"}
 ]
 synopsis: "An IDA Pro integration library"
 url {

--- a/packages/bap-ida/bap-ida.1.4.0/opam
+++ b/packages/bap-ida/bap-ida.1.4.0/opam
@@ -25,13 +25,13 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "conf-ida"
-  "bap-ida-python"
+  "bap-ida-python" {>= "1.4.0"}
   "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "oasis" {build & = "0.4.7"}
   "ppx_jane" {>= "v0.9.0" & < "v0.10"}
   "fileutils"
   "re"
-  "bap-ida-plugin"
+  "bap-ida-plugin" {= "1.4.0"}
 ]
 synopsis: "An IDA Pro integration library"
 url {

--- a/packages/bap-ida/bap-ida.1.5.0/opam
+++ b/packages/bap-ida/bap-ida.1.5.0/opam
@@ -25,13 +25,13 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "conf-ida"
-  "bap-ida-python" {>= "1.5.0"}
+  "bap-ida-python" {= "1.5.0"}
   "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "oasis" {build & >= "0.4.7"}
   "ppx_jane" {>= "v0.9.0" & < "v0.10"}
   "fileutils"
   "re"
-  "bap-ida-plugin"
+  "bap-ida-plugin" {= "1.5.0"}
 ]
 synopsis: "An IDA Pro integration library"
 url {

--- a/packages/bap-ida/bap-ida.1.6.0/opam
+++ b/packages/bap-ida/bap-ida.1.6.0/opam
@@ -25,12 +25,12 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "conf-ida"
-  "bap-ida-python" {>= "1.5.0"}
+  "bap-ida-python" {= "1.6.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
   "fileutils"
   "re"
-  "bap-ida-plugin"
+  "bap-ida-plugin" {= "1.6.0"}
 ]
 synopsis: "An IDA Pro integration library"
 url {

--- a/packages/bap-llvm/bap-llvm.1.0.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.0.0/opam
@@ -28,7 +28,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
   "conf-bap-llvm"
   "conf-env-travis"

--- a/packages/bap-llvm/bap-llvm.1.1.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.1.0/opam
@@ -28,7 +28,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
   "conf-bap-llvm"
   "conf-env-travis"

--- a/packages/bap-llvm/bap-llvm.1.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.2.0/opam
@@ -29,7 +29,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
   "conf-bap-llvm"
   "conf-env-travis"

--- a/packages/bap-llvm/bap-llvm.1.3.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.3.0/opam
@@ -29,7 +29,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
   "conf-env-travis"
   "conf-bap-llvm" {>= "1.1"}

--- a/packages/bap-mc/bap-mc.1.0.0/opam
+++ b/packages/bap-mc/bap-mc.1.0.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis: "BAP machine instruction playground"

--- a/packages/bap-mc/bap-mc.1.1.0/opam
+++ b/packages/bap-mc/bap-mc.1.1.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis: "BAP machine instruction playground"

--- a/packages/bap-mc/bap-mc.1.2.0/opam
+++ b/packages/bap-mc/bap-mc.1.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis: "BAP machine instruction playground"

--- a/packages/bap-mc/bap-mc.1.3.0/opam
+++ b/packages/bap-mc/bap-mc.1.3.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis: "BAP machine instruction playground"

--- a/packages/bap-microx/bap-microx.1.0.0/opam
+++ b/packages/bap-microx/bap-microx.1.0.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-microx"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+]
 synopsis: "A micro execution framework"
 flags: light-uninstall
 url {

--- a/packages/bap-microx/bap-microx.1.1.0/opam
+++ b/packages/bap-microx/bap-microx.1.1.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-microx"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+]
 synopsis: "A micro execution framework"
 flags: light-uninstall
 url {

--- a/packages/bap-microx/bap-microx.1.2.0/opam
+++ b/packages/bap-microx/bap-microx.1.2.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-microx"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+]
 synopsis: "A micro execution framework"
 flags: light-uninstall
 url {

--- a/packages/bap-microx/bap-microx.1.3.0/opam
+++ b/packages/bap-microx/bap-microx.1.3.0/opam
@@ -13,7 +13,10 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-microx"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+]
 synopsis: "A micro execution framework"
 flags: light-uninstall
 url {

--- a/packages/bap-mips/bap-mips.1.4.0/opam
+++ b/packages/bap-mips/bap-mips.1.4.0/opam
@@ -20,8 +20,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-mips"]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-abi"
-  "bap-c"
+  "bap-abi" {= "1.4.0"}
+  "bap-c" {= "1.4.0"}
 ]
 synopsis: "BAP MIPS lifter"
 description: "Provides lifter for MIPS and MIPS32 architectures"

--- a/packages/bap-mips/bap-mips.1.5.0/opam
+++ b/packages/bap-mips/bap-mips.1.5.0/opam
@@ -20,8 +20,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-mips"]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-abi"
-  "bap-c"
+  "bap-abi" {= "1.5.0"}
+  "bap-c" {= "1.5.0"}
 ]
 synopsis: "BAP MIPS lifter"
 description: "Provides lifter for MIPS and MIPS32 architectures"

--- a/packages/bap-mips/bap-mips.1.6.0/opam
+++ b/packages/bap-mips/bap-mips.1.6.0/opam
@@ -20,8 +20,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-mips"]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-abi"
-  "bap-c"
+  "bap-abi" {= "1.6.0"}
+  "bap-c" {= "1.6.0"}
 ]
 synopsis: "BAP MIPS lifter"
 description: "Provides lifter for MIPS and MIPS32 architectures"

--- a/packages/bap-objdump/bap-objdump.1.0.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.0.0/opam
@@ -19,7 +19,13 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 	 ["bapbundle" "remove" "objdump.plugin"]
 ]
-depends: ["ocaml" "bap-std" "re" "cmdliner" "conf-binutils"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "re"
+  "cmdliner"
+  "conf-binutils"
+]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-objdump/bap-objdump.1.1.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.1.0/opam
@@ -19,7 +19,13 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 	 ["bapbundle" "remove" "objdump.plugin"]
 ]
-depends: ["ocaml" "bap-std" "re" "cmdliner" "conf-binutils"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "re"
+  "cmdliner"
+  "conf-binutils"
+]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-objdump/bap-objdump.1.2.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.2.0/opam
@@ -19,7 +19,13 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 	 ["bapbundle" "remove" "objdump.plugin"]
 ]
-depends: ["ocaml" "bap-std" "re" "cmdliner" "conf-binutils"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "re"
+  "cmdliner"
+  "conf-binutils"
+]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-objdump/bap-objdump.1.3.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.3.0/opam
@@ -19,7 +19,13 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 	 ["bapbundle" "remove" "objdump.plugin"]
 ]
-depends: ["ocaml" "bap-std" "re" "cmdliner" "conf-binutils"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "re"
+  "cmdliner"
+  "conf-binutils"
+]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-phoenix/bap-phoenix.1.0.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.0.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
   "text-tags"
   "ocamlgraph"

--- a/packages/bap-phoenix/bap-phoenix.1.1.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.1.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
   "text-tags"
   "ocamlgraph"

--- a/packages/bap-phoenix/bap-phoenix.1.2.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.2.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
   "text-tags"
   "ocamlgraph"

--- a/packages/bap-phoenix/bap-phoenix.1.3.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.3.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
   "text-tags"
   "ocamlgraph"

--- a/packages/bap-piqi/bap-piqi.1.0.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.0.0/opam
@@ -30,7 +30,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
   "piqi" {>= "0.7.4"}
 ]

--- a/packages/bap-piqi/bap-piqi.1.1.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.1.0/opam
@@ -30,7 +30,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
   "piqi" {>= "0.7.4"}
 ]

--- a/packages/bap-piqi/bap-piqi.1.2.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.2.0/opam
@@ -30,7 +30,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
   "piqi" {>= "0.7.4"}
 ]

--- a/packages/bap-piqi/bap-piqi.1.3.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.3.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
   "piqi" {>= "0.7.4"}
 ]

--- a/packages/bap-powerpc/bap-powerpc.1.4.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.1.4.0/opam
@@ -19,8 +19,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
 
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "bap-abi"
-  "bap-c"
+  "bap-abi" {= "1.4.0"}
+  "bap-c" {= "1.4.0"}
   "bap-primus" {= "1.4.0"}
   "zarith"
 ]

--- a/packages/bap-powerpc/bap-powerpc.1.5.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.1.5.0/opam
@@ -19,8 +19,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
 
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "bap-abi"
-  "bap-c"
+  "bap-abi" {= "1.5.0"}
+  "bap-c" {= "1.5.0"}
   "bap-primus" {= "1.5.0"}
   "zarith"
 ]

--- a/packages/bap-powerpc/bap-powerpc.1.6.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.1.6.0/opam
@@ -19,8 +19,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
 
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "bap-abi"
-  "bap-c"
+  "bap-abi" {= "1.6.0"}
+  "bap-c" {= "1.6.0"}
   "bap-primus" {= "1.6.0"}
   "zarith"
 ]

--- a/packages/bap-primus-lisp/bap-primus-lisp.1.3.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.1.3.0/opam
@@ -20,7 +20,11 @@ remove: [
         ["rm" "-rf" "%{prefix}%/share/primus/site-lisp"]
         ]
 
-depends: ["ocaml" "bap-std" "bap-primus"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-primus" {= "1.3.0"}
+]
 synopsis: "Manages Primus Lisp Library"
 description: """
 Loads Primus Lisp library, controls loaded features and manages lisp

--- a/packages/bap-primus-support/bap-primus-support.1.3.0/opam
+++ b/packages/bap-primus-support/bap-primus-support.1.3.0/opam
@@ -37,7 +37,11 @@ remove: [
         ["bapbundle" "remove" "primus_wandering.plugin"]
 ]
 
-depends: ["ocaml" "bap-std" "bap-primus"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-primus" {= "1.3.0"}
+]
 synopsis: "Provides supporting components for Primus"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-primus-x86/bap-primus-x86.1.3.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.1.3.0/opam
@@ -19,7 +19,12 @@ remove: [
         ["bapbundle" "remove" "primus_x86.plugin"]
         ]
 
-depends: ["ocaml" "bap-std" "bap-primus" "bap-x86"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-primus" {= "1.3.0"}
+  "bap-x86" {= "1.3.0"}
+]
 synopsis: "The x86 CPU support package for Primus CPU emulator"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-primus-x86/bap-primus-x86.1.4.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.1.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
   "bap-primus" {= "1.4.0"}
-  "bap-x86"
+  "bap-x86" {= "1.4.0"}
 ]
 synopsis: "The x86 CPU support package for BAP Primus CPU emulator"
 url {

--- a/packages/bap-primus-x86/bap-primus-x86.1.5.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.1.5.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
   "bap-primus" {= "1.5.0"}
-  "bap-x86"
+  "bap-x86" {= "1.5.0"}
 ]
 synopsis: "The x86 CPU support package for BAP Primus CPU emulator"
 url {

--- a/packages/bap-primus-x86/bap-primus-x86.1.6.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.1.6.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
   "bap-primus" {= "1.6.0"}
-  "bap-x86"
+  "bap-x86" {= "1.6.0"}
 ]
 synopsis: "The x86 CPU support package for BAP Primus CPU emulator"
 url {

--- a/packages/bap-primus/bap-primus.1.3.0/opam
+++ b/packages/bap-primus/bap-primus.1.3.0/opam
@@ -16,7 +16,15 @@ install: [[make "install"]]
 
 remove: [["ocamlfind" "remove" "bap-primus"]]
 
-depends: ["ocaml" "bap-std" "bap-abi" "bap-c" "bap-future" "monads" "uuidm"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-abi" {= "1.3.0"}
+  "bap-c" {= "1.3.0"}
+  "bap-future" {= "1.3.0"}
+  "monads"
+  "uuidm"
+]
 synopsis: "The Microexecution Framework"
 description: """
 Primus is a framework for program microexecution. The Microexecution

--- a/packages/bap-primus/bap-primus.1.4.0/opam
+++ b/packages/bap-primus/bap-primus.1.4.0/opam
@@ -19,10 +19,10 @@ remove: [["ocamlfind" "remove" "bap-primus"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-abi"
-  "bap-c"
-  "bap-future"
-  "bap-strings"
+  "bap-abi" {= "1.4.0"}
+  "bap-c" {= "1.4.0"}
+  "bap-future" {= "1.4.0"}
+  "bap-strings" {= "1.4.0"}
   "monads"
   "uuidm"
   "graphlib" {> "1.3.0"}

--- a/packages/bap-primus/bap-primus.1.5.0/opam
+++ b/packages/bap-primus/bap-primus.1.5.0/opam
@@ -19,10 +19,10 @@ remove: [["ocamlfind" "remove" "bap-primus"]]
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-abi"
-  "bap-c"
-  "bap-future"
-  "bap-strings"
+  "bap-abi" {= "1.5.0"}
+  "bap-c" {= "1.5.0"}
+  "bap-future" {= "1.5.0"}
+  "bap-strings" {= "1.5.0"}
   "monads"
   "uuidm"
   "graphlib" {> "1.3.0"}

--- a/packages/bap-primus/bap-primus.1.6.0/opam
+++ b/packages/bap-primus/bap-primus.1.6.0/opam
@@ -19,10 +19,10 @@ remove: [["ocamlfind" "remove" "bap-primus"]]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-abi"
-  "bap-c"
-  "bap-future"
-  "bap-strings"
+  "bap-abi" {= "1.6.0"}
+  "bap-c" {= "1.6.0"}
+  "bap-future" {= "1.6.0"}
+  "bap-strings" {= "1.6.0"}
   "monads"
   "uuidm"
   "graphlib" {> "1.3.0"}

--- a/packages/bap-print/bap-print.1.0.0/opam
+++ b/packages/bap-print/bap-print.1.0.0/opam
@@ -20,7 +20,12 @@ remove: [
 
         ]
 
-depends: ["ocaml" "bap-std" "bap-demangle" "text-tags"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "bap-demangle" {= "1.0.0"}
+  "text-tags"
+]
 synopsis: "Print plugin - print project in various formats"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-print/bap-print.1.1.0/opam
+++ b/packages/bap-print/bap-print.1.1.0/opam
@@ -20,7 +20,12 @@ remove: [
 
         ]
 
-depends: ["ocaml" "bap-std" "bap-demangle" "text-tags"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "bap-demangle" {= "1.1.0"}
+  "text-tags"
+]
 synopsis: "Print plugin - print project in various formats"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-print/bap-print.1.2.0/opam
+++ b/packages/bap-print/bap-print.1.2.0/opam
@@ -20,7 +20,12 @@ remove: [
 
         ]
 
-depends: ["ocaml" "bap-std" "bap-demangle" "text-tags"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "bap-demangle" {= "1.2.0"}
+  "text-tags"
+]
 synopsis: "Print plugin - print project in various formats"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-print/bap-print.1.3.0/opam
+++ b/packages/bap-print/bap-print.1.3.0/opam
@@ -20,7 +20,12 @@ remove: [
 
         ]
 
-depends: ["ocaml" "bap-std" "bap-demangle" "text-tags"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-demangle" {= "1.3.0"}
+  "text-tags"
+]
 synopsis: "Print plugin - print project in various formats"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-print/bap-print.1.4.0/opam
+++ b/packages/bap-print/bap-print.1.4.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-demangle"
+  "bap-demangle" {= "1.4.0"}
   "text-tags"
 ]
 synopsis: "Print plugin - print project in various formats"

--- a/packages/bap-print/bap-print.1.5.0/opam
+++ b/packages/bap-print/bap-print.1.5.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-demangle"
+  "bap-demangle" {= "1.5.0"}
   "text-tags"
 ]
 synopsis: "Print plugin - print project in various formats"

--- a/packages/bap-print/bap-print.1.6.0/opam
+++ b/packages/bap-print/bap-print.1.6.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-demangle"
+  "bap-demangle" {= "1.6.0"}
   "text-tags"
 ]
 synopsis: "Print plugin - print project in various formats"

--- a/packages/bap-relocatable/bap-relocatable.1.3.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.1.3.0/opam
@@ -19,7 +19,11 @@ remove: [
         ["bapbundle" "remove" "relocatable.plugin"]
         ]
 
-depends: ["ocaml" "bap-std" "ogre"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "ogre"
+]
 synopsis: "Provides a brancher for relocatable files"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-run/bap-run.1.3.0/opam
+++ b/packages/bap-run/bap-run.1.3.0/opam
@@ -19,7 +19,11 @@ remove: [
         ["bapbundle" "remove" "run.plugin"]
         ]
 
-depends: ["ocaml" "bap-std" "bap-primus"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-primus" {= "1.3.0"}
+]
 synopsis: "A BAP plugin that executes a binary"
 description: "Uses the Primus Microexecution Framework to execute a binary."
 url {

--- a/packages/bap-saluki/bap-saluki.bap-1.4/opam
+++ b/packages/bap-saluki/bap-saluki.bap-1.4/opam
@@ -14,8 +14,8 @@ remove  : ["bapbundle" "remove" "saluki.plugin"]
 depends: [
   "ocaml"
   "bap-std"  {= "1.4.0"}
-  "bap-callsites"
-  "bap-taint-propagator"
+  "bap-callsites" {= "1.4.0"}
+  "bap-taint-propagator" {= "1.4.0"}
 ]
 synopsis:
   "A verification framework for detecting vulnerability patterns in binaries"

--- a/packages/bap-saluki/bap-saluki.bap-1.5/opam
+++ b/packages/bap-saluki/bap-saluki.bap-1.5/opam
@@ -14,8 +14,8 @@ remove  : ["bapbundle" "remove" "saluki.plugin"]
 depends: [
   "ocaml"
   "bap-std"  {= "1.5.0"}
-  "bap-callsites"
-  "bap-taint-propagator"
+  "bap-callsites" {= "1.5.0"}
+  "bap-taint-propagator" {= "1.5.0"}
 ]
 synopsis:
   "A verification framework for detecting vulnerability patterns in binaries"

--- a/packages/bap-saluki/bap-saluki.bap-1.6/opam
+++ b/packages/bap-saluki/bap-saluki.bap-1.6/opam
@@ -14,8 +14,8 @@ remove  : ["bapbundle" "remove" "saluki.plugin"]
 depends: [
   "ocaml"
   "bap-std"  {>= "1.6.0"}
-  "bap-callsites"
-  "bap-taint-propagator"
+  "bap-callsites" {= "1.6.0"}
+  "bap-taint-propagator" {= "1.6.0"}
 ]
 synopsis:
   "A verification framework for detecting vulnerability patterns in binaries"

--- a/packages/bap-server/bap-server.0.1.0/opam
+++ b/packages/bap-server/bap-server.0.1.0/opam
@@ -25,8 +25,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "core-lwt"
   "regular"
-  "bap-std"
-  "bap-arm"
+  "bap-std" {= "1.3.0"}
+  "bap-arm" {= "1.3.0"}
   "cohttp" {>= "0.20.0" & <= "0.21.0"}
   "core_kernel" {>= "113.33.00" & < "v0.9"}
   "ezjsonm" {>= "0.4.0" & < "0.4.4"}

--- a/packages/bap-server/bap-server.0.2.0/opam
+++ b/packages/bap-server/bap-server.0.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "core-lwt"
   "regular"
-  "bap"
+  "bap" {= "1.4.0"}
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}

--- a/packages/bap-server/bap-server.0.3.0/opam
+++ b/packages/bap-server/bap-server.0.3.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core-lwt"
   "regular"
-  "bap"
+  "bap" {= "1.6.0"}
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}

--- a/packages/bap-ssa/bap-ssa.1.3.0/opam
+++ b/packages/bap-ssa/bap-ssa.1.3.0/opam
@@ -14,7 +14,10 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-ssa"]
          ["bapbundle" "remove" "ssa.plugin"]]
-depends: ["ocaml" "bap-std"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+]
 synopsis: "Translates a program into the SSA form"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-std/bap-std.1.0.0/opam
+++ b/packages/bap-std/bap-std.1.0.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "base-unix"
-  "bap-future"
+  "bap-future" {= "1.0.0"}
   "camlzip"
   "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"

--- a/packages/bap-std/bap-std.1.1.0/opam
+++ b/packages/bap-std/bap-std.1.1.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "base-unix"
-  "bap-future"
+  "bap-future" {= "1.1.0"}
   "camlzip"
   "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"

--- a/packages/bap-std/bap-std.1.2.0/opam
+++ b/packages/bap-std/bap-std.1.2.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "base-unix"
-  "bap-future"
+  "bap-future" {= "1.2.0"}
   "camlzip" {>= "1.07"}
   "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"

--- a/packages/bap-std/bap-std.1.3.0/opam
+++ b/packages/bap-std/bap-std.1.3.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "base-unix"
-  "bap-future"
+  "bap-future" {= "1.3.0"}
   "camlzip" {>= "1.07"}
   "core_kernel" {>= "113.33.00" & < "v0.9"}
   "fileutils"

--- a/packages/bap-std/bap-std.1.4.0/opam
+++ b/packages/bap-std/bap-std.1.4.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "base-unix"
-  "bap-future"
+  "bap-future" {= "1.4.0"}
   "camlzip" {>= "1.07"}
   "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "bin_prot" {>= "v0.9.1" & < "v0.10"}

--- a/packages/bap-std/bap-std.1.5.0/opam
+++ b/packages/bap-std/bap-std.1.5.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "base-unix"
-  "bap-future"
+  "bap-future" {= "1.5.0"}
   "camlzip" {>= "1.07"}
   "core_kernel" {>= "v0.9.0" & < "v0.10"}
   "bin_prot" {>= "v0.9.1" & < "v0.10"}

--- a/packages/bap-std/bap-std.1.6.0/opam
+++ b/packages/bap-std/bap-std.1.6.0/opam
@@ -32,7 +32,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "base-unix"
-  "bap-future"
+  "bap-future" {= "1.6.0"}
   "camlzip" {>= "1.07"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "bin_prot" {>= "v0.11" & < "v0.12"}

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.0.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.0.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis: "BAP plugin to read symbols information from file"

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis: "BAP plugin to read symbols information from file"

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.2.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.2.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis: "BAP plugin to read symbols information from file"

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.3.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.3.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis: "BAP plugin to read symbols information from file"

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.0.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.0.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner" "bap-microx"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "cmdliner"
+  "bap-microx" {= "1.0.0"}
+]
 synopsis: "Taint propagation engine using based on microexecution"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner" "bap-microx"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "cmdliner"
+  "bap-microx" {= "1.1.0"}
+]
 synopsis: "Taint propagation engine using based on microexecution"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.2.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.2.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner" "bap-microx"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "cmdliner"
+  "bap-microx" {= "1.2.0"}
+]
 synopsis: "Taint propagation engine using based on microexecution"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.3.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.3.0/opam
@@ -14,7 +14,12 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner" "bap-microx"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "cmdliner"
+  "bap-microx" {= "1.3.0"}
+]
 synopsis: "Taint propagation engine using based on microexecution"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
   "cmdliner"
-  "bap-microx"
+  "bap-microx" {= "1.4.0"}
 ]
 synopsis: "BAP Taint propagation engine using based on microexecution"
 url {

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.5.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
   "cmdliner"
-  "bap-microx"
+  "bap-microx" {= "1.5.0"}
 ]
 synopsis: "BAP Taint propagation engine using based on microexecution"
 url {

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.6.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
   "cmdliner"
-  "bap-microx"
+  "bap-microx" {= "1.6.0"}
 ]
 synopsis: "BAP Taint propagation engine using based on microexecution"
 url {

--- a/packages/bap-taint/bap-taint.1.0.0/opam
+++ b/packages/bap-taint/bap-taint.1.0.0/opam
@@ -14,7 +14,11 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-taint"]
          ["bapbundle" "remove" "taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "cmdliner"
+]
 synopsis: "Introduce taint into a program"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-taint/bap-taint.1.1.0/opam
+++ b/packages/bap-taint/bap-taint.1.1.0/opam
@@ -14,7 +14,11 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-taint"]
          ["bapbundle" "remove" "taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "cmdliner"
+]
 synopsis: "Introduce taint into a program"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.1.0.tar.gz"

--- a/packages/bap-taint/bap-taint.1.2.0/opam
+++ b/packages/bap-taint/bap-taint.1.2.0/opam
@@ -14,7 +14,11 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-taint"]
          ["bapbundle" "remove" "taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "cmdliner"
+]
 synopsis: "Introduce taint into a program"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-taint/bap-taint.1.3.0/opam
+++ b/packages/bap-taint/bap-taint.1.3.0/opam
@@ -14,7 +14,11 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-taint"]
          ["bapbundle" "remove" "taint.plugin"]]
-depends: ["ocaml" "bap-std" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "cmdliner"
+]
 synopsis: "Introduce taint into a program"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-term-mapper/bap-term-mapper.1.0.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.0.0/opam
@@ -27,7 +27,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis: "A DSL for program transformations"

--- a/packages/bap-term-mapper/bap-term-mapper.1.1.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.1.0/opam
@@ -27,7 +27,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis: "A DSL for program transformations"

--- a/packages/bap-term-mapper/bap-term-mapper.1.2.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.2.0/opam
@@ -27,7 +27,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis: "A DSL for program transformations"

--- a/packages/bap-term-mapper/bap-term-mapper.1.3.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.3.0/opam
@@ -27,7 +27,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis: "A DSL for program transformations"

--- a/packages/bap-trace/bap-trace.1.0.0/opam
+++ b/packages/bap-trace/bap-trace.1.0.0/opam
@@ -27,8 +27,8 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
-  "bap-traces"
+  "bap-std" {= "1.0.0"}
+  "bap-traces" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-trace/bap-trace.1.1.0/opam
+++ b/packages/bap-trace/bap-trace.1.1.0/opam
@@ -27,8 +27,8 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
-  "bap-traces"
+  "bap-std" {= "1.1.0"}
+  "bap-traces" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-trace/bap-trace.1.2.0/opam
+++ b/packages/bap-trace/bap-trace.1.2.0/opam
@@ -27,8 +27,8 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
-  "bap-traces"
+  "bap-std" {= "1.2.0"}
+  "bap-traces" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-trace/bap-trace.1.3.0/opam
+++ b/packages/bap-trace/bap-trace.1.3.0/opam
@@ -27,8 +27,8 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
-  "bap-traces"
+  "bap-std" {= "1.3.0"}
+  "bap-traces" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-trace/bap-trace.1.4.0/opam
+++ b/packages/bap-trace/bap-trace.1.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "oasis" {build & = "0.4.7"}
   "bap-std" {= "1.4.0"}
-  "bap-traces"
+  "bap-traces" {= "1.4.0"}
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-trace/bap-trace.1.5.0/opam
+++ b/packages/bap-trace/bap-trace.1.5.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "1.5.0"}
-  "bap-traces"
+  "bap-traces" {= "1.5.0"}
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-trace/bap-trace.1.6.0/opam
+++ b/packages/bap-trace/bap-trace.1.6.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "1.6.0"}
-  "bap-traces"
+  "bap-traces" {= "1.6.0"}
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-traces/bap-traces.1.0.0/opam
+++ b/packages/bap-traces/bap-traces.1.0.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "uri" {>= "1.9.0"}
   "uuidm"
 ]

--- a/packages/bap-traces/bap-traces.1.1.0/opam
+++ b/packages/bap-traces/bap-traces.1.1.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "uri" {>= "1.9.0"}
   "uuidm"
 ]

--- a/packages/bap-traces/bap-traces.1.2.0/opam
+++ b/packages/bap-traces/bap-traces.1.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "uri" {>= "1.9.0"}
   "uuidm"
 ]

--- a/packages/bap-traces/bap-traces.1.3.0/opam
+++ b/packages/bap-traces/bap-traces.1.3.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml"
   "oasis" {build & >= "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "uri" {>= "1.9.0"}
   "uuidm"
 ]

--- a/packages/bap-veri/bap-veri.0.2.1/opam
+++ b/packages/bap-veri/bap-veri.0.2.1/opam
@@ -23,8 +23,8 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "bap-std"
-  "bap-traces"
+  "bap-std" {= "1.3.0"}
+  "bap-traces" {= "1.3.0"}
   "cmdliner"
   "oasis" {build}
   "ounit"

--- a/packages/bap-veri/bap-veri.0.2.2/opam
+++ b/packages/bap-veri/bap-veri.0.2.2/opam
@@ -23,13 +23,13 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
-  "bap-std" {>= "1.3.0"}
-  "bap-traces"
+  "bap-std" {= "1.4.0"}
+  "bap-traces" {= "1.4.0"}
   "cmdliner"
   "oasis" {build}
   "ounit"
   "pcre"
-  "textutils" {< "v0.9"}
+  "textutils" {>= "v0.9.0" & < "v0.10"}
   "uri"
 ]
 synopsis: "BAP Instruction Semantics Verification Tool"

--- a/packages/bap-veri/bap-veri.0.2.3/opam
+++ b/packages/bap-veri/bap-veri.0.2.3/opam
@@ -23,8 +23,8 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "bap-std" {>= "1.6.0"}
-  "bap-traces"
+  "bap-std" {= "1.6.0"}
+  "bap-traces" {= "1.6.0"}
   "cmdliner"
   "oasis" {build}
   "ounit"

--- a/packages/bap-veri/bap-veri.0.2/opam
+++ b/packages/bap-veri/bap-veri.0.2/opam
@@ -23,8 +23,8 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "bap-std"
-  "bap-traces"
+  "bap-std" {= "1.0.0"}
+  "bap-traces" {= "1.0.0"}
   "cmdliner"
   "oasis" {build}
   "ounit"

--- a/packages/bap-warn-unused/bap-warn-unused.1.0.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.0.0/opam
@@ -25,7 +25,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.0.0"}
   "cmdliner"
 ]
 synopsis:

--- a/packages/bap-warn-unused/bap-warn-unused.1.1.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.1.0/opam
@@ -25,7 +25,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.1.0"}
   "cmdliner"
 ]
 synopsis:

--- a/packages/bap-warn-unused/bap-warn-unused.1.2.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.2.0/opam
@@ -25,7 +25,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.2.0"}
   "cmdliner"
 ]
 synopsis:

--- a/packages/bap-warn-unused/bap-warn-unused.1.3.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.3.0/opam
@@ -25,7 +25,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
 depends: [
   "ocaml"
   "oasis" {build & = "0.4.7"}
-  "bap-std"
+  "bap-std" {= "1.3.0"}
   "cmdliner"
 ]
 synopsis:

--- a/packages/bap-x86/bap-x86.1.0.0/opam
+++ b/packages/bap-x86/bap-x86.1.0.0/opam
@@ -21,7 +21,14 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-abi" "bap-c" "bap-llvm" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.0.0"}
+  "bap-abi" {= "1.0.0"}
+  "bap-c" {= "1.0.0"}
+  "bap-llvm" {= "1.0.0"}
+  "cmdliner"
+  ]
 synopsis: "BAP x86 lifter"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.0.0.tar.gz"

--- a/packages/bap-x86/bap-x86.1.1.0/opam
+++ b/packages/bap-x86/bap-x86.1.1.0/opam
@@ -22,7 +22,14 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-abi" "bap-c" "bap-llvm" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.1.0"}
+  "bap-abi" {= "1.1.0"}
+  "bap-c" {= "1.1.0"}
+  "bap-llvm" {= "1.1.0"}
+  "cmdliner"
+]
 synopsis: "BAP x86 lifter"
 extra-files: ["setup-llvm-version.sh" "md5=d46974f2d2f7234cafefa4fdab89b1b4"]
 url {

--- a/packages/bap-x86/bap-x86.1.2.0/opam
+++ b/packages/bap-x86/bap-x86.1.2.0/opam
@@ -21,7 +21,14 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-abi" "bap-c" "bap-llvm" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.2.0"}
+  "bap-abi" {= "1.2.0"}
+  "bap-c" {= "1.2.0"}
+  "bap-llvm" {= "1.2.0"}
+  "cmdliner"
+]
 synopsis: "BAP x86 lifter"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.2.0.tar.gz"

--- a/packages/bap-x86/bap-x86.1.3.0/opam
+++ b/packages/bap-x86/bap-x86.1.3.0/opam
@@ -21,7 +21,14 @@ remove: [
 
 ]
 
-depends: ["ocaml" "bap-std" "bap-abi" "bap-c" "bap-llvm" "cmdliner"]
+depends: [
+  "ocaml"
+  "bap-std" {= "1.3.0"}
+  "bap-abi" {= "1.3.0"}
+  "bap-c" {= "1.3.0"}
+  "bap-llvm" {= "1.3.0"}
+  "cmdliner"
+]
 synopsis: "BAP x86 lifter"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v1.3.0.tar.gz"

--- a/packages/bap-x86/bap-x86.1.4.0/opam
+++ b/packages/bap-x86/bap-x86.1.4.0/opam
@@ -24,9 +24,9 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
-  "bap-abi"
-  "bap-c"
-  "bap-llvm"
+  "bap-abi" {= "1.4.0"}
+  "bap-c" {= "1.4.0"}
+  "bap-llvm" {= "1.4.0"}
   "cmdliner"
 ]
 synopsis: "BAP x86 lifter"

--- a/packages/bap-x86/bap-x86.1.5.0/opam
+++ b/packages/bap-x86/bap-x86.1.5.0/opam
@@ -24,9 +24,9 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
-  "bap-abi"
-  "bap-c"
-  "bap-llvm"
+  "bap-abi" {= "1.5.0"}
+  "bap-c" {= "1.5.0"}
+  "bap-llvm" {= "1.5.0"}
   "cmdliner"
 ]
 synopsis: "BAP x86 lifter"

--- a/packages/bap-x86/bap-x86.1.6.0/opam
+++ b/packages/bap-x86/bap-x86.1.6.0/opam
@@ -24,9 +24,9 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
-  "bap-abi"
-  "bap-c"
-  "bap-llvm"
+  "bap-abi" {= "1.6.0"}
+  "bap-c" {= "1.6.0"}
+  "bap-llvm" {= "1.6.0"}
   "cmdliner"
 ]
 synopsis: "BAP x86 lifter"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @gitoleg could you check if there is no mistake from me here?
cc @ivg is there a reason why `bap-saluki` has a rather weird version number? (`bap-1.5` for instance)