### PR TITLE
owl.0.2.9: safe-string constraint

### DIFF
--- a/packages/owl/owl.0.2.9/opam
+++ b/packages/owl/owl.0.2.9/opam
@@ -20,7 +20,7 @@ remove: [
   ["ocaml" "%{etc}%/owl/_oasis_remove_.ml" "%{etc}%/owl"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.06.0"}
   "atdgen" {< "1.13.0"}
   "ctypes"
   "dolog" {>= "3.0"}
@@ -29,6 +29,7 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
+  "ocaml-compiler-libs"
   "plplot"
   "eigen" {>= "0.0.3" & < "0.1.0"}
   "conf-openblas"


### PR DESCRIPTION
The [current check](http://check.ocamllabs.io/4.07.1/bad/owl.0.2.9) shows this version is broken due to:
```
# ocamlfind: Package `ocaml-compiler-libs' not found
```
but event after installing this library, the build fails due to:
```
# Error: This expression has type string but an expression was expected of type
#          bytes
```
So I added a constraint on the compiler, < 4.06.0 to avoid safe-string by default.