### PR TITLE
Disable parallel build for some old JaneStreet packages

### DIFF
--- a/packages/ppx_driver/ppx_driver.113.33.04/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.04/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/janestreet/ppx_driver.git"
 license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
-  [make]
+  [make "BUILDFLAGS=-j 1"]
 ]
 depends: [
   "ocaml" {= "4.02.3"}

--- a/packages/ppx_here/ppx_here.113.33.00/opam
+++ b/packages/ppx_here/ppx_here.113.33.00/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/janestreet/ppx_here.git"
 license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
-  [make]
+  [make "BUILDFLAGS=-j 1"]
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.00+4.03/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.00+4.03/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
 license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
-  [make]
+  [make "BUILDFLAGS=-j 1"]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_let/ppx_let.113.33.00+4.03/opam
+++ b/packages/ppx_let/ppx_let.113.33.00+4.03/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/janestreet/ppx_let.git"
 license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
-  [make]
+  [make "BUILDFLAGS=-j 1"]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.00+4.03/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.00+4.03/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"
 license: "Apache-2.0"
 build: [
   ["./configure" "--prefix" prefix]
-  [make]
+  [make "BUILDFLAGS=-j 1"]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

Should fix https://github.com/janestreet-deprecated/ppx_driver/issues/5 for those handful of packages.

I'm just going to do the same kind of pull request every time some appear on http://check.ocamllabs.io/diff (usually around 10 packages get broken due to this bug for every run). It seems less dreadful than just search for the cause of the issue and search for every packages that might have this problem.