### PR TITLE
[new release] zxcvbn (2.3+2)

### DIFF
--- a/packages/zxcvbn/zxcvbn.2.3+2/opam
+++ b/packages/zxcvbn/zxcvbn.2.3+2/opam
@@ -25,7 +25,7 @@ This library provides functions to estimate the strength of a password.
 """
 url {
   src:
-    "https://github.com/cryptosense/ocaml-zxcvbn/releases/download/v2.3+2/zxcvbn-v2.3+2.tbz"
+    "https://github.com/cryptosense/ocaml-zxcvbn/releases/download/v2.3+2/zxcvbn-v2.3.2.tbz"
   checksum: [
     "sha256=8f935b84856a09913c83b877e5aeb966a7efb8090d1d56a77aaaa48918340e05"
     "sha512=8f88eb6759b828f7aa0e191a03aad4d2739ce546be7b74a427f8298a20730def6038c006b71d2698e4daae26702022a8ef873a040f52f6b98d9f08da3a04bbc7"

--- a/packages/zxcvbn/zxcvbn.2.3+2/opam
+++ b/packages/zxcvbn/zxcvbn.2.3+2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Nathan Rebours <nathan@cryptosense.com>"
+homepage: "https://github.com/cryptosense/ocaml-zxcvbn"
+bug-reports: "https://github.com/cryptosense/ocaml-zxcvbn/issues"
+license: "BSD-2"
+dev-repo:  "git+https://github.com/cryptosense/ocaml-zxcvbn.git"
+doc: "https://cryptosense.github.io/ocaml-zxcvbn/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {build & >= "1.4.0"}
+  "ocaml" {>= "4.02.0"}
+  "ounit" {with-test}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+]
+tags: ["org:cryptosense"]
+synopsis: "Bindings for the zxcvbn password strength estimation library"
+description: """
+This library provides functions to estimate the strength of a password.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/ocaml-zxcvbn/releases/download/v2.3+2/zxcvbn-v2.3+2.tbz"
+  checksum: [
+    "sha256=8f935b84856a09913c83b877e5aeb966a7efb8090d1d56a77aaaa48918340e05"
+    "sha512=8f88eb6759b828f7aa0e191a03aad4d2739ce546be7b74a427f8298a20730def6038c006b71d2698e4daae26702022a8ef873a040f52f6b98d9f08da3a04bbc7"
+  ]
+}

--- a/packages/zxcvbn/zxcvbn.2.3+2/opam
+++ b/packages/zxcvbn/zxcvbn.2.3+2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "Nathan Rebours <nathan@cryptosense.com>"
-authors: "Nathan Rebours <nathan@cryptosense.com>"
+maintainer: "James Owen <james@cryptosense.com>"
+authors: "James Owen <james@cryptosense.com>"
 homepage: "https://github.com/cryptosense/ocaml-zxcvbn"
 bug-reports: "https://github.com/cryptosense/ocaml-zxcvbn/issues"
 license: "BSD-2"


### PR DESCRIPTION
Bindings for the zxcvbn password strength estimation library

- Project page: <a href="https://github.com/cryptosense/ocaml-zxcvbn">https://github.com/cryptosense/ocaml-zxcvbn</a>
- Documentation: <a href="https://cryptosense.github.io/ocaml-zxcvbn/doc">https://cryptosense.github.io/ocaml-zxcvbn/doc</a>

##### CHANGES:

*2019-05-17*

- Upgrade to `opam` 2
- Move build to `dune`
