### PR TITLE
fix some bounds on faraday packages

### DIFF
--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.4.0/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "faraday" {>= "0.3.0" & < "0.5.0"}
   "faraday-lwt"
-  "lwt"
+  "lwt" {< "4.0.0"}
   "base-unix"
 ]
 synopsis: "Faraday - Lwt- and Unix-specific support"

--- a/packages/faraday-lwt/faraday-lwt.0.5.1/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.5.1/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "faraday" {>= "0.3.0"}
+  "faraday" {>= "0.5.0"}
   "lwt"
 ]
 synopsis: "Faraday - Lwt-specific support"


### PR DESCRIPTION
* `faraday-lwt-unix.0.4.0` doesn't compile with recent versions of `lwt`
* `faraday-lwt.0.5.1` needs at least `faraday.0.5.0` (and not 0.3.0).

cc @seliopou 
