### PR TITLE
release of ppx_deriving.4.3

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.3/opam
@@ -10,7 +10,7 @@ tags: [ "syntax" ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [

--- a/packages/ppx_deriving/ppx_deriving.4.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune"     {build >= "1.6.3"}
+  "cppo"     {build}
+  "ppxfind"  {build}
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {with-test}
+  "ocaml" {>= "4.02"}
+]
+synopsis: "Type-driven code generation for OCaml >=4.02"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_deriving/archive/v4.3.tar.gz"
+  checksum: "sha256=89d9bb599b6212de65597b8a3e714e1c3cd6b7e5a45bcb6a4405e4feb08cd190"
+}


### PR DESCRIPTION
4.3 Changelog:

* use Format through Ppx_deriving_runtime to avoid deprecation warning
  for users of JaneStreet Base
  (Stephen Bastians and Gabriel Scherer, review by whitequark)
* silence a ambiguous-field warning (41) in generated code
  ocaml-ppx/ppx_deriving#163
  (Étienne Millon, review by Gabriel Scherer)
* use dune
  ocaml-ppx/ppx_deriving#170
  (Rudi Grinberg, Jérémie Dimino)
* silence an unused-value warning for show
  ocaml-ppx/ppx_deriving#179
  (Nathan Rebours)

First attempt: https://github.com/ocaml/opam-repository/pull/13652

The second attempt incorporated minor changes to the opam file (no
other change to the ppx_deriving pre-release), and occurred after the
revdeps failures of the first attempt have been reviewed and fixed.

Second attempt: https://github.com/ocaml/opam-repository/pull/14018

Kate helped investigate the few failures remaining with the second
attempt, and provided the motivation for finally getting the release
out -- opam-repository will always be in an imperfect state... Thanks!