### PR TITLE
3 packages from ryanslade/influxdb-ocaml at 0.2.0

### DIFF
--- a/packages/influxdb-async/influxdb-async.0.2.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.2.0/opam
@@ -9,10 +9,10 @@ dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {build}
-  "base" {< "v0.13"}
+  "base"
   "alcotest" {with-test}
-  "influxdb" {>= "0.2.0"}
-  "async" {< "v0.13"}
+  "influxdb"
+  "async"
   "cohttp"
   "cohttp-async"
   "ocaml" {>= "4.04.0"}
@@ -20,7 +20,7 @@ depends: [
 url {
   src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.2.0.tar.gz"
   checksum: [
-    "md5=70f8cd3e75a411942b3dc49dd13e9beb"
-    "sha512=55d139138d6dba77a2dae0d2c76fae2c95eca59df586da4e15f1661e7c0180afb1da75d32ef7f24e5e1dc75fe05de04ff4cad3cc6dfa7a20b70c15c47b5cd29d"
+    "md5=25402ff8fa56fd1020c6bbdd70bd5ea8"
+    "sha512=34c3e2eca70245277d4f45e6beb082643fffb40f10bf0c96a04f167991f864eb55dc98f4d8b144436e8304564748ee0ac65d91972f2eb8a3ff3f704063491e16"
   ]
 }

--- a/packages/influxdb-lwt/influxdb-lwt.0.2.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.2.0/opam
@@ -9,9 +9,9 @@ dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {build}
-  "base" {< "v0.13"}
+  "base"
   "alcotest" {with-test}
-  "influxdb" {>="0.2.0"}
+  "influxdb"
   "lwt"
   "cohttp"
   "cohttp-lwt-unix"
@@ -20,7 +20,7 @@ depends: [
 url {
   src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.2.0.tar.gz"
   checksum: [
-    "md5=70f8cd3e75a411942b3dc49dd13e9beb"
-    "sha512=55d139138d6dba77a2dae0d2c76fae2c95eca59df586da4e15f1661e7c0180afb1da75d32ef7f24e5e1dc75fe05de04ff4cad3cc6dfa7a20b70c15c47b5cd29d"
+    "md5=25402ff8fa56fd1020c6bbdd70bd5ea8"
+    "sha512=34c3e2eca70245277d4f45e6beb082643fffb40f10bf0c96a04f167991f864eb55dc98f4d8b144436e8304564748ee0ac65d91972f2eb8a3ff3f704063491e16"
   ]
 }

--- a/packages/influxdb/influxdb.0.2.0/opam
+++ b/packages/influxdb/influxdb.0.2.0/opam
@@ -9,15 +9,15 @@ dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {build}
-  "base" {< "v0.13"}
-  "stdio" {< "v0.13"}
-  "ppx_expect" {< "v0.13"}
+  "base"
+  "stdio"
+  "ppx_expect"
   "ocaml" {>= "4.04.0"}
 ]
 url {
   src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.2.0.tar.gz"
   checksum: [
-    "md5=70f8cd3e75a411942b3dc49dd13e9beb"
-    "sha512=55d139138d6dba77a2dae0d2c76fae2c95eca59df586da4e15f1661e7c0180afb1da75d32ef7f24e5e1dc75fe05de04ff4cad3cc6dfa7a20b70c15c47b5cd29d"
+    "md5=25402ff8fa56fd1020c6bbdd70bd5ea8"
+    "sha512=34c3e2eca70245277d4f45e6beb082643fffb40f10bf0c96a04f167991f864eb55dc98f4d8b144436e8304564748ee0ac65d91972f2eb8a3ff3f704063491e16"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`influxdb.0.2.0`: InfluxDB client library
-`influxdb-async.0.2.0`: InfluxDB client library using async for concurrency
-`influxdb-lwt.0.2.0`: InfluxDB client library using lwt for concurrency



---
* Homepage: https://github.com/ryanslade/influxdb-ocaml
* Source repo: git://github.com/ryanslade/influxdb-ocaml.git
* Bug tracker: https://github.com/ryanslade/influxdb-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0