### PR TITLE
[new release] routes (0.4.1)

### DIFF
--- a/packages/routes/routes.0.4.1/opam
+++ b/packages/routes/routes.0.4.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: [ "Anurag Soni <anurag@sonianurag.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anuragsoni/routes"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+doc: "https://anuragsoni.github.io/routes/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "mdx" { with-test }
+]
+synopsis: "Typed routing for OCaml applications"
+description: """
+routes provides combinators for adding typed routing
+to OCaml applications. The core library will be independent
+of any particular web framework or runtime. It does
+path based dispatch from a target url to a user
+provided handler.
+"""
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/0.4.1/routes-0.4.1.tbz"
+  checksum: [
+    "sha256=013d50c34947b944a85469ad62b956f912caa9ad85aedae3824a9b33bc393961"
+    "sha512=f3ce49d608f0a8153c2d3930f63080dc0dda4f594e834ba6bcdf246c1a21d8f73b0121e42cced37dd2d147107ab4d34b415f66aa1a9be9bf7adce0f70e5d3c62"
+  ]
+}


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

* Remove `stdcompat` (anuragsoni/routes#33)
* Add example using [opium](https://github.com/rgrinberg/opium) (anuragsoni/routes#34)
