### PR TITLE
[new release] ppx_enum (0.0.1)

### DIFF
--- a/packages/ppx_enum/ppx_enum.0.0.1/opam
+++ b/packages/ppx_enum/ppx_enum.0.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+homepage: "https://github.com/cryptosense/ppx_enum"
+bug-reports: "https://github.com/cryptosense/ppx_enum/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/ppx_enum.git"
+doc: "https://cryptosense.github.io/ppx_enum/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.07.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppxlib" {>= "0.3.0"}
+  "ppx_deriving" {with-test}
+]
+tags: ["org:cryptosense"]
+synopsis: "PPX to derive enum-like modules from variant type definitions"
+description: """
+This PPX derives simple enum-like modules from variant type definitions.
+"""
+authors: "James Owen <jamesowen@outlook.com>"
+url {
+  src:
+    "https://github.com/cryptosense/ppx_enum/releases/download/v0.0.1/ppx_enum-v0.0.1.tbz"
+  checksum: [
+    "sha256=6b66dce35a75e9b521dabcb04b895406e8547be3ef0f2dd2f5b66917502a7e5f"
+    "sha512=f033cc988251b05f2400b4544b5cbf63bac60a81ba83bf51459054e602473942d59dad5489a6207681399fff4444265452812f50b17c53171f7405bb3aae9954"
+  ]
+}


### PR DESCRIPTION
PPX to derive enum-like modules from variant type definitions

- Project page: <a href="https://github.com/cryptosense/ppx_enum">https://github.com/cryptosense/ppx_enum</a>
- Documentation: <a href="https://cryptosense.github.io/ppx_enum/doc">https://cryptosense.github.io/ppx_enum/doc</a>

##### CHANGES:

*2019-05-27*

- Initial release
