### PR TITLE
Constrain older versions of ppxlib to OCaml < 4.08

### DIFF
--- a/packages/ppxlib/ppxlib.0.1.0/opam
+++ b/packages/ppxlib/ppxlib.0.1.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "base" {>= "v0.11.0" & < "v0.13"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.2.0/opam
+++ b/packages/ppxlib/ppxlib.0.2.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "base" {>= "v0.11.0" & < "v0.13"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.2.1/opam
+++ b/packages/ppxlib/ppxlib.0.2.1/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "base" {>= "v0.11.0" & < "v0.13"}
   "dune" {build}
   "ocaml-compiler-libs" {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.2.2/opam
+++ b/packages/ppxlib/ppxlib.0.2.2/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "base" {>= "v0.11.0" & < "v0.13"}
   "jbuilder" {build & >= "1.0+beta18.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.3.0/opam
+++ b/packages/ppxlib/ppxlib.0.3.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "base" {>= "v0.11.0" & < "v0.13"}
   "dune" {build}
   "ocaml-compiler-libs" {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.3.1/opam
+++ b/packages/ppxlib/ppxlib.0.3.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.0.9"}
   "ppx_derivers"            {>= "1.0"}
   "stdio"                   {>= "v0.11.0" & < "v0.13"}
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.08.0"}
 ]
 
 description: """

--- a/packages/ppxlib/ppxlib.0.4.0/opam
+++ b/packages/ppxlib/ppxlib.0.4.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.08.0"}
   "base"                    {>= "v0.11.0" & < "v0.13"}
   "dune"                    {build}
   "ocaml-compiler-libs"     {>= "v0.11.0"}


### PR DESCRIPTION
Detected with [check.ocamllabs.io](http://check.ocamllabs.io)

To complete #14200 and #14201 