### PR TITLE
mariadb is not compatible with OCaml >= 4.08 and mariadb < 0.9 is not safe-strings compatible

### DIFF
--- a/packages/mariadb/mariadb.0.10.0/opam
+++ b/packages/mariadb/mariadb.0.10.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.5.0/opam
+++ b/packages/mariadb/mariadb.0.5.0/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mariadb"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.5.1/opam
+++ b/packages/mariadb/mariadb.0.5.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.6.0/opam
+++ b/packages/mariadb/mariadb.0.6.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.7.0/opam
+++ b/packages/mariadb/mariadb.0.7.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.8.0/opam
+++ b/packages/mariadb/mariadb.0.8.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.8.1/opam
+++ b/packages/mariadb/mariadb.0.8.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.8.2/opam
+++ b/packages/mariadb/mariadb.0.8.2/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.0.9.0/opam
+++ b/packages/mariadb/mariadb.0.9.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.1.0.0/opam
+++ b/packages/mariadb/mariadb.1.0.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.1.0.1/opam
+++ b/packages/mariadb/mariadb.1.0.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.1.1.0/opam
+++ b/packages/mariadb/mariadb.1.1.0/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.1.1.1/opam
+++ b/packages/mariadb/mariadb.1.1.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.1.1.2/opam
+++ b/packages/mariadb/mariadb.1.1.2/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "mariadb_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

cc @andrenth there is no release compatible with OCaml >= 4.08. It would be sensible to avoid the use of `warning-as-errors` for future releases