### PR TITLE
[new release] stringext (1.6.0)

### DIFF
--- a/packages/stringext/stringext.1.6.0/opam
+++ b/packages/stringext/stringext.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: "Rudi Grinberg"
+license: "MIT"
+homepage: "https://github.com/rgrinberg/stringext"
+bug-reports: "https://github.com/rgrinberg/stringext/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.0"}
+  "ounit" {with-test}
+  "qtest" {with-test & >= "2.2"}
+  "base-bytes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/rgrinberg/stringext.git"
+synopsis: "Extra string functions for OCaml"
+description: """
+Extra string functions for OCaml. Mainly splitting. All functions are in the
+Stringext module.
+"""
+url {
+  src:
+    "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz"
+  checksum: [
+    "sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+    "sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900"
+  ]
+}


### PR DESCRIPTION
Extra string functions for OCaml

- Project page: <a href="https://github.com/rgrinberg/stringext">https://github.com/rgrinberg/stringext</a>

##### CHANGES:

* Port to dune and opam 2.0 metadata format
