### PR TITLE
[new release] zxcvbn (2.3+2)

### DIFF
--- a/packages/zxcvbn/zxcvbn.2.3+2/opam
+++ b/packages/zxcvbn/zxcvbn.2.3+2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: "Nathan Rebours <nathan.p.rebours@gmail.com>"
+homepage: "https://github.com/cryptosense/ocaml-zxcvbn"
+bug-reports: "https://github.com/cryptosense/ocaml-zxcvbn/issues"
+license: "BSD-2"
+dev-repo:  "git+https://github.com/cryptosense/ocaml-zxcvbn.git"
+doc: "https://cryptosense.github.io/ocaml-zxcvbn/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {build & >= "1.4.0"}
+  "ocaml" {>= "4.04.0"}
+  "ounit" {with-test}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+]
+tags: ["org:cryptosense"]
+synopsis: "Bindings for the zxcvbn password strength estimation library"
+description: """
+This library provides functions to estimate the strength of a password.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/ocaml-zxcvbn/releases/download/v2.3%2B2/zxcvbn-v2.3.2.tbz"
+  checksum: [
+    "sha256=84f132caeb14b5a2385fc39c5d2f320326991074a084eeea9f6ea754a9f967ba"
+    "sha512=858768742086da04d79671452990e089cd7f24bdaa6b0f217389c30e7180ea3c7161f4aaaea8486a388210105a5d4e7451ebb6c8e8f6d0a334f2d151b5d0c6ee"
+  ]
+}


### PR DESCRIPTION
Bindings for the zxcvbn password strength estimation library

- Project page: <a href="https://github.com/cryptosense/ocaml-zxcvbn">https://github.com/cryptosense/ocaml-zxcvbn</a>
- Documentation: <a href="https://cryptosense.github.io/ocaml-zxcvbn/doc">https://cryptosense.github.io/ocaml-zxcvbn/doc</a>

##### CHANGES:

*2019-05-17*

- Upgrade to `opam` 2
- Move build to `dune`
