### PR TITLE
[DRAFT] Add fixed version packages for ocamlformat

### DIFF
--- a/packages/ocamlformat-0-8/ocamlformat-0-8.0.1/opam
+++ b/packages/ocamlformat-0-8/ocamlformat-0-8.0.1/opam
@@ -1,0 +1,1 @@
+../../ocamlformat/ocamlformat.0.8/opam

--- a/packages/ocamlformat-0-8/ocamlformat-0-8.0.1/opam
+++ b/packages/ocamlformat-0-8/ocamlformat-0-8.0.1/opam
@@ -14,7 +14,9 @@ url {
 license: "MIT"
 build: [
   ["tools/gen_version.sh" "src/Version.ml" version] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" "ocamlformat" "-j" jobs]
+  ["rm" "ocamlformat.install"]
+  ["mv" "_build/install/release/lib/ocamlformat" "_build/install/release/lib/ocamlformat-0-8"]
 ]
 depends: [
   "ocaml" {>= "4.05"}

--- a/packages/ocamlformat-0-8/ocamlformat-0-8.0.1/opam
+++ b/packages/ocamlformat-0-8/ocamlformat-0-8.0.1/opam
@@ -1,1 +1,30 @@
-../../ocamlformat/ocamlformat.0.8/opam
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src: "https://github.com/ocaml-ppx/ocamlformat/archive/0.8.tar.gz"
+  checksum: [
+    "md5=c3462e7bc4176b4d1126403123a99dac"
+    "sha512=f0010926ccc5a8faa661d74b7b51bcd5fc65a23cfea4c9f3cf24d2998a46149e5f73775536d0432dd502d32bc9015ac12888edf6933ec2023c64cfb597a2bb36"
+  ]
+}
+license: "MIT"
+build: [
+  ["tools/gen_version.sh" "src/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05"}
+  "base" {>= "v0.11.0" & < "v0.12"}
+  "base-unix"
+  "cmdliner"
+  "dune" {build}
+  "fpath"
+  "ocaml-migrate-parsetree" {>= "1.0.10"}
+  "stdio" {< "v0.12"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."

--- a/packages/ocamlformat-0-9/ocamlformat-0-9.0.1/opam
+++ b/packages/ocamlformat-0-9/ocamlformat-0-9.0.1/opam
@@ -1,0 +1,1 @@
+../../ocamlformat/ocamlformat.0.9/opam

--- a/packages/ocamlformat-0-9/ocamlformat-0-9.0.1/opam
+++ b/packages/ocamlformat-0-9/ocamlformat-0-9.0.1/opam
@@ -1,1 +1,32 @@
-../../ocamlformat/ocamlformat.0.9/opam
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src: "https://github.com/ocaml-ppx/ocamlformat/archive/0.9.tar.gz"
+  checksum: [
+    "md5=4e5e4df8687f2f2e820bebe1a55c0f6d"
+    "sha512=6bedb60073239867caa57171d2537a77e8857a00ce3d8280850a163baf1c4bc8625d6e6bd79cdf8a3d603241224aac5485f1e148d0c0d4144469080cf41fbc6a"
+  ]
+}
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.ml" "src/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {build & >= "1.1.1"}
+  "fpath"
+  "ocaml-migrate-parsetree" {>= "1.0.10"}
+  "octavius" {>= "1.2.0"}
+  "stdio"
+  "uutf"
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."

--- a/packages/ocamlformat-0-9/ocamlformat-0-9.0.1/opam
+++ b/packages/ocamlformat-0-9/ocamlformat-0-9.0.1/opam
@@ -14,7 +14,9 @@ url {
 license: "MIT"
 build: [
   ["ocaml" "tools/gen_version.ml" "src/Version.ml" version] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" "ocamlformat" "-j" jobs]
+  ["rm" "ocamlformat.install"]
+  ["mv" "_build/install/release/lib/ocamlformat" "_build/install/release/lib/ocamlformat-0-9"]
 ]
 depends: [
   "ocaml" {>= "4.06"}


### PR DESCRIPTION
Following up @avsm suggestion in https://github.com/ocaml-ppx/ocamlformat/issues/699
It would allow dune to use a specific ocamlformat release depending on the version required in a given project.
Is this what you had in mind?