### PR TITLE
Package ocsigen-toolkit.2.2.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.2.0.tar.gz"
+  checksum: [
+    "md5=fdef081ec554d4eb077b85a4488a0b46"
+    "sha512=908dee27a99c42e40782eeaeda5733887e3ee1d9f679770e744fdefdd8ee5ce32e2840187115ecadbc706e647f1b1f1e3df5e1774c556745447630e9a9bb0c48"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.2.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0