### PR TITLE
[new release] routes (0.4.0)

### DIFF
--- a/packages/routes/routes.0.4.0/opam
+++ b/packages/routes/routes.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: [ "Anurag Soni <anurag@sonianurag.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anuragsoni/routes"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+doc: "https://anuragsoni.github.io/routes/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "stdcompat" { >= "6" }
+  "dune" {build}
+  "alcotest" {with-test}
+  "mdx" { with-test }
+  "qcheck" { with-test }
+  "qcheck-alcotest" { with-test }
+]
+synopsis: "Typed routing for OCaml applications"
+description: """
+routes provides combinators for adding typed routing
+to OCaml applications. The core library will be independent
+of any particular web framework or runtime. It also provides
+a `sprintf` like function (it uses the same representation of
+a route as a 'format string') to reconstruct URLs.
+"""
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/0.4.0/routes-0.4.0.tbz"
+  checksum: [
+    "sha256=d59b68ca86b4337a717c9da01fb65686d93551c0bfb8a0633bcc954af5a297ea"
+    "sha512=0e202c7650975d01b9f32a77c0fd84401879cdfaf51a757ae716f3a180175da4e6944abfc1c7f6ac538773acf75060aa622822a48e31d6fbd40b57c5badc1c8c"
+  ]
+}


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

* Switch to using an applicative functor as parser. (anuragsoni/routes#27)
* Have a version of matching without HTTP methods. (anuragsoni/routes#27)
* Tokenize the path parameters into list of strings. (anuragsoni/routes#27)
* Add more tests for matchers. (anuragsoni/routes#28)
* `s` now returns the string it matches, instead of discarding it. (anuragsoni/routes#29)
