### PR TITLE
Package opam2web.2.0

### DIFF
--- a/packages/opam2web/opam2web.2.0/opam
+++ b/packages/opam2web/opam2web.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Tool to generate the opam.ocaml.org website"
+description: """
+This utility creates a static website from an OPAM universe, listing all
+available packages and their details. A homepage and OPAM documentation is 
+included as well."""
+maintainer: "The opam team"
+authors: "The opam team"
+homepage: "https://github.com/ocaml/opam2web"
+bug-reports: "https://github.com/ocaml/opam2web/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "opam-lib" {>= "1.3.0"}
+  "opamfu" {>= "0.1.2"}
+  "re"
+  "uri" {>= "1.3.11"}
+  "cow" {= "2.3.0"}
+  "js_of_ocaml" {>= "2.4.1" & < "3.3.0"}
+  "js_of_ocaml-ppx"
+  "opam-core" {>= "2.0.0"}
+  "opam-format" {>= "2.0.0"}
+  "opam-state" {>= "2.0.0"}
+  "opam-client" {>= "2.0.0"}
+  "cohttp-lwt-unix"
+  "yojson" {>= "1.6.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam2web.git"
+url {
+  src: "https://github.com/ocaml/opam2web/archive/2.0.tar.gz"
+  checksum: [
+    "md5=1f2aedca3e3a3ef7263a5d40733cdf23"
+    "sha512=700454098409968a875eda5eac851ebfe89bbd41548df9e4c804d3a9b6f3f0d9b497fe14bbe0b36a82041f93083061a43573fbcf372c6d862eb3b783798a9bca"
+  ]
+}


### PR DESCRIPTION
### `opam2web.2.0`
Tool to generate the opam.ocaml.org website
This utility creates a static website from an OPAM universe, listing all
available packages and their details. A homepage and OPAM documentation is 
included as well.



---
* Homepage: https://github.com/ocaml/opam2web
* Source repo: git+https://github.com/ocaml/opam2web.git
* Bug tracker: https://github.com/ocaml/opam2web/issues

---
:camel: Pull-request generated by opam-publish v2.0.0