### PR TITLE
conex-nocrypto: requires bigarray as its optional in cstruct 5

### DIFF
--- a/packages/conex-nocrypto/conex-nocrypto.0.10.0/opam
+++ b/packages/conex-nocrypto/conex-nocrypto.0.10.0/opam
@@ -17,7 +17,7 @@ depends: [
   "alcotest" {with-test}
   "cmdliner"
   "conex" {>= "0.10.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & <"5.0.0"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.4.0"}
   "logs"

--- a/packages/conex-nocrypto/conex-nocrypto.0.10.1/opam
+++ b/packages/conex-nocrypto/conex-nocrypto.0.10.1/opam
@@ -17,7 +17,7 @@ depends: [
   "alcotest" {with-test}
   "cmdliner"
   "conex" {>= "0.10.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & <"5.0.0"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.4.0"}
   "logs"


### PR DESCRIPTION
cc @hannesm