### PR TITLE
ppx_deriving_yojson.3.4: fix url...

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.4/opam
@@ -31,6 +31,6 @@ description: """
 ppx_deriving_yojson is a ppx_deriving plugin that provides
 a JSON codec generator."""
 url {
-  src: "https://github.com/gasche/ppx_deriving_yojson/archive/release-v3.4.tar.gz"
-  checksum: "sha512=ace726861694f41ce23d364ed75a4d1cf59ab5e4f72ce6639805732e0aea65d945731a84736b11b148a80853bff365054dc3de151fae3b2cb87a926438ff6f49"
+  src: "https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/v3.4.tar.gz"
+  checksum: "sha512=823aefb07506a0b0fe7a4b8b75ea85c88b83b53c46d1ee015993e9efc09c5d09276b83c71cf18ea20ceef5a08329d23664f8eb328dbdf06061eb5ca86aaeb33a"
 }


### PR DESCRIPTION
...by replacing the release-preparation branch with … an actual release tag

This is a follow-up to ocaml/opam-repository#14259 which was only intended
as a release-preparation PR.