### PR TITLE
[new release] charrua-unix, charrua-client-mirage, charrua, charrua-server, charrua-client and charrua-client-lwt (1.0.0)

### DIFF
--- a/packages/charrua-client-lwt/charrua-client-lwt.1.0.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua"
+bug-reports:  "https://github.com/mirage/charrua/issues"
+dev-repo:     "git+https://github.com/mirage/charrua.git"
+tags:         [ "org:mirage"]
+doc:          "https://mirage.github.io/charrua/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "charrua" {>= "1.0.0"}
+  "charrua-client" {>= "1.0.0"}
+  "cstruct" {>="3.0.2"}
+  "ipaddr" {>="3.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "duration"
+  "mirage-time-lwt"
+  "mirage-net-lwt" {>= "2.0.0"}
+  "logs"
+  "fmt"
+  "lwt"
+]
+synopsis: "A DHCP client using lwt as effectful layer"
+description: """
+`charrua-client-lwt` extends `charrua-client` with a functor `Dhcp_client_lwt`,
+using the provided modules for timing and networking logic,
+for convenient use by a program which might wish to implement a full client.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.0.0/charrua-v1.0.0.tbz"
+  checksum: [
+    "sha256=c318158366541be647cec9df9f3090879818f3257d274e13f466ed14311870b5"
+    "sha512=567889744d741572666952c6c4e02754da25dee4b32a9879b11a185aaefbf80e3aa08120cc2d1b141047a98c8f36e33b3a74b98055de529fa9743da016b1a63f"
+  ]
+}

--- a/packages/charrua-client-mirage/charrua-client-mirage.1.0.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua"
+bug-reports:  "https://github.com/mirage/charrua/issues"
+dev-repo:     "git+https://github.com/mirage/charrua.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "charrua-client-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock"
+  "mirage-time-lwt"
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "logs"
+  "lwt"
+]
+synopsis: "A DHCP client for MirageOS"
+description: """
+`charrua-client-mirage` exposes an additional `Dhcp_client_mirage` for direct use
+with the [MirageOS library operating system](https://github.com/mirage/mirage).
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.0.0/charrua-v1.0.0.tbz"
+  checksum: [
+    "sha256=c318158366541be647cec9df9f3090879818f3257d274e13f466ed14311870b5"
+    "sha512=567889744d741572666952c6c4e02754da25dee4b32a9879b11a185aaefbf80e3aa08120cc2d1b141047a98c8f36e33b3a74b98055de529fa9743da016b1a63f"
+  ]
+}

--- a/packages/charrua-client/charrua-client.1.0.0/opam
+++ b/packages/charrua-client/charrua-client.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua"
+bug-reports:  "https://github.com/mirage/charrua/issues"
+dev-repo:     "git+https://github.com/mirage/charrua.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-random-test" {with-test}
+  "charrua-server" {with-test}
+  "charrua" {>= "1.0.0"}
+  "cstruct" {>="3.0.2"}
+  "ipaddr"
+  "macaddr"
+]
+synopsis: "DHCP client implementation"
+description: """
+charrua-client is a DHCP client powered by [charrua](https://github.com/mirage/charrua).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.0.0/charrua-v1.0.0.tbz"
+  checksum: [
+    "sha256=c318158366541be647cec9df9f3090879818f3257d274e13f466ed14311870b5"
+    "sha512=567889744d741572666952c6c4e02754da25dee4b32a9879b11a185aaefbf80e3aa08120cc2d1b141047a98c8f36e33b3a74b98055de529fa9743da016b1a63f"
+  ]
+}

--- a/packages/charrua-server/charrua-server.1.0.0/opam
+++ b/packages/charrua-server/charrua-server.1.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/api"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ppx_sexp_conv"
+  "menhir"        {build}
+  "charrua"       {>= "1.0.0"}
+  "ocaml"         {>= "4.04.2"}
+  "cstruct"       {>= "3.0.1"}
+  "sexplib"
+  "ipaddr"        {>= "3.0.0"}
+  "macaddr"
+  "cstruct-unix"  {with-test}
+]
+synopsis: "DHCP server"
+description: """
+Charrua-server consists of a single `Dhcp_server` module used for constructing DHCP
+servers.
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.0.0/charrua-v1.0.0.tbz"
+  checksum: [
+    "sha256=c318158366541be647cec9df9f3090879818f3257d274e13f466ed14311870b5"
+    "sha512=567889744d741572666952c6c4e02754da25dee4b32a9879b11a185aaefbf80e3aa08120cc2d1b141047a98c8f36e33b3a74b98055de529fa9743da016b1a63f"
+  ]
+}

--- a/packages/charrua-unix/charrua-unix.1.0.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {build & >= "1.0"}
+  "ocaml" {>= "4.04.2"}
+  "lwt" {>="3.0.0"}
+  "lwt_log"
+  "charrua" {>= "1.0.0"}
+  "charrua-server" {>= "1.0.0"}
+  "cstruct-unix"
+  "cmdliner"
+  "rawlink" {>= "1.0"}
+  "tuntap" {>= "1.2.0"}
+  "mtime" {>="1.0.0"}
+]
+synopsis: "Unix DHCP daemon"
+description: """
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua](http://www.github.com/mirage/charrua).
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.0.0/charrua-v1.0.0.tbz"
+  checksum: [
+    "sha256=c318158366541be647cec9df9f3090879818f3257d274e13f466ed14311870b5"
+    "sha512=567889744d741572666952c6c4e02754da25dee4b32a9879b11a185aaefbf80e3aa08120cc2d1b141047a98c8f36e33b3a74b98055de529fa9743da016b1a63f"
+  ]
+}

--- a/packages/charrua/charrua.1.0.0/opam
+++ b/packages/charrua/charrua.1.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/api"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "ppx_sexp_conv" {>="v0.10.0"}
+  "ppx_cstruct"
+  "ocaml"         {>= "4.04.2"}
+  "cstruct"       {>= "3.0.1"}
+  "sexplib"
+  "ipaddr"        {>= "3.0.0"}
+  "macaddr"
+  "ethernet"      {>= "2.0.0"}
+  "tcpip"         {>= "3.7.0"}
+  "rresult"
+]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua consists a single modules, `Dhcp_wire` responsible for parsing and
+constructing DHCP messages
+
+You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
+http://mirage.github.io/charrua/api
+
+#### Features
+
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.0.0/charrua-v1.0.0.tbz"
+  checksum: [
+    "sha256=c318158366541be647cec9df9f3090879818f3257d274e13f466ed14311870b5"
+    "sha512=567889744d741572666952c6c4e02754da25dee4b32a9879b11a185aaefbf80e3aa08120cc2d1b141047a98c8f36e33b3a74b98055de529fa9743da016b1a63f"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* explicit sexplib dependency, compatible with cstruct 4.0.0 (mirage/charrua#99, @TheLortex)
* charrua-server is an independent opam package now (mirage/charrua#100, @hannesm)
* charrua is the new name for charrua-core (mirage/charrua#100, @hannesm)
* the repository moved to https://github.com/mirage/charrua