### PR TITLE
[new release] domain-name (0.2.0)

### DIFF
--- a/packages/domain-name/domain-name.0.2.0/opam
+++ b/packages/domain-name/domain-name.0.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/domain-name"
+doc: "https://hannesm.github.io/domain-name/doc"
+bug-reports: "https://github.com/hannesm/domain-name/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "fmt"
+  "astring"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/domain-name.git"
+synopsis: "RFC 1035 Internet domain names"
+description: """
+A domain name is a sequence of labels separated by dots, such as `foo.example`.
+Each label may contain any bytes. The length of each label may not exceed 63
+charactes.  The total length of a domain name is limited to 253 (byte
+representation is 255), but other protocols (such as SMTP) may apply even
+smaller limits.  A domain name label is case preserving, comparison is done in a
+case insensitive manner.
+"""
+url {
+  src:
+    "https://github.com/hannesm/domain-name/releases/download/v0.2.0/domain-name-v0.2.0.tbz"
+  checksum: [
+    "sha256=58026d7c80e8b0f402e7ec2a95b3704df44298deee4701d83d2b46e8ffa7b7a2"
+    "sha512=34456200efd60cdfe46a3bf04f630b45b796a5a60de517509909a41366512c34d744017a2dde5698a46e82a84a6068fe09ccd10ba945377847174dda001cbdcf"
+  ]
+}


### PR DESCRIPTION
RFC 1035 Internet domain names

- Project page: <a href="https://github.com/hannesm/domain-name">https://github.com/hannesm/domain-name</a>
- Documentation: <a href="https://hannesm.github.io/domain-name/doc">https://hannesm.github.io/domain-name/doc</a>

##### CHANGES:

* type t is now a phantom type 'a t, where 'a carries whether it is a hostname,
  a service name or a raw domain name. this lead to removal of various
  ?hostname:bool arguments
* val host : 'a t -> ([`host] t, [> `Msg of string ]) result
* analog host_exn, service, service_exn, raw
* removed is_service, is_hostname
* new submodules Host_set, Host_map, Service_set, Service_map
* new function: append : 'a t -> 'b t -> ([`raw] t, [> `Msg of string ]) result
* renamed: drop_labels{,_exn} is now drop_label{,_exn}
* renamed: prepend{,_exn} is now prepend_label{,_exn}
