### PR TITLE
Temporarily have only one .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,12 @@ pkgconfigure text eol=lf
 # NB Package-specific attributes should go in packages/NAME/.gitattributes,
 # not here, in order to ensure that they survive packages being renamed.
 
+# They are temporarily here, working around a bug in esy
+packages/core/*/files/corebuild text eol=lf
+packages/bap-llvm/*/files/detect.travis text eol=lf
+packages/freetennis/*/files/freetennis text eol=lf
+packages/ocamlfind/*/files/ocaml-stub text eol=lf
+
 # Treat patches as binary for safety
 *.patch binary
 *.patch.in binary

--- a/packages/bap-llvm/.gitattributes
+++ b/packages/bap-llvm/.gitattributes
@@ -1,1 +1,0 @@
-*/files/detect.travis text eol=lf

--- a/packages/core/.gitattributes
+++ b/packages/core/.gitattributes
@@ -1,1 +1,0 @@
-*/files/corebuild text eol=lf

--- a/packages/freetennis/.gitattributes
+++ b/packages/freetennis/.gitattributes
@@ -1,1 +1,0 @@
-*/files/freetennis text eol=lf

--- a/packages/ocamlfind/.gitattributes
+++ b/packages/ocamlfind/.gitattributes
@@ -1,1 +1,0 @@
-*/files/ocaml-stub text eol=lf


### PR DESCRIPTION
Having `.gitattributes` in project directories is causing pain to `esy` - cross reference to bug fix to follow (after which this PR can be reverted).