### PR TITLE
[new release] capnp (3.3.0)

### DIFF
--- a/packages/capnp/capnp.3.3.0/opam
+++ b/packages/capnp/capnp.3.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "capnp"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+authors: "Paul Pelzl <pelzlpj@gmail.com>"
+homepage: "https://github.com/capnproto/capnp-ocaml"
+bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "result"
+  "base"
+  "stdio"
+  "base_quickcheck" {with-test}
+  "ocplib-endian" {>= "0.7"}
+  "res"
+  "uint"
+  "ounit" {with-test}
+  "conf-capnproto" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest" "@src/benchmark/benchmarks"] {with-test}
+]
+dev-repo: "git+https://github.com/capnproto/capnp-ocaml.git"
+synopsis:
+  "OCaml code generation plugin for the Cap'n Proto serialization framework"
+description: """
+Cap'n Proto is a multi-language code generation framework designed for
+high performance through the use of lazy parsing and arena allocation.
+This package provides a plugin for the Cap'n Proto compiler which enables
+OCaml code generation, as well as corresponding runtime library support."""
+url {
+  src:
+    "https://github.com/capnproto/capnp-ocaml/releases/download/v3.3.0/capnp-v3.3.0.tbz"
+  checksum: [
+    "sha256=7b67b28a097559cad5fba538afb108eefbb4ee24b30e3cfb9dcd387619652049"
+    "sha512=d2c7133e0269e1162fa3ba320699759978e92f2c1ee606ce25353c1651e8311a382ec4b9dc2b4a9f51666821ed2ebb55619053b11c8bcdff8b0daa0fd004a9cb"
+  ]
+}


### PR DESCRIPTION
OCaml code generation plugin for the Cap'n Proto serialization framework

- Project page: <a href="https://github.com/capnproto/capnp-ocaml">https://github.com/capnproto/capnp-ocaml</a>

##### CHANGES:

This release is mostly about reducing the number of dependencies.
The only API change is that `write_message_to_file_robust` has gone.

* Remove `extunix` dependency (capnproto/capnp-ocaml#57).
  `write_message_to_file_robust` was its only user, and wasn't used by anything.
  Using `fsync` to ensure a file is written to disk is a general function that
  should be handled by the user of capnp where needed.
  Removing `extunix` also removes the indirect dependency on `camlp4`,
  which in turn allows `capnp` to build with OCaml 4.08 (and to build faster on all versions).

* Remove `Pervasives` qualifier (capnproto/capnp-ocaml#57).
  This is needed to support OCaml 4.08 without warnings.

* Remove dependency on `Core` from benchmarks (capnproto/capnp-ocaml#55).
  This was the only remaining use of the library.

* Replace uses of `Core_kernel` with plain `Base` and `Stdio` in the compiler (capnproto/capnp-ocaml#56)
  and tests (capnproto/capnp-ocaml#59).
  This greatly reduces the number of libraries you need to install to install capnp.

* Update tests for the current quickcheck API (capnproto/capnp-ocaml#54).

* Switch from jbuilder to dune (capnproto/capnp-ocaml#54).

* Require OCaml >= 4.03 (capnproto/capnp-ocaml#54).
  This allows us to drop some complexity from the jbuilder files,
  allowing them to be upgraded automatically by dune.

* Upgrade to opam 2 format (capnproto/capnp-ocaml#54).

* Convert the changelog to markdown (capnproto/capnp-ocaml#58).
  This allows it to be used with dune-release.

With these changes, the following 49 libraries that were needed to install
capnp-ocaml 3.2.1 are no longer required: `base_bigstring`, `base_quickcheck`,
`bin_prot`, `camlp4`, `core_kernel`, `extunix`, `fieldslib`,
`jane-street-headers`, `jst-config`, `num`, `ocaml-compiler-libs`,
`ocaml-migrate-parsetree`, `octavius`, `parsexp`, `ppx_assert`, `ppx_base`,
`ppx_bench`, `ppx_bin_prot`, `ppx_compare`, `ppx_custom_printf`,
`ppx_derivers`, `ppx_enumerate`, `ppx_expect`, `ppx_fail`, `ppx_fields_conv`,
`ppx_hash`, `ppx_here`, `ppx_inline_test`, `ppx_jane`, `ppx_js_style`,
`ppx_let`, `ppxlib`, `ppx_module_timer`, `ppx_optcomp`, `ppx_optional`,
`ppx_pipebang`, `ppx_sexp_conv`, `ppx_sexp_message`, `ppx_sexp_value`,
`ppx_stable`, `ppx_typerep_conv`, `ppx_variants_conv`, `re`, `seq`, `sexplib`,
`splittable_random`, `time_now`, `typerep` and `variantslib`.
