### PR TITLE
Corrected checksums for frenetic.1.0 and ox.1.0.0

### DIFF
--- a/packages/frenetic/frenetic.1.0/opam
+++ b/packages/frenetic/frenetic.1.0/opam
@@ -19,5 +19,5 @@ synopsis: "The Frenetic Network Programming Language for SDN"
 flags: light-uninstall
 url {
   src: "https://people.cs.umass.edu/~arjun/download/frenetic.1.0.tar.gz"
-  checksum: "md5=fe898ac5cdc8c06dc9d39b8d1b678af4"
+  checksum: "md5=7beb64dfbf9810927b17c8c30c62853b"
 }

--- a/packages/ox/ox.1.0.0/opam
+++ b/packages/ox/ox.1.0.0/opam
@@ -18,5 +18,5 @@ synopsis: "A platform for writing OpenFlow controllers"
 flags: light-uninstall
 url {
   src: "https://people.cs.umass.edu/~arjun/download/ox.1.0.tar.gz"
-  checksum: "md5=ff90432a72ae48d52505968df2723ba1"
+  checksum: "md5=aba54cd09130ab8228cae919958ee7fe"
 }


### PR DESCRIPTION
I accidentally deleted this tarballs from my homepage and had to rebuild them.