### PR TITLE
[new release] travesty (0.5.1)

### DIFF
--- a/packages/travesty/travesty.0.5.1/opam
+++ b/packages/travesty/travesty.0.5.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Monadically traversable containers"
+description:
+  "'Travesty' is a library for defining containers with monadic traversals,
+   inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
+   Core library ecosystem."
+maintainer: "Matt Windsor <m.windsor@imperial.ac.uk>"
+authors: "Matt Windsor <m.windsor@imperial.ac.uk>"
+license: "MIT"
+doc: "https://MattWindsor91.github.io/travesty/"
+homepage: "https://MattWindsor91.github.io/travesty"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {build}
+  "ppx_deriving"
+  "ppx_expect"
+  "ppx_jane"
+  "ppx_sexp_message"
+  "core_kernel" {>= "v0.12" & < "v0.13"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/MattWindsor91/travesty"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.5.1/travesty-v0.5.1.tbz"
+  checksum: [
+    "sha256=6096bfedbab2044c6372c918712bc5e71ffba5a373cdab37398787712c9c83af"
+    "sha512=a7a1cd7981af2c16111323cdf72ac6a45a5e58a3701376fdb3d7f3ee15fbf4003e71f94ad882ccea0d308bb229f3ac0b2c9861a231a498c22e44551f1fcf802d"
+  ]
+}


### PR DESCRIPTION
Monadically traversable containers

- Project page: <a href="https://MattWindsor91.github.io/travesty">https://MattWindsor91.github.io/travesty</a>
- Documentation: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>

##### CHANGES:

As is becoming tradition, fixes a minor documentation comment caught
between tagging on GitHub and publishing on OPAM.  See the main changelog
for details about what changed in v0.5.0.
