### PR TITLE
ppxlib.0.5.0: not compatible with compiler 4.08

### DIFF
--- a/packages/ppxlib/ppxlib.0.5.0/opam
+++ b/packages/ppxlib/ppxlib.0.5.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.08.0"}
   "base"                    {>= "v0.11.0" & < "v0.13"}
   "dune"                    {build}
   "ocaml-compiler-libs"     {>= "v0.11.0"}


### PR DESCRIPTION
Compilation under 4.08 compiler triggers many errors, among others this one:
```
File "ast/syntaxerr.ml", line 37, characters 10-93:
37 | ..........Location.errorf ~loc:opening_loc
38 |             "This '%s' might be unmatched" opening
Error: This expression has type Location/1.report
       but an expression was expected of type
         Location/2.msg = (Format.formatter -> unit) Location/1.loc
```
There used to be a type `Location.error` which has apparently been refined in two types `msg` and `report`. So I guess it's safe to say that this version of ppxlib is not compatible with 4.08.