### PR TITLE
[new release] ocaml-migrate-parsetree (1.3.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ppx_derivers"
+  "dune" {build & >= "1.6.0"}
+  "ocaml" {>= "4.02.3"}
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.3.0/ocaml-migrate-parsetree-v1.3.0.tbz"
+  checksum: [
+    "sha256=dfb05a3611783f0a49325b1e185bb1827c263d9ca2228287da55f037ad3c280e"
+    "sha512=95a12f4e9e257395aeb5024f3acf4f8e419f6df8d94e611c3660a139254252aa5e462394a5ff91c2b238351bed946e0b5aee05f22e0e2e3350fb476ab3b8b510"
+  ]
+}


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Get rid of the ocamlbuild plugin. Nobody is using it in opam and it
  is more work to maintain (ocaml-ppx/ocaml-migrate-parsetree#63, @diml)

- Set `Location.input_name` to the original filename when reading a
  binary AST (ocaml-ppx/ocaml-migrate-parsetree#66, @diml)

- Add support 4.08 (ocaml-ppx/ocaml-migrate-parsetree#70, @xclerc)
