### PR TITLE
core.v0.12.0 is not compatible with OCaml 4.08

### DIFF
--- a/packages/core/core.v0.12.0/opam
+++ b/packages/core/core.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"        {>= "4.07.0"}
+  "ocaml"        {>= "4.07.0" & < "4.08.0"}
   "jst-config"   {>= "v0.12" & < "v0.13"}
   "core_kernel"  {>= "v0.12" & < "v0.13"}
   "ppx_jane"     {>= "v0.12" & < "v0.13"}


### PR DESCRIPTION
As shown by [this CI log](http://check.ocamllabs.io/log/1560752820-1bb7c1833f0451f7fc390731698f137850b3125a/4.08.0+rc1/bad/core.v0.12.0).

notes: v0.12.1 was already marked as incompatible, and v.0.12.2 is compatible.
