### PR TITLE
Package ppx_cstubs.0.1.0

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.1.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "GPLv3"
+homepage: "https://github.com/fdopen/ppx_cstubs"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes" {>= "0.13.0" & <= "0.15.0"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
+  "ocaml-migrate-parsetree"
+  "ocamlfind" # not only a build dependency, it depends on findlib.top
+  "dune" {build & >= "1.6"}
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for quick and dirty stub generation
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for quick and dirty stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file with c stub
+code and an OCaml file with all additional boilerplate code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=5d8e71481f1053ee3c0709feeb7793dd"
+    "sha512=ddd0ac292d4102e1e432a9917e2c9b9e0420a25fcf44e53c94db007d3c7618528be98682d1a82bd4dc862bfe906332dd644ff16c978d938a41e27ed91cdd7f16"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.1.0`
Preprocessor for quick and dirty stub generation
ppx_cstubs is a ppx-based preprocessor for quick and dirty stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file with c stub
code and an OCaml file with all additional boilerplate code.



---
* Homepage: https://github.com/fdopen/ppx_cstubs
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.0