### PR TITLE
[new release] mrt-format (0.3.1)

### DIFF
--- a/packages/mrt-format/mrt-format.0.3.1/opam
+++ b/packages/mrt-format/mrt-format.0.3.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Richard Mortier <mort@cantab.net>"
+authors: [ "Richard Mortier" ]
+license: "ISC"
+
+homepage: "https://github.com/mor1/mrt-format"
+dev-repo: "git+https://github.com/mor1/mrt-format.git"
+bug-reports: "https://github.com/mor1/mrt-format/issues"
+doc: "https://mor1.github.io/mrt-format/"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"
+  "dune" {>= "1.1.0" & build}
+  "alcotest"    {with-test}
+  "cstruct"     {>= "1.0.1"}
+  "ipaddr"      {>= "2.0.0"}
+  "logs"
+  "ocamlfind"   {build}
+  "ppx_cstruct" {build}
+  "result"
+]
+
+synopsis: "MRT parsing library and CLI"
+description: "A basic implementation of the [Multi-Threaded Routing Toolkit](https://tools.ietf.org/html/rfc6396) format, following my implementation in the [Python Routeing Toolkit](https://github.com/mor1/pyrt) and documentation in the [RFC](https://tools.ietf.org/html/rfc6396) and the [PyRT README](https://github.com/mor1/pyrt/blob/master/README.mrtd). Provides (incomplete) parsing libraries and a simple CLI tool."
+url {
+  src:
+    "https://github.com/mor1/mrt-format/releases/download/0.3.1/mrt-format-0.3.1.tbz"
+  checksum: [
+    "sha256=0e8be79bebcffdef30aa8a0a3e87060aab8a87a6dbba50d798669433827bf9be"
+    "sha512=1e8b0e83e2f7f92b8bc887047df5b21ab262de4f0cd904f8b8564ac72a43f0a0fef0ac72c8d9aaa2eb3042b82bed141882a73e0edd776733f3dd43e5622faa0e"
+  ]
+}


### PR DESCRIPTION
MRT parsing library and CLI

- Project page: <a href="https://github.com/mor1/mrt-format">https://github.com/mor1/mrt-format</a>
- Documentation: <a href="https://mor1.github.io/mrt-format/">https://mor1.github.io/mrt-format/</a>

##### CHANGES:

* Add explicit dependency on `bigarray`
