### PR TITLE
remove version field

### DIFF
--- a/packages/core/core.v0.12.2/opam
+++ b/packages/core/core.v0.12.2/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "v0.12.1"
 maintainer: "opensource@janestreet.com"
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/core"


### PR DESCRIPTION
`version` field is outdated (causing warnings in `opam update`) and, if I correctly understand opam, not used anymore anyway.