### PR TITLE
liquidsoap is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.3.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.4/opam
@@ -13,7 +13,7 @@ remove: [
   ["rm" "-rf" "%{lib}%/liquidsoap" "%{prefix}%/bin/liquidsoap"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.08.0"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.1"}
   "duppy" {>= "0.8.0"}

--- a/packages/liquidsoap/liquidsoap.1.3.5/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.5/opam
@@ -13,7 +13,7 @@ remove: [
   ["rm" "-rf" "%{lib}%/liquidsoap" "%{prefix}%/bin/liquidsoap"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.08.0"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.1"}
   "duppy" {>= "0.8.0"}

--- a/packages/liquidsoap/liquidsoap.1.3.6/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.6/opam
@@ -13,7 +13,7 @@ remove: [
   ["rm" "-rf" "%{lib}%/liquidsoap" "%{prefix}%/bin/liquidsoap"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.08.0"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.1"}
   "duppy" {>= "0.8.0"}

--- a/packages/liquidsoap/liquidsoap.1.3.7/opam
+++ b/packages/liquidsoap/liquidsoap.1.3.7/opam
@@ -13,7 +13,7 @@ remove: [
   ["rm" "-rf" "%{lib}%/liquidsoap" "%{prefix}%/bin/liquidsoap"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.08.0"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.1"}
   "duppy" {>= "0.8.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

@toots there is no version of `liquidsoap` compatible with OCaml >= 4.08. Also it would be sensible to avoid the use of `warning-as-errors` for future releases.