### PR TITLE
Package owee.0.3

### DIFF
--- a/packages/owee/owee.0.3/opam
+++ b/packages/owee/owee.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: "Frédéric Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/owee"
+bug-reports: "https://github.com/let-def/owee"
+license: "MIT"
+dev-repo: "git+https://github.com/let-def/owee.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {build & >= "1.0"}
+]
+synopsis: "OCaml library to work with DWARF format"
+description: """
+Owee is an experimental library to work with DWARF format.
+It can parse ELF binaries and interpret DWARF debugline programs.
+
+It can also be used to find locations of functions from the current process."""
+url {
+  src: "https://github.com/let-def/owee/archive/v0.3.tar.gz"
+  checksum: [
+    "md5=9fae9e98ce7a87380f22911fedb29d9a"
+    "sha512=90905485c93b350b8f601ff2dcc545a92badcf7dcb97c89ea18f479d6c08926e5cd68c74bd005d23d4396f057f66a1faa27f654bc2c4ac9d8030f143f197da9d"
+  ]
+}


### PR DESCRIPTION
### `owee.0.3`
OCaml library to work with DWARF format
Owee is an experimental library to work with DWARF format.
It can parse ELF binaries and interpret DWARF debugline programs.

It can also be used to find locations of functions from the current process.



---
* Homepage: https://github.com/let-def/owee
* Source repo: git+https://github.com/let-def/owee.git
* Bug tracker: https://github.com/let-def/owee

---
:camel: Pull-request generated by opam-publish v2.0.0