### PR TITLE
[new release] ocaml-migrate-parsetree (1.2.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
@@ -4,7 +4,7 @@ authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
   "Jérémie Dimino <jeremie@dimino.org>"
 ]
-license: "LGPL-2.1"
+license: "LGPL-2.1 with OCaml linking exception"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
@@ -17,7 +17,7 @@ depends: [
   "result"
   "ppx_derivers"
   "dune" {build & >= "1.6.0"}
-  "ocaml" {>= "4.02.3" & < "4.08.0"}
+  "ocaml" {>= "4.02.3"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
@@ -29,6 +29,9 @@ rewriters independent of a compiler version.
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.2.0/ocaml-migrate-parsetree-v1.2.0.tbz"
-  checksum: "md5=cc6fb09ad6f99156c7dba47711c62c6f"
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/1.2.0/ocaml-migrate-parsetree-1.2.0.tbz"
+  checksum: [
+    "sha256=59368f852e7476edde428d78010903f5655c16bf2fd9627e472b83ec98922198"
+    "sha512=d1ed05cca71825bc10d2c3cdbdaaa448677b6d5589a0792fcf2e021bb0002d24b05a3d6fdfdbe3b39fc901817e06b8b13eeaff2d893be8bab0c0d734545deece"
+  ]
 }


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Remove unused ocamlfind dependency in the opam file

- Fix Windows compatibility by setting the output to binary mode when
  writing a binary ast (ocaml-ppx/ocaml-migrate-parsetree#57, @bryphe)

- Get rid of the ocamlbuild plugin. Nobody is using it in opam and it
  is more work to maintain

- Set `Location.input_name` to the original filename when reading a
  binary AST (ocaml-ppx/ocaml-migrate-parsetree#66, @diml)

- Add support 4.08 (ocaml-ppx/ocaml-migrate-parsetree#70, @xclerc)
