### PR TITLE
Package ocolor.1.0

### DIFF
--- a/packages/ocolor/ocolor.1.0/opam
+++ b/packages/ocolor/ocolor.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Print with style in your terminal using Format's semantic tags"
+maintainer: "Marc Chevalier <ocolor@marc-chevalier.com>"
+authors: "Marc Chevalier <ocolor@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+homepage: "https://github.com/marc-chevalier/ocolor"
+bug-reports: "https://github.com/marc-chevalier/ocolor/issues"
+dev-repo: "git+https://github.com/marc-chevalier/ocolor.git"
+license: "MIT"
+description: """
+This package provides a nice way to use ANSI escape codes thanks to Format's
+semantic tags. This mode is compositional: ending a style restore the previous
+one, instead of destroying everything.
+This package also allows using directly ANSI escape codes (with Printf).
+
+Note that this library does not intend to handle anything else than ANSI escape
+codes (in particular, not the old Windows style of styling). Moreover, it aims
+to be as pure as possible, so insensitive to the environment. As a consequence,
+there is no mechanism to detect terminal's settings. However, some configuration
+is possible, but must be done manually.
+"""
+url {
+  src: "https://github.com/marc-chevalier/ocolor/archive/1.0.tar.gz"
+  checksum: [
+    "md5=27add0c75ed96fa84dd9f16edf0b3d5a"
+    "sha512=3aaadb4af365b97c8ff4e66bacbeed1345875f6f599e416f888980773ea31ae5fbbedef7d3d82173b5aaed5d6273e876d29d9da5ee99398afc88a41ff9168bf3"
+  ]
+}

--- a/packages/ocolor/ocolor.1.0/opam
+++ b/packages/ocolor/ocolor.1.0/opam
@@ -4,7 +4,7 @@ maintainer: "Marc Chevalier <ocolor@marc-chevalier.com>"
 authors: "Marc Chevalier <ocolor@marc-chevalier.com>"
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {>= "1.6.3"}
+  "dune" {build & >= "1.6.3"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
### `ocolor.1.0`
Print with style in your terminal using Format's semantic tags
This package provides a nice way to use ANSI escape codes thanks to Format's
semantic tags. This mode is compositional: ending a style restore the previous
one, instead of destroying everything.
This package also allows using directly ANSI escape codes (with Printf).

Note that this library does not intend to handle anything else than ANSI escape
codes (in particular, not the old Windows style of styling). Moreover, it aims
to be as pure as possible, so insensitive to the environment. As a consequence,
there is no mechanism to detect terminal's settings. However, some configuration
is possible, but must be done manually.



---
* Homepage: https://github.com/marc-chevalier/ocolor
* Source repo: git+https://github.com/marc-chevalier/ocolor.git
* Bug tracker: https://github.com/marc-chevalier/ocolor/issues

---
:camel: Pull-request generated by opam-publish v2.0.0