### PR TITLE
Pass lint for ocaml-beta.disabled

### DIFF
--- a/packages/ocaml-beta/ocaml-beta.disabled/opam
+++ b/packages/ocaml-beta/ocaml-beta.disabled/opam
@@ -9,7 +9,7 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-available: os = "Enable ocaml-beta-repository"
+available: enable-ocaml-beta-repository
 homepage: "https://ocaml.org"
 synopsis: "Virtual package for enabling OCaml beta releases"
 description: """


### PR DESCRIPTION
There was a lint error in `ocaml-beta.disabled` in #14065 (I was using an old opam version on the VM I prepared the PR on 😊).

Here is a lint-passing alternative, relying on the behaviour of undefined variables rather than undefined operating system names!