### PR TITLE
[new release] mirage-block-ramdisk (0.4)

### DIFF
--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.4/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block-ramdisk"
+doc: "https://mirage.github.io/mirage-block-ramdisk/"
+bug-reports: "https://github.com/mirage/mirage-block-ramdisk/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "alcotest" {with-test}
+  "cstruct"
+  "io-page"
+  "io-page-unix" {with-test}
+  "mirage-block-lwt" {>= "1.0.0"}
+  "lwt"
+]
+build: [
+ [ "dune" "subst" ] {pinned}
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-ramdisk.git"
+synopsis: "In-memory BLOCK device for MirageOS"
+description: """
+- Can be dynamically resized
+- Supports querying sparseness information
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-ramdisk/releases/download/0.4/mirage-block-ramdisk-0.4.tbz"
+  checksum: [
+    "sha256=5ba75345c584ecc52b2da95bf50e87da15aad2cded67d2809fe621becb51fc20"
+    "sha512=edefaec72ba38d9af26423af5aa3104b5553df4fed458a8baf0084d807de3540a302a3c9534abda3f40277e62d9008187e7600d6493a77e95e51d349b38f3aaa"
+  ]
+}


### PR DESCRIPTION
In-memory BLOCK device for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-block-ramdisk">https://github.com/mirage/mirage-block-ramdisk</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-ramdisk/">https://mirage.github.io/mirage-block-ramdisk/</a>

##### CHANGES:

- port to dune (@avsm)
- odoc fixes (@avsm)
- support dune-release (@avsm)
