### PR TITLE
[new release] dtoa (0.3.2)

### DIFF
--- a/packages/dtoa/dtoa.0.3.2/opam
+++ b/packages/dtoa/dtoa.0.3.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Marshall Roch <mroch@fb.com>"
+authors: "Marshall Roch <mroch@fb.com>"
+license: "MIT"
+homepage: "https://github.com/flowtype/ocaml-dtoa"
+doc: "https://github.com/flowtype/ocaml-dtoa"
+bug-reports: "https://github.com/flowtype/ocaml-dtoa/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune" {build & >= "1.0"}
+  "ounit" {with-test & >= "2.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/flowtype/ocaml-dtoa.git"
+synopsis: "Converts OCaml floats into strings (doubles to ascii, 'd to a'), using the efficient Grisu3 algorithm"
+description: """
+This is a (partial) port of Google's double-conversion library from C++ to C.
+"""
+url {
+  src:
+    "https://github.com/flowtype/ocaml-dtoa/releases/download/v0.3.2/dtoa-v0.3.2.tbz"
+  checksum: [
+    "sha256=b613700295897ed57c2f4f1a6809084813124d9fd66c5dd5334f20dc32b0707e"
+    "sha512=16b31cd2af6b51be702dc9b9f6837e2c213f15cab634afe6c7bb6c7e827071af4694976c1d7e4e713289f41c330f2ec25685b7b26734007889513d462a2e9518"
+  ]
+}


### PR DESCRIPTION
Converts OCaml floats into strings (doubles to ascii, 'd to a'), using the efficient Grisu3 algorithm

- Project page: <a href="https://github.com/flowtype/ocaml-dtoa">https://github.com/flowtype/ocaml-dtoa</a>
- Documentation: <a href="https://github.com/flowtype/ocaml-dtoa">https://github.com/flowtype/ocaml-dtoa</a>

##### CHANGES:

Upgrade jbuilder to dune
