### PR TITLE
[new release] mirage-flow-unix, mirage-flow-lwt and mirage-flow (1.6.0)

### DIFF
--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.6.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "fmt"
+  "lwt"
+  "logs"
+  "cstruct" {>= "2.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS specialized to lwt"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v1.6.0/mirage-flow-v1.6.0.tbz"
+  checksum: [
+    "sha256=d6596e9bd2442023a3b2222db0a36fd6a97318e06853162c9938d9fab8cc63d3"
+    "sha512=2666268cb4e7208357083a733565e5f07e15ca77bd35b1a00c7fd1562b7abc8e1eb8ec1a5bd5782240993621e6bcaa7003f6143d77b8da09491e5c38b645faeb"
+  ]
+}

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.6.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "fmt"
+  "logs"
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "lwt"
+  "cstruct" {>= "3.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS on Unix"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v1.6.0/mirage-flow-v1.6.0.tbz"
+  checksum: [
+    "sha256=d6596e9bd2442023a3b2222db0a36fd6a97318e06853162c9938d9fab8cc63d3"
+    "sha512=2666268cb4e7208357083a733565e5f07e15ca77bd35b1a00c7fd1562b7abc8e1eb8ec1a5bd5782240993621e6bcaa7003f6143d77b8da09491e5c38b645faeb"
+  ]
+}

--- a/packages/mirage-flow/mirage-flow.1.6.0/opam
+++ b/packages/mirage-flow/mirage-flow.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v1.6.0/mirage-flow-v1.6.0.tbz"
+  checksum: [
+    "sha256=d6596e9bd2442023a3b2222db0a36fd6a97318e06853162c9938d9fab8cc63d3"
+    "sha512=2666268cb4e7208357083a733565e5f07e15ca77bd35b1a00c7fd1562b7abc8e1eb8ec1a5bd5782240993621e6bcaa7003f6143d77b8da09491e5c38b645faeb"
+  ]
+}


### PR DESCRIPTION
Flow implementations and combinators for MirageOS on Unix

- Project page: <a href="https://github.com/mirage/mirage-flow">https://github.com/mirage/mirage-flow</a>
- Documentation: <a href="https://mirage.github.io/mirage-flow/">https://mirage.github.io/mirage-flow/</a>

##### CHANGES:

* remove uses of `Result` (mirage/mirage-flow#40 @hannesm)
* port opam metadata to 2.0 format (mirage/mirage-flow#41 @hannesm)
* port build to dune from jbuilder (mirage/mirage-flow#41 @hannesm)
