### PR TITLE
Release stdcompat.10

### DIFF
--- a/packages/stdcompat/stdcompat.10/opam
+++ b/packages/stdcompat/stdcompat.10/opam
@@ -23,6 +23,6 @@ url {
     "https://github.com/thierry-martinez/stdcompat/releases/download/10/stdcompat-10.tar.gz"
   checksum: [
     "md5=c97c82b14e3b7a6d83f8b0b7d984b1ce"
-    "sha512=4b8548c5741714c59fe8d0bb865bf9facf83af98a94189faa35494867fe4b03e71a9e5f59e299f07b54469a94b62a058ced2edbe87518af33aba549d1de00aca"
+    "sha512=8e3a880b61d2d98185d500d7f3f866df14d3d34e8637b9c9ab60c01f6caaab5cc489fa2fb63cfe0844f195dcd242c61557e6011be372a875e0c99870a21a36fd"
   ]
 }

--- a/packages/stdcompat/stdcompat.10/opam
+++ b/packages/stdcompat/stdcompat.10/opam
@@ -22,7 +22,7 @@ url {
   src:
     "https://github.com/thierry-martinez/stdcompat/releases/download/10/stdcompat-10.tar.gz"
   checksum: [
-    "md5=c97c82b14e3b7a6d83f8b0b7d984b1ce"
-    "sha512=8e3a880b61d2d98185d500d7f3f866df14d3d34e8637b9c9ab60c01f6caaab5cc489fa2fb63cfe0844f195dcd242c61557e6011be372a875e0c99870a21a36fd"
+    "md5=57c00723359aeca46126ba5641f3f3d8"
+    "sha512=4e5e5a65489c75865e9ab6a60594709add55c36d9c0791d41d93cf6c811d78093f6a823ec8bbe02f588c4bd222f95eebfdf87d1e296917fec0d36307e4174a57"
   ]
 }

--- a/packages/stdcompat/stdcompat.10/opam
+++ b/packages/stdcompat/stdcompat.10/opam
@@ -16,7 +16,6 @@ build: [
   [make]
 ]
 install: [make "install"]
-remove: [make "uninstall"]
 dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
 url {
   src:

--- a/packages/stdcompat/stdcompat.10/opam
+++ b/packages/stdcompat/stdcompat.10/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.07" & < "4.09.0"}
+]
+depopts: ["result" "seq" "uchar" "ocamlfind"]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/10/stdcompat-10.tar.gz"
+  checksum: [
+    "md5=c97c82b14e3b7a6d83f8b0b7d984b1ce"
+    "sha512=4b8548c5741714c59fe8d0bb865bf9facf83af98a94189faa35494867fe4b03e71a9e5f59e299f07b54469a94b62a058ced2edbe87518af33aba549d1de00aca"
+  ]
+}


### PR DESCRIPTION
- New C stub with definition of caml_alloc_initialized_string for OCaml <4.05.0

- Fix: Printexc is no longer opaque

- Generate -bin-annot .cmt files for OCaml >=4.00.0