### PR TITLE
Package satyrographos.0.0.1.7

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.1.7/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL3+"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "core" {< "v0.13"}
+  "dune" {build}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving"
+  "ppx_jane" {< "v0.13"}
+  "uri" {>= "2.0.0"}
+  "yojson"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.1.7.tar.gz"
+  checksum: [
+    "md5=425f6268e9b8ebc39faac9619a0f32b1"
+    "sha512=afcad64750e7fc5331bcf59413c229faf37807b61d9f3d904510efd2a11944e427aad83a21fbf261a53ef2f6c3ebdfa4c5cebbba93af53672e29d08d1f0ae076"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.1.7`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.0