### PR TITLE
doc-ock is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/doc-ock/doc-ock.1.2.0/opam
+++ b/packages/doc-ock/doc-ock.1.2.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml-doc/odoc/issues"
 tags: ["doc" "ocaml" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "cppo" {build}
   "ocamlfind" {build}
   "jbuilder" {build}

--- a/packages/doc-ock/doc-ock.1.2.1/opam
+++ b/packages/doc-ock/doc-ock.1.2.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml-doc/odoc/issues"
 tags: ["doc" "ocaml" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "cppo" {build}
   "ocamlfind" {build}
   "jbuilder" {build}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @lpw25 there is no version of `doc-ock` compatible with OCaml 4.08