### PR TITLE
ppx_deriving_cmdliner<0.4.1 is incompatible with ppx_deriving>=4.3

### DIFF
--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml"
   "cmdliner"
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
   "ocamlfind" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.2.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml"
   "cmdliner"
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
   "ocamlfind" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.3.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.3.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml"
   "cmdliner" {>= "1.0.0"}
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
   "ocamlfind" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml"
   "cmdliner" {>= "1.0.0"}
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
   "ocamlfind" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}


### PR DESCRIPTION
Before 0.4.1, this package forgot a dependency on the ppx_deriving
runtime (ocamlfind packages 'ppx_deriving' or
'ppx_deriving.runtime') when building its own runtime
ppx_deriving_cmdliner_runtime. This worked correctly as the object
files of ppx_deriving.runtime and ppx_deriving.api were installed in
the same directory, hiding the error.

0.4.1 uses dune as its build system and everything works fine there.

For the record, applying the following patch to 0.4.0 fixes the
build (I wanted to make sure that plugin authors using ocamlbuild
could easily fix their build):

```diff
diff --git a/_tags b/_tags
index 3cbcb9e..0d9f14e 100644
--- a/_tags
+++ b/_tags
@@ -2,4 +2,5 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, cppo_V_OCAM

 "src": include
 <src/*.{ml,mli,byte,native}>: package(ppx_tools.metaquot), package(ppx_deriving.api), package(result)
+<src/ppx_deriving_cmdliner_runtime.*>: package(ppx_deriving)
 <src_test/*.{ml,byte,native}>: debug, package(result), package(oUnit), package(cmdliner), use_cmdliner
```

Build failure logs:
+ https://ci.ocamllabs.io/log/saved/docker-run-3bda0bcda9a1dc89c776e08086048b6a/5b4c2eb661b15ee9d24ac806a33399e9c8ac05c7
+ https://ci.ocamllabs.io/log/saved/docker-run-0059c5c9a3e1fdba6dbe648ce4951669/64f0542938967251be5854a462142c5160de94f7
+ https://ci.ocamllabs.io/log/saved/docker-run-ec68749a9a8433ff8f2c36e0bb848a6e/02b25b7070c3ce8a4ec81aa5e3895008940bdce1
+ https://ci.ocamllabs.io/log/saved/docker-run-64a10aa432775f710725c4729ca6dd7a/47b8e4b7ddf84ed2ad206e8d1247fda50d71bcbe


I see this issue as a bug in the package (ppx_deriving_cmdliner) build
system, rather than a breaking behavior in ppx_deriving (although of
course unobservable bugs should arguably remain unobservable for
compatibility), which justifies introducing the ppx_deriving change in
a minor release.