### PR TITLE
Package ptime.0.8.5

### DIFF
--- a/packages/ptime/ptime.0.8.5/opam
+++ b/packages/ptime/ptime.0.8.5/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The ptime programmers"]
+homepage: "https://erratique.ch/software/ptime"
+doc: "https://erratique.ch/software/ptime/doc"
+dev-repo: "git+http://erratique.ch/repos/ptime.git"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+tags: [ "time" "posix" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+ "ocaml" {>= "4.01.0"}
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "result"
+]
+depopts: [ "js_of_ocaml" ]
+conflicts: [ "js_of_ocaml" { < "3.3.0" } ]
+build:[[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]
+
+synopsis: """POSIX time for OCaml"""
+description: """\
+
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
+human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime depends on the `result` compatibility package. Ptime_clock
+depends on your system library. Ptime_clock's optional JavaScript
+support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
+distributed under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+"""
+url {
+archive: "https://erratique.ch/software/ptime/releases/ptime-0.8.5.tbz"
+checksum: "4d48055d623ecf2db792439b3e96a520"
+}


### PR DESCRIPTION
### `ptime.0.8.5`
POSIX time for OCaml
Ptime has platform independent POSIX time support in pure OCaml. It
provides a type to represent a well-defined range of POSIX timestamps
with picosecond precision, conversion with date-time values,
conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
human-readable, locale-independent representation.

The additional Ptime_clock library provides access to a system POSIX
clock and to the system's current time zone offset.

Ptime is not a calendar library.

Ptime depends on the `result` compatibility package. Ptime_clock
depends on your system library. Ptime_clock's optional JavaScript
support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
distributed under the ISC license.

[rfc3339]: http://tools.ietf.org/html/rfc3339
[jsoo]: http://ocsigen.org/js_of_ocaml/



---
* Homepage: https://erratique.ch/software/ptime
* Source repo: git+http://erratique.ch/repos/ptime.git
* Bug tracker: https://github.com/dbuenzli/ptime/issues

---
v0.8.5 2019-05-02 La Forclaz (VS)
---------------------------------

* Make the package compatible with `js_of_ocaml` 3.3.0's
  namespacing

---
:camel: Pull-request generated by opam-publish v2.0.0