### PR TITLE
spoc.20170724: Disable parallel build

### DIFF
--- a/packages/spoc/spoc.20170724/opam
+++ b/packages/spoc/spoc.20170724/opam
@@ -6,7 +6,7 @@ homepage: "https://mathiasbourgoin.github.io/SPOC/"
 bug-reports: "https://github.com/mathiasbourgoin/SPOC/issues"
 dev-repo: "git+https://github.com/mathiasbourgoin/SPOC.git"
 license: "CeCILL-B"
-build: [make]
+build: [make "-C" "Spoc" "-j1"]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @mathiasbourgoin your custom build system seems broken for parallel compilation, also it uses directly the number of cores from the machine and doesn't let the user choose the number of jobs they want to put into building this package.

```
#=== ERROR while compiling spoc.20170724 ======================================#
# context              2.0.3 | linux/x86_64 | ocaml-base-compiler.4.02.3 | file:///home/opam/opam-repository
# path                 ~/.opam/4.02.3/.opam-switch/build/spoc.20170724
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/spoc-1-d39fa9.env
# output-file          ~/.opam/log/spoc-1-d39fa9.out
### output ###
# [...]
# [34m[KernelCuda.cmx][0m
# [34m[Kernel.cmx][0m
# [33m[spoc.o][0m
# [32m[spoc.cmo][0m
# [34m[spoc.cmx][0m
# [31m[spoc.cma][0m
# [31m[spoc.cmxa][0m
# ranlib: './libspoc.a': No such file
# make[1]: *** [Makefile:66: spoc.cma] Error 2
# make[1]: *** Waiting for unfinished jobs....
# make[1]: Leaving directory '/home/opam/.opam/4.02.3/.opam-switch/build/spoc.20170724/Spoc'
# make: *** [Makefile:4: all] Error 2
```