### PR TITLE
arp{-mirage} >= 1.0.0 has dune as build dependency

### DIFF
--- a/packages/arp-mirage/arp-mirage.1.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.1.0.0/opam
@@ -9,6 +9,7 @@ license: "ISC"
 synopsis: "Address Resolution Protocol for MirageOS"
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
   "mirage-time-lwt"
   "mirage-protocols-lwt" {< "2.0.0"}
   "ethernet" {< "2.0.0"}

--- a/packages/arp-mirage/arp-mirage.2.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.0.0/opam
@@ -9,6 +9,7 @@ license: "ISC"
 synopsis: "Address Resolution Protocol for MirageOS"
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
   "mirage-time-lwt"
   "mirage-protocols-lwt" {>= "2.0.0"}
   "lwt"

--- a/packages/arp/arp.1.0.0/opam
+++ b/packages/arp/arp.1.0.0/opam
@@ -9,6 +9,7 @@ license: "ISC"
 
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
   "cstruct" {>= "2.2.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"

--- a/packages/arp/arp.2.0.0/opam
+++ b/packages/arp/arp.2.0.0/opam
@@ -9,6 +9,7 @@ license: "ISC"
 
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
   "cstruct" {>= "2.2.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"


### PR DESCRIPTION
as pointed out by @TheLortex in https://github.com/mirage/arp/pull/15