### PR TITLE
+mirage-xen-{ocaml/posix}.3.3.1

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.1/opam
@@ -5,8 +5,8 @@ tags: "org:mirage"
 homepage: "https://github.com/mirage/mirage-platform"
 bug-reports: "https://github.com/mirage/mirage-platform/issues/"
 depends: [
-  "ocaml" {>= "4.04.2" & < "4.08.0"}
-  "mirage-xen-posix" {>= "2.6.0"}
+  "ocaml" {>= "4.04.2" & < "4.09.0"}
+  "mirage-xen-posix" {>="3.3.1"}
   "conf-pkg-config"
   "ocamlfind" {build}
   "ocaml-src"
@@ -25,6 +25,6 @@ synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."
 url {
-  src: "https://github.com/mirage/mirage-platform/archive/v3.3.0.tar.gz"
-  checksum: "md5=25b42ec49cdd2c4503eb994d0279ef35"
+  src: "https://github.com/mirage/mirage-platform/archive/v3.3.1.tar.gz"
+  checksum: "md5=ef287658f37ec55bf80ff3f1d2541db5"
 }

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.3.1/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.3.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "conf-pkg-config"
+]
+substs: [
+  "xen-posix/flags/posix-cflags.tmp"
+  "xen-posix/flags/posix-libs.tmp"
+  "xen-posix/flags/minios-cflags.tmp"
+  "xen-posix/flags/minios-libs.tmp"
+  ]
+available: os = "linux"
+build: [make "xen-posix-build"]
+install: [make "xen-posix-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-posix-uninstall" "PREFIX=%{prefix}%"]
+dev-repo: "git+https://github.com/mirage/mirage-platform.git"
+synopsis: "MirageOS library for posix headers"
+description: """
+This package contains the header files to pretend a posix
+system (required to compile the OCaml runtime), plus minilibc and
+float formating."""
+url {
+  src: "https://github.com/mirage/mirage-platform/archive/v3.3.1.tar.gz"
+  checksum: "md5=ef287658f37ec55bf80ff3f1d2541db5"
+}


### PR DESCRIPTION
disable 4.08.0 on mirage-xen-ocaml.3.3.0 which fails to compile
on the release version of 4.08.0

* Fix CFLAGS generation with repeated spaces on Linux (mirage/mirage-platform#210 @TheLortex)
* Add support for 4.08 final release (continued from mirage/mirage-platform#206 by @avsm)
