### PR TITLE
Add cwe_checker package version 0.2.

### DIFF
--- a/packages/cwe_checker/cwe_checker.0.2/opam
+++ b/packages/cwe_checker/cwe_checker.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+name: "cwe_checker"
+version: "0.2"
+synopsis: "BAP plugin collection to detect common bug classes"
+description: """
+cwe_checker is a suite of tools to detect common bug classes such as use of dangerous functions and simple integer overflows. These bug classes are formally known as Common Weakness Enumerations (CWEs).
+"""
+maintainer: "CWE_checker Team <nils-edvin.enkelmann@fkie.fraunhofer.de>"
+authors: [ "Thomas Barabosch <thomas.barabosch@fkie.fraunhofer.de>" "Nils-Edvin Enkelmann <nils-edvin.enkelmann@fkie.fraunhofer.de>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/fkie-cad/cwe_checker"
+bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
+dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "1.6"}
+  "yojson" {>= "1.6.0"}
+  "bap" {>= "1.6"}
+  "alcotest" {>= "0.8.3"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+]
+depexts: [
+  "binutils"
+]
+conflicts: [
+  "fkie-cad-cwe-checker" {!= "0.2"}
+]
+build: [
+  [ "dune" "build" "--profile" "release" ]
+]
+install: [
+  [ make "uninstall" ]
+  [ make "clean" ]
+  [ make "all" ]
+]
+remove: [
+  [ make "uninstall" ]
+  [ make "clean" ]
+]
+url {
+  src: "https://github.com/fkie-cad/cwe_checker/archive/v0.2.tar.gz"
+  checksum: "md5=a63e66b89c3ec36da6a5006be0e70f90"
+}

--- a/packages/cwe_checker/cwe_checker.0.2/opam
+++ b/packages/cwe_checker/cwe_checker.0.2/opam
@@ -34,10 +34,6 @@ install: [
   [ make "clean" ]
   [ make "all" ]
 ]
-remove: [
-  [ make "uninstall" ]
-  [ make "clean" ]
-]
 url {
   src: "https://github.com/fkie-cad/cwe_checker/archive/v0.2.tar.gz"
   checksum: "md5=a63e66b89c3ec36da6a5006be0e70f90"

--- a/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.2/opam
+++ b/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 name: "fkie-cad-cwe-checker"
 version: "0.2"
-synopsis: "Virtual Package. Can be safely removed."
+synopsis: "Virtual Package. Can be safely removed"
 description: """
 The fkie-cad-cwe-checker package has been renamed to cwe_checker. This is a virtual package that can be safely removed.
 """

--- a/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.2/opam
+++ b/packages/fkie-cad-cwe-checker/fkie-cad-cwe-checker.0.2/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+name: "fkie-cad-cwe-checker"
+version: "0.2"
+synopsis: "Virtual Package. Can be safely removed."
+description: """
+The fkie-cad-cwe-checker package has been renamed to cwe_checker. This is a virtual package that can be safely removed.
+"""
+maintainer: "CWE_checker Team <nils-edvin.enkelmann@fkie.fraunhofer.de>"
+authors: [ "Thomas Barabosch <thomas.barabosch@fkie.fraunhofer.de>" "Nils-Edvin Enkelmann <nils-edvin.enkelmann@fkie.fraunhofer.de>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/fkie-cad/cwe_checker"
+bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
+dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
+depends: [
+  "cwe_checker" {>= "0.2"}
+]


### PR DESCRIPTION
With the new version v0.2 the *cwe_checker* package has been renamed from *fkie-cad-cwe-checker* to *cwe_checker*. A transitionary package for the old name is included.