### PR TITLE
meta_conf.1.1.5: Disable parallel build

### DIFF
--- a/packages/meta_conv/meta_conv.1.1.5/opam
+++ b/packages/meta_conv/meta_conv.1.1.5/opam
@@ -7,7 +7,7 @@ bug-reports: "https://bitbucket.org/camlspotter/meta_conv/issues?status=new&stat
 dev-repo: "hg+https://bitbucket.org/camlspotter/meta_conv"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
-  [ "ocaml" "setup.ml" "-build" ]
+  [ "ocaml" "setup.ml" "-build" "-j" "1" ]
 ]
 install: [
   [ "ocaml" "setup.ml" "-install" ]


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @camlspotter 

```
#=== ERROR while compiling meta_conv.1.1.5 ====================================#
# context              2.0.3 | linux/x86_64 | ocaml-base-compiler.4.02.3 | file:///home/opam/opam-repository
# path                 ~/.opam/4.02.3/.opam-switch/build/meta_conv.1.1.5
# command              ~/.opam/4.02.3/bin/ocaml setup.ml -build
# exit-code            1
# env-file             ~/.opam/log/meta_conv-1-9ace5e.env
# output-file          ~/.opam/log/meta_conv-1-9ace5e.out
### output ###
# [...]
# + ocamlfind ocamlc -annot -bin-annot -g -w A-3-4-9-40-42-44-45 -warn-error a -g -I . -I ../lib -c json_conv.mli
# File "json_conv.mli", line 1:
# Error: Corrupted compiled interface
# [...]
```