### PR TITLE
coqide: use 'version' to automatically depend on the matching coq version

### DIFF
--- a/packages/coqide/coqide.8.9.0/opam
+++ b/packages/coqide/coqide.8.9.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml" {>= "4.02.3"}
   "camlp5"
-  "coq" {= "8.9.0"}
+  "coq" {= version}
   "lablgtk"
   "conf-gtksourceview"
 ]


### PR DESCRIPTION
This also means we can just copy-paste that part in the future.