### PR TITLE
ezsqlite.0.4: remove dependency on nonexistent `str` package

### DIFF
--- a/packages/ezsqlite/ezsqlite.0.4/opam
+++ b/packages/ezsqlite/ezsqlite.0.4/opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
   "hex"
-  "str"
 ]
 synopsis: "Simplified SQLite3 bindings for OCaml"
 description:


### PR DESCRIPTION
`str` is still built into the OCaml distribution.