### PR TITLE
ppx_deriving_hardcaml: older releases don't support ppx_deriving.4.3

### DIFF
--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.0.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "hardcaml" {>= "1.1.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
 ]
 synopsis: "PPX deriving plugin for HardCaml"
 url {

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.1.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "hardcaml" {>= "1.1.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
 ]
 synopsis: "PPX deriving plugin for HardCaml"
 url {

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.2.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.1.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "hardcaml" {>= "1.1.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
 ]
 synopsis: "PPX deriving plugin for HardCaml"
 url {


### PR DESCRIPTION
The new v0.12.0 release uses ppx_jane and builds fine.

upstream PR: https://github.com/xguerin/ppx_deriving_hardcaml/pull/12

Build failure logs:
+ https://ci.ocamllabs.io/log/saved/docker-run-61a831500ef1cd867764eac765458682/7797de6206516b241664d27d9da95011aae98cc7
+ https://ci.ocamllabs.io/log/saved/docker-run-617164bbb06b71cd90d20021126172f5/3a78ff6eeb9f717aa2ca774ed38e01a227c5475a
+ https://ci.ocamllabs.io/log/saved/docker-run-5ba4343bac8c0744f8d39cdd71bdc7e8/db58ee8b88ff888d2f7a688462086d16bfb82f24