### PR TITLE
vecosek: add bound on atd

### DIFF
--- a/packages/vecosek/vecosek.0.0.0/opam
+++ b/packages/vecosek/vecosek.0.0.0/opam
@@ -19,6 +19,7 @@ depends: [
   "nonstd"
   "sosa"
   "yojson"
+  "atd" {>= "1.2.1"}
   "atdgen" {< "1.13.0"}
   "rresult"
   "misuja"


### PR DESCRIPTION
`vecosek` fails to compile when `atd.1.2.0` is installed but works with `atd.1.2.1`.

cc @smondet 
