### PR TITLE
[new release] capnp-rpc-mirage, capnp-rpc-unix, capnp-rpc-lwt and capnp-rpc (0.3.2)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
@@ -13,7 +13,7 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.0.0"}
+  "capnp" {>= "3.3.0"}
   "capnp-rpc" {>= "0.3"}
   "lwt"
   "astring"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
+authors: "Thomas Leonard <thomas.leonard@docker.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.0.0"}
+  "capnp-rpc" {>= "0.3"}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow-lwt"
+  "tls" {>= "0.8.0"}
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "asn1-combinators" {>= "0.2.0"}
+  "dune" {build & >= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.2/capnp-rpc-v0.3.2.tbz"
+  checksum: [
+    "sha256=effafa70cea4ce0fc7027d17f672769744a8e8f1d59182e1643cc7d3cbe53a9e"
+    "sha512=8e2f96ac284bda71436526489f5b992f6c1afcb8899189615877187ab5090ac1f653b1976736e0649269d0f39990afecc8f74cebf457a79934227639ccf7639f"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
+authors: "Thomas Leonard <thomas.leonard@docker.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-lwt" {>= "0.3"}
+  "astring"
+  "fmt"
+  "logs"
+  "arp-mirage"
+  "mirage-dns"
+  "mirage-stack-lwt"
+  "alcotest-lwt" {with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {with-test}
+  "mirage-vnetif" {with-test}
+  "dune" {build & >= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.2/capnp-rpc-v0.3.2.tbz"
+  checksum: [
+    "sha256=effafa70cea4ce0fc7027d17f672769744a8e8f1d59182e1643cc7d3cbe53a9e"
+    "sha512=8e2f96ac284bda71436526489f5b992f6c1afcb8899189615877187ab5090ac1f653b1976736e0649269d0f39990afecc8f74cebf457a79934227639ccf7639f"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp" {>= "3.1.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3.2"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/opam
@@ -16,6 +16,7 @@ depends: [
   "cmdliner"
   "cstruct-lwt"
   "astring"
+  "base64" {< "3.0.0"}
   "fmt" {>= "0.8.4"}
   "logs"
   "jbuilder" {build & >= "1.0+beta10"}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3.2"}
   "mirage-flow-unix"
   "cmdliner"
   "cstruct-lwt"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
+authors: "Thomas Leonard <thomas.leonard@docker.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp-rpc-lwt" {>= "0.3"}
+  "mirage-flow-unix"
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "dune" {build & >= "1.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.2/capnp-rpc-v0.3.2.tbz"
+  checksum: [
+    "sha256=effafa70cea4ce0fc7027d17f672769744a8e8f1d59182e1643cc7d3cbe53a9e"
+    "sha512=8e2f96ac284bda71436526489f5b992f6c1afcb8899189615877187ab5090ac1f653b1976736e0649269d0f39990afecc8f74cebf457a79934227639ccf7639f"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
@@ -16,6 +16,7 @@ depends: [
   "cmdliner"
   "cstruct-lwt"
   "astring"
+  "base64" {>= "3.0.0"}
   "fmt" {>= "0.8.4"}
   "logs"
   "dune" {build & >= "1.0"}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3/opam
@@ -17,6 +17,7 @@ depends: [
   "cstruct-lwt"
   "astring"
   "fmt" {>= "0.8.4"}
+  "base64" {< "3.0.0"}
   "logs"
   "jbuilder" {build & >= "1.0+beta10"}
 ]

--- a/packages/capnp-rpc/capnp-rpc.0.3.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
+authors: "Thomas Leonard <thomas.leonard@docker.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "uint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {build & >= "1.0"}
+  "alcotest" {with-test}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.2/capnp-rpc-v0.3.2.tbz"
+  checksum: [
+    "sha256=effafa70cea4ce0fc7027d17f672769744a8e8f1d59182e1643cc7d3cbe53a9e"
+    "sha512=8e2f96ac284bda71436526489f5b992f6c1afcb8899189615877187ab5090ac1f653b1976736e0649269d0f39990afecc8f74cebf457a79934227639ccf7639f"
+  ]
+}

--- a/packages/capnp/capnp.3.3.0/opam
+++ b/packages/capnp/capnp.3.3.0/opam
@@ -8,7 +8,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
   "result"
-  "base"
+  "base" {>= "v0.11"}
   "stdio"
   "base_quickcheck" {with-test}
   "ocplib-endian" {>= "0.7"}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Update for various upstream API changes, switch to the opam 2 metadata
  format, and convert from jbuilder to dune (@talex5, mirage/capnp-rpc#152).

- Adjust to mirage-stack / mirage-protocols changes (Nick Betteridge, mirage/capnp-rpc#151).
  * update mirage/network for upgraded Ipaddr
  * update Dockerfile to use opam2, apt-get update, and newer opam-repository

- Update dependencies from opam-repository (@talex5, mirage/capnp-rpc#148).
