### PR TITLE
Package stdlib-diff.0.1.3

### DIFF
--- a/packages/stdlib-diff/stdlib-diff.0.1.3/opam
+++ b/packages/stdlib-diff/stdlib-diff.0.1.3/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Symmetric Diffs for OCaml stdlib and ReasonML"
+maintainer: "Jan Hrdina <jan.hrdka@gmail.com>"
+authors: "Jan Hrdina <jan.hrdka@gmail.com>"
+license: "MIT"
+homepage: "http://github.com/jhrdina/ocaml-diff"
+bug-reports: "http://github.com/jhrdina/ocaml-diff/issues"
+dev-repo: "git+https://github.com/jhrdina/ocaml-diff.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.6.0"}
+  "reason" {>= "3.4.0"}
+]
+url {
+  src: "https://github.com/jhrdina/ocaml-diff/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=dd714e1969c6b28a143843c046970c0f"
+    "sha512=3df3b4ab6f3043fcc0486f494d47ebbfded9e8929e998f2d2435cf05090b4bd318e096bf55590826df1b5d2036c473c28f4529242044430c3e0b44072b68a5f2"
+  ]
+}


### PR DESCRIPTION
### `stdlib-diff.0.1.3`
Symmetric Diffs for OCaml stdlib and ReasonML



---
* Homepage: http://github.com/jhrdina/ocaml-diff
* Source repo: git+https://github.com/jhrdina/ocaml-diff.git
* Bug tracker: http://github.com/jhrdina/ocaml-diff/issues

---
:camel: Pull-request generated by opam-publish v2.0.0