### PR TITLE
[new release] ppx_enum (0.0.2)

### DIFF
--- a/packages/ppx_enum/ppx_enum.0.0.2/opam
+++ b/packages/ppx_enum/ppx_enum.0.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+homepage: "https://github.com/cryptosense/ppx_enum"
+bug-reports: "https://github.com/cryptosense/ppx_enum/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/ppx_enum.git"
+doc: "https://cryptosense.github.io/ppx_enum/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.07.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppxlib" {>= "0.3.0"}
+  "ppx_deriving" {with-test}
+]
+tags: ["org:cryptosense"]
+synopsis: "PPX to derive enum-like modules from variant type definitions"
+description: """
+This PPX derives simple enum-like modules from variant type definitions.
+"""
+authors: "James Owen <jamesowen@outlook.com>"
+url {
+  src:
+    "https://github.com/cryptosense/ppx_enum/releases/download/v0.0.2/ppx_enum-v0.0.2.tbz"
+  checksum: [
+    "sha256=35a551992d9341aa289eadba267737d853015cb9c33ad87c90004543f5a93a99"
+    "sha512=bf3c029c9ec8511a44a11df113c6691e0672acccd6a478f61be48f949b17d84e17f641ed1f4211924cce796e51a94fcaaea0053edbd4ad9f6cdcfa27c191f8ab"
+  ]
+}


### PR DESCRIPTION
PPX to derive enum-like modules from variant type definitions

- Project page: <a href="https://github.com/cryptosense/ppx_enum">https://github.com/cryptosense/ppx_enum</a>
- Documentation: <a href="https://cryptosense.github.io/ppx_enum/doc">https://cryptosense.github.io/ppx_enum/doc</a>

##### CHANGES:

*2019-06-14*

- Rename the deriver from `enum` to `str_enum` to avoid a naming conflict with `ppx_deriving.enum`
