### PR TITLE
mirage-block-ccm: depend on old io-page due to io-page.unix usage

### DIFF
--- a/packages/mirage-block-ccm/mirage-block-ccm.1.0.0/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-types-lwt" {< "3.0.0"}
   "nocrypto" {>= "0.5.1"}
-  "io-page" {>= "1.0.0"}
+  "io-page" {>= "1.0.0" & <"2.0.0"}
   "ounit" {with-test}
   "bisect" {with-test}
   "ocamlbuild" {build}

--- a/packages/mirage-block-ccm/mirage-block-ccm.1.0.1/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.1.0.1/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-types-lwt" {< "3.0.0"}
   "nocrypto" {>= "0.5.1"}
-  "io-page" {>= "1.0.0"}
+  "io-page" {>= "1.0.0" & <"2.0.0"}
   "ounit" {with-test}
   "bisect" {with-test}
   "ocamlbuild" {build}


### PR DESCRIPTION
see #14001