### PR TITLE
[new release] travesty (0.6.0)

### DIFF
--- a/packages/travesty/travesty.0.6.0/opam
+++ b/packages/travesty/travesty.0.6.0/opam
@@ -14,7 +14,6 @@ license: "MIT"
 dev-repo: "git+https://github.com/MattWindsor91/travesty.git"
 synopsis: "Monadically traversable containers"
 description: """
-
   'Travesty' is a library for defining containers with monadic traversals,
   inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
   Base library and ecosystem."""

--- a/packages/travesty/travesty.0.6.0/opam
+++ b/packages/travesty/travesty.0.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Matt Windsor <m.windsor@imperial.ac.uk>"]
+authors: ["Matt Windsor <m.windsor@imperial.ac.uk>"]
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+homepage: "https://MattWindsor91.github.io/travesty/"
+doc: "https://MattWindsor91.github.io/travesty/"
+license: "MIT"
+dev-repo: "git+https://github.com/MattWindsor91/travesty.git"
+synopsis: "Monadically traversable containers"
+description: """
+
+  'Travesty' is a library for defining containers with monadic traversals,
+  inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
+  Base library and ecosystem."""
+depends: [
+  "ocaml" {>= "4.07" & < "4.09"}
+  "dune" {build & > "1.10"}
+  "ppx_jane" {>= "v0.12.0" & < "v0.13.0"}
+  "base" {>= "v0.12.0" & < "v0.13.0"}
+]
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.6.0/travesty-v0.6.0.tbz"
+  checksum: [
+    "sha256=64b136dadb5d7628dbdf5db18d4cae813a69f670979b028e5ce36db41c714064"
+    "sha512=086dbe8603047b549a0b97d9e8c3252ba71db0bd30bcb03eed24a86ad39ea52ee8118a29003bd20aea06d52b39e930e263d9a53215bfa58ea4bab7f856928add"
+  ]
+}


### PR DESCRIPTION
**NB:** this is the first time I've tried submitting a package where the OPAM manifest was generated by `dune`.  `dune-release` has failed to auto-submit the pull request a few times, _and_ usually I mess up `v0.X.0` releases, so I hope that isn't a bad omen…

CHANGES:

Major release with various breaking changes and new features, the main one
being bi-traversables.

## Breaking changes

- Most module signatures have moved from `XYZ` to `XYZ_types`.  For example,
  `Bi_mappable.S2` is now `Bi_mappable_types.S2`.  This is to eliminate
  the 'intf pattern' previously used in Travesty.
- Removed `Travesty_core_kernel_exts`.  Use `Travesty_base_exts`
  instead.
- Made `Bi_mappable.Make2`'s return module type use sharing constraints
  instead of destructive substitutions.  This may cause shadowing where there
  previously wasn't any.

## Bi_traversable

This release adds a `Bi_traversable` module---effectively being to
`Traversable` as `Bi_mappable` is to `Mappable`.

`Alist`, `Tuple2`, and `Or_error` now expose `Bi_traversable.S2`, which
subsumes their previous interface.

## Biffs

This release also adds the ability to compose `Mappable`s on the inside of
`Bi_mappable`s (and `Traversables` on the inside of `Bi_traversables`): what
is often referred to as a 'biff' in the quirky world of Haskell.  This
complements the ability to compose them on the outside (a 'tannen').

## Minor improvements

- Removed spurious dependencies that caused travesty to be unavailable on
  OCaml 4.08.
- `Bi_mappable` arity-1 chaining functors now carry previously-missing
  sharing constraints equating their fixed types with those of their
  bi-mappable ancestor.
- Added experimental F#-style `>>` operator in
  `Travesty_base_exts.Fn.Compose_syntax`.
- Added bi-traversable instance for `Result`, from which `Or_error` now
 inherits.