### PR TITLE
[new release] uri (2.2.1)

### DIFF
--- a/packages/uri/uri.2.2.1/opam
+++ b/packages/uri/uri.2.2.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "re" {>= "1.9.0"}
+  "sexplib0"
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v2.2.1/uri-v2.2.1.tbz"
+  checksum: [
+    "sha256=f6348edbae9b9011b3f65e85e775f2cf7b87735c5ceb54d6962377daec3bf56b"
+    "sha512=28a4a659695d5d02f8a1b2965cbb05bc864bea5576c447707bb7db0e7411cafc78323ba6729e32b8b31fdc24a53e906274812d377e62829ebc9ebd6602331176"
+  ]
+}


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* Fix deprecation warnings in Re 1.9.0 (mirage/ocaml-uri#137 @avsm).
