### PR TITLE
[new release] bun (0.3.3)

### DIFF
--- a/packages/bun/bun.0.3.3/opam
+++ b/packages/bun/bun.0.3.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Simple management of afl-fuzz processes"
+maintainer: "maintenance@identity-function.com"
+authors: [
+  "Mindy Preston"
+  "Thomas Leonard"
+]
+license: "MIT"
+homepage: "https://github.com/yomimono/ocaml-bun"
+bug-reports: "https://github.com/yomimono/ocaml-bun/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {build & >= "1.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath"
+  "rresult" {>= "0.3.0"}
+  "astring"
+  "crowbar" {with-test}
+  "afl" {= "2.52b"}
+  "logs"
+  "fmt"
+  "lwt"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/yomimono/ocaml-bun.git"
+description: """
+A wrapper for OCaml processes using afl-fuzz, intended for easy use in CI environments.
+See the README.md for more information.
+"""
+url {
+  src:
+    "https://github.com/yomimono/ocaml-bun/releases/download/v0.3.3/bun-v0.3.3.tbz"
+  checksum: [
+    "sha256=b1a8bd7dc62f1944a6dc4172d197d2e744e2ac7f8829e865f5b500573643617c"
+    "sha512=e2d05db4d0cb0655cfda7752e281476b31297a0db6b870889c409ce58753d132c236d6471dbe8265f4999e6b8a50596ab24bc87780a827f70f2ce368c2f674e1"
+  ]
+}


### PR DESCRIPTION
Simple management of afl-fuzz processes

- Project page: <a href="https://github.com/yomimono/ocaml-bun">https://github.com/yomimono/ocaml-bun</a>

##### CHANGES:

- use Lwt to manage processes (yomimono/ocaml-bun#7, by @talex5)
- print crashes when killing a fuzzer in no-kill mode (yomimono/ocaml-bun#8, by @NathanReb)
- do some CI maintenance (yomimono/ocaml-bun#10, by @yomimono)
