### PR TITLE
[new release] github-unix, github-jsoo and github (4.2.0)

### DIFF
--- a/packages/github-jsoo/github-jsoo.4.2.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.2.0/github-unix-4.2.0.tbz"
+  checksum: [
+    "sha256=10fecdb5d58ab4dac85d615e89d0e8eab2413a243bad6ad2f4a7f8783704d745"
+    "sha512=6b89941480f9fc59aedf5b4844b0b1892229e50e034c86d4a1c5ff9afcc10778262d23cee72f62a663873a52cfece676802fd4e3af16aefb0eec24a458761484"
+  ]
+}

--- a/packages/github-unix/github-unix.4.2.0/opam
+++ b/packages/github-unix/github-unix.4.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON).  This package installs the Unix (Lwt) version."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-unix" {>= "0.99.0"}
+  "stringext"
+  "lambda-term" {>= "2.0"}
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.2.0/github-unix-4.2.0.tbz"
+  checksum: [
+    "sha256=10fecdb5d58ab4dac85d615e89d0e8eab2413a243bad6ad2f4a7f8783704d745"
+    "sha512=6b89941480f9fc59aedf5b4844b0b1892229e50e034c86d4a1c5ff9afcc10778262d23cee72f62a663873a52cfece676802fd4e3af16aefb0eec24a458761484"
+  ]
+}

--- a/packages/github/github.4.2.0/opam
+++ b/packages/github/github.4.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitHub APIv3](https://developer.github.com/v3/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+  "stringext"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.2.0/github-unix-4.2.0.tbz"
+  checksum: [
+    "sha256=10fecdb5d58ab4dac85d615e89d0e8eab2413a243bad6ad2f4a7f8783704d745"
+    "sha512=6b89941480f9fc59aedf5b4844b0b1892229e50e034c86d4a1c5ff9afcc10778262d23cee72f62a663873a52cfece676802fd4e3af16aefb0eec24a458761484"
+  ]
+}


### PR DESCRIPTION
GitHub APIv3 Unix library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Add repository permissions support (mirage/ocaml-github#226 @Aaylor)
- Regenerate opam files automatically via dune-project (mirage/ocaml-github#227 @avsm)
