### PR TITLE
links: fix dependencies on the ocaml version

### DIFF
--- a/packages/links/links.0.6.1/opam
+++ b/packages/links/links.0.6.1/opam
@@ -41,7 +41,7 @@ remove: [
   ["rm" "-rf" "%{links:doc}%/README"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.06"}
   "ocamlfind" {build}
   "deriving" {build}
   "lwt"

--- a/packages/links/links.0.7.1/opam
+++ b/packages/links/links.0.7.1/opam
@@ -52,7 +52,7 @@ depends: [
   "linenoise"
   "ANSITerminal"
   "lwt"
-  "cohttp"
+  "cohttp" {< "0.99.0"}
   "websocket-lwt"
 ]
 depopts: ["mysql" "postgresql" "sqlite3"]

--- a/packages/links/links.0.7.1/opam
+++ b/packages/links/links.0.7.1/opam
@@ -44,7 +44,7 @@ remove: [
   ["rm" "-rf" "%{links:doc}%/README"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.06"}
   "ocamlfind" {build}
   "deriving" {build}
   "cgi"

--- a/packages/links/links.0.7.2/opam
+++ b/packages/links/links.0.7.2/opam
@@ -58,7 +58,7 @@ depends: [
   "linenoise"
   "ANSITerminal"
   "lwt"
-  "cohttp"
+  "cohttp" {< "0.99.0"}
   "websocket-lwt"
   "safepass"
 ]

--- a/packages/links/links.0.7.3/opam
+++ b/packages/links/links.0.7.3/opam
@@ -50,7 +50,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "4.07"}
   "jbuilder" {build}
   "ppx_deriving"
   "ppx_deriving_yojson"

--- a/packages/links/links.0.7/opam
+++ b/packages/links/links.0.7/opam
@@ -51,7 +51,7 @@ depends: [
   "linenoise"
   "ANSITerminal"
   "lwt"
-  "cohttp"
+  "cohttp" {< "0.99.0"}
   "websocket-lwt"
 ]
 depopts: ["mysql" "postgresql" "sqlite3"]

--- a/packages/links/links.0.7/opam
+++ b/packages/links/links.0.7/opam
@@ -43,7 +43,7 @@ remove: [
   ["rm" "-rf" "%{links:doc}%/README"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.06"}
   "ocamlfind" {build}
   "deriving" {build}
   "cgi"


### PR DESCRIPTION
Versions of links older than 0.7.2 requires a <4.06 upper boud, and 0.7.3 requires a <4.07 upper bound.

CI failure log for 0.7.3: https://ci.ocamllabs.io/log/saved/docker-run-0bcc57fbc508a2dbc928a0da9774370d/5bb974aaddfb7beb2a0f5793d75cee313067a22c

I tested manually that links.0.7.1 does not build with ocaml.4.07.1 (so adding the upper bound seems right).