### PR TITLE
git.1.4.3 use the deprecated Lwt_unix.run and have warning-as-errors …

### DIFF
--- a/packages/git/git.1.4.3/opam
+++ b/packages/git/git.1.4.3/opam
@@ -24,7 +24,7 @@ depends: [
   "uri" {>= "1.3.12"}
   "cmdliner" {< "1.0.0"}
   "ocamlgraph"
-  "lwt" {>= "2.4.5"}
+  "lwt" {>= "2.4.5" & < "2.6.0"}
   "hex"
   "conduit" {>= "0.6.0" & < "0.99"}
   "cstruct" {< "3.2.0"}


### PR DESCRIPTION
…enabled

Fix http://check.ocamllabs.io/4.02.3/bad/git.1.4.3