### PR TITLE
+ qfs 0.10

### DIFF
--- a/packages/qfs/qfs.0.10/opam
+++ b/packages/qfs/qfs.0.10/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Ahrefs Pte Ltd <github@ahrefs.com>"
+authors: [ "Ahrefs Pte Ltd <github@ahrefs.com>" ]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ahrefs/ocaml-qfs"
+dev-repo: "git://github.com/ahrefs/ocaml-qfs.git"
+bug-reports: "https://github.com/ahrefs/ocaml-qfs/issues"
+tags: [ "org:ahrefs" "clib:stdc" "clib:qfs"  ]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests" {with-test}]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"] {with-test}
+  ["ocaml" "setup.ml" "-doc"] {with-doc}
+]
+install: ["ocaml" "setup.ml" "-install"]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "base-bytes"
+  "base-unix"
+  "extlib" | "extlib-compat"
+  "lwt" {>= "3.4.6"}
+  "lwt_ppx"
+  "ocamlbuild" {build}
+  "ocamlfind" {build & >= "1.5"}
+  "conf-boost"
+]
+post-messages: [
+  "
+  This package requires QFS development files installed, consult https://quantcast.github.io/qfs/
+  and https://github.com/quantcast/qfs/wiki/Developer-Documentation on how to build manually.
+
+  Tentative instructions for Debian : https://gist.githubusercontent.com/ygrek/7bb217d6ab7b25a765b7/raw
+  "
+  {failure}
+]
+synopsis: "Bindings to libqfs - client library to access QFS"
+description: "QFS is a distributed fault-tolerant filesystem by Quantcast"
+url {
+  src: "https://github.com/ahrefs/ocaml-qfs/archive/0.10.tar.gz"
+  checksum: "md5=dfb98a33d9a8158230bb8eddef1049c1"
+}


### PR DESCRIPTION
build on CI is expected to fail due to absence of qfs package (same as all previous PRs)