### PR TITLE
Package ocaml-monadic.0.4.1

### DIFF
--- a/packages/ocaml-monadic/ocaml-monadic.0.4.1/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.4.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "A PPX extension to provide an OCaml-friendly monadic syntax"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "BSD-3-clause"
+homepage: "http://github.com/zepalmer/ocaml-monadic"
+bug-reports: "https://github.com/zepalmer/ocaml-monadic/issues"
+depends: [
+  "dune" {build & >= "1.0.0"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+  "ocaml" {>= "4.04.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/zepalmer/ocaml-monadic.git"
+url {
+  src:
+    "https://github.com/zepalmer/ocaml-monadic/archive/dd42d4ae6e618f38dac93223bd58aa04386f9a02.zip"
+  checksum: [
+    "md5=408b32bc4b5225eb228b5494318bbdc9"
+    "sha512=35d16c6d7671fecbb698e9ef6a71bac25afc99293f90a070a4a044f4c939f95a9ebcf4c24ff64b4ebfa7c7aa9f3d5bad2b27c0617b23aa18f41912df9607cfec"
+  ]
+}


### PR DESCRIPTION
### `ocaml-monadic.0.4.1`
A PPX extension to provide an OCaml-friendly monadic syntax



---
* Homepage: http://github.com/zepalmer/ocaml-monadic
* Source repo: git+https://github.com/zepalmer/ocaml-monadic.git
* Bug tracker: https://github.com/zepalmer/ocaml-monadic/issues

---
:camel: Pull-request generated by opam-publish v2.0.0