### PR TITLE
Package linenoise.1.3.0

### DIFF
--- a/packages/linenoise/linenoise.1.3.0/opam
+++ b/packages/linenoise/linenoise.1.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Lightweight readline alternative"
+maintainer: "Simon Cruanes"
+authors: ["Edgar Aroutiounian <edgar.factorial@gmail.com>" "Simon Cruanes"]
+license: "BSD-3-clause"
+homepage: "https://github.com/ocaml-community/ocaml-linenoise"
+bug-reports: "https://github.com/ocaml-community/ocaml-linenoise/issues"
+depends: [
+  "dune" {build}
+  "result"
+]
+build: [
+  ["dune" "build" "@install" "-p" name]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/ocaml-linenoise.git"
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-linenoise/archive/v1.3.0.tar.gz"
+  checksum: [
+    "md5=867d1b62c2e6705c665f1e2e9199a6e0"
+    "sha512=c1f2d8aaf9ad72a24d9a3efdaef75e191975984517ddd9265c3fa76c8d3a7d51acf65cd6be0f35601d66dd1a9506799d9e803bb796170c03e02a94934283213e"
+  ]
+}


### PR DESCRIPTION
### `linenoise.1.3.0`
Lightweight readline alternative



---
* Homepage: https://github.com/ocaml-community/ocaml-linenoise
* Source repo: git+https://github.com/ocaml-community/ocaml-linenoise.git
* Bug tracker: https://github.com/ocaml-community/ocaml-linenoise/issues

---
:camel: Pull-request generated by opam-publish v2.0.0