### PR TITLE
Disable parallel build for mlcuddidl < 3.0.2

### DIFF
--- a/packages/mlcuddidl/mlcuddidl.2.3.0/opam
+++ b/packages/mlcuddidl/mlcuddidl.2.3.0/opam
@@ -5,7 +5,7 @@ homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcud
 license: "LGPL-2.1"
 build: [
   ["./configure"]
-  [make]
+  [make "-j1"]
 ]
 install: [
   [make "install"]

--- a/packages/mlcuddidl/mlcuddidl.3.0.0/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.0/opam
@@ -5,7 +5,7 @@ homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcud
 license: "LGPL-2.1"
 build: [
   ["./configure"]
-  [make]
+  [make "-j1"]
 ]
 install: [
   [make "install"]

--- a/packages/mlcuddidl/mlcuddidl.3.0.1/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.1/opam
@@ -5,7 +5,7 @@ homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcud
 license: "LGPL-2.1"
 build: [
   ["./configure"]
-  [make "-j%{jobs}%"]
+  [make "-j1"]
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

```
#=== ERROR while compiling mlcuddidl.3.0.1 ====================================#
# context              2.0.3 | linux/x86_64 | ocaml-base-compiler.4.02.3 | file:///home/opam/opam-repository
# path                 ~/.opam/4.02.3/.opam-switch/build/mlcuddidl.3.0.1
# command              /usr/bin/make -j71
# exit-code            2
# env-file             ~/.opam/log/mlcuddidl-1-489228.env
# output-file          ~/.opam/log/mlcuddidl-1-489228.out
### output ###
# - + ar rc ./libcudd_caml.a  cuddauxAddIte.o cuddauxMisc.o cuddauxAddApply.o cuddauxUtil.o cuddauxAddCamlTable.o cuddauxGenCof.o cuddauxCompose.o cuddauxTDGenCof.o cuddauxBridge.o hash_caml.o cache_caml.o memo_caml.o man_caml.o bdd_caml.o vdd_caml.o custom_caml.o add_caml.o cudd_caml.o cuddall-base.o; ranlib ./libcudd_caml.a
# - + ar rc ./libcudd_caml.a  cuddauxAddIte.o cuddauxMisc.o cuddauxAddApply.o cuddauxUtil.o cuddauxAddCamlTable.o cuddauxGenCof.o cuddauxCompose.o cuddauxTDGenCof.o cuddauxBridge.o hash_caml.o cache_caml.o memo_caml.o man_caml.o bdd_caml.o vdd_caml.o custom_caml.o add_caml.o cudd_caml.o cuddall-base.o; ranlib ./libcudd_caml.a
# - ranlib: './libcudd_caml.a': No such file
# - make: *** [Makefile:187: cudd.cmxa] Error 2
# - make: *** Waiting for unfinished jobs....
```
The problem seems that `libcudd_caml.a` is built twice in parallel. This fact seems to appear in previous version as well and even if parallel build weren't enabled, adding `-j1`, explicitly disabling parallel builds, is better.