### PR TITLE
elpi < 1.0.5 needs ppx_tools_versioned < 5.2.1.

### DIFF
--- a/packages/elpi/elpi.1.0.2/opam
+++ b/packages/elpi/elpi.1.0.2/opam
@@ -21,7 +21,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "camlp5"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {< "5.2.1"}
   "ppx_deriving"
   "ocaml-migrate-parsetree"
   "re"

--- a/packages/elpi/elpi.1.0.3/opam
+++ b/packages/elpi/elpi.1.0.3/opam
@@ -21,7 +21,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "camlp5"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {< "5.2.1"}
   "ppx_deriving"
   "ocaml-migrate-parsetree"
   "re"


### PR DESCRIPTION
The elpi commit fixing the incompatibility with >= 5.2.1 is precisely
the 1.0.5 commit:

> https://github.com/LPCIC/elpi/tree/v1.0.5
>  "Makefile: fix compilation on ppx_tools_versioned >= 5.2.1"

I tested manually that all of 1.0.{2,3,4} build correctly with 5.2.

1.0.4 does not need an opam-repository fix as it already sets
a (ppx_versioned = 5.1) dependency. (This constraint is probably too
strict, given that it builds fine with 5.2, but that's fine).