### PR TITLE
MD5 update for the macos pytorch binary package

### DIFF
--- a/packages/libtorch/libtorch.1.1.0/opam
+++ b/packages/libtorch/libtorch.1.1.0/opam
@@ -46,7 +46,7 @@ extra-source "libtorch-linux.zip" {
 }
 extra-source "libtorch-macos.zip" {
   src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.1.0.zip"
-  checksum: "md5=b75d7187b81d7a9a36a008e3e0bb6ee6"
+  checksum: "md5=70c5046a83e4b8b33772bc969562da76"
 }
 extra-source "mklml-macos.tgz" {
   src: "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz"


### PR DESCRIPTION
The PyTorch binary package for macos has recently been updated and its md5 checksum changed, this updates the opam package to match the new checksum.