### PR TITLE
Package hdf5-ocaml.0.1.5

### DIFF
--- a/packages/hdf5-ocaml/hdf5-ocaml.0.1.5/opam
+++ b/packages/hdf5-ocaml/hdf5-ocaml.0.1.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Vladimir Brankov <vbrankov@janestreet.com>"
+authors: "Vladimir Brankov <vbrankov@janestreet.com>"
+homepage: "https://github.com/vbrankov/hdf5-ocaml"
+bug-reports: "https://github.com/vbrankov/hdf5-ocaml/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/vbrankov/hdf5-ocaml.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "cppo"
+  "dune" {build & >= "1.1.0"}
+  "ocaml" {>= "4.04"}
+  "ppx_inline_test"
+  "ppx_tools_versioned"
+  "stdio"
+]
+depexts: [
+  ["hdf5"] {os-distribution = "alpine"}
+  ["epel-release" "hdf5-devel"] {os-distribution = "centos"}
+  ["libhdf5-dev"] {os-distribution = "debian"}
+  ["hdf5"] {os-distribution = "homebrew"}
+  ["libhdf5-dev"] {os-distribution = "ubuntu"}
+]
+synopsis: "Manages HDF5 files used for storing large amounts of data"
+description: "The library manages reading and writing to HDF5 files. HDF5 file
+format is used for storing and organizing large amounts of data. Also provided
+is a fast way of working with large arrays of records, much faster than OCaml
+arrays of records."
+url {
+  src: "https://github.com/vbrankov/hdf5-ocaml/archive/v0.1.5.tar.gz"
+  checksum: [
+    "md5=f1509ae61a4f1fce48076515e0bdb8a0"
+    "sha512=7efdaa6f83d3c328c625bb6daf4ed3a7aaa9e90ff3f8427a61cd723b1073c36dcd77c3350f601b2845b10758f8ed2b584b0e7eea86128e3fefc8998edcc06df7"
+  ]
+}


### PR DESCRIPTION
### `hdf5-ocaml.0.1.5`
Manages HDF5 files used for storing large amounts of data
The library manages reading and writing to HDF5 files. HDF5 file
format is used for storing and organizing large amounts of data. Also provided
is a fast way of working with large arrays of records, much faster than OCaml
arrays of records.



---
* Homepage: https://github.com/vbrankov/hdf5-ocaml
* Source repo: git+https://github.com/vbrankov/hdf5-ocaml.git
* Bug tracker: https://github.com/vbrankov/hdf5-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0