### PR TITLE
Release owl-ode, owl-ode-sundials 0.0.9

### DIFF
--- a/packages/cviode/cviode.0.0.3/opam
+++ b/packages/cviode/cviode.0.0.3/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {build}
-  "owl" {>= "0.5.0"}
-  "owl-ode" {>= "0.0.7"}
+  "owl" {>= "0.5.0" & < "0.6.0"}
+  "owl-ode" {>= "0.0.7" & < "0.0.9"}
   "owl-plplot" {with-test}
   "stdcompat" {>= "7" & with-test}
 ]

--- a/packages/owl-ode-sundials/owl-ode-sundials.0.0.7/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.0.7/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "owl" {>= "0.5.0"}
   "dune" {build & >= "1.1.0"}
-  "owl-ode" {>="0.0.7"}
+  "owl-ode" {>="0.0.7" & < "0.0.9"}
   "owl-plplot" {with-test}
   "sundialsml"
 ]

--- a/packages/owl-ode-sundials/owl-ode-sundials.0.0.9/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.0.9/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "owlbarn"
+authors: [ "Marcello Seri" "Ta-Chu Calvin Kao" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+doc: "https://owlbarn.github.io/owl_ode/ode"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "examples/van_der_pol.exe"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "owl" {>= "0.5.0"}
+  "dune" {build & >= "1.1.0"}
+  "owl-ode" {>="0.0.7"}
+  "owl-plplot" {with-test}
+  "sundialsml"
+]
+synopsis: "Owl's ODE solvers, interface with SundialsML"
+url {
+  src: "https://github.com/owlbarn/owl_ode/archive/V0.0.9.tar.gz"
+  checksum: [
+    "md5=778b6567d54fb5dd78be3ed502341aba"
+    "sha512=f8090e120e878fcc025d26208dfdecf0d40db476e771519c6400bbf97c99018c4337f285a50b91c3b5461310340bc5ef01d21cb4b53e32178ce08f13dae844a8"
+  ]
+}

--- a/packages/owl-ode-sundials/owl-ode-sundials.0.0.9/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.0.9/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "owl" {>= "0.5.0"}
   "dune" {build & >= "1.1.0"}
-  "owl-ode" {>="0.0.7"}
+  "owl-ode" {>= "0.0.9" & "0.0.10"}
   "owl-plplot" {with-test}
   "sundialsml"
 ]

--- a/packages/owl-ode-sundials/owl-ode-sundials.0.0.9/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.0.9/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "owl" {>= "0.5.0"}
   "dune" {build & >= "1.1.0"}
-  "owl-ode" {>= "0.0.9" & "0.0.10"}
+  "owl-ode" {>= "0.0.9" & < "0.0.10"}
   "owl-plplot" {with-test}
   "sundialsml"
 ]

--- a/packages/owl-ode/owl-ode.0.0.7/opam
+++ b/packages/owl-ode/owl-ode.0.0.7/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "owl" {>= "0.5.0"}
+  "owl" {>= "0.5.0" & < "0.6.0"}
   "owl-plplot" {with-test}
   "dune" {build & >= "1.1.0"}
 ]

--- a/packages/owl-ode/owl-ode.0.0.8/opam
+++ b/packages/owl-ode/owl-ode.0.0.8/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {build & >= "1.1.0"}
-  "owl" {>= "0.5.0"}
+  "owl" {>= "0.5.0" & < "0.6.0"}
   "owl-plplot" {with-test}
   "alcotest" {with-test}
 ]

--- a/packages/owl-ode/owl-ode.0.0.9/opam
+++ b/packages/owl-ode/owl-ode.0.0.9/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {build & >= "1.1.0"}
-  "owl" {>= "0.5.0"}
+  "owl" {>= "0.5.0" & < "0.6.0"}
   "owl-plplot" {with-test}
   "alcotest" {with-test}
 ]

--- a/packages/owl-ode/owl-ode.0.0.9/opam
+++ b/packages/owl-ode/owl-ode.0.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "owlbarn"
+authors: [ "Marcello Seri" "Ta-Chu Calvin Kao" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+doc: "https://owlbarn.github.io/owl_ode/owl-ode"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build & >= "1.1.0"}
+  "owl" {>= "0.5.0"}
+  "owl-plplot" {with-test}
+  "alcotest" {with-test}
+]
+synopsis: "Owl's ODE solvers"
+url {
+  src: "https://github.com/owlbarn/owl_ode/archive/V0.0.9.tar.gz"
+  checksum: [
+    "md5=778b6567d54fb5dd78be3ed502341aba"
+    "sha512=f8090e120e878fcc025d26208dfdecf0d40db476e771519c6400bbf97c99018c4337f285a50b91c3b5461310340bc5ef01d21cb4b53e32178ce08f13dae844a8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`owl-ode.0.0.9`: Owl's ODE solvers
-`owl-ode-sundials.0.0.9`: Owl's ODE solvers, interface with SundialsML



---
* Homepage: https://github.com/owlbarn/owl_ode
* Source repo: git+https://github.com/owlbarn/owl_ode.git
* Bug tracker: https://github.com/owlbarn/owl_ode/issues

---
:camel: Pull-request generated by opam-publish v2.0.0

CHANGES: 

- cleaned up and simplified interface
- last release before moving to current owl trunk