### PR TITLE
visitors depends on cppo_ocamlbuild

### DIFF
--- a/packages/visitors/visitors.20170404/opam
+++ b/packages/visitors/visitors.20170404/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
   "result"

--- a/packages/visitors/visitors.20170420/opam
+++ b/packages/visitors/visitors.20170420/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
   "result"

--- a/packages/visitors/visitors.20170725/opam
+++ b/packages/visitors/visitors.20170725/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
   "result"

--- a/packages/visitors/visitors.20170828/opam
+++ b/packages/visitors/visitors.20170828/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
   "result"

--- a/packages/visitors/visitors.20171124/opam
+++ b/packages/visitors/visitors.20171124/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
   "result"

--- a/packages/visitors/visitors.20180306/opam
+++ b/packages/visitors/visitors.20180306/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
   "result"

--- a/packages/visitors/visitors.20180513/opam
+++ b/packages/visitors/visitors.20180513/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"
   "ppx_deriving" {>= "4.0"}
   "result"


### PR DESCRIPTION
This missing dependency was not noticed before as it was a transitive
dependency through ppx_deriving. Now ppx_deriving doesn't depend on it
anymore, so builds of visitors in an empty environment (typically the
CI) fail:

https://ci.ocamllabs.io/log/saved/docker-run-3fd09aeb82dc8ddea48a0bec2d629251/e25f76f9a648739a0a93bcc6d52c5fb52cf4cae4