### PR TITLE
Fix "opam switch create <version number>"

### DIFF
--- a/packages/ocaml/ocaml.3.07+1/opam
+++ b/packages/ocaml/ocaml.3.07+1/opam
@@ -26,4 +26,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.07+2/opam
+++ b/packages/ocaml/ocaml.3.07+2/opam
@@ -26,4 +26,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.07/opam
+++ b/packages/ocaml/ocaml.3.07/opam
@@ -26,4 +26,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.08.0/opam
+++ b/packages/ocaml/ocaml.3.08.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.08.1/opam
+++ b/packages/ocaml/ocaml.3.08.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.08.2/opam
+++ b/packages/ocaml/ocaml.3.08.2/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.08.3/opam
+++ b/packages/ocaml/ocaml.3.08.3/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.08.4/opam
+++ b/packages/ocaml/ocaml.3.08.4/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.09.0/opam
+++ b/packages/ocaml/ocaml.3.09.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.09.1/opam
+++ b/packages/ocaml/ocaml.3.09.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.09.2/opam
+++ b/packages/ocaml/ocaml.3.09.2/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.09.3/opam
+++ b/packages/ocaml/ocaml.3.09.3/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.10.0/opam
+++ b/packages/ocaml/ocaml.3.10.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.10.1/opam
+++ b/packages/ocaml/ocaml.3.10.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.10.2/opam
+++ b/packages/ocaml/ocaml.3.10.2/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.11.0/opam
+++ b/packages/ocaml/ocaml.3.11.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.11.1/opam
+++ b/packages/ocaml/ocaml.3.11.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.11.2/opam
+++ b/packages/ocaml/ocaml.3.11.2/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.12.0/opam
+++ b/packages/ocaml/ocaml.3.12.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.3.12.1/opam
+++ b/packages/ocaml/ocaml.3.12.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.00.0/opam
+++ b/packages/ocaml/ocaml.4.00.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.00.1/opam
+++ b/packages/ocaml/ocaml.4.00.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.01.0/opam
+++ b/packages/ocaml/ocaml.4.01.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.02.0/opam
+++ b/packages/ocaml/ocaml.4.02.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.02.1/opam
+++ b/packages/ocaml/ocaml.4.02.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.02.2/opam
+++ b/packages/ocaml/ocaml.4.02.2/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.02.3/opam
+++ b/packages/ocaml/ocaml.4.02.3/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.03.0/opam
+++ b/packages/ocaml/ocaml.4.03.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.04.0/opam
+++ b/packages/ocaml/ocaml.4.04.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.04.1/opam
+++ b/packages/ocaml/ocaml.4.04.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.04.2/opam
+++ b/packages/ocaml/ocaml.4.04.2/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.05.0/opam
+++ b/packages/ocaml/ocaml.4.05.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.06.0/opam
+++ b/packages/ocaml/ocaml.4.06.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.06.1/opam
+++ b/packages/ocaml/ocaml.4.06.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.07.0/opam
+++ b/packages/ocaml/ocaml.4.07.0/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.07.1/opam
+++ b/packages/ocaml/ocaml.4.07.1/opam
@@ -27,4 +27,3 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: compiler

--- a/packages/ocaml/ocaml.4.08.0/opam
+++ b/packages/ocaml/ocaml.4.08.0/opam
@@ -15,7 +15,6 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
-flags: compiler
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.09.0/opam
+++ b/packages/ocaml/ocaml.4.09.0/opam
@@ -15,7 +15,6 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
-flags: compiler
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.10.0/opam
+++ b/packages/ocaml/ocaml.4.10.0/opam
@@ -15,7 +15,6 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
-flags: compiler
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/ocaml/opam-repository/pull/14065

`opam switch create <version number>` failed with:
```
[ERROR] Compiler selection '<version number>' is ambiguous. matching packages: { ocaml.<version number>, ocaml-base-compiler.<version number> }
```