### PR TITLE
Package obeam.0.1.5

### DIFF
--- a/packages/obeam/obeam.0.1.5/opam
+++ b/packages/obeam/obeam.0.1.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "A utility library for parsing BEAM format"
+maintainer: "yutopp <yutopp@gmail.com>"
+authors: ["yutopp <yutopp@gmail.com>" "amutake <amutake.s@gmail.com>"]
+license: "Boost License Version 1.0"
+homepage: "https://github.com/yutopp/obeam"
+bug-reports: "https://github.com/yutopp/obeam/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "base" {>= "v0.11.0"}
+  "stdio" {>= "v0.11.0"}
+  "bitstring" {>= "3.0.0"}
+  "camlzip" {>= "1.07"}
+  "zarith" {>= "1.7"}
+  "ppx_here" {>= "v0.11.0"}
+  "ppx_let" {>= "v0.11.0"}
+  "ppx_sexp_conv" {>= "v0.11.2"}
+  "dune" {build}
+  "bisect_ppx" {build}
+  "expect_test_helpers_kernel" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/yutopp/obeam.git"
+url {
+  src: "https://github.com/yutopp/obeam/archive/0.1.5.tar.gz"
+  checksum: [
+    "md5=061e06cfd6b387035044e795f60ebfc4"
+    "sha512=d1df746a35eef3ab09f1184b59860466af40422e940a2d2c4d6ce372fd8183e6e0ac123eb697fc3fb2893776045f0a44f4c016b6a3fcd33dd009a8c44cafb25e"
+  ]
+}


### PR DESCRIPTION
### `obeam.0.1.5`
A utility library for parsing BEAM format



---
* Homepage: https://github.com/yutopp/obeam
* Source repo: git+https://github.com/yutopp/obeam.git
* Bug tracker: https://github.com/yutopp/obeam/issues

---
:camel: Pull-request generated by opam-publish v2.0.0