### PR TITLE
core_kernel.v0.12.2

### DIFF
--- a/packages/core_kernel/core_kernel.v0.12.2/opam
+++ b/packages/core_kernel/core_kernel.v0.12.2/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.07.0" & < "4.08.0"}
+  "ocaml"               {>= "4.07.0"}
   "base"                {>= "v0.12" & < "v0.13"}
   "base_bigstring"      {>= "v0.12" & < "v0.13"}
   "base_quickcheck"     {>= "v0.12" & < "v0.13"}
@@ -42,6 +42,6 @@ largest industrial user of OCaml.
 Core_kernel is the system-independent part of Core.
 "
 url {
-  src: "https://github.com/janestreet/core_kernel/archive/v0.12.1.tar.gz"
-  checksum: "md5=c3a613bf3f87d79faf1a77aaa256a9ff"
+  src: "https://github.com/janestreet/core_kernel/archive/v0.12.2.tar.gz"
+  checksum: "md5=afc0271c35437c883b3c75fb821fe470"
 }


### PR DESCRIPTION
This pull request fixes a silly mistake in v0.12.1 that made
it incompatible with OCaml 4.08 (v0.12.1 did not include the
backport of the patch for bigarrays).

This pull request hence adds a constraint to v0.12.1, and
publishes a new version of core_kernel.

This is expected to fix the [last problems](http://check.ocamllabs.io/?comp=4.02.3&comp=4.03.0&comp=4.04.2&comp=4.05.0&comp=4.06.1&comp=4.07.1&comp=4.08.0%2Brc1&available=4.02.3&available=4.03.0&available=4.04.2&available=4.05.0&available=4.06.1&available=4.07.1&available=4.08.0%2Brc1&show-failures-only=true&show-latest-only=true&maintainers=janestreet&logsearch=&logsearch_comp=4.02.3) with Jane Street
packages, with respect to OCaml 4.08.