### PR TITLE
older decoders releases do not build with new dune

### DIFF
--- a/packages/decoders/decoders.0.1.0/opam
+++ b/packages/decoders/decoders.0.1.0/opam
@@ -170,6 +170,7 @@ depends: [
   "containers"
 ]
 build: ["jbuilder" "build" "-p" name "-j" jobs]
+conflicts: [ "dune" {>="1.7.0"} ]
 dev-repo: "git+ssh://git@github.com/mattjbray/ocaml-decoders.git"
 url {
   src:

--- a/packages/decoders/decoders.0.1.1/opam
+++ b/packages/decoders/decoders.0.1.1/opam
@@ -259,6 +259,7 @@ depends: [
   "cppo" {build}
   "containers"
 ]
+conflicts: [ "dune" {>="1.7.0"} ]
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 dev-repo: "git+ssh://git@github.com/mattjbray/ocaml-decoders.git"
 url {


### PR DESCRIPTION
due to ppx changes, but newer decoders releases work fine

found in revdeps for #14180