### PR TITLE
ppx_tools_versioned for OCaml 4.08

### DIFF
--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.0.1/opam
@@ -12,7 +12,7 @@ build: [make "all"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "ppx_tools_versioned"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {>= "1.5.0"}
   "ocaml-migrate-parsetree" {>= "0.7" & < "1.3.0"}
 ]

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.0alpha/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.0alpha/opam
@@ -13,7 +13,7 @@ build: [make "all"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "ppx_tools_versioned"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {>= "1.5.0"}
   "ocaml-migrate-parsetree" {>= "0.5" & < "1.3.0"}
 ]

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.0beta/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.0beta/opam
@@ -13,7 +13,7 @@ build: [make "all"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "ppx_tools_versioned"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {>= "1.5.0"}
   "ocaml-migrate-parsetree" {>= "0.4" & < "1.3.0"}
 ]

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.0beta1/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.0beta1/opam
@@ -13,7 +13,7 @@ build: [make "all"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "ppx_tools_versioned"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {>= "1.5.0"}
   "ocaml-migrate-parsetree" {>= "0.4" & < "1.3.0"}
 ]

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.1/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.1/opam
@@ -13,7 +13,7 @@ build: [make "all"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "ppx_tools_versioned"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {>= "1.5.0"}
   "ocaml-migrate-parsetree" {>= "1.0.7" & < "1.3.0"}
 ]

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.1/opam
@@ -15,7 +15,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "ocaml-migrate-parsetree" {>= "1.0.10" & < "1.3.0"}
 ]

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2/opam
@@ -15,7 +15,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "ocaml-migrate-parsetree" {>= "0.5" & < "1.3.0"}
 ]


### PR DESCRIPTION
This PR fixes the constraints for ppx_tools_versioned (which doesn't support OCaml 4.08), and also add a new test version for this package from the latest stable version patched to support OCaml 4.08.

The patch to support 4.08 is taken from https://github.com/xclerc/ppx_tools_versioned/commit/25e23b3620849df4c60d99da44225ea74fdacb0c
The section for OCaml 4.07 has been removed because there is currently no stable versions of `ppx_tools_versioned` with support for the 4.07 AST (see https://github.com/ocaml-ppx/ppx_tools_versioned/issues/13)

This PR follows more or less the same package scheme than the test packages for `ocaml-migrate-parsetree` added in these PRs:
* https://github.com/ocaml/opam-repository/pull/13722
* https://github.com/ocaml/opam-repository/pull/14016

cc @xclerc @let-def 