### PR TITLE
Correct the .gitattributes for patch/diff files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,8 +16,9 @@ packages/bap-llvm/*/files/detect.travis text eol=lf
 packages/freetennis/*/files/freetennis text eol=lf
 packages/ocamlfind/*/files/ocaml-stub text eol=lf
 
-# Treat patches as binary for safety
-# NOTE: Temporary commenting the next 3 lines until opam 2.1 is released (see: https://github.com/ocaml/opam/pull/3879)
-#*.patch binary
-#*.patch.in binary
-#*.diff binary
+# Do not normalise patch files (opam will ensure that patch files are
+# appropriately normalised for the target files, but direct calls to patch
+# don't benefit from this)
+*.patch -text
+*.patch.in -text
+*.diff -text


### PR DESCRIPTION
Thanks to @kit-ty-kate for the rapid diagnosis and correction work in #14287, #14331, #14339 and https://github.com/ocaml/opam/pull/3879, and apologies for the unexpected consequence of that change. I've been using a version of opam-repository with that for years, but not hit that particular kind of update, annoyingly.

I've done some [more reading](https://git-scm.com/docs/gitattributes#_end_of_line_conversion), and propose a better change here. In `.gitattributes`, `binary` is a [macro](https://git-scm.com/docs/gitattributes#_defining_macro_attributes) for `-diff -text -merge` and it is the `-diff` part which causes this:

<pre><font color="#8AE234"><b>dra@cosmic</b></font>:<font color="#729FCF"><b>~/opam-repository-prs</b></font>$ git diff
<b>diff --git a/packages/num/num.1.2/files/installation-warning.patch b/packages/num/num.1.2/files/installation-warning.patch</b>
<b>index 88ef9b6c1b..850a617b1c 100644</b>
Binary files a/packages/num/num.1.2/files/installation-warning.patch and b/packages/num/num.1.2/files/installation-warning.patch differ
</pre>

By specifying just the `-text` (which disables text file normalisation only), we then get this:

<pre><font color="#8AE234"><b>dra@cosmic</b></font>:<font color="#729FCF"><b>~/opam-repository-prs</b></font>$ git diff
<b>diff --git a/packages/num/num.1.2/files/installation-warning.patch b/packages/num/num.1.2/files/installation-warning.patch</b>
<b>index 88ef9b6c1b..850a617b1c 100644</b>
<b>--- a/packages/num/num.1.2/files/installation-warning.patch</b>
<b>+++ b/packages/num/num.1.2/files/installation-warning.patch</b>
<font color="#06989A">@@ -1,7 +1,6 @@</font>
 From db8d748b2cad0adc2698e9fcf28727083a711bae Mon Sep 17 00:00:00 2001
 From: David Allsopp &lt;david.allsopp@metastack.com&gt;
 Date: Wed, 24 Jan 2018 16:01:56 +0000
<font color="#CC0000">-Subject: [PATCH] Warn about installations broken by previous faulty package</font>
 
 ---
  Makefile | 33 +++++++++++++++++++++++++++++++++
</pre>