### PR TITLE
[new release] mirage-xen (3.4.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.3.4.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst" ] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "conf-pkg-config"
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "mirage-xen-ocaml" {>= "2.6.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "logs"
+  "fmt"
+]
+conflicts: [
+  "dune" {= "1.9.1"}
+]
+available: [ os = "linux" ]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v3.4.0/mirage-xen-v3.4.0.tbz"
+  checksum: "md5=2600727c666a78efff792bccc5e46f59"
+}


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Drop support for old ocaml-gnt package (mirage/mirage-xen#12, by @talex5)
* require dune, and conflict with broken version 1.9.1 (mirage/mirage-xen#13, by @hannesm)
