### PR TITLE
ppx_deriving_morphism: current releases don't support ppx_deriving.4.3

### DIFF
--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
@@ -24,7 +24,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.1"}
-  "ppx_deriving" {>= "3.0" & < "5.0"}
+  "ppx_deriving" {>= "3.0" & < "4.3"}
   "ppx_tools" {>= "4.02.3"}
   "ocamlfind" {build}
   "cppo" {build}

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
@@ -24,7 +24,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.1" & < "4.05"}
-  "ppx_deriving" {>= "3.0" & < "5.0"}
+  "ppx_deriving" {>= "3.0" & < "4.3"}
   "ppx_tools" {>= "4.02.3"}
   "ocamlfind" {build}
   "cppo" {build}


### PR DESCRIPTION
upstream PR: https://github.com/choeger/ppx_deriving_morphism/pull/2

Build failure log:
https://ci.ocamllabs.io/log/saved/docker-run-6614b63bdcd813869ec8f8c8641347f9/e75b4edd3a2701f41eea773a99abcdb288a63aaf