### PR TITLE
Package ocamlformat.0.9.1

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.9.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.9.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src: "https://github.com/ocaml-ppx/ocamlformat/archive/0.9.1.tar.gz"
+  checksum: [
+    "md5=5f528fcf4a4544769ede57f57a4aebec"
+    "sha512=7b663311b9849394e12f258d027a285f7b04bb5ab8d8b93600526cef5663c21e02475c2028896aebfa78674b7fecb4e3e5e11c5b0bccabb7f43605513b40618d"
+  ]
+}
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.ml" "src/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {build & >= "1.1.1"}
+  "fpath"
+  "ocaml-migrate-parsetree" {>= "1.0.10"}
+  "octavius" {>= "1.2.0"}
+  "stdio"
+  "uutf"
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."


### PR DESCRIPTION
### `ocamlformat.0.9.1`
Auto-formatter for OCaml code
OCamlFormat is a tool to automatically format OCaml code in a uniform style.



---
* Homepage: https://github.com/ocaml-ppx/ocamlformat
* Source repo: git+https://github.com/ocaml-ppx/ocamlformat.git
* Bug tracker: https://github.com/ocaml-ppx/ocamlformat/issues

---
:camel: Pull-request generated by opam-publish v2.0.0