### PR TITLE
Package ocaml-basics.0.6.0

### DIFF
--- a/packages/ocaml-basics/ocaml-basics.0.6.0/opam
+++ b/packages/ocaml-basics/ocaml-basics.0.6.0/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "Basic modules and signatures needed in most of Advanced Schema's projects"
+description: "Basic modules and signatures needed in most of Advanced Schema's projects"
+maintainer: "Antoine Luciani <aluciani@advanced-schema.com>"
+authors: "Advanced Schema"
+homepage: "http://github.com/advanced-schema/ocaml-basics"
+bug-reports: "http://github.com/advanced-schema/ocaml-basics/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/advanced-schema/ocaml-basics.git"
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "jbuilder" {>= "1.0+beta16"}
+  "result" {>= "1.2"}
+]


### PR DESCRIPTION
### `ocaml-basics.0.6.0`
Basic modules and signatures needed in most of Advanced Schema's projects
Basic modules and signatures needed in most of Advanced Schema's projects



---
* Homepage: http://github.com/advanced-schema/ocaml-basics
* Source repo: git+https://github.com/advanced-schema/ocaml-basics.git
* Bug tracker: http://github.com/advanced-schema/ocaml-basics/issues

---
:camel: Pull-request generated by opam-publish v2.0.0