### PR TITLE
[new release] postgresql (4.5.0)

### DIFF
--- a/packages/postgresql/postgresql.4.5.0/opam
+++ b/packages/postgresql/postgresql.4.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {build & >= "1.4.0"}
+  "base" {build}
+  "stdio" {build}
+  "base-bytes"
+  "conf-postgresql" {build}
+]
+
+synopsis: "Bindings to the PostgreSQL library"
+
+description: """
+Postgresql offers library functions for accessing PostgreSQL databases."""
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/4.5.0/postgresql-4.5.0.tbz"
+  checksum: [
+    "sha256=1cca5b3da400e4de060b8e61e8aff9675f67204da27c16a5bc4ec0dca4ca0905"
+    "sha512=56f3719dc1cf7ae1cf7c71db16264c8737f9114851459edf1a46b5ee2c51ecebb8ed5428c003d243a5cd518cb66a8a007ba2d2d23d01a3b9b87567a0b9871c5c"
+  ]
+}


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

* Added support for `put_copy_data`, `put_copy_end`, and `get_copy_data`

  Thanks to Petter A. Urkedal for the patch!
