### PR TITLE
Package ocsigen-i18n.3.4.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.4.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom"
+description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-rewriter"]
+           ["rm" "-f" "%{bin}%/ocsigen-i18n-checker"] ]
+
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind" {build}
+  "tyxml" { >= "4.3.0" }
+]
+authors: "Julien Sagot"
+flags: light-uninstall
+url {
+  src: "https://github.com/jrochel/ocsigen-i18n/archive/3.4.0.tar.gz"
+  checksum: [
+    "md5=c46f88b08eaef9b85aa8ad4ee97fd11c"
+    "sha512=04294b1c957a4dc4676f8e27d4b129b50c7a6f9ac3b1b1752792f55d981d24cebbed2da832e3d63c44cc139c698c8be3a50b69cca27c4f897bf8a2db39470ccb"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-i18n.3.4.0`
I18n made easy for web sites written with eliom
Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.0