### PR TITLE
vecosek-engine: add dependency

### DIFF
--- a/packages/vecosek-engine/vecosek-engine.0.0.0/opam
+++ b/packages/vecosek-engine/vecosek-engine.0.0.0/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta20"}
+  "nonstd" {>= "0.0.2"}
   "vecosek-scene"
 ]
 synopsis: ""


### PR DESCRIPTION
Unlike `vecosek-scene`, `vecosek-engine` doesn't build with `nonstd.0.0.1` because it needs `Option.iter`.

