### PR TITLE
Make flow_parser.0.{36,38,40,42,43,44}.* compatible with OCaml 4.04 and 4.05 again

### DIFF
--- a/packages/flow_parser/flow_parser.0.36.0/opam
+++ b/packages/flow_parser/flow_parser.0.36.0/opam
@@ -13,10 +13,9 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.04.0"}
+  "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.38.0/opam
+++ b/packages/flow_parser/flow_parser.0.38.0/opam
@@ -13,10 +13,9 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.04.0"}
+  "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.40.0/opam
+++ b/packages/flow_parser/flow_parser.0.40.0/opam
@@ -13,10 +13,9 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.04.0"}
+  "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.42.0/opam
+++ b/packages/flow_parser/flow_parser.0.42.0/opam
@@ -13,10 +13,9 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.04.0"}
+  "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.43.0/opam
+++ b/packages/flow_parser/flow_parser.0.43.0/opam
@@ -13,10 +13,9 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.01.0" & < "4.04.0"}
+  "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/flow_parser/flow_parser.0.44.0/opam
+++ b/packages/flow_parser/flow_parser.0.44.0/opam
@@ -13,10 +13,9 @@ homepage: "https://github.com/facebook/flow/tree/master/src/parser"
 bug-reports: "https://github.com/facebook/flow/issues"
 license: "BSD3"
 
-build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.03.0" & < "4.04.0"}
+  "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "sedlex"


### PR DESCRIPTION
As discussed in https://github.com/ocaml/opam-repository/pull/14074