### PR TITLE
add upper bound in preparation for the next major release of zed, lambda-term and utop

### DIFF
--- a/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
+++ b/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder" {build}
   "astring" {>= "0.8.3"}
   "fmt" {>= "0.8.0"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "logs"
   "lwt"

--- a/packages/github-unix/github-unix.3.0.0/opam
+++ b/packages/github-unix/github-unix.3.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp" {>= "0.20.0" & < "0.99"}
   "tls"
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github-unix/github-unix.3.0.1/opam
+++ b/packages/github-unix/github-unix.3.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-lwt-unix"
   "tls"
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github-unix/github-unix.3.1.0/opam
+++ b/packages/github-unix/github-unix.3.1.0/opam
@@ -32,7 +32,7 @@ depends: [
   "github" {="3.1.0"}
   "cohttp-lwt-unix"
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github-unix/github-unix.4.0.0/opam
+++ b/packages/github-unix/github-unix.4.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "github" {="4.0.0"}
   "cohttp-lwt-unix"
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.0.4.0/opam
+++ b/packages/github/github.0.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt"
   "atdgen"
   "yojson"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.4.1/opam
+++ b/packages/github/github.0.4.1/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt"
   "atdgen"
   "yojson"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.4.2/opam
+++ b/packages/github/github.0.4.2/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt"
   "atdgen"
   "yojson"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.4.3/opam
+++ b/packages/github/github.0.4.3/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt"
   "atdgen"
   "yojson"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.5.0/opam
+++ b/packages/github/github.0.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt"
   "atdgen" {>= "1.2.3"}
   "yojson"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.6.0/opam
+++ b/packages/github/github.0.6.0/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt"
   "atdgen" {>= "1.2.3"}
   "yojson"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.6.1/opam
+++ b/packages/github/github.0.6.1/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt"
   "atdgen" {>= "1.2.3"}
   "yojson"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.7.0/opam
+++ b/packages/github/github.0.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.7.1/opam
+++ b/packages/github/github.0.7.1/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.8.0/opam
+++ b/packages/github/github.0.8.0/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.8.1/opam
+++ b/packages/github/github.0.8.1/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.8.2/opam
+++ b/packages/github/github.0.8.2/opam
@@ -16,7 +16,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.8.3/opam
+++ b/packages/github/github.0.8.3/opam
@@ -16,7 +16,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.8.4/opam
+++ b/packages/github/github.0.8.4/opam
@@ -16,7 +16,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.8.5/opam
+++ b/packages/github/github.0.8.5/opam
@@ -16,7 +16,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.8.6/opam
+++ b/packages/github/github.0.8.6/opam
@@ -16,7 +16,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
 ]

--- a/packages/github/github.0.9.0/opam
+++ b/packages/github/github.0.9.0/opam
@@ -27,7 +27,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
   "camlp4" {build}

--- a/packages/github/github.0.9.1/opam
+++ b/packages/github/github.0.9.1/opam
@@ -27,7 +27,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
   "camlp4" {build}

--- a/packages/github/github.0.9.2/opam
+++ b/packages/github/github.0.9.2/opam
@@ -27,7 +27,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
   "camlp4" {build}

--- a/packages/github/github.0.9.3/opam
+++ b/packages/github/github.0.9.3/opam
@@ -29,7 +29,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
   "camlp4" {build}

--- a/packages/github/github.0.9.4/opam
+++ b/packages/github/github.0.9.4/opam
@@ -29,7 +29,7 @@ depends: [
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "ocamlbuild" {build}
   "camlp4" {build}

--- a/packages/github/github.1.0.0/opam
+++ b/packages/github/github.1.0.0/opam
@@ -33,7 +33,7 @@ depends: [
   "atdgen" {>= "1.5.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner"
   "base-unix"
   "ocamlbuild" {build}

--- a/packages/github/github.1.1.0/opam
+++ b/packages/github/github.1.1.0/opam
@@ -37,7 +37,7 @@ depends: [
   "atdgen" {>= "1.5.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.2.0.0/opam
+++ b/packages/github/github.2.0.0/opam
@@ -40,7 +40,7 @@ depends: [
   "atdgen" {>= "1.10.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.2.0.1/opam
+++ b/packages/github/github.2.0.1/opam
@@ -40,7 +40,7 @@ depends: [
   "atdgen" {>= "1.10.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.2.0.2/opam
+++ b/packages/github/github.2.0.2/opam
@@ -40,7 +40,7 @@ depends: [
   "atdgen" {>= "1.10.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.2.0.3/opam
+++ b/packages/github/github.2.0.3/opam
@@ -40,7 +40,7 @@ depends: [
   "atdgen" {>= "1.10.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.2.1.0/opam
+++ b/packages/github/github.2.1.0/opam
@@ -40,7 +40,7 @@ depends: [
   "atdgen" {>= "1.10.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.2.2.0/opam
+++ b/packages/github/github.2.2.0/opam
@@ -40,7 +40,7 @@ depends: [
   "atdgen" {>= "1.10.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/github/github.2.3.0/opam
+++ b/packages/github/github.2.3.0/opam
@@ -40,7 +40,7 @@ depends: [
   "atdgen" {>= "1.10.0" & < "1.13.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.1.0/opam
@@ -9,7 +9,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.01.0" & < "4.04.0"}
   "hardcaml" {>= "1.1.0" & < "2.0.0"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "ocamlbuild" {build}
   "lwt" {< "4.0.0"}
 ]

--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.0/opam
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "camlp4" {build}
   "hardcaml" {>= "1.2.0" & < "2.0.0"}
   "astring"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "lwt" {< "4.0.0"}
 ]
 synopsis: "Terminal based digital waveform viewer"

--- a/packages/lambda-term/lambda-term.1.10.1/opam
+++ b/packages/lambda-term/lambda-term.1.10.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/lambda-term/lambda-term.1.10/opam
+++ b/packages/lambda-term/lambda-term.1.10/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/lambda-term/lambda-term.1.11/opam
+++ b/packages/lambda-term/lambda-term.1.11/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
   "lwt" {>= "2.7.0" & < "4.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "lwt_react"
   "jbuilder" {build & >= "1.0+beta7"}
 ]

--- a/packages/lambda-term/lambda-term.1.12.0/opam
+++ b/packages/lambda-term/lambda-term.1.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "lwt" {>= "2.7.0" & < "4.0.0"}
   "react"
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "camomile" {>= "0.8.6"}
   "lwt_react"
   "jbuilder" {build & >= "1.0+beta9"}

--- a/packages/lambda-term/lambda-term.1.13/opam
+++ b/packages/lambda-term/lambda-term.1.13/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt" {>= "4.0.0"}
   "lwt_log"
   "react"
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "camomile" {>= "0.8.6"}
   "lwt_react"
   "jbuilder" {build & >= "1.0+beta9"}

--- a/packages/lambda-term/lambda-term.1.2/opam
+++ b/packages/lambda-term/lambda-term.1.2/opam
@@ -7,7 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "lambda-term"]]
 depends: [
   "ocaml"
-  "zed"
+  "zed" {< "2.0"}
   "lwt" {< "3.0.0"}
   "ocamlfind"
   "react" {< "1.0.0"}

--- a/packages/lambda-term/lambda-term.1.4/opam
+++ b/packages/lambda-term/lambda-term.1.4/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "3.12"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {< "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/lambda-term/lambda-term.1.5/opam
+++ b/packages/lambda-term/lambda-term.1.5/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "3.12"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {< "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/lambda-term/lambda-term.1.6/opam
+++ b/packages/lambda-term/lambda-term.1.6/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {>= "1.0.0"}
   "ocamlbuild" {build}
   "camlp4"

--- a/packages/lambda-term/lambda-term.1.7/opam
+++ b/packages/lambda-term/lambda-term.1.7/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "3.12" & < "4.06.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/lambda-term/lambda-term.1.8/opam
+++ b/packages/lambda-term/lambda-term.1.8/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/lambda-term/lambda-term.1.9/opam
+++ b/packages/lambda-term/lambda-term.1.9/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "3.0.0"}
-  "zed" {>= "1.2"}
+  "zed" {>= "1.2" & < "2.0"}
   "react" {>= "1.0.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirror/mirror.0.0.1/opam
+++ b/packages/mirror/mirror.0.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "opam-lib" {>= "1.2.0" & < "1.3"}
   "tls"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Mirror upstream OPAM package distribution files"

--- a/packages/ocp-browser/ocp-browser.1.0.0/opam
+++ b/packages/ocp-browser/ocp-browser.1.0.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Public Domain"
 depends: [
   "ocaml"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "ocp-index" {>= "1.1.4"}
 ]
 synopsis: "virtual package to force the installation of ocp-browser"

--- a/packages/ocp-browser/ocp-browser.1.1.6/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.6/opam
@@ -13,7 +13,7 @@ depends: [
   "jbuilder"
   "ocp-index" {= "1.1.6"}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
 ]
 synopsis:
   "Console browser for the documentation of installed OCaml libraries"

--- a/packages/ocp-browser/ocp-browser.1.1.7/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.7/opam
@@ -21,7 +21,7 @@ depends: [
   "jbuilder" {build}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
 ]
 url {
   src: "https://github.com/OCamlPro/ocp-index/archive/1.1.7.tar.gz"

--- a/packages/ocp-browser/ocp-browser.1.1.8/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.8/opam
@@ -21,7 +21,7 @@ depends: [
   "jbuilder" {build}
   "ocp-index" {= "1.1.7" | = version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
 ]
 url {
   src: "https://github.com/OCamlPro/ocp-index/archive/1.1.8.tar.gz"

--- a/packages/ocp-browser/ocp-browser.1.1.9/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.9/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
 ]
 url {
   src: "https://github.com/OCamlPro/ocp-index/archive/1.1.9.tar.gz"

--- a/packages/ocp-index/ocp-index.1.1.0/opam
+++ b/packages/ocp-index/ocp-index.1.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocp-indent" {>= "1.4.2"}
   "re"
   "cmdliner"
-  "lambda-term" {>= "1.7"}
+  "lambda-term" {>= "1.7" & < "2.0"}
 ]
 messages: "To install ocp-browser, please install lambda-term" {! lambda-term:installed}
 post-messages: "To use ocp-index from emacs, add the following to your .emacs:

--- a/packages/ocp-index/ocp-index.1.1.1/opam
+++ b/packages/ocp-index/ocp-index.1.1.1/opam
@@ -23,7 +23,7 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term"
+depopts: "lambda-term" {< "2.0"}
 conflicts: "lambda-term" {< "1.7"}
 messages: "To install ocp-browser, please install lambda-term" {! lambda-term:installed}
 post-messages: "To use ocp-index from emacs, add the following to your .emacs:

--- a/packages/ocp-index/ocp-index.1.1.1/opam
+++ b/packages/ocp-index/ocp-index.1.1.1/opam
@@ -23,8 +23,8 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term" {< "2.0"}
-conflicts: "lambda-term" {< "1.7"}
+depopts: "lambda-term"
+conflicts: "lambda-term" {< "1.7" | >= "2.0"}
 messages: "To install ocp-browser, please install lambda-term" {! lambda-term:installed}
 post-messages: "To use ocp-index from emacs, add the following to your .emacs:
   (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")

--- a/packages/ocp-index/ocp-index.1.1.2/opam
+++ b/packages/ocp-index/ocp-index.1.1.2/opam
@@ -17,9 +17,9 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term" {< "2.0"}
+depopts: "lambda-term"
 conflicts: [
-  "lambda-term" {< "1.7"}
+  "lambda-term" {< "1.7" | >= "2.0"}
 ]
 messages: [
   "For ocp-browser, also install lambda-term" {!lambda-term:installed}

--- a/packages/ocp-index/ocp-index.1.1.2/opam
+++ b/packages/ocp-index/ocp-index.1.1.2/opam
@@ -17,7 +17,7 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term"
+depopts: "lambda-term" {< "2.0"}
 conflicts: [
   "lambda-term" {< "1.7"}
 ]

--- a/packages/ocp-index/ocp-index.1.1.3/opam
+++ b/packages/ocp-index/ocp-index.1.1.3/opam
@@ -17,9 +17,9 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term" {< "2.0"}
+depopts: "lambda-term"
 conflicts: [
-  "lambda-term" {< "1.7"}
+  "lambda-term" {< "1.7" | >= "2.0"}
 ]
 messages: [
   "For ocp-browser, please also install package lambda-term"

--- a/packages/ocp-index/ocp-index.1.1.3/opam
+++ b/packages/ocp-index/ocp-index.1.1.3/opam
@@ -17,7 +17,7 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term"
+depopts: "lambda-term" {< "2.0"}
 conflicts: [
   "lambda-term" {< "1.7"}
 ]

--- a/packages/ocp-index/ocp-index.1.1.4/opam
+++ b/packages/ocp-index/ocp-index.1.1.4/opam
@@ -17,9 +17,9 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term" {< "2.0"}
+depopts: "lambda-term"
 conflicts: [
-  "lambda-term" {< "1.7"}
+  "lambda-term" {< "1.7" | >= "2.0"}
 ]
 messages: [
   "For ocp-browser, please also install package lambda-term"

--- a/packages/ocp-index/ocp-index.1.1.4/opam
+++ b/packages/ocp-index/ocp-index.1.1.4/opam
@@ -17,7 +17,7 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term"
+depopts: "lambda-term" {< "2.0"}
 conflicts: [
   "lambda-term" {< "1.7"}
 ]

--- a/packages/ocp-index/ocp-index.1.1.5/opam
+++ b/packages/ocp-index/ocp-index.1.1.5/opam
@@ -17,9 +17,9 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term" {< "2.0"}
+depopts: "lambda-term"
 conflicts: [
-  "lambda-term" {< "1.7"}
+  "lambda-term" {< "1.7" | >= "2.0"}
 ]
 messages: [
   "For ocp-browser, please also install package lambda-term"

--- a/packages/ocp-index/ocp-index.1.1.5/opam
+++ b/packages/ocp-index/ocp-index.1.1.5/opam
@@ -17,7 +17,7 @@ depends: [
   "re"
   "cmdliner"
 ]
-depopts: "lambda-term"
+depopts: "lambda-term" {< "2.0"}
 conflicts: [
   "lambda-term" {< "1.7"}
 ]

--- a/packages/otetris/otetris.1.0/opam
+++ b/packages/otetris/otetris.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder" {build}
   "batteries"
   "lwt" {>= "3.1.0" & < "4.0.0"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "conf-sdl-image"
   "conf-sdl-ttf"
   "conf-sdl-gfx"

--- a/packages/otetris/otetris.1.1/opam
+++ b/packages/otetris/otetris.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder" {build}
   "batteries"
   "lwt" {>= "3.1.0" & < "4.0.0"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "conf-sdl-image"
   "conf-sdl-ttf"
   "conf-sdl-gfx"

--- a/packages/prof_spacetime/prof_spacetime.0.1.0/opam
+++ b/packages/prof_spacetime/prof_spacetime.0.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"
   "yojson"
   "lwt"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "spacetime_lib" {< "0.2"}
 ]
 synopsis: "A viewer for OCaml spacetime profiles."

--- a/packages/prof_spacetime/prof_spacetime.0.2.0/opam
+++ b/packages/prof_spacetime/prof_spacetime.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conduit-lwt-unix"
   "yojson"
   "lwt"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "spacetime_lib" {>= "0.2"}
 ]
 synopsis: "A viewer for OCaml spacetime profiles."

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.10.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.10.0/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "protocol-9p"
   "protocol-9p-unix"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
   "io-page"

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.11.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "protocol-9p"
   "protocol-9p-unix"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
   "io-page"

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.11.1/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.11.1/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "protocol-9p"
   "protocol-9p-unix"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
   "io-page"

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.11.2/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.11.2/opam
@@ -22,7 +22,7 @@ depends: [
   "fmt"
   "protocol-9p"
   "protocol-9p-unix"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
   "io-page"

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.11.3/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.11.3/opam
@@ -22,7 +22,7 @@ depends: [
   "fmt"
   "protocol-9p"
   "protocol-9p-unix"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
 ]

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.12.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.12.0/opam
@@ -20,7 +20,7 @@ depends: [
   "rresult"
   "logs" {>= "0.5.0"}
   "fmt"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
 ]

--- a/packages/protocol-9p-tool/protocol-9p-tool.1.0.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "rresult"
   "logs" {>= "0.5.0"}
   "fmt"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
 ]

--- a/packages/protocol-9p/protocol-9p.0.5.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.5.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cmdliner"
   "stringext"
   "fmt"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "alcotest" {with-test & >= "0.4.0"}

--- a/packages/protocol-9p/protocol-9p.0.5.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.5.1/opam
@@ -29,7 +29,8 @@ depends: [
   "ocamlbuild" {build}
   "alcotest" {with-test & >= "0.4.0"}
 ]
-depopts: "lambda-term" {< "2.0"}
+depopts: "lambda-term"
+conflicts: "lambda-term" {>= "2.0"}
 synopsis:
   "Client and server implementation of 9P, in a Mirage-friendly style"
 description: """

--- a/packages/protocol-9p/protocol-9p.0.5.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.5.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlbuild" {build}
   "alcotest" {with-test & >= "0.4.0"}
 ]
-depopts: "lambda-term"
+depopts: "lambda-term" {< "2.0"}
 synopsis:
   "Client and server implementation of 9P, in a Mirage-friendly style"
 description: """

--- a/packages/protocol-9p/protocol-9p.0.5.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.5.2/opam
@@ -34,7 +34,7 @@ depends: [
   "ocamlbuild" {build}
   "alcotest" {with-test & >= "0.4.0"}
 ]
-depopts: ["lambda-term"]
+depopts: ["lambda-term" {< "2.0"}]
 synopsis:
   "Client and server implementation of 9P, in a Mirage-friendly style"
 description: """

--- a/packages/protocol-9p/protocol-9p.0.5.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.5.2/opam
@@ -34,7 +34,8 @@ depends: [
   "ocamlbuild" {build}
   "alcotest" {with-test & >= "0.4.0"}
 ]
-depopts: ["lambda-term" {< "2.0"}]
+depopts: ["lambda-term"]
+conflicts: "lambda-term" {>= "2.0"}
 synopsis:
   "Client and server implementation of 9P, in a Mirage-friendly style"
 description: """

--- a/packages/protocol-9p/protocol-9p.0.6.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.6.0/opam
@@ -34,7 +34,7 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term"]
+depopts: ["lambda-term" {< "2.0"}]
 synopsis:
   "Client and server implementation of 9P, in a Mirage-friendly style"
 description: """

--- a/packages/protocol-9p/protocol-9p.0.6.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.6.0/opam
@@ -34,7 +34,8 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term" {< "2.0"}]
+depopts: ["lambda-term"]
+conflicts: "lambda-term" {>= "2.0"}
 synopsis:
   "Client and server implementation of 9P, in a Mirage-friendly style"
 description: """

--- a/packages/protocol-9p/protocol-9p.0.7.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.2/opam
@@ -54,7 +54,8 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term" {< "2.0"}]
+depopts: ["lambda-term"]
+conflicts: "lambda-term" {>= "2.0"}
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.7.2/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.2/opam
@@ -54,7 +54,7 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term"]
+depopts: ["lambda-term" {< "2.0"}]
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.7.3/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.3/opam
@@ -54,7 +54,8 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term" {< "2.0"}]
+depopts: ["lambda-term"]
+conflicts: "lambda-term" {>= "2.0"}
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.7.3/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.3/opam
@@ -54,7 +54,7 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term"]
+depopts: ["lambda-term" {< "2.0"}]
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.7.4/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.4/opam
@@ -53,7 +53,8 @@ depends: [
   "topkg" {build & >= "0.7.3"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
-depopts: ["lambda-term" {< "2.0"}]
+depopts: ["lambda-term"]
+conflicts: "lambda-term" {>= "2.0"}
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.7.4/opam
+++ b/packages/protocol-9p/protocol-9p.0.7.4/opam
@@ -53,7 +53,7 @@ depends: [
   "topkg" {build & >= "0.7.3"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
-depopts: ["lambda-term"]
+depopts: ["lambda-term" {< "2.0"}]
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.8.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.8.0/opam
@@ -55,7 +55,7 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term"]
+depopts: ["lambda-term" {< "2.0"}]
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.8.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.8.0/opam
@@ -55,7 +55,8 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
-depopts: ["lambda-term" {< "2.0"}]
+depopts: ["lambda-term"]
+conflicts: "lambda-term" {>= "2.0"}
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.9.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.9.0/opam
@@ -60,7 +60,7 @@ depends: [
   "ppx_cstruct"
   "io-page-unix"
 ]
-depopts: ["lambda-term"]
+depopts: ["lambda-term" {< "2.0"}]
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.9.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.9.0/opam
@@ -60,7 +60,8 @@ depends: [
   "ppx_cstruct"
   "io-page-unix"
 ]
-depopts: ["lambda-term" {< "2.0"}]
+depopts: ["lambda-term"]
+conflicts: "lambda-term" {>= "2.0"}
 synopsis: "An implementation of the 9p protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/starterkit/starterkit.1.0.0/opam
+++ b/packages/starterkit/starterkit.1.0.0/opam
@@ -7,7 +7,7 @@ license: "BSD-3-clause"
 homepage: "https://github.com/fxfactorial/ocaml-starterkit"
 depends: [
   "ocaml"
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "ocp-indent"
   "stringext"
   "utop"

--- a/packages/utop/utop.1.10/opam
+++ b/packages/utop/utop.1.10/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.11/opam
+++ b/packages/utop/utop.1.11/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.12/opam
+++ b/packages/utop/utop.1.12/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.14/opam
+++ b/packages/utop/utop.1.14/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.15/opam
+++ b/packages/utop/utop.1.15/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "4.00" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.16/opam
+++ b/packages/utop/utop.1.16/opam
@@ -19,7 +19,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.01" & < "4.03"}
   "ocamlfind" {>= "1.4.0" & < "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.17/opam
+++ b/packages/utop/utop.1.17/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.4.0" & < "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.18.1/opam
+++ b/packages/utop/utop.1.18.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.5.6"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.18.2/opam
+++ b/packages/utop/utop.1.18.2/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.5.6"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.18/opam
+++ b/packages/utop/utop.1.18/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.4.0" & < "1.5.6"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.19.1/opam
+++ b/packages/utop/utop.1.19.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.5.6"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.19.2/opam
+++ b/packages/utop/utop.1.19.2/opam
@@ -27,7 +27,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.5.6"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.19.3/opam
+++ b/packages/utop/utop.1.19.3/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.5.6"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.19/opam
+++ b/packages/utop/utop.1.19/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.5.6"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}

--- a/packages/utop/utop.1.2.1/opam
+++ b/packages/utop/utop.1.2.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
   "zed" {< "2.0"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "react" {< "1.0.0"}
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/utop/utop.1.2.1/opam
+++ b/packages/utop/utop.1.2.1/opam
@@ -10,7 +10,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "zed"
+  "zed" {< "2.0"}
   "lambda-term"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.3.0/opam
+++ b/packages/utop/utop.1.3.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
   "zed" {< "2.0"}
-  "lambda-term"
+  "lambda-term" {< "2.0"}
   "react" {< "1.0.0"}
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/utop/utop.1.3.0/opam
+++ b/packages/utop/utop.1.3.0/opam
@@ -10,7 +10,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "zed"
+  "zed" {< "2.0"}
   "lambda-term"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.4.0/opam
+++ b/packages/utop/utop.1.4.0/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.5/opam
+++ b/packages/utop/utop.1.5/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.6/opam
+++ b/packages/utop/utop.1.6/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {= "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.7/opam
+++ b/packages/utop/utop.1.7/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.8/opam
+++ b/packages/utop/utop.1.8/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.1.9/opam
+++ b/packages/utop/utop.1.9/opam
@@ -12,7 +12,7 @@ remove: [["ocamlfind" "remove" "utop"]]
 depends: [
   "ocaml" {>= "3.12" & < "4.01"}
   "ocamlfind" {< "1.5.6"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "react" {< "1.0.0"}
   "camlp4"

--- a/packages/utop/utop.2.0.0/opam
+++ b/packages/utop/utop.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {build & >= "1.1.2"}

--- a/packages/utop/utop.2.0.1/opam
+++ b/packages/utop/utop.2.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "1.9"}
+  "lambda-term" {>= "1.9" & < "2.0"}
   "lwt"
   "react" {>= "1.0.0"}
   "cppo" {build & >= "1.1.2"}

--- a/packages/utop/utop.2.0.2/opam
+++ b/packages/utop/utop.2.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.1.0/opam
+++ b/packages/utop/utop.2.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.2.0/opam
+++ b/packages/utop/utop.2.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "1.2"}
+  "lambda-term" {>= "1.2" & < "2.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.3.0/opam
+++ b/packages/utop/utop.2.3.0/opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "1.13"}
+  "lambda-term" {>= "1.13" & < "2.0"}
   "lwt"
   "lwt_react"
   "camomile"


### PR DESCRIPTION
Hi, We are working on improving unicode support in zed, lambda-term and utop and are going to release major versions of these projects which will introduce backward incompatible API changes. see https://github.com/ocaml-community/lambda-term/issues/2#issuecomment-487348878

Reverse dependencies without an upper bound will fail the compilation when these new major versions release.