### PR TITLE
[new release] terminal_size (0.1.4)

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.4/opam
+++ b/packages/terminal_size/terminal_size.0.1.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "alcotest" {with-test}
+  "dune" {build & >= "1.10.0"}
+  "ocaml" {>= "4.02.0"}
+]
+synopsis: "Get the dimensions of the terminal"
+description: """
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/terminal_size/releases/download/v0.1.4/terminal_size-v0.1.4.tbz"
+  checksum: [
+    "sha256=6a038b3c6f5161d6a62f018118aa57a9916e7a9784cfe8fffe5c3fc213aadba8"
+    "sha512=48ec8b32e82940b577b20bf27891f14856f3c554bec961515a9c6cbb0004d2b805c6b1c7d8f0786cbf9fb67b26d919aee333ae95653f829681e7b7b6c51390c1"
+  ]
+}


### PR DESCRIPTION
Get the dimensions of the terminal

- Project page: <a href="https://github.com/cryptosense/terminal_size">https://github.com/cryptosense/terminal_size</a>
- Documentation: <a href="https://cryptosense.github.io/terminal_size/doc">https://cryptosense.github.io/terminal_size/doc</a>

##### CHANGES:

*2019-05-24*

Build system:

- Upgrade to opam 2
- Build with dune
