### PR TITLE
Cleanup the instruction for flow_parser.

### DIFF
--- a/packages/flow_parser/flow_parser.0.36.0/opam
+++ b/packages/flow_parser/flow_parser.0.36.0/opam
@@ -16,7 +16,7 @@ license: "BSD3"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.06.0"}
+  "ocaml" {>= "4.01.0" & < "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.36.0/opam
+++ b/packages/flow_parser/flow_parser.0.36.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
@@ -30,7 +29,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.36.0.tar.gz"
   checksum: "md5=44a2a93006dbbf0728f7c03737e6deac"

--- a/packages/flow_parser/flow_parser.0.38.0/opam
+++ b/packages/flow_parser/flow_parser.0.38.0/opam
@@ -16,7 +16,7 @@ license: "BSD3"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.06.0"}
+  "ocaml" {>= "4.01.0" & < "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.38.0/opam
+++ b/packages/flow_parser/flow_parser.0.38.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
@@ -30,7 +29,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.38.0.tar.gz"
   checksum: "md5=aeccb250256697c4598fb23c1c3b6af3"

--- a/packages/flow_parser/flow_parser.0.40.0/opam
+++ b/packages/flow_parser/flow_parser.0.40.0/opam
@@ -16,7 +16,7 @@ license: "BSD3"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.06.0"}
+  "ocaml" {>= "4.01.0" & < "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.40.0/opam
+++ b/packages/flow_parser/flow_parser.0.40.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
@@ -30,7 +29,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.40.0.tar.gz"
   checksum: "md5=661a4345d3111978276576908050f638"

--- a/packages/flow_parser/flow_parser.0.42.0/opam
+++ b/packages/flow_parser/flow_parser.0.42.0/opam
@@ -16,7 +16,7 @@ license: "BSD3"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.06.0"}
+  "ocaml" {>= "4.01.0" & < "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.42.0/opam
+++ b/packages/flow_parser/flow_parser.0.42.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
@@ -30,7 +29,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.42.0.tar.gz"
   checksum: "md5=e75b34445e18ad54b72326973f4f85be"

--- a/packages/flow_parser/flow_parser.0.43.0/opam
+++ b/packages/flow_parser/flow_parser.0.43.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
@@ -30,7 +29,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.43.0.tar.gz"
   checksum: "md5=236d98c54f4a6d571c54d2729a81edb2"

--- a/packages/flow_parser/flow_parser.0.43.0/opam
+++ b/packages/flow_parser/flow_parser.0.43.0/opam
@@ -16,7 +16,7 @@ license: "BSD3"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.06.0"}
+  "ocaml" {>= "4.01.0" & < "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.44.0/opam
+++ b/packages/flow_parser/flow_parser.0.44.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
@@ -31,7 +30,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.44.0.tar.gz"
   checksum: "md5=b2b5a5e032a44f255bb313993c2f6602"

--- a/packages/flow_parser/flow_parser.0.44.0/opam
+++ b/packages/flow_parser/flow_parser.0.44.0/opam
@@ -16,7 +16,7 @@ license: "BSD3"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.03.0" & < "4.06.0"}
+  "ocaml" {>= "4.03.0" & < "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "sedlex"

--- a/packages/flow_parser/flow_parser.0.46.0/opam
+++ b/packages/flow_parser/flow_parser.0.46.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
@@ -31,7 +30,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.46.0.tar.gz"
   checksum: "md5=da2357595a8ee443fa40346e2171b1e9"

--- a/packages/flow_parser/flow_parser.0.47.0/opam
+++ b/packages/flow_parser/flow_parser.0.47.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
@@ -31,7 +30,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.47.0.tar.gz"
   checksum: "md5=f7d85c086b570ef7d5693f06391bfe19"

--- a/packages/flow_parser/flow_parser.0.52.0/opam
+++ b/packages/flow_parser/flow_parser.0.52.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
@@ -31,7 +30,6 @@ produces. The Flow Parser can be compiled to native code or can be compiled to
 JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <http://flowtype.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.52.0.tar.gz"
   checksum: "md5=3952d688209f86ff66b7815827b4d898"

--- a/packages/flow_parser/flow_parser.0.62.0/opam
+++ b/packages/flow_parser/flow_parser.0.62.0/opam
@@ -13,9 +13,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "MIT"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
@@ -30,7 +29,6 @@ description: """
 It produces an AST that conforms to ESTree. The Flow Parser can be compiled to native code or can be compiled to JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <https://flow.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.62.0.tar.gz"
   checksum: "md5=64cf27ab1e1982e58ca04f2115475aa0"

--- a/packages/flow_parser/flow_parser.0.80.0/opam
+++ b/packages/flow_parser/flow_parser.0.80.0/opam
@@ -7,9 +7,8 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "MIT"
 
-build: [ "sh" "-c" "cd src/parser && make ocamlfind-install" ]
-
-remove: ["ocamlfind" "remove" "flow_parser"]
+build: [ make "-C" "src/parser" "build-parser" ]
+install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
@@ -27,7 +26,6 @@ description: """
 It produces an AST that conforms to ESTree. The Flow Parser can be compiled to native code or can be compiled to JavaScript using js_of_ocaml.
 
 To find out more about Flow, check out <https://flow.org>."""
-flags: light-uninstall
 url {
   src: "https://github.com/facebook/flow/archive/v0.80.0.tar.gz"
   checksum: "md5=1b8bdc60522a4c6d8da8d2387f27a73a"


### PR DESCRIPTION
The current opam files try to install things during the `build` step, which is forbidden by the sandbox. The instructions were also suboptimal...

cc @gabelevi  ?