### PR TITLE
ocaml compiler distribution: use parallel build for OCaml 4.07 and above

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -42,11 +42,20 @@ build: [
     "-host"
     "i386-apple-darwin13.2.0"
   ] {os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
   checksum: "md5=7730fea507d108b5e30ced23613980c8"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
   checksum: "md5=7730fea507d108b5e30ced23613980c8"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
   checksum: "md5=7730fea507d108b5e30ced23613980c8"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
   checksum: "md5=7730fea507d108b5e30ced23613980c8"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -31,11 +31,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
   checksum: "md5=7730fea507d108b5e30ced23613980c8"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
   checksum: "md5=7730fea507d108b5e30ced23613980c8"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+beta2.tar.gz"
   checksum: "md5=7730fea507d108b5e30ced23613980c8"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -24,10 +24,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -32,11 +32,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -31,11 +31,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -30,11 +30,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
   checksum: "md5=f800c2e02157fbb18051d2635af6a055"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -30,11 +30,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
   checksum: "md5=f800c2e02157fbb18051d2635af6a055"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
   checksum: "md5=f800c2e02157fbb18051d2635af6a055"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -25,11 +25,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
   checksum: "md5=f800c2e02157fbb18051d2635af6a055"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
@@ -32,11 +32,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
   checksum: "md5=f800c2e02157fbb18051d2635af6a055"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
   checksum: "md5=f800c2e02157fbb18051d2635af6a055"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc1.tar.gz"
   checksum: "md5=f800c2e02157fbb18051d2635af6a055"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc2.tar.gz"
   checksum: "md5=98d3b4cd504ab77c6e0a2dc98e69f3a1"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -30,11 +30,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc2.tar.gz"
   checksum: "md5=98d3b4cd504ab77c6e0a2dc98e69f3a1"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc2.tar.gz"
   checksum: "md5=98d3b4cd504ab77c6e0a2dc98e69f3a1"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -25,11 +25,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc2.tar.gz"
   checksum: "md5=98d3b4cd504ab77c6e0a2dc98e69f3a1"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
@@ -32,11 +32,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc2.tar.gz"
   checksum: "md5=98d3b4cd504ab77c6e0a2dc98e69f3a1"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc2.tar.gz"
   checksum: "md5=98d3b4cd504ab77c6e0a2dc98e69f3a1"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0+rc2.tar.gz"
   checksum: "md5=98d3b4cd504ab77c6e0a2dc98e69f3a1"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"
   checksum: "md5=1f78bb35a2f15d5ec737ee6a8dc6890d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
@@ -23,10 +23,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
@@ -31,10 +31,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
@@ -24,10 +24,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
@@ -31,10 +31,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
@@ -29,10 +29,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
@@ -23,10 +23,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -42,11 +42,20 @@ build: [
     "-host"
     "i386-apple-darwin13.2.0"
   ] {os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -28,3 +28,12 @@ url {
   src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-n107.tar.gz"
   checksum: "md5=45f8ceeda06ab3d335a2b9388b30b8f5"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -24,10 +24,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -30,11 +30,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -32,11 +32,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -25,11 +25,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -32,11 +32,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -32,11 +32,20 @@ build: [
     "-no-graph"
     "-no-shared-libs"
   ]
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -30,11 +30,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -42,11 +42,20 @@ build: [
     "-host"
     "i386-apple-darwin13.2.0"
   ] {os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -30,11 +30,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -32,11 +32,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -25,11 +25,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -32,11 +32,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -29,11 +29,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -23,11 +23,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1+rc1.tar.gz"
   checksum: "md5=8ddb6eddeb3dfcaccb50c78aecf2d05d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -24,11 +24,20 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
   checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -24,10 +24,19 @@ build: [
     "-aspp"
     "cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/jhjourdan/ocaml/archive/memprof_4.07.1.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
@@ -33,11 +33,20 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
@@ -24,11 +24,20 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -22,11 +22,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
   checksum: "md5=c2fabeb2f0c2a20e808b72cb8a9e095d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
   checksum: "md5=c2fabeb2f0c2a20e808b72cb8a9e095d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -21,11 +21,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
   checksum: "md5=c2fabeb2f0c2a20e808b72cb8a9e095d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
   checksum: "md5=c2fabeb2f0c2a20e808b72cb8a9e095d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -24,11 +24,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
   checksum: "md5=c2fabeb2f0c2a20e808b72cb8a9e095d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -20,11 +20,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
   checksum: "md5=c2fabeb2f0c2a20e808b72cb8a9e095d"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -22,11 +22,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
   checksum: "md5=a0bc4382e736c086b7c3f63f86f0ddac"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
   checksum: "md5=a0bc4382e736c086b7c3f63f86f0ddac"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -21,11 +21,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
   checksum: "md5=a0bc4382e736c086b7c3f63f86f0ddac"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
   checksum: "md5=a0bc4382e736c086b7c3f63f86f0ddac"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
@@ -24,11 +24,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
   checksum: "md5=a0bc4382e736c086b7c3f63f86f0ddac"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -20,11 +20,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta2.tar.gz"
   checksum: "md5=a0bc4382e736c086b7c3f63f86f0ddac"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -22,10 +22,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
   checksum: "md5=3596365b839d4c81c6f7ab764463cd24"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -21,11 +21,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
   checksum: "md5=3596365b839d4c81c6f7ab764463cd24"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
   checksum: "md5=3596365b839d4c81c6f7ab764463cd24"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
@@ -24,11 +24,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
   checksum: "md5=3596365b839d4c81c6f7ab764463cd24"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -20,11 +20,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta3.tar.gz"
   checksum: "md5=3596365b839d4c81c6f7ab764463cd24"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
@@ -24,10 +24,19 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
@@ -25,11 +25,20 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
@@ -27,11 +27,20 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
@@ -24,11 +24,20 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
@@ -25,11 +25,20 @@ build: [
     "ASPP=cc -c"
     "--enable-force-safe-string"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
@@ -27,11 +27,20 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
@@ -24,11 +24,20 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -30,11 +30,20 @@ build: [
     "--disable-graph-lib"
     "--disable-shared"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
@@ -25,11 +25,20 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
@@ -22,11 +22,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc1.tar.gz"
   checksum: "md5=737902be9699c38fcb44f1f25f6a5997"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc1.tar.gz"
   checksum: "md5=737902be9699c38fcb44f1f25f6a5997"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
@@ -21,11 +21,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc1.tar.gz"
   checksum: "md5=737902be9699c38fcb44f1f25f6a5997"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc1.tar.gz"
   checksum: "md5=737902be9699c38fcb44f1f25f6a5997"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
@@ -24,11 +24,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc1.tar.gz"
   checksum: "md5=737902be9699c38fcb44f1f25f6a5997"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
@@ -20,11 +20,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc1.tar.gz"
   checksum: "md5=737902be9699c38fcb44f1f25f6a5997"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc2.tar.gz"
   checksum: "md5=7bb2fc05f5084f1066d398e11b069f1a"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
@@ -30,11 +30,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc2.tar.gz"
   checksum: "md5=7bb2fc05f5084f1066d398e11b069f1a"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
@@ -25,11 +25,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc2.tar.gz"
   checksum: "md5=7bb2fc05f5084f1066d398e11b069f1a"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
@@ -30,11 +30,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc2.tar.gz"
   checksum: "md5=7bb2fc05f5084f1066d398e11b069f1a"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
@@ -28,11 +28,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc2.tar.gz"
   checksum: "md5=7bb2fc05f5084f1066d398e11b069f1a"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
@@ -24,11 +24,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0+rc2.tar.gz"
   checksum: "md5=7bb2fc05f5084f1066d398e11b069f1a"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
@@ -24,11 +24,20 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
@@ -26,11 +26,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0+beta1.tar.gz"
   checksum: "md5=63b43a29c9e6b39c859ac5ca6d0eb7aa"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
@@ -30,11 +30,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0+beta1.tar.gz"
   checksum: "md5=63b43a29c9e6b39c859ac5ca6d0eb7aa"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
@@ -25,11 +25,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0+beta1.tar.gz"
   checksum: "md5=63b43a29c9e6b39c859ac5ca6d0eb7aa"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
@@ -30,11 +30,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0+beta1.tar.gz"
   checksum: "md5=63b43a29c9e6b39c859ac5ca6d0eb7aa"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
@@ -28,11 +28,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0+beta1.tar.gz"
   checksum: "md5=63b43a29c9e6b39c859ac5ca6d0eb7aa"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
@@ -24,11 +24,20 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0+beta1.tar.gz"
   checksum: "md5=63b43a29c9e6b39c859ac5ca6d0eb7aa"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+afl/opam
@@ -21,10 +21,19 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+default-unsafe-string/opam
@@ -30,10 +30,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+flambda/opam
@@ -21,10 +21,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+fp+flambda/opam
@@ -30,10 +30,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk+fp/opam
@@ -28,10 +28,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+trunk/opam
@@ -20,10 +20,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+afl/opam
@@ -21,10 +21,19 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+flambda/opam
@@ -21,10 +21,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+trunk/opam
@@ -20,10 +20,19 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "world"]
-  [make "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]


### PR DESCRIPTION
TL;DR: This is a follow-up on #14118 that enables parallel builds on 4.07 and more recent, except for Cygwin.

In the old days, the OCaml compiler distribution did not support
parallel build. This support has been contributed over time, and while
the dependencies are still not 100% reliable (in particular, parallel
rebuild from a partial build often fails with cmi inconsistencies),
builds from a clean state are now very robust: they are routinely used
by developers and tested daily on our CI machines, and we haven't seen
a failure in a long while.

Enabling parallel build improves build times for everyone, at the cost
of a very low risk of breaking the build. Some context:

- On my machine, a recent sequential build took 5m15s, and a parallel
  build from the same sources took 2m53s: we can save 2m20s for every
  new switch creation for users with similar hardware. When creating
  a switch with a small number of packages, the compiler build time
  may dominate the total installation time.

- New switches are created much more often now that opam2 makes local
  switches easy. It is typical for users to create a switch for each
  project to isolate their dependencies, ending up with dozens of
  switches. The install time quickly builds up.

If a user was to find a build failure due to parallel build,
a workaround is to pass `-j 1` to opam to force sequential switch
creation:

    opam switch create <switch-name> <compiler-version> -j 1

setting the environment variable OPAMJOBS=1 would also work.

This commit was semi-automatically generated
using the following script run from the `packages/` directory:

```
for f in ocaml-base-compiler/*4.07.*/opam ocaml-variants/*4.0[789].*/opam ocaml-variants/*4.10.*/opam; do
    echo $f
    sed 's/  \[make "world.opt"\]/  [make "-j%{jobs}%" "world.opt"] {os != "cygwin"}/' -i $f
    sed 's/  \[make "world"\]/  [make "world.opt"] {os = "cygwin"}/' -i $f
done
```