### PR TITLE
fix dependencies for wamp.0.1

### DIFF
--- a/packages/wamp/wamp.0.1/opam
+++ b/packages/wamp/wamp.0.1/opam
@@ -17,7 +17,17 @@ build: [
   "native=%{ocaml:native}%"
   "native-dynlink=%{ocaml:native-dynlink}%"
 ]
-depends: ["ocaml" "ppx_deriving" "ppx_deriving_yojson" "uri"]
+
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+  "uri" {< "2.0.0"}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+]
 synopsis: "The Web Application Messaging Protocol"
 url {
   src: "https://github.com/vbmithr/ocaml-wamp/archive/0.1.tar.gz"


### PR DESCRIPTION
Upper bounds were reused from wamp.1.0. (The dependencies are not
exactly the same: 0.1 uses yojson for serialization, 1.0 uses
sexplib).

Build failure log:
+ https://ci.ocamllabs.io/log/saved/docker-run-e4088e47fe93e490485daad5cb3a980d/a5ee240bbd97e2189219e23385157e0d18540d75