### PR TITLE
[new release] eqaf (0.4)

### DIFF
--- a/packages/eqaf/eqaf.0.4/opam
+++ b/packages/eqaf/eqaf.0.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name:         "eqaf"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/eqaf"
+bug-reports:  "https://github.com/mirage/eqaf/issues"
+dev-repo:     "git+https://github.com/mirage/eqaf.git"
+doc:          "https://mirage.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs "--no-buffer" "--verbose" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {build}
+  "crowbar"        {with-test}
+]
+url {
+  src: "https://github.com/mirage/eqaf/releases/download/v0.4/eqaf-v0.4.tbz"
+  checksum: [
+    "sha256=754f9bafabd11d2e7c1ec0cfa1e045e221eee60239c537471db0892416524b81"
+    "sha512=2892d2dbe738f0e6833e3e6343978807a9a700388014681c879933f7a937ec8a3ee4a8e80ac4eaab80b502fd8ac7698270dbdefb9c05b79dd2463c86d11ff31b"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Distribution integrate an attack example
- Fuzzer to test `equal` function
- Unroll internal loop over 16 bits integers instead 32 bits
- Put x86 ASM output in implementation (and audit)
- Do second check even if first on fails (bad r²)
- Avoid indirection to `Pervasives` functions