### PR TITLE
[new release] io-page-xen, io-page and io-page-unix (2.3.0)

### DIFF
--- a/packages/io-page-unix/io-page-unix.2.3.0/opam
+++ b/packages/io-page-unix/io-page-unix.2.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "io-page" {=version}
+  "cstruct" {>= "2.0.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages on Unix"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz"
+  checksum: [
+    "sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3"
+    "sha512=ce1775bff151d62bb85405a13fe75f912c11b09cbc0a6dd81dd27b3f4c767f0b9c4d3e7383d494eb5c130311482ea69877c45b71b91153177562ffc47de4da2f"
+  ]
+}

--- a/packages/io-page-xen/io-page-xen.2.3.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "io-page" {=version}
+  "cstruct" {>= "2.0.0"}
+  "mirage-xen-ocaml"
+]
+build: [
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst"] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig"
+    "dune" "build" "-p" name "-j" jobs ]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages on Xen"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz"
+  checksum: [
+    "sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3"
+    "sha512=ce1775bff151d62bb85405a13fe75f912c11b09cbc0a6dd81dd27b3f4c767f0b9c4d3e7383d494eb5c130311482ea69877c45b71b91153177562ffc47de4da2f"
+  ]
+}

--- a/packages/io-page/io-page.2.3.0/opam
+++ b/packages/io-page/io-page.2.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "cstruct" {>= "2.0.0"}
+  "bigarray-compat"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz"
+  checksum: [
+    "sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3"
+    "sha512=ce1775bff151d62bb85405a13fe75f912c11b09cbc0a6dd81dd27b3f4c767f0b9c4d3e7383d494eb5c130311482ea69877c45b71b91153177562ffc47de4da2f"
+  ]
+}


### PR DESCRIPTION
Support for efficient handling of I/O memory pages on Xen

- Project page: <a href="https://github.com/mirage/io-page">https://github.com/mirage/io-page</a>
- Documentation: <a href="https://mirage.github.io/io-page/">https://mirage.github.io/io-page/</a>

##### CHANGES:

* Hook in the JavaScript stubs to dune (mirage/io-page#55 @jonludlam)
* Remove unnecessary dependency on `configurator`, which pulled
  in a jbuilder dependency. We have used `dune.configurator` since the
  v2.1.0 release (@avsm)
