### PR TITLE
Package qcstm.0.1.1

### DIFF
--- a/packages/qcstm/qcstm.0.1.1/opam
+++ b/packages/qcstm/qcstm.0.1.1/opam
@@ -25,7 +25,7 @@ url {
   checksum: "md5=aea97b691038c9c93d1378ba4d5ad7ad"
 }
 depends: [
-  "ocaml"  {>= "4.04.0"}
+  "ocaml"  {>= "4.05.0"}
   "qcheck" {>= "0.6"}
   "ocamlfind"  {build}
   "ocamlbuild" {build}

--- a/packages/qcstm/qcstm.0.1.1/opam
+++ b/packages/qcstm/qcstm.0.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A simple state-machine framework for OCaml based on QCheck"
+description: """
+This library implements a simple, typed state machine framework for
+property-based testing of imperative code. Tests are described by
+(a generator of) symbolic commands and two command interpreters over
+an abstract model and the system under test.
+
+The library requires a recent installation of the QCheck framework.
+"""
+tags: [
+  "state machine"
+  "test"
+  "property"
+  "quickcheck"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/jmid/qcstm"
+bug-reports: "https://github.com/jmid/qcstm/issues"
+authors: [ "Jan Midtgaard" ]
+maintainer: [ "Jan Midtgaard <mail@janmidtgaard.dk>" ]
+dev-repo: "git+https://github.com/jmid/qcstm.git"
+url {
+  src: "https://github.com/jmid/qcstm/archive/0.1.1.tar.gz"
+  checksum: "md5=aea97b691038c9c93d1378ba4d5ad7ad"
+}
+depends: [
+  "ocaml"  {>= "4.04.0"}
+  "qcheck" {>= "0.6"}
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "ppx_deriving"   {with-test}
+  "ctypes"         {with-test}
+  "ctypes-foreign" {with-test}
+]
+
+build: [
+  [make "all"]
+]
+
+install: [
+  [make "install"]
+  [make "examples"] {with-test}
+]


### PR DESCRIPTION
### `qcstm.0.1.1`
A simple state-machine framework for OCaml based on QCheck
This library implements a simple, typed state machine framework for
property-based testing of imperative code. Tests are described by
(a generator of) symbolic commands and two command interpreters over
an abstract model and the system under test.

The library requires a recent installation of the QCheck framework.



---
* Homepage: https://github.com/jmid/qcstm
* Source repo: git+https://github.com/jmid/qcstm.git
* Bug tracker: https://github.com/jmid/qcstm/issues

---
:camel: Pull-request generated by opam-publish v2.0.0