### PR TITLE
js_of_ocaml-ppx.3.0.2 is incompatible ppx_deriving>=4.3

### DIFF
--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.2/opam
@@ -21,6 +21,7 @@ depopts: ["ppx_deriving" "ppx_tools"]
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}
   "ppx_deriving"            {<="4.2.0"}
+  "ppx_deriving"            {>="4.3.0"}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"


### PR DESCRIPTION
js_of_ocaml-ppx.3.0.1 requires an old version of ppx_deriving (< 4.2),
and js_of_ocaml-ppx.3.0.2 was supposed to work with older versions (>=
4.2). But there is a bug in the dune build description, which requires
ppx_deriving instead of ppx_deriving.api, as ppx_deriving plugin
should, which makes it break with dune-using version of ppx_deriving
(>= 4.3). The bug was fixed in the upstream commit:

https://github.com/ocsigen/js_of_ocaml/commit/ec8bac63e285139c61ec8c94b8db6350b10d4f22

```
commit ec8bac63e285139c61ec8c94b8db6350b10d4f22
Author: Hugo Heuzard <hugo.heuzard@gmail.com>
Date:   Sat Feb 10 04:09:37 2018 +0000

    Ppx: fix deps for ppx_deriving_json
```

which was first included in the next release, 3.1.0.