### PR TITLE
[new release] coq-serapi (8.9.0+0.6.1)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.9.0+0.6.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.9.0+0.6.1/opam
@@ -1,0 +1,33 @@
+synopsis:     "Sexp-based serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  "Sexp-based serialization library and protocol for machine interaction with the Coq proof assistant"
+name:         "coq-serapi"
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+authors:      "Emilio Jesús Gallego Arias"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL 3"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+depends: [
+  "ocaml"         { >= "4.06.0"           }
+  "coq"           { >= "8.9.0" & < "8.10" }
+  "cmdliner"      { >= "1.0.0"            }
+  "ocamlfind"     { >= "1.8.0"            }
+  "sexplib"       { >= "v0.11.0"          }
+  "dune"          { build & >= "1.2.0"    }
+  "ppx_import"    { build & >= "1.5-3"    }
+  "ppx_deriving"  { build & >= "4.2.1"    }
+  "ppx_sexp_conv" { build & >= "v0.11.0"  }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.9.0+0.6.1/coq-serapi-8.9.0.0.6.1.tbz"
+  checksum: [
+    "sha256=136e0e4495616a0cb60b8e375b8fb7a93f6670ac31d1c13ba40454f7b6f4b671"
+    "sha512=079b890f88e638a4aae336f9827c46a8fffb5ce7eb6dec55ca1a41fe6a414fc8208d2e024689337275b19e00797f0bb26810c4de3e81a101a6dece2b1552a04b"
+  ]
+}


### PR DESCRIPTION
Sexp-based serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

* [serapi ] Add `Parse` command to parse a sentence; c.f.
             https://github.com/ejgallego/coq-serapi/issues/117
             (@ejgallego) (cc: @yangky11)
 * [sercomp] Add "print" `--mode` to print the input Coq document
             (@ejgallego) (cc: @Ptival)
 * [serlib ] Serialize `Universe.t` (@ejgallego, request by @yangky11)
 * [sercomp] Merge `sercomp` and `compser`, add `--input` parameter to `sercomp`
             (@palmskog) (cc: @ejgallego)
 * [serlib ] Much improved support for serialization of `Environ.env`
             (@yangky11 and @ejgallego c.f. ejgallego/coq-serapi#118)
 * [serapi ] Make sure every command ends with `Completed`, even if it produced
             an exception (@brando90 and @ejgallego c.f. ejgallego/coq-serapi#124)
 * [sercomp] Add `--mode=kexp` to output the final kernel environment.
             (@ejgallego c.f. ejgallego/coq-serapi#119)
 * [serlib ] Serialize more internal environment fields (@ejgallego c.f. ejgallego/coq-serapi#119)
 * [serlib ] Improvements in serialization org (@ejgallego)
 * [serlib ] Serialize kernel entries (@ejgallego @palmskog)
 * [serlib ] Fix critical bug on `Constr` deserialization; reported by @palmskog,
             fix by @SkySkimmer.
 * [sertop]  Fix backtrace printing when using `--debug` (@ejgallego)
 * [serlib ] Don't serialize VM values (@ejgallego, bug report by @palmskog)
 * [serapi ] Output location on tokenization (@ejgallego , idea by @palmskog)
 * [serapi ] Add basic documentation of the protocol (@ejgallego cc ejgallego/coq-serapi#109)
