### PR TITLE
[new release] terminal_size (0.1.4)

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.4/opam
+++ b/packages/terminal_size/terminal_size.0.1.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "alcotest" {with-test}
+  "dune" {build & >= "1.2.0"}
+  "ocaml" {>= "4.01.0"}
+]
+synopsis: "Get the dimensions of the terminal"
+description: """
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/terminal_size/releases/download/v0.1.4/terminal_size-v0.1.4.tbz"
+  checksum: [
+    "sha256=8f94050def3b713cc9db06651056a6da152394dad701f721ffd674dfe585ff50"
+    "sha512=7f4579f91bdff76317a5a9b2474a1e09f6566563e9e5e3f7211c2a1a770728842f76b498a4d64c67c39a8c62bfa1e7fce948cf1f36ec1bec034f3e069c962d2d"
+  ]
+}


### PR DESCRIPTION
Get the dimensions of the terminal

- Project page: <a href="https://github.com/cryptosense/terminal_size">https://github.com/cryptosense/terminal_size</a>
- Documentation: <a href="https://cryptosense.github.io/terminal_size/doc">https://cryptosense.github.io/terminal_size/doc</a>

##### CHANGES:

*2019-05-24*

Build system:

- Upgrade to opam 2
- Build with dune
