### PR TITLE
labltk: add bound on OCaml version

### DIFF
--- a/packages/labltk/labltk.8.06.5/opam
+++ b/packages/labltk/labltk.8.06.5/opam
@@ -15,7 +15,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "labltk"]]
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "4.08"}
   "ocamlfind"
   "conf-tcl"
   "conf-tk"


### PR DESCRIPTION
`labltk` doesn't compile on 4.08 because of the changes to configure.

reported upstream at https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1768&group_id=343&atid=1351

cc @garrigue @shindere
