### PR TITLE
async_js.v0.9.1 is not compatible with js_of_ocaml >= 3.4

### DIFF
--- a/packages/async_js/async_js.v0.9.1/opam
+++ b/packages/async_js/async_js.v0.9.1/opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta2"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {>= "3.0" & < "3.4"}
   "js_of_ocaml-ppx" {>= "3.0" & < "3.2"}
   "ocaml-migrate-parsetree" {>= "0.4"}
 ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)