### PR TITLE
Patch nocrypto.0.5.{0,1,2,3} to fix build failures with recent versions of GCC

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.0/files/werror.patch
+++ b/packages/nocrypto/nocrypto.0.5.0/files/werror.patch
@@ -1,0 +1,72 @@
+--- a/setup.ml	2019-04-16 15:03:37.793002055 +0100
++++ b/setup.ml	2019-04-16 15:03:49.008933634 +0100
+@@ -7020,7 +7020,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3"
+                              ]);
+                            (OASISExpr.EAnd
+@@ -7030,7 +7029,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-msse2";
+                                 "-maes"
+@@ -7196,7 +7194,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-DNDEBUG";
+                                 "${XEN_CFLAGS}"
+@@ -7208,7 +7205,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-DNDEBUG";
+                                 "${XEN_CFLAGS}";
+--- a/myocamlbuild.ml	2019-04-16 15:03:35.797014198 +0100
++++ b/myocamlbuild.ml	2019-04-16 15:04:00.636862379 +0100
+@@ -654,8 +654,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3"
+                    ]);
+                (OASISExpr.EAnd
+@@ -670,8 +668,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-msse2";
+@@ -700,8 +696,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-DNDEBUG";
+@@ -720,8 +714,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-DNDEBUG";

--- a/packages/nocrypto/nocrypto.0.5.0/opam
+++ b/packages/nocrypto/nocrypto.0.5.0/opam
@@ -7,6 +7,7 @@ authors:      "David Kaloper <david@numm.org>"
 maintainer:   "David Kaloper <david@numm.org>"
 license:      "BSD2"
 
+patches: ["werror.patch"]
 build: [
   [
     "./configure"
@@ -50,6 +51,7 @@ Hashes: MD5, SHA1, SHA2.
 Pubkey: RSA, DH, DSA.
 Rng: Fortuna."""
 flags: light-uninstall
+extra-files: ["werror.patch" "md5=ad8098baf5de0d9b3c66b446c8452b5d"]
 url {
   src: "https://github.com/mirleft/ocaml-nocrypto/archive/0.5.0.tar.gz"
   checksum: "md5=c6288f4d8f68390f2daefd1dd00fb8bc"

--- a/packages/nocrypto/nocrypto.0.5.1/files/werror.patch
+++ b/packages/nocrypto/nocrypto.0.5.1/files/werror.patch
@@ -1,0 +1,72 @@
+--- a/setup.ml	2019-04-16 15:02:32.357394398 +0100
++++ b/setup.ml	2019-04-16 15:02:45.789314884 +0100
+@@ -7021,7 +7021,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3"
+                              ]);
+                            (OASISExpr.EAnd
+@@ -7031,7 +7030,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-msse2";
+                                 "-maes"
+@@ -7197,7 +7195,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-DNDEBUG";
+                                 "${XEN_CFLAGS}"
+@@ -7209,7 +7206,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-DNDEBUG";
+                                 "${XEN_CFLAGS}";
+--- a/myocamlbuild.ml	2019-04-16 15:02:34.961379028 +0100
++++ b/myocamlbuild.ml	2019-04-16 16:15:30.751484060 +0100
+@@ -654,8 +654,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3"
+                    ]);
+                (OASISExpr.EAnd
+@@ -670,8 +668,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-msse2";
+@@ -700,8 +696,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-DNDEBUG";
+@@ -720,8 +714,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-DNDEBUG";

--- a/packages/nocrypto/nocrypto.0.5.1/opam
+++ b/packages/nocrypto/nocrypto.0.5.1/opam
@@ -7,6 +7,7 @@ authors:      "David Kaloper <david@numm.org>"
 maintainer:   "David Kaloper <david@numm.org>"
 license:      "BSD2"
 
+patches: ["werror.patch"]
 build: [
   [
     "./configure"
@@ -51,6 +52,7 @@ Hashes: MD5, SHA1, SHA2.
 Pubkey: RSA, DH, DSA.
 Rng: Fortuna."""
 flags: light-uninstall
+extra-files: ["werror.patch" "md5=b83722338f98d46e97a8f2237aa17be8"]
 url {
   src: "https://github.com/mirleft/ocaml-nocrypto/archive/0.5.1.tar.gz"
   checksum: "md5=228a4801e82f84658520e03450158d89"

--- a/packages/nocrypto/nocrypto.0.5.2/files/werror.patch
+++ b/packages/nocrypto/nocrypto.0.5.2/files/werror.patch
@@ -1,0 +1,72 @@
+--- a/setup.ml	2019-04-16 14:57:33.467531887 +0100
++++ b/setup.ml	2019-04-16 15:06:59.227695456 +0100
+@@ -7031,7 +7031,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3"
+                              ]);
+                            (OASISExpr.EAnd
+@@ -7041,7 +7040,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-DACCELERATE";
+                                 "-msse2";
+@@ -7208,7 +7206,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-DNDEBUG";
+                                 "${XEN_CFLAGS}"
+@@ -7220,7 +7217,6 @@
+                                 "--std=c99";
+                                 "-Wall";
+                                 "-Wextra";
+-                                "-Werror";
+                                 "-O3";
+                                 "-DNDEBUG";
+                                 "${XEN_CFLAGS}";
+--- a/myocamlbuild.ml	2019-04-16 14:57:38.307496074 +0100
++++ b/myocamlbuild.ml	2019-04-16 14:58:02.587317168 +0100
+@@ -654,8 +654,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3"
+                    ]);
+                (OASISExpr.EAnd
+@@ -670,8 +668,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-DACCELERATE";
+@@ -702,8 +698,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-DNDEBUG";
+@@ -722,8 +716,6 @@
+                       A "-ccopt";
+                       A "-Wextra";
+                       A "-ccopt";
+-                      A "-Werror";
+-                      A "-ccopt";
+                       A "-O3";
+                       A "-ccopt";
+                       A "-DNDEBUG";

--- a/packages/nocrypto/nocrypto.0.5.2/opam
+++ b/packages/nocrypto/nocrypto.0.5.2/opam
@@ -41,7 +41,7 @@ conflicts: [
 ]
 
 tags: [ "org:mirage" ]
-patches: [ "postconf.patch" ]
+patches: [ "postconf.patch" "werror.patch" ]
 synopsis: "Small functional-style crypto library."
 description: """
 Ciphers: AES, 3DES, RC4.
@@ -50,7 +50,10 @@ Pubkey: RSA, DH, DSA.
 Rng: Fortuna."""
 authors: "David Kaloper <david@numm.org>"
 flags: light-uninstall
-extra-files: ["postconf.patch" "md5=9b42fe7a62539973dc84dcb4665928ec"]
+extra-files: [
+  ["postconf.patch" "md5=9b42fe7a62539973dc84dcb4665928ec"]
+  ["werror.patch" "md5=9d31eed80a35ea4f477b21bc09453f22"]
+]
 url {
   src: "https://github.com/mirleft/ocaml-nocrypto/archive/0.5.2.tar.gz"
   checksum: "md5=ee523bc2e95e03f56d2dc9ff306ed114"

--- a/packages/nocrypto/nocrypto.0.5.3/files/werror.patch
+++ b/packages/nocrypto/nocrypto.0.5.3/files/werror.patch
@@ -1,0 +1,20 @@
+--- a/_oasis	2019-04-14 18:53:58.732983307 +0100
++++ b/_oasis	2019-04-16 13:22:25.459958829 +0100
+@@ -73,7 +73,7 @@
+   XMETARequires:   cstruct, zarith, sexplib
+   XMETAExtraLines: xen_linkopts = "-lnocrypto_xen_stubs"
+   ByteOpt:         -w A-4-29-33-40-41-42-43-34-44
+-  CCOpt:           --std=c99 -Wall -Wextra -Werror -O3
++  CCOpt:           --std=c99 -Wall -Wextra -O3
+   if flag(modernity) && architecture(amd64)
+     CCOpt+: -DACCELERATE -msse2 -maes
+ 
+@@ -117,7 +117,7 @@
+                    native/des/generic.h
+   BuildDepends:    nocrypto, mirage-entropy-xen
+   XMETARequires:   nocrypto, lwt, mirage-entropy-xen
+-  CCOpt:           --std=c99 -Wall -Wextra -Werror -O3 -DNDEBUG $XEN_CFLAGS
++  CCOpt:           --std=c99 -Wall -Wextra -O3 -DNDEBUG $XEN_CFLAGS
+   if flag(modernity) && architecture(amd64)
+     CCOpt+: -DACCELERATE -msse2 -maes
+ 

--- a/packages/nocrypto/nocrypto.0.5.3/opam
+++ b/packages/nocrypto/nocrypto.0.5.3/opam
@@ -5,6 +5,7 @@ bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"
 maintainer:   "David Kaloper <david@numm.org>"
 license:      "BSD2"
 
+patches: ["werror.patch"]
 build: [
   [
     "./configure"
@@ -52,6 +53,7 @@ Pubkey: RSA, DH, DSA.
 Rng: Fortuna."""
 authors: "David Kaloper <david@numm.org>"
 flags: light-uninstall
+extra-files: ["werror.patch" "md5=2e521fc478cdc76779cdd70b909555f1"]
 url {
   src: "https://github.com/mirleft/ocaml-nocrypto/archive/v0.5.3.tar.gz"
   checksum: "md5=1b771555139c23da4fdf02244fc7b4a9"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @hannesm 