### PR TITLE
fix upper bound on js_of_ocaml-ppx.3.0.2

### DIFF
--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.2/opam
@@ -21,7 +21,7 @@ depopts: ["ppx_deriving" "ppx_tools"]
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}
   "ppx_deriving"            {<="4.2.0"}
-  "ppx_deriving"            {>="4.3.0"}
+  "ppx_deriving"            {>="4.3"}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"


### PR DESCRIPTION
This is a minor adjustment to #14005 which has proved ineffective to guard against the issue it should fix, according to the revdeps report for #14018.