### PR TITLE
craml: add bound on fmt

### DIFF
--- a/packages/craml/craml.1.0.0/opam
+++ b/packages/craml/craml.1.0.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "astring"
   "logs"
   "cmdliner"


### PR DESCRIPTION
`craml` doesn't compile with older versions of `fmt`.
