### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.1.1)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.1.1/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile-opam" {>= "3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.1.1/dockerfile-v6.1.1.tbz"
+  checksum: [
+    "sha256=5e9d94bf15b3710d70a4f803c441296e8f7e57e761aa45f6330f2a905014704e"
+    "sha512=76f1a66af1eb3cc7c247ffa3daa4be63974d48a8d32ec976290b52a2bad2f53deed6afd4751af2343bc59a61339465870fb9ce70636106ad90aeed02e96dc236"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.1.1/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.1.1/dockerfile-v6.1.1.tbz"
+  checksum: [
+    "sha256=5e9d94bf15b3710d70a4f803c441296e8f7e57e761aa45f6330f2a905014704e"
+    "sha512=76f1a66af1eb3cc7c247ffa3daa4be63974d48a8d32ec976290b52a2bad2f53deed6afd4751af2343bc59a61339465870fb9ce70636106ad90aeed02e96dc236"
+  ]
+}

--- a/packages/dockerfile/dockerfile.6.1.1/opam
+++ b/packages/dockerfile/dockerfile.6.1.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.1.1/dockerfile-v6.1.1.tbz"
+  checksum: [
+    "sha256=5e9d94bf15b3710d70a4f803c441296e8f7e57e761aa45f6330f2a905014704e"
+    "sha512=76f1a66af1eb3cc7c247ffa3daa4be63974d48a8d32ec976290b52a2bad2f53deed6afd4751af2343bc59a61339465870fb9ce70636106ad90aeed02e96dc236"
+  ]
+}


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/">https://avsm.github.io/ocaml-dockerfile/</a>

##### CHANGES:

- Add support for Ubuntu 19.04 (Disco). (@avsm)
- Upgrade opam metadata to 2.0 format. (@avsm)
