### PR TITLE
[new release] github-unix, github-jsoo and github (4.1.0)

### DIFF
--- a/packages/github-jsoo/github-jsoo.4.1.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+"""
+
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml-lwt" {>="3.4.0"}
+  "github"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.1.0/github-4.1.0.tbz"
+  checksum: [
+    "sha256=a45964ba7dd595140aded8a641813821b81329efcb6306969a40d7ae3634d919"
+    "sha512=c04a32eb5c718ed384bf735abf4283bc5f6069236ea36cc1050e0812c2b3276eb42c83b37f6aaba3488200729d7212f2d66232ffbb1f7253ffdedb6d27feb065"
+  ]
+}

--- a/packages/github-unix/github-unix.4.1.0/opam
+++ b/packages/github-unix/github-unix.4.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON).  This package installs the Unix (Lwt) version.
+"""
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" 
+  "github" {=version}
+  "cohttp-lwt-unix"
+  "stringext"
+  "lambda-term" {>="2.0"}
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.1.0/github-4.1.0.tbz"
+  checksum: [
+    "sha256=a45964ba7dd595140aded8a641813821b81329efcb6306969a40d7ae3634d919"
+    "sha512=c04a32eb5c718ed384bf735abf4283bc5f6069236ea36cc1050e0812c2b3276eb42c83b37f6aaba3488200729d7212f2d66232ffbb1f7253ffdedb6d27feb065"
+  ]
+}

--- a/packages/github/github.4.1.0/opam
+++ b/packages/github/github.4.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON). It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml).
+"""
+
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+  "stringext"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.1.0/github-4.1.0.tbz"
+  checksum: [
+    "sha256=a45964ba7dd595140aded8a641813821b81329efcb6306969a40d7ae3634d919"
+    "sha512=c04a32eb5c718ed384bf735abf4283bc5f6069236ea36cc1050e0812c2b3276eb42c83b37f6aaba3488200729d7212f2d66232ffbb1f7253ffdedb6d27feb065"
+  ]
+}


### PR DESCRIPTION
GitHub APIv3 Unix library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Add the interface for `/user/orgs` (mirage/ocaml-github#222 @Aaylor)
- Switch to dune-release instead of topkg (mirage/ocaml-github#224 @avsm)
- Do not use deprecated `Yojson.Safe.json` (mirage/ocaml-github#224 @avsm)
- Support lambda-term/zed 2.0.0 interfaces (mirage/ocaml-github#224 @avsm)
- Use wrapped `js_of_ocaml` 3.4.0 interfaces (@avsm)
