### PR TITLE
Package gen.0.5.2

### DIFF
--- a/packages/gen/gen.0.5.2/opam
+++ b/packages/gen/gen.0.5.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Iterators for OCaml, both restartable and consumable"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "ELLIOTTCABLE"]
+tags: ["gen" "iterator" "iter" "fold"]
+homepage: "https://github.com/c-cube/gen/"
+doc: "https://c-cube.github.io/gen/"
+bug-reports: "https://github.com/c-cube/gen/issues"
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "odoc" {with-doc}
+  "qtest" {with-test}
+  "qcheck" {with-test}
+  "qtest" {with-test}
+]
+build: [
+  ["dune" "build" "@install" "-p" name]
+  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/gen.git"
+url {
+  src: "https://github.com/c-cube/gen/archive/0.5.2.tar.gz"
+  checksum: [
+    "md5=dd731ef527022ea698955db687e6cb5f"
+    "sha512=c84e5ea0c9b3a678b6a5c935eacf91265a79b68a48375c44aa5f159d4cb02283c1be0786e172a153666c670bc7ee37b931004b8747a99e5f4ab90ca63e097ff5"
+  ]
+}


### PR DESCRIPTION
### `gen.0.5.2`
Iterators for OCaml, both restartable and consumable



---
* Homepage: https://github.com/c-cube/gen/
* Source repo: git+https://github.com/c-cube/gen.git
* Bug tracker: https://github.com/c-cube/gen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0