### PR TITLE
Package: zed.2.0.2

### DIFF
--- a/packages/zed/zed.2.0.2/opam
+++ b/packages/zed/zed.2.0.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git://github.com/ocaml-community/zed.git"
 license: "BSD3"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build & >= "1.0.0"}
+  "dune" {build & >= "1.1.0"}
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"

--- a/packages/zed/zed.2.0.2/opam
+++ b/packages/zed/zed.2.0.2/opam
@@ -14,7 +14,6 @@ depends: [
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/zed/zed.2.0.2/opam
+++ b/packages/zed/zed.2.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/zed"
+bug-reports: "https://github.com/ocaml-community/zed/issues"
+dev-repo: "git://github.com/ocaml-community/zed.git"
+license: "BSD3"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.0.0"}
+  "base-bytes"
+  "camomile" {>= "1.0.1"}
+  "react"
+  "charInfo_width" {>= "1.1.0" & < "2.0~"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+url {
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.2/zed-2.0.2.tbz"
+  checksum: "md5=5c0cb1ee87147514adfd23966d58440e"
+}


### PR DESCRIPTION
* Zed\_utf8: fix an offset-stepping bug in function `unsafe_extract_prev`