### PR TITLE
[new release] ppx_import (1.6.1)

### DIFF
--- a/packages/ppx_import/ppx_import.1.6.1/opam
+++ b/packages/ppx_import/ppx_import.1.6.1/opam
@@ -1,0 +1,34 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+name: "ppx_import"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
+  "dune"                    { build &      >= "1.2.0"  }
+  "ppxlib"                  {              >= "0.3.1"  }
+  "ppx_tools_versioned"     {              >= "5.2.1"  }
+  "ocaml-migrate-parsetree" {              >= "1.1.0"  }
+  "ounit"                   { with-test                }
+  "ppx_deriving"            { with-test  & >= "4.2.1"  }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/v1.6.1/ppx_import-v1.6.1.tbz"
+  checksum: [
+    "sha256=f70687248d9e4a39726484f6c11fabedac102c786549bcbe72d27e245dbe4946"
+    "sha512=c8e0169329485c66537f9682695453bbb9271d575405831b5653d8f1e79401d2da2869ed5ce6440214e736473e215ff2e5aa265c737359ab0ac68e760188f686"
+  ]
+}


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

* Fix import of signatures with mutually recursive types
    (Thierry Martinez ocaml-ppx/ppx_import#35, review and tweaks by Gabriel Scherer)
