### PR TITLE
[new release] dune (1.9.2)

### DIFF
--- a/packages/dune/dune.1.9.2/opam
+++ b/packages/dune/dune.1.9.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-unix"
+  "base-threads"
+]
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+  "odoc" {< "1.3.0"}
+]
+
+synopsis: "Fast, portable and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+url {
+  src: "https://github.com/ocaml/dune/releases/download/1.9.2/dune-1.9.2.tbz"
+  checksum: [
+    "sha256=c2a55c038bb8a68619624e73dc825f4f9f93b2c9d0f6374121210ec847684750"
+    "sha512=56b28ccfe9aebfa108c33cc9cd9679eadd65f3ff0336282542d3230624e791a01317b7819b2df1fb60ecc8032be71624490d711242c9889b8dac0783d4241aec"
+  ]
+}


### PR DESCRIPTION
Fast, portable and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>

##### CHANGES:

- Put back library variants in development mode. We discovered a
  serious unexpected issue and we might need to adjust the design of
  this feature before we are ready to commit to a final version. Users
  will need to write `(using library_variants 0.1)` in their
  `dune-project` file if they want to use it before the design is
  finalized. (ocaml/dune#2116, @diml)

- Forbid to attach a variant to a library that implements a virtual
  library outside the current project (ocaml/dune#2104, @rgrinberg)

- Fix a bug where `dune install` would install man pages to incorrect
  paths when compared to `opam-installer`. For example dune now
  installs `(foo.1 as man1/foo.1)` correctly and previously that was
  installed to `man1/man1/foo.1`. (ocaml/dune#2105, @aalekseyev)

- Do not fail when a findlib directory doesn't exist (ocaml/dune#2101, fix ocaml/dune#2099, @diml)

- [coq] Rename `(coqlib ...)` to `(coq.theory ...)`, support for
  `coqlib` will be dropped in the 1.0 version of the Coq language
  (ocaml/dune#2055, @ejgallego)

- Fix crash when calculating library dependency closure (ocaml/dune#2090, fixes ocaml/dune#2085,
  @rgrinberg)
