### PR TITLE
Package jhupllib.0.2.1

### DIFF
--- a/packages/jhupllib/jhupllib.0.2.1/opam
+++ b/packages/jhupllib/jhupllib.0.2.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "A collection of OCaml utilities used by the JHU PL lab"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "Apache"
+homepage: "http://pl.cs.jhu.edu/"
+bug-reports: "https://github.com/JHU-PL-Lab/jhu-pl-lib/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "base-threads"
+  "batteries"
+  "dune" {build & >= "1.0+beta17"}
+  "monadlib"
+  "ocaml-monadic" {>= "0.4.1"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+  "ppx_deriving" {>= "2.0"}
+  "ppx_deriving_yojson"
+  "yojson"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/JHU-PL-Lab/jhu-pl-lib.git"
+url {
+  src:
+    "http://github.com/JHU-PL-Lab/jhupllib/archive/def6ce5e907d3f63e00767ec947b93c0a0de9c20.zip"
+  checksum: [
+    "md5=3156dda64a10c8eb805b92ca61cd733b"
+    "sha512=9b81c5a96dee675253f2f474a6556fde4d59fdf86d9661bf60cb95ce9a4e3d7c5f63a489967ffff820ed11b994dd4cd7514020171de247d1a943260d11de23b2"
+  ]
+}


### PR DESCRIPTION
### `jhupllib.0.2.1`
A collection of OCaml utilities used by the JHU PL lab



---
* Homepage: http://pl.cs.jhu.edu/
* Source repo: git+https://github.com/JHU-PL-Lab/jhu-pl-lib.git
* Bug tracker: https://github.com/JHU-PL-Lab/jhu-pl-lib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0