### PR TITLE
Mitigate dune downgrades

### DIFF
--- a/packages/decoders/decoders.0.1.0/opam
+++ b/packages/decoders/decoders.0.1.0/opam
@@ -171,6 +171,7 @@ depends: [
 ]
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 conflicts: [ "dune" {>="1.7.0"} ]
+available: false
 dev-repo: "git+ssh://git@github.com/mattjbray/ocaml-decoders.git"
 url {
   src:

--- a/packages/decoders/decoders.0.1.1/opam
+++ b/packages/decoders/decoders.0.1.1/opam
@@ -260,6 +260,7 @@ depends: [
   "containers"
 ]
 conflicts: [ "dune" {>="1.7.0"} ]
+available: false
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 dev-repo: "git+ssh://git@github.com/mattjbray/ocaml-decoders.git"
 url {

--- a/packages/lwt/lwt.3.1.0/opam
+++ b/packages/lwt/lwt.3.1.0/opam
@@ -66,6 +66,7 @@ conflicts: [
   "ocaml-variants" {= "4.02.1+BER"}
   "dune" {>= "1.7.0"}
 ]
+available: false
 url {
   src: "https://github.com/ocsigen/lwt/archive/3.1.0.tar.gz"
   checksum: "md5=e80364e38c5fae791a6506b9c113fd29"

--- a/packages/lwt/lwt.3.2.0/opam
+++ b/packages/lwt/lwt.3.2.0/opam
@@ -66,6 +66,7 @@ conflicts: [
   "ocaml-variants" {= "4.02.1+BER"}
   "dune" {>= "1.7.0"}
 ]
+available: false
 url {
   src: "https://github.com/ocsigen/lwt/archive/3.2.0.tar.gz"
   checksum: "md5=cf4256845e18c4d0f39afa7b32b3d6fe"

--- a/packages/lwt/lwt.3.2.1/opam
+++ b/packages/lwt/lwt.3.2.1/opam
@@ -66,6 +66,7 @@ conflicts: [
   "ocaml-variants" {= "4.02.1+BER"}
   "dune" {>= "1.7.0"}
 ]
+available: false
 url {
   src: "https://github.com/ocsigen/lwt/archive/3.2.1.tar.gz"
   checksum: "md5=13613bbf6b27d198bafcbd9b253a0076"

--- a/packages/lwt/lwt.3.3.0/opam
+++ b/packages/lwt/lwt.3.3.0/opam
@@ -66,6 +66,7 @@ conflicts: [
   "ocaml-variants" {= "4.02.1+BER"}
   "dune" {>= "1.7.0"}
 ]
+available: false
 url {
   src: "https://github.com/ocsigen/lwt/archive/3.3.0.tar.gz"
   checksum: "md5=47bdf4b429da94419941ebe4354f505f"

--- a/packages/ocp-index/ocp-index.1.1.6/opam
+++ b/packages/ocp-index/ocp-index.1.1.6/opam
@@ -18,6 +18,7 @@ depends: [
 conflicts: [
   "dune" {>= "1.7.0"}
 ]
+available: false
 post-messages: [
   "
 This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:

--- a/packages/ocp-index/ocp-index.1.1.7/opam
+++ b/packages/ocp-index/ocp-index.1.1.7/opam
@@ -31,6 +31,7 @@ depends: [
 conflicts: [
   "dune" {>= "1.7.0"}
 ]
+available: false
 post-messages:
   "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
 

--- a/packages/yojson/yojson.1.4.0/opam
+++ b/packages/yojson/yojson.1.4.0/opam
@@ -18,6 +18,7 @@ depends: [
 conflicts: [
   "dune" {>= "1.7.0"}
 ]
+available: false
 synopsis:
   "Yojson is an optimized parsing and printing library for the JSON format"
 description: """

--- a/packages/yojson/yojson.1.4.1/opam
+++ b/packages/yojson/yojson.1.4.1/opam
@@ -18,6 +18,7 @@ depends: [
 conflicts: [
   "dune" {>= "1.7.0"}
 ]
+available: false
 synopsis:
   "Yojson is an optimized parsing and printing library for the JSON format"
 description: """


### PR DESCRIPTION
Mitigate https://github.com/ocaml/opam-repository/issues/14185 by avoiding downgrades as much as possible. This should work for all opam packages in opam-repository but there might still be some issues for external packages or remotes.

This PR disables those packages from the repository and cannot be installed anymore:
* decoders.0.1.0
* decoders.0.1.1
* lwt.3.1.0
* lwt.3.2.0
* lwt.3.2.1
* lwt.3.3.0
* ocp-index.1.1.6
* ocp-index.1.1.7
* yojson.1.4.0
* yojson.1.4.1

None of these packages are their latest versions but this might also make some more packages uninstallable. This will be detected by Camelus.

cc @avsm @diml @AltGr 