### PR TITLE
[new release] mirage-block-unix (2.11.2)

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.11.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+authors:      "Dave Scott <dave@recoil.org>"
+maintainer:   "dave@recoil.org"
+homepage:     "https://github.com/mirage/mirage-block-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-block-unix.git"
+doc:          "https://mirage.github.io/mirage-block-unix/"
+bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
+tags:         "org:mirage"
+license:      "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >="1.0"}
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt"
+  "mirage-block-lwt" {>= "1.0.0"}
+  "rresult"
+  "io-page-unix" {>= "2.0.0"}
+  "uri" {>= "1.9.0"}
+  "logs"
+  "ounit" {with-test}
+  "diet" {with-test}
+  "fmt" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+synopsis: "MirageOS disk block driver for Unix"
+description: """
+Unix implementation of the Mirage `BLOCK_DEVICE` interface.
+
+This module provides raw I/O to files and block devices with as little
+caching as possible.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-unix/releases/download/v2.11.2/mirage-block-unix-v2.11.2.tbz"
+  checksum: [
+    "sha256=eb2a9896ca3eeae343891af1dee1031d658ee18843b437ea6a6900da8071a838"
+    "sha512=090b6d8e6951069048bad7b39f4887d5ea44cf17745d1d90d017232032d99d4dea8e0d9ed8a62efbb35e2e7e9905efec1ef296dd7d576c4c2e09c0ab9e63ec75"
+  ]
+}


### PR DESCRIPTION
MirageOS disk block driver for Unix

- Project page: <a href="https://github.com/mirage/mirage-block-unix">https://github.com/mirage/mirage-block-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-unix/">https://mirage.github.io/mirage-block-unix/</a>

##### CHANGES:

* Fix test use of io-page-unix to work with io-page>2.0.0 (@avsm)
* Remove unnecessary opam dependencies and refine `ppx_sexp_conv` one (@avsm)
