### PR TITLE
[do not merge] Disable parallel build for camomile >= 0.8.6

### DIFF
--- a/packages/camomile/camomile.0.8.6/opam
+++ b/packages/camomile/camomile.0.8.6/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 license: "LGPL-2+ with OCaml linking exception"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" "1"]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/camomile/camomile.0.8.7/opam
+++ b/packages/camomile/camomile.0.8.7/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 license: "LGPL-2+ with OCaml linking exception"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" "1"]
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/camomile/camomile.1.0.0/opam
+++ b/packages/camomile/camomile.1.0.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
   ["jbuilder" "subst" "-p" name] {pinned}
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" "1"]
 ]
 depends: [
   "ocaml" {>= "4.05.0"}

--- a/packages/camomile/camomile.1.0.1/opam
+++ b/packages/camomile/camomile.1.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
   ["jbuilder" "subst" "-p" name] {pinned}
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" "1"]
 ]
 depends: [
   "ocaml" {>= "4.02.3"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @yoriyuki It keeps happening on the CIs and I don't know what it would be except a problem with parallel build. It seems pretty random. Could you look into that? cc @rgrinberg just in case

```
#=== ERROR while compiling camomile.0.8.7 =====================================#
# context              2.0.3 | linux/x86_64 | ocaml-base-compiler.4.05.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.05.0/.opam-switch/build/camomile.0.8.7
# command              ~/.opam/4.05.0/bin/jbuilder build -p camomile -j 71
# exit-code            1
# env-file             ~/.opam/log/camomile-1-2c2b5f.env
# output-file          ~/.opam/log/camomile-1-2c2b5f.out
### output ###
# [...]
# File "Camomile/jbuild", line 4, characters 0-96:
# 4 | (rule (with-stdout-to installConfig.ml
# 5 |        (echo "let share_dir = \"/usr/share/camomile\"")))
# Warning: File installConfig.ml is both generated by a rule and present in the source tree.
# As a result, the rule is currently ignored, however this will become an error in the future.
# To keep the current behavior and get rid of this warning, add a field (fallback) to the rule.
#    ocamlyacc Camomile/internal/uReStrParser.{ml,mli}
# 4 shift/reduce conflicts.
#       ocamlc Camomile/.camomile.objs/byte/camomileLibrary.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.05.0/bin/ocamlc.opt -I Camomile -w -40 -g -bin-annot -I Camomile/.camomile.objs/byte -no-alias-deps -o Camomile/.camomile.objs/byte/camomileLibrary.cmi -c -intf Camomile/camomileLibrary.mli)
# File "camomileLibrary.mlip", line 185, characters 24-46:
# Error: Unbound module type CharEncoding.Interface
```
```

#=== ERROR while compiling camomile.1.0.1 =====================================#
# context              2.0.3 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.07.1/.opam-switch/build/camomile.1.0.1
# command              ~/.opam/4.07.1/bin/jbuilder build -p camomile -j 71
# exit-code            1
# env-file             ~/.opam/log/camomile-1-a2e72f.env
# output-file          ~/.opam/log/camomile-1-a2e72f.out
### output ###
# [...]
# Note: You can use "dune upgrade" to convert your project to dune.
# File "Camomile/jbuild", line 4, characters 0-96:
# 4 | (rule (with-stdout-to installConfig.ml
# 5 |        (echo "let share_dir = \"/usr/share/camomile\"")))
# Warning: File installConfig.ml is both generated by a rule and present in the source tree.
# As a result, the rule is currently ignored, however this will become an error in the future.
# To keep the current behavior and get rid of this warning, add a field (fallback) to the rule.
#    ocamlyacc Camomile/internal/uReStrParser.{ml,mli}
# 4 shift/reduce conflicts.
# parse_specialcasing Camomile/database/special_casing.mar (exit 2)
# (cd _build/default/Camomile && tools/parse_specialcasing.exe database unidata/SpecialCasing.txt)
# Fatal error: exception Not_found
```