### PR TITLE
mirage-console: older versions do not work with new mirage-xen

### DIFF
--- a/packages/mirage-console/mirage-console.2.1.0/opam
+++ b/packages/mirage-console/mirage-console.2.1.0/opam
@@ -18,6 +18,7 @@ conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
   "mirage-xen" {< "1.1.0"}
+  "mirage-xen" {> "3.3.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"
 install: [make "install"]

--- a/packages/mirage-console/mirage-console.2.1.1/opam
+++ b/packages/mirage-console/mirage-console.2.1.1/opam
@@ -18,6 +18,7 @@ conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
   "mirage-xen" {< "1.1.0"}
+  "mirage-xen" {> "3.3.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"
 install: [make "install"]


### PR DESCRIPTION
due to xen-gnt addition into mirage-xen.3.3.0+

revdeps for #14366