### PR TITLE
FrontC 3.4.2 - adds trailing comma to enums

### DIFF
--- a/packages/FrontC/FrontC.3.4.2/files/FrontC.install
+++ b/packages/FrontC/FrontC.3.4.2/files/FrontC.install
@@ -1,0 +1,6 @@
+bin: [
+  "calipso/calipso"
+  "calipso/calipso_stat"
+  "ctoxml/ctoxml"
+  "printc/printc"
+]

--- a/packages/FrontC/FrontC.3.4.2/files/META
+++ b/packages/FrontC/FrontC.3.4.2/files/META
@@ -1,0 +1,5 @@
+description = "Parser for the C language"
+version = "3.4.1"
+requires = "unix"
+archive(byte) = "frontc.cma"
+archive(native) = "frontc.cmxa"

--- a/packages/FrontC/FrontC.3.4.2/files/opam.patch
+++ b/packages/FrontC/FrontC.3.4.2/files/opam.patch
@@ -1,0 +1,25 @@
+diff -ru FrontC.3.4.1/Makefile.head FrontC.3.4.1/Makefile.head
+--- FrontC.3.4.1/Makefile.head	2008-04-01 15:53:52.000000000 +0200
++++ FrontC.3.4.1/Makefile.head	2012-10-05 18:14:56.993802068 +0200
+@@ -84,8 +84,8 @@
+ 	$$(OCAMLC) -a $$($(1)_LDFLAGS) $$(OCAMLC_LDFLAGS) -o $$@ $$($(1)_CMO) $$(OCAMLC_LIBS)
+ 
+ _install_$(1)_CMA:
+-	install -d $(OCAML_SITE)/$(1)
+-	install $(1).cma $$($(1)_CMIO) $(OCAML_SITE)/$(1)
++	install -d $(OCAML_SITE)/FrontC
++	install $(1).cma $$($(1)_CMIO) $(OCAML_SITE)/FrontC
+ 	
+ endef
+ 
+@@ -114,8 +114,8 @@
+ 	$$(OCAMLOPT) -a $$($(1)_LDFLAGS) $$(OCAMLOPT_LDFLAGS) -o $$@ $$($(1)_CMX) $$(OCAMLOPT_LIBS)
+ 
+ _install_$(1)_CMXA:
+-	install -d $(OCAML_SITE)/$(1)
+-	install $(1).cmxa $(1).a $$($(1)_CMIX) $(OCAML_SITE)/$(1)
++	install -d $(OCAML_SITE)/FrontC
++	install $(1).cmxa $(1).a $$($(1)_CMIX) $(OCAML_SITE)/FrontC
+ 	
+ endef
+ 

--- a/packages/FrontC/FrontC.3.4.2/opam
+++ b/packages/FrontC/FrontC.3.4.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "FrontC"
+version: "3.4.2"
+authors: "Hugues Cassé <casse@irit.fr>"
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+remove: [["ocamlfind" "remove" "FrontC"]]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
+patches: ["opam.patch"]
+install: [
+  [make "install" "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]
+  ["cp" "META" "%{lib}%/FrontC"]
+]
+synopsis: "Library providing a C parser and lexer"
+description: """
+FrontC is an OCAML library providing a C parser and lexer. The result
+is a syntactic tree easy to process with usual OCAML tree management.
+
+It provides support for ANSI C syntax, old-C K&R style syntax and the
+standard GNU CC attributes.
+
+It provides also a C pretty printer as an example of use."""
+flags: light-uninstall
+extra-files: [
+  ["opam.patch" "md5=4352830449159cb6b45de35c59a6f149"]
+  ["META" "md5=bdbf1c230e0b897a898fd35dfc4cb475"]
+  ["FrontC.install" "md5=c56e698d092d18179f9458f311c56412"]
+]
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/V_3_4_2.tar.gz"
+  checksum: "md5=76b84606069aadac0aa05662d7a77033"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/V_3_4_2.tar.gz"
+}

--- a/packages/FrontC/FrontC.3.4.2/opam
+++ b/packages/FrontC/FrontC.3.4.2/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "FrontC"
-version: "3.4.2"
 authors: "Hugues Cassé <casse@irit.fr>"
 homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"

--- a/packages/FrontC/FrontC.3.4.2/opam
+++ b/packages/FrontC/FrontC.3.4.2/opam
@@ -4,10 +4,8 @@ homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
-remove: [["ocamlfind" "remove" "FrontC"]]
 depends: [
   "ocaml"
-  "ocamlfind" {build}
 ]
 patches: ["opam.patch"]
 install: [
@@ -23,7 +21,6 @@ It provides support for ANSI C syntax, old-C K&R style syntax and the
 standard GNU CC attributes.
 
 It provides also a C pretty printer as an example of use."""
-flags: light-uninstall
 extra-files: [
   ["opam.patch" "md5=4352830449159cb6b45de35c59a6f149"]
   ["META" "md5=bdbf1c230e0b897a898fd35dfc4cb475"]


### PR DESCRIPTION
This is a minor update, that adds the abovementioned feature.