### PR TITLE
added packages/lz4_chans/lz4_chans.2.0.0

### DIFF
--- a/packages/lz4_chans/lz4_chans.2.0.0/opam
+++ b/packages/lz4_chans/lz4_chans.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/lz4-chans"
+bug-reports: "https://github.com/UnixJunkie/lz4-chans/issues"
+dev-repo: "git+https://github.com/UnixJunkie/lz4-chans.git"
+license: "BSD-3"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "base-unix"
+  "dolog"
+  "dune" {build}
+]
+depexts: [
+  ["liblz4-tool"] {os-distribution = "debian"}
+  ["liblz4-tool"] {os-distribution = "ubuntu"}
+  ["lz4"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "LZ4-compressed binary channels"
+description: """
+Open/close binary channels, with LZ4-compression happening in the background,
+using a separate process and a named pipe.
+"""
+url {
+  src: "https://github.com/UnixJunkie/lz4-chans/archive/v2.0.0.tar.gz"
+  checksum: "md5=a59b549d999a6c249bdbb96480eeeb88"
+}


### PR DESCRIPTION
protect against arbitrary command injection.
Now, only very strict filenames are accepted.
They have to match the following regexp: "^[a-zA-Z0-9._/-]+$"