### PR TITLE
logs-async.1.0: incompatible with logs.6.3.0

### DIFF
--- a/packages/logs-async/logs-async.1.0/opam
+++ b/packages/logs-async/logs-async.1.0/opam
@@ -10,7 +10,7 @@ doc: "https://vbmithr.github.io/logs-async/doc"
 build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
 depends: [
   "dune" {build & >= "1.3.0"}
-  "logs" {>= "0.6.2"}
+  "logs" {= "0.6.2"}
   "async_kernel" {>= "v0.11.1" & < "v0.13"}
 ]
 synopsis: "Jane Street Async logging with Logs"


### PR DESCRIPTION
It is getting it's result package dependency via Logs and the latter no longer depends on it.