### PR TITLE
Package ocaml-diff.0.1.2

### DIFF
--- a/packages/ocaml-diff/ocaml-diff.0.1.2/opam
+++ b/packages/ocaml-diff/ocaml-diff.0.1.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Symmetric Diffs for OCaml stdlib and ReasonML"
+maintainer: "Jan Hrdina <jan.hrdka@gmail.com>"
+authors: "Jan Hrdina <jan.hrdka@gmail.com>"
+license: "MIT"
+homepage: "http://github.com/jhrdina/ocaml-diff"
+bug-reports: "http://github.com/jhrdina/ocaml-diff/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.6.0"}
+  "reason" {>= "3.4.0"}
+]
+url {
+  src: "https://github.com/jhrdina/ocaml-diff/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=3480f39a22cba3cfbef93ee35d4ff488"
+    "sha512=02b541f04398db2c574c40e582b97c819acedbd517fbadc3effbe377b9590a7e0d81eef0c9a7afa613dbc07436fd8085457ad4408c426359ddc0b3ea3e3b38c7"
+  ]
+}


### PR DESCRIPTION
### `ocaml-diff.0.1.2`
Symmetric Diffs for OCaml stdlib and ReasonML



---
* Homepage: http://github.com/jhrdina/ocaml-diff
* Bug tracker: http://github.com/jhrdina/ocaml-diff/issues

---
:camel: Pull-request generated by opam-publish v2.0.0