### PR TITLE
2 packages from issuu/ppx_mysql at 1.0

### DIFF
--- a/packages/ppx_mysql/ppx_mysql.1.0/opam
+++ b/packages/ppx_mysql/ppx_mysql.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Dario Teixeira <dte@issuu.com>"
+synopsis: "Syntax extension for facilitating usage of MySQL bindings"
+description: """
+This syntax extension aims to reduce the pain and boilerplate associated with
+using MySQL bindings from OCaml.  It is similar in spirit to PG'OCaml, but
+without the compile-time communication with the DB engine for type inference.
+"""
+homepage: "https://github.com/issuu/ppx_mysql"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
+bug-reports: "https://github.com/issuu/ppx_mysql/issues"
+doc: "https://issuu.github.io/ppx_mysql/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "alcotest" {with-test & >= "0.8" & < "0.9"}
+  "dune" {build}
+  "ocamlformat" {with-test & >= "0.9"}
+  "ocaml" {>= "4.06.0" }
+  "ppxlib" {>= "0.2" & < "0.6"}
+  "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
+]
+authors: "Team Raccoons at Issuu"
+url {
+  src: "https://github.com/issuu/ppx_mysql/archive/1.0.tar.gz"
+  checksum: [
+    "md5=0fec3b3ab353f4ed7d963775364698a1"
+    "sha512=58a3a37535e93f14da3abc99f4b6b41462f8e9071fb7173be43f478dcd649eabd7373dd612e76f3f793bfb30c7bc76c27d662a85cdef66060893078855668e3c"
+  ]
+}

--- a/packages/ppx_mysql_identity/ppx_mysql_identity.1.0/opam
+++ b/packages/ppx_mysql_identity/ppx_mysql_identity.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Dario Teixeira <dte@issuu.com>"
+synopsis: "Convenience package for using ppx_mysql with Mysql and the identity monad for IO"
+description: """
+The ppx_mysql extension expects the existence of several modules in the current context.
+This package provides the definition of those modules for using ppx_mysql with Mysql
+(via OPAM's mysql package) and the identity monad for IO.
+"""
+homepage: "https://github.com/issuu/ppx_mysql"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
+bug-reports: "https://github.com/issuu/ppx_mysql/issues"
+doc: "https://issuu.github.io/ppx_mysql/"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "mysql" {>= "1.2" & < "2.0"}
+  "ocaml" {>= "4.06.0"}
+  "ppx_mysql" {= version}
+]
+authors: "Team Raccoons at Issuu"
+url {
+  src: "https://github.com/issuu/ppx_mysql/archive/1.0.tar.gz"
+  checksum: [
+    "md5=0fec3b3ab353f4ed7d963775364698a1"
+    "sha512=58a3a37535e93f14da3abc99f4b6b41462f8e9071fb7173be43f478dcd649eabd7373dd612e76f3f793bfb30c7bc76c27d662a85cdef66060893078855668e3c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ppx_mysql.1.0`: Syntax extension for facilitating usage of MySQL bindings
-`ppx_mysql_identity.1.0`: Convenience package for using ppx_mysql with Mysql and the identity monad for IO



---
* Homepage: https://github.com/issuu/ppx_mysql
* Source repo: git+https://github.com/issuu/ppx_mysql.git
* Bug tracker: https://github.com/issuu/ppx_mysql/issues

---
:camel: Pull-request generated by opam-publish v2.0.0