### PR TITLE
[WIP] pre-release of ppx_deriving.4.3

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune"     {build >= "1.6.3"}
+  "cppo"     {build}
+  "ppxfind"  {build}
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {with-test}
+  "ocaml" {>= "4.02"}
+]
+synopsis: "Type-driven code generation for OCaml >=4.02"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src: "https://github.com/gasche/ppx_deriving/archive/release-4.3.tar.gz"
+  checksum: "sha256=16d6014b1dbd3e58653d24dcfc45878469395fd975047ddcf18033dbd347a8e1"
+}

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
@@ -25,7 +25,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
-  "ppx_deriving" {>= "3.2" & < "5.0"}
+  "ppx_deriving" {>= "3.2" & < "4.3"}
   "ppx_derivers"
   "result" {with-test}
   "ounit" {with-test}

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
@@ -25,7 +25,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
-  "ppx_deriving" {>= "3.2" & < "5.0"}
+  "ppx_deriving" {>= "3.2" & < "4.3"}
   "ppx_derivers"
   "result" {with-test}
   "ounit" {with-test}


### PR DESCRIPTION
This is a pre-release commit to test the ppx_deriving revdeps in the
opam-repository CI. Don't merge yet!

First attempt: https://github.com/ocaml/opam-repository/pull/13652

This second attempt incorporates minor changes to the opam file (no
other change to the ppx_deriving pre-release), and occurs after the
revdeps failures of the first attempt have been reviewed and fixed.