### PR TITLE
dolmen.0.4: Disable parallel build

### DIFF
--- a/packages/dolmen/dolmen.0.4/opam
+++ b/packages/dolmen/dolmen.0.4/opam
@@ -3,7 +3,7 @@ maintainer: "guillaume.bury@gmail.com"
 license: "BSD-2-clauses"
 build: [
   ["dune" "subst"] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" "1"]
 ]
 depends: [
   "ocaml" {>= "4.02.3"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

The error is:
```
#=== ERROR while compiling dolmen.0.4 =========================================#
# context              2.0.3 | linux/x86_64 | ocaml-base-compiler.4.04.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.04.2/.opam-switch/build/dolmen.0.4
# command              ~/.opam/4.04.2/bin/dune build -p dolmen -j 71
# exit-code            1
# env-file             ~/.opam/log/dolmen-1-9399a1.env
# output-file          ~/.opam/log/dolmen-1-9399a1.out
### output ###
#       menhir src/languages/dimacs/parseDimacs__mock.ml.mock (exit 1)
# (cd _build/default/src/languages/dimacs && /home/opam/.opam/4.04.2/bin/menhir --explain --table --external-tokens Tokens_dimacs tokens_dimacs.mly parseDimacs.mly --base parseDimacs --infer-write-query parseDimacs__mock.ml.mock)
# Error: tokens_dimacs.mly: No such file or directory
```
cc @Gbury I suspect your dune file in `src/languages/dimacs` misses an explicit dependency on `tokens_dimacs.mly` somewhere. @rgrinberg might know.