### PR TITLE
z3.4.8.4: fix build for static linking by default

### DIFF
--- a/packages/z3/z3.4.8.4/files/0001-OCaml-static-fix-linking-options.patch
+++ b/packages/z3/z3.4.8.4/files/0001-OCaml-static-fix-linking-options.patch
@@ -1,0 +1,39 @@
+From c1ad450f7cde79149b73f25cc632d15830b75829 Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Tue, 21 May 2019 16:09:18 +0200
+Subject: [PATCH 1/2] OCaml / static: fix linking options
+
+---
+ scripts/mk_util.py | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/mk_util.py b/scripts/mk_util.py
+index 9076b582f..f076817d2 100644
+--- a/scripts/mk_util.py
++++ b/scripts/mk_util.py
+@@ -2253,10 +2253,12 @@ class MLComponent(Component):
+ 
+             OCAMLMKLIB = 'ocamlmklib'
+ 
+-            LIBZ3 = '-L. -lz3'
++            LIBZ3 = '-lz3'
+             if is_cygwin() and not(is_cygwin_mingw()):
+                 LIBZ3 = 'libz3.dll'
+ 
++            LIBZ3 = LIBZ3 + ' ' + ' '.join(map(lambda x: '-cclib ' + x, LDFLAGS.split()))
++
+             if DEBUG_MODE and not(is_cygwin()):
+                 # Some ocamlmklib's don't like -g; observed on cygwin, but may be others as well.
+                 OCAMLMKLIB += ' -g'
+@@ -2267,7 +2269,7 @@ class MLComponent(Component):
+             out.write('%s.cmxa: %s %s %s %s.cma\n' % (z3mls, cmxs, stubso, z3dllso, z3mls))
+             out.write('\t%s -o %s -I %s %s %s %s\n' % (OCAMLMKLIB, z3mls, self.sub_dir, stubso, cmxs, LIBZ3))
+             out.write('%s.cmxs: %s.cmxa\n' % (z3mls, z3mls))
+-            out.write('\t%s -linkall -shared -o %s.cmxs -I %s %s.cmxa\n' % (OCAMLOPTF, z3mls, self.sub_dir, z3mls))
++            out.write('\t%s -linkall -shared -o %s.cmxs -I . -I %s %s.cmxa\n' % (OCAMLOPTF, z3mls, self.sub_dir, z3mls))
+ 
+             out.write('\n')
+             out.write('ml: %s.cma %s.cmxa %s.cmxs\n' % (z3mls, z3mls, z3mls))
+-- 
+2.11.0
+

--- a/packages/z3/z3.4.8.4/files/0002-OCaml-API-build-provide-static-linking-options-by-de.patch
+++ b/packages/z3/z3.4.8.4/files/0002-OCaml-API-build-provide-static-linking-options-by-de.patch
@@ -56,7 +56,7 @@ index f076817d2..2716052c0 100644
              OCAMLMKLIB = 'ocamlmklib'
  
 -            LIBZ3 = '-lz3'
-+            LIBZ3 = '-l' + z3link
++            LIBZ3 = '-cclib -l' + z3link
              if is_cygwin() and not(is_cygwin_mingw()):
 -                LIBZ3 = 'libz3.dll'
 +                LIBZ3 = z3linkdep

--- a/packages/z3/z3.4.8.4/files/0002-OCaml-API-build-provide-static-linking-options-by-de.patch
+++ b/packages/z3/z3.4.8.4/files/0002-OCaml-API-build-provide-static-linking-options-by-de.patch
@@ -1,0 +1,81 @@
+From 921613f4618045f6926bdf84b37fe020378534b0 Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Tue, 21 May 2019 17:44:19 +0200
+Subject: [PATCH 2/2] OCaml API build: provide static linking options by
+ default
+
+when --staticlib is enabled, the linker will still choose to
+dynamically link upon encountering `-lz3` when generating an
+executable through OCaml.
+
+The interaction between the underlying C linker and OCaml make it very
+hard to choose the static version instead. The present patch works
+around this issue by copying `libz3.a` to `libz3-static.a`, and using
+`-lz3-static` instead: the static version is chosen since no dynamic
+one is found.
+
+One can get back to dynamically linking by compiling without
+`--staticlib`, or switching back to `-lz3`, but will in the latter
+case run into the same problem with specifying the option; if that
+needs to be made easier, we could provide two versions of the `cm(x)a`
+which differ only by their linking options.
+
+One last solution would be to remove `lz3` altogether from the linking
+options included in the cm(x)a, requiring either `-lz3` or
+`-lz3-static` to be specified at link time. Simpler and most flexible,
+but requires an update of all users that link with the Z3 ml api...
+---
+ scripts/mk_util.py | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/scripts/mk_util.py b/scripts/mk_util.py
+index f076817d2..2716052c0 100644
+--- a/scripts/mk_util.py
++++ b/scripts/mk_util.py
+@@ -2221,8 +2221,16 @@ class MLComponent(Component):
+ 
+             stubsc = os.path.join(src_dir, self.stubs + '.c')
+             stubso = os.path.join(self.sub_dir, self.stubs) + '$(OBJ_EXT)'
+-            z3dllso = get_component(Z3_DLL_COMPONENT).dll_name + '$(SO_EXT)'
+-            out.write('%s: %s %s\n' % (stubso, stubsc, z3dllso))
++            base_dll_name = get_component(Z3_DLL_COMPONENT).dll_name
++            if STATIC_LIB:
++                z3link = 'z3-static'
++                z3linkdep = base_dll_name + '-static$(LIB_EXT)'
++                out.write('%s: %s\n' % (z3linkdep, base_dll_name + '$(LIB_EXT)'))
++                out.write('\tcp $< $@\n')
++            else:
++                z3link = 'z3'
++                z3linkdep = base_dll_name + '$(SO_EXT)'
++            out.write('%s: %s %s\n' % (stubso, stubsc, z3linkdep))
+             out.write('\t%s -ccopt "$(CXXFLAGS_OCAML) -I %s -I %s -I %s $(CXX_OUT_FLAG)%s" -c %s\n' %
+                       (OCAMLCF, OCAML_LIB, api_src, src_dir, stubso, stubsc))
+ 
+@@ -2253,9 +2261,9 @@ class MLComponent(Component):
+ 
+             OCAMLMKLIB = 'ocamlmklib'
+ 
+-            LIBZ3 = '-lz3'
++            LIBZ3 = '-l' + z3link
+             if is_cygwin() and not(is_cygwin_mingw()):
+-                LIBZ3 = 'libz3.dll'
++                LIBZ3 = z3linkdep
+ 
+             LIBZ3 = LIBZ3 + ' ' + ' '.join(map(lambda x: '-cclib ' + x, LDFLAGS.split()))
+ 
+@@ -2264,9 +2272,10 @@ class MLComponent(Component):
+                 OCAMLMKLIB += ' -g'
+ 
+             z3mls = os.path.join(self.sub_dir, 'z3ml')
+-            out.write('%s.cma: %s %s %s\n' % (z3mls, cmos, stubso, z3dllso))
++
++            out.write('%s.cma: %s %s %s\n' % (z3mls, cmos, stubso, z3linkdep))
+             out.write('\t%s -o %s -I %s %s %s %s\n' % (OCAMLMKLIB, z3mls, self.sub_dir, stubso, cmos, LIBZ3))
+-            out.write('%s.cmxa: %s %s %s %s.cma\n' % (z3mls, cmxs, stubso, z3dllso, z3mls))
++            out.write('%s.cmxa: %s %s %s %s.cma\n' % (z3mls, cmxs, stubso, z3linkdep, z3mls))
+             out.write('\t%s -o %s -I %s %s %s %s\n' % (OCAMLMKLIB, z3mls, self.sub_dir, stubso, cmxs, LIBZ3))
+             out.write('%s.cmxs: %s.cmxa\n' % (z3mls, z3mls))
+             out.write('\t%s -linkall -shared -o %s.cmxs -I . -I %s %s.cmxa\n' % (OCAMLOPTF, z3mls, self.sub_dir, z3mls))
+-- 
+2.11.0
+

--- a/packages/z3/z3.4.8.4/opam
+++ b/packages/z3/z3.4.8.4/opam
@@ -5,14 +5,17 @@ homepage: "https://github.com/Z3prover/z3"
 bug-reports: "https://github.com/Z3prover/z3/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/Z3prover/z3.git"
-patches: ["fix-parallel-build.patch"]
+patches: [
+  "fix-parallel-build.patch"
+  "0001-OCaml-static-fix-linking-options.patch"
+  "0002-OCaml-API-build-provide-static-linking-options-by-de.patch"
+]
 build: [
   [ "python2.7" "scripts/mk_make.py" "--ml" "--staticlib" ]
   [ make "-C" "build" "-j" jobs ]
-  [ "sh" "-c" "cp build/libz3* build/api/ml/" ]
 ]
 install: [
-  [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/api/ml/*" ]
+  [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/libz3* build/api/ml/*" ]
 ]
 remove: ["ocamlfind" "remove" "z3"]
 depends: [
@@ -24,7 +27,11 @@ depends: [
 ]
 synopsis: "Z3 solver"
 flags: light-uninstall
-extra-files: ["fix-parallel-build.patch" "md5=54516d6bf1f1005508f5cbfe9c53dad2"]
+extra-files: [
+  ["fix-parallel-build.patch" "md5=54516d6bf1f1005508f5cbfe9c53dad2"]
+  ["0001-OCaml-static-fix-linking-options.patch" "md5=47ec4c4b43677f314bd06ec0c7b345e5"]
+  ["0002-OCaml-API-build-provide-static-linking-options-by-de.patch" "md5=7e984bc6d205e3707340ec60ad222c8f"]
+]
 url {
   src:
     "https://github.com/Z3Prover/z3/archive/z3-4.8.4.tar.gz"

--- a/packages/z3/z3.4.8.4/opam
+++ b/packages/z3/z3.4.8.4/opam
@@ -30,7 +30,7 @@ flags: light-uninstall
 extra-files: [
   ["fix-parallel-build.patch" "md5=54516d6bf1f1005508f5cbfe9c53dad2"]
   ["0001-OCaml-static-fix-linking-options.patch" "md5=47ec4c4b43677f314bd06ec0c7b345e5"]
-  ["0002-OCaml-API-build-provide-static-linking-options-by-de.patch" "md5=7e984bc6d205e3707340ec60ad222c8f"]
+  ["0002-OCaml-API-build-provide-static-linking-options-by-de.patch" "md5=9d7b2c02d2b98ca36798841bf227a7e7"]
 ]
 url {
   src:


### PR DESCRIPTION
The two patches have been ported to Z3 master and are backported
here. This makes the installed z3 lib link statically by default,
avoiding the problem with a runtime dependency to a .so file within
the switch (needing an update of LD_LIBRARY_PATH for the binary to
run)