### PR TITLE
Temporary commenting parts of #14287 to allow patch files again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ packages/freetennis/*/files/freetennis text eol=lf
 packages/ocamlfind/*/files/ocaml-stub text eol=lf
 
 # Treat patches as binary for safety
-*.patch binary
-*.patch.in binary
-*.diff binary
+# NOTE: Temporary commenting the next 3 lines until opam 2.1 is released (see: https://github.com/ocaml/opam/pull/3879)
+#*.patch binary
+#*.patch.in binary
+#*.diff binary


### PR DESCRIPTION
This should fix the problem occurring in https://github.com/ocaml/opam-repository/pull/14331
Once a fix is merged and opam-repository switches to a new version of opam, this PR should be safe to revert.

cc @dra27 