### PR TITLE
tcpip: versions before 3.5.1 required mirage-clock<2 (type unit change)

### DIFF
--- a/packages/mirage-clock-unix/mirage-clock-unix.1.2.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.2.0/opam
@@ -14,8 +14,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & <"1.3.0"} 
+  "mirage-clock-lwt" {>= "1.2.0" & <"1.3.0"}
   "lwt"
 ]
 build: [

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.3.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.3.0/opam
@@ -12,8 +12,8 @@ tags: ["org:mirage"]
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & <"2.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0" & <"2.0.0"}
   "lwt"
   "configurator" {build & < "v0.13"}
 ]

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.4.0/opam
@@ -11,8 +11,8 @@ tags:         ["org:mirage"]
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & <"2.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0" & <"2.0.0"}
   "lwt"
   "configurator" {build & < "v0.13"}
 ]

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.4.1/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.4.1/opam
@@ -11,8 +11,8 @@ tags:         ["org:mirage"]
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0" & <"2.0.0"}
   "lwt"
   "configurator" {build & < "v0.13"}
 ]

--- a/packages/mirage-types/mirage-types.3.0.0/opam
+++ b/packages/mirage-types/mirage-types.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build & >= "0.8.0"}
   "mirage-device" {>= "1.0.0"}
   "mirage-time" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}

--- a/packages/mirage-types/mirage-types.3.0.5/opam
+++ b/packages/mirage-types/mirage-types.3.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "mirage-device" {>= "1.0.0"}
   "mirage-time" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}

--- a/packages/mirage-types/mirage-types.3.0.7/opam
+++ b/packages/mirage-types/mirage-types.3.0.7/opam
@@ -19,7 +19,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "mirage-device" {>= "1.0.0"}
   "mirage-time" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}

--- a/packages/mirage-types/mirage-types.3.1.0/opam
+++ b/packages/mirage-types/mirage-types.3.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "mirage-device" {>= "1.0.0"}
   "mirage-time" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}

--- a/packages/mirage-types/mirage-types.3.1.1/opam
+++ b/packages/mirage-types/mirage-types.3.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "mirage-device" {>= "1.0.0"}
   "mirage-time" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}

--- a/packages/mirage-types/mirage-types.3.2.0/opam
+++ b/packages/mirage-types/mirage-types.3.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "mirage-device" {>= "1.0.0"}
   "mirage-time" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}

--- a/packages/mirage-types/mirage-types.3.3.0/opam
+++ b/packages/mirage-types/mirage-types.3.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {build & >= "1.1.0"}
   "mirage-device" {>= "1.0.0"}
   "mirage-time" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "2.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-console" {>= "2.2.0"}

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -59,7 +59,7 @@ depends: [
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "fmt"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.1.0/opam
+++ b/packages/tcpip/tcpip.3.1.0/opam
@@ -59,7 +59,7 @@ depends: [
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "fmt"
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.1.1/opam
+++ b/packages/tcpip/tcpip.3.1.1/opam
@@ -59,7 +59,7 @@ depends: [
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "fmt"
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.1.2/opam
+++ b/packages/tcpip/tcpip.3.1.2/opam
@@ -59,7 +59,7 @@ depends: [
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "fmt"
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -59,7 +59,7 @@ depends: [
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "fmt"
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.1.4/opam
+++ b/packages/tcpip/tcpip.3.1.4/opam
@@ -60,7 +60,7 @@ depends: [
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "fmt"
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.2.0/opam
+++ b/packages/tcpip/tcpip.3.2.0/opam
@@ -40,7 +40,7 @@ depends: [
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "fmt"
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.3.0/opam
+++ b/packages/tcpip/tcpip.3.3.0/opam
@@ -45,7 +45,7 @@ depends: [
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "An OCaml TCP/IP networking stack"
 description: """

--- a/packages/tcpip/tcpip.3.3.1/opam
+++ b/packages/tcpip/tcpip.3.3.1/opam
@@ -45,7 +45,7 @@ depends: [
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "An OCaml TCP/IP networking stack"
 description: """

--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -45,7 +45,7 @@ depends: [
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "An OCaml TCP/IP networking stack"
 description: """

--- a/packages/tcpip/tcpip.3.4.1/opam
+++ b/packages/tcpip/tcpip.3.4.1/opam
@@ -45,7 +45,7 @@ depends: [
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "An OCaml TCP/IP networking stack"
 description: """

--- a/packages/tcpip/tcpip.3.4.2/opam
+++ b/packages/tcpip/tcpip.3.4.2/opam
@@ -44,7 +44,7 @@ depends: [
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "An OCaml TCP/IP networking stack"
 description: """

--- a/packages/tcpip/tcpip.3.5.0/opam
+++ b/packages/tcpip/tcpip.3.5.0/opam
@@ -45,7 +45,7 @@ depends: [
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "An OCaml TCP/IP networking stack"
 description: """

--- a/packages/tcpip/tcpip.3.5.1/opam
+++ b/packages/tcpip/tcpip.3.5.1/opam
@@ -46,7 +46,7 @@ depends: [
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-random-test" {with-test}
 ]
 synopsis: "OCaml TCP/IP networking stack, used in MirageOS"


### PR DESCRIPTION
spotted in revdeps for #14001