### PR TITLE
Restore ocaml-variants beta versions

### DIFF
--- a/packages/ocaml-beta/ocaml-beta.disabled/opam
+++ b/packages/ocaml-beta/ocaml-beta.disabled/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "platform@lists.ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+available: os = "Enable ocaml-beta-repository"
+homepage: "https://ocaml.org"
+synopsis: "Virtual package for enabling OCaml beta releases"
+description: """
+This package is installed by adding ocaml-beta-repository to your switch:
+
+opam repository add ocaml-beta git+https://github.com/ocaml/ocaml-beta-repository.git
+
+or
+
+opam switch create ocaml-beta --repositories ocaml-beta=git+https://github.com/ocaml/ocaml-beta-repository.git ..."""

--- a/packages/ocaml-system/ocaml-system.4.10.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.10.0/files/gen_ocaml_config.ml.in
@@ -1,0 +1,43 @@
+let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
+                     variables { path: %%S }\n"
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
+  close_out oc

--- a/packages/ocaml-system/ocaml-system.4.10.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.0/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "4.10.0"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+extra-files: ["gen_ocaml_config.ml.in" "md5=093e7bec1ec95f9e4c6a313d73c5d840"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, without safe strings by default"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "second beta of 4.08.0, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "second beta of 4.08.0, without safe strings by default"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "second beta of 4.08.0, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "second beta of 4.08.0, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "second beta of 4.08.0, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "second beta of 4.08.0"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "third beta of 4.08.0, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "third beta of 4.08.0, without safe strings by default"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "third beta of 4.08.0, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "third beta of 4.08.0, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "third beta of 4.08.0, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "third beta of 4.08.0"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+afl/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "latest 4.08 development, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "latest 4.08 development, without safe strings by default"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+flambda/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "latest 4.08 development, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp+flambda/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "latest 4.08 development, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "latest 4.08 development, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "latest 4.08 development"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "latest 4.09 development"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.09.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.09.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+trunk/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "current trunk"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.10.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+}

--- a/packages/ocaml/ocaml.3.07+1/opam
+++ b/packages/ocaml/ocaml.3.07+1/opam
@@ -26,3 +26,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.07+2/opam
+++ b/packages/ocaml/ocaml.3.07+2/opam
@@ -26,3 +26,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.07/opam
+++ b/packages/ocaml/ocaml.3.07/opam
@@ -26,3 +26,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.08.0/opam
+++ b/packages/ocaml/ocaml.3.08.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.08.1/opam
+++ b/packages/ocaml/ocaml.3.08.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.08.2/opam
+++ b/packages/ocaml/ocaml.3.08.2/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.08.3/opam
+++ b/packages/ocaml/ocaml.3.08.3/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.08.4/opam
+++ b/packages/ocaml/ocaml.3.08.4/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.09.0/opam
+++ b/packages/ocaml/ocaml.3.09.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.09.1/opam
+++ b/packages/ocaml/ocaml.3.09.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.09.2/opam
+++ b/packages/ocaml/ocaml.3.09.2/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.09.3/opam
+++ b/packages/ocaml/ocaml.3.09.3/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.10.0/opam
+++ b/packages/ocaml/ocaml.3.10.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.10.1/opam
+++ b/packages/ocaml/ocaml.3.10.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.10.2/opam
+++ b/packages/ocaml/ocaml.3.10.2/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.11.0/opam
+++ b/packages/ocaml/ocaml.3.11.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.11.1/opam
+++ b/packages/ocaml/ocaml.3.11.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.11.2/opam
+++ b/packages/ocaml/ocaml.3.11.2/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.12.0/opam
+++ b/packages/ocaml/ocaml.3.12.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.3.12.1/opam
+++ b/packages/ocaml/ocaml.3.12.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.00.0/opam
+++ b/packages/ocaml/ocaml.4.00.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.00.1/opam
+++ b/packages/ocaml/ocaml.4.00.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.01.0/opam
+++ b/packages/ocaml/ocaml.4.01.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.02.0/opam
+++ b/packages/ocaml/ocaml.4.02.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.02.1/opam
+++ b/packages/ocaml/ocaml.4.02.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.02.2/opam
+++ b/packages/ocaml/ocaml.4.02.2/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.02.3/opam
+++ b/packages/ocaml/ocaml.4.02.3/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.03.0/opam
+++ b/packages/ocaml/ocaml.4.03.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.04.0/opam
+++ b/packages/ocaml/ocaml.4.04.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.04.1/opam
+++ b/packages/ocaml/ocaml.4.04.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.04.2/opam
+++ b/packages/ocaml/ocaml.4.04.2/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.05.0/opam
+++ b/packages/ocaml/ocaml.4.05.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.06.0/opam
+++ b/packages/ocaml/ocaml.4.06.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.06.1/opam
+++ b/packages/ocaml/ocaml.4.06.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.07.0/opam
+++ b/packages/ocaml/ocaml.4.07.0/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.07.1/opam
+++ b/packages/ocaml/ocaml.4.07.1/opam
@@ -27,3 +27,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
+flags: compiler

--- a/packages/ocaml/ocaml.4.10.0/opam
+++ b/packages/ocaml/ocaml.4.10.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config"
+  "ocaml-base-compiler" {= "4.10.0"} |
+  "ocaml-variants" {>= "4.10.0" & < "4.10.1~"} |
+  "ocaml-system" {>= "4.10.0" & < "4.10.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+flags: compiler
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
Following a proposal on caml-devel, this PR:

 - Adds the `compiler` flag to the `ocaml` packages (@rjbou - I believe this should have been there all along; it was being added to the new `ocaml` packages?)
 - Adds the unavailable package `ocaml-beta.disabled`
 - Moves all other packages from ocaml-beta-repository back to opam-repository, but with a dependency for the ocaml-variants packages on the `ocaml-beta` package (see https://github.com/ocaml/ocaml-beta-repository/pull/8)

Users installing betas should notice no changes, since you still need to add the ocaml-beta-repository in order to install beta releases. However, this change in layout means that ocaml-beta-repository never needs amending again, which reduces the risk of package duplication, reduced CI testing, selecting wrong branches, etc.