### PR TITLE
Package naboris.0.0.2

### DIFF
--- a/packages/naboris/naboris.0.0.2/opam
+++ b/packages/naboris/naboris.0.0.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built using httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "reason"
+  "httpaf"
+  "httpaf-lwt-unix"
+  "lwt"
+  "uri"
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.0.2.tar.gz"
+  checksum: [
+    "md5=81a55be70dbc2f87db83364cf872cd3a"
+    "sha512=b96a4fec24d7e2b08843b09dd5b52195335d029568ecdfdd19c10221fb7f7dae6b467d9d342e5e8b16490a4e20778f0837bde4bb73ffb8fc8a1f6feead80b1de"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.0.2`
Simple http server
Simple http server built using httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0