### PR TITLE
Package prepare.6.7.0

### DIFF
--- a/packages/prepare/prepare.6.7.0/opam
+++ b/packages/prepare/prepare.6.7.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "PPX for a client/server Web framework"
+description: "This is the PPX syntax rewriter for Eliom. Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/chrismamo1/ppx_eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/chrismamo1/ppx_eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "deriving" {>= "0.6"}
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml" {>= "3.3"}
+  "js_of_ocaml-lwt" {>= "3.3"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
+  "js_of_ocaml-tyxml" {>= "3.3"}
+  "lwt_log"
+  "lwt_ppx"
+  "tyxml" {>= "4.3.0"}
+  "ocsigenserver" {>= "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]


### PR DESCRIPTION
### `prepare.6.7.0`
PPX for a client/server Web framework
This is the PPX syntax rewriter for Eliom. Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/chrismamo1/ppx_eliom.git
* Bug tracker: https://github.com/chrismamo1/ppx_eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0