### PR TITLE
[new release] lacaml (11.0.4)

### DIFF
--- a/packages/lacaml/lacaml.11.0.4/opam
+++ b/packages/lacaml/lacaml.11.0.4/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "http://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+tags: [ "clib:lapack" "clib:blas" ]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {build & >= "1.4.0"}
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base" {build}
+  "stdio" {build}
+  "base-bytes"
+  "base-bigarray"
+]
+
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.0.4/lacaml-11.0.4.tbz"
+  checksum: [
+    "sha256=12409bcc841867ad0ce699cee0868863333e8f0d66f8262ea090074131dff9f7"
+    "sha512=a0cbb41c36d336c71e11c59565ffed184622d8d53bd1a56023519f18650ce4b03b6233e07d1a09b1730411dc02d1054983fe2c9911c660b5b99250bf544c6475"
+  ]
+}


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="http://mmottl.github.io/lacaml">http://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

* Fixed an API misspecification in `ptsv`, which leads to incorrect results.

  Thanks to Nicolas Ratier <nicolas.ratier@femto-st.fr> for the bug report!
