### PR TITLE
pyml release 20190626

### DIFF
--- a/packages/pyml/pyml.20190626/opam
+++ b/packages/pyml/pyml.20190626/opam
@@ -20,5 +20,5 @@ depopts: ["utop"]
 version: "20190626"
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/20190626.tar.gz"
-  checksum: "md5=71daf34aa017559dcca6179c3d61e8a8"
+  checksum: "md5=400c0ad62e9af1ec90cadd7dd7cfae34"
 }

--- a/packages/pyml/pyml.20190626/opam
+++ b/packages/pyml/pyml.20190626/opam
@@ -7,7 +7,6 @@ license: "BSD"
 dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
 build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
-remove: [make "uninstall" "PREFIX=%{prefix}%"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [

--- a/packages/pyml/pyml.20190626/opam
+++ b/packages/pyml/pyml.20190626/opam
@@ -17,7 +17,6 @@ depends: [
   "num"
 ]
 depopts: ["utop"]
-version: "20190626"
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/20190626.tar.gz"
   checksum: "md5=400c0ad62e9af1ec90cadd7dd7cfae34"

--- a/packages/pyml/pyml.20190626/opam
+++ b/packages/pyml/pyml.20190626/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1" & < "4.09.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "9"}
+  "num"
+]
+depopts: ["utop"]
+version: "20190626"
+url {
+  src: "https://github.com/thierry-martinez/pyml/archive/20190626.tar.gz"
+  checksum: "md5=779b54e7aad10d9ef7f7c3d598ecb7d7"
+}

--- a/packages/pyml/pyml.20190626/opam
+++ b/packages/pyml/pyml.20190626/opam
@@ -20,5 +20,5 @@ depopts: ["utop"]
 version: "20190626"
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/20190626.tar.gz"
-  checksum: "md5=779b54e7aad10d9ef7f7c3d598ecb7d7"
+  checksum: "md5=71daf34aa017559dcca6179c3d61e8a8"
 }


### PR DESCRIPTION
- Support for debug build of Python library
  (Suggested by Arlen Cox:
   https://github.com/thierry-martinez/pyml/issues/18)
- Bug fix in pyml_check_symbol_available
- `Py.compile` is a wrapper for the built-in function `compile`
  (Suggested by Dhruv Makwana:
   https://github.com/thierry-martinez/pyml/issues/25)
- Guarantees for structural and physical equalities on `Py.Object.t`
  are now documented. New predicates Py.is_none, Py.is_null, Py.Bool.is_true,
  Py.Bool.is_false, Py.Tuple.is_empty.
  (Suggested by Laurent Mazare:
   https://github.com/thierry-martinez/pyml/pull/31)
- Fix Py.Array.numpy to handle OCaml GC's moving the floatarray
  (Reported by Ilias Garnier:
   https://github.com/thierry-martinez/pyml/issues/30)