### PR TITLE
Package qcstm.0.1

### DIFF
--- a/packages/qcstm/qcstm.0.1/opam
+++ b/packages/qcstm/qcstm.0.1/opam
@@ -12,6 +12,10 @@ bug-reports: "https://github.com/jmid/qcstm/issues"
 authors: [ "Jan Midtgaard" ]
 maintainer: [ "Jan Midtgaard <mail@janmidtgaard.dk>" ]
 dev-repo: "git+https://github.com/jmid/qcstm.git"
+url {
+  src: "https://github.com/jmid/qcstm/archive/0.1.tar.gz"
+  checksum: "md5=e802a61964397ba73277d0da583a5269"
+}
 depends: [
   "ocaml" {>= "4.04.0"}
   "qcheck" {>= "0.6"}

--- a/packages/qcstm/qcstm.0.1/opam
+++ b/packages/qcstm/qcstm.0.1/opam
@@ -19,8 +19,8 @@ url {
 depends: [
   "ocaml" {>= "4.04.0"}
   "qcheck" {>= "0.6"}
-  "ocamlfind"
-  "ocamlbuild"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
 ]
 
 build: [

--- a/packages/qcstm/qcstm.0.1/opam
+++ b/packages/qcstm/qcstm.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "A simple state-machine framework for OCaml based on QCheck"
+tags: [
+  "state machine"
+  "test"
+  "property"
+  "quickcheck"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/jmid/qcstm"
+bug-reports: "https://github.com/jmid/qcstm/issues"
+authors: [ "Jan Midtgaard" ]
+maintainer: [ "Jan Midtgaard <mail@janmidtgaard.dk>" ]
+dev-repo: "git+https://github.com/jmid/qcstm.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "qcheck" {>= "0.6"}
+  "ocamlfind"
+  "ocamlbuild"
+]
+
+build: [
+    [make "all"]
+]
+
+install: [make "install"]


### PR DESCRIPTION
### `qcstm.0.1`
A simple state-machine framework for OCaml based on QCheck



---
* Homepage: https://github.com/jmid/qcstm
* Source repo: git+https://github.com/jmid/qcstm.git
* Bug tracker: https://github.com/jmid/qcstm/issues

---
:camel: Pull-request generated by opam-publish v2.0.0