### PR TITLE
[new release] encore (0.3)

### DIFF
--- a/packages/encore/encore.0.3/opam
+++ b/packages/encore/encore.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name:         "encore"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/encore"
+bug-reports:  "https://github.com/dinosaure/encore/issues"
+dev-repo:     "git+https://github.com/dinosaure/encore.git"
+doc:          "https://dinosaure.github.io/encore/"
+license:      "MIT"
+synopsis:     "Library to generate encoder/decoder which ensure isomorphism"
+description: """
+Encore is a little library to provide an interface to generate an angstrom decoder and
+an internal encoder from a shared description. The goal is to ensure a dual isomorphism
+between them.
+"""
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "angstrom" {>= "0.10.0"}
+  "fmt"
+  "ke" {>= "0.3"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/encore/releases/download/v0.3/encore-v0.3.tbz"
+  checksum: [
+    "sha256=747a6c50a09ee0846adba3ff088acc71969f0942275fcd12aebaaba2ab37db16"
+    "sha512=93aaa2cd96d53bf8fc23d65cf3249ad0f014ebc72174020a06ee7df12f10903f2177052bee75fbf8dddd44b4c496d5a0a1998b44642ce1d0a83f3c7c92f34f5c"
+  ]
+}

--- a/packages/git/git.2.0.0/opam
+++ b/packages/git/git.2.0.0/opam
@@ -34,7 +34,7 @@ depends: [
   "lru"        {>= "0.2.0" & < "0.3.0"}
   "decompress" {>= "0.8.1"}
   "checkseum"  {>= "0.0.3"}
-  "encore"
+  "encore"     {< "0.3"}
   "duff"
   "hex"
   "ocplib-endian"


### PR DESCRIPTION
Library to generate encoder/decoder which ensure isomorphism

- Project page: <a href="https://github.com/dinosaure/encore">https://github.com/dinosaure/encore</a>
- Documentation: <a href="https://dinosaure.github.io/encore/">https://dinosaure.github.io/encore/</a>

##### CHANGES:

- Fix OPAM file about how to ask to `dune` to build `encore` (@kit-ty-kate)
- Use `ke` as common implementation of ring-buffer
- Support of 4.07.0 in Travis CI
- Provide a C stubs to know if a bigarray overlaps an other
 * Compilation fixed with MirageOS (@hannesm)
- Tests about printer, parsers and combinators
- Add `from` function to let user to allocate internal buffer
- Use rev_iter instead fold and rev on internal queue
- Delete tag argument on bijection objects to be more usable
- Delete dependency of ocplib-endian and use bigstringaf instead
- Use angstrom.0.10.0 (@andreas)
