### PR TITLE
constrain older mirage-block-xen to older mirage-xen

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.0.3.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.0.3.1/opam
@@ -28,7 +28,7 @@ depends: [
   "shared-memory-ring" {>= "0.4.1"}
   "mirage-types" {= "0.3.0"}
   "io-page-xen" {>= "0.9.9"}
-  "mirage-xen" {>= "0.9.9"}
+  "mirage-xen" {>= "0.9.9" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.0.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.0.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "shared-memory-ring" {>= "0.4.1"}
   "mirage-types" {>= "0.4.0" & < "1.1.0"}
   "io-page-xen" {>= "0.9.9"}
-  "mirage-xen" {>= "0.9.9"}
+  "mirage-xen" {>= "0.9.9" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.1.0.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "shared-memory-ring" {>= "0.4.1"}
   "mirage-types" {>= "0.5.0" & < "1.1.0"}
   "io-page-xen" {>= "0.9.9"}
-  "mirage-xen" {>= "0.9.9"}
+  "mirage-xen" {>= "0.9.9" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.1.1.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-types" {>= "1.1.0" & <= "2.2.0"}
   "ipaddr"
   "io-page" {>= "1.0.0" & < "1.3.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.1.2.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-types" {>= "1.1.0" & <= "2.2.0"}
   "ipaddr"
   "io-page" {>= "1.0.0" & < "1.3.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.1.3.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-types" {>= "1.1.0" & <= "2.2.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.1.3.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.3.1/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & < "3.3.0"}
 ]
 available: os = "linux"
 synopsis:

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "rresult"
 ]
 available: os = "linux"

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
@@ -35,7 +35,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"
   "io-page" {>= "1.4.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "rresult"
 ]
 synopsis:

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
@@ -35,7 +35,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & <"3.3.0"}
   "rresult"
 ]
 synopsis:

--- a/packages/mirage-block-xen/mirage-block-xen.1.6.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "1.0.1"}
+  "mirage-xen" {>= "1.0.1" & <"3.3.0"}
   "rresult"
 ]
 build: [


### PR DESCRIPTION
this stops them picking up the mirage-xen with the ocaml-gnt
deprecation

failure noted in revdeps for #14001