### PR TITLE
[new release] ppx_import (1.6.2)

### DIFF
--- a/packages/ppx_import/ppx_import.1.6.2/opam
+++ b/packages/ppx_import/ppx_import.1.6.2/opam
@@ -1,6 +1,3 @@
-description: "A syntax extension for importing declarations from interface files"
-synopsis: "A syntax extension for importing declarations from interface files"
-name: "ppx_import"
 opam-version: "2.0"
 maintainer: "whitequark <whitequark@whitequark.org>"
 authors: [ "whitequark <whitequark@whitequark.org>" ]
@@ -10,6 +7,8 @@ license: "MIT"
 bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
 
 depends: [
   "ocaml"                   {              >= "4.04.2" & < "4.08.0" }

--- a/packages/ppx_import/ppx_import.1.6.2/opam
+++ b/packages/ppx_import/ppx_import.1.6.2/opam
@@ -1,0 +1,34 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+name: "ppx_import"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
+  "dune"                    { build &      >= "1.2.0"  }
+  "ppxlib"                  {              >= "0.3.1"  }
+  "ppx_tools_versioned"     {              >= "5.2.1"  }
+  "ocaml-migrate-parsetree" {              >= "1.1.0"  }
+  "ounit"                   { with-test                }
+  "ppx_deriving"            { with-test  & >= "4.2.1"  }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/v1.6.2/ppx_import-v1.6.2.tbz"
+  checksum: [
+    "sha256=1f10a473165fea9f8ab202356128a40e6b834bd7dce36847fad1d6686a9366a3"
+    "sha512=8bf4925908f2646aebaa9699f11eb5046bf674af4116bffa1edf9a6b6d61fbb50b21f5053d5e13772548df0aa2b2edd402fe7fa97f408c837f26c5487adb5b4d"
+  ]
+}


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

* Fix import of module types with optional arguments
    (Thierry Martinez ocaml-ppx/ppx_import#37, review by whitequark)
