### PR TITLE
Rename ulex-camlp5 into ulex

### DIFF
--- a/packages/ulex/ulex.1.2-1/opam
+++ b/packages/ulex/ulex.1.2-1/opam
@@ -1,19 +1,19 @@
 opam-version: "2.0"
 maintainer: "claudio.sacerdoticoen@unibo.it"
 authors: ["Alain.Frisch@inria.fr"]
-homepage: "https://github.com/whitequark/ulex"
-dev-repo: "git+https://github.com/whitequark/ulex.git"
-bug-reports: "https://github.com/whitequark/ulex/issues"
+homepage: "https://github.com/sacerdot/ulex"
+dev-repo: "git+https://github.com/sacerdot/ulex.git"
+bug-reports: "https://github.com/sacerdot/ulex/issues"
 synopsis: "A lexer generator for Unicode (backported to camlp5)"
 build: [
   [make]
   [make "all.opt"]
 ]
 install: [make "install"]
-remove: [["ocamlfind" "remove" "ulex-camlp5"]]
+remove: [["ocamlfind" "remove" "ulex"]]
 flags: light-uninstall
 depends: [
-  "ocaml" {>="4.02.0"} 
+  "ocaml" {>="4.02.0"}
   "ocamlfind" {build}
   "camlp5"
   "ocamlbuild" {build}


### PR DESCRIPTION
Since the ulex-camlp5 is compatible with its campl4 clone, and camlp4 is basically dead, it makes sense to make a swap once and for all. See https://github.com/ocaml/opam-repository/issues/14344 for more information.