### PR TITLE
older ppx_deriving_yojson releases are incompatible with ppx_deriving.4.3

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {< "4.05.0"}
   "yojson" {< "1.6.0"}
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
   "ocamlfind" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.1/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"
   "yojson" {< "1.6.0"}
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "4.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build}


### PR DESCRIPTION
The newer releases 3.3 and (in preparation) 3.4 should be fine.

Build failure logs:
+ https://ci.ocamllabs.io/log/saved/docker-run-b2b45318da2088bbbe4ce1951871851e/6e24acd84c36f0e128eb766c742e38506d0fdca1