### PR TITLE
v0.12.x release of Jane Street packages, with support for OCaml 4.08

### DIFF
--- a/packages/core/core.v0.12.1/opam
+++ b/packages/core/core.v0.12.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"        {>= "4.07.0" & "4.08.0"}
+  "ocaml"        {>= "4.07.0" & < "4.08.0"}
   "jst-config"   {>= "v0.12" & < "v0.13"}
   "core_kernel"  {>= "v0.12" & < "v0.13"}
   "ppx_jane"     {>= "v0.12" & < "v0.13"}

--- a/packages/core/core.v0.12.2/opam
+++ b/packages/core/core.v0.12.2/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"        {>= "4.07.0" & "4.08.0"}
+  "ocaml"        {>= "4.07.0"}
   "jst-config"   {>= "v0.12" & < "v0.13"}
   "core_kernel"  {>= "v0.12" & < "v0.13"}
   "ppx_jane"     {>= "v0.12" & < "v0.13"}
@@ -28,6 +28,6 @@ largest industrial user of OCaml.
 depexts: ["linux-headers"] {os-distribution = "alpine"}
 url {
   src:
-    "https://github.com/janestreet/core/releases/download/v0.12.1/core-v0.12.1.tbz"
-  checksum: "md5=3a1b7e7324b9884768eb1f85a3d49ad6"
+    "https://github.com/janestreet/core/archive/v0.12.2.tar.gz"
+  checksum: "md5=c521d9ae441683154b0008146c112ff4"
 }

--- a/packages/core_kernel/core_kernel.v0.12.0/opam
+++ b/packages/core_kernel/core_kernel.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.07.0" & "4.08.0"}
+  "ocaml"               {>= "4.07.0" & < "4.08.0"}
   "base"                {>= "v0.12" & < "v0.13"}
   "base_bigstring"      {>= "v0.12" & < "v0.13"}
   "base_quickcheck"     {>= "v0.12" & < "v0.13"}

--- a/packages/core_kernel/core_kernel.v0.12.1/opam
+++ b/packages/core_kernel/core_kernel.v0.12.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.07.0" & "4.08.0"}
+  "ocaml"               {>= "4.07.0"}
   "base"                {>= "v0.12" & < "v0.13"}
   "base_bigstring"      {>= "v0.12" & < "v0.13"}
   "base_quickcheck"     {>= "v0.12" & < "v0.13"}
@@ -42,6 +42,6 @@ largest industrial user of OCaml.
 Core_kernel is the system-independent part of Core.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/core_kernel-v0.12.0.tar.gz"
-  checksum: "md5=e7adb97d39a93ccd542b9d015659c480"
+  src: "https://github.com/janestreet/core_kernel/archive/v0.12.1.tar.gz"
+  checksum: "md5=c3a613bf3f87d79faf1a77aaa256a9ff"
 }

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.12.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"    {>= "4.04.2" & "4.08.0"}
+  "ocaml"    {>= "4.04.2" & < "4.08.0"}
   "base"     {>= "v0.12" & < "v0.13"}
   "bin_prot" {>= "v0.12" & < "v0.13"}
   "ppx_here" {>= "v0.12" & < "v0.13"}

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.12.1/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.12.1/opam
@@ -10,18 +10,18 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"    {>= "4.04.2" & "4.08.0"}
+  "ocaml"    {>= "4.04.2"}
   "base"     {>= "v0.12" & < "v0.13"}
   "bin_prot" {>= "v0.12" & < "v0.13"}
   "ppx_here" {>= "v0.12" & < "v0.13"}
   "dune"     {build & >= "1.5.1"}
-  "ppxlib"   {>= "0.5.0" & < "0.6.0"}
+  "ppxlib"   {>= "0.7.0" & < "0.9.0"}
 ]
 synopsis: "Generation of bin_prot readers and writers from types"
 description: "
 Part of the Jane Street's PPX rewriters collection.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_bin_prot-v0.12.0.tar.gz"
-  checksum: "md5=5951c22a0d813b5e0a12895a3cd07504"
+  src: "https://github.com/janestreet/ppx_bin_prot/archive/v0.12.1.tar.gz"
+  checksum: "md5=3c0891268b1007eb1f0ce6b63ce10215"
 }

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.12.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"         {>= "4.04.2" & "4.08.0"}
+  "ocaml"         {>= "4.04.2" & < "4.08.0"}
   "base"          {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.12.1/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.12.1/opam
@@ -10,17 +10,17 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"         {>= "4.04.2" & "4.08.0"}
+  "ocaml"         {>= "4.04.2"}
   "base"          {>= "v0.12" & < "v0.13"}
   "ppx_sexp_conv" {>= "v0.12" & < "v0.13"}
   "dune"          {build & >= "1.5.1"}
-  "ppxlib"        {>= "0.5.0" & < "0.9.0"}
+  "ppxlib"        {>= "0.7.0" & < "0.9.0"}
 ]
 synopsis: "Printf-style format-strings for user-defined string conversion"
 description: "
 Part of the Jane Street's PPX rewriters collection.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_custom_printf-v0.12.0.tar.gz"
-  checksum: "md5=e2fb959eb9b8a9b45f6687cc051889c2"
+  src: "https://github.com/janestreet/ppx_custom_printf/archive/v0.12.1.tar.gz"
+  checksum: "md5=11a28734c8251b33bc94f7cd1ba8a34a"
 }

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.07.0" & "4.08.0"}
+  "ocaml"               {>= "4.07.0" & < "4.08.0"}
   "core_kernel"         {>= "v0.12" & < "v0.13"}
   "mlt_parser"          {>= "v0.12" & < "v0.13"}
   "ppx_expect"          {>= "v0.12" & < "v0.13"}

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune"                {build & >= "1.5.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocamlfind"           {>= "1.7.2"}
-  "ppxlib"              {>= "0.5.0" & < "0.9.0"}
+  "ppxlib"              {>= "0.5.0" & < "0.7.0"}
 ]
 synopsis: "Expectation tests for the OCaml toplevel"
 description: "

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.1/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.07.0" & "4.08.0"}
+  "ocaml"               {>= "4.07.0"}
   "core_kernel"         {>= "v0.12" & < "v0.13"}
   "mlt_parser"          {>= "v0.12" & < "v0.13"}
   "ppx_expect"          {>= "v0.12" & < "v0.13"}
@@ -21,7 +21,7 @@ depends: [
   "dune"                {build & >= "1.5.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocamlfind"           {>= "1.7.2"}
-  "ppxlib"              {>= "0.5.0" & < "0.9.0"}
+  "ppxlib"              {>= "0.7.0" & < "0.9.0"}
 ]
 synopsis: "Expectation tests for the OCaml toplevel"
 description: "
@@ -31,6 +31,6 @@ compilations errors as well as provide a nice alternative to using
 the toplevel in a terminal.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/toplevel_expect_test-v0.12.0.tar.gz"
-  checksum: "md5=57dfd3dc157331dd06d9d355e6a9fa22"
+  src: "https://github.com/janestreet/toplevel_expect_test/archive/v0.12.1.tar.gz"
+  checksum: "md5=3447f1eccdde6d44cb13a89764ca0717"
 }


### PR DESCRIPTION
note 1: the previous versions are marked as incompatible with 4.08
note 2: includes https://github.com/ocaml/opam-repository/pull/14208 for the packages touched by this pull request