### PR TITLE
gpr.1.3.0: fix dependency on `threads`, which does not exist

### DIFF
--- a/packages/gpr/gpr.1.3.0/opam
+++ b/packages/gpr/gpr.1.3.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04"}
-  "threads"
+  "base-threads"
   "core" {>= "v0.9.1" & < "v0.13"}
   "lacaml" {>= "9.3.2" & < "10.0.0"}
   "gsl"


### PR DESCRIPTION
All other versions of `gpr` depend on `base-threads` instead.