### PR TITLE
hex: constrain older ones to cstruct<5 due to bigarray compat

### DIFF
--- a/packages/hex/hex.0.2.0/opam
+++ b/packages/hex/hex.0.2.0/opam
@@ -15,7 +15,7 @@ remove:  ["ocamlfind" "remove" "hex"]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
   "ocamlfind" {build}
-  "cstruct" {>= "1.5.0"}
+  "cstruct" {>= "1.5.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Minimal library providing hexadecimal converters."

--- a/packages/hex/hex.1.0.0/opam
+++ b/packages/hex/hex.1.0.0/opam
@@ -17,7 +17,7 @@ remove:  ["ocamlfind" "remove" "hex"]
 depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Minimal library providing hexadecimal converters."

--- a/packages/hex/hex.1.1.0/opam
+++ b/packages/hex/hex.1.1.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {< "4.06.0"}
   "jbuilder" {build & >= "1.0+beta8"}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "5.0.0"}
 ]
 synopsis: "Minimal library providing hexadecimal converters."
 description: """

--- a/packages/hex/hex.1.1.1/opam
+++ b/packages/hex/hex.1.1.1/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {< "4.06.0"}
   "jbuilder" {build & >= "1.0+beta8"}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "5.0.0"}
 ]
 synopsis: "Minimal library providing hexadecimal converters."
 description: """

--- a/packages/hex/hex.1.2.0/opam
+++ b/packages/hex/hex.1.2.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta8"}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "5.0.0"}
 ]
 synopsis: "Minimal library providing hexadecimal converters."
 description: """

--- a/packages/hex/hex.1.3.0/opam
+++ b/packages/hex/hex.1.3.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-hex/issues"
 depends: [
   "ocaml"
   "dune" {build & >= "1.0"}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "5.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/hex/hex.1.4.0/opam
+++ b/packages/hex/hex.1.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-hex"
 doc: "https://mirage.github.io/ocaml-hex/"
 bug-reports: "https://github.com/mirage/ocaml-hex/issues"
 depends: [
-  "ocaml" {>="4.03.0"}
+  "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
   "cstruct" {>= "1.7.0"}
   "bigarray-compat" {>= "1.0.0"}


### PR DESCRIPTION
related to #14001