### PR TITLE
ocaml compiler distribution: use parallel build for OCaml 4.07 and above

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -42,8 +42,8 @@ build: [
     "-host"
     "i386-apple-darwin13.2.0"
   ] {os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -32,8 +32,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -30,8 +30,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -25,8 +25,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
@@ -32,8 +32,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -25,8 +25,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
@@ -32,8 +32,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
@@ -31,8 +31,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -42,8 +42,8 @@ build: [
     "-host"
     "i386-apple-darwin13.2.0"
   ] {os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -17,7 +17,7 @@ build: [
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   ["sh" "-c" "cd ber-metaocaml-107 && make patch"]
-  [make "world" "bootstrap" "world.opt"]
+  [make "-j%{jobs}%" "world" "bootstrap" "world.opt"]
   [make "-C" "ber-metaocaml-107" "all"]
 ]
 install: [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -32,8 +32,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -25,8 +25,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -32,8 +32,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -32,8 +32,8 @@ build: [
     "-no-graph"
     "-no-shared-libs"
   ]
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -30,8 +30,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -42,8 +42,8 @@ build: [
     "-host"
     "i386-apple-darwin13.2.0"
   ] {os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -32,8 +32,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -25,8 +25,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -32,8 +32,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -29,8 +29,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -23,8 +23,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -24,8 +24,8 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -21,8 +21,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -24,8 +24,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -21,8 +21,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
@@ -24,8 +24,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -21,8 +21,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
@@ -24,8 +24,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+afl/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+flambda/opam
@@ -21,8 +21,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp+flambda/opam
@@ -26,8 +26,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+fp/opam
@@ -24,8 +24,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+trunk/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {


### PR DESCRIPTION
In the old days, the OCaml compiler distribution did not support
parallel build. This support has been contributed over time, and while
the dependencies are still not 100% reliable (in particular, parallel
rebuild from a partial build often fails with cmi inconsistencies),
builds from a clean state are now very robust: they are routinely used
by developers and tested daily on our CI machines, and we haven't seen
a failure in a long while.

Enabling parallel build improves build times for everyone, at the cost
of a very low risk of breaking the build. Some context:

- On my machine, a recent sequential build took 5m15s, and a parallel
  build from the same sources took 2m53s: we can save 2m20s for every
  new switch creation for users with similar hardware. When creating
  a switch with a small number of packages, the compiler build time
  may dominate the total installation time.

- New switches are created much more often now that opam2 makes local
  switches easy. It is typical for users to create a switch for each
  project to isolate their dependencies, ending up with dozens of
  switches. The install time quickly builds up.

If a user was to find a build failure due to parallel build,
a workaround is to pass `-j 1` to opam to force sequential switch
creation:

    opam switch create <switch-name> <compiler-version> -j 1

setting the environment variable OPAMJOBS=1 would also work.

This commit was semi-automatically generated using the following script:

```
for f in ocaml-base-compiler/*4.07.*/opam; do sed -i 's/make "world/make "-j%{jobs}%" "world/g' $f; done
for f in ocaml-variants/*4.0[789].*/opam; do sed -i 's/make "world/make "-j%{jobs}%" "world/g' $f; done
for f in ocaml-variants/*4.10.*/opam; do sed -i 's/make "world/make "-j%{jobs}%" "world/g' $f; done
```