### PR TITLE
Fix various hardcaml issues

### DIFF
--- a/packages/hardcaml-examples/hardcaml-examples.0.1.0/opam
+++ b/packages/hardcaml-examples/hardcaml-examples.0.1.0/opam
@@ -7,7 +7,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "hardcaml" {< "v0.13"}
+  "hardcaml" {< "2.0.0"}
   "hardcaml-waveterm"
   "omd"
   "ocamlbuild" {build}

--- a/packages/hardcaml-examples/hardcaml-examples.0.2/opam
+++ b/packages/hardcaml-examples/hardcaml-examples.0.2/opam
@@ -7,7 +7,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.03.0"}
-  "hardcaml" {< "v0.13"}
+  "hardcaml" {< "2.0.0"}
   "hardcaml-waveterm"
   "omd"
   "ocamlbuild" {build}

--- a/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.2/opam
+++ b/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.2/opam
@@ -8,7 +8,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "hardcaml" {>= "1.1.1" & < "v0.13"}
+  "hardcaml" {>= "1.1.1" & < "2.0.0"}
   "llvm" {>= "3.4" & < "3.6"}
   "ocamlbuild" {build}
   "ctypes-foreign"

--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.1/opam
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.1/opam
@@ -8,7 +8,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind"
-  "hardcaml" {< "v0.13"}
+  "hardcaml" {< "2.0.0"}
   "hardcaml-waveterm"
   "hardcaml-examples"
   "reedsolomon"

--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.2/opam
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.2/opam
@@ -8,7 +8,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind"
-  "hardcaml" {>= "1.1.1" & < "v0.13"}
+  "hardcaml" {>= "1.1.1" & < "2.0.0"}
   "hardcaml-waveterm"
   "hardcaml-examples" {>= "0.2"}
   "reedsolomon"

--- a/packages/hardcaml-vpi/hardcaml-vpi.0.1.0/opam
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.1.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
-  "hardcaml" {< "v0.13"}
+  "hardcaml" {< "2.0.0"}
   "ocamlbuild" {build}
 ]
 depexts: [

--- a/packages/hardcaml-vpi/hardcaml-vpi.0.2/opam
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.2/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
-  "hardcaml" {>= "1.1.1" & < "v0.13"}
+  "hardcaml" {>= "1.1.1" & < "2.0.0"}
   "ocamlbuild" {build}
 ]
 depexts: [

--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
@@ -8,7 +8,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.04.0"}
-  "hardcaml" {>= "1.1.0" & < "v0.13"}
+  "hardcaml" {>= "1.1.0" & < "2.0.0"}
   "lambda-term"
   "ocamlbuild" {build}
   "lwt" {< "4.0.0"}

--- a/packages/hardcaml_waveterm/hardcaml_waveterm.v0.12.0/opam
+++ b/packages/hardcaml_waveterm/hardcaml_waveterm.v0.12.0/opam
@@ -21,6 +21,7 @@ depends: [
   "num"
   "re"          {>= "1.8.0"}
 ]
+conflicts: ["hardcaml-waveterm"]
 synopsis: "A terminal based digital waveform viewer for Hardcaml"
 description: "
 The hardcaml_waveterm library renders digital waveforms to unicode. Such

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.0.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.0.0/opam
@@ -26,7 +26,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "hardcaml" {>= "1.1.0"}
+  "hardcaml" {>= "1.1.0"i & < "2.0.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
   "ppx_deriving" {>= "4.0" & < "5.0"}

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.0.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.0.0/opam
@@ -26,7 +26,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "hardcaml" {>= "1.1.0"i & < "2.0.0"}
+  "hardcaml" {>= "1.1.0" & < "2.0.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
   "ppx_deriving" {>= "4.0" & < "5.0"}

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.1.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.1.0/opam
@@ -26,7 +26,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "hardcaml" {>= "1.1.0"}
+  "hardcaml" {>= "1.1.0" & < "2.0.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
   "ppx_deriving" {>= "4.0" & < "5.0"}

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.2.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.2.0/opam
@@ -24,7 +24,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "hardcaml" {>= "1.1.0"}
+  "hardcaml" {>= "1.1.0" & < "2.0.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
   "ppx_deriving" {>= "4.0" & < "5.0"}

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_driver" {build}
   "ppx_core" {build}
   "ounit" {build}
-  "hardcaml" {>= "1.1.0" & < "v0.13"}
+  "hardcaml" {>= "1.1.0" & < "2.0.0"}
 ]
 conflicts: [ "ppxlib" ]
 synopsis: "PPX extension for HardCaml"

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.1.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ocamlfind" {build & >= "1.3.2"}
   "ppx_tools"
   "ounit" {with-test}
-  "hardcaml" {>= "1.1.0" & < "v0.13"}
+  "hardcaml" {>= "1.1.0" & < "2.0.0"}
 ]
 synopsis: "PPX extension for HardCaml"
 url {

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.2.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.2.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ocamlfind" {build & >= "1.3.2"}
   "ppx_tools"
   "ounit" {with-test}
-  "hardcaml" {>= "1.2.0" & < "v0.13"}
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "PPX extension for HardCaml"
 url {

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.3.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_tools_versioned"
   "jbuilder" {build}
   "ounit" {with-test}
-  "hardcaml" {>= "1.2.0" & < "v0.13"}
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "PPX extension for HardCaml"
 url {

--- a/packages/reedsolomon/reedsolomon.0.2/opam
+++ b/packages/reedsolomon/reedsolomon.0.2/opam
@@ -8,7 +8,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.00.1"}
   "ocamlfind"
-  "hardcaml" {< "v0.13"}
+  "hardcaml" {< "2.0.0"}
   "js_of_ocaml" {< "3.0"}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
The script used to add upper bounds to the reverse dependencies
of Jane Street packages added a number of incorrect bounds.

The "hardcaml" package exists in two sets of versions, "1.x" and
"v0.x", and the script should have added upper bounds only for
the latter (versions "1.x" are not Jane Street packages). This results
in nonsensical constraints such as `{>= "1.1.0" & < "v0.13.0"}`.

This pull request fixes such constraints, and also adds a conflict
between the "hardcaml-waveterm" and "hardcaml_waveterm" packages.
