### PR TITLE
Update xenstore_transport to 1.1.0

### DIFF
--- a/packages/xenstore_transport/xenstore_transport.1.1.0/opam
+++ b/packages/xenstore_transport/xenstore_transport.1.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Christian Lindig"
+  "David Scott"
+  "Euan Harris"
+  "John Else"
+  "Jon Ludlam"
+  "Jonathan Davies"
+  "Marcello Seri"
+  "Si Beaumont"
+  "Thomas Sanders"
+  "Vincent Bernardoff"
+]
+license: "LGPL"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "http://github.com/xapi-project/ocaml-xenstore-clients"
+doc: "http://xapi-project.github.io/ocaml-xenstore-clients"
+bug-reports: "http://github.com/xapi-project/ocaml-xenstore-clients/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ocamlfind" {build}
+  "dune" {build & >= "1.0"}
+  "lwt"
+  "xenstore" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+http://github.com/xapi-project/ocaml-xenstore-clients.git"
+synopsis: "low-level libraries for connecting to a xenstore service on a xen host."
+description: """
+These libraries contain the IO functions for communicating with a
+xenstore service on a xen host. One subpackage deals with regular Unix
+threads and another deals with Lwt co-operative threads.
+"""
+url {
+  src:
+    "https://github.com/xapi-project/ocaml-xenstore-clients/archive/v1.1.0.tar.gz"
+  checksum: "md5=3a2e01adf0a5fc4b6834fabf778d3836"
+}

--- a/packages/xenstore_transport/xenstore_transport.1.1.0/opam
+++ b/packages/xenstore_transport/xenstore_transport.1.1.0/opam
@@ -19,7 +19,6 @@ doc: "http://xapi-project.github.io/ocaml-xenstore-clients"
 bug-reports: "http://github.com/xapi-project/ocaml-xenstore-clients/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ocamlfind" {build}
   "dune" {build & >= "1.0"}
   "lwt"
   "xenstore" {>= "2.0.0"}
@@ -29,7 +28,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+http://github.com/xapi-project/ocaml-xenstore-clients.git"
-synopsis: "low-level libraries for connecting to a xenstore service on a xen host."
+synopsis: "Low-level libraries for connecting to a xenstore service on a xen host."
 description: """
 These libraries contain the IO functions for communicating with a
 xenstore service on a xen host. One subpackage deals with regular Unix


### PR DESCRIPTION
* 8bd1a27 upgrade opam metadata to 2.0 format
* b6f882d upgrade build to dune from jbuilder and update CI
* b3f805f CA-289145: close socket if error occurs when using lwt connect

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>

/CC @avsm 