### PR TITLE
+opam-depext.1.1.3

### DIFF
--- a/packages/opam-depext/opam-depext.1.1.3/opam
+++ b/packages/opam-depext/opam-depext.1.1.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
+build: [make]
+available: opam-version >= "2.0.0~beta5"
+synopsis: "Query and install external dependencies of OPAM packages"
+description: """
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can query OPAM for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them."""
+depends: [
+  "ocaml" {>= "4.0.0"}
+]
+flags: plugin
+url {
+  src:
+    "https://github.com/ocaml/opam-depext/releases/download/v1.1.3/opam-depext-full-1.1.3.tbz"
+  checksum: "md5=72c082a0a6606398669b6fc2f4c4ae84"
+}


### PR DESCRIPTION
Support test-only and docs-only dependencies in opam files via --with-test and --with-doc to opam-depext.