### PR TITLE
[new release] dune-release (1.3.1)

### DIFF
--- a/packages/dune-release/dune-release.1.3.1/opam
+++ b/packages/dune-release/dune-release.1.3.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire" "Nathan Rebours"]
+homepage: "https://github.com/samoht/dune-release"
+license: "ISC"
+dev-repo: "git+https://github.com/samoht/dune-release.git"
+bug-reports: "https://github.com/samoht/dune-release/issues"
+doc: "https://samoht.github.io/dune-release/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "opam-format"
+  "opam-state"
+  "opam-core"
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+]
+
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com).
+"""
+url {
+  src:
+    "https://github.com/samoht/dune-release/releases/download/1.3.1/dune-release-1.3.1.tbz"
+  checksum: [
+    "sha256=4424555fda41b331f785f9aba9a79e57153f100a1ccfd9a698f996e580a943f1"
+    "sha512=2550d08058670766b9f893c6497bd5c9818b7f3c446662fdcff8d7d29ec3d0166ba64fa631e929a4cff86276d8126b8cd694079ecc5a88305b0376be91822192"
+  ]
+}


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/samoht/dune-release">https://github.com/samoht/dune-release</a>
- Documentation: <a href="https://samoht.github.io/dune-release/">https://samoht.github.io/dune-release/</a>

##### CHANGES:

- Fix a bug in documentation publication where under certain circumstances the
  doc would be published in a `_html` folder instead of being published at the
  root of `gh-pages` (samoht/dune-release#157, @NathanReb)
