### PR TITLE
Add an upper bounds to ppxlib reverse dependencies

### DIFF
--- a/packages/base_quickcheck/base_quickcheck.v0.12.0/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.12.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_sexp_message"  {>= "v0.12" & < "v0.13"}
   "splittable_random" {>= "v0.12" & < "v0.13"}
   "dune"              {build & >= "1.5.1"}
-  "ppxlib"            {>= "0.5.0"}
+  "ppxlib"            {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Randomized testing framework, designed for compatibility with Base"
 description: "

--- a/packages/cconv-ppx/cconv-ppx.0.5/opam
+++ b/packages/cconv-ppx/cconv-ppx.0.5/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
   "cconv"
   "ppx_deriving" {>= "2.0"}
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
   "cppo" {build}
   "ppx_tools" {build}
   "ppxfind" {build}

--- a/packages/core/core.v0.11.1/opam
+++ b/packages/core/core.v0.11.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base-threads"
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Industrial strength alternative to OCaml's standard library"
 description: """

--- a/packages/core/core.v0.11.2/opam
+++ b/packages/core/core.v0.11.2/opam
@@ -21,7 +21,7 @@ depends: [
   "base-threads"
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Industrial strength alternative to OCaml's standard library"
 description: """

--- a/packages/core/core.v0.11.3/opam
+++ b/packages/core/core.v0.11.3/opam
@@ -21,7 +21,7 @@ depends: [
   "base-threads"
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Industrial strength alternative to OCaml's standard library"
 description: """

--- a/packages/fieldslib/fieldslib.v0.11.0/opam
+++ b/packages/fieldslib/fieldslib.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis:
   "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values"

--- a/packages/frenetic/frenetic.5.0.3/opam
+++ b/packages/frenetic/frenetic.5.0.3/opam
@@ -27,7 +27,7 @@ depends: [
   "menhir" {build & <= "20181026"}
   "mparser"
   "ocamlgraph" {>= "1.8.7"}
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
   "ppx_compare" {< "v0.13"}
   "ppx_cstruct" {<"3.4.0"}
   "ppx_deriving" {>= "4.2"}

--- a/packages/hack_parallel/hack_parallel.0.1.1/opam
+++ b/packages/hack_parallel/hack_parallel.0.1.1/opam
@@ -13,7 +13,7 @@ depends: [
   "core"
   "ocaml" {>= "4.03.0"}
   "ppx_deriving"
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
   "sexplib"
 ]
 synopsis: "Parallel and shared memory library"

--- a/packages/lablqml/lablqml.0.6/opam
+++ b/packages/lablqml/lablqml.0.6/opam
@@ -28,7 +28,7 @@ depends: [
   "dune" {build}
   "configurator" {build & < "v0.13"}
   "conf-qt" {>= "5.2.1"}
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
   "conf-pkg-config" {build}
 ]
 synopsis:

--- a/packages/let-if/let-if.0.1.0/opam
+++ b/packages/let-if/let-if.0.1.0/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
 ]
 synopsis: "This ppx brings a `let%if` construct similar Rust's `if let`."
 description: """

--- a/packages/mlt_parser/mlt_parser.v0.12.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_expect"  {>= "v0.12" & < "v0.13"}
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
   "dune"        {build & >= "1.5.1"}
-  "ppxlib"      {>= "0.5.0"}
+  "ppxlib"      {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Parsing of top-expect files"
 description: "

--- a/packages/noise/noise.0.1.0/opam
+++ b/packages/noise/noise.0.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson" {with-test}
   "ppx_let" {< "v0.13"}
-  "ppxlib" {build}
+  "ppxlib" {build & < "0.9.0"}
 ]
 conflicts: [
   "eqaf" {= "0.3"}

--- a/packages/noise/noise.0.2.0/opam
+++ b/packages/noise/noise.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson" {with-test}
   "ppx_let" {< "v0.13"}
-  "ppxlib" {build}
+  "ppxlib" {build & < "0.9.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ocamlapi_ppx/ocamlapi_ppx.0.0.2/opam
+++ b/packages/ocamlapi_ppx/ocamlapi_ppx.0.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {build}
   "ocamlapi"
   "core"
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
 ]
 url {
 archive: "https://github.com/nosman/Ocamlapi/archive/0.0.2.tar.gz"

--- a/packages/parsexp_io/parsexp_io.v0.11.0/opam
+++ b/packages/parsexp_io/parsexp_io.v0.11.0/opam
@@ -16,7 +16,7 @@ depends: [
   "stdio" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "S-expression parsing library (IO functions)"
 description:

--- a/packages/pattern/pattern.0.1.0/opam
+++ b/packages/pattern/pattern.0.1.0/opam
@@ -9,7 +9,7 @@ license: "BSD"
 dev-repo: "git+https://gitlab.inria.fr/tmartine/pattern.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "dune" {>= "1.9.1"} "ppxlib" "stdcompat" "ppx_deriving"
+  "dune" {>= "1.9.1"} "ppxlib" {< "0.9.0"} "stdcompat" "ppx_deriving"
   "ocaml" {>= "4.04.1" & < "4.08.0"}] # no ppxlib for OCaml <4.04.1
 url {
   src: "https://gitlab.inria.fr/tmartine/pattern/-/archive/0.1.0/pattern-0.1.0.tar.gz"

--- a/packages/ppx_assert/ppx_assert.v0.11.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.11.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Assert-like extension nodes that raise useful errors on failure"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_assert/ppx_assert.v0.12.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_here"      {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0"}
+  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Assert-like extension nodes that raise useful errors on failure"
 description: "

--- a/packages/ppx_base/ppx_base.v0.11.0/opam
+++ b/packages/ppx_base/ppx_base.v0.11.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Base set of ppx rewriters"
 description: """

--- a/packages/ppx_base/ppx_base.v0.12.0/opam
+++ b/packages/ppx_base/ppx_base.v0.12.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_js_style"  {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0"}
+  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Base set of ppx rewriters"
 description: "

--- a/packages/ppx_bench/ppx_bench.v0.11.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ppx_inline_test" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_bench/ppx_bench.v0.12.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"           {>= "4.04.2"}
   "ppx_inline_test" {>= "v0.12" & < "v0.13"}
   "dune"            {build & >= "1.5.1"}
-  "ppxlib"          {>= "0.5.0"}
+  "ppxlib"          {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
 description: "

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.11.1/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.11.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_here" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis: "Generation of bin_prot readers and writers from types"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_compare/ppx_compare.v0.11.1/opam
+++ b/packages/ppx_compare/ppx_compare.v0.11.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis: "Generation of comparison functions from types"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_compare/ppx_compare.v0.12.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generation of comparison functions from types"
 description: "

--- a/packages/ppx_conv_func/ppx_conv_func.v0.11.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Deprecated"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_conv_func/ppx_conv_func.v0.12.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.07.0"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Deprecated"
 description: "

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.11.1/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.11.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis: "Generate functions to read/write records in csv format"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.12.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_conv_func"   {>= "v0.12" & < "v0.13"}
   "ppx_fields_conv" {>= "v0.12" & < "v0.13"}
   "dune"            {build & >= "1.5.1"}
-  "ppxlib"          {>= "0.5.0"}
+  "ppxlib"          {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generate functions to read/write records in csv format"
 description: "

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.11.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Printf-style format-strings for user-defined string conversion"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.12.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"          {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0"}
+  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Printf-style format-strings for user-defined string conversion"
 description: "

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.12.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_jane"      {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0"}
+  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Rewrite OCaml records for use as Hardcaml Interfaces"
 description: "

--- a/packages/ppx_enum/ppx_enum.0.0.1/opam
+++ b/packages/ppx_enum/ppx_enum.0.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {build}
   "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "ppx_deriving" {with-test}
 ]
 tags: ["org:cryptosense"]

--- a/packages/ppx_enumerate/ppx_enumerate.v0.11.1/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.11.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis: "Generate a list containing all values of a finite type"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_enumerate/ppx_enumerate.v0.12.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generate a list containing all values of a finite type"
 description: "

--- a/packages/ppx_expect/ppx_expect.v0.11.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.11.0/opam
@@ -23,7 +23,7 @@ depends: [
   "stdio" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
   "re" {>= "1.5.0"}
 ]
 synopsis: "Cram like framework for OCaml"

--- a/packages/ppx_expect/ppx_expect.v0.11.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.11.1/opam
@@ -22,7 +22,7 @@ depends: [
   "stdio"                   {>= "v0.11" & < "v0.12"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib"                  {>= "0.1.0"}
+  "ppxlib"                  {>= "0.1.0" & < "0.9.0"}
   "re"                      {>= "1.5.0"}
   "ocaml"                   {>= "4.04.1"}
 ]

--- a/packages/ppx_expect/ppx_expect.v0.12.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.12.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_variants_conv" {>= "v0.12" & < "v0.13"}
   "stdio"             {>= "v0.12" & < "v0.13"}
   "dune"              {build & >= "1.5.1"}
-  "ppxlib"            {>= "0.5.0"}
+  "ppxlib"            {>= "0.5.0" & < "0.9.0"}
   "re"                {>= "1.8.0"}
 ]
 synopsis: "Cram like framework for OCaml"

--- a/packages/ppx_factory/ppx_factory.0.0.0/opam
+++ b/packages/ppx_factory/ppx_factory.0.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {build}
   "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "ppx_deriving" {with-test}
 ]
 tags: ["org:cryptosense"]

--- a/packages/ppx_fail/ppx_fail.v0.11.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_here" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Add location to calls to failwiths"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_fail/ppx_fail.v0.12.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.12" & < "v0.13"}
   "ppx_here" {>= "v0.12" & < "v0.13"}
   "dune"     {build & >= "1.5.1"}
-  "ppxlib"   {>= "0.5.0"}
+  "ppxlib"   {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Add location to calls to failwiths"
 description: "

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.11.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "fieldslib" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml records"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.12.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"      {>= "v0.12" & < "v0.13"}
   "fieldslib" {>= "v0.12" & < "v0.13"}
   "dune"      {build & >= "1.5.1"}
-  "ppxlib"    {>= "0.5.0"}
+  "ppxlib"    {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml records"
 description: "

--- a/packages/ppx_hash/ppx_hash.v0.11.1/opam
+++ b/packages/ppx_hash/ppx_hash.v0.11.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis:
   "A ppx rewriter that generates hash functions from type expressions and definitions"

--- a/packages/ppx_hash/ppx_hash.v0.12.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_compare"   {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0"}
+  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "A ppx rewriter that generates hash functions from type expressions and definitions"
 description: "

--- a/packages/ppx_here/ppx_here.v0.11.0/opam
+++ b/packages/ppx_here/ppx_here.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Expands [%here] into its location"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_here/ppx_here.v0.12.0/opam
+++ b/packages/ppx_here/ppx_here.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Expands [%here] into its location"
 description: "

--- a/packages/ppx_import/ppx_import.1.5-3-gbd627d5/opam
+++ b/packages/ppx_import/ppx_import.1.5-3-gbd627d5/opam
@@ -14,7 +14,7 @@ tags: [ "syntax" ]
 depends: [
   "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
   "dune"                    { build &      >= "1.2.0"  }
-  "ppxlib"                  {              >= "0.3.1"  }
+  "ppxlib"                  {              >= "0.3.1"  & < "0.9.0"}
   "ppx_tools_versioned"     {              >= "5.2.1"  }
   "ocaml-migrate-parsetree" {              >= "1.1.0"  }
   "ounit"                   { with-test                }

--- a/packages/ppx_import/ppx_import.1.6.1/opam
+++ b/packages/ppx_import/ppx_import.1.6.1/opam
@@ -14,7 +14,7 @@ tags: [ "syntax" ]
 depends: [
   "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
   "dune"                    { build &      >= "1.2.0"  }
-  "ppxlib"                  {              >= "0.3.1"  }
+  "ppxlib"                  {              >= "0.3.1"  & < "0.9.0"}
   "ppx_tools_versioned"     {              >= "5.2.1"  }
   "ocaml-migrate-parsetree" {              >= "1.1.0"  }
   "ounit"                   { with-test                }

--- a/packages/ppx_import/ppx_import.1.6/opam
+++ b/packages/ppx_import/ppx_import.1.6/opam
@@ -14,7 +14,7 @@ tags: [ "syntax" ]
 depends: [
   "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
   "dune"                    { build &      >= "1.2.0"  }
-  "ppxlib"                  {              >= "0.3.1"  }
+  "ppxlib"                  {              >= "0.3.1"  & < "0.9.0"}
   "ppx_tools_versioned"     {              >= "5.2.1"  }
   "ocaml-migrate-parsetree" {              >= "1.1.0"  }
   "ounit"                   { with-test                }

--- a/packages/ppx_inline_test/ppx_inline_test.v0.11.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.11.0/opam
@@ -13,7 +13,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_inline_test/ppx_inline_test.v0.12.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "

--- a/packages/ppx_jane/ppx_jane.v0.11.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.11.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_variants_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Standard Jane Street ppx rewriters"
 description: """

--- a/packages/ppx_jane/ppx_jane.v0.12.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.12.0/opam
@@ -33,7 +33,7 @@ depends: [
   "ppx_typerep_conv"  {>= "v0.12" & < "v0.13"}
   "ppx_variants_conv" {>= "v0.12" & < "v0.13"}
   "dune"              {build & >= "1.5.1"}
-  "ppxlib"            {>= "0.5.0"}
+  "ppxlib"            {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Standard Jane Street ppx rewriters"
 description: "

--- a/packages/ppx_js_style/ppx_js_style.v0.11.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
   "octavius"
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Code style checker for Jane Street Packages"
 description: """

--- a/packages/ppx_js_style/ppx_js_style.v0.12.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.12" & < "v0.13"}
   "dune"     {build & >= "1.5.1"}
   "octavius"
-  "ppxlib"   {>= "0.5.0"}
+  "ppxlib"   {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Code style checker for Jane Street Packages"
 description: "

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.6.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.6.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "js_of_ocaml" {>= "2.8"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
   "ocaml-migrate-parsetree" {>= "0.4"}
   "dune" {build & >= "1.0"}
   "webtest" {with-test}

--- a/packages/ppx_let/ppx_let.v0.11.0/opam
+++ b/packages/ppx_let/ppx_let.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Monadic let-bindings"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_let/ppx_let.v0.12.0/opam
+++ b/packages/ppx_let/ppx_let.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Monadic let-bindings"
 description: "

--- a/packages/ppx_module_timer/ppx_module_timer.v0.12.0/opam
+++ b/packages/ppx_module_timer/ppx_module_timer.v0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "stdio"    {>= "v0.12" & < "v0.13"}
   "time_now" {>= "v0.12" & < "v0.13"}
   "dune"     {build & >= "1.5.1"}
-  "ppxlib"   {>= "0.5.0"}
+  "ppxlib"   {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Ppx rewriter that records top-level module startup times"
 description: "

--- a/packages/ppx_optcomp/ppx_optcomp.v0.11.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "stdio" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_optcomp/ppx_optcomp.v0.12.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"   {>= "v0.12" & < "v0.13"}
   "stdio"  {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "

--- a/packages/ppx_optional/ppx_optional.v0.11.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Pattern matching on flat options"
 description: """

--- a/packages/ppx_optional/ppx_optional.v0.12.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Pattern matching on flat options"
 description: "

--- a/packages/ppx_pipebang/ppx_pipebang.v0.11.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.11.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis:
   "A ppx rewriter that inlines reverse application operators `|>` and `|!`"

--- a/packages/ppx_pipebang/ppx_pipebang.v0.12.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.12.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"  {>= "4.04.2"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "A ppx rewriter that inlines reverse application operators `|>` and `|!`"
 description: "

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_driver"
   "ppx_core"
   "dune" {build}
-  "ppxlib" {build}
+  "ppxlib" {build & < "0.9.0"}
   "ppx_sexp_conv" {with-test & < "v0.13"}
   "sexplib" {with-test & < "v0.13"}
   "ounit" {with-test}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.1/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_driver"
   "ppx_core"
   "dune" {build}
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
   "ppx_sexp_conv" {with-test & < "v0.13"}
   "sexplib" {with-test & < "v0.13"}
   "ounit" {with-test}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.3/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.3.1.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "base" {< "v0.13"}
   "dune" {build}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "ppx_sexp_conv" {with-test & < "v0.13"}
   "sexplib" {with-test & < "v0.13"}
   "ounit" {with-test}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.4.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.4.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "base" {< "v0.12"}
   "dune" {build}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "ppx_sexp_conv" {with-test & < "v0.12"}
   "sexplib" {with-test & < "v0.12"}
   "ounit" {with-test}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "base" {< "v0.13"}
   "dune" {build & >= "1.2"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "ppx_sexp_conv" {with-test & < "v0.13"}
   "sexplib" {with-test & < "v0.13"}
   "alcotest" {with-test & >= "0.8.0"}

--- a/packages/ppx_relit/ppx_relit.0.1/opam
+++ b/packages/ppx_relit/ppx_relit.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml-migrate-parsetree" {= "1.0.11"}
   "relit-reason"
   "base64" {< "3.0.0"}
-  "ppxlib" {= "0.3.0"}
+  "ppxlib" {= "0.3.0" & < "0.9.0"}
   "base-unix"
   "ocamlbuild" {with-test}
   "ocaml" {>= "4.06.0" & < "4.07.0"}

--- a/packages/ppx_relit/ppx_relit.0.2.0/opam
+++ b/packages/ppx_relit/ppx_relit.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "relit-reason"
   "base64" {< "3.0.0"}
   "extlib"
-  "ppxlib" {>= "0.3.1"}
+  "ppxlib" {>= "0.3.1" & < "0.9.0"}
   "base-unix"
   "ppx_expect" {with-test & < "v0.13"}
   "ocaml" {>= "4.07.0" & < "4.08.0"}

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.2/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.2/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis:
   "Generation of S-expression conversion functions from type definitions"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.12.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.12" & < "v0.13"}
   "sexplib0" {>= "v0.12" & < "v0.13"}
   "dune"     {build & >= "1.5.1"}
-  "ppxlib"   {>= "0.5.0"}
+  "ppxlib"   {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.11.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "A ppx rewriter for easy construction of s-expressions"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.12.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_here"      {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0"}
+  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "A ppx rewriter for easy construction of s-expressions"
 description: "

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.11.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis:
   "A ppx rewriter that simplifies building s-expressions from ocaml values"

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.12.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_here"      {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0"}
+  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "A ppx rewriter that simplifies building s-expressions from ocaml values"
 description: "

--- a/packages/ppx_stable/ppx_stable.v0.12.0/opam
+++ b/packages/ppx_stable/ppx_stable.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.12" & < "v0.13"}
   "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.5.0"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Stable types conversions generator"
 description: "

--- a/packages/ppx_there/ppx_there.0.0.0/opam
+++ b/packages/ppx_there/ppx_there.0.0.0/opam
@@ -14,7 +14,7 @@ run-test: [
 depends: [
   "dune" {build}
   "ocaml" {>= "4.04.2"}
-  "ppxlib" {>= "0.6.0"}
+  "ppxlib" {>= "0.6.0" & < "0.9.0"}
 ]
 synopsis: "PPX extension for improved __MODULE__"
 description: """

--- a/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.1"}
   "jbuilder" {build & >= "1.0+beta18.1"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Deprecated: use ppxlib instead"
 url {

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.1/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.1/opam
@@ -14,7 +14,7 @@ depends: [
   "typerep" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis: "Generation of runtime types from type declarations"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.12.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"    {>= "v0.12" & < "v0.13"}
   "typerep" {>= "v0.12" & < "v0.13"}
   "dune"    {build & >= "1.5.1"}
-  "ppxlib"  {>= "0.5.0"}
+  "ppxlib"  {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generation of runtime types from type declarations"
 description: "

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.11.1/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.11.1/opam
@@ -14,7 +14,7 @@ depends: [
   "variantslib" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
 ]
 synopsis:
   "Generation of accessor and iteration functions for ocaml variant types"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.12.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"        {>= "v0.12" & < "v0.13"}
   "variantslib" {>= "v0.12" & < "v0.13"}
   "dune"        {build & >= "1.5.1"}
-  "ppxlib"      {>= "0.5.0"}
+  "ppxlib"      {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.11.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.11.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Generate XML conversion functions from records"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.12.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_conv_func"   {>= "v0.12" & < "v0.13"}
   "ppx_fields_conv" {>= "v0.12" & < "v0.13"}
   "dune"            {build & >= "1.5.1"}
-  "ppxlib"          {>= "0.5.0"}
+  "ppxlib"          {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generate XML conversion functions from records"
 description: "

--- a/packages/ppx_yojson/ppx_yojson.0.1.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {build}
   "ocaml" {>= "4.04.2"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "yojson" {with-test}
 ]
 description: """

--- a/packages/ppx_yojson/ppx_yojson.0.2.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.0.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {build}
   "ocaml" {>= "4.04.2"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "ppx_deriving" {with-test}
   "yojson" {with-test}
 ]

--- a/packages/relit_helper/relit_helper.0.1/opam
+++ b/packages/relit_helper/relit_helper.0.1/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"
   "extlib"
-  "ppxlib" {= "0.3.0"}
+  "ppxlib" {= "0.3.0" & < "0.9.0"}
   "ocaml-migrate-parsetree" {= "1.0.11"}
   "base64" {< "3.0.0"}
   "relit-reason"

--- a/packages/relit_helper/relit_helper.0.2.0/opam
+++ b/packages/relit_helper/relit_helper.0.2.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "dune" {build}
   "extlib"
-  "ppxlib" {>= "0.3.1"}
+  "ppxlib" {>= "0.3.1" & < "0.9.0"}
   "ocaml-migrate-parsetree"
   "base64" {< "3.0.0"}
   "relit-reason"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune"                {build & >= "1.5.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocamlfind"           {>= "1.7.2"}
-  "ppxlib"              {>= "0.5.0"}
+  "ppxlib"              {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Expectation tests for the OCaml toplevel"
 description: "

--- a/packages/variantslib/variantslib.v0.11.0/opam
+++ b/packages/variantslib/variantslib.v0.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-migrate-parsetree" {>= "1.0"}
-  "ppxlib" {>= "0.1.0"}
+  "ppxlib" {>= "0.1.0" & < "0.9.0"}
 ]
 synopsis: "Part of Jane Street's Core library"
 description: """


### PR DESCRIPTION
The next release of ppxlib (0.9.0) will change the selected
AST from 4.07 to 4.08. It will hence break *a lot* of code.

This pull request adds an upper bounds to all reverse
dependencies, so that the next version can be released
safely.