### PR TITLE
ocsigenserver is not compatible with OCaml >= 4.08

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.2.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.1/opam
@@ -31,7 +31,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/ocsigenserver"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "react" {< "1.0.0"}
   "ssl"

--- a/packages/ocsigenserver/ocsigenserver.2.10/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.10/opam
@@ -43,7 +43,7 @@ remove: [
   ["rm" "-f" "%{man}%/man1/ocsigenserver.1"]
 ]
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "ocaml" {>= "4.06.1" & < "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"

--- a/packages/ocsigenserver/ocsigenserver.2.11.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.11.0/opam
@@ -43,7 +43,7 @@ remove: [
   ["rm" "-f" "%{man}%/man1/ocsigenserver.1"]
 ]
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "ocaml" {>= "4.06.1" & < "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"

--- a/packages/ocsigenserver/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.2.0/opam
@@ -31,7 +31,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/ocsigenserver"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "react" {< "1.0.0"}
   "ssl"

--- a/packages/ocsigenserver/ocsigenserver.2.3.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.3.1/opam
@@ -31,7 +31,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/ocsigenserver"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"

--- a/packages/ocsigenserver/ocsigenserver.2.4.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.4.0/opam
@@ -31,7 +31,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/ocsigenserver"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"

--- a/packages/ocsigenserver/ocsigenserver.2.5/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.5/opam
@@ -36,7 +36,7 @@ build: [
 ]
 remove: ["rm" "-rf" "%{lib}%/ocsigenserver"]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"

--- a/packages/ocsigenserver/ocsigenserver.2.6/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.6/opam
@@ -15,7 +15,7 @@ remove: [
   ["rm" "-f" "%{man}%/man1/ocsigenserver.1"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"

--- a/packages/ocsigenserver/ocsigenserver.2.7/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.7/opam
@@ -41,7 +41,7 @@ remove: [
   ["rm" "-f" "%{man}%/man1/ocsigenserver.1"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"

--- a/packages/ocsigenserver/ocsigenserver.2.8/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.8/opam
@@ -41,7 +41,7 @@ remove: [
   ["rm" "-f" "%{man}%/man1/ocsigenserver.1"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @jrochel there is no version of ocsigenserver compatible with OCaml 4.08