### PR TITLE
mirage-block-unix: older versions have upper bound on io-page

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
-  "io-page" {>= "1.0.0"}
+  "io-page" {>= "1.0.0" & <"2.0.0"}
   "ounit" {with-test}
   "ocamlbuild" {build}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
-  "io-page" {>= "1.0.0"}
+  "io-page" {>= "1.0.0" & <"2.0.0"}
   "logs"
   "ounit" {with-test}
   "ocamlbuild" {build}

--- a/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_cstruct" {<"3.4.0"}
   "lwt" {>= "2.4.3" & < "4.0.0"}
   "mirage-types" {>= "1.1.0" & < "3.0.0"}
-  "io-page" {>= "1.0.0"}
+  "io-page" {>= "1.0.0" & <"2.0.0"}
   "logs"
   "ounit" {with-test}
   "ocamlbuild" {build}


### PR DESCRIPTION
found in revdeps for #14367