### PR TITLE
Package goblint-cil.1.7.4

### DIFF
--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: ["gabriel@kerneis.info"]
+maintainer: "ralf.vogler@gmail.com"
+homepage: "https://cil-project.github.io/cil/"
+bug-reports: "https://github.com/goblint/cil/issues/"
+dev-repo: "git+https://github.com/goblint/cil/"
+build: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" prefix]
+  [make]
+  [make "doc"] {with-doc}
+]
+run-test: [
+  ["env" "VERBOSE=1" make "test"]
+]
+install: [
+  make "install"
+]
+remove: [
+  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" prefix]
+  [make "uninstall"]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "zarith" {build}
+  "hevea" {with-doc | with-test}
+]
+conflicts: ["cil"]
+synopsis:
+  "A front-end for the C programming language that facilitates program analysis and transformation"
+description: """
+This is a fork of the 'cil' package needed to build 'goblint'.
+Changes:
+- some warnings are made optional
+- truncated integer constants have a string representation
+- compiles with OCaml >=4.06.0, use zarith instead of num"""

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "zarith" {build}
+  "zarith"
   "hevea" {with-doc | with-test}
 ]
 depexts: [

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -12,13 +12,9 @@ build: [
 install: [
   make "install"
 ]
-remove: [
-  ["./configure" "--prefix" prefix]
-  [make "uninstall"]
-]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "ocamlbuild" {build}
   "zarith" {build}
   "hevea" {with-doc | with-test}

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -9,9 +9,6 @@ build: [
   [make]
   [make "doc"] {with-doc}
 ]
-run-test: [
-  ["env" "VERBOSE=1" make "test"]
-]
 install: [
   make "install"
 ]

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -5,7 +5,7 @@ homepage: "https://cil-project.github.io/cil/"
 bug-reports: "https://github.com/goblint/cil/issues/"
 dev-repo: "git+https://github.com/goblint/cil/"
 build: [
-  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix]
   [make]
   [make "doc"] {with-doc}
 ]
@@ -16,7 +16,7 @@ install: [
   make "install"
 ]
 remove: [
-  ["env" "FORCE_PERL_PREFIX=1" "./configure" "--prefix" prefix]
+  ["./configure" "--prefix" prefix]
   [make "uninstall"]
 ]
 depends: [

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -20,7 +20,7 @@ depends: [
   "hevea" {with-doc | with-test}
 ]
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora"}
 ]
 conflicts: ["cil"]
 synopsis:

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -39,6 +39,6 @@ url {
   src: "https://github.com/goblint/cil/archive/1.7.4.tar.gz"
   checksum: [
     "md5=091bd157c350e65e9c5616779f674cde"
-    "sha512=ddfa86c993c2d1e399742f4e9e77e4db4f255dac7f62019952e9dcd874f77cb02140bb5a8b9f3d1c158ba4e4fa057442d2f>
+    "sha512=ddfa86c993c2d1e399742f4e9e77e4db4f255dac7f62019952e9dcd874f77cb02140bb5a8b9f3d1c158ba4e4fa057442d2ffdb6d40217bc3e0f76fe8a69af6a2"
   ]
 }

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -23,6 +23,9 @@ depends: [
   "zarith" {build}
   "hevea" {with-doc | with-test}
 ]
+depexts: [
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos"}
+]
 conflicts: ["cil"]
 synopsis:
   "A front-end for the C programming language that facilitates program analysis and transformation"

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -35,3 +35,10 @@ Changes:
 - some warnings are made optional
 - truncated integer constants have a string representation
 - compiles with OCaml >=4.06.0, use zarith instead of num"""
+url {
+  src: "https://github.com/goblint/cil/archive/1.7.4.tar.gz"
+  checksum: [
+    "md5=091bd157c350e65e9c5616779f674cde"
+    "sha512=ddfa86c993c2d1e399742f4e9e77e4db4f255dac7f62019952e9dcd874f77cb02140bb5a8b9f3d1c158ba4e4fa057442d2f>
+  ]
+}


### PR DESCRIPTION
### `goblint-cil.1.7.4`
A front-end for the C programming language that facilitates program analysis and transformation
This is a fork of the 'cil' package needed to build 'goblint'.
Changes:
- some warnings are made optional
- truncated integer constants have a string representation
- compiles with OCaml >=4.06.0, use zarith instead of num



---
* Homepage: https://cil-project.github.io/cil/
* Source repo: git+https://github.com/goblint/cil/
* Bug tracker: https://github.com/goblint/cil/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0