### PR TITLE
[new release] lablgtk3-sourceview3, lablgtk3-gtkspell3 and lablgtk3 (3.0.beta6)

### DIFF
--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
@@ -21,7 +21,6 @@ depends: [
   "dune"                 { build & >= "1.4.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833
-  "dune"                 { build & >= "1.4.0"     }
   "lablgtk3"             {         >= "3.0.beta5" }
 ]
 depexts: [

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3, gtkspell library
+
+See http://lablgtk.forge.ocamlcore.org/ for more information.
+
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0"    }
+  "dune"                 { build & >= "1.4.0"
+                                 & != "1.7.0"
+                                 & != "1.7.1"     } # Due to dune/dune#1833
+  "dune"                 { build & >= "1.4.0"     }
+  "lablgtk3"             {         >= "3.0.beta5" }
+]
+depexts: [
+  ["gtkspell3-dev"] {os-distribution = "alpine"}
+  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
+  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3"] {os = "freebsd"}
+  ["gtkspell3"] {os = "openbsd"}
+  ["gtkspell3-devel"] {os-family = "suse"}
+  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
+  ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta6/lablgtk3-3.0.beta6.tbz"
+  checksum: "md5=7f0027b74aaa85329dacba062e1c2b95"
+}

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta6/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview3 library.
+
+See http://lablgtk.forge.ocamlcore.org/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0"    }
+  "dune"                 { build & >= "1.4.0"
+                                 & != "1.7.0"
+                                 & != "1.7.1"     } # Due to dune/dune#1833
+  "lablgtk3"             {         >= "3.0.beta5" }
+  "conf-gtksourceview3"  { build & >= "0"         }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta6/lablgtk3-3.0.beta6.tbz"
+  checksum: "md5=7f0027b74aaa85329dacba062e1c2b95"
+}

--- a/packages/lablgtk3/lablgtk3.3.0.beta6/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3
+
+See http://lablgtk.forge.ocamlcore.org/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL with linking exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3"
+
+depends: [
+  "ocaml"     {         >= "4.05.0" }
+  "dune"      { build & >= "1.4.0"
+                      & != "1.7.0"
+                      & != "1.7.1"  } # Due to dune/dune#1833
+  "conf-gtk3" { build & >= "18"     }
+  "cairo2"    {         >= "0.6"    }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta6/lablgtk3-3.0.beta6.tbz"
+  checksum: "md5=7f0027b74aaa85329dacba062e1c2b95"
+}


### PR DESCRIPTION
OCaml interface to GTK+ gtksourceview library

- Project page: <a href="https://github.com/garrigue/lablgtk">https://github.com/garrigue/lablgtk</a>
- Documentation: <a href="https://garrigue.github.io/lablgtk/lablgtk3-sourceview3">https://garrigue.github.io/lablgtk/lablgtk3-sourceview3</a>

##### CHANGES:

2019.04.09 [Jacques]
  * Add gdk_window_get_origin binding (garrigue/lablgtk#60) [Pierre-Marie Pedrot]
  * Convert README to markdown (garrigue/lablgtk#57) [Anton Kochkov]
  * Add additional Pango.Layout functions (garrigue/lablgtk#58) [Milo Turner]
