### PR TITLE
[new release] merlin (3.3.0)

### DIFF
--- a/packages/merlin/merlin.3.3.0/opam
+++ b/packages/merlin/merlin.3.3.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+name:         "merlin"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.1" & < "4.09"}
+  "dune" {build & >= "1.8.0"}
+  "ocamlfind" {>= "1.5.2"}
+  "yojson"
+  "mdx" {with-test & >= "1.3.0"}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam config var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.3.0/merlin-v3.3.0.tbz"
+  checksum: [
+    "sha256=b342cd38034d477457c89b0c143784ed243621c60954afe26766c793f086ebda"
+    "sha512=73513a7f21124e47eb7609344c30f5cce5e5c5880b9ab8f0c0b52d847bbd2d7c715b522cdc7327db0f935d82bc9a6f9d6312717d50da4252666dd5543991e08c"
+  ]
+}

--- a/packages/merlin/merlin.3.3.0/opam
+++ b/packages/merlin/merlin.3.3.0/opam
@@ -8,7 +8,6 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.1" & < "4.09"}


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Fri May 31 11:09:08 BST 2019

  + backend
    - interpret `-pp` flag
    - backtrack warnings in all versions, not just 4.06
    - silence C compiler warnings (by David Allsopp and Bernhard Schommer)
    - remove sturgeon support
    - allow to select sections to log
    - better error message on ocaml version mismatch
    - locate:
      + handle functors and functor applications
      + do not use the location coming from the environment
    - tweaked caching policy
    - fix environment when a file disappears
    - fix -short-paths handling of classes and class types (by Leo White)
    - don't select deprecated paths in -short-paths (by Leo White)
    - return type info in outline query (by Andrey Popp)
    - properly handle new lines in the lexer
    - better tracking of errors reported by the parser and by preprocessors
    - add support for OCaml 4.08
    - tweaked the recovery strategy in presence of syntax errors
    - timing information in replies now includes wall clock time.
    - dump command can new dump the parsetree post preprocessing

  + editors modes
    - emacs
      + fix merlin-xref.el install (by Emilio Jesus Gallego Arias)
      + keep labels matching the prefix the user has typed rather than
        dropping them (by Mitchell Plamann)
      + remove unused `merlin--overlay` function (by Wilfred Hughes)
      + show the number of errors in the modline (by Wilfred Hughes)
      + call a logger on the client side if one is defined
      + allow user to disable completion inside comments and strings
      + show errors and types even when buffer is narrowed (by Wilfred Hughes)
      + make sure PATH is updated when merlin-command is 'opam

    - vim
      + better FindBinary
      + make the log buffer a scratch buffer (by Tom Johnson)
      + execute buffer switching silently (by Fabian)
      + restore view after updating merlin type buffer (by Fabian)

  + testsuite
    - Switched to mdx with cram syntax.

Special thanks to Rudi Grinberg for helping us in reviewing and merging
pull-requests.
