### PR TITLE
[new release] mirage-time-unix, mirage-time-lwt and mirage-time (1.3.0)

### DIFF
--- a/packages/mirage-time-lwt/mirage-time-lwt.1.3.0/opam
+++ b/packages/mirage-time-lwt/mirage-time-lwt.1.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-time" {>= "1.0.0"}
+  "lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS with Lwt"
+description: """
+mirage-time-lwt defines `Mirage_time_lwt.S`, the `Mirage_time.S` signature specialized with Lwt.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v1.3.0/mirage-time-v1.3.0.tbz"
+  checksum: [
+    "sha256=8e50db9fa71526468da45790da996589a6331a8f090ed2ba3d5d3607ad67773a"
+    "sha512=e03c27248e32458f55917f9f9b19499bbe3a348fef7db324b85db1961f3d997852b13c73377d17d2b04f204ca51db29ef37279ca1d087fe0fc7e9d086093a17f"
+  ]
+}

--- a/packages/mirage-time-unix/mirage-time-unix.1.3.0/opam
+++ b/packages/mirage-time-unix/mirage-time-unix.1.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "lwt"
+  "duration"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS on Unix"
+description: """
+mirage-time-unix defines `Time`, an implementation of the `Mirage_time.S` signature for the Unix backend.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v1.3.0/mirage-time-v1.3.0.tbz"
+  checksum: [
+    "sha256=8e50db9fa71526468da45790da996589a6331a8f090ed2ba3d5d3607ad67773a"
+    "sha512=e03c27248e32458f55917f9f9b19499bbe3a348fef7db324b85db1961f3d997852b13c73377d17d2b04f204ca51db29ef37279ca1d087fe0fc7e9d086093a17f"
+  ]
+}

--- a/packages/mirage-time/mirage-time.1.3.0/opam
+++ b/packages/mirage-time/mirage-time.1.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS"
+description: """
+mirage-time defines `Mirage_time.S`, the signature for time-related operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v1.3.0/mirage-time-v1.3.0.tbz"
+  checksum: [
+    "sha256=8e50db9fa71526468da45790da996589a6331a8f090ed2ba3d5d3607ad67773a"
+    "sha512=e03c27248e32458f55917f9f9b19499bbe3a348fef7db324b85db1961f3d997852b13c73377d17d2b04f204ca51db29ef37279ca1d087fe0fc7e9d086093a17f"
+  ]
+}


### PR DESCRIPTION
Time operations for MirageOS on Unix

- Project page: <a href="https://github.com/mirage/mirage-time">https://github.com/mirage/mirage-time</a>
- Documentation: <a href="https://mirage.github.io/mirage-time/">https://mirage.github.io/mirage-time/</a>

##### CHANGES:

* Upgrade opam metadata to 2.0 format (mirage/mirage-time#7 @hannesm)
* Upgrade to dune from jbuilder (mirage/mirage-time#7 @hannesm)
* Improve test matrix to OCaml 4.07 and minimum is 4.04+ (@hannesm)
