### PR TITLE
fkie-cad-cwe-checker.0.1: Add missing dependencies and constraints

### DIFF
--- a/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.1/opam
+++ b/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.1/opam
@@ -21,6 +21,9 @@ depends: [
   "ocaml"
   "bap-std" {>= "1.5.0"}
   "yojson" {= "1.4.1"}
+  "base-unix"
+  "ppx_jane" {< "v0.11"}
+  "core_kernel" {< "v0.11"}
 ]
 synopsis:
   "A plugin for bap that detects common bug classes, e.g. use of dangerous functions and simple integer overflows"

--- a/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.1/opam
+++ b/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.1/opam
@@ -7,8 +7,9 @@ homepage: "https://github.com/fkie-cad/cwe_checker"
 bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
 dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
 license: "LGPL-3.0"
+build: [make]
 install: [
-  [make]
+  ["mkdir" "-p" "%{share}%/bap"]
   ["cp" "src/config.json" "%{share}%/bap/"]
 ]
 


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @tbarabosch you're using at least those packages explicitly in your code but they weren't explicitly listed in the dependencies. It worked only because they were dependencies of `bap-std`. Your package wasn't compatible with `core_kernel >= v0.11.0` so I added the required constraint.