### PR TITLE
Package ppx_bsx.2.0.0

### DIFF
--- a/packages/ppx_bsx/ppx_bsx.2.0.0/opam
+++ b/packages/ppx_bsx/ppx_bsx.2.0.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+
+synopsis: "ReasonReact JSX for OCaml"
+description: """
+ReasonReact JSX v3 for OCaml, ReasonReact 0.7+ and BuckleScript 6.x required
+"""
+maintainer: "CHEN Xian-an <xianan.chen@gmail.com>"
+authors: "CHEN Xian-an <xianan.chen@gmail.com>"
+tags: [ "BuckleScript" "ReasonReact" "React" "JSX" ]
+license: "MIT"
+homepage: "https://github.com/cxa/ppx_bsx"
+dev-repo: "git+https://github.com/cxa/ppx_bsx.git"
+bug-reports: "https://github.com/cxa/ppx_bsx/issues"
+doc: "https://github.com/cxa/ppx_bsx"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+]


### PR DESCRIPTION
### `ppx_bsx.2.0.0`
ReasonReact JSX for OCaml
ReasonReact JSX v3 for OCaml, ReasonReact 0.7+ and BuckleScript 6.x required



---
* Homepage: https://github.com/cxa/ppx_bsx
* Source repo: git+https://github.com/cxa/ppx_bsx.git
* Bug tracker: https://github.com/cxa/ppx_bsx/issues

---
:camel: Pull-request generated by opam-publish v2.0.0