### PR TITLE
Revert #14294 and restore package-specific .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,12 +10,6 @@ pkgconfigure text eol=lf
 # NB Package-specific attributes should go in packages/NAME/.gitattributes,
 # not here, in order to ensure that they survive packages being renamed.
 
-# They are temporarily here, working around a bug in esy
-packages/core/*/files/corebuild text eol=lf
-packages/bap-llvm/*/files/detect.travis text eol=lf
-packages/freetennis/*/files/freetennis text eol=lf
-packages/ocamlfind/*/files/ocaml-stub text eol=lf
-
 # Do not normalise patch files (opam will ensure that patch files are
 # appropriately normalised for the target files, but direct calls to patch
 # don't benefit from this)

--- a/packages/bap-llvm/.gitattributes
+++ b/packages/bap-llvm/.gitattributes
@@ -1,0 +1,1 @@
+*/files/detect.travis text eol=lf

--- a/packages/core/.gitattributes
+++ b/packages/core/.gitattributes
@@ -1,0 +1,1 @@
+*/files/corebuild text eol=lf

--- a/packages/freetennis/.gitattributes
+++ b/packages/freetennis/.gitattributes
@@ -1,0 +1,1 @@
+*/files/freetennis text eol=lf

--- a/packages/ocamlfind/.gitattributes
+++ b/packages/ocamlfind/.gitattributes
@@ -1,0 +1,1 @@
+*/files/ocaml-stub text eol=lf


### PR DESCRIPTION
**DO NOT MERGE YET!**

This PR can merged when https://github.com/esy/esy/issues/936 is resolved.

Also note https://github.com/ocaml/opam/pull/3873, though this change wouldn't affect `esy` since it doesn't use `index.tar.gz`

cc @jordwalke, @andreypopp