### PR TITLE
[new release] pcap-format (0.5.2)

### DIFF
--- a/packages/pcap-format/pcap-format.0.5.2/opam
+++ b/packages/pcap-format/pcap-format.0.5.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Dave Scott <dave@recoil.org>"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Richard Mortier"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-pcap"
+doc: "https://mirage.github.io/ocaml-pcap/"
+bug-reports: "https://github.com/mirage/ocaml-pcap/issues"
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune" {build & >= "1.0"}
+  "ppx_tools"
+  "cstruct" {>= "1.9.0"}
+  "ppx_cstruct"
+  "ounit" {with-test}
+  "mmap" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-pcap.git"
+synopsis: "Decode and encode PCAP (packet capture) files"
+description: """
+pcap-format provides an interface to encode and decode pcap files, dealing with
+both endianess, including endianess detection.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-pcap/releases/download/0.5.2/pcap-format-0.5.2.tbz"
+  checksum: [
+    "sha256=2e8cba93c4ea4497bc106a4f8396d7818b2684eae039c0a20ce47bfadecd8591"
+    "sha512=913b71f980126cc1e0ef18ab92eaaebc47adb7ef46dba8d0095f43b328d9dcc9ba7d63512c885f48664fe0397b5ea05e675300f175091c82788acd2d79b1fe25"
+  ]
+}


### PR DESCRIPTION
Decode and encode PCAP (packet capture) files

- Project page: <a href="https://github.com/mirage/ocaml-pcap">https://github.com/mirage/ocaml-pcap</a>
- Documentation: <a href="https://mirage.github.io/ocaml-pcap/">https://mirage.github.io/ocaml-pcap/</a>

##### CHANGES:

* port to dune (@avsm)
* upgrade metadata to opam 2.0 (@avsm)
* test on OCaml 4.07 (@avsm)
