### PR TITLE
0install.2.14 doesn't support OCaml >= 4.08

### DIFF
--- a/packages/0install/0install.2.14/opam
+++ b/packages/0install/0install.2.14/opam
@@ -9,7 +9,7 @@ build: [
   [make "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "yojson"
   "xmlm"
   "ounit" {with-test}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

**DON'T MERGE YET**

The error was:
```

#=== ERROR while compiling 0install.2.14 ======================================#
# context              2.0.3 | linux/x86_64 | ocaml-variants.4.08.0+beta3 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08.0+beta3/.opam-switch/build/0install.2.14
# command              /usr/bin/make all
# exit-code            2
# env-file             ~/.opam/log/0install-1-144cf1.env
# output-file          ~/.opam/log/0install-1-144cf1.out
### output ###
# 24 | val to_json : t -> Yojson.Basic.json
# [...]
# Alert deprecated: Yojson.Basic.json
# json types are being renamed and will be removed in the next Yojson major version. Use type t instead
#     ocamlopt ocaml/support/.support.objs/native/support__System.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08.0+beta3/bin/ocamlopt.opt -w -40 -g -I ocaml/support/.support.objs/byte -I ocaml/support/.support.objs/native -I /home/opam/.opam/4.08.0+beta3/lib/bytes -I /home/opam/.opam/4.08.0+beta3/lib/lwt -I /home/opam/.opam/4.08.0+beta3/lib/lwt/unix -I /home/opam/.opam/4.08.0+beta3/lib/mmap -I /home/opam/.opam/4.08.0+beta3/lib/ocaml/threads -I /home/opam/.opam[...]
# File "ocaml/support/system.ml", line 231, characters 26-35:
# 231 |         method hardlink = Unix.link
#                                 ^^^^^^^^^
# Error: This expression has type ?follow:bool -> string -> string -> unit
#        but an expression was expected of type
#          Support.Common.filepath -> Support.Common.filepath -> unit
# make: *** [Makefile:44: all] Error 1
```
however I can't find mention of such a change in the type checker in the OCaml changelog for 4.08 and I'm wondering if it's wanted or new. Upstream in 0install it was fixed in https://github.com/0install/0install/commit/2f9a338909aedd8b0cb7737326529f2932faac87

Does anybody know if this change in the type checker is wanted and point me to the line in the OCaml changlog if I missed it?