### PR TITLE
Package ppx_bsx.2.0.0

### DIFF
--- a/packages/ppx_bsx/ppx_bsx.2.0.0/opam
+++ b/packages/ppx_bsx/ppx_bsx.2.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" { = "4.06.1" }
   "markup"
   "ppxlib"
-  "dune" {build}
+  "dune" {build & >= "1.9"}
 ]
 url {
   src: "https://github.com/cxa/ppx_bsx/archive/2.0.0.tar.gz"

--- a/packages/ppx_bsx/ppx_bsx.2.0.0/opam
+++ b/packages/ppx_bsx/ppx_bsx.2.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+
+synopsis: "ReasonReact JSX for OCaml"
+description: """
+ReasonReact JSX v3 for OCaml, ReasonReact 0.7+ and BuckleScript 6.0+ required
+"""
+maintainer: "CHEN Xian-an <xianan.chen@gmail.com>"
+authors: "CHEN Xian-an <xianan.chen@gmail.com>"
+tags: [ "BuckleScript" "ReasonReact" "React" "JSX" ]
+license: "MIT"
+homepage: "https://github.com/cxa/ppx_bsx"
+dev-repo: "git+https://github.com/cxa/ppx_bsx.git"
+bug-reports: "https://github.com/cxa/ppx_bsx/issues"
+doc: "https://github.com/cxa/ppx_bsx"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { = "4.06.1" }
+  "markup"
+  "ppxlib"
+  "dune" {build}
+]
+url {
+  src: "https://github.com/cxa/ppx_bsx/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=33fdc21684128f6c3570d562d8335918"
+    "sha512=3a05e061835e3df1ffba8a728c73aa4bcb5d1e6cbe3f8bdd9357f6e8a0ba796c2bff3bc95cba4da4014325dabf3fdb97323049f22362dbeaf61356206bd3cd37"
+  ]
+}


### PR DESCRIPTION
### `ppx_bsx.2.0.0`
ReasonReact JSX for OCaml
ReasonReact JSX v3 for OCaml, ReasonReact 0.7+ and BuckleScript 6.0+ required



---
* Homepage: https://github.com/cxa/ppx_bsx
* Source repo: git+https://github.com/cxa/ppx_bsx.git
* Bug tracker: https://github.com/cxa/ppx_bsx/issues

---
:camel: Pull-request generated by opam-publish v2.0.0