### PR TITLE
[new release] mirage-xen (4.0.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.4.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.4.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst" ] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "conf-pkg-config"
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "mirage-xen-ocaml" {>= "3.3.1"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "logs"
+  "fmt"
+]
+conflicts: [
+  "dune" {= "1.9.1"}
+]
+available: [ os = "linux" ]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v4.0.0/mirage-xen-v4.0.0.tbz"
+  checksum: [
+    "sha256=6e40b291a91868ac76cb3811f33ffe8d2c30b820bd392bb3bdd54a4de690cb7d"
+    "sha512=c98e6d96f2a6b795b26027c295af9246983a890cf1345bc95f58efe09b77c92a2ebbc391ebfc9a1101f61578fc47e79ea9ff00a7d05c1c69344e33823cce339f"
+  ]
+}


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Breaking change: move from the `OS.Xen` module to `Os_xen`, in
  order to let packages specifically depend on a particular bit
  of Xen functionality. To port code, just change the module reference
  to `Os_xen` instead of `OS`. (mirage/mirage-xen#16 @TheLortex @avsm)
