### PR TITLE
[new release] mirage-net-xen and netchannel (1.11.0)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.1.11.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.11.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "3.3.0"}
+  "netchannel" {>= "1.10.1"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.11.0/mirage-net-xen-v1.11.0.tbz"
+  checksum: [
+    "sha256=ec683a731d2cdbb58d0842ccb91abfce5ee031025ef5548d8d7ecf79a860c042"
+    "sha512=89a9ccfb100aa6e56777ed051307f5afe6e4287e32b0d8799d6d612d5e01a500b0d4b51f824c466658636938773039ffa41d49ef40d3a7db1cb9649d95362d34"
+  ]
+}

--- a/packages/netchannel/netchannel.1.11.0/opam
+++ b/packages/netchannel/netchannel.1.11.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "3.3.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "rresult"
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.11.0/mirage-net-xen-v1.11.0.tbz"
+  checksum: [
+    "sha256=ec683a731d2cdbb58d0842ccb91abfce5ee031025ef5548d8d7ecf79a860c042"
+    "sha512=89a9ccfb100aa6e56777ed051307f5afe6e4287e32b0d8799d6d612d5e01a500b0d4b51f824c466658636938773039ffa41d49ef40d3a7db1cb9649d95362d34"
+  ]
+}


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Fix MAC address for netback devices (@talex5, mirage/mirage-net-xen#87).
  This changes the `CONFIGURATION` signature to provide both
  `read_frontend_mac` and `read_backend_mac`, and changes the XenStore
  implementation to return `fe:ff:ff:ff:ff:ff` for backends.
