### PR TITLE
mirage-block-unix: tests fail with io-page>2

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
@@ -16,7 +16,7 @@ remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind" {build}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"3.4.0"}
   "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
@@ -25,6 +25,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct-lwt"
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 synopsis: "MirageOS disk block driver for Unix"
 description: """
 This driver supports

--- a/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
@@ -29,6 +29,7 @@ depends: [
   "ppx_sexp_conv" {with-test & < "v0.13"}
   "ppx_type_conv" {with-test}
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: [
   ["linux-libc-dev"] {os-distribution = "debian"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
@@ -39,8 +40,6 @@ depexts: [
 ]
 synopsis: "MirageOS disk block driver for Unix"
 description: """
-[![Build Status](https://travis-ci.org/mirage/mirage-block-unix.png?branch=master)](https://travis-ci.org/mirage/mirage-block-unix) [![Coverage Status](https://coveralls.io/repos/mirage/mirage-block-unix/badge.png?branch=master)](https://coveralls.io/r/mirage/mirage-block-unix?branch=master)
-
 Unix implementation of the Mirage `BLOCK_DEVICE` interface.
 
 This module provides raw I/O to files and block devices with as little

--- a/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
@@ -29,6 +29,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "MirageOS disk block driver for Unix"
 description: """

--- a/packages/mirage-block-unix/mirage-block-unix.2.11.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.1/opam
@@ -29,6 +29,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "MirageOS disk block driver for Unix"
 description: """

--- a/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
@@ -16,7 +16,7 @@ remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind" {build}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & <"3.4.0"}
   "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
@@ -26,6 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct-lwt"
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "MirageOS disk block driver for Unix"
 description: """

--- a/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
@@ -26,6 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct-lwt"
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "MirageOS disk block driver for Unix"
 description: """

--- a/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
@@ -27,6 +27,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct-lwt"
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "MirageOS disk block driver for Unix"
 description: """

--- a/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
@@ -31,6 +31,7 @@ depends: [
   "ounit" {with-test}
   "cstruct-lwt"
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 tags: "org:mirage"
 synopsis: "MirageOS disk block driver for Unix"

--- a/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
@@ -31,6 +31,7 @@ depends: [
   "ounit" {with-test}
   "cstruct-lwt"
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 tags: "org:mirage"
 synopsis: "MirageOS disk block driver for Unix"

--- a/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.7.0/opam
@@ -29,6 +29,7 @@ depends: [
   "ounit" {with-test}
   "cstruct-lwt" {= "0"}
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 tags: "org:mirage"
 synopsis: "MirageOS disk block driver for Unix"

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
@@ -26,6 +26,7 @@ depends: [
   "fmt" {with-test}
   "cstruct-lwt"
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 tags: "org:mirage"
 synopsis: "MirageOS disk block driver for Unix"

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.3/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.3/opam
@@ -25,6 +25,7 @@ depends: [
   "ounit" {with-test}
   "fmt" {with-test}
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "MirageOS disk block driver for Unix"
 description: """

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
@@ -25,6 +25,7 @@ depends: [
   "ounit" {with-test}
   "fmt" {with-test}
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
 depexts: [
   ["linux-libc-dev"] {os-distribution = "debian"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
@@ -25,6 +25,8 @@ depends: [
   "ounit" {with-test}
   "fmt" {with-test}
 ]
+conflicts: [ "io-page" {>="2.0.0" & with-test} ]
+
 depexts: [
   ["linux-libc-dev"] {os-distribution = "debian"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
@@ -35,8 +37,6 @@ depexts: [
 ]
 synopsis: "MirageOS disk block driver for Unix"
 description: """
-[![Build Status](https://travis-ci.org/mirage/mirage-block-unix.png?branch=master)](https://travis-ci.org/mirage/mirage-block-unix) [![Coverage Status](https://coveralls.io/repos/mirage/mirage-block-unix/badge.png?branch=master)](https://coveralls.io/r/mirage/mirage-block-unix?branch=master)
-
 Unix implementation of the Mirage `BLOCK_DEVICE` interface.
 
 This module provides raw I/O to files and block devices with as little


### PR DESCRIPTION
also some other minor tidyups with descriptions
fix submitted upstream in https://github.com/mirage/mirage-block-unix/pull/97

see #14001 for revdeps failure