### PR TITLE
New package override.0.1.0

### DIFF
--- a/packages/override/override.0.1.0/opam
+++ b/packages/override/override.0.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "PPX extension for overriding modules"
+description: "PPX extensions [%%override], [%%import], [%%include] and [%%rewrite] to import and change module interfaces."
+maintainer: "Thierry Martinez <Thierry.Martinez@inria.fr>"
+authors: "Thierry Martinez <Thierry.Martinez@inria.fr>"
+homepage: "https://gitlab.inria.fr/tmartine/override"
+bug-reports: "https://gitlab.inria.fr/tmartine/override/issues"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/override.git"
+depends: [
+  "dune" "ppxlib" "stdcompat" "ppx_tools"
+  "ocaml" {>= "4.04.1" & < "4.08.0"}] # no ppxlib for OCaml <4.04.1
+url {
+  src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.1.0/override-0.1.0.tar.gz"
+  checksum: "md5=b6193e9f86da0786fb2fcc935d3cca58"
+}


### PR DESCRIPTION
- generalizes ppx_import by allowing a whole module to be imported
  with all its types, possibly with annotations.

- module overriding: mechanization of Gabriel Scherer's post on Gagallium blog
  http://gallium.inria.fr/blog/overriding-submodules/

- type rewriting: types can be systematically annotated, substituted,
  renamed, or removed. Transformations such as those that are described in
  the comments of ast/ast.ml in ppxlib sources can be mechanized.