### PR TITLE
charrua: update checksums

### DIFF
--- a/packages/charrua-core/charrua-core.0.1/opam
+++ b/packages/charrua-core/charrua-core.0.1/opam
@@ -61,5 +61,5 @@ This project became one of the [Mirage Pioneer]
 (https://github.com/mirage/mirage-www/wiki/Pioneer-Projects) projects."""
 url {
   src: "https://github.com/haesbaert/charrua-core/archive/v0.1.tar.gz"
-  checksum: "md5=80a9123e49380001b17cfdb4477e16ba"
+  checksum: "md5=e8fe482a9618cf82b785dabedb870f04"
 }

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -63,5 +63,5 @@ This project became one of the [Mirage Pioneer]
 (https://github.com/mirage/mirage-www/wiki/Pioneer-Projects) projects."""
 url {
   src: "https://github.com/haesbaert/charrua-core/archive/v0.3.tar.gz"
-  checksum: "md5=64fb05a05ef73405c6477c8cba5257ec"
+  checksum: "md5=194813e9826e8a55d3a315d5f42364e2"
 }

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -63,5 +63,5 @@ This project became one of the [Mirage Pioneer]
 (https://github.com/mirage/mirage-www/wiki/Pioneer-Projects) projects."""
 url {
   src: "https://github.com/mirage/charrua-core/archive/v0.4.tar.gz"
-  checksum: "md5=622a00845f04e98a0b534b05a8dca01b"
+  checksum: "md5=69f078e945c4a5a586db7cd7be08525e"
 }


### PR DESCRIPTION
@kit-ty-kate it looks like the repository rename `charrua-core` -> `charrua` lead to regeneration of github-provided tarballs, which were used in those earlier releases 

I downloaded the tarballs and checked with `diff -ur` against the respective git tag.

as requested in #14023