### PR TITLE
ptset: add bound on OCaml version

### DIFF
--- a/packages/ptset/ptset.1.0.0/opam
+++ b/packages/ptset/ptset.1.0.0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "ptset"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.05.0"}
   "ocamlfind"
   "obuild" {build}
 ]


### PR DESCRIPTION
`ptset` fails to compile on all ocaml versions since 4.05.0 because some functions were added to the module type `Set.S`.

cc @backtracking 
