### PR TITLE
Package pds-reachability.0.2.2

### DIFF
--- a/packages/pds-reachability/pds-reachability.0.2.2/opam
+++ b/packages/pds-reachability/pds-reachability.0.2.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A PDS reachability query library"
+description:
+  "This library performs efficient reachability queries on abstractly specified push-down systems."
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "Apache"
+homepage: "https://github.com/JHU-PL-Lab/pds-reachability"
+bug-reports: "https://github.com/JHU-PL-Lab/pds-reachability/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "base-threads"
+  "batteries"
+  "jbuilder" {build & >= "1.0+beta17"}
+  "jhupllib" {>= "0.2.1"}
+  "ocaml-monadic" {>= "0.4.1"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+  "ppx_deriving" {>= "3.2"}
+  "ppx_deriving_yojson" {>= "2.1"}
+  "yojson"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/JHU-PL-Lab/pds-reachability.git"
+url {
+  src:
+    "https://github.com/JHU-PL-Lab/pds-reachability/archive/b425d6f83d811dfa4c70e96d3bead4dfa257169e.zip"
+  checksum: [
+    "md5=0033336c6558550fb4cf4cfbc5548b24"
+    "sha512=ebda525ec2b665c3e31e939044614c3bdade5d29da404296b946500f82feef6c4470accb944cad4a5ba972990608b8e198a8dc551420d828cafa896a88e69090"
+  ]
+}


### PR DESCRIPTION
### `pds-reachability.0.2.2`
A PDS reachability query library
This library performs efficient reachability queries on abstractly specified push-down systems.



---
* Homepage: https://github.com/JHU-PL-Lab/pds-reachability
* Source repo: git+https://github.com/JHU-PL-Lab/pds-reachability.git
* Bug tracker: https://github.com/JHU-PL-Lab/pds-reachability/issues

---
:camel: Pull-request generated by opam-publish v2.0.0