### PR TITLE
Various fixes

### DIFF
--- a/packages/bistro/bistro.0.0.0/opam
+++ b/packages/bistro/bistro.0.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "core" {< "v0.13"}
   "dbm"
-  "lwt"
+  "lwt" {< "4.0.0"}
   "oasis"
   "ocamlnet"
   "pvem"

--- a/packages/bistro/bistro.0.1.0/opam
+++ b/packages/bistro/bistro.0.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "core" {< "v0.13"}
   "dbm"
-  "lwt"
+  "lwt" {< "4.0.0"}
   "ppx_tools"
   "pvem"
   "rresult"

--- a/packages/bistro/bistro.0.2.0/opam
+++ b/packages/bistro/bistro.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "core" {< "v0.9.0"}
-  "lwt"
+  "lwt" {< "4.0.0"}
   "ocamlgraph" {>= "1.8.7"}
   "ppx_tools"
   "pvem"

--- a/packages/charrua-core/charrua-core.0.8/opam
+++ b/packages/charrua-core/charrua-core.0.8/opam
@@ -28,6 +28,9 @@ depends: [
   "io-page" {with-test}
   "cstruct-unix" {with-test}
 ]
+conflicts: [
+  "ppx_driver" {< "v0.9.0"}
+]
 synopsis:
   "DHCP core library - a DHCP server and wire frame encoder and decoder"
 description: """

--- a/packages/coq/coq.8.7.1+1/opam
+++ b/packages/coq/coq.8.7.1+1/opam
@@ -20,8 +20,8 @@ build: [
     "-camlp5dir" "%{lib}%/camlp5"
     "-coqide" "no"
   ]
-  [make "-j%{jobs}%"]
-  [make "-j%{jobs}%" "byte"]
+  [make "-j1"]
+  [make "-j1" "byte"]
 ]
 install: [
   [make "install"]

--- a/packages/diet/diet.0.1/opam
+++ b/packages/diet/diet.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "jbuilder" {build & >= "1.0+beta10"}
   "ppx_tools" {build}
-  "ppx_sexp_conv" {build & < "v0.13"}
+  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.13"}
   "ppx_type_conv" {build}
   "ounit" {with-test}
 ]

--- a/packages/diet/diet.0.2/opam
+++ b/packages/diet/diet.0.2/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "sexplib"
   "dune" {build}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "ounit" {with-test}
 ]
 synopsis: "Discrete Interval Encoding Trees"

--- a/packages/diet/diet.0.3/opam
+++ b/packages/diet/diet.0.3/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "sexplib"
   "dune" {build}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "ounit" {with-test}
 ]
 build: [

--- a/packages/dockerfile/dockerfile.3.0.0/opam
+++ b/packages/dockerfile/dockerfile.3.0.0/opam
@@ -10,7 +10,7 @@ tags: ["org:mirage" "org:ocamllabs"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "ppx_sexp_conv" {< "v0.13"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.13"}
   "sexplib" {< "v0.13"}
   "base-bytes"
   "fmt"

--- a/packages/js_of_ocaml/js_of_ocaml.2.7/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.7/opam
@@ -26,6 +26,7 @@ conflicts: [
   "deriving"     {< "0.6"}
   "tyxml"        {< "3.6.0" | >= "4.0.0" }
   "ppx_deriving" {< "3.0"}
+  "ppx_deriving" {>= "4.3"}
   "reactiveData" {< "0.2"}
 ]
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.1/opam
@@ -26,6 +26,7 @@ conflicts: [
   "deriving"     {< "0.6"}
   "tyxml"        {< "4.0.0"}
   "ppx_deriving" {< "3.0"}
+  "ppx_deriving" {>= "4.3"}
   "reactiveData" {< "0.2"}
   "async_kernel" {< "113.33.00"}
   "async_kernel" {>= "v0.9.0"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.2/opam
@@ -33,6 +33,7 @@ conflicts: [
   "deriving" {< "0.6"}
   "tyxml" {< "4.0.0"}
   "ppx_deriving" {< "3.0"}
+  "ppx_deriving" {>= "4.3"}
   "reactiveData" {< "0.2"}
   "async_kernel" {< "113.33.00"}
   "async_kernel" {>= "v0.9.0"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.3/opam
@@ -33,6 +33,7 @@ conflicts: [
   "deriving" {< "0.6"}
   "tyxml" {< "4.0.0"}
   "ppx_deriving" {< "3.0"}
+  "ppx_deriving" {>= "4.3"}
   "reactiveData" {< "0.2"}
   "async_kernel" {< "113.33.00"}
   "async_kernel" {>= "v0.9.0"}

--- a/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
@@ -32,6 +32,7 @@ conflicts: [
   "deriving" {< "0.6"}
   "tyxml" {< "4.0.0"}
   "ppx_deriving" {< "3.0"}
+  "ppx_deriving" {>= "4.3"}
   "reactiveData" {< "0.2"}
 ]
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml/js_of_ocaml.2.8/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8/opam
@@ -26,6 +26,7 @@ conflicts: [
   "deriving"     {< "0.6"}
   "tyxml"        {< "4.0.0"}
   "ppx_deriving" {< "3.0"}
+  "ppx_deriving" {>= "4.3"}
   "reactiveData" {< "0.2"}
   "async_kernel" {< "113.33.00"}
   "async_kernel" {>= "v0.9.0"}

--- a/packages/pfff/pfff.0.37.1/opam
+++ b/packages/pfff/pfff.0.37.1/opam
@@ -14,7 +14,7 @@ install: [
   [make "install-libs"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "camlp4"
   "num"
   "ocamlgraph"

--- a/packages/ppx_enum/ppx_enum.0.0.2/opam
+++ b/packages/ppx_enum/ppx_enum.0.0.2/opam
@@ -13,7 +13,7 @@ run-test: [
 ]
 depends: [
   "dune" {build}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "4.08.0"}
   "ounit" {with-test & >= "2.0.0"}
   "ppxlib" {>= "0.3.0"}
   "ppx_deriving" {with-test}

--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
@@ -20,7 +20,8 @@ depopts: [
   "ppx_deriving"
 ]
 conflicts: [
-  "ppx_deriving" {< "4.1" | = "4.02.0" | = "4.02.1"}
+  "ppx_deriving" {< "4.1"}
+  "ppx_deriving" {>= "4.2"}
 ]
 synopsis: "Support Library for type-driven code generators"
 description: "Part of the Jane Street's PPX rewriters collection."

--- a/packages/websocket/websocket.2.3/opam
+++ b/packages/websocket/websocket.2.3/opam
@@ -25,7 +25,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "cppo" {build}
+  "cppo_ocamlbuild" {build}
   "containers" {>= "0.10"}
   "cohttp" {>= "0.17.1" & < "0.99"}
   "ocplib-endian" {>= "0.8"}


### PR DESCRIPTION
Detected using [check.ocamllabs.io](http://check.ocamllabs.io/)

cc @aryx for `pfff.0.37.1`. Could you return the fix in the upstream opam file if you have one?
cc @leamingrad `ppx_enum.0.0.2` is not compatible with OCaml 4.08