### PR TITLE
Add capnp-rpc-mirage upper-bounds on base64 and tcpip

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
@@ -17,11 +17,12 @@ depends: [
   "fmt"
   "logs"
   "ipaddr" {<"3.0.0"}
+  "base64" {<"3.0.0"}
   "mirage-dns"
   "mirage-stack-lwt"
   "alcotest-lwt" {with-test}
   "io-page-unix" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & <"3.5.0"}
   "mirage-vnetif" {with-test}
   "jbuilder" {build & >= "1.0+beta10"}
 ]

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "capnp" {>= "3.1.0"}
+  "capnp" {>= "3.3.0"}
   "capnp-rpc-lwt" {>= "0.3"}
   "astring"
   "fmt"
@@ -27,7 +27,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 synopsis:
-  "Cap'n Proto is a capability-based RPC system with bindings for many languages."
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
 description:
   "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
 url {

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
@@ -18,10 +18,11 @@ depends: [
   "logs"
   "mirage-dns"
   "ipaddr" {<"3.0.0"}
+  "base64" {<"3.0.0"}
   "mirage-stack-lwt"
   "alcotest-lwt" {with-test}
   "io-page-unix" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & <"3.5.0"}
   "mirage-vnetif" {with-test}
   "jbuilder" {build & >= "1.0+beta10"}
 ]

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "capnp" {>= "3.1.0"}
+  "capnp" {>= "3.3.0"}
   "capnp-rpc-lwt" {>= "0.3"}
   "astring"
   "fmt"
@@ -27,7 +27,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 synopsis:
-  "Cap'n Proto is a capability-based RPC system with bindings for many languages."
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
 description:
   "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
 url {


### PR DESCRIPTION
These constraints will be needed once https://github.com/ocaml/opam-repository/pull/14240 is merged.

/cc @avsm