### PR TITLE
[new release] digestif (0.7.2)

### DIFF
--- a/packages/callipyge/callipyge.0.2/opam
+++ b/packages/callipyge/callipyge.0.2/opam
@@ -20,6 +20,9 @@ depends: [
   "eqaf"
   "alcotest" {with-test}
 ]
+conflicts: [
+  "eqaf" {= "0.3"}
+]
 synopsis: "Pure OCaml implementation of Curve25519."
 description: "Pure OCaml implementation of Curve25519."
 url {

--- a/packages/digestif/digestif.0.7.1/opam
+++ b/packages/digestif/digestif.0.7.1/opam
@@ -51,6 +51,7 @@ depopts: [
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.1"}
+  "eqaf" {= "0.3"}
 ]
 url {
   src:

--- a/packages/digestif/digestif.0.7.2/opam
+++ b/packages/digestif/digestif.0.7.2/opam
@@ -51,6 +51,7 @@ depopts: [
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.1"}
+  "eqaf" {= "0.3"}
 ]
 url {
   src:

--- a/packages/digestif/digestif.0.7.2/opam
+++ b/packages/digestif/digestif.0.7.2/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+name:         "digestif"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {build & >= "1.9.2"}
+  "eqaf"
+  "base-bytes"
+  "base-bigarray"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+  "mirage-xen-posix"
+]
+
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v0.7.2/digestif-v0.7.2.tbz"
+  checksum: [
+    "sha256=f3e3728e3880466da8589a35a0a738d1064644b0aaa4250d87383027f6a16486"
+    "sha512=f684f8629d58e47201589956a661c18b4ebe93c11c7807c71d873b96a55b91fdef6a2c393d4fad0fab2e2e5090de76859ebcdfbefdd76144b78b19b63cd7e476"
+  ]
+}

--- a/packages/digestif/digestif.0.7/opam
+++ b/packages/digestif/digestif.0.7/opam
@@ -46,6 +46,9 @@ depends: [
   "fmt"            {with-test}
   "alcotest"       {with-test}
 ]
+conflicts: [
+  "eqaf" {= "0.3"}
+]
 url {
   src:
     "https://github.com/mirage/digestif/releases/download/v0.7/digestif-v0.7.tbz"

--- a/packages/noise/noise.0.1.0/opam
+++ b/packages/noise/noise.0.1.0/opam
@@ -28,6 +28,9 @@ depends: [
   "ppx_let" {< "v0.13"}
   "ppxlib" {build}
 ]
+conflicts: [
+  "eqaf" {= "0.3"}
+]
 synopsis: "The Noise Protocol Framework"
 description: """
 This library contains an implementation of the Noise Protocol Framework using

--- a/packages/noise/noise.0.2.0/opam
+++ b/packages/noise/noise.0.2.0/opam
@@ -27,6 +27,9 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+conflicts: [
+  "eqaf" {= "0.3"}
+]
 dev-repo: "git+https://github.com/emillon/ocaml-noise.git"
 synopsis: "The Noise Protocol Framework"
 description: """


### PR DESCRIPTION
Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)

- Project page: <a href="https://github.com/mirage/digestif">https://github.com/mirage/digestif</a>
- Documentation: <a href="https://mirage.github.io/digestif/">https://mirage.github.io/digestif/</a>

##### CHANGES:

- Add conflict with `< mirage-xen-posix.3.1.0` packages (@hannesm)
- Add a note on README.md about the linking-trick and order of dependencies (@rizo)
- Use experimental feature of variants with `dune` (@dinosaure, review @rgrinberg)

  `digestif` requires at least `dune.1.9.2`
