### PR TITLE
[new release] syndic (1.6.1)

### DIFF
--- a/packages/syndic/syndic.1.6.1/opam
+++ b/packages/syndic/syndic.1.6.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name:         "syndic"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      [ "Romain Calascibetta"
+                "Christophe Troestler" ]
+license:      "MIT"
+homepage:     "https://github.com/Cumulus/Syndic"
+dev-repo:     "git+https://github.com/Cumulus/Syndic.git"
+bug-reports:  "https://github.com/Cumulus/Syndic/issues"
+doc:          "https://cumulus.github.io/Syndic/"
+synopsis:     "RSS1, RSS2, Atom and OPML1 parsing"
+description: """
+Pure OCaml Library for parsing and writing various types of
+feeds and subscriber lists."""
+
+build: [
+  [ "dune" "subst" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+]
+
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ptime"
+  "uri" {>= "1.9"}
+  "xmlm" {>= "1.2.0"}
+  "fmt" {with-test}
+  "ocurl" {with-test}
+  "fpath" {with-test}
+  "ocplib-json-typed" {with-test}
+  "base-unix" {with-test}
+  "jsonm" {with-test}
+]
+url {
+  src:
+    "https://github.com/Cumulus/Syndic/releases/download/v1.6.1/syndic-v1.6.1.tbz"
+  checksum: [
+    "sha256=a830f3e471a4058a93ac03b979b5a96d5e75e59ec6e9e1e3dd048c081ef683c4"
+    "sha512=5d296a4e91d6321528e95cc6a11e24d03f0a5b916a4755de790a01a285f24a0ff33da26c66488769fd07d48ec9c1d1a273e0945cf85e02580c8badbe5d9cd8ad"
+  ]
+}

--- a/packages/syndic/syndic.1.6.1/opam
+++ b/packages/syndic/syndic.1.6.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "syndic"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      [ "Romain Calascibetta"
                 "Christophe Troestler" ]
@@ -16,7 +15,7 @@ feeds and subscriber lists."""
 build: [
   [ "dune" "subst" ]
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name ] {with-test}
+  [ "dune" "runtest" "-p" name ] {with-test & ocaml:version >= "4.04.1"}
 ]
 
 


### PR DESCRIPTION
CHANGES:

* `Syndic.Date.of_rfc822` accepts dates such as “May 15th, 2019”.