### PR TITLE
mark old versions of mirage-xen unavailable

### DIFF
--- a/packages/mirage-xen/mirage-xen.0.9.1/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.1/opam
@@ -13,7 +13,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.2/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.2/opam
@@ -13,7 +13,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.3/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.3/opam
@@ -13,7 +13,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.4/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.4/opam
@@ -13,7 +13,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.5/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.5/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.6/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.6/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.7/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.7/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.8/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.8/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 conflicts: ["mirage-unix"]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS platform library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.0.9.9/opam
+++ b/packages/mirage-xen/mirage-xen.0.9.9/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.1.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.1.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.1.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.1.1.1/opam
+++ b/packages/mirage-xen/mirage-xen.1.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.2.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.2.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.2.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.2.1.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.2.1.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.2.1.3/opam
+++ b/packages/mirage-xen/mirage-xen.2.1.3/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/mirage/mirage-platform"
-available: os = "linux"
+available: false
 install: [make "xen-install" "PREFIX=%{prefix}%"]
 synopsis: "MirageOS library for Xen compilation"
 url {

--- a/packages/mirage-xen/mirage-xen.2.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.2.0.tar.gz"

--- a/packages/mirage-xen/mirage-xen.2.2.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.1/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.2.1.tar.gz"

--- a/packages/mirage-xen/mirage-xen.2.2.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.2.2/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.2.2.tar.gz"

--- a/packages/mirage-xen/mirage-xen.2.3.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-xen-ocaml"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen"
 description:
   "This library consists of the OCaml `OS` module and its various C bindings."

--- a/packages/mirage-xen/mirage-xen.2.3.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.1/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-xen-ocaml"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen"
 description:
   "This library consists of the OCaml `OS` module and its various C bindings."

--- a/packages/mirage-xen/mirage-xen.2.3.2/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.2/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-xen-ocaml"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen"
 description:
   "This library consists of the OCaml `OS` module and its various C bindings."

--- a/packages/mirage-xen/mirage-xen.2.3.3/opam
+++ b/packages/mirage-xen/mirage-xen.2.3.3/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-xen-ocaml"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen"
 description:
   "This library consists of the OCaml `OS` module and its various C bindings."

--- a/packages/mirage-xen/mirage-xen.2.4.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-xen-ocaml"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen"
 description:
   "This library consists of the OCaml `OS` module and its various C bindings."

--- a/packages/mirage-xen/mirage-xen.2.4.1/opam
+++ b/packages/mirage-xen/mirage-xen.2.4.1/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-xen-ocaml"
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen"
 description:
   "This library consists of the OCaml `OS` module and its various C bindings."

--- a/packages/mirage-xen/mirage-xen.2.6.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.6.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-profile" {>= "0.3"}
   "mirage-xen-ocaml" {>= "2.6.0"}
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen"
 description:
   "This library consists of the OCaml `OS` module and its various C bindings."

--- a/packages/mirage-xen/mirage-xen.3.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.0/opam
@@ -33,7 +33,7 @@ depends: [
 conflicts: [
   "mirage-types" { < "3.0.0" }
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.0.tar.gz"

--- a/packages/mirage-xen/mirage-xen.3.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.1/opam
@@ -33,7 +33,7 @@ depends: [
 conflicts: [
   "mirage-types" { < "3.0.0" }
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.1.tar.gz"

--- a/packages/mirage-xen/mirage-xen.3.0.3/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.3/opam
@@ -33,7 +33,7 @@ depends: [
 conflicts: [
   "mirage-types" { < "3.0.0" }
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.3.tar.gz"

--- a/packages/mirage-xen/mirage-xen.3.0.4/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.4/opam
@@ -33,7 +33,7 @@ depends: [
 conflicts: [
   "mirage-types" { < "3.0.0" }
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.4.tar.gz"

--- a/packages/mirage-xen/mirage-xen.3.0.6/opam
+++ b/packages/mirage-xen/mirage-xen.3.0.6/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-xen-minios" {>= "0.7.0"}
   "logs"
 ]
-available: os = "linux"
+available: false
 synopsis: "MirageOS library for Xen compilation"
 url {
   src:

--- a/packages/mirage-xen/mirage-xen.3.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-xen-minios" {>= "0.7.0"}
   "logs"
 ]
-available: [ os = "linux" ]
+available: [ false ]
 synopsis: "Xen core platform libraries for MirageOS"
 description: """
 This package provides the MirageOS `OS` library for

--- a/packages/mirage-xen/mirage-xen.3.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.2.0/opam
@@ -32,7 +32,7 @@ depends: [
 conflicts: [
   "dune" {= "1.9.1"}
 ]
-available: [ os = "linux" ]
+available: [ false ]
 synopsis: "Xen core platform libraries for MirageOS"
 description: """
 This package provides the MirageOS `OS` library for


### PR DESCRIPTION
See [MirageOS Security Advisory #02](https://github.com/mirage/mirage-www/pull/639) for more information.