### PR TITLE
[new release] plotkicadsch and kicadsch (0.5.0)

### DIFF
--- a/packages/kicadsch/kicadsch.0.5.0/opam
+++ b/packages/kicadsch/kicadsch.0.5.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Library to read and convert Kicad Sch files"
+description: """
+Library able to read Kicad libraries and sch file and
+drive a painter to paint the schematics.
+"""
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {build}
+  "dune-release" {build}
+  "ounit" {with-test}
+  "ocaml" {>="4.05"}
+]
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.5.0/plotkicadsch-v0.5.0.tbz"
+  checksum: [
+    "sha256=e23d51468a0d50dfff56c044d782d56a6bc27be344c3f052cca4d0e1767ba841"
+    "sha512=787322504ee7dfc419092ff0691682cc8e1eaa6f59d5c6699962775c1241c18616ebba79fba9d6ff144264e314e634bc6c962e9d1092a7579be878ce08a395fd"
+  ]
+}

--- a/packages/plotkicadsch/plotkicadsch.0.5.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Utilities to print and compare version of Kicad schematics"
+description: """
+Two utilities:
+ * plotkicadsch is able to plot schematic sheets to SVG files
+ * plotgitsch is able to compare git revisions of schematics
+"""
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "dune-release" {build}
+  "kicadsch" {= "0.4.0"}
+  "tyxml" {>= "4.0.0"}
+  "lwt"
+  "lwt_ppx" {build}
+  "sha"
+  "git" {>= "2.0.0"}
+  "git-unix"
+  "base64" {>= "3.0.0"}
+  "patience_diff" { < "v0.12.0" }
+  "core_kernel"
+  "cmdliner"
+]
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.5.0/plotkicadsch-v0.5.0.tbz"
+  checksum: [
+    "sha256=e23d51468a0d50dfff56c044d782d56a6bc27be344c3f052cca4d0e1767ba841"
+    "sha512=787322504ee7dfc419092ff0691682cc8e1eaa6f59d5c6699962775c1241c18616ebba79fba9d6ff144264e314e634bc6c962e9d1092a7579be878ce08a395fd"
+  ]
+}


### PR DESCRIPTION
Utilities to print and compare version of Kicad schematics

- Project page: <a href="https://jnavila.github.io/plotkicadsch/">https://jnavila.github.io/plotkicadsch/</a>
- Documentation: <a href="https://jnavila.github.io/plotkicadsch/index">https://jnavila.github.io/plotkicadsch/index</a>

##### CHANGES:

- add compatibility with kicad 5.x
 - update 'massaging' with rescue lib
 - become independant on line endings types
 - add an option to select output directory in plotkicadsch
 - update lib versions
