### PR TITLE
js_of_ocaml-ocamlbuild: fix constraints to allow OCaml < 4.03 

### DIFF
--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0.1/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0.1/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.00.0"}
   "jbuilder" {build & >= "1.0+beta12"}
-  "ocamlbuild" {!= "0"}
+  ("ocamlbuild" {!= "0"} | ("base-ocamlbuild" "ocamlfind"))
 ]
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0.2/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0.2/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.00.0"}
   "jbuilder" {build & >= "1.0+beta12"}
-  "ocamlbuild" {!= "0"}
+  ("ocamlbuild" {!= "0"} | ("base-ocamlbuild" "ocamlfind"))
 ]
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.00.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ocamlbuild" {!= "0"}
+  ("ocamlbuild" {!= "0"} | ("base-ocamlbuild" "ocamlfind"))
 ]
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.1.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.1.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.00.0"}
   "jbuilder" {build & >= "1.0+beta17"}
-  "ocamlbuild" {!= "0"}
+  ("ocamlbuild" {!= "0"} | ("base-ocamlbuild" "ocamlfind"))
 ]
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {


### PR DESCRIPTION
Better fix compared to https://github.com/ocaml/opam-repository/pull/13908

ocamlfind installs the META file for ocamlbuild so the build failed for `js_of_ocaml-ocamlbuild` itself but not for some of the packages using it which also depends on ocamlfind